### PR TITLE
ci: add React Doctor GitHub Actions workflow

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,48 @@
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "app/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Run react-doctor on the app directory, scanning only files changed in this PR.
+
+            Execute this command:
+            ```
+            npx -y react-doctor@latest ./app --diff origin/${{ github.base_ref }} --verbose
+            ```
+
+            After the scan completes, format your response as:
+
+            ## React Doctor Score: **X/100**
+
+            | Category | Issues |
+            |----------|--------|
+            | ... | ... |
+
+            ### Top 5 Issues
+            1. ...
+
+            Where X is the actual score from the scan.
+          claude_args: "--model claude-sonnet-4-6 --max-turns 5"


### PR DESCRIPTION
Adds a CI workflow that runs React Doctor on PR changes to the `app/` directory, posting a score and top issues as a PR comment via Claude Code Action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated code quality analysis for pull requests using GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->