### PR TITLE
feat(ui): show git branch and commit hash on profile page

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,4 +1,20 @@
+import { execSync } from "child_process";
 import type { NextConfig } from "next";
+
+function getGitInfo() {
+  try {
+    const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
+    const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+    return { commitHash, branch };
+  } catch {
+    return {
+      commitHash: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "unknown",
+      branch: process.env.VERCEL_GIT_COMMIT_REF ?? "unknown",
+    };
+  }
+}
+
+const { commitHash, branch } = getGitInfo();
 
 const mixpanelProxyPathRaw = process.env.NEXT_PUBLIC_MIXPANEL_PROXY_PATH?.trim();
 const mixpanelProxyPath = mixpanelProxyPathRaw
@@ -8,6 +24,10 @@ const mixpanelProxyPath = mixpanelProxyPathRaw
   : "/ingest";
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_GIT_COMMIT_HASH: commitHash,
+    NEXT_PUBLIC_GIT_BRANCH: branch,
+  },
   images: {
     remotePatterns: [
       {

--- a/app/src/app/telegram/profile/page.tsx
+++ b/app/src/app/telegram/profile/page.tsx
@@ -28,6 +28,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTelegramUser } from "@/components/telegram/TelegramProvider";
 import { Skeleton } from "@/components/ui/skeleton";
 import { resolveEndpoint } from "@/lib/core/api";
+import { publicEnv } from "@/lib/core/config/public";
 import { getSolanaEnv } from "@/lib/solana/rpc/connection";
 import type { SolanaEnv } from "@/lib/solana/rpc/types";
 import { setLoyalEmojiStatus } from "@/lib/telegram/mini-app/emoji-status";
@@ -633,6 +634,11 @@ export default function ProfilePage() {
               onClick={handleSupport}
             />
           </SettingsSection>
+
+          {/* Build Info */}
+          <p className="text-center text-xs text-black/20 pt-2">
+            {publicEnv.gitBranch} @ {publicEnv.gitCommitHash}
+          </p>
         </div>
       </div>
     </main>

--- a/app/src/lib/core/config/public.ts
+++ b/app/src/lib/core/config/public.ts
@@ -48,4 +48,10 @@ export const publicEnv = {
 
     return value.startsWith("/") ? value : `/${value}`;
   },
+  get gitBranch(): string {
+    return normalizeOptionalValue(process.env.NEXT_PUBLIC_GIT_BRANCH) ?? "unknown";
+  },
+  get gitCommitHash(): string {
+    return normalizeOptionalValue(process.env.NEXT_PUBLIC_GIT_COMMIT_HASH) ?? "unknown";
+  },
 } as const;


### PR DESCRIPTION
## Summary
- Injects git branch name and short commit hash as build-time env vars via `next.config.ts`, with Vercel env var fallbacks
- Displays them on the Profile page below the Support section for easy version identification in Telegram client