### PR TITLE
feat(ui): replace Telegram native buttons with custom pill buttons

### DIFF
--- a/app/src/components/telegram/BottomButtonBar.tsx
+++ b/app/src/components/telegram/BottomButtonBar.tsx
@@ -5,8 +5,8 @@ import { createPortal } from "react-dom";
 
 import {
   type ButtonBarState,
-  type SingleButtonState,
   getButtonStateSnapshot,
+  type SingleButtonState,
   subscribeButtonState,
 } from "@/lib/telegram/mini-app/buttons";
 

--- a/app/src/components/telegram/BottomButtonBar.tsx
+++ b/app/src/components/telegram/BottomButtonBar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  type ButtonBarState,
+  type SingleButtonState,
+  getButtonStateSnapshot,
+  subscribeButtonState,
+} from "@/lib/telegram/mini-app/buttons";
+
+export const BUTTON_BAR_ID = "bottom-button-bar";
+
+function PillButton({ state }: { state: SingleButtonState }) {
+  return (
+    <button
+      type="button"
+      disabled={!state.isEnabled}
+      onClick={state.onClick ?? undefined}
+      className="pointer-events-auto flex h-[50px] min-w-[50px] flex-1 items-center justify-center overflow-hidden rounded-[78px] px-3 active:opacity-80"
+      style={{
+        backgroundColor: state.isEnabled ? "#000000" : "#d0d0d2",
+      }}
+    >
+      {state.showLoader ? (
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+      ) : (
+        <span className="text-[17px] leading-[22px] text-white whitespace-nowrap">
+          {state.text}
+        </span>
+      )}
+    </button>
+  );
+}
+
+const emptyState: ButtonBarState = { main: null, secondary: null };
+const getServerSnapshot = () => emptyState;
+
+export function BottomButtonBar() {
+  const state = useSyncExternalStore(
+    subscribeButtonState,
+    getButtonStateSnapshot,
+    getServerSnapshot
+  );
+
+  const hasButtons = !!(state.main || state.secondary);
+
+  return createPortal(
+    <div
+      id={BUTTON_BAR_ID}
+      className="pointer-events-none fixed bottom-0 left-0 right-0 z-[10000]"
+      style={{ display: hasButtons ? "flex" : "none" }}
+    >
+      <div
+        className="pointer-events-none flex w-full gap-2 px-8 pb-6 pt-4"
+        style={{
+          background:
+            "linear-gradient(to bottom, rgba(255,255,255,0), white 40%)",
+          paddingBottom:
+            "calc(max(24px, var(--tg-content-safe-area-inset-bottom, 0px)) + 8px)",
+        }}
+      >
+        {state.secondary && <PillButton state={state.secondary} />}
+        {state.main && <PillButton state={state.main} />}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/src/components/telegram/TelegramProvider.tsx
+++ b/app/src/components/telegram/TelegramProvider.tsx
@@ -22,6 +22,8 @@ import {
   type UserData,
 } from '@/lib/telegram/mini-app/init-data-transform';
 
+import { BottomButtonBar } from './BottomButtonBar';
+
 // Patch console.error to suppress specific Telegram SDK errors
 if (typeof window !== 'undefined') {
   const originalError = console.error;
@@ -163,6 +165,7 @@ function TelegramProviderInner({ children }: PropsWithChildren) {
       value={{ userData, cachedAvatar, setCachedAvatar, isAvatarLoading }}
     >
       {children}
+      <BottomButtonBar />
     </TelegramUserContext.Provider>
   );
 }

--- a/app/src/components/wallet/ActivitySheet.tsx
+++ b/app/src/components/wallet/ActivitySheet.tsx
@@ -2,8 +2,6 @@
 
 import { hapticFeedback } from "@telegram-apps/sdk-react";
 import { ArrowDown, X } from "lucide-react";
-
-import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import Image from "next/image";
 import {
   useCallback,
@@ -21,6 +19,7 @@ import {
   formatSenderAddress,
   formatTransactionAmount,
 } from "@/lib/solana/wallet/formatters";
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import type { IncomingTransaction, Transaction } from "@/types/wallet";
 
 const ITEMS_PER_PAGE = 10;

--- a/app/src/components/wallet/ActivitySheet.tsx
+++ b/app/src/components/wallet/ActivitySheet.tsx
@@ -2,6 +2,8 @@
 
 import { hapticFeedback } from "@telegram-apps/sdk-react";
 import { ArrowDown, X } from "lucide-react";
+
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import Image from "next/image";
 import {
   useCallback,
@@ -187,6 +189,7 @@ export default function ActivitySheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
 
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
@@ -334,7 +337,7 @@ export default function ActivitySheet({
           ref={scrollContainerRef}
           onScroll={handleScroll}
           className="flex-1 overflow-y-auto overscroll-contain"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {isLoading ? (
             <div className="flex flex-col px-4">

--- a/app/src/components/wallet/BalanceBackgroundPicker.tsx
+++ b/app/src/components/wallet/BalanceBackgroundPicker.tsx
@@ -379,7 +379,7 @@ export default function BalanceBackgroundPicker({
         {/* Content */}
         <div
           className="flex-1 flex flex-col overflow-hidden"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {/* Preview Card */}
           <div className="px-4 pt-2 pb-6">

--- a/app/src/components/wallet/ReceiveSheet.tsx
+++ b/app/src/components/wallet/ReceiveSheet.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { hapticFeedback, shareURL } from "@telegram-apps/sdk-react";
+
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import { X } from "lucide-react";
 import Image from "next/image";
 import QRCodeLib from "qrcode";
@@ -266,6 +268,7 @@ export default function ReceiveSheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
     }
@@ -442,7 +445,7 @@ export default function ReceiveSheet({
         {/* Content — scrollable */}
         <div
           className="flex-1 overflow-y-auto overscroll-contain"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           <div className="flex flex-col items-center pt-8">
             {/* Solana Icon */}

--- a/app/src/components/wallet/ReceiveSheet.tsx
+++ b/app/src/components/wallet/ReceiveSheet.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { hapticFeedback, shareURL } from "@telegram-apps/sdk-react";
-
-import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import { X } from "lucide-react";
 import Image from "next/image";
 import QRCodeLib from "qrcode";
@@ -16,6 +14,7 @@ import { createPortal } from "react-dom";
 
 import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
 import { getWalletPublicKey } from "@/lib/solana/wallet/wallet-details";
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 
 // iOS-style sheet timing (shared with TokensSheet)
 const SHEET_TRANSITION = "transform 0.4s cubic-bezier(0.32, 0.72, 0, 1)";

--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -2,8 +2,6 @@
 
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { hapticFeedback, openTelegramLink, retrieveLaunchParams } from "@telegram-apps/sdk-react";
-
-import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import {
   ArrowLeft,
   Search,
@@ -30,6 +28,7 @@ import {
 } from "@/lib/constants";
 import { fetchSolUsdPrice } from "@/lib/solana/fetch-sol-price";
 import type { TokenHolding } from "@/lib/solana/token-holdings/types";
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import {
   getCloudValue,
   setCloudValue,

--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -2,6 +2,8 @@
 
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { hapticFeedback, openTelegramLink, retrieveLaunchParams } from "@telegram-apps/sdk-react";
+
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import {
   ArrowLeft,
   Search,
@@ -554,6 +556,7 @@ export default function SendSheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
     }
@@ -764,7 +767,7 @@ export default function SendSheet({
         {/* Steps Container with Slide Animation */}
         <div
           className="relative flex-1 overflow-hidden"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {/* STEP 1: TOKEN SELECTION */}
           <div

--- a/app/src/components/wallet/SwapSheet.tsx
+++ b/app/src/components/wallet/SwapSheet.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { hapticFeedback, retrieveLaunchParams } from "@telegram-apps/sdk-react";
+
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import {
   ArrowDownUp,
   ArrowLeft,
@@ -660,6 +662,7 @@ export default function SwapSheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
     }
@@ -884,7 +887,7 @@ export default function SwapSheet({
         {/* Content Container */}
         <div
           className="relative flex-1 overflow-hidden"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {/* MAIN VIEW */}
           <div

--- a/app/src/components/wallet/SwapSheet.tsx
+++ b/app/src/components/wallet/SwapSheet.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { hapticFeedback, retrieveLaunchParams } from "@telegram-apps/sdk-react";
-
-import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import {
   ArrowDownUp,
   ArrowLeft,
@@ -29,6 +27,7 @@ import {
   NATIVE_SOL_MINT,
   type TokenHolding,
 } from "@/lib/solana/token-holdings";
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 
 // iOS-style sheet timing (shared with other sheets)
 const SHEET_TRANSITION = "transform 0.4s cubic-bezier(0.32, 0.72, 0, 1)";

--- a/app/src/components/wallet/TokensSheet.tsx
+++ b/app/src/components/wallet/TokensSheet.tsx
@@ -2,8 +2,6 @@
 
 import { hapticFeedback } from "@telegram-apps/sdk-react";
 import { Search, X } from "lucide-react";
-
-import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import Image from "next/image";
 import {
   useCallback,
@@ -16,6 +14,7 @@ import { createPortal } from "react-dom";
 
 import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
 import type { TokenHolding } from "@/lib/solana/token-holdings/types";
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 
 export type TokensSheetProps = {
   open?: boolean;

--- a/app/src/components/wallet/TokensSheet.tsx
+++ b/app/src/components/wallet/TokensSheet.tsx
@@ -2,6 +2,8 @@
 
 import { hapticFeedback } from "@telegram-apps/sdk-react";
 import { Search, X } from "lucide-react";
+
+import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
 import Image from "next/image";
 import {
   useCallback,
@@ -95,6 +97,7 @@ export default function TokensSheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
 
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
@@ -269,7 +272,7 @@ export default function TokensSheet({
         {/* Token List - scrollable */}
         <div
           className="flex-1 overflow-y-auto overscroll-contain"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {filteredTokens.map((token) => (
             <div

--- a/app/src/components/wallet/TransactionDetailsSheet.tsx
+++ b/app/src/components/wallet/TransactionDetailsSheet.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/solana/wallet/formatters";
 import { getWalletProvider } from "@/lib/solana/wallet/wallet-details";
 import {
+  hideAllButtons,
   hideMainButton,
   hideSecondaryButton,
   showMainButton,
@@ -248,6 +249,7 @@ export default function TransactionDetailsSheet({
   const closeSheet = useCallback(() => {
     if (isClosing.current) return;
     isClosing.current = true;
+    hideAllButtons();
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
     }
@@ -518,7 +520,7 @@ export default function TransactionDetailsSheet({
         {/* Content — scrollable */}
         <div
           className="flex-1 overflow-y-auto overscroll-contain"
-          style={{ paddingBottom: Math.max(safeBottom, 24) }}
+          style={{ paddingBottom: Math.max(safeBottom, 24) + 80 }}
         >
           {showError ? (
             /* Error View */


### PR DESCRIPTION
## Overview

- Replaced Telegram native MainButton/SecondaryButton with custom pill-styled buttons
- Implemented a reactive button bar using useSyncExternalStore
- Added immediate DOM visibility syncing and haptic-wrapped click handlers
- Mounted BottomButtonBar globally in TelegramProvider
- Added hideAllButtons() calls to sheet close paths
- Included extra bottom padding in sheet scroll containers
- Made minor fixes to wallet page async loading and development mocking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent bottom button bar for Telegram mini-apps with dynamic main/secondary buttons.

* **Improvements**
  * Buttons now reliably hide when sheets close, preventing lingering UI.
  * Increased bottom padding across wallet screens for better spacing with the new bar.
  * Wallet data refresh logic improved for more consistent balance/holdings updates during rapid interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->