### PR TITLE
chore(telegram): add splash page diagnostic logs for deeplink debugging

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -18,8 +18,18 @@ export default function SplashPage() {
     if (hasRedirected.current) return;
 
     const redirect = async () => {
+      // Diagnostic: log everything available on the splash page
+      console.warn("[splash] href:", window.location.href);
+      console.warn("[splash] hash:", window.location.hash);
+      console.warn(
+        "[splash] native start_param:",
+        (window as { Telegram?: { WebApp?: { initDataUnsafe?: { start_param?: string } } } })
+          .Telegram?.WebApp?.initDataUnsafe?.start_param
+      );
+
       // 1. Check startParam first (highest priority - deeplinks)
       const deeplinkRoute = getStartParamRoute();
+      console.warn("[splash] deeplinkRoute:", deeplinkRoute);
 
       if (deeplinkRoute) {
         hasRedirected.current = true;


### PR DESCRIPTION
## Summary
- Adds `console.warn` diagnostics to the splash page (`/`) to trace why deeplink start_param is not being consumed on production
- Logs: `window.location.href`, `window.location.hash`, native bridge `start_param`, and `getStartParamRoute()` result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for improved debugging and troubleshooting capabilities in the application initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->