### PR TITLE
fix(telegram): default new activated communities to hidden

### DIFF
--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -333,6 +333,7 @@ export async function handleActivateCommunityCommand(
       chatId,
       chatTitle: ctx.chat.title || "Untitled",
       activatedBy: telegramUserId,
+      isPublic: false,
       settings,
     });
 


### PR DESCRIPTION
Set /activate_community to create new communities with isPublic=false by default while preserving existing reactivation visibility behavior. Added admin command tests to assert hidden-by-default insertion and keep hide/unhide semantics unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Communities are now created in a hidden state by default when first activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->