### PR TITLE
refactor(telegram): replace bio deeplink with vr_<userId> verify param

### DIFF
--- a/app/src/app/telegram/profile/page.tsx
+++ b/app/src/app/telegram/profile/page.tsx
@@ -213,7 +213,7 @@ export default function ProfilePage() {
       if (hapticFeedback.notificationOccurred.isAvailable()) {
         hapticFeedback.notificationOccurred("success");
       }
-      router.push("/telegram/verify");
+      router.push("/telegram/verify?userId=111");
       return;
     }
 

--- a/app/src/app/telegram/verify/page.tsx
+++ b/app/src/app/telegram/verify/page.tsx
@@ -4,14 +4,14 @@ import { biometry } from "@telegram-apps/sdk";
 import { hapticFeedback, retrieveLaunchParams } from "@telegram-apps/sdk-react";
 import Lottie from "lottie-react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import QRCodeLib from "qrcode";
 import { useCallback, useEffect, useState } from "react";
 import Confetti from "react-confetti";
 import { sileo } from "sileo";
 
 import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
-import { buildBioMiniAppUrl } from "@/lib/telegram/mini-app/start-param";
+import { buildVerifyMiniAppUrl } from "@/lib/telegram/mini-app/start-param";
 
 import dogAnimation from "../../../../public/biometrics/dog.json";
 import shieldAnimation from "../../../../public/biometrics/shield.json";
@@ -186,6 +186,8 @@ export default function VerifyPage() {
   const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
   const { bottom: safeBottom } = useTelegramSafeArea();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const userId = searchParams.get("userId") ?? "111";
 
   // ---- Determine step on mount ----
   useEffect(() => {
@@ -287,14 +289,14 @@ export default function VerifyPage() {
 
   // ---- Actions ----
 
-  const bioUrl = buildBioMiniAppUrl();
+  const verifyUrl = buildVerifyMiniAppUrl(userId);
 
   const handleCopyLink = useCallback(async () => {
     if (hapticFeedback.impactOccurred.isAvailable()) {
       hapticFeedback.impactOccurred("light");
     }
     try {
-      await navigator.clipboard.writeText(bioUrl);
+      await navigator.clipboard.writeText(verifyUrl);
       setCopied(true);
       if (hapticFeedback.notificationOccurred.isAvailable()) {
         hapticFeedback.notificationOccurred("success");
@@ -306,7 +308,7 @@ export default function VerifyPage() {
         description: "Please copy it manually."
       });
     }
-  }, [bioUrl]);
+  }, [verifyUrl]);
 
   const handleRequestAccess = useCallback(async () => {
     if (hapticFeedback.impactOccurred.isAvailable()) {
@@ -407,7 +409,7 @@ export default function VerifyPage() {
         >
           <div className="flex flex-1 flex-col items-center justify-center">
             <div className="mb-8">
-              <VerifyQRCode value={bioUrl} size={240} />
+              <VerifyQRCode value={verifyUrl} size={240} />
             </div>
             <h1 className="mb-3 text-center text-[22px] font-semibold leading-[28px] text-black">
               Verification Requires a Mobile Device

--- a/app/src/hooks/useStartParam.ts
+++ b/app/src/hooks/useStartParam.ts
@@ -3,8 +3,8 @@
 import { retrieveLaunchParams } from "@telegram-apps/sdk-react";
 
 import {
-  isBioStartParam,
   parseSummaryFeedStartParam,
+  parseVerifyStartParam,
 } from "@/lib/telegram/mini-app/start-param";
 
 /**
@@ -37,9 +37,10 @@ export function getStartParamRoute(): string | undefined {
   if (typeof window === "undefined") return undefined;
 
   const mapStartParamToRoute = (startParam: string | null | undefined): string | undefined => {
-    // Check for bio (verification) deeplink first
-    if (isBioStartParam(startParam)) {
-      return "/telegram/verify";
+    // Check for verification deeplink (vr_<userId>) first
+    const verifyUserId = parseVerifyStartParam(startParam);
+    if (verifyUserId) {
+      return `/telegram/verify?userId=${verifyUserId}`;
     }
 
     const parsed = parseSummaryFeedStartParam(startParam ?? null);

--- a/app/src/lib/telegram/mini-app/start-param.ts
+++ b/app/src/lib/telegram/mini-app/start-param.ts
@@ -102,15 +102,26 @@ export function buildSummaryFeedMiniAppUrl(
   return `${MINI_APP_LINK}?startapp=${encodeURIComponent(startParam)}`;
 }
 
-// --- Biometrics verification deeplink ("bio") ---
+// --- Verification deeplink ("vr_<telegramUserId>") ---
 
-const BIO_START_PARAM = "bio";
+const VERIFY_START_PARAM_PREFIX = "vr_";
+const VERIFY_USER_ID_REGEX = /^\d+$/;
 
-export function isBioStartParam(raw: string | null | undefined): boolean {
-  if (!raw) return false;
-  return raw.trim() === BIO_START_PARAM;
+export function parseVerifyStartParam(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith(VERIFY_START_PARAM_PREFIX)) return null;
+  const userId = trimmed.slice(VERIFY_START_PARAM_PREFIX.length);
+  if (!VERIFY_USER_ID_REGEX.test(userId)) return null;
+  return userId;
 }
 
-export function buildBioMiniAppUrl(): string {
-  return `${MINI_APP_LINK}?startapp=${BIO_START_PARAM}`;
+export function isVerifyStartParam(raw: string | null | undefined): boolean {
+  return parseVerifyStartParam(raw) !== null;
+}
+
+export function buildVerifyMiniAppUrl(userId: string | number): string {
+  return `${MINI_APP_LINK}?startapp=vr_${userId}`;
 }


### PR DESCRIPTION
Replace the static `bio` startapp parameter with `vr_<telegramUserId>` format for the verify deeplink. Desktop QR code and copy link now include the user ID. The 5-tap test flow on profile uses `vr_111`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user ID parameter propagation in the verification workflow to ensure proper routing and tracking during verification processes.

* **Refactor**
  * Updated verification deep link handling to properly extract and utilize user identification parameters.
  * Enhanced the verification flow to include user ID information in navigation across all verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->