### PR TITLE
fix(telegram/provider): redirect profile to wallet on page restore

### DIFF
--- a/app/src/components/telegram/TelegramProvider.tsx
+++ b/app/src/components/telegram/TelegramProvider.tsx
@@ -87,12 +87,16 @@ function TelegramProviderInner({ children }: PropsWithChildren) {
   useEffect(() => {
     const restorePage = async () => {
       try {
-        const lastPage = await getCloudValue(LAST_PAGE_CACHE_KEY);
+        let lastPage = await getCloudValue(LAST_PAGE_CACHE_KEY);
         if (
           typeof lastPage === 'string' &&
           lastPage.startsWith('/telegram') &&
           lastPage !== pathname
         ) {
+          // Redirect profile to wallet
+          if (lastPage === '/telegram/profile') {
+            lastPage = '/telegram/wallet';
+          }
           router.replace(lastPage);
         }
       } catch (e) {


### PR DESCRIPTION
Redirect /telegram/profile to /telegram/wallet when restoring the last visited page on app open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Telegram navigation to redirect profile page access to the wallet page for improved routing consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->