### PR TITLE
ci: add id-token write permission to react-doctor workflow

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   react-doctor:


### PR DESCRIPTION
Add `id-token: write` permission to the React Doctor GitHub Actions workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support additional token operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->