### PR TITLE
fix(ui): sync header logo/balance crossfade and eliminate WebKit blink

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -10,15 +10,10 @@ export default function Header() {
     viewport.safeAreaInsetTop as Signal<number>
   );
   const [isScrolled, setIsScrolled] = useState(false);
-  const [logoOpacity, setLogoOpacity] = useState(1);
 
   useEffect(() => {
     const handleScroll = () => {
-      const y = window.scrollY;
-      setIsScrolled(y > 0);
-      // Fade logo out between 80–160px of scroll (when balance card exits viewport)
-      const opacity = y < 80 ? 1 : y > 160 ? 0 : 1 - (y - 80) / 80;
-      setLogoOpacity(opacity);
+      setIsScrolled(window.scrollY > 0);
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });
@@ -44,8 +39,8 @@ export default function Header() {
         priority
         style={{
           marginTop: -4,
-          opacity: logoOpacity,
-          transition: "opacity 0.15s ease-out",
+          opacity: "var(--header-logo-opacity, 1)",
+          willChange: "opacity",
         }}
       />
       {/* Bottom border line - only visible when scrolled */}


### PR DESCRIPTION
## Changes

- Replaced framer-motion/IntersectionObserver sticky balance pill behavior with a scroll-driven CSS-opacity approach
- Synchronized header logo via CSS variable to eliminate WebKit blinking
- Used `getBoundingClientRect()` to compute opacity progress for balance pill
- Removed redundant state and handlers (logoOpacity and IntersectionObserver)
- Fixed layout issue with header on short pages
- Improved crossfade trigger point for balance card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adds a scroll-driven crossfade between the wallet balance pill and the header logo for smoother, more polished transitions.
  * Sticky balance pill now fades in/out instead of appearing/disappearing abruptly, improving readability during scroll.
  * Header logo opacity responds fluidly to scrolling for a cleaner visual experience.
* **Refactor**
  * Keeps the sticky balance pill mounted and controls visibility via opacity, reducing jank and improving touch/pointer interactions.
* **Chores**
  * Standardizes error log formatting without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->