### PR TITLE
chore(telegram): add diagnostic logs for deeplink debugging

### DIFF
--- a/app/src/hooks/__tests__/useStartParam.test.ts
+++ b/app/src/hooks/__tests__/useStartParam.test.ts
@@ -1,55 +1,100 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { getStartParamRoute } from "../useStartParam";
 
 const GROUP_CHAT_ID = "-1002981429221";
 const SUMMARY_ID = "123e4567-e89b-12d3-a456-426614174000";
 const START_PARAM = `sf1_${GROUP_CHAT_ID}_${SUMMARY_ID}`;
+const EXPECTED_ROUTE = `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
+  GROUP_CHAT_ID
+)}&summaryId=${SUMMARY_ID}`;
 
 afterEach(() => {
   delete (globalThis as { window?: unknown }).window;
+  mock.restore();
 });
 
 describe("getStartParamRoute", () => {
-  test("parses start param from hash", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: `#tgWebAppStartParam=${START_PARAM}`,
-        search: "",
-      },
-    };
+  describe("SDK extraction (primary)", () => {
+    test("parses start param via retrieveLaunchParams", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => ({
+          tgWebAppStartParam: START_PARAM,
+        }),
+      }));
 
-    expect(getStartParamRoute()).toBe(
-      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
-        GROUP_CHAT_ID
-      )}&summaryId=${SUMMARY_ID}`
-    );
+      (globalThis as { window?: unknown }).window = {
+        location: { hash: "", search: "" },
+      };
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+
+    test("returns undefined when SDK has no start param", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => ({
+          tgWebAppStartParam: undefined,
+        }),
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: { hash: "", search: "" },
+      };
+
+      expect(getStartParamRoute()).toBeUndefined();
+    });
   });
 
-  test("falls back to search params", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: "",
-        search: `?tgWebAppStartParam=${START_PARAM}`,
-      },
-    };
+  describe("manual fallback (when SDK throws)", () => {
+    test("parses start param from hash", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
 
-    expect(getStartParamRoute()).toBe(
-      `/telegram/summaries/feed?groupChatId=${encodeURIComponent(
-        GROUP_CHAT_ID
-      )}&summaryId=${SUMMARY_ID}`
-    );
-  });
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: `#tgWebAppStartParam=${START_PARAM}`,
+          search: "",
+        },
+      };
 
-  test("returns undefined for invalid payload", () => {
-    (globalThis as { window?: unknown }).window = {
-      location: {
-        hash: "#tgWebAppStartParam=invalid",
-        search: "",
-      },
-    };
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
 
-    expect(getStartParamRoute()).toBeUndefined();
+    test("falls back to search params", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: "",
+          search: `?tgWebAppStartParam=${START_PARAM}`,
+        },
+      };
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+
+    test("returns undefined for invalid payload", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      (globalThis as { window?: unknown }).window = {
+        location: {
+          hash: "#tgWebAppStartParam=invalid",
+          search: "",
+        },
+      };
+
+      expect(getStartParamRoute()).toBeUndefined();
+    });
   });
 });
-

--- a/app/src/hooks/useStartParam.ts
+++ b/app/src/hooks/useStartParam.ts
@@ -32,15 +32,22 @@ export function getStartParamRoute(): string | undefined {
     return `/telegram/summaries/feed?${params.toString()}`;
   };
 
+  // TODO: remove diagnostic logs after deeplink debugging
+  console.warn("[deeplink] href:", window.location.href);
+  console.warn("[deeplink] hash:", window.location.hash);
+  console.warn("[deeplink] search:", window.location.search);
+
   // 1. Try SDK extraction (handles all Telegram client variations)
   try {
     const launchParams = retrieveLaunchParams();
+    console.warn("[deeplink] SDK tgWebAppStartParam:", launchParams.tgWebAppStartParam);
     const routeFromSdk = mapStartParamToRoute(launchParams.tgWebAppStartParam);
     if (routeFromSdk) {
+      console.warn("[deeplink] route from SDK:", routeFromSdk);
       return routeFromSdk;
     }
-  } catch {
-    // SDK extraction failed (e.g. not in Telegram context) — fall through
+  } catch (e) {
+    console.warn("[deeplink] SDK extraction failed:", e);
   }
 
   // 2. Fallback: manual hash / search-param parsing
@@ -49,6 +56,7 @@ export function getStartParamRoute(): string | undefined {
     if (hash) {
       const params = new URLSearchParams(hash.slice(1));
       const startParam = params.get("tgWebAppStartParam");
+      console.warn("[deeplink] hash startParam:", startParam);
       const routeFromHash = mapStartParamToRoute(startParam);
       if (routeFromHash) {
         return routeFromHash;
@@ -57,6 +65,7 @@ export function getStartParamRoute(): string | undefined {
 
     const searchParams = new URLSearchParams(window.location.search);
     const startParam = searchParams.get("tgWebAppStartParam");
+    console.warn("[deeplink] search startParam:", startParam);
     const routeFromSearch = mapStartParamToRoute(startParam);
     if (routeFromSearch) {
       return routeFromSearch;
@@ -65,5 +74,6 @@ export function getStartParamRoute(): string | undefined {
     console.debug("Failed to parse startParam from URL:", error);
   }
 
+  console.warn("[deeplink] no route found, falling back");
   return undefined;
 }


### PR DESCRIPTION
Temporary diagnostic logs to trace why deeplink start param is not consumed on prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced reliability of start parameter detection with improved fallback mechanisms to handle various initialization states.

* **Tests**
  * Expanded test coverage to validate multiple parameter extraction paths and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->