### PR TITLE
refactor(telegram): standardize summary deeplink flow and tracking

### DIFF
--- a/app/src/app/api/summaries/route.ts
+++ b/app/src/app/api/summaries/route.ts
@@ -12,11 +12,11 @@ type CommunityPhotoSettings = {
 export async function GET(req: Request): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(req.url);
-    const chatId = searchParams.get("chatId");
+    const groupChatId = searchParams.get("groupChatId");
     const db = getDatabase();
 
-    const result = chatId
-      ? await fetchSummariesByChatId(db, chatId)
+    const result = groupChatId
+      ? await fetchSummariesByGroupChatId(db, groupChatId)
       : (
           await db
             .select({
@@ -63,13 +63,13 @@ type SummaryWithCommunity = Summary & {
   community: { chatId: bigint; settings: unknown };
 };
 
-async function fetchSummariesByChatId(
+async function fetchSummariesByGroupChatId(
   db: ReturnType<typeof getDatabase>,
-  chatId: string
+  groupChatId: string
 ): Promise<SummaryWithCommunity[]> {
   const community = await db.query.communities.findFirst({
     where: and(
-      eq(communities.chatId, BigInt(chatId)),
+      eq(communities.chatId, BigInt(groupChatId)),
       eq(communities.isPublic, true)
     ),
   });

--- a/app/src/app/telegram/summaries/feed/page.tsx
+++ b/app/src/app/telegram/summaries/feed/page.tsx
@@ -1,39 +1,114 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense, useMemo } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useSummaries } from "@/components/summaries/SummariesContext";
 import SummaryFeed from "@/components/summaries/SummaryFeed";
 
 function SummaryFeedContent() {
   const searchParams = useSearchParams();
-  const chatId = searchParams.get("chatId") || undefined;
-  const { summaries: allSummaries } = useSummaries();
+  const groupChatId = searchParams.get("groupChatId") || undefined;
+  const summaryId = searchParams.get("summaryId") || undefined;
+  const { summaries: cachedSummaries } = useSummaries();
+  const [feedSummaries, setFeedSummaries] = useState(cachedSummaries);
+  const canFetchByGroupChatId = Boolean(
+    groupChatId && /^-?\d+$/.test(groupChatId)
+  );
 
-  // Find the group title from the selected summary
-  const groupTitle = useMemo(() => {
-    if (!chatId || allSummaries.length === 0) return undefined;
-    const selectedSummary = allSummaries.find((s) => s.id === chatId);
-    return selectedSummary?.title;
-  }, [chatId, allSummaries]);
+  const isSummaryInGroup = useCallback(
+    (summary: { chatId?: string; title: string }) => {
+      if (!groupChatId) {
+        return true;
+      }
 
-  const groupChatId = useMemo(() => {
-    if (!chatId || allSummaries.length === 0) return undefined;
-    const selectedSummary = allSummaries.find((s) => s.id === chatId);
-    return selectedSummary?.chatId;
-  }, [chatId, allSummaries]);
+      if (summary.chatId) {
+        return summary.chatId === groupChatId;
+      }
 
-  // Filter summaries to only include those from the same group
+      // Mock summaries may not include chatId yet; fallback to title key.
+      return summary.title === groupChatId;
+    },
+    [groupChatId]
+  );
+
+  useEffect(() => {
+    setFeedSummaries(cachedSummaries);
+  }, [cachedSummaries]);
+
+  const hasTargetSummary = useMemo(() => {
+    if (!summaryId) return true;
+    return feedSummaries.some(
+      (summary) => summary.id === summaryId && isSummaryInGroup(summary)
+    );
+  }, [feedSummaries, summaryId, isSummaryInGroup]);
+  const hasGroupSummaries = useMemo(() => {
+    if (!groupChatId) return feedSummaries.length > 0;
+    return feedSummaries.some((summary) => isSummaryInGroup(summary));
+  }, [feedSummaries, groupChatId, isSummaryInGroup]);
+
+  useEffect(() => {
+    if (!groupChatId || !canFetchByGroupChatId) {
+      return;
+    }
+
+    if (hasGroupSummaries && (!summaryId || hasTargetSummary)) {
+      return;
+    }
+
+    let cancelled = false;
+    const fetchGroupSummaries = async () => {
+      try {
+        const response = await fetch(
+          `/api/summaries?groupChatId=${encodeURIComponent(groupChatId)}`
+        );
+        if (!response.ok) {
+          return;
+        }
+
+        const data = await response.json();
+        if (cancelled || !Array.isArray(data.summaries)) {
+          return;
+        }
+
+        setFeedSummaries(data.summaries);
+      } catch {
+        // Keep cached summaries fallback
+      }
+    };
+
+    fetchGroupSummaries();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    canFetchByGroupChatId,
+    groupChatId,
+    isSummaryInGroup,
+    summaryId,
+    hasTargetSummary,
+    hasGroupSummaries,
+  ]);
+
   const groupSummaries = useMemo(() => {
-    if (!groupTitle || allSummaries.length === 0) return undefined;
-    return allSummaries.filter((s) => s.title === groupTitle);
-  }, [groupTitle, allSummaries]);
+    if (!groupChatId) {
+      return feedSummaries.length > 0 ? feedSummaries : undefined;
+    }
+
+    const filtered = feedSummaries.filter((summary) => isSummaryInGroup(summary));
+    return filtered.length > 0 ? filtered : undefined;
+  }, [feedSummaries, groupChatId, isSummaryInGroup]);
+
+  const groupTitle = useMemo(() => {
+    if (!groupSummaries || groupSummaries.length === 0) return undefined;
+    return groupSummaries[0].title;
+  }, [groupSummaries]);
 
   // Pass filtered summaries for the specific group
   return (
     <SummaryFeed
-      initialChatId={chatId}
+      initialSummaryId={summaryId}
       summaries={groupSummaries}
       groupChatId={groupChatId}
       groupTitle={groupTitle}

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -241,15 +241,17 @@ export default function SummariesPage() {
   const [isGroupsLoading, setIsGroupsLoading] = useState(true);
   const { summaries: cachedSummaries, setSummaries, hasCachedData } = useSummaries();
 
-  // Transform summaries to unique group chats format (deduplicate by title)
-  const transformToGroupChats = (summaries: Array<{ id: string; title: string; photoBase64?: string; photoMimeType?: string; topics?: Array<{ content: string }> }>) => {
+  // Transform summaries to unique group chats format (deduplicate by group chat id)
+  const transformToGroupChats = (summaries: Array<{ chatId?: string; title: string; photoBase64?: string; photoMimeType?: string; topics?: Array<{ content: string }> }>) => {
     const groupMap = new Map<string, GroupChat>();
 
     for (const summary of summaries) {
+      const groupKey = summary.chatId ?? summary.title;
+
       // Only keep the first (most recent) summary for each group
-      if (!groupMap.has(summary.title)) {
-        groupMap.set(summary.title, {
-          id: summary.id,
+      if (!groupMap.has(groupKey)) {
+        groupMap.set(groupKey, {
+          id: groupKey,
           title: summary.title,
           subtitle: summary.topics?.[0]?.content || "",
           photoBase64: summary.photoBase64,
@@ -375,7 +377,9 @@ export default function SummariesPage() {
 
     // Groups tab: navigate to SummaryFeed page (vertical swipe)
     if (activeTab === "groups") {
-      router.push(`/telegram/summaries/feed?chatId=${chat.id}`);
+      router.push(
+        `/telegram/summaries/feed?groupChatId=${encodeURIComponent(chat.id)}`
+      );
       return;
     }
 

--- a/app/src/hooks/__tests__/useStartParam.test.ts
+++ b/app/src/hooks/__tests__/useStartParam.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { getStartParamRoute } from "../useStartParam";
+
+const GROUP_CHAT_ID = "-1002981429221";
+const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
+const START_PARAM = `sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`;
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe("getStartParamRoute", () => {
+  test("parses start param from hash", () => {
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        hash: `#tgWebAppStartParam=${START_PARAM}`,
+        search: "",
+      },
+    };
+
+    expect(getStartParamRoute()).toBe(
+      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
+        GROUP_CHAT_ID
+      )}&summaryId=${SUMMARY_ID}`
+    );
+  });
+
+  test("falls back to search params", () => {
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        hash: "",
+        search: `?tgWebAppStartParam=${START_PARAM}`,
+      },
+    };
+
+    expect(getStartParamRoute()).toBe(
+      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
+        GROUP_CHAT_ID
+      )}&summaryId=${SUMMARY_ID}`
+    );
+  });
+
+  test("returns undefined for invalid payload", () => {
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        hash: "#tgWebAppStartParam=invalid",
+        search: "",
+      },
+    };
+
+    expect(getStartParamRoute()).toBeUndefined();
+  });
+});
+

--- a/app/src/lib/core/__tests__/analytics.test.ts
+++ b/app/src/lib/core/__tests__/analytics.test.ts
@@ -60,6 +60,9 @@ mock.module("@/lib/core/config/public", () => ({
 }));
 
 let analytics: typeof import("../analytics");
+const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
+const GROUP_CHAT_ID = "-1001234567890";
+const VALID_START_PARAM = `sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`;
 
 describe("analytics identifyTelegramUser", () => {
   beforeAll(async () => {
@@ -129,7 +132,7 @@ describe("analytics identifyTelegramUser", () => {
 
   test("adds launch context to tracked events while context is set", () => {
     analytics.setTelegramLaunchContext({
-      startParamRaw: "post_42",
+      startParamRaw: VALID_START_PARAM,
       chatType: "channel",
       chatInstance: "99887766",
     });
@@ -140,9 +143,29 @@ describe("analytics identifyTelegramUser", () => {
     expect(trackCalls[0]).toEqual({
       event: "Page View",
       properties: {
-        launch_start_param_raw: "post_42",
-        launch_chat_type: "channel",
-        launch_chat_instance: "99887766",
+        start_param_raw: VALID_START_PARAM,
+        group_chat_id: GROUP_CHAT_ID,
+        summary_id: SUMMARY_ID,
+        path: "/telegram/wallet",
+      },
+    });
+  });
+
+  test("uses none placeholders when launch start param is missing", () => {
+    analytics.setTelegramLaunchContext({
+      chatType: "channel",
+      chatInstance: "99887766",
+    });
+
+    analytics.track("Page View", { path: "/telegram/wallet" });
+
+    expect(trackCalls).toHaveLength(1);
+    expect(trackCalls[0]).toEqual({
+      event: "Page View",
+      properties: {
+        start_param_raw: "none",
+        group_chat_id: "none",
+        summary_id: "none",
         path: "/telegram/wallet",
       },
     });
@@ -150,7 +173,7 @@ describe("analytics identifyTelegramUser", () => {
 
   test("stops attaching launch context after clear", () => {
     analytics.setTelegramLaunchContext({
-      startParamRaw: "post_42",
+      startParamRaw: VALID_START_PARAM,
       chatType: "channel",
       chatInstance: "99887766",
     });

--- a/app/src/lib/core/analytics.ts
+++ b/app/src/lib/core/analytics.ts
@@ -3,6 +3,7 @@
 import mixpanel from "mixpanel-browser";
 
 import { publicEnv } from "@/lib/core/config/public";
+import { parseSummaryFeedStartParam } from "@/lib/telegram/mini-app/start-param";
 import type {
   TelegramIdentity,
   TelegramLaunchContext,
@@ -79,30 +80,20 @@ function setUserProfileOnce(properties: AnalyticsProperties): void {
 function mapLaunchContextToEventProperties(
   context: TelegramLaunchContext
 ): AnalyticsProperties {
-  const properties: AnalyticsProperties = {};
+  const startParamRaw = normalizeOptionalString(context.startParamRaw) ?? "none";
+  const parsedStartParam = parseSummaryFeedStartParam(context.startParamRaw);
 
-  if (context.startParamRaw) {
-    properties.launch_start_param_raw = context.startParamRaw;
-  }
-  if (context.chatType) {
-    properties.launch_chat_type = context.chatType;
-  }
-  if (context.chatInstance) {
-    properties.launch_chat_instance = context.chatInstance;
-  }
-
-  return properties;
+  return {
+    start_param_raw: startParamRaw,
+    group_chat_id: parsedStartParam?.groupChatId ?? "none",
+    summary_id: parsedStartParam?.summaryId ?? "none",
+  };
 }
 
 export function setTelegramLaunchContext(
   context: TelegramLaunchContext | null
 ): void {
-  if (!context) {
-    currentLaunchContext = {};
-    return;
-  }
-
-  currentLaunchContext = mapLaunchContextToEventProperties(context);
+  currentLaunchContext = mapLaunchContextToEventProperties(context ?? {});
 }
 
 export function clearTelegramLaunchContext(): void {

--- a/app/src/lib/core/analytics.ts
+++ b/app/src/lib/core/analytics.ts
@@ -3,11 +3,11 @@
 import mixpanel from "mixpanel-browser";
 
 import { publicEnv } from "@/lib/core/config/public";
-import { parseSummaryFeedStartParam } from "@/lib/telegram/mini-app/start-param";
 import type {
   TelegramIdentity,
   TelegramLaunchContext,
 } from "@/lib/telegram/mini-app/init-data-transform";
+import { parseSummaryFeedStartParam } from "@/lib/telegram/mini-app/start-param";
 
 type AnalyticsProperties = Record<string, unknown>;
 

--- a/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Bot } from "grammy";
 
-import { MINI_APP_FEED_LINK } from "../constants";
+import { buildSummaryFeedMiniAppUrl } from "@/lib/telegram/mini-app/start-param";
 
 mock.module("server-only", () => ({}));
 
@@ -129,15 +129,23 @@ describe("summary delivery guards", () => {
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveLength(3);
     expect(rows[1]).toHaveLength(1);
-    expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}`);
+    expect(rows[0][0]?.callback_data).toBe(
+      `sv:u:${SUMMARY_ID}:${summaryResult!.community.chatId}`
+    );
     expect(rows[0][0]?.style).toBe("success");
     expect(rows[0][1]?.text).toBe("Score: 3");
-    expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}`);
-    expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}`);
+    expect(rows[0][1]?.callback_data).toBe(
+      `sv:s:${SUMMARY_ID}:${summaryResult!.community.chatId}`
+    );
+    expect(rows[0][2]?.callback_data).toBe(
+      `sv:d:${SUMMARY_ID}:${summaryResult!.community.chatId}`
+    );
     expect(rows[0][2]?.style).toBe("danger");
     expect(rows[1][0]?.text).toBe("Open");
     expect(rows[1][0]?.style).toBe("primary");
-    expect(rows[1][0]?.url).toBe(MINI_APP_FEED_LINK);
+    expect(rows[1][0]?.url).toBe(
+      buildSummaryFeedMiniAppUrl(summaryResult!.community.chatId, SUMMARY_ID)
+    );
   });
 
   test("sendSummaryById returns no_summaries when summary does not exist", async () => {

--- a/app/src/lib/telegram/bot-api/constants.ts
+++ b/app/src/lib/telegram/bot-api/constants.ts
@@ -1,5 +1,3 @@
 export const CHANNEL_USERNAME = "@loyal_tg";
 export const CUSTOM_EMOJI_ID = "5361803602862052361";
-export const MINI_APP_LINK = "https://t.me/askloyal_tgbot/app";
-export const MINI_APP_FEED_LINK = "https://t.me/askloyal_tgbot/app?startapp=feed";
 export const CA_COMMAND_CHAT_ID = "-1002981429221";

--- a/app/src/lib/telegram/bot-api/inline.ts
+++ b/app/src/lib/telegram/bot-api/inline.ts
@@ -1,7 +1,7 @@
 import type { Context, InlineQueryContext } from "grammy";
 import { InlineQueryResult } from "grammy/types";
 
-import { MINI_APP_LINK } from "./constants";
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
 
 //TODO: implement results
 export const handleInlineQuery = async (ctx: InlineQueryContext<Context>) => {

--- a/app/src/lib/telegram/bot-api/prepared-inline-message.ts
+++ b/app/src/lib/telegram/bot-api/prepared-inline-message.ts
@@ -1,8 +1,9 @@
 import { InlineKeyboard, InlineQueryResultBuilder } from "grammy";
 import { PreparedInlineMessage } from "grammy/types";
 
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
+
 import { getBot } from "./bot";
-import { MINI_APP_LINK } from "./constants";
 
 export const prepareInlineMessage = async (
   userId: number,

--- a/app/src/lib/telegram/bot-api/send-transaction-notification.ts
+++ b/app/src/lib/telegram/bot-api/send-transaction-notification.ts
@@ -1,9 +1,9 @@
 import { InlineKeyboard } from "grammy";
 
 import { resolveEndpoint } from "@/lib/core/api";
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
 
 import { getBot } from "./bot";
-import { MINI_APP_LINK } from "./constants";
 
 const buildOgImageUrl = (
   sender: string,

--- a/app/src/lib/telegram/bot-api/start-carousel.ts
+++ b/app/src/lib/telegram/bot-api/start-carousel.ts
@@ -7,8 +7,7 @@ import {
 } from "grammy";
 
 import { resolveEndpoint } from "@/lib/core/api";
-
-import { MINI_APP_LINK } from "./constants";
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
 
 type StartCarouselAction = "prev" | "next";
 

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -226,6 +226,7 @@ export async function sendLatestSummary(
     },
     {
       destinationChatId,
+      sourceCommunityChatId: sourceChatId,
       replyToMessageId,
     }
   );
@@ -260,6 +261,7 @@ export async function sendSummaryById(
     },
     {
       destinationChatId: options?.destinationChatId ?? summary.community.chatId,
+      sourceCommunityChatId: summary.community.chatId,
       replyToMessageId: options?.replyToMessageId,
     }
   );
@@ -351,6 +353,7 @@ async function sendSummaryToChat(
   summary: Pick<Summary, "createdAt" | "id" | "oneliner">,
   options: {
     destinationChatId: bigint;
+    sourceCommunityChatId: bigint;
     replyToMessageId?: number;
   }
 ): Promise<void> {
@@ -365,6 +368,7 @@ async function sendSummaryToChat(
 
   const voteTotals = await getSummaryVoteTotals(summary.id);
   const keyboard = buildSummaryVoteKeyboard(
+    options.sourceCommunityChatId,
     summary.id,
     voteTotals.likes,
     voteTotals.dislikes

--- a/app/src/lib/telegram/constants.ts
+++ b/app/src/lib/telegram/constants.ts
@@ -1,0 +1,2 @@
+export const MINI_APP_LINK = "https://t.me/askloyal_tgbot/app";
+

--- a/app/src/lib/telegram/mini-app/__tests__/start-param.test.ts
+++ b/app/src/lib/telegram/mini-app/__tests__/start-param.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSummaryFeedMiniAppUrl,
+  buildSummaryFeedStartParam,
+  parseSummaryFeedStartParam,
+} from "../start-param";
+
+const GROUP_CHAT_ID = "-1002981429221";
+const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
+
+describe("start-param summary feed codec", () => {
+  test("builds and parses a valid summary feed start param", () => {
+    const startParam = buildSummaryFeedStartParam(GROUP_CHAT_ID, SUMMARY_ID);
+
+    expect(startParam).toBe(`sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`);
+    expect(parseSummaryFeedStartParam(startParam)).toEqual({
+      groupChatId: GROUP_CHAT_ID,
+      summaryId: SUMMARY_ID,
+      version: "sf1",
+    });
+  });
+
+  test("builds mini app URL with startapp payload", () => {
+    expect(buildSummaryFeedMiniAppUrl(GROUP_CHAT_ID, SUMMARY_ID)).toBe(
+      `https://t.me/askloyal_tgbot/app?startapp=sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`
+    );
+  });
+
+  test("rejects invalid prefix", () => {
+    expect(
+      parseSummaryFeedStartParam(`wrong_${GROUP_CHAT_ID}_${SUMMARY_ID}`)
+    ).toBeNull();
+  });
+
+  test("rejects invalid chat id", () => {
+    expect(parseSummaryFeedStartParam(`sf1_not-a-chat_${SUMMARY_ID}`)).toBeNull();
+  });
+
+  test("rejects invalid summary id", () => {
+    expect(parseSummaryFeedStartParam(`sf1_${GROUP_CHAT_ID}_invalid`)).toBeNull();
+  });
+
+  test("rejects payloads longer than Telegram limit", () => {
+    const veryLongChatId = `-${"9".repeat(80)}`;
+
+    expect(() =>
+      buildSummaryFeedStartParam(veryLongChatId, SUMMARY_ID)
+    ).toThrow("Start param exceeds Telegram limits");
+  });
+});
+

--- a/app/src/lib/telegram/mini-app/start-param.ts
+++ b/app/src/lib/telegram/mini-app/start-param.ts
@@ -1,0 +1,103 @@
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
+
+const START_PARAM_PREFIX = "sf1";
+const START_PARAM_MAX_LENGTH = 64;
+const START_PARAM_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9_-]+$/;
+const TELEGRAM_CHAT_ID_REGEX = /^-?\d+$/;
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export type ParsedSummaryFeedStartParam = {
+  groupChatId: string;
+  summaryId: string;
+  version: "sf1";
+};
+
+function normalizeStringValue(value: bigint | number | string): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+
+  return String(value);
+}
+
+function isValidTelegramChatId(value: string): boolean {
+  return TELEGRAM_CHAT_ID_REGEX.test(value);
+}
+
+function isValidSummaryId(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+function isValidStartParamEnvelope(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= START_PARAM_MAX_LENGTH &&
+    START_PARAM_ALLOWED_CHARS_REGEX.test(value)
+  );
+}
+
+export function buildSummaryFeedStartParam(
+  groupChatId: bigint | number | string,
+  summaryId: string
+): string {
+  const normalizedGroupChatId = normalizeStringValue(groupChatId);
+  const normalizedSummaryId = summaryId.trim();
+
+  if (!isValidTelegramChatId(normalizedGroupChatId)) {
+    throw new Error("Invalid Telegram group chat id for start param");
+  }
+
+  if (!isValidSummaryId(normalizedSummaryId)) {
+    throw new Error("Invalid summary id for start param");
+  }
+
+  const startParam = `${START_PARAM_PREFIX}_${normalizedGroupChatId}_${normalizedSummaryId}`;
+
+  if (!isValidStartParamEnvelope(startParam)) {
+    throw new Error("Start param exceeds Telegram limits");
+  }
+
+  return startParam;
+}
+
+export function parseSummaryFeedStartParam(
+  raw: string | null | undefined
+): ParsedSummaryFeedStartParam | null {
+  if (!raw) {
+    return null;
+  }
+
+  const normalizedRaw = raw.trim();
+  if (!isValidStartParamEnvelope(normalizedRaw)) {
+    return null;
+  }
+
+  const parts = normalizedRaw.split("_");
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [prefix, groupChatId, summaryId] = parts;
+  if (prefix !== START_PARAM_PREFIX) {
+    return null;
+  }
+
+  if (!isValidTelegramChatId(groupChatId) || !isValidSummaryId(summaryId)) {
+    return null;
+  }
+
+  return {
+    groupChatId,
+    summaryId,
+    version: "sf1",
+  };
+}
+
+export function buildSummaryFeedMiniAppUrl(
+  groupChatId: bigint | number | string,
+  summaryId: string
+): string {
+  const startParam = buildSummaryFeedStartParam(groupChatId, summaryId);
+  return `${MINI_APP_LINK}?startapp=${encodeURIComponent(startParam)}`;
+}


### PR DESCRIPTION
Refactors Telegram summary deep-linking to use explicit groupChatId/summaryId flow, opens the targeted summary reliably, and removes callback lookup overhead by encoding group chat id in vote callback payloads. Also cleans up shared Mini App link constants and updates tracking fields/tests for the new start-param structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-based filtering and lazy loading for summary feeds
  * Improved deeplink/start-param support and mini-app URLs for direct summary access
  * Group-aware summary vote buttons and “Open in mini-app” links

* **Chores**
  * Telegram integration updated to pass group context through summary delivery and votes
  * Analytics payloads updated to include start param, group and summary identifiers

* **Tests**
  * New unit tests for start-param parsing and related flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->