### PR TITLE
feat(telegram): track bot add/remove group mixpanel events

### DIFF
--- a/app/src/lib/telegram/bot-api/analytics.ts
+++ b/app/src/lib/telegram/bot-api/analytics.ts
@@ -1,0 +1,70 @@
+import Mixpanel from "mixpanel";
+
+import { serverEnv } from "@/lib/core/config/server";
+
+type MixpanelTrackPrimitive = boolean | null | number | string;
+type TrackingIdentifier = bigint | number | string;
+
+export type MixpanelTrackProperties = Record<string, MixpanelTrackPrimitive>;
+
+type BotTrackingInput = {
+  chatId?: TrackingIdentifier | null;
+  chatType?: string | null;
+  userId?: TrackingIdentifier | null;
+};
+
+function normalizeIdentifier(
+  value: TrackingIdentifier | null | undefined
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return value.toString();
+}
+
+function resolveDistinctId(input: BotTrackingInput): string {
+  const telegramUserId = normalizeIdentifier(input.userId);
+  if (telegramUserId) {
+    return `tg:${telegramUserId}`;
+  }
+
+  const telegramChatId = normalizeIdentifier(input.chatId);
+  if (telegramChatId) {
+    return `tg-chat:${telegramChatId}`;
+  }
+
+  return "tg:unknown";
+}
+
+export function createBotTrackingProperties(
+  input: BotTrackingInput
+): MixpanelTrackProperties {
+  return {
+    distinct_id: resolveDistinctId(input),
+    telegram_chat_id: normalizeIdentifier(input.chatId),
+    telegram_chat_type: input.chatType ?? null,
+    telegram_user_id: normalizeIdentifier(input.userId),
+  };
+}
+
+export function trackBotEvent(
+  eventName: string,
+  properties: MixpanelTrackProperties
+): void {
+  const token = serverEnv.mixpanelToken;
+  if (!token) {
+    return;
+  }
+
+  try {
+    const mixpanel = Mixpanel.init(token);
+    mixpanel.track(eventName, properties, (error: unknown) => {
+      if (error) {
+        console.error(`Failed to track Mixpanel event: ${eventName}`, error);
+      }
+    });
+  } catch (error) {
+    console.error(`Failed to track Mixpanel event: ${eventName}`, error);
+  }
+}


### PR DESCRIPTION
Adds shared bot Mixpanel tracking helpers and emits events when Loyal is added to or removed from a group via my_chat_member updates. Keeps tracking non-blocking and adds tests to verify event emission and failure-path behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics tracking for Telegram bot events, including when the bot is added to or removed from groups and channels.
  * Bot now automatically tracks command usage and user interactions for improved insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->