### PR TITLE
feat(telegram): track mixpanel bot command and vote events

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -25,6 +25,7 @@
         "grammy": "1.40.0",
         "lightningcss": "^1.30.2",
         "lucide-react": "^0.552.0",
+        "mixpanel": "^0.20.0",
         "mixpanel-browser": "^2.74.0",
         "next": "^15.5.7",
         "ogl": "^1.0.11",
@@ -1363,6 +1364,8 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
+    "json-logic-js": ["json-logic-js@2.0.5", "", {}, "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -1482,6 +1485,8 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "mixpanel": ["mixpanel@0.20.0", "", { "dependencies": { "https-proxy-agent": "7.0.6", "json-logic-js": "2.0.5" } }, "sha512-va/dizV9tWgumKU3WQR2ZbMsb3NDlSaF7enDwtRiVIz2HCu7Cl3dq8BMV7ufB5LiNWtgtoELHsJvJv+hGhpvxw=="],
 
     "mixpanel-browser": ["mixpanel-browser@2.74.0", "", { "dependencies": { "@mixpanel/rrweb": "2.0.0-alpha.18.2", "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.2" } }, "sha512-FWifdAaI+8zKEROb9T+gy0NRZB0gaCC5iy20rDjZ3C+KCwCsJcITT6lAYErWbwwmk3Ei34JBjLsnrDLPYj+hOw=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "grammy": "1.40.0",
     "lightningcss": "^1.30.2",
     "lucide-react": "^0.552.0",
+    "mixpanel": "^0.20.0",
     "mixpanel-browser": "^2.74.0",
     "next": "^15.5.7",
     "ogl": "^1.0.11",

--- a/app/src/lib/core/config/__tests__/server.test.ts
+++ b/app/src/lib/core/config/__tests__/server.test.ts
@@ -19,6 +19,7 @@ const SERVER_ENV_KEYS = [
   "DEPLOYMENT_PK",
   "ASKLOYAL_TGBOT_KEY",
   "TELEGRAM_SETUP_SECRET",
+  "NEXT_PUBLIC_MIXPANEL_TOKEN",
   "CRON_SECRET",
   "TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM",
   "TELEGRAM_SUMMARY_PEER_OVERRIDE_TO",
@@ -49,6 +50,7 @@ let serverEnv: {
   deploymentPrivateKey: string;
   askLoyalBotToken: string;
   telegramSetupSecret: string;
+  mixpanelToken: string | undefined;
   cronSecret: string;
   telegramSummaryPeerOverride: { fromPeerId: bigint; toPeerId: bigint } | null;
   cloudflareCdnBaseUrl: string | null;
@@ -95,10 +97,12 @@ describe("server config", () => {
 
   test("returns optional values when present", () => {
     process.env.MESSAGE_ENCRYPTION_KEY = "  key  ";
+    process.env.NEXT_PUBLIC_MIXPANEL_TOKEN = "  token  ";
     process.env.CLOUDFLARE_R2_S3_ENDPOINT = "  https://r2.example.com  ";
     process.env.CLOUDFLARE_R2_UPLOAD_PREFIX = "  uploads  ";
 
     expect(serverEnv.messageEncryptionKey).toBe("key");
+    expect(serverEnv.mixpanelToken).toBe("token");
     expect(serverEnv.cloudflareR2S3Endpoint).toBe("https://r2.example.com");
     expect(serverEnv.cloudflareR2UploadPrefix).toBe("uploads");
   });

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -92,6 +92,9 @@ export const serverEnv = {
   get telegramSetupSecret(): string {
     return getRequiredEnv("TELEGRAM_SETUP_SECRET");
   },
+  get mixpanelToken(): string | undefined {
+    return getOptionalEnv("NEXT_PUBLIC_MIXPANEL_TOKEN");
+  },
   get cronSecret(): string {
     return getRequiredEnv("CRON_SECRET");
   },


### PR DESCRIPTION
Adds server-side Mixpanel tracking for successful /start and /summary bot command responses and successful summary vote callbacks. Includes test coverage for command and vote tracking behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for improved user insights. The bot now captures data on command usage (/start and /summary) and summary voting interactions (likes and dislikes), enabling better understanding of user engagement patterns and feature adoption to guide future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->