### PR TITLE
ci(react-doctor): post score as PR comment and checkout head ref

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,15 +20,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - uses: anthropics/claude-code-action@v1
+        id: doctor
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          show_full_output: "true"
           prompt: |
             Run react-doctor on the app directory, scanning only files changed in this PR.
 
@@ -56,3 +57,13 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 5
             --allowedTools "Bash(npx*)"
+
+      - name: Post score to PR
+        if: always() && steps.doctor.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          jq -r '.result // empty' /home/runner/work/_temp/claude-execution-output.json > /tmp/comment-body.md
+          if [ -s /tmp/comment-body.md ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment-body.md
+          fi


### PR DESCRIPTION
## Summary
- Checkout the PR head ref so react-doctor diffs against the correct branch
- Add a post-scan step that extracts the Claude execution output and posts the score as a PR comment
- Remove `show_full_output` in favor of the structured comment approach