### PR TITLE
feat(wallet): wire swap transaction details and add shield icon for deposits

### DIFF
--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -250,14 +250,18 @@ const MOCK_ACTIVITY_INFO: Record<string, MockActivityInfo> = {
 const MOCK_WALLET_TRANSACTIONS: Transaction[] = [
   {
     id: "mock-1",
-    type: "outgoing",
-    transferType: "transfer",
+    type: "incoming",
+    transferType: "swap",
     amountLamports: 250_000_000,
     sender: undefined,
-    recipient: "UQAt...qZir",
+    recipient: undefined,
     timestamp: Date.now() - 86400000 * 2,
     status: "completed",
     signature: "mock-sig-1",
+    swapFromSymbol: "USDC",
+    swapToSymbol: "SOL",
+    swapToAmount: 0.25,
+    swapToAmountUsd: 25.0,
   },
   {
     id: "mock-2",
@@ -697,6 +701,11 @@ export default function Home() {
         timestamp: transaction.timestamp,
         networkFeeLamports: transaction.networkFeeLamports,
         signature: transaction.signature,
+        // Swap transaction fields
+        swapFromSymbol: transaction.swapFromSymbol,
+        swapToSymbol: transaction.swapToSymbol,
+        swapToAmount: transaction.swapToAmount,
+        swapToAmountUsd: transaction.swapToAmountUsd,
       };
       setSelectedTransaction(detailsData);
       setTransactionDetailsSheetOpen(true);
@@ -2636,6 +2645,8 @@ export default function Home() {
                         const mockInfo = USE_MOCK_DATA
                           ? MOCK_ACTIVITY_INFO[transaction.id]
                           : undefined;
+                        const isDepositForUsername =
+                          transaction.transferType === "deposit_for_username";
                         const transferTypeLabel =
                           transaction.transferType === "store"
                             ? "Store data"
@@ -2762,7 +2773,16 @@ export default function Home() {
                           >
                             {/* Left - Icon */}
                             <div className="py-1.5 pr-3">
-                              {mockInfo ? (
+                              {isDepositForUsername ? (
+                                <div className="w-12 h-12 rounded-full overflow-hidden relative">
+                                  <Image
+                                    src="/loyal-shield.png"
+                                    alt="To be claimed"
+                                    fill
+                                    className="object-cover"
+                                  />
+                                </div>
+                              ) : mockInfo ? (
                                 <div className="w-12 h-12 rounded-full overflow-hidden relative bg-[#f2f2f7]">
                                   <Image
                                     src={mockInfo.tokenIcon}
@@ -2962,6 +2982,10 @@ export default function Home() {
             : undefined
         }
         onCancelDeposit={handleCancelDeposit}
+        swapFromSymbol={selectedTransaction?.swapFromSymbol}
+        swapToSymbol={selectedTransaction?.swapToSymbol}
+        swapToAmount={selectedTransaction?.swapToAmount}
+        swapToAmountUsd={selectedTransaction?.swapToAmountUsd}
       />
       <ActivitySheet
         open={isActivitySheetOpen}

--- a/app/src/lib/solana/rpc/types.ts
+++ b/app/src/lib/solana/rpc/types.ts
@@ -10,7 +10,8 @@ export type WalletTransfer = {
     | "verify_telegram_init_data"
     | "store"
     | "claim_deposit"
-    | "deposit_for_username";
+    | "deposit_for_username"
+    | "swap";
   amountLamports: number;
   netChangeLamports: number;
   feeLamports: number;

--- a/app/src/types/wallet.ts
+++ b/app/src/types/wallet.ts
@@ -18,6 +18,11 @@ export type Transaction = {
   // For outgoing transactions
   recipient?: string;
   timestamp: number;
+  // For swap transactions
+  swapFromSymbol?: string;
+  swapToSymbol?: string;
+  swapToAmount?: number;
+  swapToAmountUsd?: number;
 };
 
 // Legacy type for internal use - will be removed
@@ -47,4 +52,9 @@ export type TransactionDetailsData = {
   networkFeeLamports?: number;
   comment?: string;
   signature?: string; // Transaction signature for explorer link
+  // For swap transactions
+  swapFromSymbol?: string;
+  swapToSymbol?: string;
+  swapToAmount?: number;
+  swapToAmountUsd?: number;
 };


### PR DESCRIPTION
• Added swap fields to mock transaction data
• Passed swap props into TransactionDetailsSheet
• Rendered a dedicated swap details view for proper transaction representation
• Displayed loyal-shield.png icon for deposit_for_username entries instead of token icon
• Improved transaction details sheet to correctly show swap transaction details (title, amounts, USD value, status, fees, and actions)

<!-- GitButler Footer Boundary Top -->
---
This is **part 8 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #43 👈 
- <kbd>&nbsp;7&nbsp;</kbd> #42 
- <kbd>&nbsp;6&nbsp;</kbd> #41 
- <kbd>&nbsp;5&nbsp;</kbd> #40 
- <kbd>&nbsp;4&nbsp;</kbd> #39 
- <kbd>&nbsp;3&nbsp;</kbd> #38 
- <kbd>&nbsp;2&nbsp;</kbd> #37 
- <kbd>&nbsp;1&nbsp;</kbd> #36 
<!-- GitButler Footer Boundary Bottom -->

