### PR TITLE
feat(telegram/bot-api): restrict /ca command to designated community chat

### DIFF
--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -7,7 +7,7 @@ import { admins, communities } from "@/lib/core/schema";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat } from "@/lib/telegram/utils";
 
-import { MINI_APP_LINK } from "./constants";
+import { CA_COMMAND_CHAT_ID, MINI_APP_LINK } from "./constants";
 
 export const handleStartCommand = async (
   ctx: CommandContext<Context>,
@@ -54,6 +54,11 @@ export const handleCaCommand = async (
   const chatId = ctx.chat?.id;
   if (!chatId) {
     console.error("Chat ID not found in ca command");
+    return;
+  }
+
+  // Only respond in the designated community chat
+  if (chatId !== Number(CA_COMMAND_CHAT_ID)) {
     return;
   }
 

--- a/app/src/lib/telegram/bot-api/constants.ts
+++ b/app/src/lib/telegram/bot-api/constants.ts
@@ -1,3 +1,4 @@
 export const CHANNEL_USERNAME = "@loyal_tg";
 export const CUSTOM_EMOJI_ID = "5361803602862052361";
 export const MINI_APP_LINK = "https://t.me/askloyal_tgbot/app";
+export const CA_COMMAND_CHAT_ID = "-1002981429221";


### PR DESCRIPTION
Restrict the /ca command to only respond in the designated Loyal community chat (-1002981429221).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram bot command responses are now restricted to a designated chat channel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->