### PR TITLE
feat(summaries): redesign Chat Highlights page from dark to light theme

### DIFF
--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -2,15 +2,14 @@
 
 import {
   hapticFeedback,
-  themeParams,
   useSignal,
   viewport,
 } from "@telegram-apps/sdk-react";
 import type { Signal } from "@telegram-apps/signals";
 import { motion, type PanInfo } from "framer-motion";
-import { CircleHelp, X } from "lucide-react";
+import { X } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { getAvatarColor, getFirstLetter } from "@/components/summaries/avatar-utils";
 import { MOCK_SUMMARIES } from "@/components/summaries/mock-data";
@@ -26,13 +25,11 @@ type GroupChat = {
 };
 
 interface ChatItemSkeletonProps {
-  showDivider?: boolean;
   titleWidth?: string;
   subtitleWidth?: string;
 }
 
 function ChatItemSkeleton({
-  showDivider = true,
   titleWidth = "w-32",
   subtitleWidth = "w-48",
 }: ChatItemSkeletonProps) {
@@ -41,16 +38,15 @@ function ChatItemSkeleton({
       <div className="flex items-center w-full py-2">
         {/* Avatar Skeleton */}
         <div className="pr-3">
-          <div className="w-14 h-14 rounded-full bg-white/5 animate-pulse" />
+          <div className="w-12 h-12 rounded-full bg-black/5 animate-pulse" />
         </div>
 
         {/* Title and Subtitle Skeleton */}
         <div className="flex-1 min-w-0 flex flex-col gap-1.5">
-          <div className={`${titleWidth} h-5 bg-white/5 animate-pulse rounded`} />
-          <div className={`${subtitleWidth} h-4 bg-white/5 animate-pulse rounded`} />
+          <div className={`${titleWidth} h-5 bg-black/5 animate-pulse rounded`} />
+          <div className={`${subtitleWidth} h-4 bg-black/5 animate-pulse rounded`} />
         </div>
       </div>
-      {showDivider && <div className="h-px bg-white/10 ml-[68px]" />}
     </div>
   );
 }
@@ -70,7 +66,6 @@ function ChatListSkeleton({ count = 5 }: { count?: number }) {
       {Array.from({ length: count }).map((_, index) => (
         <ChatItemSkeleton
           key={index}
-          showDivider={index < count - 1}
           titleWidth={SKELETON_CONFIGS[index % SKELETON_CONFIGS.length].titleWidth}
           subtitleWidth={SKELETON_CONFIGS[index % SKELETON_CONFIGS.length].subtitleWidth}
         />
@@ -82,68 +77,70 @@ function ChatListSkeleton({ count = 5 }: { count?: number }) {
 interface ChatItemProps {
   chat: { id: string; title: string; subtitle?: string; photoBase64?: string; photoMimeType?: string };
   onClick: () => void;
-  showDivider?: boolean;
 }
 
-function ChatItem({ chat, onClick, showDivider = true }: ChatItemProps) {
+function ChatItem({ chat, onClick }: ChatItemProps) {
   const avatarColor = getAvatarColor(chat.title);
   const firstLetter = getFirstLetter(chat.title);
 
   return (
-    <div className="px-4">
+    <div className="relative px-4">
       <button
         onClick={onClick}
-        className="flex items-center w-full py-2 active:opacity-80 transition-opacity text-left"
+        className="flex items-center w-full active:opacity-80 transition-opacity text-left"
       >
         {/* Avatar */}
-        <div className="pr-3">
+        <div className="pr-3 py-1.5">
           {chat.photoBase64 ? (
             <img
               src={`data:${chat.photoMimeType || "image/jpeg"};base64,${chat.photoBase64}`}
               alt={chat.title}
-              className="w-14 h-14 rounded-full object-cover"
+              className="w-12 h-12 rounded-full object-cover"
             />
           ) : (
             <div
-              className="w-14 h-14 rounded-full flex items-center justify-center"
+              className="w-12 h-12 rounded-full flex items-center justify-center"
               style={{ backgroundColor: avatarColor }}
             >
-              <span className="text-xl font-medium text-white">{firstLetter}</span>
+              <span className="text-lg font-medium text-white">{firstLetter}</span>
             </div>
           )}
         </div>
 
         {/* Title and Subtitle */}
-        <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-          <p className="text-base text-white leading-5 truncate">{chat.title}</p>
+        <div className="flex-1 min-w-0 flex flex-col gap-0.5 py-2.5">
+          <p className="text-base text-black font-medium leading-5 truncate">{chat.title}</p>
           {chat.subtitle && (
-            <p className="text-[13px] text-white/60 leading-4 truncate">
+            <p className="text-[13px] text-black/50 leading-4 truncate">
               {chat.subtitle}
             </p>
           )}
         </div>
       </button>
-      {showDivider && <div className="h-px bg-white/10 ml-[68px]" />}
+      {/* Separator */}
+      <div className="absolute bottom-0 right-0 left-[76px] h-px">
+        <div className="h-[0.33px] bg-black/12 w-full" />
+      </div>
     </div>
   );
 }
 
 // Tab types
-type TabId = "groups" | "direct" | "spam";
+type TabId = "groups" | "direct" | "personal" | "work";
 
 interface Tab {
   id: TabId;
   label: string;
   count: number;
-  hasDividerBefore?: boolean;
+  hasDividerAfter?: boolean;
 }
 
 // Tab data will be computed dynamically
 const getTabsData = (groupCount: number): Tab[] => [
-  { id: "groups", label: "Groups", count: groupCount },
-  // TEMPORARILY HIDDEN - Re-enable when real data is available
-  // { id: "direct", label: "Direct", count: MOCK_DIRECT_CHATS.length, hasDividerBefore: true },
-  // { id: "spam", label: "Spam", count: MOCK_SPAM_CHATS.length },
+  { id: "groups", label: "Groups", count: groupCount, hasDividerAfter: true },
+  { id: "direct", label: "Direct", count: 0 },
+  { id: "personal", label: "Personal", count: 0 },
+  { id: "work", label: "Work", count: 0 },
 ];
 
 
@@ -155,14 +152,14 @@ interface EmptyStateBannerProps {
 function EmptyStateBanner({ onClose, onConnectChats }: EmptyStateBannerProps) {
   return (
     <div className="px-3 pt-1 pb-2">
-      <div className="relative bg-white/[0.06] rounded-2xl overflow-hidden pl-4 pr-11 py-4">
+      <div className="relative bg-black/[0.04] rounded-2xl overflow-hidden pl-4 pr-11 py-4">
         <div className="flex flex-col gap-3">
           {/* Text Content */}
           <div className="flex flex-col gap-0.5">
-            <p className="text-base font-medium text-white leading-5 tracking-[-0.18px]">
+            <p className="text-base font-medium text-black leading-5 tracking-[-0.18px]">
               No summarized chats yet
             </p>
-            <p className="text-[13px] text-white/60 leading-[18px] tracking-[-0.08px]">
+            <p className="text-[13px] text-black/50 leading-[18px] tracking-[-0.08px]">
               Connect your Telegram groups to start getting summaries here.
             </p>
           </div>
@@ -171,9 +168,9 @@ function EmptyStateBanner({ onClose, onConnectChats }: EmptyStateBannerProps) {
           <div>
             <button
               onClick={onConnectChats}
-              className="bg-white/[0.06] backdrop-blur-xl rounded-full px-4 py-2 active:opacity-80 transition-opacity"
+              className="bg-black/[0.06] rounded-full px-4 py-2 active:opacity-80 transition-opacity"
             >
-              <span className="text-sm font-medium text-white leading-5">
+              <span className="text-sm font-medium text-black leading-5">
                 Connect Chats
               </span>
             </button>
@@ -185,34 +182,8 @@ function EmptyStateBanner({ onClose, onConnectChats }: EmptyStateBannerProps) {
           onClick={onClose}
           className="absolute top-2 right-2 p-1 active:opacity-80 transition-opacity"
         >
-          <X size={24} strokeWidth={1.5} className="text-white/60" />
+          <X size={24} strokeWidth={1.5} className="text-black/40" />
         </button>
-      </div>
-    </div>
-  );
-}
-
-interface TooltipProps {
-  text: string;
-  color: string;
-}
-
-function Tooltip({ text, color }: TooltipProps) {
-  return (
-    <div className="absolute top-full right-0 mt-2.5 z-20">
-      {/* Tail/Arrow - centered under the ? icon (button is ~48px, center at 24px) */}
-      <div className="absolute -top-2 right-[18px] w-4 h-2 overflow-hidden">
-        <div
-          className="w-4 h-4 rotate-45 origin-bottom-left"
-          style={{ backgroundColor: color }}
-        />
-      </div>
-      {/* Tooltip Body */}
-      <div
-        className="rounded-xl p-2.5 shadow-[0px_0px_4px_0px_rgba(0,0,0,0.04),0px_4px_32px_0px_rgba(0,0,0,0.16)]"
-        style={{ backgroundColor: color }}
-      >
-        <p className="text-[13px] text-white leading-4 text-center whitespace-nowrap">{text}</p>
       </div>
     </div>
   );
@@ -228,14 +199,11 @@ export default function SummariesPage() {
   const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
 
   const [isBannerDismissed, setIsBannerDismissed] = useState(false);
-  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const [activeTab, setActiveTab] = useState<TabId>(() => {
     // Initialize from localStorage, default to "groups"
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem(ACTIVE_TAB_STORAGE_KEY);
-      // TEMPORARILY SIMPLIFIED - Re-enable when Direct/Spam are back
-      // if (saved === "groups" || saved === "direct" || saved === "spam") {
-      if (saved === "groups") {
+      if (saved === "groups" || saved === "direct" || saved === "personal" || saved === "work") {
         return saved;
       }
     }
@@ -243,16 +211,8 @@ export default function SummariesPage() {
   });
   const [isConnectBotModalOpen, setIsConnectBotModalOpen] = useState(false);
   const [swipeDirection, setSwipeDirection] = useState<1 | -1>(1); // 1 = from right, -1 = from left
-  const tooltipRef = useRef<HTMLDivElement>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const [buttonColor] = useState(() => {
-    try {
-      return themeParams.buttonColor() || "#2990ff";
-    } catch {
-      return "#2990ff";
-    }
-  });
   const [groupChats, setGroupChats] = useState<GroupChat[]>([]);
   const [isGroupsLoading, setIsGroupsLoading] = useState(true);
   const { summaries: cachedSummaries, setSummaries, hasCachedData } = useSummaries();
@@ -322,13 +282,7 @@ export default function SummariesPage() {
 
   // Get tabs data and current chat list based on active tab
   const tabs = getTabsData(groupChats.length);
-  // TEMPORARILY SIMPLIFIED - Re-enable when Direct/Spam are back
-  const currentChatList = groupChats;
-  // const currentChatList = activeTab === "groups"
-  //   ? groupChats
-  //   : activeTab === "direct"
-  //     ? MOCK_DIRECT_CHATS
-  //     : MOCK_SPAM_CHATS;
+  const currentChatList = activeTab === "groups" ? groupChats : [];
 
   // Save active tab to localStorage when it changes
   useEffect(() => {
@@ -340,7 +294,7 @@ export default function SummariesPage() {
     if (activeTab === "groups") {
       setIsLoading(isGroupsLoading);
     } else {
-      // Brief delay for mock data tabs for smooth transition
+      // Brief delay for placeholder tabs for smooth transition
       setIsLoading(true);
       const timer = setTimeout(() => setIsLoading(false), 150);
       return () => clearTimeout(timer);
@@ -351,9 +305,7 @@ export default function SummariesPage() {
   const handleSwipe = useCallback(
     (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
       const SWIPE_THRESHOLD = 50;
-      // TEMPORARILY SIMPLIFIED - Re-enable when Direct/Spam are back
-      const tabOrder: TabId[] = ["groups"];
-      // const tabOrder: TabId[] = ["groups", "direct", "spam"];
+      const tabOrder: TabId[] = ["groups", "direct", "personal", "work"];
       const currentIndex = tabOrder.indexOf(activeTab);
 
       if (info.offset.x < -SWIPE_THRESHOLD && currentIndex < tabOrder.length - 1) {
@@ -375,30 +327,6 @@ export default function SummariesPage() {
     [activeTab]
   );
 
-  // Close tooltip when clicking outside
-  useEffect(() => {
-    if (!isTooltipVisible) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        tooltipRef.current &&
-        !tooltipRef.current.contains(event.target as Node)
-      ) {
-        setIsTooltipVisible(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isTooltipVisible]);
-
-  const handleHelpClick = () => {
-    if (hapticFeedback.impactOccurred.isAvailable()) {
-      hapticFeedback.impactOccurred("light");
-    }
-    setIsTooltipVisible((prev) => !prev);
-  };
-
   const handleChatClick = (chat: { id: string; title: string; subtitle?: string; messageCount?: number }) => {
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
@@ -410,7 +338,7 @@ export default function SummariesPage() {
       return;
     }
 
-    // Direct and Spam tabs: navigate to DirectFeed page (horizontal swipe)
+    // Direct and other tabs: navigate to DirectFeed page (horizontal swipe)
     router.push(`/telegram/summaries/direct?chatId=${chat.id}&tab=${activeTab}`);
   };
 
@@ -428,62 +356,32 @@ export default function SummariesPage() {
     // TODO: Navigate to connect chats flow
   };
 
-  const handleConnectBot = () => {
-    if (hapticFeedback.impactOccurred.isAvailable()) {
-      hapticFeedback.impactOccurred("medium");
-    }
-    setIsConnectBotModalOpen(true);
-  };
-
   return (
     <main
-      className="text-white font-sans overflow-y-auto relative flex flex-col"
-      style={{ background: "#000", height: `calc(100vh - ${headerHeight}px)` }}
+      className="text-foreground font-sans overflow-y-auto relative flex flex-col"
+      style={{ background: "#fff", height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Header - fixed at top */}
       <div
         className="sticky top-0 z-10"
-        style={{ background: "#000" }}
+        style={{ background: "#fff" }}
       >
-        <div className="flex items-center pl-4 pr-1.5">
-          <div className="flex-1 py-3 pr-3">
-            <h1 className="text-xl font-semibold text-white leading-6">Chat Highlights</h1>
-          </div>
-          <div className="h-12 flex items-center relative" ref={tooltipRef}>
-            <button className="p-2.5" onClick={handleHelpClick}>
-              <CircleHelp
-                size={28}
-                strokeWidth={1.5}
-                className="text-white opacity-40"
-              />
-            </button>
-            {isTooltipVisible && (
-              <Tooltip
-                text="These are your Telegram chats that have summaries available."
-                color={buttonColor}
-              />
-            )}
+        <div className="flex items-center px-4">
+          <div className="flex-1 py-3">
+            <h1 className="text-[22px] font-semibold text-black leading-7">Chat Highlights</h1>
           </div>
         </div>
 
         {/* Tabs */}
-        <div className="flex pl-4 border-b border-white/10">
+        <div className="flex pl-4 border-b border-black/10">
           {tabs.map((tab, index) => (
             <div key={tab.id} className="flex items-center">
-              {/* Vertical divider before tab if specified */}
-              {tab.hasDividerBefore && (
-                <div className="flex items-center self-stretch px-2">
-                  <div className="w-px h-5 bg-white/20 rounded-[1px]" />
-                </div>
-              )}
               <button
                 onClick={() => {
                   if (hapticFeedback.impactOccurred.isAvailable()) {
                     hapticFeedback.impactOccurred("light");
                   }
-                  // TEMPORARILY SIMPLIFIED - Re-enable when Direct/Spam are back
-                  const tabOrder: TabId[] = ["groups"];
-                  // const tabOrder: TabId[] = ["groups", "direct", "spam"];
+                  const tabOrder: TabId[] = ["groups", "direct", "personal", "work"];
                   const currentIndex = tabOrder.indexOf(activeTab);
                   const targetIndex = tabOrder.indexOf(tab.id);
                   setSwipeDirection(targetIndex > currentIndex ? 1 : -1);
@@ -491,25 +389,28 @@ export default function SummariesPage() {
                 }}
                 className={`flex items-center gap-1.5 pr-4 pb-2.5 pt-1 relative transition-colors ${
                   index > 0 ? "pl-4" : ""
-                } ${activeTab === tab.id ? "text-white" : "text-white/60"}`}
+                } ${activeTab === tab.id ? "text-black" : "text-black/40"}`}
               >
                 <span className="text-base font-medium leading-5 tracking-[-0.176px]">{tab.label}</span>
                 {tab.count > 0 && (
-                  <span
-                    className="text-xs font-medium leading-4 px-1.5 py-0.5 rounded-full text-white"
-                    style={{ backgroundColor: buttonColor }}
-                  >
+                  <span className="min-w-5 h-5 flex items-center justify-center text-xs font-medium rounded-full text-white bg-[#FF3B30] px-1.5">
                     {tab.count}
                   </span>
                 )}
                 {activeTab === tab.id && (
                   <div
-                    className={`absolute bottom-0 right-3 h-[3px] rounded-t-[4px] rounded-b-[1px] bg-white ${
+                    className={`absolute bottom-0 right-3 h-[3px] rounded-t-[4px] rounded-b-[1px] bg-black ${
                       index > 0 ? "left-3" : "left-0"
                     }`}
                   />
                 )}
               </button>
+              {/* Vertical divider after tab if specified */}
+              {tab.hasDividerAfter && (
+                <div className="flex items-center self-stretch px-2">
+                  <div className="w-px h-5 bg-black/15 rounded-[1px]" />
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -529,11 +430,6 @@ export default function SummariesPage() {
       >
         {isLoading ? (
           <div className="flex-1 flex flex-col pt-2 pb-4">
-            {/* TEMPORARILY HIDDEN - Re-enable when Direct/Spam are back */}
-            {/* {(activeTab === "direct" || activeTab === "spam") && (
-              <ConnectBotBanner onConnectBot={handleConnectBot} />
-            )} */}
-
             <ChatListSkeleton count={5} />
 
             {/* Bottom padding for navigation */}
@@ -550,17 +446,11 @@ export default function SummariesPage() {
           </div>
         ) : (
           <div className="flex-1 flex flex-col pt-2 pb-4">
-            {/* TEMPORARILY HIDDEN - Re-enable when Direct/Spam are back */}
-            {/* {(activeTab === "direct" || activeTab === "spam") && (
-              <ConnectBotBanner onConnectBot={handleConnectBot} />
-            )} */}
-
-            {currentChatList.map((chat, index) => (
+            {currentChatList.map((chat) => (
               <ChatItem
                 key={chat.id}
                 chat={chat}
                 onClick={() => handleChatClick(chat)}
-                showDivider={index < currentChatList.length - 1}
               />
             ))}
 


### PR DESCRIPTION
## Overview
Redesigned the Chat Highlights page with significant visual and structural updates:

- Converted page from dark to light theme
- Expanded tab system from single Groups tab to four tabs (Groups, Direct, Personal, Work)
- Updated color scheme, typography, and layout
- Removed unused code and simplified components

## Key Changes
- Switched global backgrounds and text colors to light theme
- Updated badge styling with fixed red color
- Adjusted avatar sizes and font weights
- Added vertical dividers and hairline separators
- Cleaned up unused imports and code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Personal" and "Work" tabs to organize conversations by category.

* **Style**
  * Refreshed chat list UI with darker color scheme and updated typography.
  * Adjusted avatar sizing and chat item spacing for improved readability.
  * Updated tab bar styling with refined active tab indicator.
  * Removed tooltip UI from header for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->