### PR TITLE
Fix telegram mini-app modal background and refine UI fades

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -47,3 +47,5 @@ next-env.d.ts
 certificates
 
 /refs
+
+CLAUDE.md

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -119,6 +119,8 @@
   html {
     touch-action: manipulation;
     -webkit-text-size-adjust: 100%;
+    background: #000 !important;
+    background-color: #000 !important;
   }
   body {
     @apply bg-background text-foreground;
@@ -126,7 +128,29 @@
     -webkit-user-select: none;
     -webkit-touch-callout: none;
     overscroll-behavior: none;
+    background: #000 !important;
+    background-color: #000 !important;
   }
+}
+
+/* Override telegram-ui AppRoot and ALL its children backgrounds */
+.tgui-root,
+.tgui-root > *,
+.tgui-root > * > *,
+[class^="tgui"],
+[class*=" tgui"],
+[class*="AppRoot"],
+[class*="appRoot"] {
+  --tgui--bg_color: #000 !important;
+  --tg-theme-bg-color: #000 !important;
+  --tg-bg-color: #000 !important;
+  background: #000 !important;
+  background-color: #000 !important;
+}
+
+/* But allow modal content to have its own background */
+[data-vaul-drawer] [class*="rounded"] {
+  background: inherit;
 }
 
 /* Ensure modals/sheets appear above page content */
@@ -141,4 +165,21 @@
 /* Make modal overlay more subtle */
 [data-vaul-overlay] {
   background-color: rgba(0, 0, 0, 0.3) !important;
+}
+
+/* Fix vaul drawer wrapper backgrounds - prevent gray during modal open */
+[data-vaul-drawer-wrapper],
+body[data-vaul-drawer-wrapper],
+html[data-vaul-drawer-wrapper],
+[vaul-drawer-wrapper] {
+  background: #000 !important;
+  background-color: #000 !important;
+}
+
+/* Make drawer container transparent so modal content shows through */
+[data-vaul-drawer],
+[data-vaul-drawer] > div:not([class]),
+[data-vaul-drawer-content] {
+  background: transparent !important;
+  background-color: transparent !important;
 }

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,5 @@
-import "./globals.css";
 import "@telegram-apps/telegram-ui/dist/styles.css";
+import "./globals.css";
 
 import { AppRoot } from "@telegram-apps/telegram-ui";
 import type { Metadata } from "next";

--- a/app/src/app/telegram/layout.tsx
+++ b/app/src/app/telegram/layout.tsx
@@ -29,7 +29,7 @@ export default function TelegramLayout({
   return (
     <div
       className="flex flex-col"
-      style={{ background: "#16161a", minHeight: "100vh" }}
+      style={{ background: "#000", minHeight: "100vh" }}
     >
       <Header />
       <div

--- a/app/src/app/telegram/profile/page.tsx
+++ b/app/src/app/telegram/profile/page.tsx
@@ -256,16 +256,11 @@ export default function ProfilePage() {
   }, []);
 
   return (
-    <main className="min-h-screen text-white font-sans selection:bg-teal-500/30 overflow-hidden relative">
-      {/* Background */}
-      <div
-        className="fixed inset-0 z-0 pointer-events-none"
-        style={{
-          background: "#16161a",
-        }}
-      />
-
-      <div className="relative z-10 pb-32 max-w-md mx-auto flex flex-col min-h-screen">
+    <main
+      className="min-h-screen text-white font-sans selection:bg-teal-500/30 overflow-hidden relative"
+      style={{ background: "#000" }}
+    >
+      <div className="pb-32 max-w-md mx-auto flex flex-col min-h-screen">
         {/* Avatar and Name Section */}
         <div className="flex flex-col gap-4 items-center justify-center pt-8 pb-6 px-8">
           {/* Avatar */}

--- a/app/src/app/telegram/summaries/direct/page.tsx
+++ b/app/src/app/telegram/summaries/direct/page.tsx
@@ -509,7 +509,7 @@ function DirectFeedContent() {
     return (
       <div
         className="fixed inset-0 flex items-center justify-center"
-        style={{ background: "#16161a" }}
+        style={{ background: "#000" }}
       >
         <p className="text-white/60">No chats available</p>
       </div>
@@ -522,7 +522,7 @@ function DirectFeedContent() {
   return (
     <main
       className="text-white font-sans overflow-hidden relative flex flex-col"
-      style={{ background: "#16161a", height: `calc(100vh - ${headerHeight}px)` }}
+      style={{ background: "#000", height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Header */}
       <div
@@ -776,7 +776,7 @@ export default function DirectFeedPage() {
       fallback={
         <div
           className="h-full flex items-center justify-center"
-          style={{ background: "#16161a" }}
+          style={{ background: "#000" }}
         >
           <p className="text-white/60">Loading...</p>
         </div>

--- a/app/src/app/telegram/summaries/feed/page.tsx
+++ b/app/src/app/telegram/summaries/feed/page.tsx
@@ -40,7 +40,7 @@ export default function SummaryFeedPage() {
       fallback={
         <div
           className="fixed inset-0 flex items-center justify-center"
-          style={{ background: "#16161a" }}
+          style={{ background: "#000" }}
         >
           <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
         </div>

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -438,14 +438,12 @@ export default function SummariesPage() {
   return (
     <main
       className="text-white font-sans overflow-y-auto relative flex flex-col"
-      style={{ background: "#16161a", height: `calc(100vh - ${headerHeight}px)` }}
+      style={{ background: "#000", height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Header - fixed at top */}
       <div
         className="sticky top-0 z-10"
-        style={{
-          background: "#16161a",
-        }}
+        style={{ background: "#000" }}
       >
         <div className="flex items-center pl-4 pr-1.5">
           <div className="flex-1 py-3 pr-3">

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -1688,7 +1688,7 @@ export default function Home() {
       )}
       <main
         className="min-h-screen text-white font-sans overflow-hidden relative flex flex-col"
-        style={{ background: "#16161a" }}
+        style={{ background: "#000" }}
       >
         {/* Sticky Balance Pill */}
         <AnimatePresence>
@@ -2259,15 +2259,12 @@ export default function Home() {
         </div>
 
         {/* Bottom Fade Gradient */}
-        <div className="fixed bottom-0 left-0 right-0 h-32 z-40 pointer-events-none">
-          <Image
-            src="/icons/fade-up.png"
-            alt=""
-            fill
-            className="object-cover object-bottom"
-            priority
-          />
-        </div>
+        <div
+          className="fixed bottom-0 left-0 right-0 h-32 z-40 pointer-events-none"
+          style={{
+            background: "linear-gradient(to bottom, transparent, #000)",
+          }}
+        />
       </main>
 
       <SendSheet

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
       style={{
         paddingTop: Math.max(safeAreaInsetTop || 0, 12) + 10,
         paddingBottom: 16,
-        background: "#16161a",
+        background: "#000",
         borderBottom: "none",
         boxShadow: "none",
       }}
@@ -36,9 +36,18 @@ export default function Header() {
       <div
         className="absolute left-0 right-0 pointer-events-none transition-opacity duration-150"
         style={{
-          bottom: -12,
-          height: 12,
-          background: "linear-gradient(to bottom, #16161a, transparent)",
+          bottom: -6,
+          height: 6,
+          background: "linear-gradient(to bottom, #000, transparent)",
+          opacity: isScrolled ? 1 : 0,
+        }}
+      />
+      {/* Bottom border line - only visible when scrolled */}
+      <div
+        className="absolute left-0 right-0 bottom-0 pointer-events-none transition-opacity duration-150"
+        style={{
+          height: 1,
+          background: "rgba(255, 255, 255, 0.08)",
           opacity: isScrolled ? 1 : 0,
         }}
       />

--- a/app/src/components/summaries/ChatSummarySheet.tsx
+++ b/app/src/components/summaries/ChatSummarySheet.tsx
@@ -338,7 +338,7 @@ const ChatSummarySheet = forwardRef<ChatSummarySheetRef, ChatSummarySheetProps>(
     >
       <div
         style={{
-          background: "#16161a",
+          background: "#000",
           paddingBottom: Math.max(safeBottom, 80),
           height: "100%",
           maxHeight: "100%",

--- a/app/src/components/summaries/DatePicker.tsx
+++ b/app/src/components/summaries/DatePicker.tsx
@@ -300,7 +300,7 @@ export default function DatePicker({
           className="absolute left-0 top-0 h-10 w-9 z-10 pointer-events-none"
           style={{
             background:
-              "linear-gradient(to right, #16161a, rgba(22, 22, 26, 0))",
+              "linear-gradient(to right, #000, rgba(0, 0, 0, 0))",
           }}
         />
 
@@ -309,7 +309,7 @@ export default function DatePicker({
           className="absolute right-0 top-0 h-10 w-9 z-10 pointer-events-none"
           style={{
             background:
-              "linear-gradient(to left, #16161a, rgba(22, 22, 26, 0))",
+              "linear-gradient(to left, #000, rgba(0, 0, 0, 0))",
           }}
         />
 

--- a/app/src/components/summaries/SummaryFeed.tsx
+++ b/app/src/components/summaries/SummaryFeed.tsx
@@ -306,6 +306,7 @@ export default function SummaryFeed({
 
   // Date picker collapse state based on scroll
   const [isDatePickerCollapsed, setIsDatePickerCollapsed] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
   const lastScrollTopRef = useRef(0);
   const scrollThresholdRef = useRef(0); // Accumulate scroll delta before triggering
 
@@ -335,6 +336,7 @@ export default function SummaryFeed({
         setIsSliding(true);
         setSelectedDate(targetDate);
         prevDateRef.current = targetDate;
+        setIsScrolled(false);
 
         if (scrollContainerRef.current) {
           scrollContainerRef.current.scrollTop = 0;
@@ -431,6 +433,9 @@ export default function SummaryFeed({
     const target = e.currentTarget;
     const scrollTop = target.scrollTop;
 
+    // Track if content is scrolled (for top fade gradient)
+    setIsScrolled(scrollTop > 5);
+
     // Only enable collapse behavior if content is actually scrollable
     const isScrollable = target.scrollHeight > target.clientHeight + 50;
     if (!isScrollable) {
@@ -482,6 +487,7 @@ export default function SummaryFeed({
       // Update selected date
       setSelectedDate(date);
       prevDateRef.current = date;
+      setIsScrolled(false);
 
       // Reset scroll position
       if (scrollContainerRef.current) {
@@ -511,7 +517,7 @@ export default function SummaryFeed({
     return (
       <div
         className="fixed inset-0 flex items-center justify-center"
-        style={{ background: "#16161a" }}
+        style={{ background: "#000" }}
       >
         <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
       </div>
@@ -522,7 +528,7 @@ export default function SummaryFeed({
     return (
       <div
         className="fixed inset-0 flex flex-col items-center justify-center gap-4"
-        style={{ background: "#16161a" }}
+        style={{ background: "#000" }}
       >
         <p className="text-white/60">{error}</p>
         <button
@@ -539,7 +545,7 @@ export default function SummaryFeed({
     return (
       <div
         className="fixed inset-0 flex items-center justify-center"
-        style={{ background: "#16161a" }}
+        style={{ background: "#000" }}
       >
         <p className="text-white/60">No summaries available</p>
       </div>
@@ -553,7 +559,7 @@ export default function SummaryFeed({
     <main
       className="text-white font-sans overflow-hidden relative flex flex-col"
       style={{
-        background: "#16161a",
+        background: "#000",
         height: `calc(100vh - ${headerHeight}px)`,
       }}
     >
@@ -657,12 +663,13 @@ export default function SummaryFeed({
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
-        {/* Fade gradient at top */}
+        {/* Fade gradient at top - only show when scrolled */}
         <div
-          className="absolute top-0 left-0 right-0 h-6 z-10 pointer-events-none"
+          className="absolute top-0 left-0 right-0 h-2 z-10 pointer-events-none transition-opacity duration-150"
           style={{
             background:
-              "linear-gradient(to bottom, #16161a 0%, transparent 100%)",
+              "linear-gradient(to bottom, #000 0%, transparent 100%)",
+            opacity: isScrolled ? 1 : 0,
           }}
         />
 

--- a/app/src/components/wallet/ReceiveSheet.tsx
+++ b/app/src/components/wallet/ReceiveSheet.tsx
@@ -325,10 +325,7 @@ export default function ReceiveSheet({
     >
       <div
         style={{
-          background: "rgba(38, 38, 38, 0.55)",
-          backgroundBlendMode: "luminosity",
-          backdropFilter: "blur(24px)",
-          WebkitBackdropFilter: "blur(24px)",
+          background: "#1c1c1e",
           paddingBottom: Math.max(safeBottom, 80),
         }}
         className="flex flex-col text-white relative overflow-hidden min-h-[500px] rounded-t-3xl"


### PR DESCRIPTION
Override telegram-ui and AppRoot backgrounds and adjust global styles to
prevent a gray backdrop showing behind modals/sheets. Load globals.css
after telegram-ui styles to ensure overrides take effect, make
drawer/modal containers transparent while keeping modal content
backgrounds, and set body/root backgrounds to pure black.

Additionally, refine several UI visuals: reduce header/top fade heights
and opacity, show top fade only when scrolled, add a subtle 1px bottom
border on header when scrolled, adjust multiple page/background colors
to #000, convert some image fade to a CSS gradient, and fix ReceiveSheet
background to a solid dark tone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated application theme to pure black backgrounds throughout for a darker, more cohesive visual appearance.
  * Enhanced scroll-state indicators in feed and header components that activate on user scrolling.
  * Simplified background layers and styling structure for cleaner UI rendering.
  * Replaced image-based fade effects with CSS gradients for improved performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->