### PR TITLE
refactor(summaries): simplify cron summary generation and delivery flow

### DIFF
--- a/app/src/app/api/cron/summaries/route.ts
+++ b/app/src/app/api/cron/summaries/route.ts
@@ -1,45 +1,26 @@
 import { timingSafeEqual } from "crypto";
-import {
-  and,
-  eq,
-  gte,
-  inArray,
-  isNull,
-  lte,
-  sql,
-} from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 import { serverEnv } from "@/lib/core/config/server";
 import { getDatabase } from "@/lib/core/database";
-import { communities, messages, summaries } from "@/lib/core/schema";
+import { communities } from "@/lib/core/schema";
 import { getBot } from "@/lib/telegram/bot-api/bot";
 import {
-  attemptSummaryNotificationDelivery,
-  type AttemptSummaryNotificationDeliveryResult,
   generateOrGetSummaryForRun,
   type GenerateOrGetSummaryForRunResult,
-  MIN_MESSAGES_FOR_SUMMARY,
+  sendSummaryById,
   type SummaryRunContext,
 } from "@/lib/telegram/bot-api/summaries";
+import type { SendSummaryResult } from "@/lib/telegram/bot-api/types";
 import { SUMMARY_INTERVAL_MS } from "@/lib/telegram/utils";
 
 export const runtime = "nodejs";
-
-const DAILY_TRIGGER_TYPE = "cron_daily_la";
 
 type ActiveCommunityRecord = {
   id: string;
   chatId: bigint;
   chatTitle: string;
-  summaryNotificationsEnabled: boolean;
-};
-
-type PendingDeliveryRecord = {
-  chatId: bigint;
-  communityId: string;
-  isActive: boolean;
-  summaryId: string;
   summaryNotificationsEnabled: boolean;
 };
 
@@ -53,28 +34,25 @@ type CommunityProcessingError = {
 
 export type SummaryCronStats = {
   activeCommunities: number;
-  candidates: number;
   deliveryAttempted: number;
   deliveryFailed: number;
   deliverySucceeded: number;
   errors: number;
-  existingForRun: number;
+  existingToday: number;
   generated: number;
   processed: number;
+  skippedByMasterSwitch: number;
   skippedNotEnoughMessages: number;
 };
 
 type RunDailyCommunitySummariesOptions = {
   activeCommunityCount: number;
-  candidateCommunities: ActiveCommunityRecord[];
-  deliverSummary: (
-    summaryId: string
-  ) => Promise<AttemptSummaryNotificationDeliveryResult>;
+  communities: ActiveCommunityRecord[];
+  deliverSummary: (summaryId: string) => Promise<SendSummaryResult>;
   generateSummaryForRun: (
     communityId: string,
     chatTitle: string
   ) => Promise<GenerateOrGetSummaryForRunResult>;
-  listPendingDeliveries: () => Promise<PendingDeliveryRecord[]>;
 };
 
 type RunDailyCommunitySummariesResult = {
@@ -106,36 +84,16 @@ export async function POST(request: Request): Promise<NextResponse> {
     where: eq(communities.isActive, true),
   });
 
-  const messageCountsByCommunityId = await loadMessageCountsByCommunityForRun(
-    activeCommunities.map((community) => community.id),
-    run
-  );
-
-  const communitiesMeetingVolume = Array.from(messageCountsByCommunityId.entries())
-    .filter(([, messageCount]) => messageCount >= MIN_MESSAGES_FOR_SUMMARY)
-    .map(([communityId]) => communityId);
-
-  const existingSummaryCommunityIds = await loadExistingSummaryCommunityIdsForRun(
-    communitiesMeetingVolume,
-    run
-  );
-
-  const candidateCommunities = selectCandidateCommunities({
-    activeCommunities,
-    existingSummaryCommunityIds,
-    messageCountsByCommunityId,
-  });
-
   let botPromise: Promise<Awaited<ReturnType<typeof getBot>>> | null = null;
   const result = await runDailyCommunitySummaries({
     activeCommunityCount: activeCommunities.length,
-    candidateCommunities,
+    communities: activeCommunities,
     deliverSummary: async (summaryId) => {
       if (!botPromise) {
         botPromise = getBot();
       }
 
-      return attemptSummaryNotificationDelivery(await botPromise, summaryId);
+      return sendSummaryById(await botPromise, summaryId);
     },
     generateSummaryForRun: (communityId, chatTitle) =>
       generateOrGetSummaryForRun({
@@ -143,7 +101,6 @@ export async function POST(request: Request): Promise<NextResponse> {
         communityId,
         run,
       }),
-    listPendingDeliveries: () => loadPendingRunSummaryDeliveries(run),
   });
 
   const hasErrors = result.stats.errors > 0;
@@ -159,47 +116,18 @@ export async function POST(request: Request): Promise<NextResponse> {
   );
 }
 
-export function getLosAngelesDateKey(date: Date): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    day: "2-digit",
-    month: "2-digit",
-    timeZone: "America/Los_Angeles",
-    year: "numeric",
-  }).formatToParts(date);
-
-  const day = parts.find((part) => part.type === "day")?.value;
-  const month = parts.find((part) => part.type === "month")?.value;
-  const year = parts.find((part) => part.type === "year")?.value;
-
-  if (!day || !month || !year) {
-    throw new Error("Unable to resolve Los Angeles local date key");
-  }
-
-  return `${year}-${month}-${day}`;
-}
-
 export function buildDailySummaryRunContext(date: Date = new Date()): SummaryRunContext {
+  const dayStartUtc = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+  const dayEndUtc = new Date(dayStartUtc.getTime() + 24 * 60 * 60 * 1000 - 1);
+
   return {
-    triggerKey: `cron-daily-la:${getLosAngelesDateKey(date)}`,
-    triggerType: DAILY_TRIGGER_TYPE,
+    dayEndUtc,
+    dayStartUtc,
     windowEnd: date,
     windowStart: new Date(date.getTime() - SUMMARY_INTERVAL_MS),
   };
-}
-
-export function selectCandidateCommunities(input: {
-  activeCommunities: ActiveCommunityRecord[];
-  existingSummaryCommunityIds: Set<string>;
-  messageCountsByCommunityId: Map<string, number>;
-}): ActiveCommunityRecord[] {
-  return input.activeCommunities.filter((community) => {
-    const messageCount = input.messageCountsByCommunityId.get(community.id) ?? 0;
-    if (messageCount < MIN_MESSAGES_FOR_SUMMARY) {
-      return false;
-    }
-
-    return !input.existingSummaryCommunityIds.has(community.id);
-  });
 }
 
 export async function runDailyCommunitySummaries(
@@ -207,38 +135,27 @@ export async function runDailyCommunitySummaries(
 ): Promise<RunDailyCommunitySummariesResult> {
   const stats: SummaryCronStats = {
     activeCommunities: options.activeCommunityCount,
-    candidates: options.candidateCommunities.length,
     deliveryAttempted: 0,
     deliveryFailed: 0,
     deliverySucceeded: 0,
     errors: 0,
-    existingForRun: 0,
+    existingToday: 0,
     generated: 0,
+    skippedByMasterSwitch: 0,
     processed: 0,
     skippedNotEnoughMessages: 0,
   };
   const errors: CommunityProcessingError[] = [];
 
-  for (const community of options.candidateCommunities) {
+  for (const community of options.communities) {
     stats.processed += 1;
 
+    let generationResult: GenerateOrGetSummaryForRunResult;
     try {
-      const generationResult = await options.generateSummaryForRun(
+      generationResult = await options.generateSummaryForRun(
         community.id,
         community.chatTitle
       );
-
-      if (generationResult.status === "created") {
-        stats.generated += 1;
-        continue;
-      }
-
-      if (generationResult.status === "existing") {
-        stats.existingForRun += 1;
-        continue;
-      }
-
-      stats.skippedNotEnoughMessages += 1;
     } catch (error) {
       stats.errors += 1;
       errors.push({
@@ -247,31 +164,40 @@ export async function runDailyCommunitySummaries(
         error: error instanceof Error ? error.message : String(error),
         scope: "generation",
       });
+      continue;
     }
-  }
 
-  const pendingDeliveries = await options.listPendingDeliveries();
-  for (const pending of pendingDeliveries) {
-    if (!pending.isActive || !pending.summaryNotificationsEnabled) {
+    if (generationResult.status === "not_enough_messages") {
+      stats.skippedNotEnoughMessages += 1;
+      continue;
+    }
+
+    if (generationResult.status === "created") {
+      stats.generated += 1;
+    }
+
+    if (generationResult.status === "existing") {
+      stats.existingToday += 1;
+    }
+
+    if (!community.summaryNotificationsEnabled) {
+      stats.skippedByMasterSwitch += 1;
       continue;
     }
 
     stats.deliveryAttempted += 1;
-
     try {
-      const deliveryResult = await options.deliverSummary(pending.summaryId);
-      if (!deliveryResult.delivered) {
-        if (deliveryResult.reason === "not_found") {
-          stats.deliveryFailed += 1;
-          stats.errors += 1;
-          errors.push({
-            chatId: String(pending.chatId),
-            communityId: pending.communityId,
-            error: "Summary not found during delivery",
-            scope: "delivery",
-            summaryId: pending.summaryId,
-          });
-        }
+      const deliveryResult = await options.deliverSummary(generationResult.summaryId);
+      if (!deliveryResult.sent) {
+        stats.deliveryFailed += 1;
+        stats.errors += 1;
+        errors.push({
+          chatId: String(community.chatId),
+          communityId: community.id,
+          error: `Summary delivery rejected: ${deliveryResult.reason}`,
+          scope: "delivery",
+          summaryId: generationResult.summaryId,
+        });
         continue;
       }
 
@@ -280,102 +206,16 @@ export async function runDailyCommunitySummaries(
       stats.deliveryFailed += 1;
       stats.errors += 1;
       errors.push({
-        chatId: String(pending.chatId),
-        communityId: pending.communityId,
+        chatId: String(community.chatId),
+        communityId: community.id,
         error: error instanceof Error ? error.message : String(error),
         scope: "delivery",
-        summaryId: pending.summaryId,
+        summaryId: generationResult.summaryId,
       });
     }
   }
 
   return { errors, stats };
-}
-
-async function loadMessageCountsByCommunityForRun(
-  activeCommunityIds: string[],
-  run: SummaryRunContext
-): Promise<Map<string, number>> {
-  if (activeCommunityIds.length === 0) {
-    return new Map();
-  }
-
-  const db = getDatabase();
-  const rows = await db
-    .select({
-      communityId: messages.communityId,
-      messageCount: sql<number>`count(*)`,
-    })
-    .from(messages)
-    .where(
-      and(
-        inArray(messages.communityId, activeCommunityIds),
-        gte(messages.createdAt, run.windowStart),
-        lte(messages.createdAt, run.windowEnd)
-      )
-    )
-    .groupBy(messages.communityId);
-
-  return new Map(
-    rows.map((row) => [row.communityId, Number(row.messageCount)])
-  );
-}
-
-async function loadExistingSummaryCommunityIdsForRun(
-  communityIds: string[],
-  run: SummaryRunContext
-): Promise<Set<string>> {
-  if (communityIds.length === 0) {
-    return new Set();
-  }
-
-  const db = getDatabase();
-  const rows = await db
-    .select({ communityId: summaries.communityId })
-    .from(summaries)
-    .where(
-      and(
-        inArray(summaries.communityId, communityIds),
-        eq(summaries.triggerType, run.triggerType),
-        eq(summaries.triggerKey, run.triggerKey)
-      )
-    );
-
-  return new Set(rows.map((row) => row.communityId));
-}
-
-async function loadPendingRunSummaryDeliveries(
-  run: SummaryRunContext
-): Promise<PendingDeliveryRecord[]> {
-  const db = getDatabase();
-  const unsentSummaries = await db.query.summaries.findMany({
-    columns: {
-      communityId: true,
-      id: true,
-    },
-    where: and(
-      eq(summaries.triggerType, run.triggerType),
-      eq(summaries.triggerKey, run.triggerKey),
-      isNull(summaries.notificationSentAt)
-    ),
-    with: {
-      community: {
-        columns: {
-          chatId: true,
-          isActive: true,
-          summaryNotificationsEnabled: true,
-        },
-      },
-    },
-  });
-
-  return unsentSummaries.map((summary) => ({
-    chatId: summary.community.chatId,
-    communityId: summary.communityId,
-    isActive: summary.community.isActive,
-    summaryId: summary.id,
-    summaryNotificationsEnabled: summary.community.summaryNotificationsEnabled,
-  }));
 }
 
 function validateAuthHeader(request: Request): NextResponse | null {

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -2,10 +2,6 @@
   "crons": [
     {
       "path": "/api/cron/summaries",
-      "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/cron/summaries",
       "schedule": "0 6 * * *"
     }
   ]


### PR DESCRIPTION
## Summary

- refactor cron summaries route to process active communities in one pass
- move summary generation/delivery orchestration to shared bot API helper
- switch run context from LA trigger keys to UTC daily windowing
- drop pending-delivery queue flow in favor of generation-triggered sends
- lower minimum messages for summary creation from 5 to 3
- update summary service and cron/delivery tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Summaries now generate with a lower message threshold, enabling earlier generation for communities (minimum changed from 5 to 3 messages).

* **Bug Fixes**
  * Enhanced duplicate summary prevention across daily runs.
  * Improved summary delivery reliability through streamlined delivery mechanism.
  * Updated daily summary cron job scheduling for better timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->