### PR TITLE
fix(telegram): add summaries tracking and harden sdk cloud storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,13 @@ Service layer patterns:
   - Never import `@/lib/core/config/server` from client code or shared barrels consumed by client code.
   - Keep server-only entrypoints isolated in dedicated modules (e.g. `server.ts` or `*.server.ts`) and import them only from server contexts (`/app/api`, server actions, other server-only modules).
   - For dual-use modules (client + server), keep `index.ts` client-safe and expose server-only helpers via a separate server entrypoint.
+  - Components imported by `app/src/app/layout.tsx` and other root wrappers must be verified as SSR-safe before merge.
+  - Browser-only SDKs (`@telegram-apps/*`, `window`/`document`/`localStorage` dependent modules, Mixpanel browser SDK, etc.) must be loaded behind `dynamic(..., { ssr: false })` in a Client Component, or via a dedicated client-only wrapper component imported from layout.
+  - If a component must stay client-only but is imported in layout/provider trees, use lazy client entrypoints and keep browser globals behind `useEffect` or client-guarded code paths.
+- **Root Layout Change Checklist**:
+  - After any change to `app/src/app/layout.tsx`, `/app/src/app/**/layout.tsx`, or global provider trees, run `cd app && bun run build`.
+  - Verify production build/`_not-found` prerender path succeeds without `ReferenceError: window is not defined`.
+  - Check changed modules for top-level browser API usage and ensure any browser-only dependencies are behind client-only boundaries.
 
 ### Troubleshooting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,13 @@ Service layer patterns:
   - Never import `@/lib/core/config/server` from client code or shared barrels consumed by client code.
   - Keep server-only entrypoints isolated in dedicated modules (e.g. `server.ts` or `*.server.ts`) and import them only from server contexts (`/app/api`, server actions, other server-only modules).
   - For dual-use modules (client + server), keep `index.ts` client-safe and expose server-only helpers via a separate server entrypoint.
+  - Components imported by `app/src/app/layout.tsx` and other root wrappers must be verified as SSR-safe before merge.
+  - Browser-only SDKs (`@telegram-apps/*`, `window`/`document`/`localStorage` dependent modules, Mixpanel browser SDK, etc.) must be loaded behind `dynamic(..., { ssr: false })` in a Client Component, or via a dedicated client-only wrapper component imported from layout.
+  - If a component must stay client-only but is imported in layout/provider trees, use lazy client entrypoints and keep browser globals behind `useEffect` or client-guarded code paths.
+- **Root Layout Change Checklist**:
+  - After any change to `app/src/app/layout.tsx`, `/app/src/app/**/layout.tsx`, or global provider trees, run `cd app && bun run build`.
+  - Verify production build/`_not-found` prerender path succeeds without `ReferenceError: window is not defined`.
+  - Check changed modules for top-level browser API usage and ensure any browser-only dependencies are behind client-only boundaries.
 
 ### Troubleshooting
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_SOLANA_ENV=devnet
 NEXT_PUBLIC_SERVER_HOST=
 NEXT_PUBLIC_GAS_PUBLIC_KEY=
 NEXT_PUBLIC_USE_MOCK_SUMMARIES=false
+NEXT_PUBLIC_MIXPANEL_TOKEN=
+# Optional, defaults to /ingest
+NEXT_PUBLIC_MIXPANEL_PROXY_PATH=
 
 # Server env (required for app features)
 DATABASE_URL=postgresql://...

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -25,6 +25,7 @@
         "grammy": "^1.39.3",
         "lightningcss": "^1.30.2",
         "lucide-react": "^0.552.0",
+        "mixpanel-browser": "^2.74.0",
         "next": "^15.5.7",
         "ogl": "^1.0.11",
         "qrcode": "^1.5.4",
@@ -394,6 +395,18 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mixpanel/rrdom": ["@mixpanel/rrdom@2.0.0-alpha.18.2", "", { "dependencies": { "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18" } }, "sha512-vX/tbnS14ZzzatC7vOyvAm9tOLU8tof0BuppBlphzEx1YHTSw8DQiAmyAc0AmXidchLV0W+cUHV/WsehPLh2hQ=="],
+
+    "@mixpanel/rrweb": ["@mixpanel/rrweb@2.0.0-alpha.18.2", "", { "dependencies": { "@mixpanel/rrdom": "^2.0.0-alpha.18", "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18", "@mixpanel/rrweb-types": "^2.0.0-alpha.18", "@mixpanel/rrweb-utils": "^2.0.0-alpha.18", "@types/css-font-loading-module": "0.0.7", "@xstate/fsm": "^1.4.0", "base64-arraybuffer": "^1.0.1", "mitt": "^3.0.0" } }, "sha512-J3dVTEu6Z4p8di7y9KKvUooNuBjX97DdG6XGWoPEPi07A9512h9M8MEtvlY3mK0PGfuC0Mz5Pv/Ws6gjGYfKQg=="],
+
+    "@mixpanel/rrweb-plugin-console-record": ["@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.2", "", { "peerDependencies": { "@mixpanel/rrweb": "^2.0.0-alpha.18", "@mixpanel/rrweb-utils": "^2.0.0-alpha.18" } }, "sha512-Xkwh2gSdLqHRkWSXv8CPVCPQj5L85KnWc5DZQ0CXNRFgm2hTl5/YP6zfUubVs2JVXZHGcSGU+g7JVO2WcFJyyg=="],
+
+    "@mixpanel/rrweb-snapshot": ["@mixpanel/rrweb-snapshot@2.0.0-alpha.18.2", "", { "dependencies": { "postcss": "^8.4.38" } }, "sha512-2kSnjZZ3QZ9zOz/isOt8s54mXUUDgXk/u0eEi/rE0xBWDeuA0NHrBcqiMc+w4F/yWWUpo5F5zcuPeYpc6ufAsw=="],
+
+    "@mixpanel/rrweb-types": ["@mixpanel/rrweb-types@2.0.0-alpha.18.2", "", {}, "sha512-ucIYe1mfJ2UksvXW+d3bOySTB2/0yUSqQJlUydvbBz6OO2Bhq3nJHyLXV9ExkgUMZm1ZyDcvvmNUd1+5tAXlpA=="],
+
+    "@mixpanel/rrweb-utils": ["@mixpanel/rrweb-utils@2.0.0-alpha.18.2", "", {}, "sha512-OomKIB6GTx5xvCLJ7iic2khT/t/tnCJUex13aEqsbSqIT/UzUUsqf+LTrgUK5ex+f6odmkCNjre2y5jvpNqn+g=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.2", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw=="],
@@ -708,6 +721,8 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/css-font-loading-module": ["@types/css-font-loading-module@0.0.7", "", {}, "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -818,6 +833,8 @@
 
     "@xelene/vaul-with-scroll-fix": ["@xelene/vaul-with-scroll-fix@0.1.4", "", { "dependencies": { "@radix-ui/react-dialog": "^1.0.4" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-R9J7y92rzZKIQLtFHKtzRsb4x8G26cvwGIDSf7OQZCdROFt7xic4Yz1BlFYjm8oiQsYV4SFSQfOzatZjvxz5XQ=="],
 
+    "@xstate/fsm": ["@xstate/fsm@1.6.5", "", {}, "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw=="],
+
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
@@ -893,6 +910,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -1463,6 +1482,8 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "mixpanel-browser": ["mixpanel-browser@2.74.0", "", { "dependencies": { "@mixpanel/rrweb": "2.0.0-alpha.18.2", "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.2" } }, "sha512-FWifdAaI+8zKEROb9T+gy0NRZB0gaCC5iy20rDjZ3C+KCwCsJcITT6lAYErWbwwmk3Ei34JBjLsnrDLPYj+hOw=="],
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,5 +1,12 @@
 import type { NextConfig } from "next";
 
+const mixpanelProxyPathRaw = process.env.NEXT_PUBLIC_MIXPANEL_PROXY_PATH?.trim();
+const mixpanelProxyPath = mixpanelProxyPathRaw
+  ? mixpanelProxyPathRaw.startsWith("/")
+    ? mixpanelProxyPathRaw
+    : `/${mixpanelProxyPathRaw}`
+  : "/ingest";
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -12,6 +19,14 @@ const nextConfig: NextConfig = {
         hostname: "t.me",
       },
     ],
+  },
+  async rewrites() {
+    return [
+      {
+        source: `${mixpanelProxyPath}/:path*`,
+        destination: "https://api-js.mixpanel.com/:path*",
+      },
+    ];
   },
 };
 

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "grammy": "^1.39.3",
     "lightningcss": "^1.30.2",
     "lucide-react": "^0.552.0",
+    "mixpanel-browser": "^2.74.0",
     "next": "^15.5.7",
     "ogl": "^1.0.11",
     "qrcode": "^1.5.4",

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 
+import { AnalyticsBootstrap } from "@/components/analytics/AnalyticsBootstrap";
 import { TelegramProvider } from "@/components/telegram/TelegramProvider";
 
 const geistSans = Geist({
@@ -47,6 +48,7 @@ export default function RootLayout({
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} suppressHydrationWarning>
         <AppRoot suppressHydrationWarning>
+          <AnalyticsBootstrap />
           <TelegramProvider>
             {children}
           </TelegramProvider>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,13 +1,9 @@
 import "@telegram-apps/telegram-ui/dist/styles.css";
 import "./globals.css";
 
-import { AppRoot } from "@telegram-apps/telegram-ui";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
-
-import { AnalyticsBootstrapClient } from "@/components/analytics/AnalyticsBootstrapClient";
-import { TelegramProvider } from "@/components/telegram/TelegramProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -47,12 +43,7 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} suppressHydrationWarning>
-        <AppRoot suppressHydrationWarning>
-          <AnalyticsBootstrapClient />
-          <TelegramProvider>
-            {children}
-          </TelegramProvider>
-        </AppRoot>
+        {children}
       </body>
     </html>
   );

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 
-import { AnalyticsBootstrap } from "@/components/analytics/AnalyticsBootstrap";
+import { AnalyticsBootstrapClient } from "@/components/analytics/AnalyticsBootstrapClient";
 import { TelegramProvider } from "@/components/telegram/TelegramProvider";
 
 const geistSans = Geist({
@@ -48,7 +48,7 @@ export default function RootLayout({
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} suppressHydrationWarning>
         <AppRoot suppressHydrationWarning>
-          <AnalyticsBootstrap />
+          <AnalyticsBootstrapClient />
           <TelegramProvider>
             {children}
           </TelegramProvider>

--- a/app/src/app/telegram/TelegramLayoutClient.tsx
+++ b/app/src/app/telegram/TelegramLayoutClient.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useSignal, viewport } from "@telegram-apps/sdk-react";
+import type { Signal } from "@telegram-apps/signals";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { AnalyticsBootstrapClient } from "@/components/analytics/AnalyticsBootstrapClient";
+import Header from "@/components/Header";
+import BottomNav from "@/components/telegram/BottomNav";
+import Onboarding from "@/components/telegram/Onboarding";
+import { TelegramAppRootClient } from "@/components/telegram/TelegramAppRootClient";
+import { TelegramProvider } from "@/components/telegram/TelegramProvider";
+import {
+  getCloudValue,
+  setCloudValue,
+} from "@/lib/telegram/mini-app/cloud-storage";
+
+const ONBOARDING_DONE_KEY = "onboarding_done";
+
+export default function TelegramLayoutClient({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const safeAreaInsetTop = useSignal(
+    viewport.safeAreaInsetTop as Signal<number>
+  );
+  const pathname = usePathname();
+  // null = loading, true = show, false = don't show
+  const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
+
+  // Check cloud storage for onboarding completion
+  useEffect(() => {
+    getCloudValue(ONBOARDING_DONE_KEY).then((value) => {
+      setShowOnboarding(value !== "1");
+    });
+  }, []);
+
+  const handleOnboardingDone = () => {
+    setShowOnboarding(false);
+    void setCloudValue(ONBOARDING_DONE_KEY, "1");
+  };
+
+  // Reset scroll position when navigating between pages
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  // Header height: safe area + 10px + logo (27px) + padding bottom (16px)
+  const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
+
+  return (
+    <TelegramAppRootClient>
+      <AnalyticsBootstrapClient />
+      <TelegramProvider>
+        <div
+          className="flex flex-col"
+          style={{ background: "#fff", minHeight: "100vh" }}
+        >
+          <Header />
+          {showOnboarding ? (
+            <Onboarding
+              headerHeight={headerHeight}
+              onDone={handleOnboardingDone}
+            />
+          ) : showOnboarding === false ? (
+            <>
+              <div
+                className="flex-1"
+                style={{ paddingTop: headerHeight }}
+              >
+                {children}
+              </div>
+              <BottomNav />
+            </>
+          ) : null}
+        </div>
+      </TelegramProvider>
+    </TelegramAppRootClient>
+  );
+}

--- a/app/src/app/telegram/layout.tsx
+++ b/app/src/app/telegram/layout.tsx
@@ -1,74 +1,15 @@
 "use client";
 
-import { useSignal, viewport } from "@telegram-apps/sdk-react";
-import type { Signal } from "@telegram-apps/signals";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 
-import Header from "@/components/Header";
-import BottomNav from "@/components/telegram/BottomNav";
-import Onboarding from "@/components/telegram/Onboarding";
-import {
-  getCloudValue,
-  setCloudValue,
-} from "@/lib/telegram/mini-app/cloud-storage";
-
-const ONBOARDING_DONE_KEY = "onboarding_done";
+const TelegramLayoutClient = dynamic(() => import("./TelegramLayoutClient"), {
+  ssr: false,
+});
 
 export default function TelegramLayout({
-  children
+  children,
 }: {
   children: React.ReactNode;
 }) {
-  const safeAreaInsetTop = useSignal(
-    viewport.safeAreaInsetTop as Signal<number>
-  );
-  const pathname = usePathname();
-  // null = loading, true = show, false = don't show
-  const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
-
-  // Check cloud storage for onboarding completion
-  useEffect(() => {
-    getCloudValue(ONBOARDING_DONE_KEY).then((value) => {
-      setShowOnboarding(value !== "1");
-    });
-  }, []);
-
-  const handleOnboardingDone = () => {
-    setShowOnboarding(false);
-    void setCloudValue(ONBOARDING_DONE_KEY, "1");
-  };
-
-  // Reset scroll position when navigating between pages
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
-
-  // Header height: safe area + 10px + logo (27px) + padding bottom (16px)
-  const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
-
-  return (
-    <div
-      className="flex flex-col"
-      style={{ background: "#fff", minHeight: "100vh" }}
-    >
-      <Header />
-      {showOnboarding ? (
-        <Onboarding
-          headerHeight={headerHeight}
-          onDone={handleOnboardingDone}
-        />
-      ) : showOnboarding === false ? (
-        <>
-          <div
-            className="flex-1"
-            style={{ paddingTop: headerHeight }}
-          >
-            {children}
-          </div>
-          <BottomNav />
-        </>
-      ) : null}
-    </div>
-  );
+  return <TelegramLayoutClient>{children}</TelegramLayoutClient>;
 }

--- a/app/src/app/telegram/summaries/feed/page.tsx
+++ b/app/src/app/telegram/summaries/feed/page.tsx
@@ -18,6 +18,12 @@ function SummaryFeedContent() {
     return selectedSummary?.title;
   }, [chatId, allSummaries]);
 
+  const groupChatId = useMemo(() => {
+    if (!chatId || allSummaries.length === 0) return undefined;
+    const selectedSummary = allSummaries.find((s) => s.id === chatId);
+    return selectedSummary?.chatId;
+  }, [chatId, allSummaries]);
+
   // Filter summaries to only include those from the same group
   const groupSummaries = useMemo(() => {
     if (!groupTitle || allSummaries.length === 0) return undefined;
@@ -29,6 +35,7 @@ function SummaryFeedContent() {
     <SummaryFeed
       initialChatId={chatId}
       summaries={groupSummaries}
+      groupChatId={groupChatId}
       groupTitle={groupTitle}
     />
   );

--- a/app/src/app/telegram/summaries/summaries-analytics.ts
+++ b/app/src/app/telegram/summaries/summaries-analytics.ts
@@ -1,0 +1,15 @@
+export const SUMMARIES_ANALYTICS_PATH = "/telegram/summaries/feed";
+
+export const SUMMARIES_ANALYTICS_EVENTS = {
+  viewCommunitySummaryDay: "View Community Summary Day",
+} as const;
+
+export const SUMMARY_SELECTION_SOURCES = {
+  initial: "initial",
+  swipe: "swipe",
+  datePicker: "date_picker",
+  todayButton: "today_button",
+} as const;
+
+export type SummarySelectionSource =
+  (typeof SUMMARY_SELECTION_SOURCES)[keyof typeof SUMMARY_SELECTION_SOURCES];

--- a/app/src/app/telegram/wallet/__tests__/wallet-analytics.test.ts
+++ b/app/src/app/telegram/wallet/__tests__/wallet-analytics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { CLAIM_SOURCES, SEND_METHODS, SWAP_METHODS } from "../wallet-analytics";
+import {
+  getSendMethod,
+  WALLET_ANALYTICS_EVENTS,
+  WALLET_ANALYTICS_PATH,
+} from "../wallet-analytics";
+
+describe("wallet analytics constants", () => {
+  test("uses the wallet path expected by event tracking", () => {
+    expect(WALLET_ANALYTICS_PATH).toBe("/telegram/wallet");
+  });
+
+  test("keeps wallet event names stable", () => {
+    expect(WALLET_ANALYTICS_EVENTS).toEqual({
+      openSend: 'Open "Send"',
+      sendFunds: "Send Funds",
+      sendFundsFailed: "Send Funds Failed",
+      openReceive: 'Open "Receive"',
+      openSwap: 'Open "Swap"',
+      openSecureSwap: 'Open "Secure swap"',
+      swapTokens: "Swap tokens",
+      swapTokensFailed: "Swap tokens Failed",
+      claimFunds: "Claim funds",
+    });
+  });
+
+  test("keeps wallet method/source constants stable", () => {
+    expect(SEND_METHODS).toEqual({
+      telegram: "telegram",
+      walletAddress: "wallet_address",
+      unknown: "unknown",
+    });
+    expect(SWAP_METHODS).toEqual({
+      regular: "regular",
+      secure: "secure",
+    });
+    expect(CLAIM_SOURCES).toEqual({
+      manual: "manual",
+      auto: "auto",
+    });
+  });
+});
+
+describe("getSendMethod", () => {
+  test("returns wallet_address for valid Solana addresses", () => {
+    expect(getSendMethod("11111111111111111111111111111111")).toBe(
+      SEND_METHODS.walletAddress
+    );
+  });
+
+  test("returns telegram for valid Telegram usernames", () => {
+    expect(getSendMethod("@askloyal")).toBe(SEND_METHODS.telegram);
+  });
+
+  test("returns unknown for invalid recipients", () => {
+    expect(getSendMethod("not-a-recipient")).toBe(SEND_METHODS.unknown);
+  });
+});

--- a/app/src/app/telegram/wallet/wallet-analytics.ts
+++ b/app/src/app/telegram/wallet/wallet-analytics.ts
@@ -1,0 +1,52 @@
+import {
+  isValidSolanaAddress,
+  isValidTelegramUsername,
+} from "@/components/wallet/SendSheet";
+
+export const WALLET_ANALYTICS_PATH = "/telegram/wallet";
+
+export const WALLET_ANALYTICS_EVENTS = {
+  openSend: 'Open "Send"',
+  sendFunds: "Send Funds",
+  sendFundsFailed: "Send Funds Failed",
+  openReceive: 'Open "Receive"',
+  openSwap: 'Open "Swap"',
+  openSecureSwap: 'Open "Secure swap"',
+  swapTokens: "Swap tokens",
+  swapTokensFailed: "Swap tokens Failed",
+  claimFunds: "Claim funds",
+} as const;
+
+export const SEND_METHODS = {
+  telegram: "telegram",
+  walletAddress: "wallet_address",
+  unknown: "unknown",
+} as const;
+
+export const SWAP_METHODS = {
+  regular: "regular",
+  secure: "secure",
+} as const;
+
+export const CLAIM_SOURCES = {
+  manual: "manual",
+  auto: "auto",
+} as const;
+
+export type SendMethod = (typeof SEND_METHODS)[keyof typeof SEND_METHODS];
+export type SwapMethod = (typeof SWAP_METHODS)[keyof typeof SWAP_METHODS];
+export type ClaimSource = (typeof CLAIM_SOURCES)[keyof typeof CLAIM_SOURCES];
+
+export function getSendMethod(recipient: string): SendMethod {
+  const trimmedRecipient = recipient.trim();
+
+  if (isValidSolanaAddress(trimmedRecipient)) {
+    return SEND_METHODS.walletAddress;
+  }
+
+  if (isValidTelegramUsername(trimmedRecipient)) {
+    return SEND_METHODS.telegram;
+  }
+
+  return SEND_METHODS.unknown;
+}

--- a/app/src/components/analytics/AnalyticsBootstrap.tsx
+++ b/app/src/components/analytics/AnalyticsBootstrap.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import { initAnalytics, track } from "@/lib/core/analytics";
+
+const PAGE_VIEW_EVENT = "Page View";
+
+export function AnalyticsBootstrap() {
+  const pathname = usePathname();
+  const lastTrackedPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  useEffect(() => {
+    if (!pathname || !pathname.startsWith("/telegram")) {
+      return;
+    }
+
+    if (lastTrackedPathRef.current === pathname) {
+      return;
+    }
+
+    lastTrackedPathRef.current = pathname;
+
+    track(PAGE_VIEW_EVENT, { path: pathname });
+  }, [pathname]);
+
+  return null;
+}

--- a/app/src/components/analytics/AnalyticsBootstrap.tsx
+++ b/app/src/components/analytics/AnalyticsBootstrap.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/core/analytics";
 import { parseTelegramAnalyticsContextFromInitData } from "@/lib/telegram/mini-app/init-data-transform";
 
-const PAGE_VIEW_EVENT = "Page View";
 const IDENTITY_WAIT_TIMEOUT_MS = 1500;
 
 type ShouldTrackTelegramPageViewParams = {
@@ -43,6 +42,9 @@ export const shouldTrackTelegramPageView = ({
 
   return true;
 };
+
+export const getTelegramPageViewEventName = (pathname: string): string =>
+  `View ${pathname}`;
 
 export function AnalyticsBootstrap() {
   const pathname = usePathname();
@@ -118,7 +120,7 @@ export function AnalyticsBootstrap() {
     lastTrackedPathRef.current = pathname;
     didTrackFirstTelegramPageRef.current = true;
 
-    track(PAGE_VIEW_EVENT, { path: pathname });
+    track(getTelegramPageViewEventName(pathname), { path: pathname });
   }, [canTrackWithoutIdentity, pathname, telegramIdentity]);
 
   return null;

--- a/app/src/components/analytics/AnalyticsBootstrapClient.tsx
+++ b/app/src/components/analytics/AnalyticsBootstrapClient.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AnalyticsBootstrap } from "@/components/analytics/AnalyticsBootstrap";
+
+export function AnalyticsBootstrapClient() {
+  return <AnalyticsBootstrap />;
+}

--- a/app/src/components/analytics/__tests__/AnalyticsBootstrap.test.ts
+++ b/app/src/components/analytics/__tests__/AnalyticsBootstrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldTrackTelegramPageView } from "../AnalyticsBootstrap";
+
+describe("shouldTrackTelegramPageView", () => {
+  test("returns true for first Telegram pageview when identity is ready", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/telegram/wallet",
+        didTrackForCurrentPath: false,
+        hasIdentity: true,
+        canTrackWithoutIdentity: false,
+      })
+    ).toBe(true);
+  });
+
+  test("returns false after first pageview has already been tracked for a path", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/telegram/wallet",
+        didTrackForCurrentPath: true,
+        hasIdentity: true,
+        canTrackWithoutIdentity: true,
+      })
+    ).toBe(false);
+  });
+
+  test("returns true for pathname transition when first-track flag is reset", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/telegram/profile",
+        didTrackForCurrentPath: false,
+        hasIdentity: true,
+        canTrackWithoutIdentity: true,
+      })
+    ).toBe(true);
+  });
+
+  test("blocks tracking when identity is unresolved and fallback window is not reached", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/telegram/wallet",
+        didTrackForCurrentPath: false,
+        hasIdentity: false,
+        canTrackWithoutIdentity: false,
+      })
+    ).toBe(false);
+  });
+
+  test("allows tracking without identity after fallback window", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/telegram/wallet",
+        didTrackForCurrentPath: false,
+        hasIdentity: false,
+        canTrackWithoutIdentity: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/app/src/components/analytics/__tests__/AnalyticsBootstrap.test.ts
+++ b/app/src/components/analytics/__tests__/AnalyticsBootstrap.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, test } from "bun:test";
 
-import { shouldTrackTelegramPageView } from "../AnalyticsBootstrap";
+import {
+  getTelegramPageViewEventName,
+  shouldTrackTelegramPageView,
+} from "../AnalyticsBootstrap";
+
+describe("getTelegramPageViewEventName", () => {
+  test("formats wallet path into View event name", () => {
+    expect(getTelegramPageViewEventName("/telegram/wallet")).toBe(
+      "View /telegram/wallet"
+    );
+  });
+
+  test("formats feed path into View event name", () => {
+    expect(getTelegramPageViewEventName("/telegram/feed")).toBe(
+      "View /telegram/feed"
+    );
+  });
+});
 
 describe("shouldTrackTelegramPageView", () => {
   test("returns true for first Telegram pageview when identity is ready", () => {
@@ -56,5 +73,16 @@ describe("shouldTrackTelegramPageView", () => {
         canTrackWithoutIdentity: true,
       })
     ).toBe(true);
+  });
+
+  test("returns false for non-Telegram paths", () => {
+    expect(
+      shouldTrackTelegramPageView({
+        pathname: "/profile",
+        didTrackForCurrentPath: false,
+        hasIdentity: true,
+        canTrackWithoutIdentity: true,
+      })
+    ).toBe(false);
   });
 });

--- a/app/src/components/telegram/TelegramAppRootClient.tsx
+++ b/app/src/components/telegram/TelegramAppRootClient.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { AppRoot } from "@telegram-apps/telegram-ui";
+import type { PropsWithChildren } from "react";
+
+export function TelegramAppRootClient({ children }: PropsWithChildren) {
+  return <AppRoot suppressHydrationWarning>{children}</AppRoot>;
+}

--- a/app/src/lib/core/__tests__/analytics.test.ts
+++ b/app/src/lib/core/__tests__/analytics.test.ts
@@ -1,0 +1,169 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const initCalls: unknown[] = [];
+const identifyCalls: string[] = [];
+const trackCalls: Array<{ event: string; properties?: Record<string, unknown> }> = [];
+const registerOnceCalls: Array<Record<string, unknown>> = [];
+const registerCalls: Array<Record<string, unknown>> = [];
+const peopleSetOnceCalls: Array<Record<string, unknown>> = [];
+const peopleSetCalls: Array<Record<string, unknown>> = [];
+
+let currentDistinctId = "$device:anon";
+
+const mixpanelMock = {
+  init: (...args: unknown[]) => {
+    initCalls.push(args);
+  },
+  track: (event: string, properties?: Record<string, unknown>) => {
+    trackCalls.push({ event, properties });
+  },
+  identify: (distinctId: string) => {
+    identifyCalls.push(distinctId);
+    currentDistinctId = distinctId;
+  },
+  get_distinct_id: () => currentDistinctId,
+  register_once: (properties: Record<string, unknown>) => {
+    registerOnceCalls.push(properties);
+  },
+  register: (properties: Record<string, unknown>) => {
+    registerCalls.push(properties);
+  },
+  reset: mock(() => {}),
+  people: {
+    set: (properties: Record<string, unknown>) => {
+      peopleSetCalls.push(properties);
+    },
+    set_once: (properties: Record<string, unknown>) => {
+      peopleSetOnceCalls.push(properties);
+    },
+  },
+};
+
+mock.module("mixpanel-browser", () => ({
+  default: mixpanelMock,
+}));
+
+mock.module("@/lib/core/config/public", () => ({
+  publicEnv: {
+    mixpanelToken: "test-mixpanel-token",
+    mixpanelProxyPath: "/ingest",
+    solanaEnv: "mainnet",
+  },
+}));
+
+let analytics: typeof import("../analytics");
+
+describe("analytics identifyTelegramUser", () => {
+  beforeAll(async () => {
+    analytics = await import("../analytics");
+  });
+
+  beforeEach(() => {
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "https://loyal.example" },
+    };
+    initCalls.length = 0;
+    identifyCalls.length = 0;
+    trackCalls.length = 0;
+    registerOnceCalls.length = 0;
+    registerCalls.length = 0;
+    peopleSetOnceCalls.length = 0;
+    peopleSetCalls.length = 0;
+    currentDistinctId = "$device:anon";
+    analytics.__resetAnalyticsStateForTests();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test("deduplicates identify/profile calls for the same Telegram user", () => {
+    const identity = {
+      telegramId: "123456789",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      username: "ada",
+      photoUrl: "https://example.com/avatar.png",
+      languageCode: "en",
+      isPremium: true,
+    };
+
+    analytics.identifyTelegramUser(identity);
+    analytics.identifyTelegramUser(identity);
+
+    expect(initCalls).toHaveLength(1);
+    expect(identifyCalls).toEqual(["tg:123456789"]);
+    expect(registerOnceCalls).toHaveLength(1);
+    expect(registerCalls).toHaveLength(1);
+    expect(peopleSetOnceCalls).toHaveLength(1);
+    expect(peopleSetCalls).toHaveLength(0);
+    expect(peopleSetOnceCalls[0]).toMatchObject({
+      telegram_language_code: "en",
+      telegram_is_premium: true,
+    });
+  });
+
+  test("identifies and profiles again when Telegram user changes", () => {
+    analytics.identifyTelegramUser({
+      telegramId: "1",
+      firstName: "First",
+      username: "first",
+    });
+    analytics.identifyTelegramUser({
+      telegramId: "2",
+      firstName: "Second",
+      username: "second",
+    });
+
+    expect(identifyCalls).toEqual(["tg:1", "tg:2"]);
+    expect(peopleSetOnceCalls).toHaveLength(2);
+  });
+
+  test("adds launch context to tracked events while context is set", () => {
+    analytics.setTelegramLaunchContext({
+      startParamRaw: "post_42",
+      chatType: "channel",
+      chatInstance: "99887766",
+    });
+
+    analytics.track("Page View", { path: "/telegram/wallet" });
+
+    expect(trackCalls).toHaveLength(1);
+    expect(trackCalls[0]).toEqual({
+      event: "Page View",
+      properties: {
+        launch_start_param_raw: "post_42",
+        launch_chat_type: "channel",
+        launch_chat_instance: "99887766",
+        path: "/telegram/wallet",
+      },
+    });
+  });
+
+  test("stops attaching launch context after clear", () => {
+    analytics.setTelegramLaunchContext({
+      startParamRaw: "post_42",
+      chatType: "channel",
+      chatInstance: "99887766",
+    });
+    analytics.clearTelegramLaunchContext();
+
+    analytics.track("Page View", { path: "/telegram/wallet" });
+
+    expect(trackCalls).toHaveLength(1);
+    expect(trackCalls[0]).toEqual({
+      event: "Page View",
+      properties: {
+        path: "/telegram/wallet",
+      },
+    });
+  });
+});

--- a/app/src/lib/core/analytics.ts
+++ b/app/src/lib/core/analytics.ts
@@ -3,10 +3,30 @@
 import mixpanel from "mixpanel-browser";
 
 import { publicEnv } from "@/lib/core/config/public";
+import type {
+  TelegramIdentity,
+  TelegramLaunchContext,
+} from "@/lib/telegram/mini-app/init-data-transform";
 
 type AnalyticsProperties = Record<string, unknown>;
 
 let isInitialized = false;
+let lastIdentifiedDistinctId: string | null = null;
+let lastProfiledDistinctId: string | null = null;
+let lastRegisteredDistinctId: string | null = null;
+let lastRegisteredUsername: string | null = null;
+let currentLaunchContext: AnalyticsProperties = {};
+
+const TELEGRAM_IDENTITY_PROVIDER = "telegram" as const;
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
 
 function isClientEnvironment(): boolean {
   return typeof window !== "undefined";
@@ -48,6 +68,47 @@ export function initAnalytics(): void {
   }
 }
 
+function setUserProfileOnce(properties: AnalyticsProperties): void {
+  try {
+    mixpanel.people.set_once(properties);
+  } catch (error) {
+    console.error("Failed to set Mixpanel profile once", error);
+  }
+}
+
+function mapLaunchContextToEventProperties(
+  context: TelegramLaunchContext
+): AnalyticsProperties {
+  const properties: AnalyticsProperties = {};
+
+  if (context.startParamRaw) {
+    properties.launch_start_param_raw = context.startParamRaw;
+  }
+  if (context.chatType) {
+    properties.launch_chat_type = context.chatType;
+  }
+  if (context.chatInstance) {
+    properties.launch_chat_instance = context.chatInstance;
+  }
+
+  return properties;
+}
+
+export function setTelegramLaunchContext(
+  context: TelegramLaunchContext | null
+): void {
+  if (!context) {
+    currentLaunchContext = {};
+    return;
+  }
+
+  currentLaunchContext = mapLaunchContextToEventProperties(context);
+}
+
+export function clearTelegramLaunchContext(): void {
+  currentLaunchContext = {};
+}
+
 export function track(event: string, properties?: AnalyticsProperties): void {
   if (!canTrack()) {
     return;
@@ -59,9 +120,93 @@ export function track(event: string, properties?: AnalyticsProperties): void {
   }
 
   try {
-    mixpanel.track(event, properties);
+    mixpanel.track(event, {
+      ...currentLaunchContext,
+      ...(properties ?? {}),
+    });
   } catch (error) {
     console.error("Failed to track Mixpanel event", error);
+  }
+}
+
+export function identifyTelegramUser(identity: TelegramIdentity | null): void {
+  if (!identity || !canTrack()) {
+    return;
+  }
+
+  initAnalytics();
+  if (!isInitialized) {
+    return;
+  }
+
+  const distinctId = `tg:${identity.telegramId}`;
+  const username = normalizeOptionalString(identity.username);
+  const canSkipCompletely =
+    lastIdentifiedDistinctId === distinctId &&
+    lastProfiledDistinctId === distinctId &&
+    lastRegisteredDistinctId === distinctId &&
+    lastRegisteredUsername === username;
+
+  if (canSkipCompletely) {
+    return;
+  }
+
+  try {
+    const currentDistinctId = mixpanel.get_distinct_id();
+    if (
+      lastIdentifiedDistinctId !== distinctId &&
+      currentDistinctId !== distinctId
+    ) {
+      mixpanel.identify(distinctId);
+    }
+
+    mixpanel.register_once({
+      telegram_id: identity.telegramId,
+      identity_provider: TELEGRAM_IDENTITY_PROVIDER,
+    });
+
+    if (username) {
+      mixpanel.register({
+        telegram_username: username,
+      });
+    }
+
+    if (lastProfiledDistinctId !== distinctId) {
+      const profileProperties: AnalyticsProperties = {
+        telegram_id: identity.telegramId,
+        identity_provider: TELEGRAM_IDENTITY_PROVIDER,
+      };
+
+      if (username) {
+        profileProperties.$username = username;
+        profileProperties.telegram_username = username;
+      }
+      if (identity.firstName) {
+        profileProperties.$first_name = identity.firstName;
+      }
+      if (identity.lastName) {
+        profileProperties.$last_name = identity.lastName;
+      }
+      if (identity.photoUrl) {
+        profileProperties.$avatar = identity.photoUrl;
+      }
+      if (identity.languageCode) {
+        profileProperties.$language = identity.languageCode;
+        profileProperties.telegram_language_code = identity.languageCode;
+      }
+      if (identity.isPremium !== undefined) {
+        profileProperties.telegram_is_premium = identity.isPremium;
+      }
+
+      setUserProfileOnce(profileProperties);
+      lastProfiledDistinctId = distinctId;
+    }
+
+    lastIdentifiedDistinctId = distinctId;
+    lastRegisteredDistinctId = distinctId;
+    lastRegisteredUsername = username;
+  } catch (error) {
+    console.error("Failed to identify Telegram Mixpanel user", error);
   }
 }
 
@@ -114,4 +259,13 @@ export function setUserProfile(properties: AnalyticsProperties): void {
   } catch (error) {
     console.error("Failed to set Mixpanel profile", error);
   }
+}
+
+export function __resetAnalyticsStateForTests(): void {
+  isInitialized = false;
+  lastIdentifiedDistinctId = null;
+  lastProfiledDistinctId = null;
+  lastRegisteredDistinctId = null;
+  lastRegisteredUsername = null;
+  currentLaunchContext = {};
 }

--- a/app/src/lib/core/analytics.ts
+++ b/app/src/lib/core/analytics.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import mixpanel from "mixpanel-browser";
+
+import { publicEnv } from "@/lib/core/config/public";
+
+type AnalyticsProperties = Record<string, unknown>;
+
+let isInitialized = false;
+
+function isClientEnvironment(): boolean {
+  return typeof window !== "undefined";
+}
+
+function canTrack(): boolean {
+  return isClientEnvironment() && Boolean(publicEnv.mixpanelToken);
+}
+
+function getApiHost(): string {
+  return `${window.location.origin}${publicEnv.mixpanelProxyPath}`;
+}
+
+export function initAnalytics(): void {
+  if (!canTrack() || isInitialized) {
+    return;
+  }
+
+  const isDevnetDemoMode = publicEnv.solanaEnv === "devnet";
+
+  try {
+    mixpanel.init(publicEnv.mixpanelToken!, {
+      api_host: getApiHost(),
+      debug: isDevnetDemoMode,
+      track_pageview: false,
+      persistence: "localStorage",
+    });
+
+    if (isDevnetDemoMode) {
+      mixpanel.register({
+        app_mode: "demo",
+        app_solana_env: "devnet",
+      });
+    }
+
+    isInitialized = true;
+  } catch (error) {
+    console.error("Failed to initialize Mixpanel", error);
+  }
+}
+
+export function track(event: string, properties?: AnalyticsProperties): void {
+  if (!canTrack()) {
+    return;
+  }
+
+  initAnalytics();
+  if (!isInitialized) {
+    return;
+  }
+
+  try {
+    mixpanel.track(event, properties);
+  } catch (error) {
+    console.error("Failed to track Mixpanel event", error);
+  }
+}
+
+export function identify(distinctId: string): void {
+  if (!canTrack()) {
+    return;
+  }
+
+  initAnalytics();
+  if (!isInitialized) {
+    return;
+  }
+
+  try {
+    mixpanel.identify(distinctId);
+  } catch (error) {
+    console.error("Failed to identify Mixpanel user", error);
+  }
+}
+
+export function resetAnalytics(): void {
+  if (!canTrack()) {
+    return;
+  }
+
+  initAnalytics();
+  if (!isInitialized) {
+    return;
+  }
+
+  try {
+    mixpanel.reset();
+  } catch (error) {
+    console.error("Failed to reset Mixpanel user", error);
+  }
+}
+
+export function setUserProfile(properties: AnalyticsProperties): void {
+  if (!canTrack()) {
+    return;
+  }
+
+  initAnalytics();
+  if (!isInitialized) {
+    return;
+  }
+
+  try {
+    mixpanel.people.set(properties);
+  } catch (error) {
+    console.error("Failed to set Mixpanel profile", error);
+  }
+}

--- a/app/src/lib/core/config/public.ts
+++ b/app/src/lib/core/config/public.ts
@@ -3,6 +3,7 @@ import { isStrictTrue, normalizeOptionalValue } from "./shared";
 export type PublicSolanaEnv = "mainnet" | "testnet" | "devnet" | "localnet";
 
 const DEFAULT_SOLANA_ENV: PublicSolanaEnv = "devnet";
+const DEFAULT_MIXPANEL_PROXY_PATH = "/ingest";
 
 const PUBLIC_SOLANA_ENV_VALUES: readonly PublicSolanaEnv[] = [
   "mainnet",
@@ -32,5 +33,19 @@ export const publicEnv = {
     return isStrictTrue(
       normalizeOptionalValue(process.env.NEXT_PUBLIC_USE_MOCK_SUMMARIES)
     );
+  },
+  get mixpanelToken(): string | undefined {
+    return normalizeOptionalValue(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN);
+  },
+  get mixpanelProxyPath(): string {
+    const value = normalizeOptionalValue(
+      process.env.NEXT_PUBLIC_MIXPANEL_PROXY_PATH
+    );
+
+    if (!value) {
+      return DEFAULT_MIXPANEL_PROXY_PATH;
+    }
+
+    return value.startsWith("/") ? value : `/${value}`;
   },
 } as const;

--- a/app/src/lib/telegram/mini-app/__tests__/init-data-transform.test.ts
+++ b/app/src/lib/telegram/mini-app/__tests__/init-data-transform.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  parseTelegramAnalyticsContextFromInitData,
+  parseTelegramIdentityFromInitData,
+  parseUserFromInitData,
+} from "../init-data-transform";
+
+describe("parseTelegramIdentityFromInitData", () => {
+  test("parses user identity from stringified Telegram user payload", () => {
+    const rawInitData = [
+      "query_id=aa",
+      `user=${encodeURIComponent(
+        JSON.stringify({
+          id: 123456789,
+          first_name: "Ada",
+          last_name: "Lovelace",
+          username: "ada",
+          photo_url: "https://example.com/avatar.png",
+          language_code: "en",
+          is_premium: true,
+        })
+      )}`,
+      "auth_date=1700000000",
+      "hash=hash",
+    ].join("&");
+
+    expect(parseTelegramIdentityFromInitData(rawInitData)).toEqual({
+      telegramId: "123456789",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      username: "ada",
+      photoUrl: "https://example.com/avatar.png",
+      languageCode: "en",
+      isPremium: true,
+    });
+  });
+
+  test("parses user identity from object-shaped user payload", () => {
+    const rawInitData = [
+      "query_id=aa",
+      "user[id]=987654321",
+      "user[first_name]=Linus",
+      "user[last_name]=Torvalds",
+      "user[username]=linus",
+      "hash=hash",
+    ].join("&");
+
+    expect(parseTelegramIdentityFromInitData(rawInitData)).toEqual({
+      telegramId: "987654321",
+      firstName: "Linus",
+      lastName: "Torvalds",
+      username: "linus",
+      photoUrl: undefined,
+      languageCode: undefined,
+      isPremium: undefined,
+    });
+  });
+
+  test("returns null for malformed stringified user payload", () => {
+    const originalWarn = console.warn;
+    console.warn = mock(() => {});
+
+    try {
+      const rawInitData = [
+        "query_id=aa",
+        `user=${encodeURIComponent("{bad-json")}`,
+        "hash=hash",
+      ].join("&");
+
+      expect(parseTelegramIdentityFromInitData(rawInitData)).toBeNull();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("returns null when Telegram user id is missing", () => {
+    const rawInitData = [
+      "query_id=aa",
+      `user=${encodeURIComponent(
+        JSON.stringify({
+          first_name: "No",
+          username: "missing_id",
+        })
+      )}`,
+      "hash=hash",
+    ].join("&");
+
+    expect(parseTelegramIdentityFromInitData(rawInitData)).toBeNull();
+  });
+});
+
+describe("parseUserFromInitData", () => {
+  test("reuses Telegram identity parser output", () => {
+    const rawInitData = [
+      "query_id=aa",
+      `user=${encodeURIComponent(
+        JSON.stringify({
+          id: 10101010,
+          first_name: "Grace",
+          last_name: "Hopper",
+          username: "grace",
+          language_code: "en",
+          is_premium: false,
+        })
+      )}`,
+      "hash=hash",
+    ].join("&");
+
+    expect(parseUserFromInitData(rawInitData)).toEqual({
+      telegramId: "10101010",
+      firstName: "Grace",
+      lastName: "Hopper",
+      username: "grace",
+      photoUrl: undefined,
+      languageCode: "en",
+      isPremium: false,
+    });
+  });
+});
+
+describe("parseTelegramAnalyticsContextFromInitData", () => {
+  test("extracts raw launch context fields from init data", () => {
+    const rawInitData = [
+      "query_id=aa",
+      `user=${encodeURIComponent(
+        JSON.stringify({
+          id: 10101010,
+          first_name: "Grace",
+        })
+      )}`,
+      "start_param=post_42_campaign_abc",
+      "chat_type=channel",
+      "chat_instance=99887766",
+      "hash=hash",
+    ].join("&");
+
+    expect(parseTelegramAnalyticsContextFromInitData(rawInitData)).toEqual({
+      identity: {
+        telegramId: "10101010",
+        firstName: "Grace",
+        lastName: undefined,
+        username: undefined,
+        photoUrl: undefined,
+        languageCode: undefined,
+        isPremium: undefined,
+      },
+      launchContext: {
+        startParamRaw: "post_42_campaign_abc",
+        chatType: "channel",
+        chatInstance: "99887766",
+      },
+    });
+  });
+
+  test("returns undefined launch fields when they are missing", () => {
+    const rawInitData = [
+      "query_id=aa",
+      `user=${encodeURIComponent(
+        JSON.stringify({
+          id: 4242,
+          first_name: "User",
+        })
+      )}`,
+      "hash=hash",
+    ].join("&");
+
+    expect(parseTelegramAnalyticsContextFromInitData(rawInitData)).toEqual({
+      identity: {
+        telegramId: "4242",
+        firstName: "User",
+        lastName: undefined,
+        username: undefined,
+        photoUrl: undefined,
+        languageCode: undefined,
+        isPremium: undefined,
+      },
+      launchContext: {
+        startParamRaw: undefined,
+        chatType: undefined,
+        chatInstance: undefined,
+      },
+    });
+  });
+});

--- a/app/src/lib/telegram/mini-app/cloud-storage.ts
+++ b/app/src/lib/telegram/mini-app/cloud-storage.ts
@@ -1,15 +1,41 @@
-import { cloudStorage } from "@telegram-apps/sdk";
-
 import { CloudKeyInput } from "@/types/telegram";
-
-import { isInMiniApp } from "./index";
 
 const normalizeKeys = (input: CloudKeyInput): string[] =>
   Array.isArray(input) ? input : [input];
 
-const canUseCloudStorage = (): boolean => {
-  if (!isInMiniApp()) return false;
+type TelegramCloudStorage = (typeof import("@telegram-apps/sdk"))["cloudStorage"];
+type TelegramSdkModule = typeof import("@telegram-apps/sdk");
 
+let sdkInitialized = false;
+
+const getCloudStorage = async (): Promise<TelegramCloudStorage | null> => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const sdk = await import("@telegram-apps/sdk");
+    await ensureSdkInitialized(sdk);
+    return sdk.cloudStorage;
+  } catch (error) {
+    console.error("Failed to load Telegram cloud storage SDK", error);
+    return null;
+  }
+};
+
+const ensureSdkInitialized = async (sdk: TelegramSdkModule): Promise<void> => {
+  if (sdkInitialized) return;
+
+  try {
+    sdk.init();
+  } catch {
+    // SDK may already be initialized or unavailable in non-Telegram contexts.
+  } finally {
+    sdkInitialized = true;
+  }
+};
+
+const canUseCloudStorage = (cloudStorage: TelegramCloudStorage): boolean => {
   try {
     return cloudStorage.isSupported();
   } catch (error) {
@@ -29,7 +55,9 @@ export async function setCloudValue(
   key: string,
   value: string
 ): Promise<boolean> {
-  if (!canUseCloudStorage()) return false;
+  const cloudStorage = await getCloudStorage();
+  if (!cloudStorage) return false;
+  if (!canUseCloudStorage(cloudStorage)) return false;
   if (!cloudStorage.setItem.isAvailable()) return false;
 
   if (!hasKeys([key])) return false;
@@ -46,7 +74,9 @@ export async function setCloudValue(
 export async function getCloudValue(
   keyOrKeys: CloudKeyInput
 ): Promise<string | Record<string, string> | null> {
-  if (!canUseCloudStorage()) return null;
+  const cloudStorage = await getCloudStorage();
+  if (!cloudStorage) return null;
+  if (!canUseCloudStorage(cloudStorage)) return null;
   if (!cloudStorage.getItem.isAvailable()) return null;
 
   const keys = normalizeKeys(keyOrKeys);
@@ -67,7 +97,9 @@ export async function getCloudValue(
 export async function deleteCloudValue(
   keyOrKeys: CloudKeyInput
 ): Promise<boolean> {
-  if (!canUseCloudStorage()) return false;
+  const cloudStorage = await getCloudStorage();
+  if (!cloudStorage) return false;
+  if (!canUseCloudStorage(cloudStorage)) return false;
   if (!cloudStorage.deleteItem.isAvailable()) return false;
 
   const keys = normalizeKeys(keyOrKeys);


### PR DESCRIPTION
Adds Mixpanel tracking for community summary day views with community and selection-source context. Also hardens Telegram SDK/cloud-storage boundaries to avoid SSR build failures and cloud keypair persistence races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive analytics tracking across wallet operations: send, receive, swap, and claim transactions now capture detailed user interactions and outcomes.
  * Integrated analytics for summary feed viewing with interaction source tracking.

* **Chores**
  * Configured Mixpanel event analytics integration.
  * Enhanced wallet keypair persistence with retry logic for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->