### PR TITLE
Auto-delete community commands and reply to /summary (ASK-174)

### DIFF
--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -115,6 +115,13 @@ export async function handleActivateCommunityCommand(
 ): Promise<void> {
   if (!ctx.from || !ctx.chat) return;
 
+  // Delete the command message to keep chat clean
+  try {
+    await ctx.deleteMessage();
+  } catch (error) {
+    console.warn("Failed to delete /activate_community command message", error);
+  }
+
   if (!isCommunityChat(ctx.chat.type)) {
     await ctx.reply("This command can only be used in group chats.");
     return;
@@ -204,7 +211,7 @@ export async function handleSummaryCommand(
   const chatId = BigInt(ctx.chat.id);
 
   try {
-    const result = await sendLatestSummary(bot, chatId);
+    const result = await sendLatestSummary(bot, chatId, ctx.msg?.message_id);
 
     if (!result.sent) {
       if (result.reason === "not_activated") {
@@ -230,6 +237,16 @@ export async function handleDeactivateCommunityCommand(
   bot: Bot
 ): Promise<void> {
   if (!ctx.from || !ctx.chat) return;
+
+  // Delete the command message to keep chat clean
+  try {
+    await ctx.deleteMessage();
+  } catch (error) {
+    console.warn(
+      "Failed to delete /deactivate_community command message",
+      error
+    );
+  }
 
   if (!isCommunityChat(ctx.chat.type)) {
     await ctx.reply("This command can only be used in group chats.");


### PR DESCRIPTION
Auto-delete /activate_community and /deactivate_community messages after processing. Make /summary reply to the command issuer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command messages now automatically delete to keep chat clean.
  * Summaries can be sent as replies to specific messages with automatic fallback handling.

* **Improvements**
  * Enhanced error handling for message operations with graceful fallback logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->