### PR TITLE
docs(onboarding): document webhook community lifecycle

### DIFF
--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -19,6 +19,7 @@ import {
   handleCommunityMessage,
   handleGLoyalReaction,
 } from "@/lib/telegram/bot-api/message-handlers";
+import { handleMyChatMemberUpdate } from "@/lib/telegram/bot-api/my-chat-member";
 import {
   handleNotificationSettingsCallback,
   NOTIFICATION_SETTINGS_CALLBACK_DATA_REGEX,
@@ -118,6 +119,10 @@ bot.on("business_connection", async (ctx) => {
   } catch (error) {
     console.error("Failed to handle business connection", error);
   }
+});
+
+bot.on("my_chat_member", async (ctx) => {
+  await handleMyChatMemberUpdate(ctx);
 });
 
 bot.on("message:forum_topic_created", async (ctx) => {

--- a/app/src/lib/telegram/bot-api/__tests__/my-chat-member.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/my-chat-member.test.ts
@@ -1,0 +1,256 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "grammy";
+
+let mockDb: {
+  insert: () => {
+    values: (values: Record<string, unknown>) => {
+      onConflictDoUpdate: (config: {
+        set: Record<string, unknown>;
+        target: unknown;
+      }) => Promise<void>;
+    };
+  };
+};
+
+let evictCalls: Array<bigint | number | string> = [];
+
+let upsertShouldThrow = false;
+let insertValuesCaptured: Array<Record<string, unknown>>;
+let conflictSetCaptured: Array<Record<string, unknown>>;
+let conflictTargetCaptured: unknown[] = [];
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+mock.module("../message-handlers", () => ({
+  evictActiveCommunityCache: (chatId: bigint | number | string) => {
+    evictCalls.push(chatId);
+  },
+}));
+
+let handleMyChatMemberUpdate: (ctx: Context) => Promise<void>;
+
+const COMMUNITY_CHAT_ID = -1009876543210;
+const ONBOARDING_MESSAGE =
+  "Thanks for adding me. Run /activate_community to enable summaries for this community.\nAfter activation, summaries are available in this chat and in the app.\nUse /notifications to set notification cycles.\nUse /hide or /unhide to control public visibility.";
+
+function createContext(options: {
+  chatType: "group" | "supergroup" | "channel" | "private";
+  newStatus:
+    | "administrator"
+    | "creator"
+    | "kicked"
+    | "left"
+    | "member"
+    | "restricted";
+  oldStatus:
+    | "administrator"
+    | "creator"
+    | "kicked"
+    | "left"
+    | "member"
+    | "restricted";
+  sendMessageShouldThrow?: boolean;
+}) {
+  const sendMessageCalls: Array<{ chatId: number | string; text: string }> = [];
+
+  const ctx = {
+    api: {
+      sendMessage: async (chatId: number | string, text: string) => {
+        sendMessageCalls.push({ chatId, text });
+        if (options.sendMessageShouldThrow) {
+          throw new Error("send failed");
+        }
+        return {} as never;
+      },
+    },
+    update: {
+      my_chat_member: {
+        chat: {
+          id: COMMUNITY_CHAT_ID,
+          title: "New Community Title",
+          type: options.chatType,
+        },
+        from: {
+          id: 777,
+        },
+        new_chat_member: {
+          status: options.newStatus,
+        },
+        old_chat_member: {
+          status: options.oldStatus,
+        },
+      },
+    },
+  } as unknown as Context;
+
+  return { ctx, sendMessageCalls };
+}
+
+describe("my chat member onboarding", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../my-chat-member");
+    handleMyChatMemberUpdate = loadedModule.handleMyChatMemberUpdate;
+  });
+
+  beforeEach(() => {
+    upsertShouldThrow = false;
+    evictCalls = [];
+    insertValuesCaptured = [];
+    conflictSetCaptured = [];
+    conflictTargetCaptured = [];
+
+    mockDb = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          insertValuesCaptured.push(values);
+          return {
+            onConflictDoUpdate: async (config) => {
+              conflictSetCaptured.push(config.set);
+              conflictTargetCaptured.push(config.target);
+              if (upsertShouldThrow) {
+                throw new Error("upsert failed");
+              }
+            },
+          };
+        },
+      }),
+    };
+  });
+
+  test("upserts inactive hidden community when bot is freshly added", async () => {
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "supergroup",
+      oldStatus: "left",
+      newStatus: "member",
+    });
+
+    await handleMyChatMemberUpdate(ctx);
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(insertValuesCaptured[0]?.chatId).toBe(BigInt(COMMUNITY_CHAT_ID));
+    expect(insertValuesCaptured[0]?.chatTitle).toBe("New Community Title");
+    expect(insertValuesCaptured[0]?.activatedBy).toBe(BigInt(777));
+    expect(insertValuesCaptured[0]?.isActive).toBe(false);
+    expect(insertValuesCaptured[0]?.isPublic).toBe(false);
+    expect(insertValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+    expect(conflictSetCaptured).toHaveLength(1);
+    expect(conflictSetCaptured[0]?.chatTitle).toBe("New Community Title");
+    expect(conflictSetCaptured[0]?.isActive).toBe(false);
+    expect(conflictSetCaptured[0]?.isPublic).toBe(false);
+    expect(conflictSetCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+    expect(conflictTargetCaptured).toHaveLength(1);
+    expect(evictCalls).toEqual([BigInt(COMMUNITY_CHAT_ID)]);
+    expect(sendMessageCalls).toEqual([
+      { chatId: COMMUNITY_CHAT_ID, text: ONBOARDING_MESSAGE },
+    ]);
+  });
+
+  test("supports channel onboarding with the same upsert behavior", async () => {
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "channel",
+      oldStatus: "kicked",
+      newStatus: "administrator",
+    });
+
+    await handleMyChatMemberUpdate(ctx);
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(conflictSetCaptured).toHaveLength(1);
+    expect(evictCalls).toEqual([BigInt(COMMUNITY_CHAT_ID)]);
+    expect(sendMessageCalls).toHaveLength(1);
+  });
+
+  test("ignores non-join status transitions", async () => {
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "supergroup",
+      oldStatus: "member",
+      newStatus: "administrator",
+    });
+
+    await handleMyChatMemberUpdate(ctx);
+
+    expect(insertValuesCaptured).toHaveLength(0);
+    expect(conflictSetCaptured).toHaveLength(0);
+    expect(evictCalls).toHaveLength(0);
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  test("ignores unsupported chat types", async () => {
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "private",
+      oldStatus: "left",
+      newStatus: "member",
+    });
+
+    await handleMyChatMemberUpdate(ctx);
+
+    expect(insertValuesCaptured).toHaveLength(0);
+    expect(conflictSetCaptured).toHaveLength(0);
+    expect(evictCalls).toHaveLength(0);
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  test("evicts cache and does not crash when upsert fails", async () => {
+    upsertShouldThrow = true;
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "group",
+      oldStatus: "left",
+      newStatus: "member",
+    });
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      await handleMyChatMemberUpdate(ctx);
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(evictCalls).toEqual([BigInt(COMMUNITY_CHAT_ID)]);
+    expect(sendMessageCalls).toHaveLength(0);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs onboarding send failures without reverting upsert intent", async () => {
+    const { ctx } = createContext({
+      chatType: "group",
+      oldStatus: "left",
+      newStatus: "member",
+      sendMessageShouldThrow: true,
+    });
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      await handleMyChatMemberUpdate(ctx);
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(conflictSetCaptured).toHaveLength(1);
+    expect(evictCalls).toEqual([BigInt(COMMUNITY_CHAT_ID)]);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("onboarding message includes activation and visibility commands", async () => {
+    const { ctx, sendMessageCalls } = createContext({
+      chatType: "group",
+      oldStatus: "left",
+      newStatus: "member",
+    });
+
+    await handleMyChatMemberUpdate(ctx);
+
+    const sentMessage = sendMessageCalls[0]?.text ?? "";
+    expect(sentMessage).toContain("/activate_community");
+    expect(sentMessage).toContain("/notifications");
+    expect(sentMessage).toContain("/hide");
+    expect(sentMessage).toContain("/unhide");
+  });
+});

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -12,6 +12,7 @@ import { getTelegramDisplayName, isCommunityChat } from "@/lib/telegram/utils";
 import { CA_COMMAND_CHAT_ID } from "./constants";
 import { getChat } from "./get-chat";
 import { downloadTelegramFile } from "./get-file";
+import { evictActiveCommunityCache } from "./message-handlers";
 import { sendNotificationSettingsMessage } from "./notification-settings";
 import { sendStartCarousel } from "./start-carousel";
 import { sendLatestSummary } from "./summaries";
@@ -525,6 +526,7 @@ export async function handleDeactivateCommunityCommand(
       .set({ isActive: false, updatedAt: new Date() })
       .where(eq(communities.id, existingCommunity.id));
 
+    evictActiveCommunityCache(chatId);
     await ctx.reply("Community deactivated. Message tracking has been disabled.");
   } catch (error) {
     console.error("Failed to deactivate community", error);

--- a/app/src/lib/telegram/bot-api/message-handlers.ts
+++ b/app/src/lib/telegram/bot-api/message-handlers.ts
@@ -51,6 +51,12 @@ export async function handleGLoyalReaction(ctx: Context, bot: Bot): Promise<void
 // Cache of active community IDs (chatId string -> communityUUID)
 const activeCommunities = new Map<string, string>();
 
+export function evictActiveCommunityCache(
+  chatId: bigint | number | string
+): void {
+  activeCommunities.delete(String(chatId));
+}
+
 export async function handleCommunityMessage(ctx: Context): Promise<void> {
   const chat = ctx.chat;
   if (!chat) return;

--- a/app/src/lib/telegram/bot-api/my-chat-member.ts
+++ b/app/src/lib/telegram/bot-api/my-chat-member.ts
@@ -1,0 +1,84 @@
+import type { Context } from "grammy";
+
+import { getDatabase } from "@/lib/core/database";
+import { communities } from "@/lib/core/schema";
+import { isCommunityChat } from "@/lib/telegram/utils";
+
+import { evictActiveCommunityCache } from "./message-handlers";
+
+const ONBOARDING_MESSAGE =
+  "Thanks for adding me. Run /activate_community to enable summaries for this community.\nAfter activation, summaries are available in this chat and in the app.\nUse /notifications to set notification cycles.\nUse /hide or /unhide to control public visibility.";
+
+function isFreshJoinTransition(oldStatus: string, newStatus: string): boolean {
+  const joinedFrom = oldStatus === "left" || oldStatus === "kicked";
+  const joinedTo = newStatus === "member" || newStatus === "administrator";
+  return joinedFrom && joinedTo;
+}
+
+function isSupportedCommunityChat(chatType: string): boolean {
+  return isCommunityChat(chatType);
+}
+
+export async function handleMyChatMemberUpdate(ctx: Context): Promise<void> {
+  const myChatMemberUpdate = ctx.update.my_chat_member;
+  if (!myChatMemberUpdate) {
+    return;
+  }
+
+  if (!isSupportedCommunityChat(myChatMemberUpdate.chat.type)) {
+    return;
+  }
+
+  const oldStatus = myChatMemberUpdate.old_chat_member.status;
+  const newStatus = myChatMemberUpdate.new_chat_member.status;
+  if (!isFreshJoinTransition(oldStatus, newStatus)) {
+    return;
+  }
+
+  const chatId = BigInt(myChatMemberUpdate.chat.id);
+  const chatTitle = myChatMemberUpdate.chat.title || "Untitled";
+  const activatedBy = BigInt(myChatMemberUpdate.from.id);
+  const upsertTimestamp = new Date();
+  let isCommunityUpserted = false;
+
+  try {
+    const db = getDatabase();
+    await db
+      .insert(communities)
+      .values({
+        activatedBy,
+        chatId,
+        chatTitle,
+        isActive: false,
+        isPublic: false,
+        updatedAt: upsertTimestamp,
+      })
+      .onConflictDoUpdate({
+        target: communities.chatId,
+        set: {
+          chatTitle,
+          isActive: false,
+          isPublic: false,
+          updatedAt: upsertTimestamp,
+        },
+      });
+    isCommunityUpserted = true;
+  } catch (error) {
+    console.error("Failed to upsert community from my_chat_member update", error);
+  } finally {
+    evictActiveCommunityCache(chatId);
+  }
+
+  if (!isCommunityUpserted) {
+    return;
+  }
+
+  try {
+    await ctx.api.sendMessage(myChatMemberUpdate.chat.id, ONBOARDING_MESSAGE);
+  } catch (error) {
+    console.error(
+      "Failed to send onboarding message for my_chat_member update",
+      error
+    );
+  }
+}

--- a/docs/miniapp/database.md
+++ b/docs/miniapp/database.md
@@ -112,7 +112,7 @@ export type InsertUser = typeof users.$inferInsert;
 | --------------------- | -------------------------------------------------------------------------------------- |
 | `admins`              | Global admin whitelist for privileged community actions (activate/deactivate/settings) |
 | `users`               | Telegram users who interact with the bot                                               |
-| `communities`         | Activated Telegram group chats for message tracking                                    |
+| `communities`         | Telegram communities tracked by the bot lifecycle; may be pre-activation/inactive      |
 | `communityMembers`    | Many-to-many: users ↔ communities                                                      |
 | `messages`            | Chat messages from tracked communities                                                 |
 | `summaries`           | AI-generated daily chat summaries with topics                                          |

--- a/docs/miniapp/deeplinks-start-param.md
+++ b/docs/miniapp/deeplinks-start-param.md
@@ -11,6 +11,7 @@ Webhook wiring lives in `/app/src/app/api/telegram/webhook/route.ts`.
 
 - `bot.command("summary", ...)` enters the summary delivery flow.
 - `bot.callbackQuery(SUMMARY_VOTE_CALLBACK_DATA_REGEX, ...)` handles vote button callbacks that also rebuild the same keyboard.
+- `bot.on("my_chat_member", ...)` handles bot add/remove lifecycle updates for community state. This does not create deep links, but it does affect whether a community is active/public.
 
 Deep-link generation path:
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,12 +11,12 @@ Step-by-step onboarding for Telegram community admins and bot operators.
 
 1. Prepare bot/operator prerequisites
 2. Add the bot to a Telegram community
-3. Activate community tracking with `/activate_community`
-4. Configure summary notifications with `/notifications`
-5. Validate behavior for authorized and unauthorized users
+3. Bot join webhook (`my_chat_member`) creates or resets community as inactive + non-public
+4. Activate community tracking with `/activate_community`
+5. Configure summary notifications with `/notifications`
+6. Validate behavior for authorized and unauthorized users
 
 ## Guides
 
 - [Add Bot and Activate Community](./add-bot-and-activate-community.md)
 - [Set Up Notification Settings](./notifications.md)
-

--- a/docs/onboarding/add-bot-and-activate-community.md
+++ b/docs/onboarding/add-bot-and-activate-community.md
@@ -56,6 +56,14 @@ ON CONFLICT (telegram_id) DO NOTHING;
 3. Promote the bot to admin if your community policy requires elevated permissions.
 4. Send a test text message in the group (used later to verify tracking).
 
+When the bot is added, Telegram sends a `my_chat_member` update.  
+The webhook handles this by creating or updating the community row as:
+
+- `isActive = false`
+- `isPublic = false`
+
+The bot also sends a short onboarding message in chat with next steps.
+
 ## Activate Community
 
 1. In the target community chat, run `/activate_community`.
@@ -71,7 +79,7 @@ Expected bot message:
 
 What happens:
 
-- Community row is created in `communities`
+- Community row is created in `communities` (or reused if it already exists from join webhook onboarding)
 - Community is marked active
 - Message tracking for this chat becomes eligible immediately
 
@@ -107,6 +115,15 @@ What happens:
 
 - Activation is denied
 - No community activation state change is applied
+
+### Bot removed from community
+
+When the bot is removed (via `my_chat_member` transition to `left` or `kicked`), webhook handling updates the community to:
+
+- `isActive = false`
+- `isPublic = false`
+
+No onboarding message is sent on removal.
 
 ## Verify Message Collection
 


### PR DESCRIPTION
This updates onboarding and mini-app docs to reflect my_chat_member webhook behavior when the bot is added or removed from communities. It clarifies inactive/non-public lifecycle state and where this fits into activation and summary flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bot now automatically initializes communities when added to groups, creating a community record and sending onboarding instructions.
  * Bot properly handles removal scenarios by updating community status accordingly.

* **Tests**
  * Added comprehensive test suite covering bot lifecycle events and community cache operations.

* **Documentation**
  * Updated documentation to reflect new bot lifecycle initialization during community addition and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->