### PR TITLE
fix(telegram): block summary sends when master switch is off

### DIFF
--- a/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
@@ -1,0 +1,133 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Bot, CommandContext, Context } from "grammy";
+
+mock.module("server-only", () => ({}));
+
+type MockSendSummaryResult =
+  | { sent: true }
+  | {
+      sent: false;
+      reason: "no_summaries" | "not_activated" | "notifications_disabled";
+    };
+
+let sendLatestSummaryResult: MockSendSummaryResult = { sent: true };
+const sendLatestSummaryCalls: unknown[] = [];
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => ({}),
+}));
+
+mock.module("../get-chat", () => ({
+  getChat: async () => ({}),
+}));
+
+mock.module("../get-file", () => ({
+  downloadTelegramFile: async () => ({
+    body: Buffer.from(""),
+    contentType: "image/jpeg",
+  }),
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: async () => "user-1",
+}));
+
+mock.module("../start-carousel", () => ({
+  sendStartCarousel: async () => {},
+}));
+
+mock.module("../notification-settings", () => ({
+  sendNotificationSettingsMessage: async () => {},
+}));
+
+mock.module("../summaries", () => ({
+  sendLatestSummary: async (...args: unknown[]) => {
+    sendLatestSummaryCalls.push(args);
+    return sendLatestSummaryResult;
+  },
+}));
+
+let handleSummaryCommand: typeof import("../commands").handleSummaryCommand;
+
+function createSummaryCommandContext() {
+  const replyCalls: string[] = [];
+
+  const ctx = {
+    chat: {
+      id: -1009876543210,
+      type: "supergroup",
+    },
+    msg: {
+      message_id: 789,
+    },
+    reply: async (text: string) => {
+      replyCalls.push(text);
+      return {} as never;
+    },
+  } as unknown as CommandContext<Context>;
+
+  return { ctx, replyCalls };
+}
+
+describe("handleSummaryCommand", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../commands");
+    handleSummaryCommand = loadedModule.handleSummaryCommand;
+  });
+
+  beforeEach(() => {
+    sendLatestSummaryResult = { sent: true };
+    sendLatestSummaryCalls.length = 0;
+  });
+
+  test("replies when summary notifications are disabled for community", async () => {
+    sendLatestSummaryResult = {
+      sent: false,
+      reason: "notifications_disabled",
+    };
+    const { ctx, replyCalls } = createSummaryCommandContext();
+
+    await handleSummaryCommand(ctx, {} as Bot);
+
+    expect(replyCalls).toEqual([
+      "Summary notifications are turned off for this community. Use /notifications to turn them on.",
+    ]);
+    expect(sendLatestSummaryCalls).toHaveLength(1);
+    expect(sendLatestSummaryCalls[0]).toEqual([
+      {},
+      BigInt(-1009876543210),
+      {
+        destinationChatId: BigInt(-1009876543210),
+        replyToMessageId: 789,
+      },
+    ]);
+  });
+
+  test("keeps existing not_activated behavior", async () => {
+    sendLatestSummaryResult = {
+      sent: false,
+      reason: "not_activated",
+    };
+    const { ctx, replyCalls } = createSummaryCommandContext();
+
+    await handleSummaryCommand(ctx, {} as Bot);
+
+    expect(replyCalls).toEqual([
+      "This community is not activated. Use /activate_community to enable summaries.",
+    ]);
+  });
+
+  test("keeps existing no_summaries behavior", async () => {
+    sendLatestSummaryResult = {
+      sent: false,
+      reason: "no_summaries",
+    };
+    const { ctx, replyCalls } = createSummaryCommandContext();
+
+    await handleSummaryCommand(ctx, {} as Bot);
+
+    expect(replyCalls).toEqual([
+      "No summaries available yet. Summaries are generated daily when there's enough activity.",
+    ]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
@@ -1,0 +1,130 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Bot } from "grammy";
+
+mock.module("server-only", () => ({}));
+
+type CommunityRecord = {
+  chatId: bigint;
+  id: string;
+  isActive: boolean;
+  summaryNotificationsEnabled: boolean;
+};
+
+type SummaryWithCommunityRecord = {
+  community: {
+    chatId: bigint;
+    isActive: boolean;
+    summaryNotificationsEnabled: boolean;
+  };
+  createdAt: Date;
+  id: string;
+  notificationSentAt: Date | null;
+  oneliner: string;
+} | null;
+
+let communityResult: CommunityRecord | null = null;
+let summaryResult: SummaryWithCommunityRecord = null;
+let updateCallCount = 0;
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => ({
+    query: {
+      communities: {
+        findFirst: async () => communityResult,
+      },
+      summaries: {
+        findFirst: async () => summaryResult,
+      },
+    },
+    update: () => {
+      updateCallCount += 1;
+      return {
+        set: () => ({
+          where: () => ({
+            returning: async () => [],
+          }),
+        }),
+      };
+    },
+  }),
+}));
+
+mock.module("@/lib/redpill", () => ({
+  chatCompletion: async () => {
+    throw new Error("chatCompletion should not be called in delivery guard tests");
+  },
+}));
+
+let attemptSummaryNotificationDelivery: typeof import("../summaries").attemptSummaryNotificationDelivery;
+let sendLatestSummary: typeof import("../summaries").sendLatestSummary;
+
+describe("summary delivery guards", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../summaries");
+    attemptSummaryNotificationDelivery = loadedModule.attemptSummaryNotificationDelivery;
+    sendLatestSummary = loadedModule.sendLatestSummary;
+  });
+
+  beforeEach(() => {
+    communityResult = null;
+    summaryResult = null;
+    updateCallCount = 0;
+  });
+
+  test("sendLatestSummary returns notifications_disabled and does not send to chat", async () => {
+    const sendMessageCalls: unknown[] = [];
+    const bot = {
+      api: {
+        sendMessage: async (...args: unknown[]) => {
+          sendMessageCalls.push(args);
+          return {} as never;
+        },
+      },
+    } as unknown as Bot;
+
+    communityResult = {
+      chatId: BigInt("-1001234567890"),
+      id: "community-1",
+      isActive: true,
+      summaryNotificationsEnabled: false,
+    };
+
+    const result = await sendLatestSummary(bot, BigInt("-1001234567890"));
+
+    expect(result).toEqual({ sent: false, reason: "notifications_disabled" });
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  test("attemptSummaryNotificationDelivery returns notifications_disabled and does not send", async () => {
+    const sendMessageCalls: unknown[] = [];
+    const bot = {
+      api: {
+        sendMessage: async (...args: unknown[]) => {
+          sendMessageCalls.push(args);
+          return {} as never;
+        },
+      },
+    } as unknown as Bot;
+
+    summaryResult = {
+      community: {
+        chatId: BigInt("-1001234567890"),
+        isActive: true,
+        summaryNotificationsEnabled: false,
+      },
+      createdAt: new Date("2026-02-12T00:00:00Z"),
+      id: "summary-1",
+      notificationSentAt: null,
+      oneliner: "Daily recap",
+    };
+
+    const result = await attemptSummaryNotificationDelivery(bot, "summary-1");
+
+    expect(result).toEqual({
+      delivered: false,
+      reason: "notifications_disabled",
+    });
+    expect(sendMessageCalls).toHaveLength(0);
+    expect(updateCallCount).toBe(0);
+  });
+});

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -262,6 +262,10 @@ export async function handleSummaryCommand(
         await ctx.reply(
           "This community is not activated. Use /activate_community to enable summaries."
         );
+      } else if (result.reason === "notifications_disabled") {
+        await ctx.reply(
+          "Summary notifications are turned off for this community. Use /notifications to turn them on."
+        );
       } else if (result.reason === "no_summaries") {
         await ctx.reply(
           "No summaries available yet. Summaries are generated daily when there's enough activity."

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -237,6 +237,10 @@ export async function sendLatestSummary(
     return { sent: false, reason: "not_activated" };
   }
 
+  if (!community.summaryNotificationsEnabled) {
+    return { sent: false, reason: "notifications_disabled" };
+  }
+
   const latestSummary = await db.query.summaries.findFirst({
     where: eq(summaries.communityId, community.id),
     orderBy: [desc(summaries.createdAt)],
@@ -273,6 +277,10 @@ export async function sendSummaryById(
 
   if (!summary.community.isActive) {
     return { sent: false, reason: "not_activated" };
+  }
+
+  if (!summary.community.summaryNotificationsEnabled) {
+    return { sent: false, reason: "notifications_disabled" };
   }
 
   await sendSummaryToChat(

--- a/app/src/lib/telegram/bot-api/types.ts
+++ b/app/src/lib/telegram/bot-api/types.ts
@@ -4,7 +4,10 @@ export type HandleSummaryCommandOptions = {
 
 export type SendSummaryResult =
   | { sent: true }
-  | { sent: false; reason: "not_activated" | "no_summaries" };
+  | {
+      sent: false;
+      reason: "not_activated" | "no_summaries" | "notifications_disabled";
+    };
 
 export type SendLatestSummaryOptions = {
   destinationChatId?: bigint;

--- a/docs/onboarding/add-bot-and-activate-community.md
+++ b/docs/onboarding/add-bot-and-activate-community.md
@@ -110,9 +110,11 @@ After successful activation:
 3. Optionally run `/summary`:
 - If no summaries exist yet, expected response is:
 `No summaries available yet. Summaries are generated daily when there's enough activity.`
+- If summary master switch is off for the community, expected response is:
+`Summary notifications are turned off for this community. Use /notifications to turn them on.`
 
 ## Notes
 
 - Summary generation/delivery is scheduled via `/api/cron/summaries`, not immediate at activation time.
 - Activation only enables tracking and eligibility for subsequent summary runs.
-
+- `/summary` and scheduled summary notifications both respect the community notification master switch.

--- a/docs/onboarding/notifications.md
+++ b/docs/onboarding/notifications.md
@@ -53,4 +53,4 @@ Each successful change updates the panel and shows:
 
 - Keep this as an admin-only operation controlled by the whitelist.
 - Notification configuration is per-community and can be changed any time.
-
+- If the master switch is `Off`, the bot will not post summary messages to that community chat, including `/summary` command responses and scheduled notifications.


### PR DESCRIPTION
Block group summary delivery when a community has summary notifications disabled, including /summary command responses.\n\nAdds regression coverage for manual and cron paths and updates onboarding docs to match.