### PR TITLE
feat(app/telegram): add schema and service for threaded bot conversations

### DIFF
--- a/app/drizzle/0003_bent_night_nurse.sql
+++ b/app/drizzle/0003_bent_night_nurse.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "bot_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"thread_id" uuid NOT NULL,
+	"sender_type" text NOT NULL,
+	"encrypted_content" jsonb NOT NULL,
+	"telegram_message_id" bigint,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "bot_threads" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"telegram_chat_id" bigint NOT NULL,
+	"telegram_thread_id" integer,
+	"title" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "bot_messages" ADD CONSTRAINT "bot_messages_thread_id_bot_threads_id_fk" FOREIGN KEY ("thread_id") REFERENCES "public"."bot_threads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bot_threads" ADD CONSTRAINT "bot_threads_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bot_messages_thread_created_idx" ON "bot_messages" USING btree ("thread_id","created_at");--> statement-breakpoint
+CREATE INDEX "bot_messages_telegram_id_idx" ON "bot_messages" USING btree ("telegram_message_id");--> statement-breakpoint
+CREATE INDEX "bot_threads_user_id_idx" ON "bot_threads" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "bot_threads_telegram_unique_idx" ON "bot_threads" USING btree ("telegram_chat_id","telegram_thread_id");--> statement-breakpoint
+CREATE INDEX "bot_threads_status_idx" ON "bot_threads" USING btree ("status");

--- a/app/drizzle/meta/0003_snapshot.json
+++ b/app/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,964 @@
+{
+  "id": "20bbf3b8-03b5-4963-a3b8-0c9db16646d9",
+  "prevId": "3a6a974c-358e-414e-b1c7-a099f8842e76",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1769913050781,
       "tag": "0002_strong_marvel_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1770186824696,
+      "tag": "0003_bent_night_nurse",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/lib/telegram/bot-thread-service.ts
+++ b/app/src/lib/telegram/bot-thread-service.ts
@@ -1,0 +1,362 @@
+import { and, asc, count, eq, isNull } from "drizzle-orm";
+
+import { getDatabase } from "@/lib/core/database";
+import {
+  botMessages,
+  type BotThread,
+  botThreads,
+  type EncryptedMessageContent,
+  type SenderType,
+  type ThreadStatus,
+} from "@/lib/core/schema";
+import { decrypt, encrypt } from "@/lib/encryption";
+import type { ChatMessage } from "@/lib/redpill";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Decrypted message content types.
+ */
+export type TextContent = { type: "text"; text: string };
+export type ImageContent = {
+  type: "image";
+  url: string;
+  metadata?: { fileName?: string; fileSize?: number };
+};
+export type VoiceContent = {
+  type: "voice";
+  url: string;
+  metadata?: { duration?: number };
+};
+export type MessageContent = TextContent | ImageContent | VoiceContent;
+
+/**
+ * Decrypted message with full metadata.
+ */
+export type DecryptedMessage = {
+  id: string;
+  senderType: SenderType;
+  content: MessageContent;
+  createdAt: Date;
+  telegramMessageId: bigint | null;
+};
+
+// ============================================================================
+// INTERNAL HELPERS
+// ============================================================================
+
+/**
+ * Builds where conditions for thread lookup by Telegram context.
+ */
+function buildThreadWhereConditions(
+  telegramChatId: bigint,
+  telegramThreadId?: number
+) {
+  const chatCondition = eq(botThreads.telegramChatId, telegramChatId);
+  const threadCondition =
+    telegramThreadId !== undefined
+      ? eq(botThreads.telegramThreadId, telegramThreadId)
+      : isNull(botThreads.telegramThreadId);
+
+  return and(chatCondition, threadCondition);
+}
+
+// ============================================================================
+// THREAD MANAGEMENT
+// ============================================================================
+
+/**
+ * Gets or creates a bot thread for a user conversation.
+ * Idempotent - uses onConflictDoNothing for race condition safety.
+ *
+ * @param params.userId - User's UUID from database
+ * @param params.telegramChatId - Telegram chat ID (user's DM chat ID)
+ * @param params.telegramThreadId - Optional Telegram message_thread_id for threaded conversations
+ * @param params.title - Optional thread title
+ * @returns Thread UUID
+ */
+export async function getOrCreateThread(params: {
+  userId: string;
+  telegramChatId: bigint;
+  telegramThreadId?: number;
+  title?: string;
+}): Promise<string> {
+  const db = getDatabase();
+
+  const whereConditions = buildThreadWhereConditions(
+    params.telegramChatId,
+    params.telegramThreadId
+  );
+
+  // Check for existing thread first (fast path)
+  const existing = await db.query.botThreads.findFirst({
+    where: whereConditions,
+  });
+
+  if (existing) {
+    return existing.id;
+  }
+
+  // Try to create new thread (race-condition safe with onConflictDoNothing)
+  const result = await db
+    .insert(botThreads)
+    .values({
+      userId: params.userId,
+      telegramChatId: params.telegramChatId,
+      telegramThreadId: params.telegramThreadId,
+      title: params.title,
+      status: "active",
+    })
+    .onConflictDoNothing()
+    .returning({ id: botThreads.id });
+
+  // If insert succeeded, return the new ID
+  if (result.length > 0) {
+    return result[0].id;
+  }
+
+  // If conflict occurred, query the existing thread
+  const conflictedThread = await db.query.botThreads.findFirst({
+    where: whereConditions,
+  });
+
+  if (!conflictedThread) {
+    throw new Error("Failed to create or find thread after conflict");
+  }
+
+  return conflictedThread.id;
+}
+
+/**
+ * Gets a thread by its UUID.
+ */
+export async function getThread(threadId: string): Promise<BotThread | null> {
+  const db = getDatabase();
+
+  const thread = await db.query.botThreads.findFirst({
+    where: eq(botThreads.id, threadId),
+  });
+
+  return thread ?? null;
+}
+
+/**
+ * Updates thread metadata (title, status).
+ */
+export async function updateThread(
+  threadId: string,
+  updates: {
+    title?: string;
+    status?: ThreadStatus;
+  }
+): Promise<void> {
+  const db = getDatabase();
+
+  await db
+    .update(botThreads)
+    .set({
+      ...updates,
+      updatedAt: new Date(),
+    })
+    .where(eq(botThreads.id, threadId));
+}
+
+/**
+ * Gets the most recent thread for a user.
+ */
+export async function getUserLatestThread(
+  userId: string
+): Promise<{ id: string; title: string | null } | null> {
+  const db = getDatabase();
+
+  const thread = await db.query.botThreads.findFirst({
+    where: eq(botThreads.userId, userId),
+    orderBy: (botThreads, { desc }) => [desc(botThreads.updatedAt)],
+  });
+
+  return thread ? { id: thread.id, title: thread.title } : null;
+}
+
+// ============================================================================
+// MESSAGE OPERATIONS
+// ============================================================================
+
+/**
+ * Adds an encrypted message to a thread.
+ * Uses a transaction to ensure message insert and thread update are atomic.
+ *
+ * @param params.threadId - Thread UUID
+ * @param params.senderType - 'user', 'bot', or 'system'
+ * @param params.content - Plain text string or structured content
+ * @param params.telegramMessageId - Optional Telegram message ID for deduplication
+ * @returns Message UUID or null if encryption fails
+ */
+export async function addMessage(params: {
+  threadId: string;
+  senderType: SenderType;
+  content: string | MessageContent;
+  telegramMessageId?: bigint;
+}): Promise<string | null> {
+  const db = getDatabase();
+
+  // Normalize content to MessageContent structure
+  const messageContent: MessageContent =
+    typeof params.content === "string"
+      ? { type: "text", text: params.content }
+      : params.content;
+
+  // Serialize and encrypt the content
+  const plaintext = JSON.stringify(messageContent);
+  const encrypted = await encrypt(plaintext);
+
+  if (!encrypted) {
+    console.error("Failed to encrypt message content");
+    return null;
+  }
+
+  // Build encrypted content object
+  const encryptedContent: EncryptedMessageContent = {
+    type: messageContent.type,
+    ciphertext: encrypted.ciphertext,
+    iv: encrypted.iv,
+    metadata: "metadata" in messageContent ? messageContent.metadata : undefined,
+  };
+
+  // Use transaction to ensure atomicity of message insert + thread update
+  const messageId = await db.transaction(async (tx) => {
+    // Store message
+    const [message] = await tx
+      .insert(botMessages)
+      .values({
+        threadId: params.threadId,
+        senderType: params.senderType,
+        encryptedContent,
+        telegramMessageId: params.telegramMessageId,
+      })
+      .returning({ id: botMessages.id });
+
+    // Update thread timestamp
+    await tx
+      .update(botThreads)
+      .set({ updatedAt: new Date() })
+      .where(eq(botThreads.id, params.threadId));
+
+    return message.id;
+  });
+
+  return messageId;
+}
+
+/**
+ * Retrieves decrypted messages for a thread.
+ * Returns messages in chronological order.
+ *
+ * @param threadId - Thread UUID
+ * @param options.limit - Maximum number of messages to return
+ * @returns Array of decrypted messages
+ */
+export async function getThreadMessages(
+  threadId: string,
+  options?: { limit?: number }
+): Promise<DecryptedMessage[]> {
+  const db = getDatabase();
+
+  const messages = await db.query.botMessages.findMany({
+    where: eq(botMessages.threadId, threadId),
+    orderBy: [asc(botMessages.createdAt)],
+    limit: options?.limit,
+  });
+
+  // Decrypt all messages
+  const decrypted: DecryptedMessage[] = [];
+
+  for (const msg of messages) {
+    const encContent = msg.encryptedContent;
+    const plaintext = await decrypt({
+      ciphertext: encContent.ciphertext,
+      iv: encContent.iv,
+    });
+
+    if (!plaintext) {
+      console.error(`Failed to decrypt message ${msg.id}`);
+      continue;
+    }
+
+    try {
+      const content: MessageContent = JSON.parse(plaintext);
+      decrypted.push({
+        id: msg.id,
+        senderType: msg.senderType,
+        content,
+        createdAt: msg.createdAt,
+        telegramMessageId: msg.telegramMessageId,
+      });
+    } catch (error) {
+      console.error(`Failed to parse message content for ${msg.id}`, error);
+    }
+  }
+
+  return decrypted;
+}
+
+// ============================================================================
+// AI INTEGRATION
+// ============================================================================
+
+/**
+ * Retrieves thread messages formatted for AI chat completion.
+ * Converts sender types: 'user' -> 'user', 'bot' -> 'assistant'.
+ * System messages are excluded.
+ *
+ * @param threadId - Thread UUID
+ * @param options.limit - Maximum number of messages to include
+ * @returns Array of ChatMessage objects ready for AI API
+ *
+ * @example
+ * const messages = await getThreadMessagesForAI(threadId);
+ * const response = await chatCompletion({
+ *   model: "phala/gpt-oss-120b",
+ *   messages: [{ role: "system", content: "..." }, ...messages],
+ * });
+ */
+export async function getThreadMessagesForAI(
+  threadId: string,
+  options?: { limit?: number }
+): Promise<ChatMessage[]> {
+  const messages = await getThreadMessages(threadId, options);
+
+  return messages
+    .filter((msg) => msg.senderType !== "system")
+    .map((msg): ChatMessage => {
+      const role: "user" | "assistant" =
+        msg.senderType === "user" ? "user" : "assistant";
+
+      // Extract text content or create placeholder for non-text
+      let content: string;
+      if (msg.content.type === "text") {
+        content = msg.content.text;
+      } else if (msg.content.type === "image") {
+        content = `[Image: ${msg.content.metadata?.fileName || "image"}]`;
+      } else {
+        content = `[Voice message: ${msg.content.metadata?.duration || 0}s]`;
+      }
+
+      return { role, content };
+    });
+}
+
+/**
+ * Gets the message count for a thread using efficient SQL COUNT.
+ */
+export async function getThreadMessageCount(threadId: string): Promise<number> {
+  const db = getDatabase();
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(botMessages)
+    .where(eq(botMessages.threadId, threadId));
+
+  return Number(result.count);
+}

--- a/docs/miniapp/database.md
+++ b/docs/miniapp/database.md
@@ -52,3 +52,70 @@ DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/dbname?sslmode=requ
 ```
 
 See [Environment Variables](./environment-vars.md) for full setup.
+
+## Schema Patterns
+
+### Typed JSONB Columns
+
+Use `.$type<T>()` for type-safe JSONB columns:
+
+```typescript
+// Array of objects
+topics: jsonb("topics")
+  .$type<{ title: string; content: string; sources: string[] }[]>()
+  .notNull()
+
+// Discriminated union (for encrypted content)
+encryptedContent: jsonb("encrypted_content")
+  .$type<EncryptedMessageContent>()
+  .notNull()
+```
+
+### Relations Setup
+
+Define relations separately from tables for type-safe eager loading:
+
+```typescript
+export const usersRelations = relations(users, ({ one, many }) => ({
+  messages: many(messages),
+  botThreads: many(botThreads),
+  businessConnection: one(businessConnections),
+}));
+
+// Usage with type-safe `with:`
+const user = await db.query.users.findFirst({
+  where: eq(users.telegramId, telegramId),
+  with: { botThreads: true },
+});
+```
+
+### Type Exports
+
+Always export both select and insert types:
+
+```typescript
+export type User = typeof users.$inferSelect;
+export type InsertUser = typeof users.$inferInsert;
+```
+
+### Index Strategies
+
+| Index Type | Use Case | Example |
+|------------|----------|---------|
+| `uniqueIndex` | Prevent duplicates, enforce uniqueness | `uniqueIndex().on(table.telegramId)` |
+| Composite `index` | Optimize multi-column queries | `index().on(table.communityId, table.createdAt)` |
+| Filter `index` | Optimize status/flag filtering | `index().on(table.isActive)` |
+
+## Tables Reference
+
+| Table | Purpose |
+|-------|---------|
+| `admins` | Global admin whitelist (Telegram users who can activate communities) |
+| `users` | Telegram users who interact with the bot |
+| `communities` | Activated Telegram group chats for message tracking |
+| `communityMembers` | Many-to-many: users ↔ communities |
+| `messages` | Chat messages from tracked communities |
+| `summaries` | AI-generated daily chat summaries with topics |
+| `businessConnections` | Telegram Business bot connections to user accounts |
+| `botThreads` | Bot conversation sessions (supports Telegram threaded messages) |
+| `botMessages` | Individual encrypted messages within bot threads |


### PR DESCRIPTION
Adds bot_threads and bot_messages tables with encrypted message storage for Telegram bot conversations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added threaded conversation system for organizing bot interactions and maintaining conversation history
  * Enabled encrypted message storage to enhance communication security
  * New configuration option for message encryption support

* **Documentation**
  * Expanded documentation with database patterns, service layer patterns, and practical code examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->