### PR TITLE
fix(telegram): use dynamic headerHeight for toast offset

### DIFF
--- a/app/src/app/telegram/TelegramLayoutClient.tsx
+++ b/app/src/app/telegram/TelegramLayoutClient.tsx
@@ -97,7 +97,7 @@ export default function TelegramLayoutClient({
     <TelegramAppRootClient>
       <Toaster
         position="top-center"
-        offset={130}
+        offset={headerHeight}
         options={{
           fill: "black",
           styles: {


### PR DESCRIPTION
## Summary
- Replace hardcoded 130px toast offset with computed `headerHeight` so toasts render just below the app header on all screen sizes and safe area configurations

## Test plan
- [ ] Trigger error toast on verify flow and confirm it appears just below the header
- [ ] Test on iOS and Android devices with different screen sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification positioning now dynamically adjusts based on header height instead of using a fixed offset, ensuring notifications display correctly across different layouts and screen configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->