### PR TITLE
fix(wallet): prevent green dog flash on failed Send/Swap transactions

### DIFF
--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -1825,6 +1825,7 @@ export default function Home() {
         showMainButton({
           text: "Confirm and Send",
           onClick: () => {
+            setIsSendingTransaction(true); // Set loading state BEFORE showing result view
             setSendStep(5);
             handleSubmitSend();
           },
@@ -1917,6 +1918,7 @@ export default function Home() {
           text: "Confirm and Swap",
           onClick: () => {
             hapticFeedback.impactOccurred("medium");
+            setIsSwapping(true); // Set loading state BEFORE showing result view
             setSwapView("result");
             void handleSubmitSwap();
           },


### PR DESCRIPTION
• Fixed race condition in Send and Swap flows
• Ensured loading state is set before showing result view
• Prevented brief success state (green dog) on failed transactions
• Added immediate loader display by setting loading flags before view transition