### PR TITLE
feat(solana/rpc): add localnet support for testing

### DIFF
--- a/app/src/lib/solana/rpc/connection.ts
+++ b/app/src/lib/solana/rpc/connection.ts
@@ -1,24 +1,50 @@
 import { Connection } from "@solana/web3.js";
 
 import {
+  LOCALNET_RPC_URL,
+  LOCALNET_RPC_WS,
   SECURE_DEVNET_RPC_URL,
   SECURE_DEVNET_RPC_WS,
   SECURE_MAINNET_RPC_URL,
   SECURE_MAINNET_RPC_WS,
 } from "./constants";
+import type { SolanaEnv } from "./types";
 
-const defaultSolanaEnv = "devnet";
-const selectedSolanaEnv =
-  process.env.NEXT_PUBLIC_SOLANA_ENV || defaultSolanaEnv;
+const DEFAULT_SOLANA_ENV: SolanaEnv = "devnet";
 
-const rpcEndpoint =
-  selectedSolanaEnv === "mainnet"
-    ? SECURE_MAINNET_RPC_URL
-    : SECURE_DEVNET_RPC_URL;
-const websocketEndpoint =
-  selectedSolanaEnv === "mainnet"
-    ? SECURE_MAINNET_RPC_WS
-    : SECURE_DEVNET_RPC_WS;
+export const getSolanaEnv = (): SolanaEnv => {
+  const env = process.env.NEXT_PUBLIC_SOLANA_ENV;
+  if (env === "mainnet" || env === "devnet" || env === "localnet") {
+    return env;
+  }
+  return DEFAULT_SOLANA_ENV;
+};
+
+const getEndpoints = (
+  env: SolanaEnv
+): { rpcEndpoint: string; websocketEndpoint: string } => {
+  switch (env) {
+    case "mainnet":
+      return {
+        rpcEndpoint: SECURE_MAINNET_RPC_URL,
+        websocketEndpoint: SECURE_MAINNET_RPC_WS,
+      };
+    case "localnet":
+      return {
+        rpcEndpoint: LOCALNET_RPC_URL,
+        websocketEndpoint: LOCALNET_RPC_WS,
+      };
+    case "devnet":
+    default:
+      return {
+        rpcEndpoint: SECURE_DEVNET_RPC_URL,
+        websocketEndpoint: SECURE_DEVNET_RPC_WS,
+      };
+  }
+};
+
+const selectedSolanaEnv = getSolanaEnv();
+const { rpcEndpoint, websocketEndpoint } = getEndpoints(selectedSolanaEnv);
 
 let cachedConnection: Connection | null = null;
 let cachedWebsocketConnection: Connection | null = null;

--- a/app/src/lib/solana/rpc/constants.ts
+++ b/app/src/lib/solana/rpc/constants.ts
@@ -7,3 +7,6 @@ export const SECURE_DEVNET_RPC_URL =
   "https://aurora-o23cd4-fast-devnet.helius-rpc.com";
 export const SECURE_DEVNET_RPC_WS =
   "wss://aurora-o23cd4-fast-devnet.helius-rpc.com";
+
+export const LOCALNET_RPC_URL = "http://127.0.0.1:8899";
+export const LOCALNET_RPC_WS = "ws://127.0.0.1:8900";

--- a/app/src/lib/solana/rpc/types.ts
+++ b/app/src/lib/solana/rpc/types.ts
@@ -1,3 +1,5 @@
+export type SolanaEnv = "mainnet" | "devnet" | "localnet";
+
 export type WalletTransfer = {
   signature: string;
   slot: number;

--- a/docs/miniapp/environment-vars.md
+++ b/docs/miniapp/environment-vars.md
@@ -7,7 +7,7 @@ All environment variables used by `/app/src/lib/`.
 | Variable | Used By | Description |
 |----------|---------|-------------|
 | `NEXT_PUBLIC_TELEGRAM_BOT_ID` | `constants.ts` | Telegram bot ID |
-| `NEXT_PUBLIC_SOLANA_ENV` | `solana/rpc/` | `"mainnet"` or `"devnet"` (defaults to devnet) |
+| `NEXT_PUBLIC_SOLANA_ENV` | `solana/rpc/` | `"mainnet"`, `"devnet"`, or `"localnet"` (defaults to devnet) |
 | `ASKLOYAL_TGBOT_KEY` | `telegram/bot-api/` | Telegram bot token from BotFather |
 | `REDPILL_AI_API_KEY` | `redpill/` | API key for RedPill AI service |
 | `DATABASE_URL` | `core/database.ts` | Neon PostgreSQL connection string |
@@ -27,7 +27,7 @@ All environment variables used by `/app/src/lib/`.
 NEXT_PUBLIC_TELEGRAM_BOT_ID=your_bot_id
 ASKLOYAL_TGBOT_KEY=your_bot_token
 
-# Solana
+# Solana - use "mainnet", "devnet", or "localnet"
 NEXT_PUBLIC_SOLANA_ENV=devnet
 
 # AI
@@ -39,3 +39,23 @@ DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/dbname?sslmode=requ
 # Optional - API host
 NEXT_PUBLIC_SERVER_HOST=https://your-api.com
 ```
+
+## Localnet Setup
+
+To use localnet for local testing:
+
+```bash
+# Terminal 1 - Start local validator
+solana-test-validator
+
+# Terminal 2 - Run app with localnet
+NEXT_PUBLIC_SOLANA_ENV=localnet bun dev
+```
+
+| Environment | RPC Endpoint | WebSocket |
+|-------------|--------------|-----------|
+| `mainnet` | Helius mainnet | Helius WSS |
+| `devnet` | Helius devnet | Helius WSS |
+| `localnet` | `http://127.0.0.1:8899` | `ws://127.0.0.1:8900` |
+
+Note: On localnet, MagicBlock price feeds fall back to devnet.

--- a/docs/miniapp/folder-reference.md
+++ b/docs/miniapp/folder-reference.md
@@ -49,16 +49,22 @@ Solana blockchain integration.
 
 ### `/solana/rpc/`
 
-RPC connection management using Helius endpoints.
+RPC connection management using Helius endpoints (mainnet/devnet) or local validator (localnet).
 
 | Constant | Source | Value |
 |----------|--------|-------|
 | `SECURE_MAINNET_RPC_URL` | Hardcoded | Helius mainnet endpoint |
 | `SECURE_DEVNET_RPC_URL` | Hardcoded | Helius devnet endpoint |
+| `LOCALNET_RPC_URL` | Hardcoded | `http://127.0.0.1:8899` |
 
-Selected by `NEXT_PUBLIC_SOLANA_ENV` (defaults to `devnet`).
+Selected by `NEXT_PUBLIC_SOLANA_ENV`:
+- `"mainnet"` - Production (Helius)
+- `"devnet"` - Testing (Helius, default)
+- `"localnet"` - Local development (`solana-test-validator`)
 
-**Key exports:** `getConnection()`, `getWebsocketConnection()`
+**Key exports:** `getConnection()`, `getWebsocketConnection()`, `getSolanaEnv()`
+
+**Type exports:** `SolanaEnv` - Union type for valid environment values
 
 ### `/solana/wallet/`
 
@@ -129,6 +135,8 @@ MagicBlock integration for live SOL/USD price via Pyth Lazer oracle.
 | `SOLANA_PYTH_LAZER_ID` | Hardcoded | `6` (SOL/USD feed) |
 
 **Key export:** `fetchSolUsdPrice()` - Returns current SOL price in USD
+
+Note: On localnet, MagicBlock uses devnet as a fallback for price data.
 
 ---
 


### PR DESCRIPTION
Adds `localnet` as a valid `NEXT_PUBLIC_SOLANA_ENV` option for local testing with `solana-test-validator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localnet environment support, enabling you to run the app against a local Solana validator in addition to mainnet and devnet.

* **Documentation**
  * Updated guides with localnet setup instructions, including how to start a local validator and configure the app. Added endpoint mappings and noted that price feeds fall back to devnet when running on localnet.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->