### PR TITLE
ci(react-doctor): add issues permission, full output, and fix tool quoting

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
   id-token: write
 
 jobs:
@@ -27,6 +28,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: "true"
           prompt: |
             Run react-doctor on the app directory, scanning only files changed in this PR.
 
@@ -53,4 +55,4 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 5
-            --allowedTools Bash(npx*)
+            --allowedTools "Bash(npx*)"


### PR DESCRIPTION
## Summary
- Add `issues: write` permission for the React Doctor workflow
- Enable `show_full_output` for better debugging visibility
- Fix `--allowedTools` quoting to properly pass the glob pattern

## Test plan
- [ ] Verify React Doctor workflow triggers correctly on PR
- [ ] Confirm tool restrictions work with quoted glob