### PR TITLE
feat(telegram): update summary vote buttons with custom emoji states

### DIFF
--- a/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries-delivery.test.ts
@@ -6,6 +6,10 @@ import { buildSummaryFeedMiniAppUrl } from "@/lib/telegram/mini-app/start-param"
 mock.module("server-only", () => ({}));
 
 const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
+const SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID = "5447485069386090205";
+const SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID = "5445146433923616423";
+const SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID = "5375302886936842644";
+const SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID = "5445293605272984280";
 
 type CommunityRecord = {
   chatId: bigint;
@@ -120,7 +124,7 @@ describe("summary delivery guards", () => {
       sent: true,
     });
     expect(sendMessageCalls).toHaveLength(1);
-    const [, , messageOptions] = sendMessageCalls[0] as [
+    const [, messageText, messageOptions] = sendMessageCalls[0] as [
       number,
       string,
       {
@@ -128,6 +132,7 @@ describe("summary delivery guards", () => {
           inline_keyboard: Array<
             Array<{
               callback_data?: string;
+              icon_custom_emoji_id?: string;
               style?: string;
               text?: string;
               url?: string;
@@ -136,6 +141,9 @@ describe("summary delivery guards", () => {
         };
       },
     ];
+    expect(messageText).toContain("Daily recap");
+    expect(messageText).not.toContain("Summary:");
+    expect(messageText).not.toContain("<tg-emoji");
     const rows = messageOptions.reply_markup.inline_keyboard;
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveLength(3);
@@ -143,17 +151,31 @@ describe("summary delivery guards", () => {
     expect(rows[0][0]?.callback_data).toBe(
       `sv:u:${SUMMARY_ID}:${summaryResult!.community.chatId}`
     );
-    expect(rows[0][0]?.style).toBe("success");
+    expect(rows[0][0]?.text).toBe("Like");
+    expect(rows[0][0]?.style).toBeUndefined();
+    expect(rows[0][0]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID
+    );
     expect(rows[0][1]?.text).toBe("Score: 3");
+    expect(rows[0][1]?.icon_custom_emoji_id).toBe(
+      SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID
+    );
     expect(rows[0][1]?.callback_data).toBe(
       `sv:s:${SUMMARY_ID}:${summaryResult!.community.chatId}`
     );
     expect(rows[0][2]?.callback_data).toBe(
       `sv:d:${SUMMARY_ID}:${summaryResult!.community.chatId}`
     );
-    expect(rows[0][2]?.style).toBe("danger");
+    expect(rows[0][2]?.text).toBe("Dislike");
+    expect(rows[0][2]?.style).toBeUndefined();
+    expect(rows[0][2]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID
+    );
     expect(rows[1][0]?.text).toBe("Open");
     expect(rows[1][0]?.style).toBe("primary");
+    expect(rows[1][0]?.icon_custom_emoji_id).toBe(
+      SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID
+    );
     expect(rows[1][0]?.url).toBe(
       buildSummaryFeedMiniAppUrl(summaryResult!.community.chatId, SUMMARY_ID)
     );

--- a/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
@@ -21,6 +21,12 @@ type InsertedVoteValues = {
 
 const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
 const GROUP_CHAT_ID = "-1001234567890";
+const SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID = "5447485069386090205";
+const SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID = "5445146433923616423";
+const SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID = "5375302886936842644";
+const SUMMARY_SCORE_ZERO_CUSTOM_EMOJI_ID = "5447522585925426434";
+const SUMMARY_SCORE_NEGATIVE_CUSTOM_EMOJI_ID = "5447484068658714886";
+const SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID = "5445293605272984280";
 
 let currentVoteTotals = { likes: 0, dislikes: 0 };
 let insertBehavior: "inserted" | "duplicate" | "throw" = "inserted";
@@ -169,21 +175,63 @@ describe("summary vote keyboard", () => {
     expect(rows[0]).toHaveLength(3);
     expect(rows[1]).toHaveLength(1);
 
-    expect(rows[0][0]?.text).toBe("👍👍👍");
-    expect(rows[0][0]?.style).toBe("success");
+    expect(rows[0][0]?.text).toBe("Like");
+    expect(rows[0][0]?.style).toBeUndefined();
+    expect(rows[0][0]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID
+    );
     expect(rows[0][0]?.callback_data).toBe(`sv:u:${SUMMARY_ID}:${GROUP_CHAT_ID}`);
 
     expect(rows[0][1]?.text).toBe("Score: 3");
+    expect(rows[0][1]?.icon_custom_emoji_id).toBe(
+      SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID
+    );
     expect(rows[0][1]?.callback_data).toBe(`sv:s:${SUMMARY_ID}:${GROUP_CHAT_ID}`);
 
-    expect(rows[0][2]?.text).toBe("👎👎👎");
-    expect(rows[0][2]?.style).toBe("danger");
+    expect(rows[0][2]?.text).toBe("Dislike");
+    expect(rows[0][2]?.style).toBeUndefined();
+    expect(rows[0][2]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID
+    );
     expect(rows[0][2]?.callback_data).toBe(`sv:d:${SUMMARY_ID}:${GROUP_CHAT_ID}`);
 
     expect(rows[1][0]?.text).toBe("Open");
     expect(rows[1][0]?.style).toBe("primary");
+    expect(rows[1][0]?.icon_custom_emoji_id).toBe(
+      SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID
+    );
     expect(rows[1][0]?.url).toBe(
       buildSummaryFeedMiniAppUrl(GROUP_CHAT_ID, SUMMARY_ID)
+    );
+  });
+
+  test("uses neutral score icon when score is zero", () => {
+    const keyboard = buildSummaryVoteKeyboard(
+      BigInt(GROUP_CHAT_ID),
+      SUMMARY_ID,
+      4,
+      4
+    );
+    const rows = keyboard.inline_keyboard;
+
+    expect(rows[0][1]?.text).toBe("Score: 0");
+    expect(rows[0][1]?.icon_custom_emoji_id).toBe(
+      SUMMARY_SCORE_ZERO_CUSTOM_EMOJI_ID
+    );
+  });
+
+  test("uses negative score icon when score is below zero", () => {
+    const keyboard = buildSummaryVoteKeyboard(
+      BigInt(GROUP_CHAT_ID),
+      SUMMARY_ID,
+      1,
+      3
+    );
+    const rows = keyboard.inline_keyboard;
+
+    expect(rows[0][1]?.text).toBe("Score: -2");
+    expect(rows[0][1]?.icon_custom_emoji_id).toBe(
+      SUMMARY_SCORE_NEGATIVE_CUSTOM_EMOJI_ID
     );
   });
 });
@@ -268,7 +316,12 @@ describe("handleSummaryVoteCallback", () => {
       {
         reply_markup: {
           inline_keyboard: Array<
-            Array<{ callback_data?: string; style?: string; text?: string }>
+            Array<{
+              callback_data?: string;
+              icon_custom_emoji_id?: string;
+              style?: string;
+              text?: string;
+            }>
           >;
         };
       },
@@ -277,12 +330,21 @@ describe("handleSummaryVoteCallback", () => {
     expect(payload.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe(
       `sv:u:${SUMMARY_ID}:${GROUP_CHAT_ID}`
     );
-    expect(payload.reply_markup.inline_keyboard[0]?.[0]?.style).toBe("success");
+    expect(payload.reply_markup.inline_keyboard[0]?.[0]?.style).toBeUndefined();
+    expect(payload.reply_markup.inline_keyboard[0]?.[0]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID
+    );
     expect(payload.reply_markup.inline_keyboard[0]?.[1]?.text).toBe("Score: 1");
+    expect(payload.reply_markup.inline_keyboard[0]?.[1]?.icon_custom_emoji_id).toBe(
+      SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID
+    );
     expect(payload.reply_markup.inline_keyboard[0]?.[1]?.callback_data).toBe(
       `sv:s:${SUMMARY_ID}:${GROUP_CHAT_ID}`
     );
-    expect(payload.reply_markup.inline_keyboard[0]?.[2]?.style).toBe("danger");
+    expect(payload.reply_markup.inline_keyboard[0]?.[2]?.style).toBeUndefined();
+    expect(payload.reply_markup.inline_keyboard[0]?.[2]?.icon_custom_emoji_id).toBe(
+      SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID
+    );
 
     expect(answerCalls).toEqual([undefined]);
     expect(mixpanelTrackCalls).toEqual([

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -37,6 +37,12 @@ const GROUP_CHAT_ID_REGEX_PART = "-?\\d+";
 const DUPLICATE_VOTE_ALERT_CACHE_TIME_SECONDS = 300;
 const BOT_SUMMARY_LIKE_EVENT = "Bot Summary Like";
 const BOT_SUMMARY_DISLIKE_EVENT = "Bot Summary Dislike";
+const SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID = "5447485069386090205";
+const SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID = "5445146433923616423";
+const SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID = "5375302886936842644";
+const SUMMARY_SCORE_ZERO_CUSTOM_EMOJI_ID = "5447522585925426434";
+const SUMMARY_SCORE_NEGATIVE_CUSTOM_EMOJI_ID = "5447484068658714886";
+const SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID = "5445293605272984280";
 
 function getVoteEventName(
   voteAction: PersistedSummaryVoteAction
@@ -121,12 +127,13 @@ export function buildSummaryVoteKeyboard(
   dislikes: number
 ): InlineKeyboard {
   const score = likes - dislikes;
+  const scoreCustomEmojiId = resolveScoreCustomEmojiId(score);
 
   return new InlineKeyboard()
     .text(
       {
-        style: "success",
-        text: "👍👍👍",
+        text: "Like",
+        icon_custom_emoji_id: SUMMARY_VOTE_LIKE_CUSTOM_EMOJI_ID,
       },
       encodeSummaryVoteCallbackData({
         action: "u",
@@ -135,7 +142,10 @@ export function buildSummaryVoteKeyboard(
       })
     )
     .text(
-      `Score: ${score}`,
+      {
+        text: `Score: ${score}`,
+        icon_custom_emoji_id: scoreCustomEmojiId,
+      },
       encodeSummaryVoteCallbackData({
         action: "s",
         groupChatId: groupChatId.toString(),
@@ -144,8 +154,8 @@ export function buildSummaryVoteKeyboard(
     )
     .text(
       {
-        style: "danger",
-        text: "👎👎👎",
+        text: "Dislike",
+        icon_custom_emoji_id: SUMMARY_VOTE_DISLIKE_CUSTOM_EMOJI_ID,
       },
       encodeSummaryVoteCallbackData({
         action: "d",
@@ -158,9 +168,22 @@ export function buildSummaryVoteKeyboard(
       {
         style: "primary",
         text: "Open",
+        icon_custom_emoji_id: SUMMARY_OPEN_BUTTON_CUSTOM_EMOJI_ID,
       },
       buildSummaryFeedMiniAppUrl(groupChatId, summaryId)
     );
+}
+
+function resolveScoreCustomEmojiId(score: number): string {
+  if (score > 0) {
+    return SUMMARY_SCORE_POSITIVE_CUSTOM_EMOJI_ID;
+  }
+
+  if (score < 0) {
+    return SUMMARY_SCORE_NEGATIVE_CUSTOM_EMOJI_ID;
+  }
+
+  return SUMMARY_SCORE_ZERO_CUSTOM_EMOJI_ID;
 }
 
 export async function getSummaryVoteTotals(


### PR DESCRIPTION
Updated summary vote inline keyboard labels and custom emoji IDs for like/dislike/open, including score-state emoji by sign. Removed top summary-message emoji header and refreshed bot-api tests for keyboard payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Summary messages now display custom emoji icons on action buttons (Like, Dislike, Open) for enhanced visual feedback
* Score displays include contextual emoji icons that vary based on the score value
* Improved message formatting for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->