### PR TITLE
Disable vertical swipes in Telegram Mini App

### DIFF
--- a/app/src/components/telegram/TelegramProvider.tsx
+++ b/app/src/components/telegram/TelegramProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { init } from '@telegram-apps/sdk';
+import { init, postEvent } from '@telegram-apps/sdk';
 import { useRawInitData } from '@telegram-apps/sdk-react';
 import { usePathname } from 'next/navigation';
 import {
@@ -79,6 +79,13 @@ function TelegramProviderInner({ children }: PropsWithChildren) {
       init();
     } catch (error) {
       console.error('Failed to initialize Telegram SDK:', error);
+    }
+
+    // Disable vertical swipes to prevent conflict with app's swipe gestures (Bot API 7.7+)
+    try {
+      postEvent('web_app_setup_swipe_behavior', { allow_vertical_swipe: false });
+    } catch (error) {
+      console.error('Failed to disable vertical swipes:', error);
     }
   }, []);
 


### PR DESCRIPTION
• Disabled vertical swipe-to-close gesture in Telegram Mini App
• Used Telegram SDK's `postEvent web_app_setup_swipe_behavior` with `allow_vertical_swipe: false`
• Prevented conflicts with horizontal swipe gestures
• Added error logging for SDK initialization setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertical swipe gesture behavior in Telegram web app to prevent unintended navigation while maintaining intended horizontal swipe functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->