### PR TITLE
fix(summaries): prevent redundant API requests on page load

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,5 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true,
+  "telemetry": false
+}

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -9,7 +9,7 @@ import type { Signal } from "@telegram-apps/signals";
 import { motion, type PanInfo } from "framer-motion";
 import { X } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getAvatarColor, getFirstLetter } from "@/components/summaries/avatar-utils";
 import { MOCK_SUMMARIES } from "@/components/summaries/mock-data";
@@ -270,7 +270,11 @@ export default function SummariesPage() {
   }, [hasCachedData, cachedSummaries]);
 
   // Fetch fresh data (in background if we have cache)
+  const fetchedRef = useRef(false);
   useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
     const fetchGroupChats = async () => {
       // Use mock data in development when flag is set
       if (publicEnv.useMockSummaries) {


### PR DESCRIPTION
• Added a `fetchedRef` guard to prevent redundant API requests on the summaries page
• Imported `useRef` to support the one-time fetch effect
• Resolved issue with multiple API calls caused by React Strict Mode and effect dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate data fetching on the Telegram summaries page, improving performance.

* **Chores**
  * Updated project configuration and ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->