### PR TITLE
feat(wallet): update balance to calculate total asset portfolio

### DIFF
--- a/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
+++ b/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
@@ -118,7 +118,9 @@ export async function fetchTokenHoldings(
   }
 
   const inflight = inflightRequests.get(publicKey);
-  if (!forceRefresh && inflight) {
+  // Coalesce concurrent requests even if a force refresh is requested.
+  // Force refresh still bypasses the TTL check above.
+  if (inflight) {
     return inflight;
   }
 

--- a/app/src/lib/solana/token-holdings/index.ts
+++ b/app/src/lib/solana/token-holdings/index.ts
@@ -4,9 +4,11 @@ import {
   NATIVE_SOL_MINT,
 } from "./constants";
 import { fetchTokenHoldings } from "./fetch-token-holdings";
+import { computePortfolioTotals } from "./portfolio";
 import type { TokenHolding } from "./types";
 
 export {
+  computePortfolioTotals,
   DEFAULT_TOKEN_ICON,
   fetchTokenHoldings,
   KNOWN_TOKEN_ICONS,

--- a/app/src/lib/solana/token-holdings/portfolio.ts
+++ b/app/src/lib/solana/token-holdings/portfolio.ts
@@ -1,0 +1,88 @@
+import { SOL_PRICE_USD } from "@/lib/constants";
+
+import { NATIVE_SOL_MINT } from "./constants";
+import type { TokenHolding } from "./types";
+
+export type PortfolioTotals = {
+  totalUsd: number;
+  totalSol: number | null;
+  pricedCount: number;
+  unpricedCount: number;
+  effectiveSolPriceUsd: number | null;
+};
+
+function floorToDecimals(value: number, decimals: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const factor = Math.pow(10, decimals);
+  return Math.floor(value * factor) / factor;
+}
+
+function getEffectiveSolPriceUsd(
+  holdings: TokenHolding[],
+  fallbackSolPriceUsd: number | null
+): number | null {
+  const solHolding = holdings.find((h) => h.mint === NATIVE_SOL_MINT);
+  const fromHoldings = solHolding?.priceUsd;
+  const candidate =
+    (typeof fromHoldings === "number" && Number.isFinite(fromHoldings)
+      ? fromHoldings
+      : null) ??
+    (typeof fallbackSolPriceUsd === "number" && Number.isFinite(fallbackSolPriceUsd)
+      ? fallbackSolPriceUsd
+      : null) ??
+    (typeof SOL_PRICE_USD === "number" && Number.isFinite(SOL_PRICE_USD)
+      ? SOL_PRICE_USD
+      : null);
+
+  return candidate;
+}
+
+function holdingUsdValue(holding: TokenHolding): number | null {
+  if (typeof holding.valueUsd === "number" && Number.isFinite(holding.valueUsd)) {
+    return holding.valueUsd;
+  }
+  if (typeof holding.priceUsd === "number" && Number.isFinite(holding.priceUsd)) {
+    const value = holding.balance * holding.priceUsd;
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+export function computePortfolioTotals(
+  holdings: TokenHolding[],
+  fallbackSolPriceUsd: number | null
+): PortfolioTotals {
+  let totalUsd = 0;
+  let pricedCount = 0;
+  let unpricedCount = 0;
+
+  for (const holding of holdings) {
+    const value = holdingUsdValue(holding);
+    if (value === null) {
+      unpricedCount++;
+      continue;
+    }
+    pricedCount++;
+    totalUsd += value;
+  }
+
+  totalUsd = floorToDecimals(totalUsd, 2);
+
+  const effectiveSolPriceUsd = getEffectiveSolPriceUsd(
+    holdings,
+    fallbackSolPriceUsd
+  );
+  const totalSol =
+    effectiveSolPriceUsd && effectiveSolPriceUsd > 0
+      ? floorToDecimals(totalUsd / effectiveSolPriceUsd, 4)
+      : null;
+
+  return {
+    totalUsd,
+    totalSol,
+    pricedCount,
+    unpricedCount,
+    effectiveSolPriceUsd,
+  };
+}
+

--- a/app/src/lib/solana/wallet/subscribe-wallet-asset-changes.ts
+++ b/app/src/lib/solana/wallet/subscribe-wallet-asset-changes.ts
@@ -1,0 +1,127 @@
+import { type GetProgramAccountsFilter, PublicKey } from "@solana/web3.js";
+
+import { getWebsocketConnection } from "../rpc/connection";
+
+// SPL Token programs
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+);
+const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+);
+
+export type SubscribeWalletAssetChangesOptions = {
+  commitment?: "processed" | "confirmed" | "finalized";
+  debounceMs?: number;
+  /**
+   * Subscribe to the wallet's native SOL account changes.
+   * If the caller already subscribes to balance elsewhere, disable to avoid duplicate websocket listeners.
+   */
+  includeNative?: boolean;
+};
+
+/**
+ * Subscribes to changes that can impact a wallet's portfolio:
+ * - Native SOL (wallet system account, optional)
+ * - SPL token accounts owned by the wallet (Token + Token-2022)
+ *
+ * Emits debounced `onChange()` calls to avoid refetch storms.
+ */
+export async function subscribeToWalletAssetChanges(
+  walletAddress: string,
+  onChange: () => void,
+  options: SubscribeWalletAssetChangesOptions = {}
+): Promise<() => Promise<void>> {
+  const walletPubkey = new PublicKey(walletAddress);
+  const connection = getWebsocketConnection();
+
+  const commitment = options.commitment ?? "confirmed";
+  const debounceMs = options.debounceMs ?? 750;
+  const includeNative = options.includeNative ?? true;
+
+  let closed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pending = false;
+
+  const emit = () => {
+    if (closed) return;
+
+    if (debounceMs <= 0) {
+      try {
+        onChange();
+      } catch (err) {
+        console.error("Error in wallet asset change handler", err);
+      }
+      return;
+    }
+
+    if (timer) clearTimeout(timer);
+    pending = true;
+    timer = setTimeout(() => {
+      timer = null;
+      if (closed) return;
+      if (!pending) return;
+      pending = false;
+      try {
+        onChange();
+      } catch (err) {
+        console.error("Error in wallet asset change handler", err);
+      }
+    }, debounceMs);
+  };
+
+  const ownerMemcmpFilter: GetProgramAccountsFilter = {
+    memcmp: {
+      // owner field offset in SPL Token account layout (both Token + Token-2022)
+      offset: 32,
+      bytes: walletPubkey.toBase58(),
+    },
+  };
+
+  // Classic SPL token accounts are fixed-size (165 bytes).
+  const tokenProgramFilters: GetProgramAccountsFilter[] = [
+    { dataSize: 165 },
+    ownerMemcmpFilter,
+  ];
+
+  // Token-2022 accounts can include extensions, so sizes vary. Filter only by owner.
+  const token2022ProgramFilters: GetProgramAccountsFilter[] = [
+    ownerMemcmpFilter,
+  ];
+
+  const accountSubId = includeNative
+    ? await connection.onAccountChange(walletPubkey, emit, commitment)
+    : null;
+
+  // SPL Token (Tokenkeg) accounts owned by wallet
+  const tokenSubId = await connection.onProgramAccountChange(
+    TOKEN_PROGRAM_ID,
+    emit,
+    commitment,
+    tokenProgramFilters
+  );
+
+  // SPL Token-2022 accounts owned by wallet
+  const token2022SubId = await connection.onProgramAccountChange(
+    TOKEN_2022_PROGRAM_ID,
+    emit,
+    commitment,
+    token2022ProgramFilters
+  );
+
+  return async () => {
+    closed = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+
+    await Promise.allSettled([
+      ...(accountSubId !== null
+        ? [connection.removeAccountChangeListener(accountSubId)]
+        : []),
+      connection.removeProgramAccountChangeListener(tokenSubId),
+      connection.removeProgramAccountChangeListener(token2022SubId),
+    ]);
+  };
+}


### PR DESCRIPTION
Replace SOL-only balance display with full portfolio totals across all token holdings, add WebSocket subscriptions for real-time asset change detection, and update docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time wallet asset change detection to trigger holdings updates automatically when account balances or token positions change.
  * Introduced portfolio calculation utilities to compute total USD value and total SOL balance from token holdings with configurable price fallback logic.

* **Documentation**
  * Updated API reference with new wallet subscription and portfolio calculation features, including usage examples and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->