### PR TITLE
feat(app): implement startParam deeplink for feed

### DIFF
--- a/app/src/hooks/useStartParam.ts
+++ b/app/src/hooks/useStartParam.ts
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Route mapping for startParam values.
+ * Maps Telegram startParam string values to their corresponding app routes.
+ */
+export const START_PARAM_ROUTES: Record<string, string> = {
+  feed: "/telegram/summaries/feed",
+};
+
+/**
+ * Parse startParam from URL and return the mapped route.
+ * Works before React/SDK initialization - can be called in splash screen.
+ *
+ * Telegram passes startParam in the URL hash as tgWebAppStartParam.
+ * Format: #tgWebAppStartParam=value or in query string.
+ *
+ * @returns The mapped route path if startParam is valid, undefined otherwise.
+ */
+export function getStartParamRoute(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  try {
+    // Try to get from URL hash (Telegram format: #tgWebAppStartParam=value)
+    const hash = window.location.hash;
+    if (hash) {
+      const params = new URLSearchParams(hash.slice(1));
+      const startParam = params.get("tgWebAppStartParam");
+      if (startParam && START_PARAM_ROUTES[startParam]) {
+        return START_PARAM_ROUTES[startParam];
+      }
+    }
+
+    // Also check URL search params as fallback
+    const searchParams = new URLSearchParams(window.location.search);
+    const startParam = searchParams.get("tgWebAppStartParam");
+    if (startParam && START_PARAM_ROUTES[startParam]) {
+      return START_PARAM_ROUTES[startParam];
+    }
+  } catch (error) {
+    console.debug("Failed to parse startParam from URL:", error);
+  }
+
+  return undefined;
+}

--- a/app/src/lib/telegram/bot-api/constants.ts
+++ b/app/src/lib/telegram/bot-api/constants.ts
@@ -1,4 +1,5 @@
 export const CHANNEL_USERNAME = "@loyal_tg";
 export const CUSTOM_EMOJI_ID = "5361803602862052361";
 export const MINI_APP_LINK = "https://t.me/askloyal_tgbot/app";
+export const MINI_APP_FEED_LINK = "https://t.me/askloyal_tgbot/app?startapp=feed";
 export const CA_COMMAND_CHAT_ID = "-1002981429221";

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -12,7 +12,7 @@ import { chatCompletion } from "@/lib/redpill";
 import { SUMMARY_INTERVAL_MS } from "@/lib/telegram/utils";
 
 import { buildSummaryMessageWithPreview } from "./build-summary-og-url";
-import { MINI_APP_LINK } from "./constants";
+import { MINI_APP_FEED_LINK } from "./constants";
 
 export const MIN_MESSAGES_FOR_SUMMARY = 5;
 
@@ -158,7 +158,7 @@ export async function sendLatestSummary(
     latestSummary.createdAt
   );
 
-  const keyboard = new InlineKeyboard().url("Read in full", MINI_APP_LINK);
+  const keyboard = new InlineKeyboard().url("Read in full", MINI_APP_FEED_LINK);
 
   const messageOptions = {
     parse_mode: "HTML" as const,


### PR DESCRIPTION
Adds deeplink support so clicking 'Read in full' on summary messages opens the mini app directly to the feed page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram deeplinks that direct users to specific app pages. Users can now be sent direct links to navigate to the feed or other sections, with automatic fallback to their last viewed page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->