### PR TITLE
feat(summaries): add community profile pictures to chat list

### DIFF
--- a/app/src/app/api/summaries/route.ts
+++ b/app/src/app/api/summaries/route.ts
@@ -17,20 +17,28 @@ export async function GET(req: Request): Promise<NextResponse> {
           orderBy: [desc(summaries.createdAt)],
         });
 
-    const transformedSummaries = result.map((item) => ({
-      id: item.id,
-      chatId: String(item.community.chatId),
-      title: item.chatTitle,
-      messageCount: item.messageCount,
-      oneliner: item.oneliner,
-      topics: item.topics.map((topic, index) => ({
-        id: `${item.id}-${index}`,
-        title: topic.title,
-        content: topic.content,
-        sources: topic.sources,
-      })),
-      createdAt: item.createdAt.toISOString(),
-    }));
+    const transformedSummaries = result.map((item) => {
+      const settings = item.community.settings as {
+        photoBase64?: string;
+        photoMimeType?: string;
+      } | null;
+      return {
+        id: item.id,
+        chatId: String(item.community.chatId),
+        title: item.chatTitle,
+        messageCount: item.messageCount,
+        oneliner: item.oneliner,
+        photoBase64: settings?.photoBase64,
+        photoMimeType: settings?.photoMimeType,
+        topics: item.topics.map((topic, index) => ({
+          id: `${item.id}-${index}`,
+          title: topic.title,
+          content: topic.content,
+          sources: topic.sources,
+        })),
+        createdAt: item.createdAt.toISOString(),
+      };
+    });
 
     return NextResponse.json({ summaries: transformedSummaries });
   } catch (error) {
@@ -43,7 +51,7 @@ export async function GET(req: Request): Promise<NextResponse> {
 }
 
 type SummaryWithCommunity = Summary & {
-  community: { chatId: bigint };
+  community: { chatId: bigint; settings: unknown };
 };
 
 async function fetchSummariesByChatId(

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -21,6 +21,8 @@ type GroupChat = {
   id: string;
   title: string;
   subtitle: string;
+  photoBase64?: string;
+  photoMimeType?: string;
 };
 
 interface ChatItemSkeletonProps {
@@ -78,7 +80,7 @@ function ChatListSkeleton({ count = 5 }: { count?: number }) {
 }
 
 interface ChatItemProps {
-  chat: { id: string; title: string; subtitle?: string };
+  chat: { id: string; title: string; subtitle?: string; photoBase64?: string; photoMimeType?: string };
   onClick: () => void;
   showDivider?: boolean;
 }
@@ -95,12 +97,20 @@ function ChatItem({ chat, onClick, showDivider = true }: ChatItemProps) {
       >
         {/* Avatar */}
         <div className="pr-3">
-          <div
-            className="w-14 h-14 rounded-full flex items-center justify-center"
-            style={{ backgroundColor: avatarColor }}
-          >
-            <span className="text-xl font-medium text-white">{firstLetter}</span>
-          </div>
+          {chat.photoBase64 ? (
+            <img
+              src={`data:${chat.photoMimeType || "image/jpeg"};base64,${chat.photoBase64}`}
+              alt={chat.title}
+              className="w-14 h-14 rounded-full object-cover"
+            />
+          ) : (
+            <div
+              className="w-14 h-14 rounded-full flex items-center justify-center"
+              style={{ backgroundColor: avatarColor }}
+            >
+              <span className="text-xl font-medium text-white">{firstLetter}</span>
+            </div>
+          )}
         </div>
 
         {/* Title and Subtitle */}
@@ -248,7 +258,7 @@ export default function SummariesPage() {
   const { summaries: cachedSummaries, setSummaries, hasCachedData } = useSummaries();
 
   // Transform summaries to unique group chats format (deduplicate by title)
-  const transformToGroupChats = (summaries: Array<{ id: string; title: string; topics?: Array<{ content: string }> }>) => {
+  const transformToGroupChats = (summaries: Array<{ id: string; title: string; photoBase64?: string; photoMimeType?: string; topics?: Array<{ content: string }> }>) => {
     const groupMap = new Map<string, GroupChat>();
 
     for (const summary of summaries) {
@@ -258,6 +268,8 @@ export default function SummariesPage() {
           id: summary.id,
           title: summary.title,
           subtitle: summary.topics?.[0]?.content || "",
+          photoBase64: summary.photoBase64,
+          photoMimeType: summary.photoMimeType,
         });
       }
     }


### PR DESCRIPTION
Fetches community profile photos from Telegram on `/activate_community` and stores them as base64 in `communities.settings`. Photos are displayed in the summaries chat list with fallback to generated avatars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community profile photos now display in the chat interface when available, enhancing visual identification of communities. The system intelligently falls back to letter-based avatars when photos are unavailable. Community photo metadata is automatically synchronized during activation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->