### PR TITLE
feat(telegram): add private user settings schema and /settings command

### DIFF
--- a/app/drizzle/0007_curvy_glorian.sql
+++ b/app/drizzle/0007_curvy_glorian.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "user_settings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"model" text DEFAULT 'phala/gpt-oss-120b' NOT NULL,
+	"notifications" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_settings" ADD CONSTRAINT "user_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_settings_user_id_idx" ON "user_settings" USING btree ("user_id");

--- a/app/drizzle/meta/0007_snapshot.json
+++ b/app/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1294 @@
+{
+  "id": "8c43846d-2035-4383-b78d-2ee2fb0fde51",
+  "prevId": "8815f760-33ae-406e-942f-0fffb83739ce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771046097651,
       "tag": "0006_known_thunderbolt_ross",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771311965999,
+      "tag": "0007_curvy_glorian",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -8,6 +8,7 @@ import {
   handleDeactivateCommunityCommand,
   handleHideCommunityCommand,
   handleNotificationsCommand,
+  handleSettingsCommand,
   handleStartCommand,
   handleSummaryCommand,
   handleUnhideCommunityCommand,
@@ -32,6 +33,10 @@ import {
   SUMMARY_VOTE_CALLBACK_DATA_REGEX,
 } from "@/lib/telegram/bot-api/summary-votes";
 import {
+  handleUserSettingsCallback,
+  USER_SETTINGS_CALLBACK_DATA_REGEX,
+} from "@/lib/telegram/bot-api/user-settings";
+import {
   handleDirectMessage,
   handleDirectTopicCreatedMessage,
 } from "@/lib/telegram/conversation-service";
@@ -41,6 +46,10 @@ const bot = await getBot();
 
 bot.command("start", async (ctx: CommandContext<Context>) => {
   await handleStartCommand(ctx, bot);
+});
+
+bot.chatType("private").command("settings", async (ctx) => {
+  await handleSettingsCommand(ctx);
 });
 
 bot.command("ca", async (ctx: CommandContext<Context>) => {
@@ -87,6 +96,10 @@ bot.callbackQuery(START_CAROUSEL_CALLBACK_DATA_REGEX, async (ctx) => {
 
 bot.callbackQuery(NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX, async (ctx) => {
   await handleNotificationSettingsCallback(ctx);
+});
+
+bot.callbackQuery(USER_SETTINGS_CALLBACK_DATA_REGEX, async (ctx) => {
+  await handleUserSettingsCallback(ctx);
 });
 
 bot.callbackQuery(SUMMARY_VOTE_CALLBACK_DATA_REGEX, async (ctx) => {

--- a/app/src/lib/telegram/bot-api/__tests__/commands-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-settings.test.ts
@@ -1,0 +1,217 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CommandContext, Context } from "grammy";
+
+import type { UserSettings } from "@/lib/core/schema";
+
+mock.module("server-only", () => ({}));
+
+let mockDb: {
+  insert: () => {
+    values: (
+      values: Record<string, unknown>
+    ) => { onConflictDoNothing: () => Promise<void> };
+  };
+  query: {
+    userSettings: { findFirst: () => Promise<UserSettings | null> };
+  };
+};
+
+let getOrCreateUserImpl: () => Promise<string> = async () => "user-1";
+let userSettingsFindResult: UserSettings | null = null;
+let insertValuesCaptured: Array<Record<string, unknown>> = [];
+
+mock.module("mixpanel", () => ({
+  default: {
+    init: () => ({
+      track: (
+        _eventName: string,
+        _properties: Record<string, unknown>,
+        callback?: (error?: unknown) => void
+      ) => {
+        callback?.();
+      },
+    }),
+  },
+}));
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: async () => getOrCreateUserImpl(),
+}));
+
+mock.module("../notification-settings", () => ({
+  sendNotificationSettingsMessage: async () => {},
+}));
+
+mock.module("../start-carousel", () => ({
+  sendStartCarousel: async () => {},
+}));
+
+mock.module("../summaries", () => ({
+  sendLatestSummary: async () => ({ sent: true as const }),
+}));
+
+mock.module("../get-chat", () => ({
+  getChat: async () => ({}),
+}));
+
+mock.module("../get-file", () => ({
+  downloadTelegramFile: async () => ({
+    body: Buffer.from(""),
+    contentType: "image/jpeg",
+  }),
+}));
+
+let handleSettingsCommand: typeof import("../commands").handleSettingsCommand;
+
+function createUserSettings(overrides?: Partial<UserSettings>): UserSettings {
+  return {
+    id: "dd54f4c3-3e4d-40d6-8af2-4bf14ee4b7c7",
+    userId: "550e8400-e29b-41d4-a716-446655440000",
+    model: "phala/gpt-oss-120b",
+    notifications: true,
+    createdAt: new Date("2026-02-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createPrivateCommandContext() {
+  const replyCalls: Array<{ options?: unknown; text: string }> = [];
+
+  const ctx = {
+    chat: {
+      id: 777,
+      type: "private",
+    },
+    from: {
+      first_name: "Test",
+      id: 777,
+      username: "test_user",
+    },
+    reply: async (text: string, options?: unknown) => {
+      replyCalls.push({ options, text });
+      return {} as never;
+    },
+  } as unknown as CommandContext<Context>;
+
+  return { ctx, replyCalls };
+}
+
+function createGroupCommandContext() {
+  const replyCalls: Array<{ options?: unknown; text: string }> = [];
+
+  const ctx = {
+    chat: {
+      id: -1009876543210,
+      type: "supergroup",
+    },
+    from: {
+      first_name: "Test",
+      id: 777,
+      username: "test_user",
+    },
+    reply: async (text: string, options?: unknown) => {
+      replyCalls.push({ options, text });
+      return {} as never;
+    },
+  } as unknown as CommandContext<Context>;
+
+  return { ctx, replyCalls };
+}
+
+describe("settings command", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../commands");
+    handleSettingsCommand = loadedModule.handleSettingsCommand;
+  });
+
+  beforeEach(() => {
+    insertValuesCaptured = [];
+    getOrCreateUserImpl = async () => "550e8400-e29b-41d4-a716-446655440000";
+    userSettingsFindResult = createUserSettings();
+
+    mockDb = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          insertValuesCaptured.push(values);
+          return {
+            onConflictDoNothing: async () => {},
+          };
+        },
+      }),
+      query: {
+        userSettings: {
+          findFirst: async () => userSettingsFindResult,
+        },
+      },
+    };
+  });
+
+  test("sends user settings panel in private chat and ensures row exists", async () => {
+    const { ctx, replyCalls } = createPrivateCommandContext();
+
+    await handleSettingsCommand(ctx);
+
+    expect(insertValuesCaptured).toEqual([
+      { userId: "550e8400-e29b-41d4-a716-446655440000" },
+    ]);
+    expect(replyCalls).toHaveLength(1);
+    expect(replyCalls[0]?.text).toContain("Your notification settings");
+    expect(replyCalls[0]?.options).toEqual(
+      expect.objectContaining({
+        parse_mode: "HTML",
+      })
+    );
+  });
+
+  test("replies with error when settings row cannot be loaded", async () => {
+    userSettingsFindResult = null;
+    const { ctx, replyCalls } = createPrivateCommandContext();
+
+    await handleSettingsCommand(ctx);
+
+    expect(replyCalls).toEqual([
+      {
+        options: undefined,
+        text: "Unable to load your settings right now. Please try again.",
+      },
+    ]);
+  });
+
+  test("does nothing for non-private chats", async () => {
+    const { ctx, replyCalls } = createGroupCommandContext();
+
+    await handleSettingsCommand(ctx);
+
+    expect(insertValuesCaptured).toHaveLength(0);
+    expect(replyCalls).toHaveLength(0);
+  });
+
+  test("replies with error when user resolution fails", async () => {
+    getOrCreateUserImpl = async () => {
+      throw new Error("user resolution failed");
+    };
+    const { ctx, replyCalls } = createPrivateCommandContext();
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      await handleSettingsCommand(ctx);
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(replyCalls).toEqual([
+      {
+        options: undefined,
+        text: "Unable to load your settings right now. Please try again.",
+      },
+    ]);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/register-commands.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/register-commands.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from "bun:test";
+
+describe("registerBotCommands", () => {
+  test("registers /settings in private scope and keeps group commands", async () => {
+    const setMyCommands = mock(async () => true as const);
+    const bot = {
+      api: {
+        setMyCommands,
+      },
+    };
+
+    const { registerBotCommands } = await import("../register-commands");
+
+    await registerBotCommands(bot as never);
+
+    expect(setMyCommands).toHaveBeenCalledTimes(2);
+
+    expect(setMyCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        { command: "start", description: "Start the bot and get help" },
+        {
+          command: "settings",
+          description: "Manage your private notification settings",
+        },
+      ],
+      { scope: { type: "all_private_chats" } }
+    );
+
+    expect(setMyCommands).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([
+        { command: "summary", description: "Get the latest chat summary" },
+        {
+          command: "notifications",
+          description: "Configure summary notifications (admins only)",
+        },
+      ]),
+      { scope: { type: "all_group_chats" } }
+    );
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/user-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/user-settings.test.ts
@@ -1,0 +1,309 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CallbackQueryContext, Context } from "grammy";
+
+import type { UserSettings } from "@/lib/core/schema";
+
+let mockDb: {
+  query: {
+    users: { findFirst: () => Promise<{ id: string } | null> };
+    userSettings: { findFirst: () => Promise<UserSettings | null> };
+  };
+  update: () => {
+    set: (values: Record<string, unknown>) => {
+      where: () => Promise<void>;
+    };
+  };
+};
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+let OUTDATED_USER_SETTINGS_ALERT_TEXT: string;
+let UNAUTHORIZED_USER_SETTINGS_ALERT_TEXT: string;
+let USER_SETTINGS_CALLBACK_DATA_REGEX: RegExp;
+let buildUserSettingsKeyboard: (
+  userId: string,
+  notifications: boolean
+) => {
+  inline_keyboard: Array<
+    Array<{ callback_data?: string; text?: string; url?: string }>
+  >;
+};
+let buildUserSettingsUpdateValues: (callbackData: {
+  userId: string;
+  dimension: "notif";
+  value: "off" | "on";
+}) => {
+  notifications: boolean;
+  updatedAt: Date;
+};
+let encodeUserSettingsCallbackData: (callbackData: {
+  userId: string;
+  dimension: "notif";
+  value: "off" | "on";
+}) => string;
+let handleUserSettingsCallback: (
+  ctx: CallbackQueryContext<Context>
+) => Promise<void>;
+let parseUserSettingsCallbackData: (data: string) => {
+  userId: string;
+  dimension: "notif";
+  value: "off" | "on";
+} | null;
+
+let actorResult: { id: string } | null;
+let settingsFindResults: Array<UserSettings | null>;
+let updateValuesCaptured: Array<Record<string, unknown>>;
+
+function createUserSettings(overrides?: Partial<UserSettings>): UserSettings {
+  return {
+    id: "dd54f4c3-3e4d-40d6-8af2-4bf14ee4b7c7",
+    userId: "550e8400-e29b-41d4-a716-446655440000",
+    model: "phala/gpt-oss-120b",
+    notifications: true,
+    createdAt: new Date("2026-02-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-02-12T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createCallbackContext(options: {
+  data: string;
+  includeFrom?: boolean;
+  fromId?: number;
+  chatId?: number;
+  messageId?: number;
+}) {
+  const answerCalls: unknown[] = [];
+  const editCalls: unknown[][] = [];
+
+  const rawContext: Record<string, unknown> = {
+    callbackQuery: {
+      data: options.data,
+      message: {
+        chat: { id: options.chatId ?? 777 },
+        message_id: options.messageId ?? 101,
+      },
+    },
+    answerCallbackQuery: async (payload?: unknown) => {
+      answerCalls.push(payload);
+      return true as const;
+    },
+    api: {
+      editMessageText: async (...args: unknown[]) => {
+        editCalls.push(args);
+        return {} as never;
+      },
+    },
+  };
+
+  if (options.includeFrom !== false) {
+    rawContext.from = { id: options.fromId ?? 777 };
+  }
+
+  return {
+    answerCalls,
+    ctx: rawContext as unknown as CallbackQueryContext<Context>,
+    editCalls,
+  };
+}
+
+describe("user settings helpers", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../user-settings");
+    ({
+      OUTDATED_USER_SETTINGS_ALERT_TEXT,
+      UNAUTHORIZED_USER_SETTINGS_ALERT_TEXT,
+      USER_SETTINGS_CALLBACK_DATA_REGEX,
+      buildUserSettingsKeyboard,
+      buildUserSettingsUpdateValues,
+      encodeUserSettingsCallbackData,
+      handleUserSettingsCallback,
+      parseUserSettingsCallbackData,
+    } = loadedModule);
+  });
+
+  beforeEach(() => {
+    actorResult = null;
+    settingsFindResults = [];
+    updateValuesCaptured = [];
+
+    mockDb = {
+      query: {
+        users: {
+          findFirst: async () => actorResult,
+        },
+        userSettings: {
+          findFirst: async () => settingsFindResults.shift() ?? null,
+        },
+      },
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updateValuesCaptured.push(values);
+          return {
+            where: async () => {},
+          };
+        },
+      }),
+    };
+  });
+
+  test("parses valid callback data", () => {
+    const userId = "550e8400-e29b-41d4-a716-446655440000";
+
+    expect(
+      parseUserSettingsCallbackData(
+        encodeUserSettingsCallbackData({
+          userId,
+          dimension: "notif",
+          value: "on",
+        })
+      )
+    ).toEqual({
+      userId,
+      dimension: "notif",
+      value: "on",
+    });
+  });
+
+  test("rejects malformed callback data", () => {
+    expect(
+      parseUserSettingsCallbackData(
+        "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:24"
+      )
+    ).toBeNull();
+    expect(
+      parseUserSettingsCallbackData(
+        "usr:settings:550e8400-e29b-41d4-a716-446655440000:master:on"
+      )
+    ).toBeNull();
+    expect(parseUserSettingsCallbackData("invalid:data")).toBeNull();
+  });
+
+  test("regex trigger only matches expected callback format", () => {
+    expect(
+      USER_SETTINGS_CALLBACK_DATA_REGEX.test(
+        "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on"
+      )
+    ).toBe(true);
+    expect(
+      USER_SETTINGS_CALLBACK_DATA_REGEX.test(
+        "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on:extra"
+      )
+    ).toBe(false);
+    expect(
+      USER_SETTINGS_CALLBACK_DATA_REGEX.test("usr:settings:not-a-uuid:notif:on")
+    ).toBe(false);
+  });
+
+  test("builds a one-row keyboard with active markers and callback payloads", () => {
+    const userId = "550e8400-e29b-41d4-a716-446655440000";
+    const keyboard = buildUserSettingsKeyboard(userId, true);
+    const rows = keyboard.inline_keyboard;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveLength(2);
+    expect(rows[0][1]?.text).toContain("✅");
+    expect(rows[0][1]?.callback_data).toBe(
+      "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on"
+    );
+  });
+
+  test("maps callback action to typed DB update values", () => {
+    const update = buildUserSettingsUpdateValues({
+      userId: "550e8400-e29b-41d4-a716-446655440000",
+      dimension: "notif",
+      value: "off",
+    });
+
+    expect(update.notifications).toBe(false);
+    expect(update.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test("shows authorization alert when user presses another account's callback", async () => {
+    actorResult = { id: "6f717210-4b32-4df5-a76c-f799ebf1dad8" };
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      data: "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on",
+    });
+
+    await handleUserSettingsCallback(ctx);
+
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: UNAUTHORIZED_USER_SETTINGS_ALERT_TEXT,
+      },
+    ]);
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(editCalls).toHaveLength(0);
+  });
+
+  test("shows stale-panel alert when settings row is missing", async () => {
+    actorResult = { id: "550e8400-e29b-41d4-a716-446655440000" };
+    settingsFindResults = [null];
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      data: "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on",
+    });
+
+    await handleUserSettingsCallback(ctx);
+
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: OUTDATED_USER_SETTINGS_ALERT_TEXT,
+      },
+    ]);
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(editCalls).toHaveLength(0);
+  });
+
+  test("shows stale-panel alert when callback message is from another chat", async () => {
+    actorResult = { id: "550e8400-e29b-41d4-a716-446655440000" };
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      chatId: -1009876543210,
+      data: "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:on",
+      fromId: 777,
+    });
+
+    await handleUserSettingsCallback(ctx);
+
+    expect(answerCalls).toEqual([
+      {
+        show_alert: true,
+        text: OUTDATED_USER_SETTINGS_ALERT_TEXT,
+      },
+    ]);
+    expect(updateValuesCaptured).toHaveLength(0);
+    expect(editCalls).toHaveLength(0);
+  });
+
+  test("updates DB and refreshes keyboard when user toggles notifications", async () => {
+    actorResult = { id: "550e8400-e29b-41d4-a716-446655440000" };
+    const initialSettings = createUserSettings({ notifications: true });
+    const updatedSettings = createUserSettings({ notifications: false });
+    settingsFindResults = [initialSettings, updatedSettings];
+
+    const { answerCalls, ctx, editCalls } = createCallbackContext({
+      chatId: 777,
+      data: "usr:settings:550e8400-e29b-41d4-a716-446655440000:notif:off",
+      messageId: 123,
+    });
+
+    await handleUserSettingsCallback(ctx);
+
+    expect(updateValuesCaptured).toHaveLength(1);
+    expect(updateValuesCaptured[0]?.notifications).toBe(false);
+    expect(updateValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+
+    expect(editCalls).toHaveLength(1);
+    expect(editCalls[0]?.[0]).toBe(777);
+    expect(editCalls[0]?.[1]).toBe(123);
+    expect(editCalls[0]?.[2]).toContain("Your notification settings");
+
+    expect(answerCalls).toEqual([{ text: "Settings updated" }]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/register-commands.ts
+++ b/app/src/lib/telegram/bot-api/register-commands.ts
@@ -3,7 +3,13 @@ import type { Bot } from "grammy";
 export async function registerBotCommands(bot: Bot): Promise<void> {
   // Commands for private chats
   await bot.api.setMyCommands(
-    [{ command: "start", description: "Start the bot and get help" }],
+    [
+      { command: "start", description: "Start the bot and get help" },
+      {
+        command: "settings",
+        description: "Manage your private notification settings",
+      },
+    ],
     { scope: { type: "all_private_chats" } }
   );
 

--- a/app/src/lib/telegram/bot-api/user-settings.ts
+++ b/app/src/lib/telegram/bot-api/user-settings.ts
@@ -1,0 +1,231 @@
+import { eq } from "drizzle-orm";
+import {
+  type CallbackQueryContext,
+  type CommandContext,
+  type Context,
+  InlineKeyboard,
+} from "grammy";
+
+import { getDatabase } from "@/lib/core/database";
+import type { UserSettings } from "@/lib/core/schema";
+import { userSettings } from "@/lib/core/schema";
+import { users } from "@/lib/core/schema";
+
+import { isMessageNotModifiedError } from "./callback-query-utils";
+
+export const USER_SETTINGS_CALLBACK_PREFIX = "usr";
+export const USER_SETTINGS_CONTEXT = "settings";
+export const USER_SETTINGS_CALLBACK_DATA_REGEX =
+  /^usr:settings:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}):(notif):(on|off)$/;
+
+export const UNAUTHORIZED_USER_SETTINGS_ALERT_TEXT =
+  "This settings panel belongs to a different user account.";
+export const OUTDATED_USER_SETTINGS_ALERT_TEXT =
+  "This settings panel is outdated. Run /settings again.";
+
+type UserSettingsCallbackData = {
+  userId: string;
+  dimension: "notif";
+  value: "off" | "on";
+};
+
+type UserSettingsState = Pick<UserSettings, "model" | "notifications" | "userId">;
+
+export type UserSettingsUpdateValues = {
+  notifications: boolean;
+  updatedAt: Date;
+};
+
+export function encodeUserSettingsCallbackData(
+  callbackData: UserSettingsCallbackData
+): string {
+  return `${USER_SETTINGS_CALLBACK_PREFIX}:${USER_SETTINGS_CONTEXT}:${callbackData.userId}:${callbackData.dimension}:${callbackData.value}`;
+}
+
+export function parseUserSettingsCallbackData(
+  data: string
+): UserSettingsCallbackData | null {
+  const matches = USER_SETTINGS_CALLBACK_DATA_REGEX.exec(data);
+  if (!matches) {
+    return null;
+  }
+
+  const userId = matches[1];
+  const dimension = matches[2];
+  const rawValue = matches[3];
+
+  if (dimension !== "notif") {
+    return null;
+  }
+
+  if (rawValue !== "off" && rawValue !== "on") {
+    return null;
+  }
+
+  return {
+    userId,
+    dimension: "notif",
+    value: rawValue,
+  };
+}
+
+export function buildUserSettingsMessageText(model: string): string {
+  return [
+    "Your notification settings",
+    "",
+    "Toggle sound notifications for this bot in your private chat.",
+    "",
+    `Current model: <code>${escapeHtml(model)}</code>`,
+  ].join("\n");
+}
+
+export function buildUserSettingsKeyboard(
+  userId: string,
+  notifications: boolean
+): InlineKeyboard {
+  return new InlineKeyboard()
+    .text(
+      renderButtonLabel("🔕 Off", !notifications),
+      encodeUserSettingsCallbackData({
+        userId,
+        dimension: "notif",
+        value: "off",
+      })
+    )
+    .text(
+      renderButtonLabel("🔔 On", notifications),
+      encodeUserSettingsCallbackData({
+        userId,
+        dimension: "notif",
+        value: "on",
+      })
+    );
+}
+
+export function buildUserSettingsUpdateValues(
+  callbackData: UserSettingsCallbackData
+): UserSettingsUpdateValues {
+  return {
+    notifications: callbackData.value === "on",
+    updatedAt: new Date(),
+  };
+}
+
+export async function sendUserSettingsMessage(
+  ctx: CommandContext<Context>,
+  settings: UserSettingsState
+): Promise<void> {
+  await ctx.reply(buildUserSettingsMessageText(settings.model), {
+    parse_mode: "HTML",
+    reply_markup: buildUserSettingsKeyboard(settings.userId, settings.notifications),
+  });
+}
+
+export async function handleUserSettingsCallback(
+  ctx: CallbackQueryContext<Context>
+): Promise<void> {
+  const callbackData = parseUserSettingsCallbackData(ctx.callbackQuery.data);
+  if (!callbackData) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  if (!ctx.from) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  try {
+    const db = getDatabase();
+    const actor = await db.query.users.findFirst({
+      where: eq(users.telegramId, BigInt(ctx.from.id)),
+      columns: {
+        id: true,
+      },
+    });
+
+    if (!actor || actor.id !== callbackData.userId) {
+      await ctx.answerCallbackQuery({
+        text: UNAUTHORIZED_USER_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    const callbackMessage = ctx.callbackQuery.message;
+    if (!callbackMessage || callbackMessage.chat.id !== ctx.from.id) {
+      await ctx.answerCallbackQuery({
+        text: OUTDATED_USER_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    const currentSettings = await db.query.userSettings.findFirst({
+      where: eq(userSettings.userId, callbackData.userId),
+    });
+
+    if (!currentSettings) {
+      await ctx.answerCallbackQuery({
+        text: OUTDATED_USER_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    await db
+      .update(userSettings)
+      .set(buildUserSettingsUpdateValues(callbackData))
+      .where(eq(userSettings.userId, callbackData.userId));
+
+    const updatedSettings = await db.query.userSettings.findFirst({
+      where: eq(userSettings.userId, callbackData.userId),
+    });
+
+    if (!updatedSettings) {
+      await ctx.answerCallbackQuery({
+        text: OUTDATED_USER_SETTINGS_ALERT_TEXT,
+        show_alert: true,
+      });
+      return;
+    }
+
+    try {
+      await ctx.api.editMessageText(
+        callbackMessage.chat.id,
+        callbackMessage.message_id,
+        buildUserSettingsMessageText(updatedSettings.model),
+        {
+          parse_mode: "HTML",
+          reply_markup: buildUserSettingsKeyboard(
+            updatedSettings.userId,
+            updatedSettings.notifications
+          ),
+        }
+      );
+    } catch (error) {
+      if (!isMessageNotModifiedError(error)) {
+        throw error;
+      }
+    }
+
+    await ctx.answerCallbackQuery({ text: "Settings updated" });
+  } catch (error) {
+    console.error("Failed to update user settings", error);
+    await ctx.answerCallbackQuery({
+      text: "Unable to update settings right now.",
+      show_alert: true,
+    });
+  }
+}
+
+function renderButtonLabel(label: string, isActive: boolean): string {
+  return isActive ? `✅ ${label}` : label;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}


### PR DESCRIPTION
Add a new user_settings table linked to users and wire a private /settings command with inline notification toggles. This includes callback handling, command registration/webhook wiring, migration artifacts, and focused tests for parser/auth/stale-panel behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/settings` command for Telegram bot private chats enabling users to manage preferences
  * New settings panel allows toggling notification preferences with visual indicators for current state
  * Users can now customize their notification settings from a dedicated interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->