### PR TITLE
feat(telegram/bot-api): add command registration and /deactivate_community (ASK-222)

### DIFF
--- a/app/src/app/api/telegram/setup-commands/route.ts
+++ b/app/src/app/api/telegram/setup-commands/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { getBot } from "@/lib/telegram/bot-api/bot";
+import { registerBotCommands } from "@/lib/telegram/bot-api/register-commands";
+
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const expectedToken = process.env.ASKLOYAL_TGBOT_KEY;
+
+  if (authHeader !== `Bearer ${expectedToken}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const bot = await getBot();
+    await registerBotCommands(bot);
+    return NextResponse.json({ success: true, message: "Commands registered" });
+  } catch (error) {
+    console.error("Failed to register commands:", error);
+    return NextResponse.json(
+      { error: "Failed to register commands" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -5,6 +5,7 @@ import { getBot } from "@/lib/telegram/bot-api/bot";
 import {
   handleActivateCommunityCommand,
   handleCaCommand,
+  handleDeactivateCommunityCommand,
   handleStartCommand,
   handleSummaryCommand,
 } from "@/lib/telegram/bot-api/commands";
@@ -27,6 +28,10 @@ bot.command("ca", async (ctx: CommandContext<Context>) => {
 
 bot.command("activate_community", async (ctx: CommandContext<Context>) => {
   await handleActivateCommunityCommand(ctx, bot);
+});
+
+bot.command("deactivate_community", async (ctx: CommandContext<Context>) => {
+  await handleDeactivateCommunityCommand(ctx, bot);
 });
 
 bot.command("summary", async (ctx: CommandContext<Context>) => {

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -224,3 +224,70 @@ export async function handleSummaryCommand(
     );
   }
 }
+
+export async function handleDeactivateCommunityCommand(
+  ctx: CommandContext<Context>,
+  bot: Bot
+): Promise<void> {
+  if (!ctx.from || !ctx.chat) return;
+
+  if (!isCommunityChat(ctx.chat.type)) {
+    await ctx.reply("This command can only be used in group chats.");
+    return;
+  }
+
+  const telegramUserId = BigInt(ctx.from.id);
+
+  try {
+    const db = getDatabase();
+
+    // Check if user is in admin whitelist
+    const admin = await db.query.admins.findFirst({
+      where: eq(admins.telegramId, telegramUserId),
+    });
+
+    if (!admin) {
+      await ctx.reply(
+        "You are not authorized to deactivate communities. Contact an administrator."
+      );
+      return;
+    }
+
+    // Check if user is a Telegram group admin
+    const member = await bot.api.getChatMember(ctx.chat.id, ctx.from.id);
+    if (member.status !== "creator" && member.status !== "administrator") {
+      await ctx.reply("Only group admins can deactivate community tracking.");
+      return;
+    }
+
+    const chatId = BigInt(ctx.chat.id);
+
+    // Find the community
+    const existingCommunity = await db.query.communities.findFirst({
+      where: eq(communities.chatId, chatId),
+    });
+
+    if (!existingCommunity) {
+      await ctx.reply("This community is not activated.");
+      return;
+    }
+
+    if (!existingCommunity.isActive) {
+      await ctx.reply("This community is already deactivated.");
+      return;
+    }
+
+    // Deactivate the community
+    await db
+      .update(communities)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(eq(communities.id, existingCommunity.id));
+
+    await ctx.reply("Community deactivated. Message tracking has been disabled.");
+  } catch (error) {
+    console.error("Failed to deactivate community", error);
+    await ctx.reply(
+      "An error occurred while deactivating the community. Please try again."
+    );
+  }
+}

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -254,7 +254,15 @@ export async function handleDeactivateCommunityCommand(
     }
 
     // Check if user is a Telegram group admin
-    const member = await bot.api.getChatMember(ctx.chat.id, ctx.from.id);
+    let member;
+    try {
+      member = await bot.api.getChatMember(ctx.chat.id, ctx.from.id);
+    } catch {
+      await ctx.reply(
+        "Unable to verify admin status. Ensure the bot has permission to view chat members."
+      );
+      return;
+    }
     if (member.status !== "creator" && member.status !== "administrator") {
       await ctx.reply("Only group admins can deactivate community tracking.");
       return;

--- a/app/src/lib/telegram/bot-api/register-commands.ts
+++ b/app/src/lib/telegram/bot-api/register-commands.ts
@@ -1,0 +1,26 @@
+import type { Bot } from "grammy";
+
+export async function registerBotCommands(bot: Bot): Promise<void> {
+  // Commands for private chats
+  await bot.api.setMyCommands(
+    [{ command: "start", description: "Start the bot and get help" }],
+    { scope: { type: "all_private_chats" } }
+  );
+
+  // Commands for group chats
+  await bot.api.setMyCommands(
+    [
+      { command: "summary", description: "Get the latest chat summary" },
+      { command: "ca", description: "Show $LOYAL contract address" },
+      {
+        command: "activate_community",
+        description: "Enable message tracking (admins only)",
+      },
+      {
+        command: "deactivate_community",
+        description: "Disable message tracking (admins only)",
+      },
+    ],
+    { scope: { type: "all_group_chats" } }
+  );
+}


### PR DESCRIPTION
Adds API endpoint to register bot commands with Telegram (scoped for private/group chats) and implements /deactivate_community command to disable message tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to deactivate communities through Telegram bot commands.
  * Implemented Telegram bot command registration system for both private and group chats with proper command descriptions.
  * Added secured API endpoint for Telegram bot command setup with authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->