### PR TITLE
feat(telegram): add notification controls with whitelist-only admin auth

### DIFF
--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -6,6 +6,7 @@ import {
   handleActivateCommunityCommand,
   handleCaCommand,
   handleDeactivateCommunityCommand,
+  handleNotificationsCommand,
   handleStartCommand,
   handleSummaryCommand,
 } from "@/lib/telegram/bot-api/commands";
@@ -15,6 +16,10 @@ import {
   handleCommunityMessage,
   handleGLoyalReaction,
 } from "@/lib/telegram/bot-api/message-handlers";
+import {
+  handleNotificationSettingsCallback,
+  NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX,
+} from "@/lib/telegram/bot-api/notification-settings";
 import {
   handleStartCarouselCallback,
   START_CAROUSEL_CALLBACK_DATA_REGEX,
@@ -37,11 +42,11 @@ bot.command("ca", async (ctx: CommandContext<Context>) => {
 });
 
 bot.command("activate_community", async (ctx: CommandContext<Context>) => {
-  await handleActivateCommunityCommand(ctx, bot);
+  await handleActivateCommunityCommand(ctx);
 });
 
 bot.command("deactivate_community", async (ctx: CommandContext<Context>) => {
-  await handleDeactivateCommunityCommand(ctx, bot);
+  await handleDeactivateCommunityCommand(ctx);
 });
 
 bot.command("summary", async (ctx: CommandContext<Context>) => {
@@ -54,12 +59,20 @@ bot.command("summary", async (ctx: CommandContext<Context>) => {
   });
 });
 
+bot.command("notifications", async (ctx: CommandContext<Context>) => {
+  await handleNotificationsCommand(ctx);
+});
+
 bot.on("inline_query", async (ctx) => {
   await handleInlineQuery(ctx as InlineQueryContext<Context>);
 });
 
 bot.callbackQuery(START_CAROUSEL_CALLBACK_DATA_REGEX, async (ctx) => {
   await handleStartCarouselCallback(ctx);
+});
+
+bot.callbackQuery(NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX, async (ctx) => {
+  await handleNotificationSettingsCallback(ctx);
 });
 
 // Keep this fallback at the end so unknown callback queries don't show

--- a/app/src/lib/core/schema.ts
+++ b/app/src/lib/core/schema.ts
@@ -74,8 +74,9 @@ export type EncryptedMessageContent = {
 // ============================================================================
 
 /**
- * Global admins whitelist - Telegram users who can activate communities.
- * Must be both in this table AND a Telegram group admin to activate.
+ * Global admins whitelist for privileged community actions.
+ * Users in this table can activate/deactivate communities and manage
+ * notification settings.
  */
 export const admins = pgTable(
   "admins",
@@ -118,7 +119,7 @@ export const users = pgTable(
 
 /**
  * Telegram group chats activated for message tracking.
- * Only users in the admins whitelist can activate communities.
+ * Privileged management actions are controlled by the admins whitelist.
  */
 export const communities = pgTable(
   "communities",

--- a/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
@@ -1,0 +1,181 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CommandContext, Context } from "grammy";
+
+import type { Community } from "@/lib/core/schema";
+
+mock.module("server-only", () => ({}));
+
+let mockDb: {
+  query: {
+    admins: { findFirst: () => Promise<{ id: string } | null> };
+    communities: { findFirst: () => Promise<Community | null> };
+  };
+  update: () => {
+    set: (values: Record<string, unknown>) => {
+      where: () => Promise<void>;
+    };
+  };
+};
+
+let getChatCalls = 0;
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+mock.module("../get-chat", () => ({
+  getChat: async () => {
+    getChatCalls += 1;
+    return {};
+  },
+}));
+
+mock.module("../get-file", () => ({
+  downloadTelegramFile: async () => ({
+    body: Buffer.from(""),
+    contentType: "image/jpeg",
+  }),
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: async () => "user-1",
+}));
+
+let handleActivateCommunityCommand: (
+  ctx: CommandContext<Context>
+) => Promise<void>;
+let handleDeactivateCommunityCommand: (
+  ctx: CommandContext<Context>
+) => Promise<void>;
+
+let adminResult: { id: string } | null;
+let communityResult: Community | null;
+let updateValuesCaptured: Array<Record<string, unknown>>;
+
+function createCommunity(overrides?: Partial<Community>): Community {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    chatId: BigInt("-1009876543210"),
+    chatTitle: "Test Community",
+    activatedBy: BigInt("123456789"),
+    isActive: true,
+    summaryNotificationsEnabled: true,
+    summaryNotificationTimeHours: 24,
+    summaryNotificationMessageCount: null,
+    isPublic: true,
+    settings: {},
+    activatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createCommandContext() {
+  const replyCalls: string[] = [];
+
+  const ctx = {
+    chat: {
+      id: -1009876543210,
+      title: "Test Community",
+      type: "supergroup",
+    },
+    deleteMessage: async () => true as const,
+    from: {
+      first_name: "Admin",
+      id: 777,
+      username: "admin_user",
+    },
+    reply: async (text: string) => {
+      replyCalls.push(text);
+      return {} as never;
+    },
+  } as unknown as CommandContext<Context>;
+
+  return { ctx, replyCalls };
+}
+
+describe("commands admin authorization", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../commands");
+    handleActivateCommunityCommand = loadedModule.handleActivateCommunityCommand;
+    handleDeactivateCommunityCommand = loadedModule.handleDeactivateCommunityCommand;
+  });
+
+  beforeEach(() => {
+    adminResult = null;
+    communityResult = null;
+    getChatCalls = 0;
+    updateValuesCaptured = [];
+
+    mockDb = {
+      query: {
+        admins: {
+          findFirst: async () => adminResult,
+        },
+        communities: {
+          findFirst: async () => communityResult,
+        },
+      },
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updateValuesCaptured.push(values);
+          return {
+            where: async () => {},
+          };
+        },
+      }),
+    };
+  });
+
+  test("activate succeeds for whitelisted user without requiring Telegram chat-admin check", async () => {
+    adminResult = { id: "admin-1" };
+    communityResult = createCommunity({ isActive: true });
+    const { ctx, replyCalls } = createCommandContext();
+
+    await handleActivateCommunityCommand(ctx);
+
+    expect(getChatCalls).toBe(1);
+    expect(updateValuesCaptured).toHaveLength(1);
+    expect(updateValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+    expect(replyCalls).toContain("Community is already activated. Data updated!");
+  });
+
+  test("activate rejects non-whitelisted user", async () => {
+    adminResult = null;
+    const { ctx, replyCalls } = createCommandContext();
+
+    await handleActivateCommunityCommand(ctx);
+
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(replyCalls).toEqual([
+      "You are not authorized to activate communities. Contact an administrator to be added to the whitelist.",
+    ]);
+  });
+
+  test("deactivate succeeds for whitelisted user without requiring Telegram chat-admin check", async () => {
+    adminResult = { id: "admin-1" };
+    communityResult = createCommunity({ isActive: true });
+    const { ctx, replyCalls } = createCommandContext();
+
+    await handleDeactivateCommunityCommand(ctx);
+
+    expect(updateValuesCaptured).toHaveLength(1);
+    expect(updateValuesCaptured[0]?.isActive).toBe(false);
+    expect(updateValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+    expect(replyCalls).toContain(
+      "Community deactivated. Message tracking has been disabled."
+    );
+  });
+
+  test("deactivate rejects non-whitelisted user", async () => {
+    adminResult = null;
+    const { ctx, replyCalls } = createCommandContext();
+
+    await handleDeactivateCommunityCommand(ctx);
+
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(replyCalls).toEqual([
+      "You are not authorized to deactivate communities. Contact an administrator to be added to the whitelist.",
+    ]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
@@ -1,0 +1,380 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CallbackQueryContext, Context } from "grammy";
+
+import type { Community } from "@/lib/core/schema";
+
+let mockDb: {
+  query: {
+    admins: { findFirst: () => Promise<{ id: string } | null> };
+    communities: { findFirst: () => Promise<Community | null> };
+  };
+  update: () => {
+    set: (values: Record<string, unknown>) => {
+      where: () => Promise<void>;
+    };
+  };
+};
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+let NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX: RegExp;
+let OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT: string;
+let UNAUTHORIZED_NOTIFICATION_SETTINGS_ALERT_TEXT: string;
+let buildNotificationSettingsKeyboard: (community: Community) => {
+  inline_keyboard: Array<
+    Array<{ callback_data?: string; text?: string; url?: string }>
+  >;
+};
+let buildNotificationSettingsUpdateValues: (callbackData: {
+  communityId: string;
+  dimension: "time" | "msg" | "master";
+  value: "off" | "on" | 24 | 48 | 500 | 1000;
+}) => {
+  summaryNotificationMessageCount?: 500 | 1000 | null;
+  summaryNotificationTimeHours?: 24 | 48 | null;
+  summaryNotificationsEnabled?: boolean;
+  updatedAt: Date;
+};
+let encodeNotificationSettingsCallbackData: (callbackData: {
+  communityId: string;
+  dimension: "time" | "msg" | "master";
+  value: "off" | "on" | 24 | 48 | 500 | 1000;
+}) => string;
+let handleNotificationSettingsCallback: (
+  ctx: CallbackQueryContext<Context>
+) => Promise<void>;
+let parseNotificationSettingsCallbackData: (
+  data: string
+) =>
+  | {
+      communityId: string;
+      dimension: "time" | "msg" | "master";
+      value: "off" | "on" | 24 | 48 | 500 | 1000;
+    }
+  | null;
+
+let adminResult: { id: string } | null;
+let communityFindResults: Array<Community | null>;
+let updateValuesCaptured: Array<Record<string, unknown>>;
+
+function createCommunity(overrides?: Partial<Community>): Community {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    chatId: BigInt("-1009876543210"),
+    chatTitle: "Test Community",
+    activatedBy: BigInt("123456789"),
+    isActive: true,
+    summaryNotificationsEnabled: true,
+    summaryNotificationTimeHours: 24,
+    summaryNotificationMessageCount: null,
+    isPublic: true,
+    settings: {},
+    activatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createCallbackContext(options: {
+  data: string;
+  includeFrom?: boolean;
+  fromId?: number;
+  chatId?: number;
+  messageId?: number;
+}) {
+  const answerCalls: unknown[] = [];
+  const editCalls: unknown[][] = [];
+
+  const rawContext: Record<string, unknown> = {
+    callbackQuery: {
+      data: options.data,
+      message: {
+        chat: { id: options.chatId ?? -1009876543210 },
+        message_id: options.messageId ?? 99,
+      },
+    },
+    answerCallbackQuery: async (payload?: unknown) => {
+      answerCalls.push(payload);
+      return true as const;
+    },
+    api: {
+      editMessageText: async (...args: unknown[]) => {
+        editCalls.push(args);
+        return {} as never;
+      },
+    },
+  };
+
+  if (options.includeFrom !== false) {
+    rawContext.from = { id: options.fromId ?? 777 };
+  }
+
+  return {
+    answerCalls,
+    ctx: rawContext as unknown as CallbackQueryContext<Context>,
+    editCalls,
+  };
+}
+
+describe("notification settings helpers", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../notification-settings");
+    ({
+      NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX,
+      OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+      UNAUTHORIZED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+      buildNotificationSettingsKeyboard,
+      buildNotificationSettingsUpdateValues,
+      encodeNotificationSettingsCallbackData,
+      handleNotificationSettingsCallback,
+      parseNotificationSettingsCallbackData,
+    } = loadedModule);
+  });
+
+  beforeEach(() => {
+    adminResult = null;
+    communityFindResults = [];
+    updateValuesCaptured = [];
+
+    mockDb = {
+      query: {
+        admins: {
+          findFirst: async () => adminResult,
+        },
+        communities: {
+          findFirst: async () => communityFindResults.shift() ?? null,
+        },
+      },
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updateValuesCaptured.push(values);
+          return {
+            where: async () => {},
+          };
+        },
+      }),
+    };
+  });
+
+  test("parses valid callback data for each dimension", () => {
+    const communityId = "550e8400-e29b-41d4-a716-446655440000";
+
+    expect(
+      parseNotificationSettingsCallbackData(
+        encodeNotificationSettingsCallbackData({
+          communityId,
+          dimension: "time",
+          value: 48,
+        })
+      )
+    ).toEqual({
+      communityId,
+      dimension: "time",
+      value: 48,
+    });
+
+    expect(
+      parseNotificationSettingsCallbackData(
+        encodeNotificationSettingsCallbackData({
+          communityId,
+          dimension: "msg",
+          value: 1000,
+        })
+      )
+    ).toEqual({
+      communityId,
+      dimension: "msg",
+      value: 1000,
+    });
+
+    expect(
+      parseNotificationSettingsCallbackData(
+        encodeNotificationSettingsCallbackData({
+          communityId,
+          dimension: "master",
+          value: "on",
+        })
+      )
+    ).toEqual({
+      communityId,
+      dimension: "master",
+      value: "on",
+    });
+  });
+
+  test("rejects malformed and mismatched callback data", () => {
+    expect(
+      parseNotificationSettingsCallbackData(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:500"
+      )
+    ).toBeNull();
+    expect(
+      parseNotificationSettingsCallbackData(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:msg:24"
+      )
+    ).toBeNull();
+    expect(
+      parseNotificationSettingsCallbackData(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:master:1000"
+      )
+    ).toBeNull();
+    expect(
+      parseNotificationSettingsCallbackData(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:msg:9999"
+      )
+    ).toBeNull();
+    expect(parseNotificationSettingsCallbackData("invalid:data")).toBeNull();
+  });
+
+  test("regex trigger only matches expected callback format", () => {
+    expect(
+      NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX.test(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:24"
+      )
+    ).toBe(true);
+    expect(
+      NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX.test(
+        "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:24:extra"
+      )
+    ).toBe(false);
+    expect(
+      NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX.test(
+        "notif:settings:not-a-uuid:time:24"
+      )
+    ).toBe(false);
+  });
+
+  test("builds a three-row keyboard with active markers and callback payloads", () => {
+    const community = createCommunity({
+      summaryNotificationsEnabled: true,
+      summaryNotificationTimeHours: 24,
+      summaryNotificationMessageCount: null,
+    });
+    const keyboard = buildNotificationSettingsKeyboard(community);
+    const rows = keyboard.inline_keyboard;
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveLength(3);
+    expect(rows[1]).toHaveLength(3);
+    expect(rows[2]).toHaveLength(2);
+
+    expect(rows[0][1]?.text).toContain("✅");
+    expect(rows[0][1]?.callback_data).toBe(
+      "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:24"
+    );
+    expect(rows[1][0]?.text).toContain("✅");
+    expect(rows[1][0]?.callback_data).toBe(
+      "notif:settings:550e8400-e29b-41d4-a716-446655440000:msg:off"
+    );
+    expect(rows[2][1]?.text).toContain("✅");
+    expect(rows[2][1]?.callback_data).toBe(
+      "notif:settings:550e8400-e29b-41d4-a716-446655440000:master:on"
+    );
+  });
+
+  test("maps callback actions to typed DB update values", () => {
+    const timeUpdate = buildNotificationSettingsUpdateValues({
+      communityId: "550e8400-e29b-41d4-a716-446655440000",
+      dimension: "time",
+      value: "off",
+    });
+    expect(timeUpdate.summaryNotificationTimeHours).toBeNull();
+    expect(timeUpdate.summaryNotificationMessageCount).toBeUndefined();
+    expect(timeUpdate.summaryNotificationsEnabled).toBeUndefined();
+    expect(timeUpdate.updatedAt).toBeInstanceOf(Date);
+
+    const messageUpdate = buildNotificationSettingsUpdateValues({
+      communityId: "550e8400-e29b-41d4-a716-446655440000",
+      dimension: "msg",
+      value: 500,
+    });
+    expect(messageUpdate.summaryNotificationMessageCount).toBe(500);
+    expect(messageUpdate.summaryNotificationTimeHours).toBeUndefined();
+    expect(messageUpdate.summaryNotificationsEnabled).toBeUndefined();
+    expect(messageUpdate.updatedAt).toBeInstanceOf(Date);
+
+    const masterUpdate = buildNotificationSettingsUpdateValues({
+      communityId: "550e8400-e29b-41d4-a716-446655440000",
+      dimension: "master",
+      value: "off",
+    });
+    expect(masterUpdate.summaryNotificationsEnabled).toBe(false);
+    expect(masterUpdate.summaryNotificationTimeHours).toBeUndefined();
+    expect(masterUpdate.summaryNotificationMessageCount).toBeUndefined();
+    expect(masterUpdate.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test("shows authorization alert when non-admin presses callback button", async () => {
+    adminResult = null;
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      data: "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:24",
+    });
+
+    await handleNotificationSettingsCallback(ctx);
+
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: UNAUTHORIZED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+      },
+    ]);
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(editCalls).toHaveLength(0);
+  });
+
+  test("shows stale-panel alert when callback message chat does not match community", async () => {
+    adminResult = { id: "admin-1" };
+    communityFindResults = [
+      createCommunity({ chatId: BigInt("-1001111111111") }),
+    ];
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      chatId: -1002222222222,
+      data: "notif:settings:550e8400-e29b-41d4-a716-446655440000:master:on",
+    });
+
+    await handleNotificationSettingsCallback(ctx);
+
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+      },
+    ]);
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(editCalls).toHaveLength(0);
+  });
+
+  test("updates DB and refreshes keyboard when authorized admin changes setting", async () => {
+    adminResult = { id: "admin-1" };
+    const initialCommunity = createCommunity({
+      summaryNotificationMessageCount: null,
+    });
+    const updatedCommunity = createCommunity({
+      summaryNotificationMessageCount: 500,
+    });
+    communityFindResults = [initialCommunity, updatedCommunity];
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      chatId: -1009876543210,
+      data: "notif:settings:550e8400-e29b-41d4-a716-446655440000:msg:500",
+      messageId: 123,
+    });
+
+    await handleNotificationSettingsCallback(ctx);
+
+    expect(updateValuesCaptured).toHaveLength(1);
+    expect(updateValuesCaptured[0]?.summaryNotificationMessageCount).toBe(500);
+    expect(updateValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+
+    expect(editCalls).toHaveLength(1);
+    expect(editCalls[0]?.[0]).toBe(-1009876543210);
+    expect(editCalls[0]?.[1]).toBe(123);
+    expect(editCalls[0]?.[2]).toContain("Notification settings for this community");
+
+    expect(answerCalls).toEqual([{ text: "Notification settings updated" }]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/notification-settings.ts
+++ b/app/src/lib/telegram/bot-api/notification-settings.ts
@@ -111,9 +111,9 @@ export function buildNotificationSettingsMessageText(): string {
   return [
     "Notification settings for this community",
     "",
-    "⏱ Time trigger: Off | 24h | 48h",
-    "💬 Message trigger: Off | 500 | 1000",
-    "🔔 Master switch: Off | On",
+    "⏱ <b>Time trigger</b>: Off | 24h | 48h",
+    "💬 <b>Message trigger</b>: Off | 500 | 1000",
+    "🔔 <b>Master switch</b>: Off | On",
     "",
     "Only whitelisted admins can change these settings.",
   ].join("\n");
@@ -227,6 +227,7 @@ export async function sendNotificationSettingsMessage(
   community: NotificationSettingsState
 ): Promise<void> {
   await ctx.reply(buildNotificationSettingsMessageText(), {
+    parse_mode: "HTML",
     reply_markup: buildNotificationSettingsKeyboard(community),
   });
 }
@@ -300,6 +301,7 @@ export async function handleNotificationSettingsCallback(
         callbackMessage.message_id,
         buildNotificationSettingsMessageText(),
         {
+          parse_mode: "HTML",
           reply_markup: buildNotificationSettingsKeyboard(updatedCommunity),
         }
       );

--- a/app/src/lib/telegram/bot-api/notification-settings.ts
+++ b/app/src/lib/telegram/bot-api/notification-settings.ts
@@ -1,0 +1,342 @@
+import { eq } from "drizzle-orm";
+import type { CallbackQueryContext, CommandContext, Context } from "grammy";
+import { InlineKeyboard } from "grammy";
+
+import { getDatabase } from "@/lib/core/database";
+import {
+  admins,
+  communities,
+  type Community,
+  type SummaryNotificationMessageCount,
+  type SummaryNotificationTimeHours,
+} from "@/lib/core/schema";
+
+export const NOTIFICATION_SETTINGS_CALLBACK_PREFIX = "notif";
+export const NOTIFICATION_SETTINGS_CONTEXT = "settings";
+export const NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX =
+  /^notif:settings:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}):(time|msg|master):(off|24|48|500|1000|on)$/;
+
+export const UNAUTHORIZED_NOTIFICATION_SETTINGS_ALERT_TEXT =
+  "Only authorized users can do this. Text @spacesymmetry if you want to change something.";
+export const OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT =
+  "This settings panel is outdated. Run /notifications again.";
+
+type NotificationDimension = "time" | "msg" | "master";
+type NotificationSettingsCallbackData =
+  | {
+      communityId: string;
+      dimension: "time";
+      value: SummaryNotificationTimeHours | "off";
+    }
+  | {
+      communityId: string;
+      dimension: "msg";
+      value: SummaryNotificationMessageCount | "off";
+    }
+  | {
+      communityId: string;
+      dimension: "master";
+      value: "off" | "on";
+    };
+
+type NotificationSettingsState = Pick<
+  Community,
+  | "id"
+  | "summaryNotificationsEnabled"
+  | "summaryNotificationTimeHours"
+  | "summaryNotificationMessageCount"
+>;
+
+export type NotificationSettingsUpdateValues = {
+  summaryNotificationTimeHours?: SummaryNotificationTimeHours | null;
+  summaryNotificationMessageCount?: SummaryNotificationMessageCount | null;
+  summaryNotificationsEnabled?: boolean;
+  updatedAt: Date;
+};
+
+export function encodeNotificationSettingsCallbackData(
+  callbackData: NotificationSettingsCallbackData
+): string {
+  return `${NOTIFICATION_SETTINGS_CALLBACK_PREFIX}:${NOTIFICATION_SETTINGS_CONTEXT}:${callbackData.communityId}:${callbackData.dimension}:${callbackData.value}`;
+}
+
+export function parseNotificationSettingsCallbackData(
+  data: string
+): NotificationSettingsCallbackData | null {
+  const matches = NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX.exec(data);
+  if (!matches) {
+    return null;
+  }
+
+  const communityId = matches[1];
+  const dimension = matches[2] as NotificationDimension;
+  const rawValue = matches[3];
+
+  switch (dimension) {
+    case "time":
+      if (rawValue === "off") {
+        return { communityId, dimension, value: "off" };
+      }
+      if (rawValue === "24" || rawValue === "48") {
+        return {
+          communityId,
+          dimension,
+          value: Number(rawValue) as SummaryNotificationTimeHours,
+        };
+      }
+      return null;
+    case "msg":
+      if (rawValue === "off") {
+        return { communityId, dimension, value: "off" };
+      }
+      if (rawValue === "500" || rawValue === "1000") {
+        return {
+          communityId,
+          dimension,
+          value: Number(rawValue) as SummaryNotificationMessageCount,
+        };
+      }
+      return null;
+    case "master":
+      if (rawValue === "off" || rawValue === "on") {
+        return { communityId, dimension, value: rawValue };
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function buildNotificationSettingsMessageText(): string {
+  return [
+    "Notification settings for this community",
+    "",
+    "⏱ Time trigger: Off | 24h | 48h",
+    "💬 Message trigger: Off | 500 | 1000",
+    "🔔 Master switch: Off | On",
+    "",
+    "Only whitelisted admins can change these settings.",
+  ].join("\n");
+}
+
+export function buildNotificationSettingsKeyboard(
+  community: NotificationSettingsState
+): InlineKeyboard {
+  return new InlineKeyboard()
+    .text(
+      renderButtonLabel("⏱ Off", community.summaryNotificationTimeHours === null),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "time",
+        value: "off",
+      })
+    )
+    .text(
+      renderButtonLabel("⏱ 24h", community.summaryNotificationTimeHours === 24),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "time",
+        value: 24,
+      })
+    )
+    .text(
+      renderButtonLabel("⏱ 48h", community.summaryNotificationTimeHours === 48),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "time",
+        value: 48,
+      })
+    )
+    .row()
+    .text(
+      renderButtonLabel("💬 Off", community.summaryNotificationMessageCount === null),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "msg",
+        value: "off",
+      })
+    )
+    .text(
+      renderButtonLabel("💬 500", community.summaryNotificationMessageCount === 500),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "msg",
+        value: 500,
+      })
+    )
+    .text(
+      renderButtonLabel(
+        "💬 1000",
+        community.summaryNotificationMessageCount === 1000
+      ),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "msg",
+        value: 1000,
+      })
+    )
+    .row()
+    .text(
+      renderButtonLabel("🔕 Off", !community.summaryNotificationsEnabled),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "master",
+        value: "off",
+      })
+    )
+    .text(
+      renderButtonLabel("🔔 On", community.summaryNotificationsEnabled),
+      encodeNotificationSettingsCallbackData({
+        communityId: community.id,
+        dimension: "master",
+        value: "on",
+      })
+    );
+}
+
+export function buildNotificationSettingsUpdateValues(
+  callbackData: NotificationSettingsCallbackData
+): NotificationSettingsUpdateValues {
+  const baseUpdate: NotificationSettingsUpdateValues = {
+    updatedAt: new Date(),
+  };
+
+  switch (callbackData.dimension) {
+    case "time":
+      return {
+        ...baseUpdate,
+        summaryNotificationTimeHours:
+          callbackData.value === "off" ? null : callbackData.value,
+      };
+    case "msg":
+      return {
+        ...baseUpdate,
+        summaryNotificationMessageCount:
+          callbackData.value === "off" ? null : callbackData.value,
+      };
+    case "master":
+      return {
+        ...baseUpdate,
+        summaryNotificationsEnabled: callbackData.value === "on",
+      };
+  }
+}
+
+export async function sendNotificationSettingsMessage(
+  ctx: CommandContext<Context>,
+  community: NotificationSettingsState
+): Promise<void> {
+  await ctx.reply(buildNotificationSettingsMessageText(), {
+    reply_markup: buildNotificationSettingsKeyboard(community),
+  });
+}
+
+export async function handleNotificationSettingsCallback(
+  ctx: CallbackQueryContext<Context>
+): Promise<void> {
+  const callbackData = parseNotificationSettingsCallbackData(ctx.callbackQuery.data);
+  if (!callbackData) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  if (!ctx.from) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  try {
+    const db = getDatabase();
+    const telegramUserId = BigInt(ctx.from.id);
+    const admin = await db.query.admins.findFirst({
+      where: eq(admins.telegramId, telegramUserId),
+    });
+
+    if (!admin) {
+      await ctx.answerCallbackQuery({
+        text: UNAUTHORIZED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    const community = await db.query.communities.findFirst({
+      where: eq(communities.id, callbackData.communityId),
+    });
+    const callbackMessage = ctx.callbackQuery.message;
+
+    if (
+      !community ||
+      !callbackMessage ||
+      String(community.chatId) !== String(callbackMessage.chat.id)
+    ) {
+      await ctx.answerCallbackQuery({
+        text: OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    await db
+      .update(communities)
+      .set(buildNotificationSettingsUpdateValues(callbackData))
+      .where(eq(communities.id, community.id));
+
+    const updatedCommunity = await db.query.communities.findFirst({
+      where: eq(communities.id, community.id),
+    });
+
+    if (!updatedCommunity) {
+      await ctx.answerCallbackQuery({
+        text: OUTDATED_NOTIFICATION_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    try {
+      await ctx.api.editMessageText(
+        callbackMessage.chat.id,
+        callbackMessage.message_id,
+        buildNotificationSettingsMessageText(),
+        {
+          reply_markup: buildNotificationSettingsKeyboard(updatedCommunity),
+        }
+      );
+    } catch (error) {
+      if (!isMessageNotModifiedError(error)) {
+        throw error;
+      }
+    }
+
+    await ctx.answerCallbackQuery({ text: "Notification settings updated" });
+  } catch (error) {
+    console.error("Failed to update notification settings", error);
+    await ctx.answerCallbackQuery({
+      text: "Unable to update notification settings right now.",
+      show_alert: true,
+    });
+  }
+}
+
+function renderButtonLabel(label: string, isActive: boolean): string {
+  return isActive ? `✅ ${label}` : label;
+}
+
+function isMessageNotModifiedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const maybeError = error as {
+    description?: unknown;
+    message?: unknown;
+  };
+
+  return (
+    (typeof maybeError.description === "string" &&
+      maybeError.description.includes("message is not modified")) ||
+    (typeof maybeError.message === "string" &&
+      maybeError.message.includes("message is not modified"))
+  );
+}

--- a/app/src/lib/telegram/bot-api/register-commands.ts
+++ b/app/src/lib/telegram/bot-api/register-commands.ts
@@ -13,6 +13,10 @@ export async function registerBotCommands(bot: Bot): Promise<void> {
       { command: "summary", description: "Get the latest chat summary" },
       { command: "ca", description: "Show $LOYAL contract address" },
       {
+        command: "notifications",
+        description: "Configure summary notifications (admins only)",
+      },
+      {
         command: "activate_community",
         description: "Enable message tracking (admins only)",
       },

--- a/docs/miniapp/database.md
+++ b/docs/miniapp/database.md
@@ -4,11 +4,11 @@ Neon PostgreSQL integration using Drizzle ORM.
 
 ## Overview
 
-| File | Purpose |
-|------|---------|
+| File                       | Purpose                       |
+| -------------------------- | ----------------------------- |
 | `src/lib/core/database.ts` | Database connection singleton |
-| `src/lib/core/schema.ts` | Drizzle table definitions |
-| `drizzle.config.ts` | Migration configuration |
+| `src/lib/core/schema.ts`   | Drizzle table definitions     |
+| `drizzle.config.ts`        | Migration configuration       |
 
 ## Usage
 
@@ -37,11 +37,11 @@ export const users = pgTable("users", {
 
 Run from `/app` directory:
 
-| Command | Description |
-|---------|-------------|
+| Command           | Description                             |
+| ----------------- | --------------------------------------- |
 | `bun db:generate` | Generate migrations from schema changes |
-| `bun db:migrate` | Apply migrations to database |
-| `bun db:studio` | Open Drizzle Studio GUI |
+| `bun db:migrate`  | Apply migrations to database            |
+| `bun db:studio`   | Open Drizzle Studio GUI                 |
 
 ## Environment
 
@@ -63,12 +63,12 @@ Use `.$type<T>()` for type-safe JSONB columns:
 // Array of objects
 topics: jsonb("topics")
   .$type<{ title: string; content: string; sources: string[] }[]>()
-  .notNull()
+  .notNull();
 
 // Discriminated union (for encrypted content)
 encryptedContent: jsonb("encrypted_content")
   .$type<EncryptedMessageContent>()
-  .notNull()
+  .notNull();
 ```
 
 ### Relations Setup
@@ -100,22 +100,22 @@ export type InsertUser = typeof users.$inferInsert;
 
 ### Index Strategies
 
-| Index Type | Use Case | Example |
-|------------|----------|---------|
-| `uniqueIndex` | Prevent duplicates, enforce uniqueness | `uniqueIndex().on(table.telegramId)` |
-| Composite `index` | Optimize multi-column queries | `index().on(table.communityId, table.createdAt)` |
-| Filter `index` | Optimize status/flag filtering | `index().on(table.isActive)` |
+| Index Type        | Use Case                               | Example                                          |
+| ----------------- | -------------------------------------- | ------------------------------------------------ |
+| `uniqueIndex`     | Prevent duplicates, enforce uniqueness | `uniqueIndex().on(table.telegramId)`             |
+| Composite `index` | Optimize multi-column queries          | `index().on(table.communityId, table.createdAt)` |
+| Filter `index`    | Optimize status/flag filtering         | `index().on(table.isActive)`                     |
 
 ## Tables Reference
 
-| Table | Purpose |
-|-------|---------|
-| `admins` | Global admin whitelist (Telegram users who can activate communities) |
-| `users` | Telegram users who interact with the bot |
-| `communities` | Activated Telegram group chats for message tracking |
-| `communityMembers` | Many-to-many: users ↔ communities |
-| `messages` | Chat messages from tracked communities |
-| `summaries` | AI-generated daily chat summaries with topics |
-| `businessConnections` | Telegram Business bot connections to user accounts |
-| `botThreads` | Bot conversation sessions (supports Telegram threaded messages) |
-| `botMessages` | Individual encrypted messages within bot threads |
+| Table                 | Purpose                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `admins`              | Global admin whitelist for privileged community actions (activate/deactivate/settings) |
+| `users`               | Telegram users who interact with the bot                                               |
+| `communities`         | Activated Telegram group chats for message tracking                                    |
+| `communityMembers`    | Many-to-many: users ↔ communities                                                      |
+| `messages`            | Chat messages from tracked communities                                                 |
+| `summaries`           | AI-generated daily chat summaries with topics                                          |
+| `businessConnections` | Telegram Business bot connections to user accounts                                     |
+| `botThreads`          | Bot conversation sessions (supports Telegram threaded messages)                        |
+| `botMessages`         | Individual encrypted messages within bot threads                                       |


### PR DESCRIPTION
This adds a notifications inline keyboard flow for summary notification settings and wires callback handling with whitelist-based authorization. It also aligns activate/deactivate access to whitelist-only checks, updates related docs/comments, and adds targeted bot-api tests for authorization and callback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added notification settings configuration for communities, allowing admins to set notification frequency (off/24h/48h), message thresholds (off/500/1000), and a master switch.
  * Added new `/notifications` command to access notification settings.

* **Refactor**
  * Improved admin authorization for community management commands.

* **Tests**
  * Added test coverage for admin commands and notification settings workflows.

* **Documentation**
  * Updated database documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->