### PR TITLE
feat(telegram): add Mixpanel onboarding analytics events

### DIFF
--- a/app/src/app/telegram/TelegramLayoutClient.tsx
+++ b/app/src/app/telegram/TelegramLayoutClient.tsx
@@ -16,10 +16,14 @@ import {
   getUnconsumedStartParamRoute,
   markStartParamConsumed,
 } from "@/hooks/useStartParam";
+import { track } from "@/lib/core/analytics";
 import {
   getCloudValue,
   setCloudValue,
 } from "@/lib/telegram/mini-app/cloud-storage";
+
+import type { OnboardingCompletionMethod } from "./onboarding-analytics";
+import { ONBOARDING_ANALYTICS_EVENTS } from "./onboarding-analytics";
 
 const ONBOARDING_DONE_KEY = "onboarding_done";
 
@@ -67,11 +71,16 @@ export default function TelegramLayoutClient({
   // Check cloud storage for onboarding completion
   useEffect(() => {
     getCloudValue(ONBOARDING_DONE_KEY).then((value) => {
-      setShowOnboarding(value !== "1");
+      const shouldShow = value !== "1";
+      setShowOnboarding(shouldShow);
+      if (shouldShow) {
+        track(ONBOARDING_ANALYTICS_EVENTS.onboardingStarted);
+      }
     });
   }, []);
 
-  const handleOnboardingDone = () => {
+  const handleOnboardingDone = (method: OnboardingCompletionMethod) => {
+    track(ONBOARDING_ANALYTICS_EVENTS.onboardingEnded, { method });
     setShowOnboarding(false);
     void setCloudValue(ONBOARDING_DONE_KEY, "1");
   };

--- a/app/src/app/telegram/onboarding-analytics.ts
+++ b/app/src/app/telegram/onboarding-analytics.ts
@@ -1,0 +1,12 @@
+export const ONBOARDING_ANALYTICS_EVENTS = {
+  onboardingStarted: "Onboarding Started",
+  onboardingEnded: "Onboarding Ended",
+} as const;
+
+export const ONBOARDING_COMPLETION_METHODS = {
+  completed: "completed",
+  skipped: "skipped",
+} as const;
+
+export type OnboardingCompletionMethod =
+  (typeof ONBOARDING_COMPLETION_METHODS)[keyof typeof ONBOARDING_COMPLETION_METHODS];

--- a/app/src/components/telegram/Onboarding.tsx
+++ b/app/src/components/telegram/Onboarding.tsx
@@ -4,6 +4,9 @@ import { hapticFeedback } from "@telegram-apps/sdk-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useState } from "react";
 
+import type { OnboardingCompletionMethod } from "@/app/telegram/onboarding-analytics";
+import { ONBOARDING_COMPLETION_METHODS } from "@/app/telegram/onboarding-analytics";
+
 const screens = [
   {
     title: "Group Summaries",
@@ -63,7 +66,7 @@ export default function Onboarding({
   onDone,
   headerHeight,
 }: {
-  onDone: () => void;
+  onDone: (method: OnboardingCompletionMethod) => void;
   headerHeight: number;
 }) {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -93,14 +96,14 @@ export default function Onboarding({
 
   const handleNext = () => {
     if (isLast) {
-      onDone();
+      onDone(ONBOARDING_COMPLETION_METHODS.completed);
     } else {
       paginate(1);
     }
   };
 
   const handleSkip = () => {
-    onDone();
+    onDone(ONBOARDING_COMPLETION_METHODS.skipped);
   };
 
   return (


### PR DESCRIPTION
Track "Onboarding Started" and "Onboarding Ended" Mixpanel events for the first-time user onboarding flow, with completion method (completed vs skipped).