### PR TITLE
feat(summaries): add oneliner field and OG preview improvements (ASK-231)

### DIFF
--- a/app/drizzle/0001_curved_johnny_blaze.sql
+++ b/app/drizzle/0001_curved_johnny_blaze.sql
@@ -1,0 +1,8 @@
+-- Add column as nullable first
+ALTER TABLE "summaries" ADD COLUMN "oneliner" text;
+
+-- Backfill existing rows with first topic title (truncated to 110 chars)
+UPDATE "summaries" SET "oneliner" = LEFT(topics->0->>'title', 110) WHERE "oneliner" IS NULL;
+
+-- Make column NOT NULL
+ALTER TABLE "summaries" ALTER COLUMN "oneliner" SET NOT NULL;

--- a/app/drizzle/meta/0001_snapshot.json
+++ b/app/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,614 @@
+{
+  "id": "4bdbfed2-1e53-4ce7-9a0e-8694967c8dc5",
+  "prevId": "67a3e3cc-c6ed-40a3-bae5-271b887b55ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769502523349,
       "tag": "0000_jazzy_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1769657160531,
+      "tag": "0001_curved_johnny_blaze",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/summaries/route.ts
+++ b/app/src/app/api/summaries/route.ts
@@ -22,6 +22,7 @@ export async function GET(req: Request): Promise<NextResponse> {
       chatId: String(item.community.chatId),
       title: item.chatTitle,
       messageCount: item.messageCount,
+      oneliner: item.oneliner,
       topics: item.topics.map((topic, index) => ({
         id: `${item.id}-${index}`,
         title: topic.title,

--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -6,6 +6,7 @@ import {
   handleActivateCommunityCommand,
   handleCaCommand,
   handleStartCommand,
+  handleSummaryCommand,
 } from "@/lib/telegram/bot-api/commands";
 import { sendBusinessConnectionMessage } from "@/lib/telegram/bot-api/handle-business-connection";
 import { handleInlineQuery } from "@/lib/telegram/bot-api/inline";
@@ -26,6 +27,10 @@ bot.command("ca", async (ctx: CommandContext<Context>) => {
 
 bot.command("activate_community", async (ctx: CommandContext<Context>) => {
   await handleActivateCommunityCommand(ctx, bot);
+});
+
+bot.command("summary", async (ctx: CommandContext<Context>) => {
+  await handleSummaryCommand(ctx, bot);
 });
 
 bot.on("inline_query", async (ctx) => {

--- a/app/src/lib/core/api.ts
+++ b/app/src/lib/core/api.ts
@@ -1,13 +1,11 @@
-export const resolveEndpoint = (path: string): string => {
+export function resolveEndpoint(path: string): string {
   const serverHost = process.env.NEXT_PUBLIC_SERVER_HOST;
   if (!serverHost) return path;
 
   try {
-    const configured = new URL(serverHost);
-    const url = new URL(path, configured);
-
+    const url = new URL(path, serverHost);
     return url.toString();
   } catch {
     return path;
   }
-};
+}

--- a/app/src/lib/core/schema.ts
+++ b/app/src/lib/core/schema.ts
@@ -168,6 +168,7 @@ export const summaries = pgTable(
     topics: jsonb("topics")
       .$type<{ title: string; content: string; sources: string[] }[]>()
       .notNull(),
+    oneliner: text("oneliner").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/app/src/lib/telegram/bot-api/build-summary-og-url.ts
+++ b/app/src/lib/telegram/bot-api/build-summary-og-url.ts
@@ -8,7 +8,7 @@ function formatDate(date: Date): string {
 
 export function buildSummaryOgImageUrl(text: string, date: Date): string {
   const endpoint = resolveEndpoint("api/og/share-summary");
-  const url = new URL(endpoint);
+  const url = new URL(endpoint, "http://localhost");
   url.searchParams.set("text", text);
   url.searchParams.set("date", formatDate(date));
   return url.toString();

--- a/app/src/lib/telegram/bot-api/build-summary-og-url.ts
+++ b/app/src/lib/telegram/bot-api/build-summary-og-url.ts
@@ -1,0 +1,24 @@
+import { resolveEndpoint } from "@/lib/core/api";
+
+const formatDate = (date: Date): string => {
+  return date.toLocaleDateString("en-US", { month: "long", day: "numeric" });
+};
+
+export const buildSummaryOgImageUrl = (text: string, date: Date): string => {
+  const endpoint = resolveEndpoint("api/og/share-summary");
+  const url = new URL(endpoint);
+  url.searchParams.set("text", text);
+  url.searchParams.set("date", formatDate(date));
+  return url.toString();
+};
+
+const INVISIBLE_CHAR = String.fromCharCode(0x200b);
+
+export const buildSummaryMessageWithPreview = (
+  messageText: string,
+  ogText: string,
+  date: Date
+): string => {
+  const photoUrl = buildSummaryOgImageUrl(ogText, date);
+  return `${messageText}<a href="${photoUrl}">${INVISIBLE_CHAR}</a>`;
+};

--- a/app/src/lib/telegram/bot-api/build-summary-og-url.ts
+++ b/app/src/lib/telegram/bot-api/build-summary-og-url.ts
@@ -1,24 +1,24 @@
 import { resolveEndpoint } from "@/lib/core/api";
 
-const formatDate = (date: Date): string => {
-  return date.toLocaleDateString("en-US", { month: "long", day: "numeric" });
-};
+const INVISIBLE_CHAR = "\u200b";
 
-export const buildSummaryOgImageUrl = (text: string, date: Date): string => {
+function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", { month: "long", day: "numeric" });
+}
+
+export function buildSummaryOgImageUrl(text: string, date: Date): string {
   const endpoint = resolveEndpoint("api/og/share-summary");
   const url = new URL(endpoint);
   url.searchParams.set("text", text);
   url.searchParams.set("date", formatDate(date));
   return url.toString();
-};
+}
 
-const INVISIBLE_CHAR = String.fromCharCode(0x200b);
-
-export const buildSummaryMessageWithPreview = (
+export function buildSummaryMessageWithPreview(
   messageText: string,
   ogText: string,
   date: Date
-): string => {
+): string {
   const photoUrl = buildSummaryOgImageUrl(ogText, date);
   return `${messageText}<a href="${photoUrl}">${INVISIBLE_CHAR}</a>`;
-};
+}

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -146,7 +146,8 @@ export async function sendLatestSummary(
     return { sent: false, reason: "no_summaries" };
   }
 
-  const messageBody = `<b>${community.chatTitle} Daily Summary</b>\n\n${latestSummary.oneliner}\n\n<a href="${MINI_APP_LINK}">View full summary in Loyal</a>`;
+  const safeOneliner = escapeTelegramHtml(latestSummary.oneliner);
+  const messageBody = `<b>${community.chatTitle} Daily Summary</b>\n\n${safeOneliner}\n\n<a href="${MINI_APP_LINK}">View full summary in Loyal</a>`;
 
   const messageWithPreview = buildSummaryMessageWithPreview(
     messageBody,
@@ -160,4 +161,11 @@ export async function sendLatestSummary(
   });
 
   return { sent: true };
+}
+
+function escapeTelegramHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -1,15 +1,21 @@
-import { and, asc, eq, gte } from "drizzle-orm";
+import { and, asc, desc, eq, gte } from "drizzle-orm";
+import type { Bot } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
-import { messages, summaries, type Topic } from "@/lib/core/schema";
+import { communities, messages, summaries, type Topic } from "@/lib/core/schema";
 import { chatCompletion } from "@/lib/redpill";
 import { SUMMARY_INTERVAL_MS } from "@/lib/telegram/utils";
+
+import { buildSummaryMessageWithPreview } from "./build-summary-og-url";
+import { MINI_APP_LINK } from "./constants";
 
 export const MIN_MESSAGES_FOR_SUMMARY = 5;
 
 export const SYSTEM_PROMPT = `You summarize group chat conversations into topics. Output JSON:
 {"topics":[{"title":"Topic Name","content":"Summary paragraph","sources":["Name1","Name2"]}]}
 Keep summaries concise. List 1-5 topics. Sources are participant names who contributed to each topic.`;
+
+export const ONELINER_PROMPT = `Given these discussion topics from a group chat, write a single catchy sentence (max 110 characters) that captures the essence of the day's conversation. Output only the sentence, no quotes or formatting.`;
 
 export async function generateChatSummary(
   communityId: string,
@@ -48,6 +54,7 @@ export async function generateChatSummary(
   }
 
   const topics = parseAndValidateTopics(summaryText);
+  const oneliner = await generateOneliner(topics);
 
   await db.insert(summaries).values({
     communityId,
@@ -56,7 +63,26 @@ export async function generateChatSummary(
     fromMessageId: recentMessages[0].telegramMessageId,
     toMessageId: recentMessages[recentMessages.length - 1].telegramMessageId,
     topics,
+    oneliner,
   });
+}
+
+export async function generateOneliner(topics: Topic[]): Promise<string> {
+  const topicsSummary = topics
+    .map((t) => `${t.title}: ${t.content}`)
+    .join("\n");
+
+  const response = await chatCompletion({
+    model: "phala/gpt-oss-120b",
+    messages: [
+      { role: "system", content: ONELINER_PROMPT },
+      { role: "user", content: topicsSummary },
+    ],
+    temperature: 0.5,
+  });
+
+  const oneliner = response.choices?.[0]?.message?.content?.trim() ?? "";
+  return oneliner.slice(0, 110);
 }
 
 export function parseAndValidateTopics(summaryText: string): Topic[] {
@@ -88,4 +114,50 @@ function isValidTopic(topic: unknown): topic is Topic {
     typeof t.content === "string" &&
     Array.isArray(t.sources)
   );
+}
+
+export type SendSummaryResult =
+  | { sent: true }
+  | { sent: false; reason: "not_activated" | "no_summaries" };
+
+export async function sendLatestSummary(
+  bot: Bot,
+  chatId: bigint
+): Promise<SendSummaryResult> {
+  const db = getDatabase();
+
+  const community = await db.query.communities.findFirst({
+    where: and(
+      eq(communities.chatId, chatId),
+      eq(communities.isActive, true)
+    ),
+  });
+
+  if (!community) {
+    return { sent: false, reason: "not_activated" };
+  }
+
+  const latestSummary = await db.query.summaries.findFirst({
+    where: eq(summaries.communityId, community.id),
+    orderBy: [desc(summaries.createdAt)],
+  });
+
+  if (!latestSummary) {
+    return { sent: false, reason: "no_summaries" };
+  }
+
+  const messageBody = `<b>${community.chatTitle} Daily Summary</b>\n\n${latestSummary.oneliner}\n\n<a href="${MINI_APP_LINK}">View full summary in Loyal</a>`;
+
+  const messageWithPreview = buildSummaryMessageWithPreview(
+    messageBody,
+    latestSummary.oneliner,
+    latestSummary.createdAt
+  );
+
+  await bot.api.sendMessage(Number(chatId), messageWithPreview, {
+    parse_mode: "HTML",
+    link_preview_options: { prefer_large_media: true },
+  });
+
+  return { sent: true };
 }


### PR DESCRIPTION
Adds oneliner field to summaries schema and exposes it in the API.
Fixes OG image URL construction and adds HTML escaping for Telegram messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/summary` command to retrieve the latest community summary in Telegram
  * Summaries now include a brief one-liner description
  * Auto-post generated summaries to chat automatically
  * Generate shareable preview images for summaries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->