### PR TITLE
refactor(telegram): consolidate blocked-user notification handling

### DIFF
--- a/app/src/lib/telegram/bot-api/__tests__/handle-business-connection.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/handle-business-connection.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { BusinessConnection as TelegramBusinessConnection } from "grammy/types";
+
+const sendMessageCalls: Array<{ chatId: number; text: string }> = [];
+const upsertInsertValuesCaptured: Array<Record<string, unknown>> = [];
+const upsertConflictSetCaptured: Array<Record<string, unknown>> = [];
+const getOrCreateUserCalls: Array<{
+  displayName: string;
+  telegramUserId: bigint;
+  username: string | null;
+}> = [];
+let usersFindFirstResult: { id: string } | null = null;
+let userSettingsFindFirstResult: { notifications: boolean } | null = null;
+
+const mockDb = {
+  insert: () => ({
+    values: (values: Record<string, unknown>) => {
+      upsertInsertValuesCaptured.push(values);
+      return {
+        onConflictDoUpdate: async (config: {
+          set: Record<string, unknown>;
+          target: unknown;
+        }) => {
+          upsertConflictSetCaptured.push(config.set);
+        },
+      };
+    },
+  }),
+  query: {
+    userSettings: {
+      findFirst: async () => userSettingsFindFirstResult,
+    },
+    users: {
+      findFirst: async () => usersFindFirstResult,
+    },
+  },
+};
+
+mock.module("server-only", () => ({}));
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+mock.module("../bot", () => ({
+  getBot: async () => ({
+    api: {
+      sendMessage: async (chatId: number, text: string) => {
+        sendMessageCalls.push({ chatId, text });
+        return {} as never;
+      },
+    },
+  }),
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: async (
+    telegramUserId: bigint,
+    userData: { displayName: string; username: string | null }
+  ) => {
+    getOrCreateUserCalls.push({
+      displayName: userData.displayName,
+      telegramUserId,
+      username: userData.username,
+    });
+    return "resolved-user-id";
+  },
+}));
+
+let handleBusinessConnection: typeof import("../handle-business-connection").handleBusinessConnection;
+
+function createBusinessConnection(isEnabled: boolean): TelegramBusinessConnection {
+  return {
+    date: 1_735_257_600,
+    id: "business-connection-id",
+    is_enabled: isEnabled,
+    rights: { can_reply: true },
+    user: {
+      first_name: "Taylor",
+      id: 777,
+      is_bot: false,
+      username: "taylor",
+    },
+    user_chat_id: 777,
+  } as unknown as TelegramBusinessConnection;
+}
+
+describe("handleBusinessConnection", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../handle-business-connection");
+    handleBusinessConnection = loadedModule.handleBusinessConnection;
+  });
+
+  beforeEach(() => {
+    sendMessageCalls.length = 0;
+    upsertInsertValuesCaptured.length = 0;
+    upsertConflictSetCaptured.length = 0;
+    getOrCreateUserCalls.length = 0;
+    usersFindFirstResult = { id: "resolved-user-id" };
+    userSettingsFindFirstResult = { notifications: true };
+  });
+
+  test("skips sending user message when notifications are disabled", async () => {
+    userSettingsFindFirstResult = { notifications: false };
+
+    await handleBusinessConnection(createBusinessConnection(true));
+
+    expect(getOrCreateUserCalls).toHaveLength(1);
+    expect(upsertInsertValuesCaptured).toHaveLength(1);
+    expect(upsertConflictSetCaptured).toHaveLength(1);
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  test("sends user message when notifications are enabled", async () => {
+    await handleBusinessConnection(createBusinessConnection(true));
+
+    expect(getOrCreateUserCalls).toHaveLength(1);
+    expect(upsertInsertValuesCaptured).toHaveLength(1);
+    expect(sendMessageCalls).toEqual([
+      {
+        chatId: 777,
+        text: "You've connected Loyal to messages.",
+      },
+    ]);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/send-transaction-notification.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/send-transaction-notification.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const sendMessageCalls: unknown[][] = [];
+let usersFindFirstResult: { id: string } | null = null;
+let userSettingsFindFirstResult: { notifications: boolean } | null = null;
+
+const mockDb = {
+  query: {
+    userSettings: {
+      findFirst: async () => userSettingsFindFirstResult,
+    },
+    users: {
+      findFirst: async () => usersFindFirstResult,
+    },
+  },
+};
+
+mock.module("@/lib/core/api", () => ({
+  resolveEndpoint: () => "https://example.com/api/og/share",
+}));
+
+mock.module("../bot", () => ({
+  getBot: async () => ({
+    api: {
+      sendMessage: async (...args: unknown[]) => {
+        sendMessageCalls.push(args);
+        return {} as never;
+      },
+    },
+  }),
+}));
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+let sendTransactionNotification: typeof import("../send-transaction-notification").sendTransactionNotification;
+
+describe("sendTransactionNotification", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../send-transaction-notification");
+    sendTransactionNotification = loadedModule.sendTransactionNotification;
+  });
+
+  beforeEach(() => {
+    sendMessageCalls.length = 0;
+    usersFindFirstResult = { id: "user-1" };
+    userSettingsFindFirstResult = { notifications: true };
+  });
+
+  test("skips notification send when user notifications are disabled", async () => {
+    userSettingsFindFirstResult = { notifications: false };
+
+    await sendTransactionNotification(123456, "alice", "bob", 1.25, 210.55);
+
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  test("sends notification when user notifications are enabled", async () => {
+    await sendTransactionNotification(123456, "alice", "bob", 1.25, 210.55);
+
+    expect(sendMessageCalls).toHaveLength(1);
+    expect(sendMessageCalls[0]?.[0]).toBe(123456);
+    expect(sendMessageCalls[0]?.[1]).toContain("You received <b>1.25 SOL</b>");
+  });
+});

--- a/app/src/lib/telegram/bot-api/handle-business-connection.ts
+++ b/app/src/lib/telegram/bot-api/handle-business-connection.ts
@@ -8,6 +8,8 @@ import {
 import { getBot } from "@/lib/telegram/bot-api/bot";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 
+import { isNotificationsEnabledForUserId } from "./user-settings";
+
 const bot = await getBot();
 
 /**
@@ -40,6 +42,11 @@ export async function handleBusinessConnection(
     rights: (rights as BusinessBotRights) ?? {},
     connectedAt: new Date(date * 1000),
   });
+
+  const notificationsEnabled = await isNotificationsEnabledForUserId(userId);
+  if (!notificationsEnabled) {
+    return;
+  }
 
   // Notify user
   await sendBusinessConnectionMessage(userChatId, isEnabled);

--- a/app/src/lib/telegram/bot-api/my-chat-member.ts
+++ b/app/src/lib/telegram/bot-api/my-chat-member.ts
@@ -3,7 +3,7 @@ import type { Context } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
 import { communities } from "@/lib/core/schema";
-import { isCommunityChat } from "@/lib/telegram/utils";
+import { isCommunityChat, isPrivateChat } from "@/lib/telegram/utils";
 
 import { createBotTrackingProperties, trackBotEvent } from "./analytics";
 import { evictActiveCommunityCache } from "./message-handlers";
@@ -12,6 +12,8 @@ const ONBOARDING_MESSAGE =
   "Thanks for adding me. Run /activate_community to enable summaries for this community.\nAfter activation, summaries are available in this chat and in the app.\nUse /notifications to set notification cycles.\nUse /hide or /unhide to control public visibility.";
 const BOT_ADDED_TO_GROUP_EVENT = "Bot Added to Group";
 const BOT_REMOVED_FROM_GROUP_EVENT = "Bot Removed from Group";
+const BOT_BLOCKED_BY_USER_EVENT = "Bot Blocked by User";
+const BOT_UNBLOCKED_BY_USER_EVENT = "Bot Unblocked by User";
 
 function isFreshJoinTransition(oldStatus: string, newStatus: string): boolean {
   const joinedFrom = oldStatus === "left" || oldStatus === "kicked";
@@ -33,18 +35,59 @@ function isSupportedCommunityChat(chatType: string): boolean {
   return isCommunityChat(chatType);
 }
 
+function isPrivateBlockTransition(oldStatus: string, newStatus: string): boolean {
+  const blockedFrom = oldStatus === "member" || oldStatus === "restricted";
+  const blockedTo = newStatus === "kicked";
+  return blockedFrom && blockedTo;
+}
+
+function isPrivateUnblockTransition(oldStatus: string, newStatus: string): boolean {
+  const unblockedFrom = oldStatus === "kicked";
+  const unblockedTo = newStatus === "member" || newStatus === "restricted";
+  return unblockedFrom && unblockedTo;
+}
+
 export async function handleMyChatMemberUpdate(ctx: Context): Promise<void> {
   const myChatMemberUpdate = ctx.update.my_chat_member;
   if (!myChatMemberUpdate) {
     return;
   }
 
-  if (!isSupportedCommunityChat(myChatMemberUpdate.chat.type)) {
+  const chatType = myChatMemberUpdate.chat.type;
+  const oldStatus = myChatMemberUpdate.old_chat_member.status;
+  const newStatus = myChatMemberUpdate.new_chat_member.status;
+  if (isPrivateChat(chatType)) {
+    const isBlockTransition = isPrivateBlockTransition(oldStatus, newStatus);
+    const isUnblockTransition = isPrivateUnblockTransition(oldStatus, newStatus);
+
+    if (!isBlockTransition && !isUnblockTransition) {
+      return;
+    }
+
+    const eventName = isBlockTransition
+      ? BOT_BLOCKED_BY_USER_EVENT
+      : BOT_UNBLOCKED_BY_USER_EVENT;
+    const transitionType = isBlockTransition ? "block" : "unblock";
+    trackBotEvent(
+      eventName,
+      {
+        ...createBotTrackingProperties({
+          chatId: myChatMemberUpdate.chat.id,
+          chatType,
+          userId: myChatMemberUpdate.from.id,
+        }),
+        new_status: newStatus,
+        old_status: oldStatus,
+        transition_type: transitionType,
+      }
+    );
     return;
   }
 
-  const oldStatus = myChatMemberUpdate.old_chat_member.status;
-  const newStatus = myChatMemberUpdate.new_chat_member.status;
+  if (!isSupportedCommunityChat(chatType)) {
+    return;
+  }
+
   const isJoinTransition = isFreshJoinTransition(oldStatus, newStatus);
   const isRemovedTransition = isRemovalTransition(oldStatus, newStatus);
 

--- a/app/src/lib/telegram/bot-api/send-transaction-notification.ts
+++ b/app/src/lib/telegram/bot-api/send-transaction-notification.ts
@@ -4,6 +4,7 @@ import { resolveEndpoint } from "@/lib/core/api";
 import { MINI_APP_LINK } from "@/lib/telegram/constants";
 
 import { getBot } from "./bot";
+import { isNotificationsEnabledForTelegramUser } from "./user-settings";
 
 const buildOgImageUrl = (
   sender: string,
@@ -27,6 +28,13 @@ export const sendTransactionNotification = async (
   solAmount: number,
   usdAmount: number
 ): Promise<void> => {
+  const notificationsEnabled = await isNotificationsEnabledForTelegramUser(
+    BigInt(userId)
+  );
+  if (!notificationsEnabled) {
+    return;
+  }
+
   const bot = await getBot();
   const photoUrl = buildOgImageUrl(
     senderUsername,


### PR DESCRIPTION
Consolidates blocked-user notification preference handling into existing Telegram settings and user-service modules to remove duplication and keep behavior DRY. Adds tests for block/unblock-driven notification suppression in private flows while preserving existing community handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User notification management: disable or enable Telegram notifications per user.
  * Private chat block/unblock transitions with automatic notification control.
  * Transaction notifications and business connection updates now respect user notification settings.
  * Improved user profile handling with configurable avatar update behavior.

* **Tests**
  * Added comprehensive test coverage for notification settings, user chat events, and transaction notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->