### PR TITLE
feat(telegram): add script-based bot command registration

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,8 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "telegram:setup-commands": "bun run --conditions react-server scripts/telegram/setup-commands.ts",
+    "telegram:setup-chat-commands": "bun run --conditions react-server scripts/telegram/setup-chat-commands.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"

--- a/app/scripts/telegram/setup-chat-commands.test.ts
+++ b/app/scripts/telegram/setup-chat-commands.test.ts
@@ -1,0 +1,92 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getBotMock = mock(async () => ({}));
+
+mock.module("@/lib/telegram/bot-api/bot", () => ({
+  getBot: getBotMock,
+}));
+
+let DEFAULT_CHAT_ID: typeof import("./setup-chat-commands").DEFAULT_CHAT_ID;
+let CHAT_USER_COMMANDS: typeof import("./setup-chat-commands").CHAT_USER_COMMANDS;
+let CHAT_ADMIN_COMMANDS: typeof import("./setup-chat-commands").CHAT_ADMIN_COMMANDS;
+let registerCommandsForChat: typeof import("./setup-chat-commands").registerCommandsForChat;
+let runSetupChatCommandsCli: typeof import("./setup-chat-commands").runSetupChatCommandsCli;
+
+describe("telegram setup chat commands script", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("./setup-chat-commands");
+    DEFAULT_CHAT_ID = loadedModule.DEFAULT_CHAT_ID;
+    CHAT_USER_COMMANDS = loadedModule.CHAT_USER_COMMANDS;
+    CHAT_ADMIN_COMMANDS = loadedModule.CHAT_ADMIN_COMMANDS;
+    registerCommandsForChat = loadedModule.registerCommandsForChat;
+    runSetupChatCommandsCli = loadedModule.runSetupChatCommandsCli;
+  });
+
+  beforeEach(() => {
+    getBotMock.mockReset();
+  });
+
+  test("registers chat and chat admin scopes for default chat", async () => {
+    const setMyCommandsMock = mock(async () => true);
+    const fakeBot = { api: { setMyCommands: setMyCommandsMock } };
+    getBotMock.mockResolvedValue(fakeBot);
+    const consoleInfoMock = mock(() => undefined);
+    const previousConsoleInfo = console.info;
+    console.info = consoleInfoMock;
+
+    try {
+      const exitCode = await runSetupChatCommandsCli();
+      expect(exitCode).toBe(0);
+      expect(getBotMock).toHaveBeenCalledTimes(1);
+      expect(setMyCommandsMock).toHaveBeenCalledTimes(2);
+      expect(setMyCommandsMock).toHaveBeenNthCalledWith(1, CHAT_USER_COMMANDS, {
+        scope: { type: "chat", chat_id: DEFAULT_CHAT_ID },
+      });
+      expect(setMyCommandsMock).toHaveBeenNthCalledWith(2, CHAT_ADMIN_COMMANDS, {
+        scope: { type: "chat_administrators", chat_id: DEFAULT_CHAT_ID },
+      });
+      expect(consoleInfoMock).toHaveBeenCalledWith(
+        `Telegram bot commands registered for chat ${DEFAULT_CHAT_ID}.`
+      );
+    } finally {
+      console.info = previousConsoleInfo;
+    }
+  });
+
+  test("registers commands for explicit chat id", async () => {
+    const setMyCommandsMock = mock(async () => true);
+    const fakeBot = { api: { setMyCommands: setMyCommandsMock } };
+
+    await registerCommandsForChat(
+      fakeBot as unknown as Parameters<typeof registerCommandsForChat>[0],
+      "-1001111111111"
+    );
+
+    expect(setMyCommandsMock).toHaveBeenCalledTimes(2);
+    expect(setMyCommandsMock).toHaveBeenNthCalledWith(1, CHAT_USER_COMMANDS, {
+      scope: { type: "chat", chat_id: "-1001111111111" },
+    });
+    expect(setMyCommandsMock).toHaveBeenNthCalledWith(2, CHAT_ADMIN_COMMANDS, {
+      scope: { type: "chat_administrators", chat_id: "-1001111111111" },
+    });
+  });
+
+  test("returns non-zero exit code when command registration fails", async () => {
+    const expectedError = new Error("failed to setup chat commands");
+    getBotMock.mockRejectedValue(expectedError);
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      const exitCode = await runSetupChatCommandsCli(DEFAULT_CHAT_ID);
+      expect(exitCode).toBe(1);
+      expect(consoleErrorMock).toHaveBeenCalledWith(
+        `Failed to register Telegram bot commands for chat ${DEFAULT_CHAT_ID}.`,
+        expectedError
+      );
+    } finally {
+      console.error = previousConsoleError;
+    }
+  });
+});

--- a/app/scripts/telegram/setup-chat-commands.ts
+++ b/app/scripts/telegram/setup-chat-commands.ts
@@ -1,0 +1,75 @@
+import type { Bot } from "grammy";
+
+import { getBot } from "@/lib/telegram/bot-api/bot";
+
+type BotCommand = { command: string; description: string };
+
+export const DEFAULT_CHAT_ID = "-1002981429221";
+
+export const CHAT_USER_COMMANDS: BotCommand[] = [
+  { command: "summary", description: "Get the latest chat summary" },
+  { command: "ca", description: "Show $LOYAL contract address" },
+];
+
+export const CHAT_ADMIN_ONLY_COMMANDS: BotCommand[] = [
+  {
+    command: "notifications",
+    description: "Configure summary notifications (admins only)",
+  },
+  {
+    command: "activate_community",
+    description: "Enable message tracking (admins only)",
+  },
+  {
+    command: "deactivate_community",
+    description: "Disable message tracking (admins only)",
+  },
+  {
+    command: "hide",
+    description: "Hide this community from public summaries (admins only)",
+  },
+  {
+    command: "unhide",
+    description: "Show this community in public summaries (admins only)",
+  },
+];
+
+export const CHAT_ADMIN_COMMANDS: BotCommand[] = [
+  ...CHAT_USER_COMMANDS,
+  ...CHAT_ADMIN_ONLY_COMMANDS,
+];
+
+export async function registerCommandsForChat(
+  bot: Bot,
+  chatId: string = DEFAULT_CHAT_ID
+): Promise<void> {
+  await bot.api.setMyCommands(CHAT_USER_COMMANDS, {
+    scope: { type: "chat", chat_id: chatId },
+  });
+  await bot.api.setMyCommands(CHAT_ADMIN_COMMANDS, {
+    scope: { type: "chat_administrators", chat_id: chatId },
+  });
+}
+
+export async function runSetupChatCommands(chatId: string = DEFAULT_CHAT_ID): Promise<void> {
+  const bot = await getBot();
+  await registerCommandsForChat(bot, chatId);
+}
+
+export async function runSetupChatCommandsCli(
+  chatId: string = DEFAULT_CHAT_ID
+): Promise<number> {
+  try {
+    await runSetupChatCommands(chatId);
+    console.info(`Telegram bot commands registered for chat ${chatId}.`);
+    return 0;
+  } catch (error) {
+    console.error(`Failed to register Telegram bot commands for chat ${chatId}.`, error);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  const chatId = process.argv[2] ?? DEFAULT_CHAT_ID;
+  process.exit(await runSetupChatCommandsCli(chatId));
+}

--- a/app/scripts/telegram/setup-chat-commands.ts
+++ b/app/scripts/telegram/setup-chat-commands.ts
@@ -69,7 +69,12 @@ export async function runSetupChatCommandsCli(
   }
 }
 
-if (import.meta.main) {
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+if (isDirectExecution("setup-chat-commands.ts")) {
   const chatId = process.argv[2] ?? DEFAULT_CHAT_ID;
   process.exit(await runSetupChatCommandsCli(chatId));
 }

--- a/app/scripts/telegram/setup-commands.test.ts
+++ b/app/scripts/telegram/setup-commands.test.ts
@@ -1,0 +1,72 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getBotMock = mock(async () => ({}));
+const registerBotCommandsMock = mock(async () => undefined);
+
+mock.module("@/lib/telegram/bot-api/bot", () => ({
+  getBot: getBotMock,
+}));
+mock.module("@/lib/telegram/bot-api/register-commands", () => ({
+  registerBotCommands: registerBotCommandsMock,
+}));
+
+let runSetupCommands: typeof import("./setup-commands").runSetupCommands;
+let runSetupCommandsCli: typeof import("./setup-commands").runSetupCommandsCli;
+
+describe("telegram setup commands script", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("./setup-commands");
+    runSetupCommands = loadedModule.runSetupCommands;
+    runSetupCommandsCli = loadedModule.runSetupCommandsCli;
+  });
+
+  beforeEach(() => {
+    getBotMock.mockReset();
+    registerBotCommandsMock.mockReset();
+  });
+
+  test("registers bot commands successfully", async () => {
+    const fakeBot = { api: {} };
+    getBotMock.mockResolvedValue(fakeBot);
+    const consoleInfoMock = mock(() => undefined);
+    const previousConsoleInfo = console.info;
+    console.info = consoleInfoMock;
+
+    try {
+      const exitCode = await runSetupCommandsCli();
+      expect(exitCode).toBe(0);
+
+      expect(getBotMock).toHaveBeenCalledTimes(1);
+      expect(registerBotCommandsMock).toHaveBeenCalledTimes(1);
+      expect(registerBotCommandsMock).toHaveBeenCalledWith(fakeBot);
+      expect(consoleInfoMock).toHaveBeenCalledTimes(1);
+      expect(consoleInfoMock).toHaveBeenCalledWith(
+        "Telegram bot commands registered successfully."
+      );
+    } finally {
+      console.info = previousConsoleInfo;
+    }
+  });
+
+  test("returns non-zero exit code when command registration fails", async () => {
+    const expectedError = new Error("failed to setup commands");
+    getBotMock.mockRejectedValue(expectedError);
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      await expect(runSetupCommands()).rejects.toThrow("failed to setup commands");
+
+      const exitCode = await runSetupCommandsCli();
+      expect(exitCode).toBe(1);
+      expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+      expect(consoleErrorMock).toHaveBeenCalledWith(
+        "Failed to register Telegram bot commands.",
+        expectedError
+      );
+    } finally {
+      console.error = previousConsoleError;
+    }
+  });
+});

--- a/app/scripts/telegram/setup-commands.ts
+++ b/app/scripts/telegram/setup-commands.ts
@@ -1,0 +1,22 @@
+import { getBot } from "@/lib/telegram/bot-api/bot";
+import { registerBotCommands } from "@/lib/telegram/bot-api/register-commands";
+
+export async function runSetupCommands(): Promise<void> {
+  const bot = await getBot();
+  await registerBotCommands(bot);
+}
+
+export async function runSetupCommandsCli(): Promise<number> {
+  try {
+    await runSetupCommands();
+    console.info("Telegram bot commands registered successfully.");
+    return 0;
+  } catch (error) {
+    console.error("Failed to register Telegram bot commands.", error);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  process.exit(await runSetupCommandsCli());
+}

--- a/app/scripts/telegram/setup-commands.ts
+++ b/app/scripts/telegram/setup-commands.ts
@@ -17,6 +17,11 @@ export async function runSetupCommandsCli(): Promise<number> {
   }
 }
 
-if (import.meta.main) {
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+if (isDirectExecution("setup-commands.ts")) {
   process.exit(await runSetupCommandsCli());
 }

--- a/docs/onboarding/add-bot-and-activate-community.md
+++ b/docs/onboarding/add-bot-and-activate-community.md
@@ -18,7 +18,14 @@ Reference: `app/.env.example`.
 
 ### Register Telegram bot commands
 
-Call the setup endpoint once after deployment (or when commands change):
+Run the setup script once after deployment (or when commands change):
+
+```bash
+cd app
+bun run telegram:setup-commands
+```
+
+Optional fallback (if you prefer endpoint-based setup):
 
 - Endpoint: `POST /api/telegram/setup-commands`
 - Auth header: `Authorization: Bearer <TELEGRAM_SETUP_SECRET>`


### PR DESCRIPTION
Adds Bun scripts to register Telegram bot commands directly via getBot() instead of relying on the setup endpoint flow. Includes scoped chat/admin command registration for -1002981429221 and tests for the new script entrypoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm scripts to configure Telegram bot commands, including a chat-specific setup option.

* **Documentation**
  * Updated onboarding guide to recommend running the new script-based Telegram command setup after deployment (with example invocation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->