### PR TITLE
fix(telegram): remove message-count controls from notifications panel

### DIFF
--- a/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
@@ -246,7 +246,7 @@ describe("notification settings helpers", () => {
     ).toBe(false);
   });
 
-  test("builds a three-row keyboard with active markers and callback payloads", () => {
+  test("builds a two-row keyboard with active markers and callback payloads", () => {
     const community = createCommunity({
       summaryNotificationsEnabled: true,
       summaryNotificationTimeHours: 24,
@@ -255,21 +255,16 @@ describe("notification settings helpers", () => {
     const keyboard = buildNotificationSettingsKeyboard(community);
     const rows = keyboard.inline_keyboard;
 
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveLength(3);
-    expect(rows[1]).toHaveLength(3);
-    expect(rows[2]).toHaveLength(2);
+    expect(rows[1]).toHaveLength(2);
 
     expect(rows[0][1]?.text).toContain("✅");
     expect(rows[0][1]?.callback_data).toBe(
       "notif:settings:550e8400-e29b-41d4-a716-446655440000:time:24"
     );
-    expect(rows[1][0]?.text).toContain("✅");
-    expect(rows[1][0]?.callback_data).toBe(
-      "notif:settings:550e8400-e29b-41d4-a716-446655440000:msg:off"
-    );
-    expect(rows[2][1]?.text).toContain("✅");
-    expect(rows[2][1]?.callback_data).toBe(
+    expect(rows[1][1]?.text).toContain("✅");
+    expect(rows[1][1]?.callback_data).toBe(
       "notif:settings:550e8400-e29b-41d4-a716-446655440000:master:on"
     );
   });

--- a/app/src/lib/telegram/bot-api/notification-settings.ts
+++ b/app/src/lib/telegram/bot-api/notification-settings.ts
@@ -112,7 +112,6 @@ export function buildNotificationSettingsMessageText(): string {
     "Notification settings for this community",
     "",
     "⏱ <b>Time trigger</b>: Off | 24h | 48h",
-    "💬 <b>Message trigger</b>: Off | 500 | 1000",
     "🔔 <b>Master switch</b>: Off | On",
     "",
     "Only whitelisted admins can change these settings.",
@@ -145,34 +144,6 @@ export function buildNotificationSettingsKeyboard(
         communityId: community.id,
         dimension: "time",
         value: 48,
-      })
-    )
-    .row()
-    .text(
-      renderButtonLabel("💬 Off", community.summaryNotificationMessageCount === null),
-      encodeNotificationSettingsCallbackData({
-        communityId: community.id,
-        dimension: "msg",
-        value: "off",
-      })
-    )
-    .text(
-      renderButtonLabel("💬 500", community.summaryNotificationMessageCount === 500),
-      encodeNotificationSettingsCallbackData({
-        communityId: community.id,
-        dimension: "msg",
-        value: 500,
-      })
-    )
-    .text(
-      renderButtonLabel(
-        "💬 1000",
-        community.summaryNotificationMessageCount === 1000
-      ),
-      encodeNotificationSettingsCallbackData({
-        communityId: community.id,
-        dimension: "msg",
-        value: 1000,
       })
     )
     .row()


### PR DESCRIPTION
Removes the message-count trigger line and inline buttons from the /notifications settings panel. Keeps existing msg callback handling for backward compatibility with older settings messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Message trigger option from notification settings. Previously offering Off, 500, and 1000 millisecond configurations, the notification settings interface has been simplified to focus on remaining control options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->