### PR TITLE
refactor(wallet): rewrite SwapSheet with light theme, confirm step, and fix token paths

### DIFF
--- a/app/src/components/wallet/SwapSheet.tsx
+++ b/app/src/components/wallet/SwapSheet.tsx
@@ -1,29 +1,24 @@
 "use client";
 
-import { hapticFeedback, themeParams } from "@telegram-apps/sdk-react";
-import { Modal, VisuallyHidden } from "@telegram-apps/telegram-ui";
-import { Drawer } from "@xelene/vaul-with-scroll-fix";
+import { hapticFeedback, retrieveLaunchParams } from "@telegram-apps/sdk-react";
 import {
   ArrowDownUp,
   ArrowLeft,
-  Check,
   ChevronRight,
   Search,
-  ShieldAlert,
   X,
 } from "lucide-react";
 import Image from "next/image";
 import {
-  type CSSProperties,
-  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
-import { useModalSnapPoint, useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
+import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
 import { SOL_PRICE_USD } from "@/lib/constants";
 import { fetchSolUsdPrice } from "@/lib/solana/fetch-sol-price";
 import {
@@ -32,6 +27,10 @@ import {
   NATIVE_SOL_MINT,
   type TokenHolding,
 } from "@/lib/solana/token-holdings";
+
+// iOS-style sheet timing (shared with other sheets)
+const SHEET_TRANSITION = "transform 0.4s cubic-bezier(0.32, 0.72, 0, 1)";
+const OVERLAY_TRANSITION = "opacity 0.3s ease";
 
 // Token type definition
 export type Token = {
@@ -79,7 +78,7 @@ const FALLBACK_TOKENS: Token[] = [
   {
     symbol: "SOL",
     name: "Solana",
-    icon: "/solana-sol-logo.png",
+    icon: "/tokens/solana-sol-logo.png",
     decimals: 9,
     balance: 0,
     priceUsd: SOL_PRICE_USD,
@@ -88,7 +87,7 @@ const FALLBACK_TOKENS: Token[] = [
   {
     symbol: "USDT",
     name: "Tether USD",
-    icon: "/USDT.png",
+    icon: "/tokens/USDT.png",
     decimals: 6,
     balance: 0,
     priceUsd: 1,
@@ -108,129 +107,9 @@ function holdingToToken(holding: TokenHolding): Token {
   };
 }
 
-// Shared token list item component
-type TokenListItemProps = {
-  token: Token;
-  onSelect: (token: Token) => void;
-};
-
-function TokenListItem({ token, onSelect }: TokenListItemProps): React.ReactElement {
-  const balanceUsd = token.balance * token.priceUsd;
-
-  return (
-    <button
-      onClick={() => onSelect(token)}
-      className="w-full flex items-center px-3 rounded-2xl active:bg-white/[0.03] transition-colors"
-    >
-      <div className="py-1.5 pr-3">
-        <div className="w-12 h-12 rounded-full overflow-hidden bg-white/10">
-          <Image src={token.icon} alt={token.symbol} width={48} height={48} />
-        </div>
-      </div>
-      <div className="flex-1 flex flex-col gap-0.5 py-2.5">
-        <p className="text-base text-white text-left leading-5">{token.symbol}</p>
-        <p className="text-[13px] text-white/60 text-left leading-4">{token.name}</p>
-      </div>
-      <div className="flex flex-col gap-0.5 items-end py-2.5 pl-3">
-        <p className="text-base leading-5 text-white/60 text-right">
-          {token.balance.toLocaleString("en-US", {
-            maximumFractionDigits: token.decimals > 6 ? 4 : 2,
-          })}
-        </p>
-        <p className="text-[13px] leading-4 text-white/60 text-right">
-          ${balanceUsd.toFixed(2)}
-        </p>
-      </div>
-      <div className="pl-3 py-2 flex items-center justify-center h-10">
-        <ChevronRight size={16} strokeWidth={1.5} className="text-white/40" />
-      </div>
-    </button>
-  );
-}
-
-// Shared token select view component
-type TokenSelectViewProps = {
-  title: string;
-  viewKey: "selectFrom" | "selectTo" | "selectSecure";
-  currentView: "main" | "selectFrom" | "selectTo" | "selectSecure" | "result";
-  searchQuery: string;
-  onSearchChange: (query: string) => void;
-  tokens: Token[];
-  onSelectToken: (token: Token) => void;
-  onBack: () => void;
-};
-
-function TokenSelectView({
-  title,
-  viewKey,
-  currentView,
-  searchQuery,
-  onSearchChange,
-  tokens,
-  onSelectToken,
-  onBack,
-}: TokenSelectViewProps): React.ReactElement {
-  const isActive = currentView === viewKey;
-
-  return (
-    <div
-      className="absolute inset-0 flex flex-col transition-all duration-300 ease-out"
-      style={{
-        background: "#1c1c1e",
-        transform: `translateX(${isActive ? 0 : 100}%)`,
-        opacity: isActive ? 1 : 0,
-        pointerEvents: isActive ? "auto" : "none",
-      }}
-    >
-      {/* Header */}
-      <div className="relative h-[52px] flex items-center justify-center shrink-0">
-        <button
-          onClick={onBack}
-          className="absolute left-2 p-1.5 rounded-full flex items-center justify-center active:scale-95 active:bg-white/10 transition-all duration-150"
-          style={{ background: "rgba(255, 255, 255, 0.06)" }}
-        >
-          <ArrowLeft size={22} strokeWidth={1.5} className="text-white/60" />
-        </button>
-        <span className="text-base font-medium text-white tracking-[-0.176px]">
-          {title}
-        </span>
-      </div>
-
-      {/* Search Input */}
-      <div className="px-4 py-2">
-        <div
-          className="flex items-center rounded-[75px] overflow-hidden px-3"
-          style={{ background: "rgba(255, 255, 255, 0.06)" }}
-        >
-          <div className="pr-3 py-3 flex items-center justify-center">
-            <Search size={24} strokeWidth={1.5} className="text-white/40" />
-          </div>
-          <input
-            type="text"
-            placeholder="Search token"
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="flex-1 py-3.5 bg-transparent text-base text-white placeholder:text-white/40 focus:outline-none"
-          />
-        </div>
-      </div>
-
-      {/* Token List */}
-      <div className="flex-1 overflow-y-auto">
-        {tokens.map((token) => (
-          <TokenListItem
-            key={token.mint ?? token.symbol}
-            token={token}
-            onSelect={onSelectToken}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
+export type SwapView = "main" | "selectFrom" | "selectTo" | "confirm" | "result";
 
 export type SwapSheetProps = {
-  trigger?: ReactNode | null;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   tokenHoldings?: TokenHolding[];
@@ -241,17 +120,17 @@ export type SwapSheetProps = {
   activeTab?: "swap" | "secure";
   onTabChange?: (tab: "swap" | "secure") => void;
   // Result state props
-  view?: "main" | "selectFrom" | "selectTo" | "selectSecure" | "result";
-  onViewChange?: (view: "main" | "selectFrom" | "selectTo" | "selectSecure" | "result") => void;
+  view?: SwapView;
+  onViewChange?: (view: SwapView) => void;
   swapError?: string | null;
   swappedFromAmount?: number;
   swappedFromSymbol?: string;
   swappedToAmount?: number;
   swappedToSymbol?: string;
+  isSwapping?: boolean;
 };
 
 export default function SwapSheet({
-  trigger,
   open,
   onOpenChange,
   tokenHoldings = [],
@@ -263,26 +142,35 @@ export default function SwapSheet({
   view: viewProp,
   onViewChange,
   swapError,
-  swappedFromAmount,
-  swappedFromSymbol,
   swappedToAmount,
   swappedToSymbol,
+  isSwapping = false,
 }: SwapSheetProps) {
-  const snapPoint = useModalSnapPoint();
   const { bottom: safeBottom } = useTelegramSafeArea();
+  const [mounted, setMounted] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [rendered, setRendered] = useState(false);
+  const [show, setShow] = useState(false);
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const dragStartY = useRef(0);
+  const dragDelta = useRef(0);
+  const isDragging = useRef(false);
+  const isClosing = useRef(false);
 
-  // Get Telegram theme button color
-  const [buttonColor] = useState(() => {
+  // Detect iOS for platform-specific focus handling
+  const [isIOS] = useState(() => {
     try {
-      return themeParams.buttonColor() || "#2990ff";
+      const params = retrieveLaunchParams();
+      return params.tgWebAppPlatform === "ios";
     } catch {
-      return "#2990ff";
+      return false;
     }
   });
 
   // State
   const [internalActiveTab, setInternalActiveTab] = useState<"swap" | "secure">("swap");
-  const [internalView, setInternalView] = useState<"main" | "selectFrom" | "selectTo" | "selectSecure" | "result">("main");
+  const [internalView, setInternalView] = useState<SwapView>("main");
 
   // Use controlled tab if provided, otherwise internal
   const activeTab = activeTabProp ?? internalActiveTab;
@@ -301,7 +189,7 @@ export default function SwapSheet({
   // Use controlled view if provided, otherwise internal
   const view = viewProp ?? internalView;
   const setView = useCallback(
-    (newView: "main" | "selectFrom" | "selectTo" | "selectSecure" | "result") => {
+    (newView: SwapView) => {
       if (onViewChange) {
         onViewChange(newView);
       } else {
@@ -313,9 +201,7 @@ export default function SwapSheet({
 
   // Compute available tokens from holdings or use fallback
   const availableTokens = useMemo(() => {
-    // Use fallback if 1 or fewer tokens
     if (tokenHoldings.length <= 1) {
-      // If user has 1 token (likely SOL), merge it with fallback
       if (tokenHoldings.length === 1) {
         const userToken = holdingToToken(tokenHoldings[0]);
         const fallbackWithoutUserToken = FALLBACK_TOKENS.filter(
@@ -325,11 +211,10 @@ export default function SwapSheet({
       }
       return FALLBACK_TOKENS;
     }
-
     return tokenHoldings.map(holdingToToken);
   }, [tokenHoldings]);
 
-  // Secure mode state - token to secure
+  // Secure mode state
   const [secureToken, setSecureToken] = useState<Token>(
     () => availableTokens[0] ?? FALLBACK_TOKENS[0]
   );
@@ -337,6 +222,8 @@ export default function SwapSheet({
   const secureAmountInputRef = useRef<HTMLInputElement>(null);
   const secureAmountTextRef = useRef<HTMLParagraphElement>(null);
   const [secureCaretLeft, setSecureCaretLeft] = useState(0);
+
+  // Swap state
   const [fromToken, setFromToken] = useState<Token>(
     () => availableTokens[0] ?? FALLBACK_TOKENS[0]
   );
@@ -388,6 +275,34 @@ export default function SwapSheet({
     };
   }, [solPriceUsdProp]);
 
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Open: mount elements, force layout, then trigger CSS transition
+  useEffect(() => {
+    if (open) {
+      isClosing.current = false;
+      setRendered(true);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (rendered && open && !show && !isClosing.current) {
+      sheetRef.current?.getBoundingClientRect();
+      setShow(true);
+    }
+  }, [rendered, open, show]);
+
+  // Measure header
+  useEffect(() => {
+    if (!open) return;
+    const header = document.querySelector("header");
+    if (header) {
+      setHeaderHeight(header.getBoundingClientRect().bottom);
+    }
+  }, [open]);
+
   // Reset state when opening
   useEffect(() => {
     if (open) {
@@ -397,7 +312,6 @@ export default function SwapSheet({
       setInternalView("main");
       setInternalActiveTab("swap");
 
-      // Reset to first available tokens
       const firstToken = availableTokens[0] ?? FALLBACK_TOKENS[0];
       const secondToken =
         availableTokens[1] ??
@@ -431,16 +345,18 @@ export default function SwapSheet({
   // Focus amount input when sheet opens or returns to main view
   useEffect(() => {
     if (open && view === "main") {
-      const timer = setTimeout(() => {
-        if (activeTab === "swap") {
-          amountInputRef.current?.focus({ preventScroll: true });
-        } else {
-          secureAmountInputRef.current?.focus({ preventScroll: true });
-        }
-      }, 300);
-      return () => clearTimeout(timer);
+      if (!isIOS) {
+        const timer = setTimeout(() => {
+          if (activeTab === "swap") {
+            amountInputRef.current?.focus({ preventScroll: true });
+          } else {
+            secureAmountInputRef.current?.focus({ preventScroll: true });
+          }
+        }, 300);
+        return () => clearTimeout(timer);
+      }
     }
-  }, [open, view, activeTab]);
+  }, [open, view, activeTab, isIOS]);
 
   // Update caret position for swap
   useEffect(() => {
@@ -464,7 +380,6 @@ export default function SwapSheet({
   const receiveAmount = useMemo(() => {
     const val = parseFloat(amountStr);
     if (isNaN(val) || val <= 0) return 0;
-
     const fromValueUsd = val * fromToken.priceUsd;
     const toAmount = fromValueUsd / toToken.priceUsd;
     return toAmount;
@@ -473,7 +388,6 @@ export default function SwapSheet({
   // Format receive amount for display
   const receiveAmountDisplay = useMemo(() => {
     if (receiveAmount === 0) return "0";
-    // Show more decimals for SOL
     const decimals = toToken.symbol === "SOL" ? 6 : 2;
     return receiveAmount.toFixed(decimals).replace(/\.?0+$/, "") || "0";
   }, [receiveAmount, toToken.symbol]);
@@ -511,6 +425,8 @@ export default function SwapSheet({
     if (open && view === "main") {
       const isValid = activeTab === "swap" ? isSwapValid : isSecureValid;
       onValidationChange?.(isValid);
+    } else if (open && view === "confirm") {
+      onValidationChange?.(true);
     } else {
       onValidationChange?.(false);
     }
@@ -532,8 +448,12 @@ export default function SwapSheet({
     }
   }, [open, activeTab, fromToken, toToken, amountStr, onSwapParamsChange]);
 
-  // Determine if in result view (for hiding main view during result)
-  const isResultView = view === "result";
+  // Insufficient balance check
+  const insufficientBalance = useMemo(() => {
+    const val = parseFloat(amountStr);
+    if (isNaN(val) || val <= 0) return false;
+    return val > fromToken.balance;
+  }, [amountStr, fromToken.balance]);
 
   // Swap from/to tokens
   const handleSwapTokens = useCallback(() => {
@@ -541,11 +461,9 @@ export default function SwapSheet({
     const temp = fromToken;
     setFromToken(toToken);
     setToToken(temp);
-    // Also convert the amount
     if (amountStr) {
       const val = parseFloat(amountStr);
       if (!isNaN(val) && val > 0) {
-        // Convert using the exchange rate
         const fromValueUsd = val * fromToken.priceUsd;
         const newAmount = fromValueUsd / toToken.priceUsd;
         const decimals = toToken.symbol === "SOL" ? 6 : 2;
@@ -569,7 +487,6 @@ export default function SwapSheet({
       const currentFrom = fromToken;
       const currentTo = toToken;
 
-      // Apply SOL price if needed
       const tokenWithPrice = {
         ...token,
         priceUsd:
@@ -579,20 +496,17 @@ export default function SwapSheet({
       };
 
       if (type === "from") {
-        // If selecting same as "to", swap them
         if (token.mint === currentTo.mint) {
           setToToken(currentFrom);
         }
         setFromToken(tokenWithPrice);
       } else {
-        // If selecting same as "from", swap them
         if (token.mint === currentFrom.mint) {
           setFromToken(currentTo);
         }
         setToToken(tokenWithPrice);
       }
 
-      // Go back to main view
       setView("main");
     },
     [fromToken, toToken, solPriceUsd, setView]
@@ -614,7 +528,8 @@ export default function SwapSheet({
   const handleOpenSecureTokenSelect = useCallback(() => {
     hapticFeedback.impactOccurred("light");
     setSearchQuery("");
-    setView("selectSecure");
+    // Reuse selectFrom for secure token selection
+    setView("selectFrom");
   }, [setView]);
 
   // Select secure token
@@ -645,12 +560,6 @@ export default function SwapSheet({
     [secureToken.balance, secureToken.symbol]
   );
 
-  // Handler for going back from token select views
-  const handleBackToMain = useCallback(() => {
-    hapticFeedback.impactOccurred("light");
-    setView("main");
-  }, [setView]);
-
   // Handler wrappers for TokenSelectView callbacks
   const handleSelectFromToken = useCallback(
     (token: Token) => handleSelectToken(token, "from"),
@@ -662,98 +571,265 @@ export default function SwapSheet({
     [handleSelectToken]
   );
 
-  // Filter tokens based on search
-  const filteredTokens = useMemo(() => {
-    if (!searchQuery) return availableTokens;
-    const query = searchQuery.toLowerCase();
-    return availableTokens.filter(
-      (t) =>
-        t.symbol.toLowerCase().includes(query) ||
-        t.name.toLowerCase().includes(query)
-    );
-  }, [searchQuery, availableTokens]);
+  // Filter tokens: exclude the opposite token from the list
+  const filteredFromTokens = useMemo(() => {
+    let tokens = availableTokens.filter((t) => t.mint !== toToken.mint);
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      tokens = tokens.filter(
+        (t) =>
+          t.symbol.toLowerCase().includes(query) ||
+          t.name.toLowerCase().includes(query)
+      );
+    }
+    return tokens;
+  }, [searchQuery, availableTokens, toToken.mint]);
 
-  const modalStyle = useMemo(
-    () =>
-      ({
-        "--tgui--bg_color": "transparent",
-        "--tgui--divider": "rgba(255, 255, 255, 0.05)",
-      }) as CSSProperties,
-    []
+  const filteredToTokens = useMemo(() => {
+    let tokens = availableTokens.filter((t) => t.mint !== fromToken.mint);
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      tokens = tokens.filter(
+        (t) =>
+          t.symbol.toLowerCase().includes(query) ||
+          t.name.toLowerCase().includes(query)
+      );
+    }
+    return tokens;
+  }, [searchQuery, availableTokens, fromToken.mint]);
+
+  // Sheet animation handlers
+  const unmount = useCallback(() => {
+    setRendered(false);
+    setShow(false);
+    onOpenChange?.(false);
+    isClosing.current = false;
+  }, [onOpenChange]);
+
+  const closeSheet = useCallback(() => {
+    if (isClosing.current) return;
+    isClosing.current = true;
+    if (hapticFeedback.impactOccurred.isAvailable()) {
+      hapticFeedback.impactOccurred("light");
+    }
+    if (sheetRef.current) {
+      sheetRef.current.style.transition = SHEET_TRANSITION;
+      sheetRef.current.style.transform = "translateY(100%)";
+    }
+    if (overlayRef.current) {
+      overlayRef.current.style.transition = OVERLAY_TRANSITION;
+      overlayRef.current.style.opacity = "0";
+    }
+  }, []);
+
+  const handleTransitionEnd = useCallback(
+    (e: React.TransitionEvent) => {
+      if (e.propertyName === "transform" && isClosing.current) {
+        unmount();
+      }
+    },
+    [unmount],
   );
 
-  const [snapPoints] = useState(() => [snapPoint]);
+  // Close when parent sets open=false while sheet is still showing
+  useEffect(() => {
+    if (!open && rendered && show && !isClosing.current) {
+      closeSheet();
+    }
+  }, [open, rendered, show, closeSheet]);
 
-  return (
-    <Modal
-      aria-label="Swap tokens"
-      trigger={trigger || <button style={{ display: "none" }} />}
-      open={open}
-      onOpenChange={onOpenChange}
-      style={modalStyle}
-      snapPoints={snapPoints}
-    >
+  // Pull-down-to-close
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    isDragging.current = true;
+    dragStartY.current = e.touches[0].clientY;
+    dragDelta.current = 0;
+    if (sheetRef.current) {
+      sheetRef.current.style.transition = "none";
+    }
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isDragging.current) return;
+    const delta = e.touches[0].clientY - dragStartY.current;
+    dragDelta.current = Math.max(0, delta);
+    if (sheetRef.current) {
+      sheetRef.current.style.transform = `translateY(${dragDelta.current}px)`;
+    }
+    if (overlayRef.current) {
+      const opacity = Math.max(0.2, 1 - dragDelta.current / 300);
+      overlayRef.current.style.opacity = String(opacity);
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    if (dragDelta.current > 120) {
+      closeSheet();
+    } else {
+      if (sheetRef.current) {
+        sheetRef.current.style.transition = SHEET_TRANSITION;
+        sheetRef.current.style.transform = "translateY(0px)";
+      }
+      if (overlayRef.current) {
+        overlayRef.current.style.transition = OVERLAY_TRANSITION;
+        overlayRef.current.style.opacity = "1";
+      }
+    }
+    dragDelta.current = 0;
+  }, [closeSheet]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (rendered) {
+      document.body.style.overflow = "hidden";
+      return () => { document.body.style.overflow = ""; };
+    }
+  }, [rendered]);
+
+  if (!mounted || !rendered) return null;
+
+  const sheetTopOffset = headerHeight || 56;
+
+  // Rate display for confirmation
+  const rateDisplay = `1 ${toToken.symbol} ≈ ${(toToken.priceUsd / fromToken.priceUsd).toFixed(
+    fromToken.symbol === "SOL" ? 4 : 2
+  )} ${fromToken.symbol}`;
+
+  const content = (
+    <>
+      {/* Overlay */}
       <div
+        ref={overlayRef}
+        onClick={closeSheet}
+        className="fixed inset-0 z-[9998]"
         style={{
-          background: "#1c1c1e",
-          paddingBottom: Math.max(safeBottom, 80),
+          background: "rgba(0, 0, 0, 0.3)",
+          opacity: show ? 1 : 0,
+          transition: OVERLAY_TRANSITION,
         }}
-        className="flex flex-col text-white relative overflow-hidden min-h-[500px] rounded-t-3xl"
-      >
-        <Drawer.Title asChild>
-          <VisuallyHidden>Swap tokens</VisuallyHidden>
-        </Drawer.Title>
+      />
 
-        {/* Header with Tabs */}
-        <div className="relative h-[52px] flex items-center justify-center shrink-0">
-          {/* Tabs */}
+      {/* Sheet */}
+      <div
+        ref={sheetRef}
+        onTransitionEnd={handleTransitionEnd}
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        style={{
+          top: sheetTopOffset,
+          transform: show ? "translateY(0)" : "translateY(100%)",
+          transition: SHEET_TRANSITION,
+          boxShadow: "0px -4px 40px rgba(0, 0, 0, 0.08)",
+        }}
+      >
+        {/* Handle bar */}
+        <div
+          className="flex justify-center pt-2 pb-1 shrink-0 cursor-grab active:cursor-grabbing"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
           <div
-            className="flex items-center p-0.5 rounded-full"
-            style={{
-              background: "rgba(255, 255, 255, 0.06)",
-            }}
-          >
+            className="w-9 h-1 rounded-full"
+            style={{ background: "rgba(0, 0, 0, 0.15)" }}
+          />
+        </div>
+
+        {/* Header */}
+        <div
+          className="relative h-[44px] flex items-center justify-center shrink-0 px-4"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          {/* Back Button — confirm view */}
+          {view === "confirm" && (
             <button
-              onClick={() => setActiveTab("swap")}
-              className={`px-4 py-2 rounded-full text-[13px] leading-4 transition-all ${
-                activeTab === "swap"
-                  ? "bg-white/[0.06] text-white"
-                  : "text-white/60"
-              }`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                hapticFeedback.impactOccurred("light");
+                setView("main");
+              }}
+              className="absolute left-3 p-1.5 rounded-full flex items-center justify-center active:scale-95 transition-all duration-150"
             >
-              Swap
+              <ArrowLeft
+                size={22}
+                strokeWidth={1.5}
+                style={{ color: "rgba(60, 60, 67, 0.6)" }}
+              />
             </button>
-            <button
-              onClick={() => setActiveTab("secure")}
-              className={`px-4 py-2 rounded-full text-[13px] leading-4 transition-all ${
-                activeTab === "secure"
-                  ? "bg-white/[0.06] text-white"
-                  : "text-white/60"
-              }`}
+          )}
+
+          {/* Main view: Tabs */}
+          {view === "main" && (
+            <div
+              className="flex items-center p-0.5 rounded-full"
+              style={{ background: "#f2f2f7" }}
             >
-              Secure
-            </button>
-          </div>
+              <button
+                onClick={() => setActiveTab("swap")}
+                className={`px-4 py-2 rounded-full text-[13px] leading-4 font-medium transition-all ${
+                  activeTab === "swap"
+                    ? "bg-white text-black shadow-sm"
+                    : "text-black/40"
+                }`}
+              >
+                Swap
+              </button>
+              <button
+                onClick={() => setActiveTab("secure")}
+                className={`px-4 py-2 rounded-full text-[13px] leading-4 font-medium transition-all ${
+                  activeTab === "secure"
+                    ? "bg-white text-black shadow-sm"
+                    : "text-black/40"
+                }`}
+              >
+                Secure
+              </button>
+            </div>
+          )}
+
+          {/* Token selection: Title */}
+          {view === "selectFrom" && (
+            <span className="text-[17px] font-semibold text-black leading-[22px]">
+              You swap
+            </span>
+          )}
+          {view === "selectTo" && (
+            <span className="text-[17px] font-semibold text-black leading-[22px]">
+              You receive
+            </span>
+          )}
+
+          {/* Confirm / Result: Title */}
+          {(view === "confirm" || view === "result") && (
+            <span className="text-[17px] font-semibold text-black leading-[22px]">
+              Swap {fromToken.symbol} to {toToken.symbol}
+            </span>
+          )}
 
           {/* Close Button */}
-          <Modal.Close>
-            <div
-              onClick={() => hapticFeedback.impactOccurred("light")}
-              className="absolute right-2 p-1.5 rounded-full flex items-center justify-center active:scale-95 active:bg-white/10 transition-all duration-150 cursor-pointer"
-              style={{
-                background: "rgba(255, 255, 255, 0.06)",
-              }}
-            >
-              <X size={24} strokeWidth={1.5} className="text-white/60" />
-            </div>
-          </Modal.Close>
+          <button
+            onClick={closeSheet}
+            className="absolute right-3 w-[30px] h-[30px] rounded-full flex items-center justify-center active:scale-95 transition-all duration-150"
+            style={{ background: "rgba(0, 0, 0, 0.06)" }}
+          >
+            <X
+              size={20}
+              strokeWidth={2}
+              style={{ color: "rgba(60, 60, 67, 0.6)" }}
+            />
+          </button>
         </div>
 
         {/* Content Container */}
-        <div className="relative flex-1 overflow-hidden">
-          {/* MAIN VIEW - in normal flow */}
+        <div
+          className="relative flex-1 overflow-hidden"
+          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+        >
+          {/* MAIN VIEW */}
           <div
-            className="flex flex-col transition-all duration-300 ease-out"
+            className="absolute inset-0 flex flex-col overflow-y-auto transition-all duration-300 ease-out"
             style={{
               transform: `translateX(${view === "main" ? 0 : -100}%)`,
               opacity: view === "main" ? 1 : 0,
@@ -766,9 +842,14 @@ export default function SwapSheet({
                 {/* You Swap Card */}
                 <div
                   className="flex flex-col px-4 py-3 rounded-[20px] relative"
-                  style={{ background: "#2c2c2e" }}
+                  style={{ background: "#f2f2f7" }}
                 >
-                  <p className="text-base leading-5 text-white/60">You swap</p>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    You swap
+                  </p>
 
                   <div className="flex gap-1 items-center h-12">
                     {/* Amount Input */}
@@ -793,20 +874,22 @@ export default function SwapSheet({
                       />
                       <p
                         ref={amountTextRef}
-                        className="text-[28px] font-semibold leading-8 text-white"
+                        className="text-[28px] font-semibold leading-8"
+                        style={{ color: insufficientBalance ? "#f9363c" : "#000" }}
                       >
                         {amountStr || ""}
                       </p>
                       {!amountStr && (
-                        <p className="text-[28px] font-semibold leading-8 text-white/40">
+                        <p className="text-[28px] font-semibold leading-8 text-black/30">
                           0
                         </p>
                       )}
                       {/* Caret */}
                       <div
-                        className="absolute w-0.5 h-8 bg-white top-1/2 -translate-y-1/2"
+                        className="absolute w-[1.5px] h-8 top-1/2 -translate-y-1/2"
                         style={{
                           left: `${caretLeft}px`,
+                          background: "#f9363c",
                           animation: "blink 1s step-end infinite",
                         }}
                       />
@@ -816,7 +899,7 @@ export default function SwapSheet({
                     <button
                       onClick={() => handleOpenTokenSelect("from")}
                       className="flex items-center px-1 rounded-[54px] active:scale-95 transition-transform"
-                      style={{ background: "rgba(255, 255, 255, 0.06)" }}
+                      style={{ background: "rgba(0, 0, 0, 0.06)" }}
                     >
                       <div className="pr-1.5">
                         <div className="w-7 h-7 rounded-full overflow-hidden">
@@ -828,13 +911,13 @@ export default function SwapSheet({
                           />
                         </div>
                       </div>
-                      <span className="text-base leading-5 text-white py-2.5 pr-1">
+                      <span className="text-base leading-5 text-black py-2.5 pr-1">
                         {fromToken.symbol}
                       </span>
                       <ChevronRight
                         size={16}
                         strokeWidth={1.5}
-                        className="text-white/40"
+                        style={{ color: "rgba(60, 60, 67, 0.3)" }}
                       />
                     </button>
                   </div>
@@ -842,44 +925,56 @@ export default function SwapSheet({
                   {/* Bottom Row */}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1.5">
-                      {/* Small swap icon */}
                       <div
                         className="w-5 h-5 rounded-full flex items-center justify-center"
-                        style={{ background: "rgba(255, 255, 255, 0.1)" }}
+                        style={{ background: "rgba(0, 0, 0, 0.06)" }}
                       >
-                        <ArrowDownUp size={12} strokeWidth={2} className="text-white/60" />
+                        <ArrowDownUp size={12} strokeWidth={2} style={{ color: "rgba(60, 60, 67, 0.6)" }} />
                       </div>
-                      <p className="text-base leading-5 text-white/60">
+                      <p
+                        className="text-[13px] leading-4"
+                        style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                      >
                         1 {fromToken.symbol} ≈ ${fromToken.priceUsd.toFixed(4)}
                       </p>
                     </div>
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       {fromToken.balance.toLocaleString("en-US", {
                         maximumFractionDigits: fromToken.symbol === "SOL" ? 4 : 2,
                       })}
                     </p>
                   </div>
 
-                  {/* Swap Button - positioned at bottom of card */}
+                  {/* Swap Direction Button */}
                   <button
                     onClick={handleSwapTokens}
-                    className="absolute -bottom-[18px] left-1/2 -translate-x-1/2 w-7 h-7 rounded-full bg-white flex items-center justify-center active:scale-95 transition-transform z-10"
+                    className="absolute -bottom-[18px] left-1/2 -translate-x-1/2 w-7 h-7 rounded-full bg-white flex items-center justify-center active:scale-95 transition-transform z-10 shadow-sm"
+                    style={{ border: "1px solid rgba(0, 0, 0, 0.06)" }}
                   >
-                    <ArrowDownUp size={20} strokeWidth={2} className="text-black" />
+                    <ArrowDownUp size={16} strokeWidth={2} className="text-black" />
                   </button>
                 </div>
 
                 {/* You Receive Card */}
                 <div
                   className="flex flex-col px-4 py-3 rounded-[20px]"
-                  style={{ background: "#2c2c2e" }}
+                  style={{ background: "#f2f2f7" }}
                 >
-                  <p className="text-base leading-5 text-white/60">You receive</p>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    You receive
+                  </p>
 
                   <div className="flex gap-1 items-center h-12">
-                    {/* Amount Display */}
                     <div className="flex-1 flex items-baseline">
-                      <p className="text-[28px] font-semibold leading-8 text-white/40">
+                      <p
+                        className={`text-[28px] font-semibold leading-8 ${receiveAmount > 0 ? "text-black" : "text-black/30"}`}
+                      >
                         {receiveAmountDisplay}
                       </p>
                     </div>
@@ -888,7 +983,7 @@ export default function SwapSheet({
                     <button
                       onClick={() => handleOpenTokenSelect("to")}
                       className="flex items-center px-1 rounded-[54px] active:scale-95 transition-transform"
-                      style={{ background: "rgba(255, 255, 255, 0.06)" }}
+                      style={{ background: "rgba(0, 0, 0, 0.06)" }}
                     >
                       <div className="pr-1.5">
                         <div className="w-7 h-7 rounded-full overflow-hidden">
@@ -900,23 +995,29 @@ export default function SwapSheet({
                           />
                         </div>
                       </div>
-                      <span className="text-base leading-5 text-white py-2.5 pr-1">
+                      <span className="text-base leading-5 text-black py-2.5 pr-1">
                         {toToken.symbol}
                       </span>
                       <ChevronRight
                         size={16}
                         strokeWidth={1.5}
-                        className="text-white/40"
+                        style={{ color: "rgba(60, 60, 67, 0.3)" }}
                       />
                     </button>
                   </div>
 
                   {/* Bottom Row */}
                   <div className="flex items-center justify-between">
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       ${receiveUsdValue.toFixed(2)}
                     </p>
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       {toToken.balance.toLocaleString("en-US", {
                         maximumFractionDigits: toToken.symbol === "SOL" ? 4 : 2,
                       })}{" "}
@@ -930,35 +1031,30 @@ export default function SwapSheet({
                   {[25, 50].map((pct) => (
                     <button
                       key={pct}
+                      onMouseDown={(e) => e.preventDefault()}
                       onClick={() => handlePresetPercentage(pct)}
-                      className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-white text-center active:opacity-70 transition-opacity"
-                      style={{ background: "#2c2c2e" }}
+                      className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-center active:opacity-70 transition-opacity"
+                      style={{ background: "rgba(249, 54, 60, 0.14)", color: "#f9363c" }}
                     >
                       {pct}%
                     </button>
                   ))}
                   <button
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() => handlePresetPercentage(100)}
-                    className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-white text-center active:opacity-70 transition-opacity"
-                    style={{ background: "#2c2c2e" }}
+                    className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-center active:opacity-70 transition-opacity"
+                    style={{ background: "rgba(249, 54, 60, 0.14)", color: "#f9363c" }}
                   >
                     Max
                   </button>
                 </div>
 
                 {/* Insufficient balance error */}
-                {(() => {
-                  const val = parseFloat(amountStr);
-                  if (isNaN(val) || val <= 0) return null;
-                  if (val > fromToken.balance) {
-                    return (
-                      <p className="text-[13px] text-red-400 leading-4 px-1">
-                        Insufficient balance
-                      </p>
-                    );
-                  }
-                  return null;
-                })()}
+                {insufficientBalance && (
+                  <p className="text-[13px] leading-4 px-1" style={{ color: "#f9363c" }}>
+                    Insufficient balance
+                  </p>
+                )}
               </div>
             )}
 
@@ -968,12 +1064,16 @@ export default function SwapSheet({
                 {/* You Secure Card */}
                 <div
                   className="flex flex-col px-4 py-3 rounded-[20px] relative"
-                  style={{ background: "#2c2c2e" }}
+                  style={{ background: "#f2f2f7" }}
                 >
-                  <p className="text-base leading-5 text-white/60">You secure</p>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    You secure
+                  </p>
 
                   <div className="flex gap-1 items-center h-12">
-                    {/* Amount Input */}
                     <div className="flex-1 flex items-baseline relative">
                       <input
                         ref={secureAmountInputRef}
@@ -995,30 +1095,29 @@ export default function SwapSheet({
                       />
                       <p
                         ref={secureAmountTextRef}
-                        className="text-[28px] font-semibold leading-8 text-white"
+                        className="text-[28px] font-semibold leading-8 text-black"
                       >
                         {secureAmountStr || ""}
                       </p>
                       {!secureAmountStr && (
-                        <p className="text-[28px] font-semibold leading-8 text-white/40">
+                        <p className="text-[28px] font-semibold leading-8 text-black/30">
                           0
                         </p>
                       )}
-                      {/* Caret */}
                       <div
-                        className="absolute w-0.5 h-8 bg-white top-1/2 -translate-y-1/2"
+                        className="absolute w-[1.5px] h-8 top-1/2 -translate-y-1/2"
                         style={{
                           left: `${secureCaretLeft}px`,
+                          background: "#f9363c",
                           animation: "blink 1s step-end infinite",
                         }}
                       />
                     </div>
 
-                    {/* Token Selector */}
                     <button
                       onClick={handleOpenSecureTokenSelect}
                       className="flex items-center px-1 rounded-[54px] active:scale-95 transition-transform"
-                      style={{ background: "rgba(255, 255, 255, 0.06)" }}
+                      style={{ background: "rgba(0, 0, 0, 0.06)" }}
                     >
                       <div className="pr-1.5">
                         <div className="w-7 h-7 rounded-full overflow-hidden">
@@ -1030,13 +1129,13 @@ export default function SwapSheet({
                           />
                         </div>
                       </div>
-                      <span className="text-base leading-5 text-white py-2.5 pr-1">
+                      <span className="text-base leading-5 text-black py-2.5 pr-1">
                         {secureToken.symbol}
                       </span>
                       <ChevronRight
                         size={16}
                         strokeWidth={1.5}
-                        className="text-white/40"
+                        style={{ color: "rgba(60, 60, 67, 0.3)" }}
                       />
                     </button>
                   </div>
@@ -1044,49 +1143,58 @@ export default function SwapSheet({
                   {/* Bottom Row */}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1.5">
-                      {/* Small swap icon */}
                       <div
                         className="w-5 h-5 rounded-full flex items-center justify-center"
-                        style={{ background: "rgba(255, 255, 255, 0.1)" }}
+                        style={{ background: "rgba(0, 0, 0, 0.06)" }}
                       >
-                        <ArrowDownUp size={12} strokeWidth={2} className="text-white/60" />
+                        <ArrowDownUp size={12} strokeWidth={2} style={{ color: "rgba(60, 60, 67, 0.6)" }} />
                       </div>
-                      <p className="text-base leading-5 text-white/60">
+                      <p
+                        className="text-[13px] leading-4"
+                        style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                      >
                         ${secureUsdValue.toFixed(2)}
                       </p>
                     </div>
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       {secureToken.balance.toLocaleString("en-US", {
                         maximumFractionDigits: secureToken.symbol === "SOL" ? 4 : 2,
                       })}
                     </p>
                   </div>
 
-                  {/* Arrow Down Icon - positioned at bottom of card */}
-                  <div className="absolute -bottom-[18px] left-1/2 -translate-x-1/2 w-7 h-7 rounded-full bg-white flex items-center justify-center z-10">
-                    <ArrowDownUp size={20} strokeWidth={2} className="text-black" />
+                  <div
+                    className="absolute -bottom-[18px] left-1/2 -translate-x-1/2 w-7 h-7 rounded-full bg-white flex items-center justify-center z-10 shadow-sm"
+                    style={{ border: "1px solid rgba(0, 0, 0, 0.06)" }}
+                  >
+                    <ArrowDownUp size={16} strokeWidth={2} className="text-black" />
                   </div>
                 </div>
 
                 {/* You Receive Card (Secured Token) */}
                 <div
                   className="flex flex-col px-4 py-3 rounded-[20px]"
-                  style={{ background: "#2c2c2e" }}
+                  style={{ background: "#f2f2f7" }}
                 >
-                  <p className="text-base leading-5 text-white/60">You receive</p>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    You receive
+                  </p>
 
                   <div className="flex gap-1 items-center h-12">
-                    {/* Amount Display - same as input (1:1) */}
                     <div className="flex-1 flex items-baseline">
-                      <p className="text-[28px] font-semibold leading-8 text-white">
+                      <p className="text-[28px] font-semibold leading-8 text-black">
                         {secureAmountStr || "0"}
                       </p>
                     </div>
 
-                    {/* Token Display (not selectable) - token + shield badge */}
                     <div className="flex items-center px-1 pr-3.5">
                       <div className="flex items-center pr-1.5">
-                        {/* Token icon */}
                         <div className="w-7 h-7 rounded-full overflow-hidden">
                           <Image
                             src={secureToken.icon}
@@ -1095,7 +1203,6 @@ export default function SwapSheet({
                             height={28}
                           />
                         </div>
-                        {/* Shield badge overlapping */}
                         <div className="w-7 h-7 rounded-full overflow-hidden -ml-2 bg-[#f9363c] flex items-center justify-center">
                           <Image
                             src="/loyal-shield.png"
@@ -1106,7 +1213,7 @@ export default function SwapSheet({
                           />
                         </div>
                       </div>
-                      <span className="text-base leading-5 text-white py-2.5">
+                      <span className="text-base leading-5 text-black py-2.5">
                         {secureToken.symbol}
                       </span>
                     </div>
@@ -1114,10 +1221,16 @@ export default function SwapSheet({
 
                   {/* Bottom Row */}
                   <div className="flex items-center justify-between">
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       ${secureUsdValue.toFixed(2)}
                     </p>
-                    <p className="text-base leading-5 text-white/60">
+                    <p
+                      className="text-[13px] leading-4"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
                       0 {secureToken.symbol}
                     </p>
                   </div>
@@ -1128,17 +1241,19 @@ export default function SwapSheet({
                   {[25, 50].map((pct) => (
                     <button
                       key={pct}
+                      onMouseDown={(e) => e.preventDefault()}
                       onClick={() => handleSecurePresetPercentage(pct)}
-                      className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-white text-center active:opacity-70 transition-opacity"
-                      style={{ background: "#2c2c2e" }}
+                      className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-center active:opacity-70 transition-opacity"
+                      style={{ background: "rgba(249, 54, 60, 0.14)", color: "#f9363c" }}
                     >
                       {pct}%
                     </button>
                   ))}
                   <button
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() => handleSecurePresetPercentage(100)}
-                    className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-white text-center active:opacity-70 transition-opacity"
-                    style={{ background: "#2c2c2e" }}
+                    className="flex-1 min-w-[64px] px-4 py-2 rounded-[40px] text-sm leading-5 text-center active:opacity-70 transition-opacity"
+                    style={{ background: "rgba(249, 54, 60, 0.14)", color: "#f9363c" }}
                   >
                     Max
                   </button>
@@ -1150,7 +1265,7 @@ export default function SwapSheet({
                   if (isNaN(val) || val <= 0) return null;
                   if (val > secureToken.balance) {
                     return (
-                      <p className="text-[13px] text-red-400 leading-4 px-1">
+                      <p className="text-[13px] leading-4 px-1" style={{ color: "#f9363c" }}>
                         Insufficient balance
                       </p>
                     );
@@ -1161,164 +1276,352 @@ export default function SwapSheet({
             )}
           </div>
 
-          {/* Token Select Views */}
-          <TokenSelectView
-            title="You swap"
-            viewKey="selectFrom"
-            currentView={view}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            tokens={filteredTokens}
-            onSelectToken={handleSelectFromToken}
-            onBack={handleBackToMain}
-          />
-          <TokenSelectView
-            title="You receive"
-            viewKey="selectTo"
-            currentView={view}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            tokens={filteredTokens}
-            onSelectToken={handleSelectToToken}
-            onBack={handleBackToMain}
-          />
-          <TokenSelectView
-            title="You secure"
-            viewKey="selectSecure"
-            currentView={view}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            tokens={filteredTokens}
-            onSelectToken={handleSelectSecureToken}
-            onBack={handleBackToMain}
-          />
-
-          {/* RESULT VIEW (SUCCESS or ERROR) */}
+          {/* TOKEN SELECT: FROM */}
           <div
             className="absolute inset-0 flex flex-col transition-all duration-300 ease-out"
             style={{
-              background: "#1c1c1e",
-              transform: `translateX(${isResultView ? 0 : 100}%)`,
-              opacity: isResultView ? 1 : 0,
-              pointerEvents: isResultView ? "auto" : "none",
+              transform: `translateX(${view === "selectFrom" ? 0 : 100}%)`,
+              opacity: view === "selectFrom" ? 1 : 0,
+              pointerEvents: view === "selectFrom" ? "auto" : "none",
             }}
           >
-            {swapError ? (
-              /* Error Content */
-              <div className="flex-1 flex flex-col items-center justify-center px-6 pb-24">
-                {/* Animated Error Icon */}
-                <div className="relative mb-5">
-                  <div
-                    className="w-[72px] h-[72px] rounded-full flex items-center justify-center"
-                    style={{
-                      background: "#FF4D4D",
-                      animation: isResultView ? "result-pulse 0.6s ease-out" : "none",
-                    }}
+            {/* Search Input */}
+            <div className="px-4 pt-2 pb-3 shrink-0">
+              <div
+                className="flex items-center rounded-[47px] px-4"
+                style={{ background: "#f2f2f7" }}
+              >
+                <Search
+                  size={20}
+                  strokeWidth={1.5}
+                  className="shrink-0 mr-2"
+                  style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                />
+                <input
+                  type="text"
+                  placeholder="Search token"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="flex-1 bg-transparent py-3 text-[17px] leading-[22px] text-black placeholder:text-[rgba(60,60,67,0.6)] outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Token List */}
+            <div className="flex-1 overflow-y-auto">
+              {filteredFromTokens.map((token) => (
+                <button
+                  key={token.mint ?? token.symbol}
+                  onClick={() =>
+                    activeTab === "secure"
+                      ? handleSelectSecureToken(token)
+                      : handleSelectFromToken(token)
+                  }
+                  className="w-full flex items-center px-4 active:bg-black/[0.03] transition-colors"
+                >
+                  <div className="py-1.5 pr-3">
+                    <div className="w-12 h-12 rounded-full overflow-hidden bg-[#f2f2f7]">
+                      <Image src={token.icon} alt={token.symbol} width={48} height={48} />
+                    </div>
+                  </div>
+                  <div className="flex-1 flex flex-col gap-0.5 py-2.5">
+                    <p className="text-[17px] font-medium text-black leading-[22px] text-left">{token.symbol}</p>
+                    <p
+                      className="text-[15px] leading-5 text-left"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
+                      ${token.priceUsd.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-0.5 items-end py-2.5 pl-3">
+                    <p className="text-[17px] text-black leading-[22px] text-right">
+                      {token.balance.toLocaleString("en-US", {
+                        maximumFractionDigits: token.decimals > 6 ? 4 : 2,
+                      })}
+                    </p>
+                    <p
+                      className="text-[15px] leading-5 text-right"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
+                      ${(token.balance * token.priceUsd).toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* TOKEN SELECT: TO */}
+          <div
+            className="absolute inset-0 flex flex-col transition-all duration-300 ease-out"
+            style={{
+              transform: `translateX(${view === "selectTo" ? 0 : 100}%)`,
+              opacity: view === "selectTo" ? 1 : 0,
+              pointerEvents: view === "selectTo" ? "auto" : "none",
+            }}
+          >
+            {/* Search Input */}
+            <div className="px-4 pt-2 pb-3 shrink-0">
+              <div
+                className="flex items-center rounded-[47px] px-4"
+                style={{ background: "#f2f2f7" }}
+              >
+                <Search
+                  size={20}
+                  strokeWidth={1.5}
+                  className="shrink-0 mr-2"
+                  style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                />
+                <input
+                  type="text"
+                  placeholder="Search token"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="flex-1 bg-transparent py-3 text-[17px] leading-[22px] text-black placeholder:text-[rgba(60,60,67,0.6)] outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Token List */}
+            <div className="flex-1 overflow-y-auto">
+              {filteredToTokens.map((token) => (
+                <button
+                  key={token.mint ?? token.symbol}
+                  onClick={() => handleSelectToToken(token)}
+                  className="w-full flex items-center px-4 active:bg-black/[0.03] transition-colors"
+                >
+                  <div className="py-1.5 pr-3">
+                    <div className="w-12 h-12 rounded-full overflow-hidden bg-[#f2f2f7]">
+                      <Image src={token.icon} alt={token.symbol} width={48} height={48} />
+                    </div>
+                  </div>
+                  <div className="flex-1 flex flex-col gap-0.5 py-2.5">
+                    <p className="text-[17px] font-medium text-black leading-[22px] text-left">{token.symbol}</p>
+                    <p
+                      className="text-[15px] leading-5 text-left"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
+                      ${token.priceUsd.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-0.5 items-end py-2.5 pl-3">
+                    <p className="text-[17px] text-black leading-[22px] text-right">
+                      {token.balance.toLocaleString("en-US", {
+                        maximumFractionDigits: token.decimals > 6 ? 4 : 2,
+                      })}
+                    </p>
+                    <p
+                      className="text-[15px] leading-5 text-right"
+                      style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                    >
+                      ${(token.balance * token.priceUsd).toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* CONFIRMATION VIEW */}
+          <div
+            className="absolute inset-0 flex flex-col overflow-y-auto transition-all duration-300 ease-out"
+            style={{
+              transform: `translateX(${view === "confirm" ? 0 : 100}%)`,
+              opacity: view === "confirm" ? 1 : 0,
+              pointerEvents: view === "confirm" ? "auto" : "none",
+            }}
+          >
+            {/* Amount Display */}
+            <div className="px-4 pt-4 pb-2">
+              <div className="px-2 flex flex-col gap-1">
+                {/* From amount (negative) */}
+                <div className="flex gap-2 items-baseline">
+                  <p className="text-[32px] font-semibold leading-[38px] text-black">
+                    −{amountStr || "0"}
+                  </p>
+                  <p
+                    className="text-[22px] font-semibold leading-7 tracking-[0.4px]"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
                   >
-                    <ShieldAlert
-                      className="text-white"
-                      size={40}
-                      strokeWidth={2}
-                      style={{
-                        animation: isResultView
-                          ? "result-icon 0.4s ease-out 0.2s both"
-                          : "none",
-                      }}
+                    {fromToken.symbol}
+                  </p>
+                </div>
+                {/* To amount (positive, green) */}
+                <div className="flex gap-2 items-baseline">
+                  <p className="text-[32px] font-semibold leading-[38px]" style={{ color: "#34C759" }}>
+                    +{receiveAmountDisplay}
+                  </p>
+                  <p
+                    className="text-[22px] font-semibold leading-7 tracking-[0.4px]"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    {toToken.symbol}
+                  </p>
+                </div>
+                {/* USD equivalent */}
+                <p
+                  className="text-base leading-[22px] mt-1"
+                  style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                >
+                  ≈${receiveUsdValue.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </p>
+              </div>
+            </div>
+
+            {/* Details Card */}
+            <div className="px-4 pt-3">
+              <div
+                className="flex flex-col rounded-[20px] px-4 py-3 gap-3"
+                style={{ background: "#f2f2f7" }}
+              >
+                {/* Rate */}
+                <div className="flex items-center justify-between">
+                  <p
+                    className="text-[15px] leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    Rate
+                  </p>
+                  <p className="text-[15px] leading-5 text-black">
+                    {rateDisplay}
+                  </p>
+                </div>
+                {/* Slippage */}
+                <div className="flex items-center justify-between">
+                  <p
+                    className="text-[15px] leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    Slippage
+                  </p>
+                  <p className="text-[15px] leading-5 text-black">1%</p>
+                </div>
+                {/* Network Fee */}
+                <div className="flex items-center justify-between">
+                  <p
+                    className="text-[15px] leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    Network Fee
+                  </p>
+                  <p className="text-[15px] leading-5 text-black">
+                    0.00005 SOL ≈ $0.00
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* RESULT VIEW (swapping / success / error) */}
+          <div
+            className="absolute inset-0 flex flex-col transition-all duration-300 ease-out"
+            style={{
+              transform: `translateX(${view === "result" ? 0 : 100}%)`,
+              opacity: view === "result" ? 1 : 0,
+              pointerEvents: view === "result" ? "auto" : "none",
+            }}
+          >
+            {isSwapping ? (
+              /* Swapping in progress */
+              <div className="flex-1 flex flex-col items-center justify-center px-6 pb-24">
+                {/* Token icons side by side */}
+                <div className="flex items-center gap-2 mb-5">
+                  <div className="w-[56px] h-[56px] rounded-full overflow-hidden bg-[#f2f2f7]">
+                    <Image
+                      src={fromToken.icon}
+                      alt={fromToken.symbol}
+                      width={56}
+                      height={56}
+                    />
+                  </div>
+                  <ChevronRight
+                    size={20}
+                    strokeWidth={2}
+                    style={{ color: "rgba(60, 60, 67, 0.3)" }}
+                  />
+                  <div className="w-[56px] h-[56px] rounded-full overflow-hidden bg-[#f2f2f7]">
+                    <Image
+                      src={toToken.icon}
+                      alt={toToken.symbol}
+                      width={56}
+                      height={56}
                     />
                   </div>
                 </div>
-
-                {/* Error Text */}
-                <div className="flex flex-col gap-3 items-center text-center max-w-[280px]">
-                  <h2 className="text-2xl font-semibold text-white leading-7">
+                <div className="flex flex-col gap-2 items-center text-center max-w-[280px]">
+                  <h2 className="text-xl font-semibold text-black leading-6">
+                    Swapping...
+                  </h2>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    You can close this screen and continue using the app
+                  </p>
+                </div>
+              </div>
+            ) : swapError ? (
+              /* Error */
+              <div className="flex-1 flex flex-col items-center justify-center px-6 pb-24">
+                <div className="relative mb-5">
+                  <Image
+                    src="/dogs/dog-cry.png"
+                    alt="Error"
+                    width={96}
+                    height={96}
+                  />
+                </div>
+                <div className="flex flex-col gap-2 items-center text-center max-w-[280px]">
+                  <h2 className="text-xl font-semibold text-black leading-6">
                     Swap failed
                   </h2>
-                  <p className="text-base leading-5 text-white/60">{swapError}</p>
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    {swapError}
+                  </p>
                 </div>
               </div>
             ) : (
-              /* Success Content */
+              /* Success */
               <div className="flex-1 flex flex-col items-center justify-center px-6 pb-24">
-                {/* Animated Success Icon */}
                 <div className="relative mb-5">
-                  <div
-                    className="w-[72px] h-[72px] rounded-full flex items-center justify-center"
-                    style={{
-                      background: buttonColor,
-                      animation: isResultView ? "result-pulse 0.6s ease-out" : "none",
-                    }}
-                  >
-                    <Check
-                      className="text-white"
-                      size={40}
-                      strokeWidth={2.5}
-                      style={{
-                        animation: isResultView
-                          ? "result-icon 0.4s ease-out 0.2s both"
-                          : "none",
-                      }}
-                    />
-                  </div>
+                  <Image
+                    src="/dogs/dog-green.png"
+                    alt="Success"
+                    width={96}
+                    height={96}
+                  />
                 </div>
-
-                {/* Success Text */}
-                <div className="flex flex-col gap-3 items-center text-center max-w-[280px]">
-                  <h2 className="text-2xl font-semibold text-white leading-7">
-                    Swap complete
+                <div className="flex flex-col gap-2 items-center text-center max-w-[280px]">
+                  <h2 className="text-xl font-semibold text-black leading-6">
+                    Swap Completed
                   </h2>
-                  <p className="text-base leading-5 text-white/60">
-                    <span className="text-white">
-                      {swappedFromAmount?.toFixed(4).replace(/\.?0+$/, "") || "0"}{" "}
-                      {swappedFromSymbol || ""}
-                    </span>{" "}
-                    swapped to{" "}
-                    <span className="text-white">
-                      {swappedToAmount?.toFixed(6).replace(/\.?0+$/, "") || "0"}{" "}
+                  <p
+                    className="text-base leading-5"
+                    style={{ color: "rgba(60, 60, 67, 0.6)" }}
+                  >
+                    <span className="text-black">
+                      {swappedToAmount?.toFixed(4).replace(/\.?0+$/, "") || "0"}{" "}
                       {swappedToSymbol || ""}
                     </span>
+                    {" "}has been deposited to your wallet
                   </p>
                 </div>
               </div>
             )}
           </div>
         </div>
-
-        {/* Animation styles */}
-        <style jsx>{`
-          @keyframes blink {
-            0%,
-            100% {
-              opacity: 1;
-            }
-            50% {
-              opacity: 0;
-            }
-          }
-          @keyframes result-pulse {
-            0% {
-              transform: scale(0);
-              opacity: 0;
-            }
-            50% {
-              transform: scale(1.1);
-            }
-            100% {
-              transform: scale(1);
-              opacity: 1;
-            }
-          }
-          @keyframes result-icon {
-            0% {
-              transform: scale(0) rotate(-45deg);
-              opacity: 0;
-            }
-            100% {
-              transform: scale(1) rotate(0deg);
-              opacity: 1;
-            }
-          }
-        `}</style>
       </div>
-    </Modal>
+    </>
   );
+
+  return createPortal(content, document.body);
 }

--- a/app/src/lib/solana/token-holdings/constants.ts
+++ b/app/src/lib/solana/token-holdings/constants.ts
@@ -5,8 +5,8 @@ export const NATIVE_SOL_DECIMALS = 9;
 
 // Known token icons (fallback when Helius has no image)
 export const KNOWN_TOKEN_ICONS: Record<string, string> = {
-  "So11111111111111111111111111111111111111112": "/solana-sol-logo.png",
-  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB": "/USDT.png",
+  "So11111111111111111111111111111111111111112": "/tokens/solana-sol-logo.png",
+  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB": "/tokens/USDT.png",
 };
 
-export const DEFAULT_TOKEN_ICON = "/icons/token-default.svg";
+export const DEFAULT_TOKEN_ICON = "/tokens/solana-sol-logo.png";


### PR DESCRIPTION
## Changes

- Rewrote SwapSheet with a light theme and CSS transitions using createPortal
- Introduced a confirm view and 3-state result view (swapping / success / error)
- Updated wallet integration and token icon paths
- Consolidated token icons under `/tokens/`
- Updated `KNOWN_TOKEN_ICONS` and `DEFAULT_TOKEN_ICON`
- Exposed `SwapView` type
- Wired `isSwapping` state to wallet page
- Improved button flows and haptic feedback
- Handled iOS focus quirks
- Enhanced token selection lists
- Added pull-to-close and overlay animation handling

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #43 
- <kbd>&nbsp;7&nbsp;</kbd> #42 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #41 
- <kbd>&nbsp;5&nbsp;</kbd> #40 
- <kbd>&nbsp;4&nbsp;</kbd> #39 
- <kbd>&nbsp;3&nbsp;</kbd> #38 
- <kbd>&nbsp;2&nbsp;</kbd> #37 
- <kbd>&nbsp;1&nbsp;</kbd> #36 
<!-- GitButler Footer Boundary Bottom -->

