### PR TITLE
feat(wallet): show SPL token transfers in activity

### DIFF
--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -746,6 +746,9 @@ export default function Home() {
         type: transaction.type === "incoming" ? "incoming" : "outgoing",
         amountLamports: transaction.amountLamports,
         transferType: transaction.transferType,
+        tokenMint: transaction.tokenMint,
+        tokenAmount: transaction.tokenAmount,
+        tokenDecimals: transaction.tokenDecimals,
         recipient: transaction.recipient,
         recipientUsername,
         sender: transaction.sender,
@@ -952,6 +955,9 @@ export default function Home() {
         type: isIncoming ? "incoming" : "outgoing",
         transferType: transfer.type,
         amountLamports: transfer.amountLamports,
+        tokenMint: transfer.tokenMint,
+        tokenAmount: transfer.tokenAmount,
+        tokenDecimals: transfer.tokenDecimals,
         sender: isIncoming ? counterparty : undefined,
         recipient: !isIncoming ? counterparty : undefined,
         timestamp: transfer.timestamp ?? Date.now(),
@@ -3379,6 +3385,7 @@ export default function Home() {
         showSuccess={showClaimSuccess}
         showError={claimError}
         solPriceUsd={solPriceUsd}
+        tokenHoldings={tokenHoldings}
         onShare={
           selectedTransaction?.transferType === "deposit_for_username"
             ? handleShareDepositTransaction
@@ -3400,6 +3407,7 @@ export default function Home() {
         walletTransactions={walletTransactions}
         incomingTransactions={incomingTransactions}
         onTransactionClick={handleOpenWalletTransactionDetails}
+        tokenHoldings={tokenHoldings}
         isLoading={
           (isFetchingTransactions && walletTransactions.length === 0) ||
           (isFetchingDeposits && incomingTransactions.length === 0)

--- a/app/src/lib/solana/rpc/types.ts
+++ b/app/src/lib/solana/rpc/types.ts
@@ -19,6 +19,10 @@ export type WalletTransfer = {
   feeLamports: number;
   status: "success" | "failed";
   counterparty?: string;
+  // Optional SPL token transfer fields (used when type === "transfer" and tx is a pure token transfer)
+  tokenMint?: string;
+  tokenAmount?: string; // human-readable (decimal-adjusted, truncated for display)
+  tokenDecimals?: number;
 };
 
 export type GetAccountTransactionHistoryOptions = {

--- a/app/src/lib/solana/token-holdings/resolve-token-info.ts
+++ b/app/src/lib/solana/token-holdings/resolve-token-info.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_TOKEN_ICON, KNOWN_TOKEN_ICONS } from "./constants";
+import type { TokenHolding } from "./types";
+
+const shortenMint = (mint: string): string =>
+  mint.length > 10 ? `${mint.slice(0, 4)}...${mint.slice(-4)}` : mint;
+
+export function resolveTokenInfo(
+  mint: string,
+  holdings: TokenHolding[]
+): { symbol: string; icon: string } {
+  const holding = holdings.find((h) => h.mint === mint);
+  const symbol = holding?.symbol?.trim() ? holding.symbol : shortenMint(mint);
+  const icon =
+    holding?.imageUrl ||
+    KNOWN_TOKEN_ICONS[mint] ||
+    DEFAULT_TOKEN_ICON;
+
+  return { symbol, icon };
+}

--- a/app/src/types/wallet.ts
+++ b/app/src/types/wallet.ts
@@ -12,6 +12,10 @@ export type Transaction = {
   networkFeeLamports?: number;
   signature?: string;
   transferType?: WalletTransfer["type"];
+  // Optional SPL token transfer fields
+  tokenMint?: string;
+  tokenAmount?: string;
+  tokenDecimals?: number;
   // For incoming transactions
   sender?: string;
   username?: string;
@@ -43,6 +47,10 @@ export type TransactionDetailsData = {
   type: "incoming" | "outgoing";
   amountLamports: number;
   transferType?: WalletTransfer["type"];
+  // Optional SPL token transfer fields
+  tokenMint?: string;
+  tokenAmount?: string;
+  tokenDecimals?: number;
   // For outgoing transactions
   recipient?: string;
   recipientUsername?: string;

--- a/docs/solana/README.md
+++ b/docs/solana/README.md
@@ -1,6 +1,6 @@
-# Solana Smart Contract Documentation
+# Solana Documentation
 
-Documentation for the Anchor programs in this project.
+Solana-related documentation for this project (Anchor programs + app/RPC integration).
 
 ## Programs
 
@@ -12,3 +12,4 @@ Documentation for the Anchor programs in this project.
 ## Quick Links
 
 - [Localnet Testing](./localnet-testing.md) - Step-by-step local development setup
+- [Wallet Activity + RPC Parsing](./wallet-activity.md) - How we derive SOL/SPL token activity from RPC transactions

--- a/docs/solana/wallet-activity.md
+++ b/docs/solana/wallet-activity.md
@@ -1,0 +1,74 @@
+# Wallet Activity + RPC Parsing
+
+This document describes how the app derives wallet activity (incoming/outgoing) from Solana RPC transactions, including SPL token transfers.
+
+## Data Flow (High Level)
+
+- `app/src/lib/solana/rpc/get-account-txn-history.ts` fetches parsed transactions via `getParsedTransactions(...)` and maps them to `WalletTransfer`.
+  - UI screens (activity list + transaction details) consume these transfers and render either:
+  - SOL transfers (lamports delta), or
+  - SPL token transfers (token balance delta), using `tokenMint/tokenAmount/tokenDecimals`.
+
+## `WalletTransfer` Shape
+
+`app/src/lib/solana/rpc/types.ts`:
+
+- Always present (core transfer data):
+  - `signature`, `slot`, `timestamp`
+  - `direction` (`in` | `out`)
+  - `amountLamports` (SOL transfers)
+  - `feeLamports`, `status`, `counterparty?`
+  - `type` (decoded program types like `deposit_for_username`, `claim_deposit`, etc, else `transfer`)
+- Optional (only for detected SPL token transfers):
+  - `tokenMint?: string`
+  - `tokenAmount?: string` (decimal-adjusted UI amount, truncated for display)
+  - `tokenDecimals?: number`
+
+Current behavior: when a transfer is classified as an SPL token transfer, `amountLamports` is set to `0` and token fields are set.
+
+## How SPL Token Transfers Are Detected
+
+Implementation: `findTokenBalanceChange(...)` in `app/src/lib/solana/rpc/get-account-txn-history.ts`.
+
+1. Read `meta.preTokenBalances` and `meta.postTokenBalances`.
+2. Filter balances down to token accounts belonging to the wallet:
+   - Preferred: `owner === walletAddress`
+   - Fallback (when `owner` is missing): treat the wallet's associated token account (ATA) as wallet-owned by re-deriving the ATA for `mint` and comparing.
+3. Sum balances by mint (multiple token accounts per mint are supported).
+4. Compute `delta = post - pre` for each mint and pick the mint with the largest absolute delta.
+5. Produce:
+   - `direction` from sign of delta
+   - `tokenMint`, `tokenDecimals`
+   - `tokenAmount` formatted from raw base units with truncation (currently max 4 fractional digits)
+
+## How Counterparty Is Inferred For SPL Transfers
+
+Implementation: `findSplTokenTransferCounterparty(...)` in `app/src/lib/solana/rpc/get-account-txn-history.ts`.
+
+- Scans top-level and inner instructions for parsed `spl-token` / `spl-token-2022` instructions of type `transfer` / `transferChecked`.
+- Determines whether the wallet token account is the `source` (outgoing) or `destination` (incoming).
+- Returns the counterparty owner if known from token balance metadata; otherwise returns the counterparty token account address.
+
+## UI Display Rules
+
+- `app/src/components/wallet/ActivitySheet.tsx`
+  - If `transaction.tokenMint` + `transaction.tokenAmount` exist, the row displays `tokenAmount` and token symbol instead of `SOL`.
+  - Token symbol/icon are resolved from `tokenHoldings` using `resolveTokenInfo(...)`:
+    - Uses holdings symbol/image when available
+    - Falls back to `KNOWN_TOKEN_ICONS` and finally `DEFAULT_TOKEN_ICON`
+- `app/src/components/wallet/TransactionDetailsSheet.tsx`
+  - If token transfer: show token symbol as main unit and compute USD from the matching holding's `priceUsd` (if present).
+  - Else: compute USD from `solPriceUsd`.
+
+## Token Icons (Fallback)
+
+If a token does not come back with an image URL, we fall back to a small known-icons map:
+
+- Update `app/src/lib/solana/token-holdings/constants.ts` (`KNOWN_TOKEN_ICONS`)
+- Add the image file under `app/public/tokens/`
+
+## Caveats / Known Limitations
+
+- Multi-token transactions (e.g. swaps) can change multiple mints; we currently select the single mint with the largest absolute balance delta.
+- Some transactions may include both SOL and SPL balance changes; for pure token transfers we display the token change and treat SOL as `amountLamports = 0`.
+- Counterparty inference is best-effort and can fall back to token account addresses when owner metadata is missing.


### PR DESCRIPTION
Show SPL token transfers (sends, receives, swaps) alongside SOL transactions in the wallet activity feed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SPL token transfers now display in wallet activity with token icons, symbols, and amounts
  * Token-specific USD price calculations for accurate valuations
  * Enhanced transaction details showing comprehensive token information

* **Documentation**
  * Added guide on wallet activity parsing for SOL and SPL token transfers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->