### PR TITLE
feat(profile): replace mainnet toggle with network dropdown (mainnet/testnet/devnet)

### DIFF
--- a/app/src/lib/solana/rpc/connection.ts
+++ b/app/src/lib/solana/rpc/connection.ts
@@ -7,6 +7,8 @@ import {
   SECURE_DEVNET_RPC_WS,
   SECURE_MAINNET_RPC_URL,
   SECURE_MAINNET_RPC_WS,
+  TESTNET_RPC_URL,
+  TESTNET_RPC_WS,
 } from "./constants";
 import type { SolanaEnv } from "./types";
 
@@ -15,12 +17,12 @@ const DEFAULT_SOLANA_ENV: SolanaEnv = "devnet";
 export const getSolanaEnv = (): SolanaEnv => {
   if (typeof window !== "undefined") {
     const override = localStorage.getItem("solana-env-override");
-    if (override === "mainnet" || override === "devnet" || override === "localnet") {
+    if (override === "mainnet" || override === "testnet" || override === "devnet" || override === "localnet") {
       return override;
     }
   }
   const env = process.env.NEXT_PUBLIC_SOLANA_ENV;
-  if (env === "mainnet" || env === "devnet" || env === "localnet") {
+  if (env === "mainnet" || env === "testnet" || env === "devnet" || env === "localnet") {
     return env;
   }
   return DEFAULT_SOLANA_ENV;
@@ -34,6 +36,11 @@ const getEndpoints = (
       return {
         rpcEndpoint: SECURE_MAINNET_RPC_URL,
         websocketEndpoint: SECURE_MAINNET_RPC_WS,
+      };
+    case "testnet":
+      return {
+        rpcEndpoint: TESTNET_RPC_URL,
+        websocketEndpoint: TESTNET_RPC_WS,
       };
     case "localnet":
       return {

--- a/app/src/lib/solana/rpc/constants.ts
+++ b/app/src/lib/solana/rpc/constants.ts
@@ -8,5 +8,8 @@ export const SECURE_DEVNET_RPC_URL =
 export const SECURE_DEVNET_RPC_WS =
   "wss://aurora-o23cd4-fast-devnet.helius-rpc.com";
 
+export const TESTNET_RPC_URL = "https://api.testnet.solana.com";
+export const TESTNET_RPC_WS = "wss://api.testnet.solana.com";
+
 export const LOCALNET_RPC_URL = "http://127.0.0.1:8899";
 export const LOCALNET_RPC_WS = "ws://127.0.0.1:8900";

--- a/app/src/lib/solana/rpc/types.ts
+++ b/app/src/lib/solana/rpc/types.ts
@@ -1,4 +1,4 @@
-export type SolanaEnv = "mainnet" | "devnet" | "localnet";
+export type SolanaEnv = "mainnet" | "testnet" | "devnet" | "localnet";
 
 export type WalletTransfer = {
   signature: string;


### PR DESCRIPTION
## Overview

- Replaced Mainnet toggle with a Network dropdown in the profile page
- Added support for Mainnet, Testnet, and Devnet network selections
- Implemented dropdown with chevron, red checkmark, and outside-click closing
- Extended SolanaEnv type to include "testnet"
- Added Testnet RPC URL and WebSocket constants
- Persisted network selection in localStorage
- Added app reload functionality after network change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Testnet support as a selectable Solana network environment
  * Enhanced network selection UI with a dropdown menu for seamlessly switching between Mainnet, Testnet, and Devnet
  * Added haptic feedback when selecting a network environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->