### PR TITLE
docs(onboarding): add community activation and notification setup guides

### DIFF
--- a/docs/miniapp/README.md
+++ b/docs/miniapp/README.md
@@ -25,3 +25,6 @@ Quick reference for `/app/src/lib/`.
 - [Environment Variables](./environment-vars.md) - Required setup
 - [Folder Reference](./folder-reference.md) - Detailed breakdown
 - [Database](./database.md) - Drizzle ORM schema and migrations
+- [Onboarding Overview](../onboarding/README.md) - Add bot, activate communities, configure notifications
+- [Activate Community Guide](../onboarding/add-bot-and-activate-community.md) - Step-by-step activation flow
+- [Notification Settings Guide](../onboarding/notifications.md) - Configure summary notifications

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,0 +1,22 @@
+# Onboarding
+
+Step-by-step onboarding for Telegram community admins and bot operators.
+
+## Who This Is For
+
+- Community admins who need to activate summaries in a Telegram group/supergroup
+- Operators who manage bot setup, environment variables, and database whitelist access
+
+## Flow Overview
+
+1. Prepare bot/operator prerequisites
+2. Add the bot to a Telegram community
+3. Activate community tracking with `/activate_community`
+4. Configure summary notifications with `/notifications`
+5. Validate behavior for authorized and unauthorized users
+
+## Guides
+
+- [Add Bot and Activate Community](./add-bot-and-activate-community.md)
+- [Set Up Notification Settings](./notifications.md)
+

--- a/docs/onboarding/add-bot-and-activate-community.md
+++ b/docs/onboarding/add-bot-and-activate-community.md
@@ -1,0 +1,118 @@
+# Add Bot and Activate Community
+
+This guide covers the full onboarding flow to enable community message tracking and summaries.
+
+## Prerequisites
+
+### Operator setup
+
+Ensure these environment variables are configured for the app deployment:
+
+- `ASKLOYAL_TGBOT_KEY`
+- `TELEGRAM_SETUP_SECRET`
+- `CRON_SECRET`
+- `DATABASE_URL`
+- `REDPILL_AI_API_KEY`
+
+Reference: `app/.env.example`.
+
+### Register Telegram bot commands
+
+Call the setup endpoint once after deployment (or when commands change):
+
+- Endpoint: `POST /api/telegram/setup-commands`
+- Auth header: `Authorization: Bearer <TELEGRAM_SETUP_SECRET>`
+
+This registers group commands including:
+
+- `/activate_community`
+- `/deactivate_community`
+- `/summary`
+- `/notifications`
+
+### Add admins to whitelist
+
+Only users in the `admins` table can activate/deactivate communities and change notification settings.
+
+Minimal SQL example:
+
+```sql
+INSERT INTO admins (telegram_id, username, display_name)
+VALUES (123456789, 'example_user', 'Example User')
+ON CONFLICT (telegram_id) DO NOTHING;
+```
+
+## Add the Bot to a Telegram Community
+
+1. Open your target Telegram group or supergroup.
+2. Add your bot as a member.
+3. Promote the bot to admin if your community policy requires elevated permissions.
+4. Send a test text message in the group (used later to verify tracking).
+
+## Activate Community
+
+1. In the target community chat, run `/activate_community`.
+2. The command must be executed in a community chat (group/supergroup/channel), not private chat.
+
+## Expected Outcomes
+
+### Whitelisted admin, first activation
+
+Expected bot message:
+
+`Community activated for message tracking!`
+
+What happens:
+
+- Community row is created in `communities`
+- Community is marked active
+- Message tracking for this chat becomes eligible immediately
+
+### Whitelisted admin, community already active
+
+Expected bot message:
+
+`Community is already activated. Data updated!`
+
+What happens:
+
+- Existing community metadata is refreshed
+- Community remains active
+
+### Whitelisted admin, community exists but was deactivated
+
+Expected bot message:
+
+`Community reactivated for message tracking!`
+
+What happens:
+
+- Existing community is reactivated
+- Message tracking resumes
+
+### User not in whitelist
+
+Expected bot message:
+
+`You are not authorized to activate communities. Contact an administrator to be added to the whitelist.`
+
+What happens:
+
+- Activation is denied
+- No community activation state change is applied
+
+## Verify Message Collection
+
+After successful activation:
+
+1. Send a few new text messages in the community.
+2. Confirm message ingestion in `messages` for that community (via DB query or internal tools).
+3. Optionally run `/summary`:
+- If no summaries exist yet, expected response is:
+`No summaries available yet. Summaries are generated daily when there's enough activity.`
+
+## Notes
+
+- Summary generation/delivery is scheduled via `/api/cron/summaries`, not immediate at activation time.
+- Activation only enables tracking and eligibility for subsequent summary runs.
+

--- a/docs/onboarding/notifications.md
+++ b/docs/onboarding/notifications.md
@@ -1,0 +1,56 @@
+# Set Up Notification Settings
+
+This guide explains how admins configure summary notification settings for an activated community.
+
+## Prerequisites
+
+1. The bot is added to the community.
+2. The community is already activated with `/activate_community`.
+3. The user changing settings is whitelisted in the `admins` table.
+
+## Open Notification Settings
+
+1. In the activated community chat, run `/notifications`.
+2. The bot sends an inline settings panel for that community.
+
+If the community is not activated, expected response is:
+
+`This community is not activated. Use /activate_community to enable summaries.`
+
+## Configure Settings
+
+Use the inline buttons in the panel:
+
+- Time trigger: `Off`, `24h`, `48h`
+- Message trigger: `Off`, `500`, `1000`
+- Master switch: `Off`, `On`
+
+Each successful change updates the panel and shows:
+
+`Notification settings updated`
+
+## Authorization Behavior
+
+### Whitelisted admin
+
+- Can change settings directly from the inline panel
+- Updated values are stored on the community record
+
+### Non-whitelisted user
+
+- Settings change is rejected
+- Expected alert text:
+`Only authorized users can do this. Text @spacesymmetry if you want to change something.`
+
+## Operational Checklist
+
+1. Confirm `/notifications` works in the target community.
+2. Toggle each setting once to verify update path.
+3. Ensure the final setting combination matches community preference.
+4. Re-run `/notifications` if Telegram shows a stale panel.
+
+## Notes
+
+- Keep this as an admin-only operation controlled by the whitelist.
+- Notification configuration is per-community and can be changed any time.
+


### PR DESCRIPTION
Add onboarding documentation for admins and operators to add the bot, activate communities, and configure notifications. Link the new onboarding guides from the miniapp docs quick links for discoverability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive onboarding documentation for Telegram community administrators and bot operators to streamline setup processes.
  * Included detailed guides covering bot registration, community activation workflows, and notification configuration options.
  * Documented prerequisites, step-by-step procedures, verification steps, and operational checklists for complete implementation.
  * Updated Quick Links section with new reference materials for quick access to onboarding resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->