### PR TITLE
feat(telegram/bot-api): add transaction notification function

### DIFF
--- a/app/src/lib/telegram/bot-api/send-transaction-notification.ts
+++ b/app/src/lib/telegram/bot-api/send-transaction-notification.ts
@@ -1,0 +1,52 @@
+import { InlineKeyboard } from "grammy";
+
+import { resolveEndpoint } from "@/lib/core/api";
+
+import { getBot } from "./bot";
+import { MINI_APP_LINK } from "./constants";
+
+const buildOgImageUrl = (
+  sender: string,
+  receiver: string,
+  solAmount: number,
+  usdAmount: number
+): string => {
+  const endpoint = resolveEndpoint("api/og/share");
+  const url = new URL(endpoint);
+  url.searchParams.set("sender", sender);
+  url.searchParams.set("receiver", receiver);
+  url.searchParams.set("solAmount", solAmount.toString());
+  url.searchParams.set("usdAmount", usdAmount.toString());
+  return url.toString();
+};
+
+export const sendTransactionNotification = async (
+  userId: number,
+  senderUsername: string,
+  receiverUsername: string,
+  solAmount: number,
+  usdAmount: number
+): Promise<void> => {
+  const bot = await getBot();
+  const photoUrl = buildOgImageUrl(
+    senderUsername,
+    receiverUsername,
+    solAmount,
+    usdAmount
+  );
+
+  const invisibleChar = String.fromCharCode(0x200b);
+  const text = `You received <b>${solAmount} SOL</b> from <b>${senderUsername}</b>!\n\nTap the button below to claim your funds.<a href="${photoUrl}">${invisibleChar}</a>`;
+
+  const keyboard = new InlineKeyboard().url("Claim Now", MINI_APP_LINK);
+
+  await bot.api.sendMessage(userId, text, {
+    parse_mode: "HTML",
+    reply_markup: keyboard,
+    link_preview_options: {
+      url: photoUrl,
+      prefer_large_media: true,
+      show_above_text: true,
+    },
+  });
+};


### PR DESCRIPTION
Add function to send transaction notifications with OG image preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Telegram users now receive transaction notifications with sender and receiver details
* Notifications display transaction amounts in both SOL and USD
* Each notification includes a preview image and a "Claim Now" button for quick access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->