### PR TITLE
fix(ui): prevent safe area layout shift on Telegram mini-app load

### DIFF
--- a/app/src/app/telegram/summaries/direct/page.tsx
+++ b/app/src/app/telegram/summaries/direct/page.tsx
@@ -5,10 +5,7 @@ import {
   hapticFeedback,
   openTelegramLink,
   swipeBehavior,
-  useSignal,
-  viewport,
 } from "@telegram-apps/sdk-react";
-import type { Signal } from "@telegram-apps/signals";
 import { CheckCheck, MessageCircleWarning } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -20,6 +17,7 @@ import {
   useState,
 } from "react";
 
+import { useDeviceSafeAreaTop } from "@/hooks/useTelegramSafeArea";
 import {
   hideMainButton,
   showMainButton,
@@ -261,9 +259,7 @@ const EASE_OUT = "cubic-bezier(0.0, 0.0, 0.2, 1)";
 
 function DirectFeedContent() {
   const router = useRouter();
-  const safeAreaInsetTop = useSignal(
-    viewport.safeAreaInsetTop as Signal<number>
-  );
+  const safeAreaInsetTop = useDeviceSafeAreaTop();
   const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
 
   const searchParams = useSearchParams();

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -2,10 +2,7 @@
 
 import {
   hapticFeedback,
-  useSignal,
-  viewport,
 } from "@telegram-apps/sdk-react";
-import type { Signal } from "@telegram-apps/signals";
 import { motion, type PanInfo } from "framer-motion";
 import { X } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -15,6 +12,7 @@ import { getAvatarColor, getFirstLetter } from "@/components/summaries/avatar-ut
 import { MOCK_SUMMARIES } from "@/components/summaries/mock-data";
 import { useSummaries } from "@/components/summaries/SummariesContext";
 import ConnectBotModal from "@/components/telegram/ConnectBotModal";
+import { useDeviceSafeAreaTop } from "@/hooks/useTelegramSafeArea";
 import { publicEnv } from "@/lib/core/config/public";
 
 type GroupChat = {
@@ -218,9 +216,7 @@ const ACTIVE_TAB_STORAGE_KEY = "summaries_active_tab";
 
 export default function SummariesPage() {
   const router = useRouter();
-  const safeAreaInsetTop = useSignal(
-    viewport.safeAreaInsetTop as Signal<number>
-  );
+  const safeAreaInsetTop = useDeviceSafeAreaTop();
   const headerHeight = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
 
   const [isBannerDismissed, setIsBannerDismissed] = useState(false);

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -37,7 +37,7 @@ import SwapSheet, {
 import TokensSheet from "@/components/wallet/TokensSheet";
 import TransactionDetailsSheet from "@/components/wallet/TransactionDetailsSheet";
 import { useSwap } from "@/hooks/useSwap";
-import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
+import { useDeviceSafeAreaTop, useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
 import {
   BALANCE_BG_KEY,
   DISPLAY_CURRENCY_KEY,
@@ -507,7 +507,7 @@ export default function Home() {
   const rawInitData = useRawInitData();
   const { bottom: _safeBottom } = useTelegramSafeArea();
   // Get device safe area only (not content safe area) to align with native header buttons
-  const safeAreaInsetTop = useSignal(viewport.safeAreaInsetTop);
+  const safeAreaInsetTop = useDeviceSafeAreaTop();
   const [isSendSheetOpen, setSendSheetOpen] = useState(false);
   const [isSwapSheetOpen, setSwapSheetOpen] = useState(false);
   const [swapActiveTab, setSwapActiveTab] = useState<"swap" | "secure">("swap");

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { useSignal, viewport } from "@telegram-apps/sdk-react";
-import type { Signal } from "@telegram-apps/signals";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
+import { useDeviceSafeAreaTop } from "@/hooks/useTelegramSafeArea";
+
 export default function Header() {
-  const safeAreaInsetTop = useSignal(
-    viewport.safeAreaInsetTop as Signal<number>
-  );
+  const safeAreaInsetTop = useDeviceSafeAreaTop();
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {

--- a/app/src/components/summaries/SummaryFeed.tsx
+++ b/app/src/components/summaries/SummaryFeed.tsx
@@ -4,10 +4,7 @@ import {
   backButton,
   hapticFeedback,
   swipeBehavior,
-  useSignal,
-  viewport,
 } from "@telegram-apps/sdk-react";
-import type { Signal } from "@telegram-apps/signals";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -17,6 +14,7 @@ import {
   SUMMARY_SELECTION_SOURCES,
   type SummarySelectionSource,
 } from "@/app/telegram/summaries/summaries-analytics";
+import { useDeviceSafeAreaTop } from "@/hooks/useTelegramSafeArea";
 import { track } from "@/lib/core/analytics";
 
 import { getAvatarColor, getFirstLetter } from "./avatar-utils";
@@ -169,9 +167,7 @@ export default function SummaryFeed({
   groupTitle: initialGroupTitle,
 }: SummaryFeedProps) {
   const router = useRouter();
-  const safeAreaInsetTop = useSignal(
-    viewport.safeAreaInsetTop as Signal<number>
-  );
+  const safeAreaInsetTop = useDeviceSafeAreaTop();
   const topOffset = Math.max(safeAreaInsetTop || 0, 12) + 10 + 27 + 16;
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/app/src/hooks/useTelegramSafeArea.ts
+++ b/app/src/hooks/useTelegramSafeArea.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { useSignal, viewport } from "@telegram-apps/sdk-react";
+import type { Signal } from "@telegram-apps/signals";
 import { useCallback, useEffect, useState } from "react";
 
 interface SafeAreaInsets {
@@ -17,6 +19,11 @@ const getWebApp = () => {
   } } }).Telegram?.WebApp;
 };
 
+const getDeviceSafeAreaTopValue = (): number => {
+  if (typeof window === "undefined") return 0;
+  return getWebApp()?.safeAreaInset?.top ?? 0;
+};
+
 const getSafeArea = (): SafeAreaInsets => {
   const webApp = getWebApp();
   if (!webApp) return { top: 0, bottom: 0 };
@@ -32,10 +39,39 @@ const getSafeArea = (): SafeAreaInsets => {
 };
 
 /**
- * Hook that provides Telegram safe area insets.
+ * Hook that returns the device safe area top inset (notch/status bar area).
+ * Combines the SDK signal (reactive, populated after async viewport.mount())
+ * with the native WebApp value (synchronous best-effort fallback).
+ */
+export function useDeviceSafeAreaTop(): number {
+  // SDK signal — reactive, fires when viewport.mount() resolves
+  const sdkTop = useSignal(viewport.safeAreaInsetTop as Signal<number>);
+
+  // Native value — synchronous read, updated via Telegram client events
+  const [nativeTop, setNativeTop] = useState(getDeviceSafeAreaTopValue);
+
+  useEffect(() => {
+    const update = () => setNativeTop(getDeviceSafeAreaTopValue());
+    // Re-check in case value appeared between render and effect
+    update();
+    const webApp = getWebApp();
+    webApp?.onEvent?.("safeAreaChanged", update);
+    webApp?.onEvent?.("viewportChanged", update);
+    return () => {
+      webApp?.offEvent?.("safeAreaChanged", update);
+      webApp?.offEvent?.("viewportChanged", update);
+    };
+  }, []);
+
+  // SDK takes precedence; native value as fallback
+  return sdkTop || nativeTop;
+}
+
+/**
+ * Hook that provides combined Telegram safe area insets (device + content).
  */
 export function useTelegramSafeArea(): SafeAreaInsets {
-  const [insets, setInsets] = useState<SafeAreaInsets>({ top: 0, bottom: 0 });
+  const [insets, setInsets] = useState<SafeAreaInsets>(getSafeArea);
 
   const updateInsets = useCallback(() => {
     setInsets(getSafeArea());


### PR DESCRIPTION
## Summary
- Move `initTelegram()` call from wallet page to layout level so `viewport.mount()` runs for all pages — fixes safe area never updating after network change reload
- Gate layout visibility (`visibility: hidden`) until safe area inset is resolved (non-zero value or 150ms timeout for notch-less devices) — eliminates content jump on initial load
- Centralize `viewport.safeAreaInsetTop` reading into `useDeviceSafeAreaTop()` hook combining SDK signal with native WebApp fallback

## Test plan
- [x] Open mini-app on iPhone — logo should appear aligned with Telegram close button, no upward jump
- [x] Change network in Profile — content should stay at correct position after reload
- [x] Open summaries and direct feed pages — safe area should be correct without navigating to wallet first
- [x] Test on Android device (notch and no-notch) — verify 150ms timeout fallback works for no-notch devices