### PR TITLE
chore(ui): clean up lint warnings and configure underscore-prefix convention

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -28,6 +28,14 @@ const eslintConfig = [
     rules: {
       "simple-import-sort/imports": "error",
       "simple-import-sort/exports": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
     },
   },
   {
@@ -108,6 +116,12 @@ const eslintConfig = [
           ],
         },
       ],
+    },
+  },
+  {
+    files: ["src/app/api/og/**/*.tsx"],
+    rules: {
+      "@next/next/no-img-element": "off",
     },
   },
 ];

--- a/app/src/app/telegram/summaries/direct/page.tsx
+++ b/app/src/app/telegram/summaries/direct/page.tsx
@@ -637,6 +637,7 @@ function DirectFeedContent() {
               {/* Avatar */}
               <div className="pr-3 py-1.5">
                 {nextChat.avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={nextChat.avatarUrl}
                     alt={nextChat.title}
@@ -717,6 +718,7 @@ function DirectFeedContent() {
             {/* Avatar */}
             <div className="pr-3 py-1.5">
               {currentChat.avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={currentChat.avatarUrl}
                   alt={currentChat.title}

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -100,6 +100,7 @@ function ChatItem({ chat, onClick }: ChatItemProps) {
         {/* Avatar */}
         <div className="pr-3 py-1.5">
           {photoSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={photoSrc}
               alt={chat.title}

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -69,6 +69,7 @@ import {
 import {
   prepareStoreInitDataTxn,
   sendStoreInitDataTxn,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   verifyAndClaimDeposit,
 } from "@/lib/solana/verify-and-claim-deposit";
 import {
@@ -1670,7 +1671,7 @@ export default function Home() {
 
       if (closingBehavior.enableConfirmation.isAvailable()) {
         closingBehavior.enableConfirmation();
-        const isEnabled = closingBehavior.isConfirmationEnabled();
+        const _isEnabled = closingBehavior.isConfirmationEnabled();
       } else {
         console.warn("enableConfirmation is not available");
       }
@@ -1771,7 +1772,7 @@ export default function Home() {
 
     void (async () => {
       try {
-        const { keypair, isNew } = await ensureWalletKeypair();
+        const { keypair, isNew: _isNew } = await ensureWalletKeypair();
         const publicKeyBase58 = keypair.publicKey.toBase58();
 
         // Store wallet address in module-level cache for future mounts
@@ -2971,7 +2972,7 @@ export default function Home() {
                           transaction.transferType === "unshield";
                         const isSecureOrUnshield =
                           isSecureTransaction || isUnshieldTransaction;
-                        const isDepositForUsername =
+                        const _isDepositForUsername =
                           transaction.transferType === "deposit_for_username";
                         const transferTypeLabel =
                           transaction.transferType === "store"

--- a/app/src/components/summaries/ChatSummarySheet.tsx
+++ b/app/src/components/summaries/ChatSummarySheet.tsx
@@ -192,11 +192,6 @@ const ChatSummarySheet = forwardRef<ChatSummarySheetRef, ChatSummarySheetProps>(
   // Swipe direction: 'left' for keep unread, 'right' for mark read
   const swipeDirection = swipeX > 0 ? "right" : swipeX < 0 ? "left" : null;
 
-  // Back card visibility - show when swiping
-  const backCardOpacity = useMemo(() => {
-    return Math.min(Math.abs(swipeX) / 50, 0.5);
-  }, [swipeX]);
-
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     const touch = e.touches[0];
     touchStartRef.current = { x: touch.clientX, y: touch.clientY };

--- a/app/src/components/summaries/DatePicker.tsx
+++ b/app/src/components/summaries/DatePicker.tsx
@@ -70,7 +70,7 @@ export default function DatePicker({
   onDateSelect,
 }: DatePickerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const availableDateSet = new Set(availableDates);
+  const availableDateSet = useMemo(() => new Set(availableDates), [availableDates]);
   const todayKey = getTodayKey();
 
   const latestDateWithData = useMemo(() => {

--- a/app/src/components/summaries/SummaryFeed.tsx
+++ b/app/src/components/summaries/SummaryFeed.tsx
@@ -67,6 +67,7 @@ function SourceAvatars({ sources }: { sources: string[] }) {
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center px-8 py-16">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src="/dogs/dog-green.png"
         alt=""
@@ -658,6 +659,7 @@ export default function SummaryFeed({
         >
           {/* Avatar */}
           {groupPhoto ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={`data:${groupPhoto.mimeType};base64,${groupPhoto.base64}`}
               alt={groupTitle}

--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -141,13 +141,6 @@ const truncateDecimals = (num: number, decimals: number): string => {
   return truncated.toFixed(decimals);
 };
 
-// Format number for display: truncate to max decimals, remove trailing zeros
-const formatForDisplay = (num: number, maxDecimals: number): string => {
-  const factor = Math.pow(10, maxDecimals);
-  const truncated = Math.floor(num * factor) / factor;
-  return String(Number(truncated.toFixed(maxDecimals)));
-};
-
 type LastAmount = {
   sol: number;
   usd: number;
@@ -308,7 +301,7 @@ export default function SendSheet({
   const [amountStr, setAmountStr] = useState("");
   const [recipient, setRecipient] = useState("");
   const [currency, setCurrency] = useState<'SOL' | 'USD'>('SOL');
-  const [lastAmount, setLastAmount] = useState<LastAmount | null>(null);
+  const [, setLastAmount] = useState<LastAmount | null>(null);
   const [recentRecipients, setRecentRecipients] = useState<RecentRecipient[]>([]);
   const [solPriceUsdState, setSolPriceUsdState] = useState<number | null>(null);
   const [isSolPriceLoadingState, setIsSolPriceLoadingState] = useState(true);
@@ -585,22 +578,6 @@ export default function SendSheet({
   };
 
   const tokenSymbol = selectedToken?.symbol || 'SOL';
-
-  // Computed display values
-  const secondaryDisplay = useMemo(() => {
-    const val = parseFloat(amountStr);
-    if (isNaN(val)) return currency === 'SOL' ? '≈ $0.00' : `≈ 0.00 ${tokenSymbol}`;
-
-    if (!solPriceUsd) {
-      return currency === 'SOL' ? '≈ $—' : `≈ — ${tokenSymbol}`;
-    }
-
-    if (currency === 'SOL') {
-      return `≈ $${(val * solPriceUsd).toFixed(2)}`;
-    } else {
-      return `≈ ${(val / solPriceUsd).toFixed(4)} ${tokenSymbol}`;
-    }
-  }, [amountStr, currency, solPriceUsd, tokenSymbol]);
 
   // Insufficient balance check
   const insufficientBalance = useMemo(() => {

--- a/app/src/components/wallet/TransactionDetailsSheet.tsx
+++ b/app/src/components/wallet/TransactionDetailsSheet.tsx
@@ -94,6 +94,7 @@ export default function TransactionDetailsSheet({
   swapToAmount,
   swapToAmountUsd,
   secureTokenSymbol,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   secureTokenIcon,
   secureAmount,
   secureAmountUsd,

--- a/app/src/lib/solana/verify-and-claim-deposit.ts
+++ b/app/src/lib/solana/verify-and-claim-deposit.ts
@@ -1,7 +1,7 @@
-import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
 import { PublicKey, Transaction } from "@solana/web3.js";
 
-import { TelegramVerification } from "../../../../target/types/telegram_verification";
+// import { TelegramVerification } from "../../../../target/types/telegram_verification";
 import { resolveEndpoint } from "../core/api";
 import { claimDeposit } from "./deposits/claim-deposit";
 import {
@@ -28,14 +28,14 @@ export const verifyAndClaimDeposit = async (
   const transferProgram = getTelegramTransferProgram(provider);
   const verificationProgram = getTelegramVerificationProgram(provider);
 
-  const sessionData = await storeInitData(
+  const _sessionData = await storeInitData(
     provider,
     verificationProgram,
     recipient,
     processedInitDataBytes
   );
 
-  const verified = await verifyInitData(
+  const _verified = await verifyInitData(
     provider,
     wallet,
     recipient,


### PR DESCRIPTION
## Summary
- Remove dead code from SendSheet and ChatSummarySheet, fix useMemo in DatePicker
- Configure ESLint `_` prefix convention for WIP unused vars, disable `no-img-element` for OG routes
- Silence remaining img warnings in summaries with inline disables, prefix WIP vars in wallet/verification files