### PR TITLE
feat(telegram): add styled summary inline keyboard buttons

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -22,7 +22,7 @@
         "drizzle-orm": "^0.45.1",
         "ethers": "^6.16.0",
         "framer-motion": "^12.23.25",
-        "grammy": "^1.39.3",
+        "grammy": "1.40.0",
         "lightningcss": "^1.30.2",
         "lucide-react": "^0.552.0",
         "mixpanel-browser": "^2.74.0",
@@ -307,7 +307,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
-    "@grammyjs/types": ["@grammyjs/types@3.23.0", "", {}, "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g=="],
+    "@grammyjs/types": ["@grammyjs/types@3.24.0", "", {}, "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -1209,7 +1209,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "grammy": ["grammy@1.39.3", "", { "dependencies": { "@grammyjs/types": "3.23.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw=="],
+    "grammy": ["grammy@1.40.0", "", { "dependencies": { "@grammyjs/types": "3.24.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 

--- a/app/drizzle/0006_known_thunderbolt_ross.sql
+++ b/app/drizzle/0006_known_thunderbolt_ross.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "summary_votes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"summary_id" uuid NOT NULL,
+	"action" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "summary_votes_action_check" CHECK ("summary_votes"."action" IN ('LIKE', 'DISLIKE'))
+);
+--> statement-breakpoint
+ALTER TABLE "summary_votes" ADD CONSTRAINT "summary_votes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "summary_votes" ADD CONSTRAINT "summary_votes_summary_id_summaries_id_fk" FOREIGN KEY ("summary_id") REFERENCES "public"."summaries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "summary_votes_summary_user_uidx" ON "summary_votes" USING btree ("summary_id","user_id");--> statement-breakpoint
+CREATE INDEX "summary_votes_summary_action_idx" ON "summary_votes" USING btree ("summary_id","action");

--- a/app/drizzle/meta/0006_snapshot.json
+++ b/app/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1210 @@
+{
+  "id": "8815f760-33ae-406e-942f-0fffb83739ce",
+  "prevId": "1991cf81-2389-4148-9085-1f395e0a3df3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1770876327749,
       "tag": "0005_puzzling_lady_ursula",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1771046097651,
+      "tag": "0006_known_thunderbolt_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "drizzle-orm": "^0.45.1",
     "ethers": "^6.16.0",
     "framer-motion": "^12.23.25",
-    "grammy": "^1.39.3",
+    "grammy": "1.40.0",
     "lightningcss": "^1.30.2",
     "lucide-react": "^0.552.0",
     "mixpanel-browser": "^2.74.0",

--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -28,6 +28,10 @@ import {
 } from "@/lib/telegram/bot-api/start-carousel";
 import { resolveSummaryCommunityPeerId } from "@/lib/telegram/bot-api/summary-chat-id";
 import {
+  handleSummaryVoteCallback,
+  SUMMARY_VOTE_CALLBACK_DATA_REGEX,
+} from "@/lib/telegram/bot-api/summary-votes";
+import {
   handleDirectMessage,
   handleDirectTopicCreatedMessage,
 } from "@/lib/telegram/conversation-service";
@@ -83,6 +87,10 @@ bot.callbackQuery(START_CAROUSEL_CALLBACK_DATA_REGEX, async (ctx) => {
 
 bot.callbackQuery(NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX, async (ctx) => {
   await handleNotificationSettingsCallback(ctx);
+});
+
+bot.callbackQuery(SUMMARY_VOTE_CALLBACK_DATA_REGEX, async (ctx) => {
+  await handleSummaryVoteCallback(ctx);
 });
 
 // Keep this fallback at the end so unknown callback queries don't show

--- a/app/src/lib/telegram/bot-api/__tests__/grammy-inline-keyboard-style.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/grammy-inline-keyboard-style.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { InlineKeyboard } from "grammy";
+
+describe("grammy inline keyboard style support", () => {
+  test("keeps style and icon metadata on callback buttons", () => {
+    const keyboard = new InlineKeyboard().text(
+      {
+        icon_custom_emoji_id: "5373141891321699084",
+        style: "primary",
+        text: "Claim now",
+      },
+      "claim:123"
+    );
+
+    const button = keyboard.inline_keyboard[0]?.[0];
+
+    expect(button).toEqual({
+      callback_data: "claim:123",
+      icon_custom_emoji_id: "5373141891321699084",
+      style: "primary",
+      text: "Claim now",
+    });
+  });
+
+  test("keeps style metadata on URL buttons", () => {
+    const keyboard = new InlineKeyboard().url(
+      {
+        style: "success",
+        text: "Open",
+      },
+      "https://t.me/askloyal"
+    );
+
+    const button = keyboard.inline_keyboard[0]?.[0];
+
+    expect(button).toEqual({
+      style: "success",
+      text: "Open",
+      url: "https://t.me/askloyal",
+    });
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
@@ -115,7 +115,12 @@ describe("summary delivery guards", () => {
       {
         reply_markup: {
           inline_keyboard: Array<
-            Array<{ callback_data?: string; text?: string; url?: string }>
+            Array<{
+              callback_data?: string;
+              style?: string;
+              text?: string;
+              url?: string;
+            }>
           >;
         };
       },
@@ -125,9 +130,13 @@ describe("summary delivery guards", () => {
     expect(rows[0]).toHaveLength(3);
     expect(rows[1]).toHaveLength(1);
     expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}`);
+    expect(rows[0][0]?.style).toBe("success");
     expect(rows[0][1]?.text).toBe("Score: 3");
     expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}`);
     expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}`);
+    expect(rows[0][2]?.style).toBe("danger");
+    expect(rows[1][0]?.text).toBe("Open");
+    expect(rows[1][0]?.style).toBe("primary");
     expect(rows[1][0]?.url).toBe(MINI_APP_FEED_LINK);
   });
 

--- a/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
@@ -27,6 +27,10 @@ type SummaryWithCommunityRecord = {
 
 let communityResult: CommunityRecord | null = null;
 let summaryResult: SummaryWithCommunityRecord = null;
+let summaryVoteTotalsResult: { dislikes: number; likes: number } = {
+  dislikes: 0,
+  likes: 0,
+};
 
 mock.module("@/lib/core/database", () => ({
   getDatabase: () => ({
@@ -38,6 +42,15 @@ mock.module("@/lib/core/database", () => ({
         findFirst: async () => summaryResult,
       },
     },
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            groupBy: async () => [summaryVoteTotalsResult],
+          }),
+        }),
+      }),
+    }),
   }),
 }));
 
@@ -60,6 +73,10 @@ describe("summary delivery guards", () => {
   beforeEach(() => {
     communityResult = null;
     summaryResult = null;
+    summaryVoteTotalsResult = {
+      dislikes: 0,
+      likes: 0,
+    };
   });
 
   test("sendSummaryById sends summary when community is active and enabled", async () => {
@@ -83,6 +100,10 @@ describe("summary delivery guards", () => {
       id: SUMMARY_ID,
       oneliner: "Daily recap",
     };
+    summaryVoteTotalsResult = {
+      dislikes: 2,
+      likes: 5,
+    };
 
     const result = await sendSummaryById(bot, SUMMARY_ID);
 
@@ -103,9 +124,10 @@ describe("summary delivery guards", () => {
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveLength(3);
     expect(rows[1]).toHaveLength(1);
-    expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}:0:0`);
-    expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}:0:0`);
-    expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}:0:0`);
+    expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}`);
+    expect(rows[0][1]?.text).toBe("Score: 3");
+    expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}`);
+    expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}`);
     expect(rows[1][0]?.url).toBe(MINI_APP_FEED_LINK);
   });
 

--- a/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
@@ -124,15 +124,18 @@ describe("summary vote keyboard", () => {
     expect(rows[1]).toHaveLength(1);
 
     expect(rows[0][0]?.text).toBe("👍👍👍");
+    expect(rows[0][0]?.style).toBe("success");
     expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}`);
 
     expect(rows[0][1]?.text).toBe("Score: 3");
     expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}`);
 
     expect(rows[0][2]?.text).toBe("👎👎👎");
+    expect(rows[0][2]?.style).toBe("danger");
     expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}`);
 
-    expect(rows[1][0]?.text).toBe("Read in full");
+    expect(rows[1][0]?.text).toBe("Open");
+    expect(rows[1][0]?.style).toBe("primary");
     expect(rows[1][0]?.url).toBe(MINI_APP_FEED_LINK);
   });
 });
@@ -215,7 +218,9 @@ describe("handleSummaryVoteCallback", () => {
       number,
       {
         reply_markup: {
-          inline_keyboard: Array<Array<{ callback_data?: string; text?: string }>>;
+          inline_keyboard: Array<
+            Array<{ callback_data?: string; style?: string; text?: string }>
+          >;
         };
       },
     ];
@@ -223,10 +228,12 @@ describe("handleSummaryVoteCallback", () => {
     expect(payload.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe(
       `sv:u:${SUMMARY_ID}`
     );
+    expect(payload.reply_markup.inline_keyboard[0]?.[0]?.style).toBe("success");
     expect(payload.reply_markup.inline_keyboard[0]?.[1]?.text).toBe("Score: 1");
     expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
       `sv:s:${SUMMARY_ID}`
     );
+    expect(payload.reply_markup.inline_keyboard[0]?.[2]?.style).toBe("danger");
 
     expect(answerCalls).toEqual([undefined]);
   });

--- a/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
@@ -264,6 +264,7 @@ describe("handleSummaryVoteCallback", () => {
     expect(editCalls).toHaveLength(0);
     expect(answerCalls).toEqual([
       {
+        cache_time: 300,
         show_alert: true,
         text: "You've voted already!",
       },

--- a/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+import type { CallbackQueryContext, Context } from "grammy";
+
+import { MINI_APP_FEED_LINK } from "../constants";
+import {
+  buildSummaryVoteKeyboard,
+  encodeSummaryVoteCallbackData,
+  handleSummaryVoteCallback,
+  parseSummaryVoteCallbackData,
+  SUMMARY_VOTE_CALLBACK_DATA_REGEX,
+} from "../summary-votes";
+
+const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
+const MAX_VOTE_COUNT = 2_147_483_647;
+
+describe("summary vote callback parser", () => {
+  test("parses valid callback data", () => {
+    const data = encodeSummaryVoteCallbackData({
+      action: "u",
+      dislikes: 4,
+      likes: 7,
+      summaryId: SUMMARY_ID,
+    });
+
+    expect(parseSummaryVoteCallbackData(data)).toEqual({
+      action: "u",
+      dislikes: 4,
+      likes: 7,
+      summaryId: SUMMARY_ID,
+    });
+  });
+
+  test("rejects invalid callback data", () => {
+    expect(parseSummaryVoteCallbackData("sv:u:bad-id:0:0")).toBeNull();
+    expect(parseSummaryVoteCallbackData("sv:u:123:0:0")).toBeNull();
+    expect(parseSummaryVoteCallbackData("sv:u:123:0")).toBeNull();
+    expect(parseSummaryVoteCallbackData("unknown")).toBeNull();
+  });
+
+  test("rejects callback data with counts above int32 max", () => {
+    expect(
+      parseSummaryVoteCallbackData(`sv:u:${SUMMARY_ID}:${MAX_VOTE_COUNT + 1}:0`)
+    ).toBeNull();
+    expect(
+      parseSummaryVoteCallbackData(`sv:d:${SUMMARY_ID}:0:${MAX_VOTE_COUNT + 1}`)
+    ).toBeNull();
+  });
+
+  test("regex trigger only matches expected callback format", () => {
+    expect(
+      SUMMARY_VOTE_CALLBACK_DATA_REGEX.test(`sv:s:${SUMMARY_ID}:12:3`)
+    ).toBe(true);
+    expect(
+      SUMMARY_VOTE_CALLBACK_DATA_REGEX.test(`sv:s:${SUMMARY_ID}:12:3:extra`)
+    ).toBe(false);
+  });
+});
+
+describe("summary vote keyboard", () => {
+  test("builds two rows with vote callbacks and mini app URL button", () => {
+    const keyboard = buildSummaryVoteKeyboard(SUMMARY_ID, 5, 2);
+    const rows = keyboard.inline_keyboard;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveLength(3);
+    expect(rows[1]).toHaveLength(1);
+
+    expect(rows[0][0]?.text).toBe("👍👍👍");
+    expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}:5:2`);
+
+    expect(rows[0][1]?.text).toBe("Score: 3");
+    expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}:5:2`);
+
+    expect(rows[0][2]?.text).toBe("👎👎👎");
+    expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}:5:2`);
+
+    expect(rows[1][0]?.text).toBe("Read in full");
+    expect(rows[1][0]?.url).toBe(MINI_APP_FEED_LINK);
+  });
+});
+
+describe("handleSummaryVoteCallback", () => {
+  test("shows score alert for score button", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:s:${SUMMARY_ID}:4:1`,
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(0);
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: "Current summary score is 3.",
+      },
+    ]);
+  });
+
+  test("increments likes and updates keyboard for upvote", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:u:${SUMMARY_ID}:1:2`,
+        message: {
+          chat: { id: -1001234 },
+          message_id: 99,
+        },
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(1);
+    const [, , payload] = editCalls[0] as [number, number, { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string }>> } }];
+    expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
+      `sv:s:${SUMMARY_ID}:2:2`
+    );
+    expect(answerCalls).toEqual([undefined]);
+  });
+
+  test("clamps likes at int32 max during upvote", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:u:${SUMMARY_ID}:${MAX_VOTE_COUNT}:1`,
+        message: {
+          chat: { id: -1001234 },
+          message_id: 99,
+        },
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(1);
+    const [, , payload] = editCalls[0] as [
+      number,
+      number,
+      {
+        reply_markup: {
+          inline_keyboard: Array<Array<{ callback_data?: string }>>;
+        };
+      },
+    ];
+    expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
+      `sv:s:${SUMMARY_ID}:${MAX_VOTE_COUNT}:1`
+    );
+    expect(answerCalls).toEqual([undefined]);
+  });
+
+  test("increments dislikes and updates keyboard for downvote", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:d:${SUMMARY_ID}:2:1`,
+        message: {
+          chat: { id: -1001234 },
+          message_id: 99,
+        },
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(1);
+    const [, , payload] = editCalls[0] as [number, number, { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string }>> } }];
+    expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
+      `sv:s:${SUMMARY_ID}:2:2`
+    );
+    expect(answerCalls).toEqual([undefined]);
+  });
+
+  test("clamps dislikes at int32 max during downvote", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:d:${SUMMARY_ID}:1:${MAX_VOTE_COUNT}`,
+        message: {
+          chat: { id: -1001234 },
+          message_id: 99,
+        },
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(1);
+    const [, , payload] = editCalls[0] as [
+      number,
+      number,
+      {
+        reply_markup: {
+          inline_keyboard: Array<Array<{ callback_data?: string }>>;
+        };
+      },
+    ];
+    expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
+      `sv:s:${SUMMARY_ID}:1:${MAX_VOTE_COUNT}`
+    );
+    expect(answerCalls).toEqual([undefined]);
+  });
+
+  test("answers callback when vote callback has no message payload", async () => {
+    const answerCalls: unknown[] = [];
+    const editCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async (...args: unknown[]) => {
+          editCalls.push(args);
+        },
+      },
+      callbackQuery: {
+        data: `sv:u:${SUMMARY_ID}:1:1`,
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(editCalls).toHaveLength(0);
+    expect(answerCalls).toEqual([undefined]);
+  });
+
+  test("silently handles message-is-not-modified edit errors", async () => {
+    const answerCalls: unknown[] = [];
+
+    const ctx = {
+      answerCallbackQuery: async (payload?: unknown) => {
+        answerCalls.push(payload);
+      },
+      api: {
+        editMessageReplyMarkup: async () => {
+          throw {
+            description: "Bad Request: message is not modified",
+          };
+        },
+      },
+      callbackQuery: {
+        data: `sv:u:${SUMMARY_ID}:5:5`,
+        message: {
+          chat: { id: -1001234 },
+          message_id: 99,
+        },
+      },
+    } as unknown as CallbackQueryContext<Context>;
+
+    await handleSummaryVoteCallback(ctx);
+
+    expect(answerCalls).toEqual([undefined]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/callback-query-utils.ts
+++ b/app/src/lib/telegram/bot-api/callback-query-utils.ts
@@ -1,0 +1,17 @@
+export function isMessageNotModifiedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const maybeError = error as {
+    description?: unknown;
+    message?: unknown;
+  };
+
+  return (
+    (typeof maybeError.description === "string" &&
+      maybeError.description.includes("message is not modified")) ||
+    (typeof maybeError.message === "string" &&
+      maybeError.message.includes("message is not modified"))
+  );
+}

--- a/app/src/lib/telegram/bot-api/notification-settings.ts
+++ b/app/src/lib/telegram/bot-api/notification-settings.ts
@@ -11,6 +11,8 @@ import {
   type SummaryNotificationTimeHours,
 } from "@/lib/core/schema";
 
+import { isMessageNotModifiedError } from "./callback-query-utils";
+
 export const NOTIFICATION_SETTINGS_CALLBACK_PREFIX = "notif";
 export const NOTIFICATION_SETTINGS_CONTEXT = "settings";
 export const NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX =
@@ -294,22 +296,4 @@ export async function handleNotificationSettingsCallback(
 
 function renderButtonLabel(label: string, isActive: boolean): string {
   return isActive ? `✅ ${label}` : label;
-}
-
-function isMessageNotModifiedError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  const maybeError = error as {
-    description?: unknown;
-    message?: unknown;
-  };
-
-  return (
-    (typeof maybeError.description === "string" &&
-      maybeError.description.includes("message is not modified")) ||
-    (typeof maybeError.message === "string" &&
-      maybeError.message.includes("message is not modified"))
-  );
 }

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -20,7 +20,7 @@ import {
 import { chatCompletion } from "@/lib/redpill";
 
 import { buildSummaryMessageWithPreview } from "./build-summary-og-url";
-import { buildSummaryVoteKeyboard } from "./summary-votes";
+import { buildSummaryVoteKeyboard, getSummaryVoteTotals } from "./summary-votes";
 import type { SendLatestSummaryOptions, SendSummaryResult } from "./types";
 
 export const MIN_MESSAGES_FOR_SUMMARY = 3;
@@ -363,7 +363,12 @@ async function sendSummaryToChat(
     summary.createdAt
   );
 
-  const keyboard = buildSummaryVoteKeyboard(summary.id, 0, 0);
+  const voteTotals = await getSummaryVoteTotals(summary.id);
+  const keyboard = buildSummaryVoteKeyboard(
+    summary.id,
+    voteTotals.likes,
+    voteTotals.dislikes
+  );
 
   const messageOptions = {
     parse_mode: "HTML" as const,

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -7,7 +7,7 @@ import {
   lte,
   sql,
 } from "drizzle-orm";
-import { type Bot, InlineKeyboard } from "grammy";
+import { type Bot } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
 import {
@@ -20,7 +20,7 @@ import {
 import { chatCompletion } from "@/lib/redpill";
 
 import { buildSummaryMessageWithPreview } from "./build-summary-og-url";
-import { MINI_APP_FEED_LINK } from "./constants";
+import { buildSummaryVoteKeyboard } from "./summary-votes";
 import type { SendLatestSummaryOptions, SendSummaryResult } from "./types";
 
 export const MIN_MESSAGES_FOR_SUMMARY = 3;
@@ -221,6 +221,7 @@ export async function sendLatestSummary(
     bot,
     {
       createdAt: latestSummary.createdAt,
+      id: latestSummary.id,
       oneliner: latestSummary.oneliner,
     },
     {
@@ -254,6 +255,7 @@ export async function sendSummaryById(
     bot,
     {
       createdAt: summary.createdAt,
+      id: summary.id,
       oneliner: summary.oneliner,
     },
     {
@@ -346,7 +348,7 @@ function buildSummaryInput(
 
 async function sendSummaryToChat(
   bot: Bot,
-  summary: Pick<Summary, "createdAt" | "oneliner">,
+  summary: Pick<Summary, "createdAt" | "id" | "oneliner">,
   options: {
     destinationChatId: bigint;
     replyToMessageId?: number;
@@ -361,7 +363,7 @@ async function sendSummaryToChat(
     summary.createdAt
   );
 
-  const keyboard = new InlineKeyboard().url("Read in full", MINI_APP_FEED_LINK);
+  const keyboard = buildSummaryVoteKeyboard(summary.id, 0, 0);
 
   const messageOptions = {
     parse_mode: "HTML" as const,

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -1,0 +1,167 @@
+import type { CallbackQueryContext, Context } from "grammy";
+import { InlineKeyboard } from "grammy";
+
+import { isMessageNotModifiedError } from "./callback-query-utils";
+import { MINI_APP_FEED_LINK } from "./constants";
+
+type SummaryVoteAction = "u" | "d" | "s";
+
+type SummaryVoteCallbackData = {
+  action: SummaryVoteAction;
+  dislikes: number;
+  likes: number;
+  summaryId: string;
+};
+
+const SUMMARY_ID_REGEX_PART =
+  "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+const MAX_VOTE_COUNT = 2_147_483_647;
+
+export const SUMMARY_VOTE_CALLBACK_DATA_REGEX = new RegExp(
+  `^sv:(u|d|s):(${SUMMARY_ID_REGEX_PART}):(\\d+):(\\d+)$`
+);
+
+export function encodeSummaryVoteCallbackData(
+  callbackData: SummaryVoteCallbackData
+): string {
+  return `sv:${callbackData.action}:${callbackData.summaryId}:${callbackData.likes}:${callbackData.dislikes}`;
+}
+
+export function parseSummaryVoteCallbackData(
+  data: string
+): SummaryVoteCallbackData | null {
+  const matches = SUMMARY_VOTE_CALLBACK_DATA_REGEX.exec(data);
+  if (!matches) {
+    return null;
+  }
+
+  const action = matches[1];
+  const summaryId = matches[2];
+  const likes = Number(matches[3]);
+  const dislikes = Number(matches[4]);
+
+  if (action !== "u" && action !== "d" && action !== "s") {
+    return null;
+  }
+
+  if (
+    !Number.isInteger(likes) ||
+    !Number.isInteger(dislikes) ||
+    likes < 0 ||
+    dislikes < 0 ||
+    likes > MAX_VOTE_COUNT ||
+    dislikes > MAX_VOTE_COUNT
+  ) {
+    return null;
+  }
+
+  return {
+    action,
+    dislikes,
+    likes,
+    summaryId,
+  };
+}
+
+export function buildSummaryVoteKeyboard(
+  summaryId: string,
+  likes: number,
+  dislikes: number
+): InlineKeyboard {
+  const score = likes - dislikes;
+
+  return new InlineKeyboard()
+    .text(
+      "👍👍👍",
+      encodeSummaryVoteCallbackData({
+        action: "u",
+        dislikes,
+        likes,
+        summaryId,
+      })
+    )
+    .text(
+      `Score: ${score}`,
+      encodeSummaryVoteCallbackData({
+        action: "s",
+        dislikes,
+        likes,
+        summaryId,
+      })
+    )
+    .text(
+      "👎👎👎",
+      encodeSummaryVoteCallbackData({
+        action: "d",
+        dislikes,
+        likes,
+        summaryId,
+      })
+    )
+    .row()
+    .url("Read in full", MINI_APP_FEED_LINK);
+}
+
+export async function handleSummaryVoteCallback(
+  ctx: CallbackQueryContext<Context>
+): Promise<void> {
+  const callbackData = parseSummaryVoteCallbackData(ctx.callbackQuery.data);
+  if (!callbackData) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  const score = callbackData.likes - callbackData.dislikes;
+  if (callbackData.action === "s") {
+    await ctx.answerCallbackQuery({
+      show_alert: true,
+      text: `Current summary score is ${score}.`,
+    });
+    return;
+  }
+
+  const callbackMessage = ctx.callbackQuery.message;
+  if (!callbackMessage) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  const nextLikes =
+    callbackData.action === "u"
+      ? incrementVoteCount(callbackData.likes)
+      : callbackData.likes;
+  const nextDislikes =
+    callbackData.action === "d"
+      ? incrementVoteCount(callbackData.dislikes)
+      : callbackData.dislikes;
+
+  try {
+    await ctx.api.editMessageReplyMarkup(
+      callbackMessage.chat.id,
+      callbackMessage.message_id,
+      {
+        reply_markup: buildSummaryVoteKeyboard(
+          callbackData.summaryId,
+          nextLikes,
+          nextDislikes
+        ),
+      }
+    );
+    await ctx.answerCallbackQuery();
+  } catch (error) {
+    if (isMessageNotModifiedError(error)) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    console.error("Failed to update summary vote keyboard", error);
+    await ctx.answerCallbackQuery({
+      show_alert: true,
+      text: "Unable to update summary score right now.",
+    });
+  }
+}
+
+function incrementVoteCount(currentValue: number): number {
+  return Math.min(currentValue + 1, MAX_VOTE_COUNT);
+}

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -1,5 +1,15 @@
+import { eq, sql } from "drizzle-orm";
 import type { CallbackQueryContext, Context } from "grammy";
 import { InlineKeyboard } from "grammy";
+
+import { getDatabase } from "@/lib/core/database";
+import {
+  summaries,
+  type SummaryVoteAction as PersistedSummaryVoteAction,
+  summaryVotes,
+} from "@/lib/core/schema";
+import { getOrCreateUser } from "@/lib/telegram/user-service";
+import { getTelegramDisplayName } from "@/lib/telegram/utils";
 
 import { isMessageNotModifiedError } from "./callback-query-utils";
 import { MINI_APP_FEED_LINK } from "./constants";
@@ -8,23 +18,26 @@ type SummaryVoteAction = "u" | "d" | "s";
 
 type SummaryVoteCallbackData = {
   action: SummaryVoteAction;
+  summaryId: string;
+};
+
+export type SummaryVoteTotals = {
   dislikes: number;
   likes: number;
-  summaryId: string;
+  score: number;
 };
 
 const SUMMARY_ID_REGEX_PART =
   "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
-const MAX_VOTE_COUNT = 2_147_483_647;
 
 export const SUMMARY_VOTE_CALLBACK_DATA_REGEX = new RegExp(
-  `^sv:(u|d|s):(${SUMMARY_ID_REGEX_PART}):(\\d+):(\\d+)$`
+  `^sv:(u|d|s):(${SUMMARY_ID_REGEX_PART})$`
 );
 
 export function encodeSummaryVoteCallbackData(
   callbackData: SummaryVoteCallbackData
 ): string {
-  return `sv:${callbackData.action}:${callbackData.summaryId}:${callbackData.likes}:${callbackData.dislikes}`;
+  return `sv:${callbackData.action}:${callbackData.summaryId}`;
 }
 
 export function parseSummaryVoteCallbackData(
@@ -37,28 +50,13 @@ export function parseSummaryVoteCallbackData(
 
   const action = matches[1];
   const summaryId = matches[2];
-  const likes = Number(matches[3]);
-  const dislikes = Number(matches[4]);
 
   if (action !== "u" && action !== "d" && action !== "s") {
     return null;
   }
 
-  if (
-    !Number.isInteger(likes) ||
-    !Number.isInteger(dislikes) ||
-    likes < 0 ||
-    dislikes < 0 ||
-    likes > MAX_VOTE_COUNT ||
-    dislikes > MAX_VOTE_COUNT
-  ) {
-    return null;
-  }
-
   return {
     action,
-    dislikes,
-    likes,
     summaryId,
   };
 }
@@ -75,8 +73,6 @@ export function buildSummaryVoteKeyboard(
       "👍👍👍",
       encodeSummaryVoteCallbackData({
         action: "u",
-        dislikes,
-        likes,
         summaryId,
       })
     )
@@ -84,8 +80,6 @@ export function buildSummaryVoteKeyboard(
       `Score: ${score}`,
       encodeSummaryVoteCallbackData({
         action: "s",
-        dislikes,
-        likes,
         summaryId,
       })
     )
@@ -93,13 +87,60 @@ export function buildSummaryVoteKeyboard(
       "👎👎👎",
       encodeSummaryVoteCallbackData({
         action: "d",
-        dislikes,
-        likes,
         summaryId,
       })
     )
     .row()
     .url("Read in full", MINI_APP_FEED_LINK);
+}
+
+export async function getSummaryVoteTotals(
+  summaryId: string
+): Promise<SummaryVoteTotals> {
+  const db = getDatabase();
+
+  const [result] = await db
+    .select({
+      dislikes: sql<number>`coalesce(sum(case when ${summaryVotes.action} = 'DISLIKE' then 1 else 0 end), 0)`,
+      likes: sql<number>`coalesce(sum(case when ${summaryVotes.action} = 'LIKE' then 1 else 0 end), 0)`,
+    })
+    .from(summaries)
+    .leftJoin(summaryVotes, eq(summaryVotes.summaryId, summaries.id))
+    .where(eq(summaries.id, summaryId))
+    .groupBy(summaries.id);
+
+  return toSummaryVoteTotals({
+    dislikes: Number(result?.dislikes ?? 0),
+    likes: Number(result?.likes ?? 0),
+  });
+}
+
+function toSummaryVoteTotals(input: {
+  dislikes: number;
+  likes: number;
+}): SummaryVoteTotals {
+  const likes = Number.isFinite(input.likes) ? input.likes : 0;
+  const dislikes = Number.isFinite(input.dislikes) ? input.dislikes : 0;
+
+  return {
+    dislikes,
+    likes,
+    score: likes - dislikes,
+  };
+}
+
+function mapVoteAction(
+  action: SummaryVoteAction
+): PersistedSummaryVoteAction | null {
+  if (action === "u") {
+    return "LIKE";
+  }
+
+  if (action === "d") {
+    return "DISLIKE";
+  }
+
+  return null;
 }
 
 export async function handleSummaryVoteCallback(
@@ -111,12 +152,20 @@ export async function handleSummaryVoteCallback(
     return;
   }
 
-  const score = callbackData.likes - callbackData.dislikes;
   if (callbackData.action === "s") {
-    await ctx.answerCallbackQuery({
-      show_alert: true,
-      text: `Current summary score is ${score}.`,
-    });
+    try {
+      const voteTotals = await getSummaryVoteTotals(callbackData.summaryId);
+      await ctx.answerCallbackQuery({
+        show_alert: true,
+        text: `Current summary score is ${voteTotals.score}.`,
+      });
+    } catch (error) {
+      console.error("Failed to fetch summary score", error);
+      await ctx.answerCallbackQuery({
+        show_alert: true,
+        text: "Unable to load summary score right now.",
+      });
+    }
     return;
   }
 
@@ -126,24 +175,52 @@ export async function handleSummaryVoteCallback(
     return;
   }
 
-  const nextLikes =
-    callbackData.action === "u"
-      ? incrementVoteCount(callbackData.likes)
-      : callbackData.likes;
-  const nextDislikes =
-    callbackData.action === "d"
-      ? incrementVoteCount(callbackData.dislikes)
-      : callbackData.dislikes;
+  if (!ctx.from) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
 
   try {
+    const voteAction = mapVoteAction(callbackData.action);
+    if (!voteAction) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    const userId = await getOrCreateUser(BigInt(ctx.from.id), {
+      username: ctx.from.username || null,
+      displayName: getTelegramDisplayName(ctx.from),
+    });
+
+    const db = getDatabase();
+    const insertedVote = await db
+      .insert(summaryVotes)
+      .values({
+        action: voteAction,
+        summaryId: callbackData.summaryId,
+        userId,
+      })
+      .onConflictDoNothing()
+      .returning({ id: summaryVotes.id });
+
+    if (insertedVote.length === 0) {
+      await ctx.answerCallbackQuery({
+        show_alert: true,
+        text: "You've voted already!",
+      });
+      return;
+    }
+
+    const voteTotals = await getSummaryVoteTotals(callbackData.summaryId);
+
     await ctx.api.editMessageReplyMarkup(
       callbackMessage.chat.id,
       callbackMessage.message_id,
       {
         reply_markup: buildSummaryVoteKeyboard(
           callbackData.summaryId,
-          nextLikes,
-          nextDislikes
+          voteTotals.likes,
+          voteTotals.dislikes
         ),
       }
     );
@@ -160,8 +237,4 @@ export async function handleSummaryVoteCallback(
       text: "Unable to update summary score right now.",
     });
   }
-}
-
-function incrementVoteCount(currentValue: number): number {
-  return Math.min(currentValue + 1, MAX_VOTE_COUNT);
 }

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -29,6 +29,7 @@ export type SummaryVoteTotals = {
 
 const SUMMARY_ID_REGEX_PART =
   "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+const DUPLICATE_VOTE_ALERT_CACHE_TIME_SECONDS = 300;
 
 export const SUMMARY_VOTE_CALLBACK_DATA_REGEX = new RegExp(
   `^sv:(u|d|s):(${SUMMARY_ID_REGEX_PART})$`
@@ -205,6 +206,7 @@ export async function handleSummaryVoteCallback(
 
     if (insertedVote.length === 0) {
       await ctx.answerCallbackQuery({
+        cache_time: DUPLICATE_VOTE_ALERT_CACHE_TIME_SECONDS,
         show_alert: true,
         text: "You've voted already!",
       });

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -71,7 +71,10 @@ export function buildSummaryVoteKeyboard(
 
   return new InlineKeyboard()
     .text(
-      "👍👍👍",
+      {
+        style: "success",
+        text: "👍👍👍",
+      },
       encodeSummaryVoteCallbackData({
         action: "u",
         summaryId,
@@ -85,14 +88,23 @@ export function buildSummaryVoteKeyboard(
       })
     )
     .text(
-      "👎👎👎",
+      {
+        style: "danger",
+        text: "👎👎👎",
+      },
       encodeSummaryVoteCallbackData({
         action: "d",
         summaryId,
       })
     )
     .row()
-    .url("Read in full", MINI_APP_FEED_LINK);
+    .url(
+      {
+        style: "primary",
+        text: "Open",
+      },
+      MINI_APP_FEED_LINK
+    );
 }
 
 export async function getSummaryVoteTotals(


### PR DESCRIPTION
Upgrade grammY to support inline button style metadata and apply button styles for summary actions. Like is success, Dislike is danger, and Open is primary, with tests updated to verify the payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now like or dislike summaries using interactive buttons in Telegram.
  * Vote scores are calculated and displayed dynamically based on user actions.

* **Chores**
  * Updated dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->