### PR TITLE
fix(telegram): improve deeplink UX with flash prevention and consumed state

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -119,8 +119,8 @@
   html {
     touch-action: manipulation;
     -webkit-text-size-adjust: 100%;
-    background: #000 !important;
-    background-color: #000 !important;
+    background: #fff !important;
+    background-color: #fff !important;
   }
   body {
     @apply bg-background text-foreground;
@@ -128,8 +128,8 @@
     -webkit-user-select: none;
     -webkit-touch-callout: none;
     overscroll-behavior: none;
-    background: #000 !important;
-    background-color: #000 !important;
+    background: #fff !important;
+    background-color: #fff !important;
   }
 }
 

--- a/app/src/app/telegram/TelegramLayoutClient.tsx
+++ b/app/src/app/telegram/TelegramLayoutClient.tsx
@@ -3,7 +3,7 @@
 import { useSignal, viewport } from "@telegram-apps/sdk-react";
 import type { Signal } from "@telegram-apps/signals";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { AnalyticsBootstrapClient } from "@/components/analytics/AnalyticsBootstrapClient";
 import Header from "@/components/Header";
@@ -11,7 +11,10 @@ import BottomNav from "@/components/telegram/BottomNav";
 import Onboarding from "@/components/telegram/Onboarding";
 import { TelegramAppRootClient } from "@/components/telegram/TelegramAppRootClient";
 import { TelegramProvider } from "@/components/telegram/TelegramProvider";
-import { getStartParamRoute } from "@/hooks/useStartParam";
+import {
+  getUnconsumedStartParamRoute,
+  markStartParamConsumed,
+} from "@/hooks/useStartParam";
 import {
   getCloudValue,
   setCloudValue,
@@ -29,22 +32,36 @@ export default function TelegramLayoutClient({
     viewport.safeAreaInsetTop as Signal<number>
   );
   const pathname = usePathname();
-  const hasCheckedDeeplink = useRef(false);
   // null = loading, true = show, false = don't show
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
 
-  // Deeplink detection: when Telegram reopens a cached mini-app at the
-  // last-visited page (bypassing the splash screen at /), we still need
-  // to honour start_param and redirect to the target route.
-  useEffect(() => {
-    if (hasCheckedDeeplink.current) return;
-    hasCheckedDeeplink.current = true;
+  // Detect deeplink synchronously on first render to prevent
+  // flash of cached page content (black screen / flicker).
+  const [deeplinkRoute, setDeeplinkRoute] = useState<string | undefined>(
+    () => {
+      if (typeof window === "undefined") return undefined;
+      return getUnconsumedStartParamRoute();
+    }
+  );
 
-    const deeplinkRoute = getStartParamRoute();
-    if (deeplinkRoute && pathname !== deeplinkRoute.split("?")[0]) {
+  // Redirect to deeplink route once on mount
+  useEffect(() => {
+    if (!deeplinkRoute) return;
+    if (pathname !== deeplinkRoute.split("?")[0]) {
       router.replace(deeplinkRoute);
     }
-  }, [pathname, router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+  }, []);
+
+  // Mark consumed and clear state once navigation to target completes,
+  // so refreshes and back-navigation don't re-trigger the redirect.
+  useEffect(() => {
+    if (!deeplinkRoute) return;
+    if (pathname === deeplinkRoute.split("?")[0]) {
+      markStartParamConsumed(deeplinkRoute);
+      setDeeplinkRoute(undefined);
+    }
+  }, [deeplinkRoute, pathname]);
 
   // Check cloud storage for onboarding completion
   useEffect(() => {
@@ -65,6 +82,15 @@ export default function TelegramLayoutClient({
 
   // Header height: safe area + 10px + logo (27px) + padding bottom (16px)
   const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
+
+  // While redirecting to deeplink, render blank screen to avoid flashing
+  // the cached page content before navigation completes.
+  const isRedirecting =
+    deeplinkRoute && pathname !== deeplinkRoute.split("?")[0];
+
+  if (isRedirecting) {
+    return <div style={{ background: "#fff", minHeight: "100vh" }} />;
+  }
 
   return (
     <TelegramAppRootClient>

--- a/app/src/hooks/useStartParam.ts
+++ b/app/src/hooks/useStartParam.ts
@@ -108,3 +108,29 @@ export function getStartParamRoute(): string | undefined {
 
   return undefined;
 }
+
+const CONSUMED_KEY = "deeplink_consumed_route";
+
+/**
+ * Returns the deeplink route only if it hasn't been consumed yet.
+ * Use this in UI consumers to avoid re-triggering redirects on page refresh.
+ */
+export function getUnconsumedStartParamRoute(): string | undefined {
+  const route = getStartParamRoute();
+  if (!route) return undefined;
+  try {
+    if (sessionStorage.getItem(CONSUMED_KEY) === route) return undefined;
+  } catch {
+    // sessionStorage not available
+  }
+  return route;
+}
+
+/** Mark the deeplink route as consumed so page refreshes don't re-trigger it. */
+export function markStartParamConsumed(route: string): void {
+  try {
+    sessionStorage.setItem(CONSUMED_KEY, route);
+  } catch {
+    // sessionStorage not available
+  }
+}


### PR DESCRIPTION
## Summary
- Detect deeplinks synchronously to show white screen instead of flashing cached page content
- Change html/body background from #000 to #fff to prevent black flash before React hydrates
- Mark deeplinks as consumed in sessionStorage so page refreshes don't re-trigger redirects
- Fix back button showing blank screen by clearing deeplink state after navigation completes

## Test plan
- Open mini-app via deeplink — should see white screen then summary, no black flash
- Navigate to another page, refresh — should stay on current page, not redirect to summary
- Click back button — should navigate normally, no blank screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented instant deeplink navigation, removing delays for faster redirect handling
  * Added safeguards to prevent duplicate deeplink processing during navigation

* **Bug Fixes**
  * Enhanced deeplink redirect reliability and consistency

* **Style**
  * Updated background color from dark to light theme
<!-- end of auto-generated comment: release notes by coderabbit.ai -->