### PR TITLE
fix(telegram): detect deeplinks in Telegram layout when splash page is bypassed

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -18,18 +18,8 @@ export default function SplashPage() {
     if (hasRedirected.current) return;
 
     const redirect = async () => {
-      // Diagnostic: log everything available on the splash page
-      console.warn("[splash] href:", window.location.href);
-      console.warn("[splash] hash:", window.location.hash);
-      console.warn(
-        "[splash] native start_param:",
-        (window as { Telegram?: { WebApp?: { initDataUnsafe?: { start_param?: string } } } })
-          .Telegram?.WebApp?.initDataUnsafe?.start_param
-      );
-
       // 1. Check startParam first (highest priority - deeplinks)
       const deeplinkRoute = getStartParamRoute();
-      console.warn("[splash] deeplinkRoute:", deeplinkRoute);
 
       if (deeplinkRoute) {
         hasRedirected.current = true;

--- a/app/src/hooks/__tests__/useStartParam.test.ts
+++ b/app/src/hooks/__tests__/useStartParam.test.ts
@@ -125,4 +125,44 @@ describe("getStartParamRoute", () => {
       expect(getStartParamRoute()).toBeUndefined();
     });
   });
+
+  describe("tgWebAppData blob extraction (when start_param is only inside init data)", () => {
+    const TG_WEB_APP_DATA = `user=%7B%22id%22%3A123%7D&start_param=${START_PARAM}&auth_date=1234`;
+
+    test("extracts start_param from tgWebAppData in hash", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      stubWindow({
+        location: {
+          hash: `#tgWebAppData=${encodeURIComponent(TG_WEB_APP_DATA)}&tgWebAppVersion=8.0`,
+          search: "",
+          href: `https://example.com/#tgWebAppData=${encodeURIComponent(TG_WEB_APP_DATA)}&tgWebAppVersion=8.0`,
+        },
+      });
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+
+    test("extracts start_param from tgWebAppData in query string", () => {
+      mock.module("@telegram-apps/sdk-react", () => ({
+        retrieveLaunchParams: () => {
+          throw new Error("Not in Telegram context");
+        },
+      }));
+
+      stubWindow({
+        location: {
+          hash: "",
+          search: "",
+          href: `https://example.com/?tgWebAppData=${encodeURIComponent(TG_WEB_APP_DATA)}`,
+        },
+      });
+
+      expect(getStartParamRoute()).toBe(EXPECTED_ROUTE);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Telegram may reopen a cached mini-app at the last-visited page (e.g. `/telegram/wallet`), bypassing the splash screen at `/` where deeplink detection previously lived
- Adds deeplink detection in `TelegramLayoutClient` so `start_param` is honoured regardless of entry point
- Adds 4th extraction strategy: parse `start_param` directly from the `tgWebAppData` URL blob for clients that don't expose a separate `tgWebAppStartParam` parameter
- Removes diagnostic logs from splash page (PR #109)
- 8 tests pass