### PR TITLE
fix(telegram): use SDK retrieveLaunchParams for deeplink start param extraction

### DIFF
--- a/app/src/hooks/__tests__/useStartParam.test.ts
+++ b/app/src/hooks/__tests__/useStartParam.test.ts
@@ -1,55 +1,100 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { getStartParamRoute } from "../useStartParam";
 
 const GROUP_CHAT_ID = "-1002981429221";
 const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
 const START_PARAM = `sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`;
+const EXPECTED_ROUTE = `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
+  GROUP_CHAT_ID
+)}&summaryId=${SUMMARY_ID}`;
 
 afterEach(() => {
   delete (globalThis as { window?: unknown }).window;
+  mock.restore();
 });
 
 describe("getStartParamRoute", () => {
-  test("parses start param from hash", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: `#tgWebAppStartParam=${START_PARAM}`,
-        search: "",
-      },
-    };
+  describe("SDK extraction (primary)", () => {
+    test("parses start param via retrieveLaunchParams", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => ({
+          tgWebAppStartParam: START_PARAM,
+        }),
+      }));
 
-    expect(getStartParamRoute()).toBe(
-      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
-        GROUP_CHAT_ID
-      )}&summaryId=${SUMMARY_ID}`
-    );
+      (globalThis as { window?: unknown }).window = {
+        location: { hash: "", search: "" },
+      };
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+
+    test("returns undefined when SDK has no start param", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => ({
+          tgWebAppStartParam: undefined,
+        }),
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: { hash: "", search: "" },
+      };
+
+      expect(getStartParamRoute()).toBeUndefined();
+    });
   });
 
-  test("falls back to search params", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: "",
-        search: `?tgWebAppStartParam=${START_PARAM}`,
-      },
-    };
+  describe("manual fallback (when SDK throws)", () => {
+    test("parses start param from hash", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
 
-    expect(getStartParamRoute()).toBe(
-      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
-        GROUP_CHAT_ID
-      )}&summaryId=${SUMMARY_ID}`
-    );
-  });
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: `#tgWebAppStartParam=${START_PARAM}`,
+          search: "",
+        },
+      };
 
-  test("returns undefined for invalid payload", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: "#tgWebAppStartParam=invalid",
-        search: "",
-      },
-    };
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
 
-    expect(getStartParamRoute()).toBeUndefined();
+    test("falls back to search params", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: "",
+          search: `?tgWebAppStartParam=${START_PARAM}`,
+        },
+      };
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+
+    test("returns undefined for invalid payload", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: "#tgWebAppStartParam=invalid",
+          search: "",
+        },
+      };
+
+      expect(getStartParamRoute()).toBeUndefined();
+    });
   });
 });
-


### PR DESCRIPTION
Uses the Telegram SDK's `retrieveLaunchParams()` instead of manual URL hash parsing in `getStartParamRoute()`. The SDK handles multiple sources and Telegram client variations that the manual approach missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced Telegram initialization process with improved error handling and robust fallback strategies for reliable route parameter extraction.

* **Tests**
  * Added comprehensive test coverage for route extraction scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->