### PR TITLE
fix(telegram): suppress non-success community command replies

### DIFF
--- a/app/drizzle/0008_spotty_lockheed.sql
+++ b/app/drizzle/0008_spotty_lockheed.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "telegram_helper_message_cleanup" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chat_id" bigint NOT NULL,
+	"message_id" integer NOT NULL,
+	"delete_after" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "telegram_helper_message_cleanup_delete_after_idx" ON "telegram_helper_message_cleanup" USING btree ("delete_after");--> statement-breakpoint
+CREATE UNIQUE INDEX "telegram_helper_message_cleanup_chat_message_uidx" ON "telegram_helper_message_cleanup" USING btree ("chat_id","message_id");

--- a/app/drizzle/meta/0008_snapshot.json
+++ b/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1376 @@
+{
+  "id": "7b53da59-a421-4f34-a028-b08f675e511d",
+  "prevId": "8c43846d-2035-4383-b78d-2ee2fb0fde51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_helper_message_cleanup": {
+      "name": "telegram_helper_message_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_helper_message_cleanup_delete_after_idx": {
+          "name": "telegram_helper_message_cleanup_delete_after_idx",
+          "columns": [
+            {
+              "expression": "delete_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_helper_message_cleanup_chat_message_uidx": {
+          "name": "telegram_helper_message_cleanup_chat_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1771311965999,
       "tag": "0007_curvy_glorian",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1771479840368,
+      "tag": "0008_spotty_lockheed",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/cron/_shared/auth.test.ts
+++ b/app/src/app/api/cron/_shared/auth.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const TEST_ENV_KEYS = ["CRON_SECRET"] as const;
+
+function clearTestEnv(): void {
+  for (const key of TEST_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+describe("cron auth helper", () => {
+  beforeEach(() => {
+    clearTestEnv();
+  });
+
+  afterEach(() => {
+    clearTestEnv();
+  });
+
+  test("returns 500 when CRON_SECRET is missing", async () => {
+    const { validateCronAuthHeader } = await import("./auth");
+    const request = new Request("http://localhost/api/cron/example", {
+      method: "POST",
+      headers: { authorization: "Bearer anything" },
+    });
+
+    const response = validateCronAuthHeader(request);
+    expect(response?.status).toBe(500);
+    expect(await response?.json()).toEqual({ error: "Server misconfigured" });
+  });
+
+  test("returns 401 for missing or invalid auth", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    const { validateCronAuthHeader } = await import("./auth");
+
+    const missingHeaderRequest = new Request("http://localhost/api/cron/example", {
+      method: "POST",
+    });
+    const missingHeaderResponse = validateCronAuthHeader(missingHeaderRequest);
+    expect(missingHeaderResponse?.status).toBe(401);
+
+    const invalidHeaderRequest = new Request("http://localhost/api/cron/example", {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-secret" },
+    });
+    const invalidHeaderResponse = validateCronAuthHeader(invalidHeaderRequest);
+    expect(invalidHeaderResponse?.status).toBe(401);
+  });
+
+  test("returns null for valid bearer token", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    const { validateCronAuthHeader } = await import("./auth");
+
+    const request = new Request("http://localhost/api/cron/example", {
+      method: "POST",
+      headers: { authorization: "Bearer expected-secret" },
+    });
+
+    expect(validateCronAuthHeader(request)).toBeNull();
+  });
+});

--- a/app/src/app/api/cron/_shared/auth.ts
+++ b/app/src/app/api/cron/_shared/auth.ts
@@ -1,0 +1,33 @@
+import { timingSafeEqual } from "crypto";
+import { NextResponse } from "next/server";
+
+import { serverEnv } from "@/lib/core/config/server";
+
+export function validateCronAuthHeader(request: Request): NextResponse | null {
+  let expectedToken: string;
+  try {
+    expectedToken = serverEnv.cronSecret;
+  } catch {
+    console.error("CRON_SECRET environment variable is not set");
+    return NextResponse.json(
+      { error: "Server misconfigured" },
+      { status: 500 }
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const expected = Buffer.from(`Bearer ${expectedToken}`);
+  const provided = Buffer.from(authHeader);
+  if (
+    expected.length !== provided.length ||
+    !timingSafeEqual(expected, provided)
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/app/src/app/api/cron/telegram-helper-cleanup/route.test.ts
+++ b/app/src/app/api/cron/telegram-helper-cleanup/route.test.ts
@@ -1,0 +1,359 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const TEST_ENV_KEYS = ["CRON_SECRET"] as const;
+
+type CleanupQueueRow = {
+  chatId: bigint;
+  createdAt: Date;
+  deleteAfter: Date;
+  id: string;
+  messageId: number;
+};
+
+const DEFAULT_CLAIM_RESULT = [{ id: "claimed" }];
+
+let cleanupQueueRows: CleanupQueueRow[] = [];
+let claimReturningQueue: Array<Array<{ id: string }>> = [];
+let deleteMessageCalls: Array<{ chatId: string; messageId: number }> = [];
+let deleteQueueWhereCalls = 0;
+let updateWhereCalls: Array<{ returningCalled: boolean; values: unknown }> = [];
+let deleteMessageImpl: (
+  chatId: string,
+  messageId: number
+) => Promise<void> = async (chatId, messageId) => {
+  deleteMessageCalls.push({ chatId, messageId });
+};
+
+function clearTestEnv(): void {
+  for (const key of TEST_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => ({
+    delete: () => ({
+      where: async () => {
+        deleteQueueWhereCalls += 1;
+      },
+    }),
+    query: {
+      telegramHelperMessageCleanup: {
+        findMany: async () => cleanupQueueRows,
+      },
+    },
+    update: () => ({
+      set: (values: unknown) => ({
+        where: () => {
+          const call = { returningCalled: false, values };
+          updateWhereCalls.push(call);
+          return {
+            returning: async () => {
+              call.returningCalled = true;
+              return claimReturningQueue.shift() ?? DEFAULT_CLAIM_RESULT;
+            },
+          };
+        },
+      }),
+    }),
+  }),
+}));
+
+mock.module("@/lib/telegram/bot-api/bot", () => ({
+  getBot: async () => ({
+    api: {
+      deleteMessage: async (chatId: string, messageId: number) =>
+        deleteMessageImpl(chatId, messageId),
+    },
+  }),
+}));
+
+let POST: (request: Request) => Promise<Response>;
+
+function createDueQueueRow(overrides?: Partial<CleanupQueueRow>): CleanupQueueRow {
+  const now = Date.now();
+  return {
+    chatId: BigInt("-1001234"),
+    createdAt: new Date(now - 2 * 60 * 1000),
+    deleteAfter: new Date(now - 5 * 1000),
+    id: "q-1",
+    messageId: 11,
+    ...overrides,
+  };
+}
+
+describe("telegram helper cleanup cron route", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("./route");
+    POST = loadedModule.POST;
+  });
+
+  beforeEach(() => {
+    clearTestEnv();
+    cleanupQueueRows = [];
+    claimReturningQueue = [];
+    deleteMessageCalls = [];
+    deleteQueueWhereCalls = 0;
+    updateWhereCalls = [];
+    deleteMessageImpl = async (chatId, messageId) => {
+      deleteMessageCalls.push({ chatId, messageId });
+    };
+  });
+
+  afterEach(() => {
+    clearTestEnv();
+  });
+
+  test("returns 500 when CRON_SECRET is missing", async () => {
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer any-token" },
+      }
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Server misconfigured" });
+  });
+
+  test("returns 401 when Authorization does not match CRON_SECRET", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer wrong-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  test("returns quickly when queue is empty", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      stats: {
+        claimed: 0,
+        droppedExpired: 0,
+        due: 0,
+        queueDeleted: 0,
+        retryScheduled: 0,
+        skippedAlreadyClaimed: 0,
+        successfulDeletes: 0,
+        terminalErrors: 0,
+        transientErrors: 0,
+      },
+    });
+    expect(deleteMessageCalls).toHaveLength(0);
+    expect(deleteQueueWhereCalls).toBe(0);
+  });
+
+  test("claim success then delete success removes row", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    cleanupQueueRows = [createDueQueueRow()];
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(deleteMessageCalls).toEqual([{ chatId: "-1001234", messageId: 11 }]);
+    expect(deleteQueueWhereCalls).toBe(1);
+    expect(payload.stats).toEqual({
+      claimed: 1,
+      droppedExpired: 0,
+      due: 1,
+      queueDeleted: 1,
+      retryScheduled: 0,
+      skippedAlreadyClaimed: 0,
+      successfulDeletes: 1,
+      terminalErrors: 0,
+      transientErrors: 0,
+    });
+  });
+
+  test("skips candidate when claim lease is lost", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    cleanupQueueRows = [createDueQueueRow()];
+    claimReturningQueue = [[]];
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(deleteMessageCalls).toHaveLength(0);
+    expect(deleteQueueWhereCalls).toBe(0);
+    expect(payload.stats).toEqual({
+      claimed: 0,
+      droppedExpired: 0,
+      due: 1,
+      queueDeleted: 0,
+      retryScheduled: 0,
+      skippedAlreadyClaimed: 1,
+      successfulDeletes: 0,
+      terminalErrors: 0,
+      transientErrors: 0,
+    });
+  });
+
+  test("drops row on terminal Telegram delete errors after claim", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    cleanupQueueRows = [createDueQueueRow({ messageId: 22 })];
+    deleteMessageImpl = async () => {
+      throw {
+        description: "Bad Request: message to delete not found",
+        error_code: 400,
+      };
+    };
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(deleteQueueWhereCalls).toBe(1);
+    expect(payload.stats).toEqual({
+      claimed: 1,
+      droppedExpired: 0,
+      due: 1,
+      queueDeleted: 1,
+      retryScheduled: 0,
+      skippedAlreadyClaimed: 0,
+      successfulDeletes: 0,
+      terminalErrors: 1,
+      transientErrors: 0,
+    });
+  });
+
+  test("reschedules transient failures within retry window", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    cleanupQueueRows = [
+      createDueQueueRow({
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+        messageId: 33,
+      }),
+    ];
+    deleteMessageImpl = async () => {
+      throw { description: "Too Many Requests", error_code: 429 };
+    };
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    const rescheduleCalls = updateWhereCalls.filter(
+      (call) => !call.returningCalled
+    );
+    expect(response.status).toBe(200);
+    expect(deleteQueueWhereCalls).toBe(0);
+    expect(rescheduleCalls).toHaveLength(1);
+    expect(payload.stats).toEqual({
+      claimed: 1,
+      droppedExpired: 0,
+      due: 1,
+      queueDeleted: 0,
+      retryScheduled: 1,
+      skippedAlreadyClaimed: 0,
+      successfulDeletes: 0,
+      terminalErrors: 0,
+      transientErrors: 1,
+    });
+  });
+
+  test("drops transient failures that exceed retry window", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    cleanupQueueRows = [
+      createDueQueueRow({
+        createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+        messageId: 44,
+      }),
+    ];
+    deleteMessageImpl = async () => {
+      throw { description: "Too Many Requests", error_code: 429 };
+    };
+
+    const request = new Request(
+      "http://localhost/api/cron/telegram-helper-cleanup",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer expected-secret" },
+      }
+    );
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    const rescheduleCalls = updateWhereCalls.filter(
+      (call) => !call.returningCalled
+    );
+    expect(response.status).toBe(200);
+    expect(rescheduleCalls).toHaveLength(0);
+    expect(deleteQueueWhereCalls).toBe(1);
+    expect(payload.stats).toEqual({
+      claimed: 1,
+      droppedExpired: 1,
+      due: 1,
+      queueDeleted: 1,
+      retryScheduled: 0,
+      skippedAlreadyClaimed: 0,
+      successfulDeletes: 0,
+      terminalErrors: 0,
+      transientErrors: 1,
+    });
+  });
+});

--- a/app/src/app/api/cron/telegram-helper-cleanup/route.ts
+++ b/app/src/app/api/cron/telegram-helper-cleanup/route.ts
@@ -1,0 +1,256 @@
+import { and, asc, eq, inArray, lte } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { getDatabase } from "@/lib/core/database";
+import { telegramHelperMessageCleanup } from "@/lib/core/schema";
+import { getBot } from "@/lib/telegram/bot-api/bot";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+export const runtime = "nodejs";
+
+const CLEANUP_BATCH_LIMIT = 200;
+const CLAIM_LEASE_MS = 120_000;
+const RETRY_DELAY_MS = 60_000;
+const MAX_RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+type CleanupQueueItem = {
+  createdAt: Date;
+  deleteAfter: Date;
+  chatId: bigint;
+  id: string;
+  messageId: number;
+};
+
+export type TelegramHelperCleanupStats = {
+  claimed: number;
+  droppedExpired: number;
+  due: number;
+  queueDeleted: number;
+  retryScheduled: number;
+  skippedAlreadyClaimed: number;
+  successfulDeletes: number;
+  terminalErrors: number;
+  transientErrors: number;
+};
+
+export async function GET(request: Request): Promise<NextResponse> {
+  return POST(request);
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const authErrorResponse = validateCronAuthHeader(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
+  }
+
+  const now = new Date();
+  const db = getDatabase();
+  const dueMessages = await db.query.telegramHelperMessageCleanup.findMany({
+    columns: {
+      createdAt: true,
+      deleteAfter: true,
+      chatId: true,
+      id: true,
+      messageId: true,
+    },
+    limit: CLEANUP_BATCH_LIMIT,
+    orderBy: asc(telegramHelperMessageCleanup.deleteAfter),
+    where: lte(telegramHelperMessageCleanup.deleteAfter, now),
+  });
+
+  const stats: TelegramHelperCleanupStats = {
+    claimed: 0,
+    droppedExpired: 0,
+    due: dueMessages.length,
+    queueDeleted: 0,
+    retryScheduled: 0,
+    skippedAlreadyClaimed: 0,
+    successfulDeletes: 0,
+    terminalErrors: 0,
+    transientErrors: 0,
+  };
+
+  if (dueMessages.length === 0) {
+    return NextResponse.json({ ok: true, stats });
+  }
+
+  const bot = await getBot();
+  const queueIdsToDelete: string[] = [];
+  const claimLeaseUntil = new Date(now.getTime() + CLAIM_LEASE_MS);
+  const retryAfter = new Date(now.getTime() + RETRY_DELAY_MS);
+
+  for (const item of dueMessages) {
+    const claimed = await claimDueCleanupItem(
+      item.id,
+      now,
+      claimLeaseUntil
+    );
+    if (!claimed) {
+      stats.skippedAlreadyClaimed += 1;
+      continue;
+    }
+    stats.claimed += 1;
+
+    const deleteOutcome = await deleteTelegramHelperMessage(
+      bot,
+      item,
+      stats
+    );
+
+    if (deleteOutcome === "success" || deleteOutcome === "terminal") {
+      queueIdsToDelete.push(item.id);
+      continue;
+    }
+
+    const itemAgeMs = now.getTime() - item.createdAt.getTime();
+    if (itemAgeMs > MAX_RETRY_WINDOW_MS) {
+      stats.droppedExpired += 1;
+      queueIdsToDelete.push(item.id);
+      continue;
+    }
+
+    await rescheduleCleanupItem(item.id, retryAfter);
+    stats.retryScheduled += 1;
+  }
+
+  if (queueIdsToDelete.length > 0) {
+    await db
+      .delete(telegramHelperMessageCleanup)
+      .where(inArray(telegramHelperMessageCleanup.id, queueIdsToDelete));
+  }
+  stats.queueDeleted = queueIdsToDelete.length;
+
+  return NextResponse.json({ ok: true, stats });
+}
+
+async function deleteTelegramHelperMessage(
+  bot: Awaited<ReturnType<typeof getBot>>,
+  item: CleanupQueueItem,
+  stats: TelegramHelperCleanupStats
+): Promise<"success" | "terminal" | "transient"> {
+  try {
+    await bot.api.deleteMessage(String(item.chatId), item.messageId);
+    stats.successfulDeletes += 1;
+    return "success";
+  } catch (error) {
+    const parsedError = parseTelegramError(error);
+    const errorMessage =
+      parsedError.description ??
+      (error instanceof Error ? error.message : String(error));
+
+    if (isTransientTelegramDeleteError(error)) {
+      stats.transientErrors += 1;
+      console.warn("[cron/telegram-helper-cleanup] Transient delete failure", {
+        chatId: String(item.chatId),
+        error: errorMessage,
+        errorCode: parsedError.errorCode,
+        messageId: item.messageId,
+        queueId: item.id,
+      });
+      return "transient";
+    }
+
+    stats.terminalErrors += 1;
+    console.warn("[cron/telegram-helper-cleanup] Terminal delete failure", {
+      chatId: String(item.chatId),
+      error: errorMessage,
+      errorCode: parsedError.errorCode,
+      messageId: item.messageId,
+      queueId: item.id,
+    });
+    return "terminal";
+  }
+}
+
+async function claimDueCleanupItem(
+  itemId: string,
+  now: Date,
+  claimLeaseUntil: Date
+): Promise<boolean> {
+  const db = getDatabase();
+  const claimed = await db
+    .update(telegramHelperMessageCleanup)
+    .set({ deleteAfter: claimLeaseUntil })
+    .where(
+      and(
+        eq(telegramHelperMessageCleanup.id, itemId),
+        lte(telegramHelperMessageCleanup.deleteAfter, now)
+      )
+    )
+    .returning({ id: telegramHelperMessageCleanup.id });
+
+  return claimed.length > 0;
+}
+
+async function rescheduleCleanupItem(itemId: string, retryAfter: Date): Promise<void> {
+  const db = getDatabase();
+  await db
+    .update(telegramHelperMessageCleanup)
+    .set({ deleteAfter: retryAfter })
+    .where(eq(telegramHelperMessageCleanup.id, itemId));
+}
+
+function isTransientTelegramDeleteError(error: unknown): boolean {
+  const parsedError = parseTelegramError(error);
+  if (!parsedError.errorCode) {
+    return true;
+  }
+
+  if (parsedError.errorCode === 429) {
+    return true;
+  }
+
+  if (parsedError.errorCode >= 500) {
+    return true;
+  }
+
+  if (parsedError.errorCode === 400 || parsedError.errorCode === 403) {
+    return false;
+  }
+
+  if (
+    parsedError.description &&
+    /message to delete not found|message can't be deleted|chat not found|bot was kicked|forbidden/i.test(
+      parsedError.description
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function parseTelegramError(error: unknown): {
+  description?: string;
+  errorCode?: number;
+} {
+  if (!error || typeof error !== "object") {
+    return {};
+  }
+
+  const maybeError = error as {
+    description?: unknown;
+    error_code?: unknown;
+    response?: {
+      description?: unknown;
+      error_code?: unknown;
+    };
+  };
+
+  const errorCode =
+    typeof maybeError.error_code === "number"
+      ? maybeError.error_code
+      : typeof maybeError.response?.error_code === "number"
+      ? maybeError.response.error_code
+      : undefined;
+
+  const description =
+    typeof maybeError.description === "string"
+      ? maybeError.description
+      : typeof maybeError.response?.description === "string"
+      ? maybeError.response.description
+      : undefined;
+
+  return { description, errorCode };
+}

--- a/app/src/lib/telegram/bot-api/__tests__/commands-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-settings.test.ts
@@ -7,9 +7,9 @@ mock.module("server-only", () => ({}));
 
 let mockDb: {
   insert: () => {
-    values: (
-      values: Record<string, unknown>
-    ) => { onConflictDoNothing: () => Promise<void> };
+    values: (values: Record<string, unknown>) => {
+      onConflictDoNothing: () => Promise<void>;
+    };
   };
   query: {
     userSettings: { findFirst: () => Promise<UserSettings | null> };
@@ -40,10 +40,6 @@ mock.module("@/lib/core/database", () => ({
 
 mock.module("@/lib/telegram/user-service", () => ({
   getOrCreateUser: async () => getOrCreateUserImpl(),
-}));
-
-mock.module("../notification-settings", () => ({
-  sendNotificationSettingsMessage: async () => {},
 }));
 
 mock.module("../start-carousel", () => ({

--- a/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
@@ -19,6 +19,7 @@ type MockSendSummaryResult =
     };
 
 let sendLatestSummaryResult: MockSendSummaryResult = { sent: true };
+let sendLatestSummaryError: Error | null = null;
 const sendLatestSummaryCalls: unknown[] = [];
 const mixpanelInitTokens: string[] = [];
 const mixpanelTrackCalls: Array<{
@@ -78,6 +79,9 @@ mock.module("../start-carousel", () => ({
 mock.module("../summaries", () => ({
   sendLatestSummary: async (...args: unknown[]) => {
     sendLatestSummaryCalls.push(args);
+    if (sendLatestSummaryError) {
+      throw sendLatestSummaryError;
+    }
     return sendLatestSummaryResult;
   },
 }));
@@ -143,6 +147,7 @@ describe("commands analytics tracking", () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_MIXPANEL_TOKEN = "test-mixpanel-token";
     sendLatestSummaryResult = { sent: true };
+    sendLatestSummaryError = null;
     sendLatestSummaryCalls.length = 0;
     mixpanelInitTokens.length = 0;
     mixpanelTrackCalls.length = 0;
@@ -208,7 +213,7 @@ describe("commands analytics tracking", () => {
     ]);
   });
 
-  test("replies when summary notifications are disabled for community", async () => {
+  test("suppresses reply when summary notifications are disabled for community", async () => {
     sendLatestSummaryResult = {
       sent: false,
       reason: "notifications_disabled",
@@ -217,12 +222,8 @@ describe("commands analytics tracking", () => {
 
     await handleSummaryCommand(ctx, {} as Bot);
 
-    expect(replyCalls).toEqual([
-      "Summary notifications are turned off for this community. Use /notifications to turn them on.",
-    ]);
-    expect(autoCleanupReplyTexts).toEqual([
-      "Summary notifications are turned off for this community. Use /notifications to turn them on.",
-    ]);
+    expect(replyCalls).toHaveLength(0);
+    expect(autoCleanupReplyTexts).toHaveLength(0);
     expect(sendLatestSummaryCalls).toHaveLength(1);
     expect(sendLatestSummaryCalls[0]).toEqual([
       {},
@@ -235,7 +236,7 @@ describe("commands analytics tracking", () => {
     expect(mixpanelTrackCalls).toHaveLength(0);
   });
 
-  test("keeps existing not_activated behavior", async () => {
+  test("suppresses reply when community is not activated", async () => {
     sendLatestSummaryResult = {
       sent: false,
       reason: "not_activated",
@@ -244,12 +245,11 @@ describe("commands analytics tracking", () => {
 
     await handleSummaryCommand(ctx, {} as Bot);
 
-    expect(replyCalls).toEqual([
-      "This community is not activated. Use /activate_community to enable summaries.",
-    ]);
+    expect(replyCalls).toHaveLength(0);
+    expect(autoCleanupReplyTexts).toHaveLength(0);
   });
 
-  test("keeps existing no_summaries behavior", async () => {
+  test("suppresses reply when no summaries are available", async () => {
     sendLatestSummaryResult = {
       sent: false,
       reason: "no_summaries",
@@ -258,8 +258,18 @@ describe("commands analytics tracking", () => {
 
     await handleSummaryCommand(ctx, {} as Bot);
 
-    expect(replyCalls).toEqual([
-      "No summaries available yet. Summaries are generated daily when there's enough activity.",
-    ]);
+    expect(replyCalls).toHaveLength(0);
+    expect(autoCleanupReplyTexts).toHaveLength(0);
+  });
+
+  test("suppresses reply when summary delivery throws", async () => {
+    sendLatestSummaryError = new Error("summary delivery failed");
+    const { ctx, replyCalls } = createSummaryCommandContext();
+
+    await handleSummaryCommand(ctx, {} as Bot);
+
+    expect(replyCalls).toHaveLength(0);
+    expect(autoCleanupReplyTexts).toHaveLength(0);
+    expect(mixpanelTrackCalls).toHaveLength(0);
   });
 });

--- a/app/src/lib/telegram/bot-api/__tests__/helper-message-cleanup.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/helper-message-cleanup.test.ts
@@ -1,0 +1,123 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CommandContext, Context } from "grammy";
+
+mock.module("server-only", () => ({}));
+
+let mockDb: {
+  insert: () => {
+    values: (values: Record<string, unknown>) => {
+      onConflictDoNothing: () => Promise<void>;
+    };
+  };
+};
+
+const insertValuesCaptured: Array<Record<string, unknown>> = [];
+let onConflictDoNothingCalls = 0;
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+let replyWithAutoCleanup: typeof import("../helper-message-cleanup").replyWithAutoCleanup;
+let scheduleHelperMessageDeletion: typeof import("../helper-message-cleanup").scheduleHelperMessageDeletion;
+let sendMessageWithAutoCleanup: typeof import("../helper-message-cleanup").sendMessageWithAutoCleanup;
+
+describe("helper message cleanup helpers", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../helper-message-cleanup");
+    replyWithAutoCleanup = loadedModule.replyWithAutoCleanup;
+    scheduleHelperMessageDeletion = loadedModule.scheduleHelperMessageDeletion;
+    sendMessageWithAutoCleanup = loadedModule.sendMessageWithAutoCleanup;
+  });
+
+  beforeEach(() => {
+    insertValuesCaptured.length = 0;
+    onConflictDoNothingCalls = 0;
+
+    mockDb = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          insertValuesCaptured.push(values);
+          return {
+            onConflictDoNothing: async () => {
+              onConflictDoNothingCalls += 1;
+            },
+          };
+        },
+      }),
+    };
+  });
+
+  test("scheduleHelperMessageDeletion stores queue rows with computed deleteAfter", async () => {
+    const before = Date.now();
+    await scheduleHelperMessageDeletion("-1009876543210", 777, 60_000);
+    const after = Date.now();
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    const row = insertValuesCaptured[0];
+    expect(row?.chatId).toBe(BigInt("-1009876543210"));
+    expect(row?.messageId).toBe(777);
+    expect(row?.deleteAfter).toBeInstanceOf(Date);
+    const deleteAfterMs = (row?.deleteAfter as Date).getTime();
+    expect(deleteAfterMs).toBeGreaterThanOrEqual(before + 60_000);
+    expect(deleteAfterMs).toBeLessThanOrEqual(after + 60_000);
+    expect(onConflictDoNothingCalls).toBe(1);
+  });
+
+  test("scheduleHelperMessageDeletion remains idempotent with onConflictDoNothing", async () => {
+    await scheduleHelperMessageDeletion("-1009876543210", 1, 60_000);
+    await scheduleHelperMessageDeletion("-1009876543210", 1, 60_000);
+
+    expect(insertValuesCaptured).toHaveLength(2);
+    expect(onConflictDoNothingCalls).toBe(2);
+  });
+
+  test("replyWithAutoCleanup schedules only for community chats", async () => {
+    const communityCtx = {
+      chat: {
+        id: -1009876543210,
+        type: "supergroup",
+      },
+      reply: async () => ({ message_id: 77 } as never),
+    } as unknown as CommandContext<Context>;
+
+    const privateCtx = {
+      chat: {
+        id: 777,
+        type: "private",
+      },
+      reply: async () => ({ message_id: 88 } as never),
+    } as unknown as CommandContext<Context>;
+
+    await replyWithAutoCleanup(communityCtx, "community helper");
+    await replyWithAutoCleanup(privateCtx, "private helper");
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(insertValuesCaptured[0]?.chatId).toBe(BigInt("-1009876543210"));
+    expect(insertValuesCaptured[0]?.messageId).toBe(77);
+  });
+
+  test("sendMessageWithAutoCleanup schedules only for community chats", async () => {
+    const api = {
+      sendMessage: async () => ({ message_id: 505 } as never),
+    } as unknown as Pick<Context["api"], "sendMessage">;
+
+    await sendMessageWithAutoCleanup({
+      api,
+      chatId: "-1009876543210",
+      chatType: "supergroup",
+      text: "onboarding helper",
+    });
+
+    await sendMessageWithAutoCleanup({
+      api,
+      chatId: "777",
+      chatType: "private",
+      text: "private helper",
+    });
+
+    expect(insertValuesCaptured).toHaveLength(1);
+    expect(insertValuesCaptured[0]?.chatId).toBe(BigInt("-1009876543210"));
+    expect(insertValuesCaptured[0]?.messageId).toBe(505);
+  });
+});

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -15,6 +15,7 @@ import {
 import { CA_COMMAND_CHAT_ID } from "./constants";
 import { getChat } from "./get-chat";
 import { downloadTelegramFile } from "./get-file";
+import { replyWithAutoCleanup } from "./helper-message-cleanup";
 import { evictActiveCommunityCache } from "./message-handlers";
 import { sendNotificationSettingsMessage } from "./notification-settings";
 import { sendStartCarousel } from "./start-carousel";
@@ -110,7 +111,7 @@ async function findActiveCommunityOrReply(
   });
 
   if (!existingCommunity || !existingCommunity.isActive) {
-    await ctx.reply(COMMUNITY_NOT_ACTIVATED_YET_REPLY_TEXT);
+    await replyWithAutoCleanup(ctx, COMMUNITY_NOT_ACTIVATED_YET_REPLY_TEXT);
     return null;
   }
 
@@ -122,10 +123,7 @@ export async function handleStartCommand(
   bot: Bot
 ): Promise<void> {
   await sendStartCarousel(ctx, bot);
-  trackBotEvent(
-    BOT_START_COMMAND_EVENT,
-    createCommandTrackingProperties(ctx)
-  );
+  trackBotEvent(BOT_START_COMMAND_EVENT, createCommandTrackingProperties(ctx));
 }
 
 export async function handleCaCommand(
@@ -217,7 +215,10 @@ export async function handleActivateCommunityCommand(
   }
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -232,7 +233,8 @@ export async function handleActivateCommunityCommand(
     });
 
     if (!admin) {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "You are not authorized to activate communities. Contact an administrator to be added to the whitelist."
       );
       return;
@@ -272,7 +274,10 @@ export async function handleActivateCommunityCommand(
             updatedAt: new Date(),
           })
           .where(eq(communities.id, existingCommunity.id));
-        await ctx.reply("Community is already activated. Data updated!");
+        await replyWithAutoCleanup(
+          ctx,
+          "Community is already activated. Data updated!"
+        );
         return;
       }
 
@@ -286,7 +291,10 @@ export async function handleActivateCommunityCommand(
           updatedAt: new Date(),
         })
         .where(eq(communities.id, existingCommunity.id));
-      await ctx.reply("Community reactivated for message tracking!");
+      await replyWithAutoCleanup(
+        ctx,
+        "Community reactivated for message tracking!"
+      );
       return;
     }
 
@@ -306,10 +314,14 @@ export async function handleActivateCommunityCommand(
       settings,
     });
 
-    await ctx.reply("Community activated for message tracking!");
+    await replyWithAutoCleanup(
+      ctx,
+      "Community activated for message tracking!"
+    );
   } catch (error) {
     console.error("Failed to activate community", error);
-    await ctx.reply(
+    await replyWithAutoCleanup(
+      ctx,
       "An error occurred while activating the community. Please try again."
     );
   }
@@ -323,7 +335,10 @@ export async function handleSummaryCommand(
   if (!ctx.chat) return;
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -346,21 +361,25 @@ export async function handleSummaryCommand(
     }
 
     if (result.reason === "not_activated") {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "This community is not activated. Use /activate_community to enable summaries."
       );
     } else if (result.reason === "notifications_disabled") {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "Summary notifications are turned off for this community. Use /notifications to turn them on."
       );
     } else if (result.reason === "no_summaries") {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "No summaries available yet. Summaries are generated daily when there's enough activity."
       );
     }
   } catch (error) {
     console.error("Failed to send summary", error);
-    await ctx.reply(
+    await replyWithAutoCleanup(
+      ctx,
       "An error occurred while fetching the summary. Please try again."
     );
   }
@@ -372,7 +391,10 @@ export async function handleNotificationsCommand(
   if (!ctx.chat) return;
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -384,7 +406,8 @@ export async function handleNotificationsCommand(
     });
 
     if (!community || !community.isActive) {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "This community is not activated. Use /activate_community to enable summaries."
       );
       return;
@@ -393,7 +416,8 @@ export async function handleNotificationsCommand(
     await sendNotificationSettingsMessage(ctx, community);
   } catch (error) {
     console.error("Failed to send notification settings", error);
-    await ctx.reply(
+    await replyWithAutoCleanup(
+      ctx,
       "An error occurred while loading notification settings. Please try again."
     );
   }
@@ -447,7 +471,10 @@ export async function handleDeactivateCommunityCommand(
   }
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -462,7 +489,8 @@ export async function handleDeactivateCommunityCommand(
     });
 
     if (!admin) {
-      await ctx.reply(
+      await replyWithAutoCleanup(
+        ctx,
         "You are not authorized to deactivate communities. Contact an administrator to be added to the whitelist."
       );
       return;
@@ -476,12 +504,12 @@ export async function handleDeactivateCommunityCommand(
     });
 
     if (!existingCommunity) {
-      await ctx.reply("This community is not activated.");
+      await replyWithAutoCleanup(ctx, "This community is not activated.");
       return;
     }
 
     if (!existingCommunity.isActive) {
-      await ctx.reply("This community is already deactivated.");
+      await replyWithAutoCleanup(ctx, "This community is already deactivated.");
       return;
     }
 
@@ -492,10 +520,14 @@ export async function handleDeactivateCommunityCommand(
       .where(eq(communities.id, existingCommunity.id));
 
     evictActiveCommunityCache(chatId);
-    await ctx.reply("Community deactivated. Message tracking has been disabled.");
+    await replyWithAutoCleanup(
+      ctx,
+      "Community deactivated. Message tracking has been disabled."
+    );
   } catch (error) {
     console.error("Failed to deactivate community", error);
-    await ctx.reply(
+    await replyWithAutoCleanup(
+      ctx,
       "An error occurred while deactivating the community. Please try again."
     );
   }
@@ -513,7 +545,10 @@ export async function handleHideCommunityCommand(
   }
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -529,7 +564,7 @@ export async function handleHideCommunityCommand(
     }
 
     if (!existingCommunity.isPublic) {
-      await ctx.reply("This community is already hidden.");
+      await replyWithAutoCleanup(ctx, "This community is already hidden.");
       return;
     }
 
@@ -538,16 +573,16 @@ export async function handleHideCommunityCommand(
       .set({ isPublic: false, updatedAt: new Date() })
       .where(eq(communities.id, existingCommunity.id));
 
-    await ctx.reply("Community hidden from public summaries.");
+    await replyWithAutoCleanup(ctx, "Community hidden from public summaries.");
   } catch (error) {
     if (isUnauthorizedVisibilityError(error)) {
       console.warn("Unauthorized /hide command attempt", error);
-      await ctx.reply(UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
+      await replyWithAutoCleanup(ctx, UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
       return;
     }
 
     console.error("Failed to hide community", error);
-    await ctx.reply(VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
+    await replyWithAutoCleanup(ctx, VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
   }
 }
 
@@ -563,7 +598,10 @@ export async function handleUnhideCommunityCommand(
   }
 
   if (!isCommunityChat(ctx.chat.type)) {
-    await ctx.reply("This command can only be used in group chats.");
+    await replyWithAutoCleanup(
+      ctx,
+      "This command can only be used in group chats."
+    );
     return;
   }
 
@@ -579,7 +617,7 @@ export async function handleUnhideCommunityCommand(
     }
 
     if (existingCommunity.isPublic) {
-      await ctx.reply("This community is already visible.");
+      await replyWithAutoCleanup(ctx, "This community is already visible.");
       return;
     }
 
@@ -588,15 +626,18 @@ export async function handleUnhideCommunityCommand(
       .set({ isPublic: true, updatedAt: new Date() })
       .where(eq(communities.id, existingCommunity.id));
 
-    await ctx.reply("Community is now visible in public summaries.");
+    await replyWithAutoCleanup(
+      ctx,
+      "Community is now visible in public summaries."
+    );
   } catch (error) {
     if (isUnauthorizedVisibilityError(error)) {
       console.warn("Unauthorized /unhide command attempt", error);
-      await ctx.reply(UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
+      await replyWithAutoCleanup(ctx, UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
       return;
     }
 
     console.error("Failed to unhide community", error);
-    await ctx.reply(VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
+    await replyWithAutoCleanup(ctx, VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
   }
 }

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -3,7 +3,7 @@ import type { CommandContext, Context } from "grammy";
 import { Bot, InlineKeyboard } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
-import { admins, communities, userSettings } from "@/lib/core/schema";
+import { admins, communities, type Community, userSettings } from "@/lib/core/schema";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat } from "@/lib/telegram/utils";
 
@@ -28,16 +28,15 @@ interface CommunityPhoto {
   mimeType: string;
 }
 
-const COMMUNITY_NOT_ACTIVATED_YET_REPLY_TEXT =
-  "This community is not activated yet. Use /activate_community to enable it.";
 const SETTINGS_LOAD_ERROR_REPLY_TEXT =
   "Unable to load your settings right now. Please try again.";
-const UNAUTHORIZED_VISIBILITY_REPLY_TEXT =
-  "You are not authorized to manage community visibility. Contact an administrator to be added to the whitelist.";
-const VISIBILITY_UPDATE_ERROR_REPLY_TEXT =
-  "An error occurred while updating community visibility. Please try again.";
-
-type VisibilityAction = "HIDE" | "UNHIDE";
+type CommunityCommandName =
+  | "/activate_community"
+  | "/deactivate_community"
+  | "/hide"
+  | "/unhide"
+  | "/summary"
+  | "/notifications";
 
 const BOT_START_COMMAND_EVENT = "Bot /start Command";
 const BOT_SUMMARY_COMMAND_EVENT = "Bot /summary Command";
@@ -75,29 +74,53 @@ async function fetchCommunityPhoto(
   }
 }
 
-async function assertWhitelistedAdminOrThrow(
+async function isWhitelistedAdmin(
   db: ReturnType<typeof getDatabase>,
-  telegramUserId: bigint,
-  action: VisibilityAction
-): Promise<void> {
+  telegramUserId: bigint
+): Promise<boolean> {
   const admin = await db.query.admins.findFirst({
     where: eq(admins.telegramId, telegramUserId),
   });
 
-  if (!admin) {
-    throw new Error(`UNAUTHORIZED_${action}`);
+  return Boolean(admin);
+}
+
+type CommunityReplyOptions = Parameters<typeof replyWithAutoCleanup>[2];
+
+async function replyCommunitySuccess(
+  ctx: CommandContext<Context>,
+  text: string,
+  options?: CommunityReplyOptions
+): Promise<void> {
+  await replyWithAutoCleanup(ctx, text, options);
+}
+
+function suppressCommunityFailure(
+  command: CommunityCommandName,
+  reason: string,
+  ctx: CommandContext<Context>,
+  error?: unknown
+): void {
+  const details = {
+    command,
+    reason,
+    telegram_chat_id: ctx.chat ? String(ctx.chat.id) : null,
+    telegram_chat_type: ctx.chat?.type ?? null,
+    telegram_user_id: ctx.from ? String(ctx.from.id) : null,
+  };
+
+  if (error) {
+    console.error("Suppressed community command reply", {
+      ...details,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
   }
+
+  console.warn("Suppressed community command reply", details);
 }
 
-function isUnauthorizedVisibilityError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.message.startsWith("UNAUTHORIZED_HIDE") ||
-      error.message.startsWith("UNAUTHORIZED_UNHIDE"))
-  );
-}
-
-async function findActiveCommunityOrReply(
+async function findActiveCommunity(
   ctx: CommandContext<Context>,
   db: ReturnType<typeof getDatabase>
 ) {
@@ -111,11 +134,67 @@ async function findActiveCommunityOrReply(
   });
 
   if (!existingCommunity || !existingCommunity.isActive) {
-    await replyWithAutoCleanup(ctx, COMMUNITY_NOT_ACTIVATED_YET_REPLY_TEXT);
     return null;
   }
 
   return existingCommunity;
+}
+
+function mergeCommunitySettings(
+  existingSettings: unknown,
+  nextSettings: Record<string, unknown>
+): Record<string, unknown> {
+  const current =
+    existingSettings && typeof existingSettings === "object"
+      ? (existingSettings as Record<string, unknown>)
+      : {};
+
+  return {
+    ...current,
+    ...nextSettings,
+  };
+}
+
+async function syncActivationForExistingCommunity(params: {
+  ctx: CommandContext<Context>;
+  db: ReturnType<typeof getDatabase>;
+  existingCommunity: Community;
+  settings: Record<string, unknown>;
+}): Promise<void> {
+  const mergedSettings = mergeCommunitySettings(
+    params.existingCommunity.settings,
+    params.settings
+  );
+
+  if (params.existingCommunity.isActive) {
+    await params.db
+      .update(communities)
+      .set({
+        chatTitle: params.ctx.chat?.title || "Untitled",
+        settings: mergedSettings,
+        updatedAt: new Date(),
+      })
+      .where(eq(communities.id, params.existingCommunity.id));
+    await replyCommunitySuccess(
+      params.ctx,
+      "Community is already activated. Data updated!"
+    );
+    return;
+  }
+
+  await params.db
+    .update(communities)
+    .set({
+      isActive: true,
+      chatTitle: params.ctx.chat?.title || "Untitled",
+      settings: mergedSettings,
+      updatedAt: new Date(),
+    })
+    .where(eq(communities.id, params.existingCommunity.id));
+  await replyCommunitySuccess(
+    params.ctx,
+    "Community reactivated for message tracking!"
+  );
 }
 
 export async function handleStartCommand(
@@ -227,16 +306,8 @@ export async function handleActivateCommunityCommand(
   try {
     const db = getDatabase();
 
-    // Check if user is in admin whitelist
-    const admin = await db.query.admins.findFirst({
-      where: eq(admins.telegramId, telegramUserId),
-    });
-
-    if (!admin) {
-      await replyWithAutoCleanup(
-        ctx,
-        "You are not authorized to activate communities. Contact an administrator to be added to the whitelist."
-      );
+    if (!(await isWhitelistedAdmin(db, telegramUserId))) {
+      suppressCommunityFailure("/activate_community", "unauthorized", ctx);
       return;
     }
 
@@ -258,43 +329,12 @@ export async function handleActivateCommunityCommand(
     });
 
     if (existingCommunity) {
-      // Merge new settings with existing settings
-      const mergedSettings = {
-        ...((existingCommunity.settings as object) || {}),
-        ...settings,
-      };
-
-      if (existingCommunity.isActive) {
-        // Update community data even if already active
-        await db
-          .update(communities)
-          .set({
-            chatTitle: ctx.chat.title || "Untitled",
-            settings: mergedSettings,
-            updatedAt: new Date(),
-          })
-          .where(eq(communities.id, existingCommunity.id));
-        await replyWithAutoCleanup(
-          ctx,
-          "Community is already activated. Data updated!"
-        );
-        return;
-      }
-
-      // Reactivate the community with updated data
-      await db
-        .update(communities)
-        .set({
-          isActive: true,
-          chatTitle: ctx.chat.title || "Untitled",
-          settings: mergedSettings,
-          updatedAt: new Date(),
-        })
-        .where(eq(communities.id, existingCommunity.id));
-      await replyWithAutoCleanup(
+      await syncActivationForExistingCommunity({
         ctx,
-        "Community reactivated for message tracking!"
-      );
+        db,
+        existingCommunity,
+        settings,
+      });
       return;
     }
 
@@ -305,25 +345,47 @@ export async function handleActivateCommunityCommand(
       displayName,
     });
 
-    // Create new community
-    await db.insert(communities).values({
-      chatId,
-      chatTitle: ctx.chat.title || "Untitled",
-      activatedBy: telegramUserId,
-      isPublic: false,
+    // Race-safe insert: another request may activate the same chat concurrently.
+    const inserted = await db
+      .insert(communities)
+      .values({
+        chatId,
+        chatTitle: ctx.chat.title || "Untitled",
+        activatedBy: telegramUserId,
+        isPublic: false,
+        settings,
+      })
+      .onConflictDoNothing()
+      .returning({ id: communities.id });
+
+    if (inserted.length > 0) {
+      await replyCommunitySuccess(
+        ctx,
+        "Community activated for message tracking!"
+      );
+      return;
+    }
+
+    const racedCommunity = await db.query.communities.findFirst({
+      where: eq(communities.chatId, chatId),
+    });
+    if (!racedCommunity) {
+      suppressCommunityFailure(
+        "/activate_community",
+        "insert_conflict_community_missing",
+        ctx
+      );
+      return;
+    }
+
+    await syncActivationForExistingCommunity({
+      ctx,
+      db,
+      existingCommunity: racedCommunity,
       settings,
     });
-
-    await replyWithAutoCleanup(
-      ctx,
-      "Community activated for message tracking!"
-    );
   } catch (error) {
-    console.error("Failed to activate community", error);
-    await replyWithAutoCleanup(
-      ctx,
-      "An error occurred while activating the community. Please try again."
-    );
+    suppressCommunityFailure("/activate_community", "internal_error", ctx, error);
   }
 }
 
@@ -360,28 +422,9 @@ export async function handleSummaryCommand(
       return;
     }
 
-    if (result.reason === "not_activated") {
-      await replyWithAutoCleanup(
-        ctx,
-        "This community is not activated. Use /activate_community to enable summaries."
-      );
-    } else if (result.reason === "notifications_disabled") {
-      await replyWithAutoCleanup(
-        ctx,
-        "Summary notifications are turned off for this community. Use /notifications to turn them on."
-      );
-    } else if (result.reason === "no_summaries") {
-      await replyWithAutoCleanup(
-        ctx,
-        "No summaries available yet. Summaries are generated daily when there's enough activity."
-      );
-    }
+    suppressCommunityFailure("/summary", result.reason, ctx);
   } catch (error) {
-    console.error("Failed to send summary", error);
-    await replyWithAutoCleanup(
-      ctx,
-      "An error occurred while fetching the summary. Please try again."
-    );
+    suppressCommunityFailure("/summary", "internal_error", ctx, error);
   }
 }
 
@@ -400,26 +443,30 @@ export async function handleNotificationsCommand(
 
   try {
     const db = getDatabase();
+    if (!ctx.from) {
+      suppressCommunityFailure("/notifications", "missing_user_context", ctx);
+      return;
+    }
+
+    const telegramUserId = BigInt(ctx.from.id);
+    if (!(await isWhitelistedAdmin(db, telegramUserId))) {
+      suppressCommunityFailure("/notifications", "unauthorized", ctx);
+      return;
+    }
+
     const chatId = BigInt(ctx.chat.id);
     const community = await db.query.communities.findFirst({
       where: eq(communities.chatId, chatId),
     });
 
     if (!community || !community.isActive) {
-      await replyWithAutoCleanup(
-        ctx,
-        "This community is not activated. Use /activate_community to enable summaries."
-      );
+      suppressCommunityFailure("/notifications", "not_activated", ctx);
       return;
     }
 
     await sendNotificationSettingsMessage(ctx, community);
   } catch (error) {
-    console.error("Failed to send notification settings", error);
-    await replyWithAutoCleanup(
-      ctx,
-      "An error occurred while loading notification settings. Please try again."
-    );
+    suppressCommunityFailure("/notifications", "internal_error", ctx, error);
   }
 }
 
@@ -483,16 +530,8 @@ export async function handleDeactivateCommunityCommand(
   try {
     const db = getDatabase();
 
-    // Check if user is in admin whitelist
-    const admin = await db.query.admins.findFirst({
-      where: eq(admins.telegramId, telegramUserId),
-    });
-
-    if (!admin) {
-      await replyWithAutoCleanup(
-        ctx,
-        "You are not authorized to deactivate communities. Contact an administrator to be added to the whitelist."
-      );
+    if (!(await isWhitelistedAdmin(db, telegramUserId))) {
+      suppressCommunityFailure("/deactivate_community", "unauthorized", ctx);
       return;
     }
 
@@ -504,12 +543,16 @@ export async function handleDeactivateCommunityCommand(
     });
 
     if (!existingCommunity) {
-      await replyWithAutoCleanup(ctx, "This community is not activated.");
+      suppressCommunityFailure("/deactivate_community", "not_activated", ctx);
       return;
     }
 
     if (!existingCommunity.isActive) {
-      await replyWithAutoCleanup(ctx, "This community is already deactivated.");
+      suppressCommunityFailure(
+        "/deactivate_community",
+        "already_deactivated",
+        ctx
+      );
       return;
     }
 
@@ -520,15 +563,16 @@ export async function handleDeactivateCommunityCommand(
       .where(eq(communities.id, existingCommunity.id));
 
     evictActiveCommunityCache(chatId);
-    await replyWithAutoCleanup(
+    await replyCommunitySuccess(
       ctx,
       "Community deactivated. Message tracking has been disabled."
     );
   } catch (error) {
-    console.error("Failed to deactivate community", error);
-    await replyWithAutoCleanup(
+    suppressCommunityFailure(
+      "/deactivate_community",
+      "internal_error",
       ctx,
-      "An error occurred while deactivating the community. Please try again."
+      error
     );
   }
 }
@@ -556,15 +600,19 @@ export async function handleHideCommunityCommand(
 
   try {
     const db = getDatabase();
-    await assertWhitelistedAdminOrThrow(db, telegramUserId, "HIDE");
+    if (!(await isWhitelistedAdmin(db, telegramUserId))) {
+      suppressCommunityFailure("/hide", "unauthorized", ctx);
+      return;
+    }
 
-    const existingCommunity = await findActiveCommunityOrReply(ctx, db);
+    const existingCommunity = await findActiveCommunity(ctx, db);
     if (!existingCommunity) {
+      suppressCommunityFailure("/hide", "not_activated", ctx);
       return;
     }
 
     if (!existingCommunity.isPublic) {
-      await replyWithAutoCleanup(ctx, "This community is already hidden.");
+      suppressCommunityFailure("/hide", "already_hidden", ctx);
       return;
     }
 
@@ -573,16 +621,9 @@ export async function handleHideCommunityCommand(
       .set({ isPublic: false, updatedAt: new Date() })
       .where(eq(communities.id, existingCommunity.id));
 
-    await replyWithAutoCleanup(ctx, "Community hidden from public summaries.");
+    await replyCommunitySuccess(ctx, "Community hidden from public summaries.");
   } catch (error) {
-    if (isUnauthorizedVisibilityError(error)) {
-      console.warn("Unauthorized /hide command attempt", error);
-      await replyWithAutoCleanup(ctx, UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
-      return;
-    }
-
-    console.error("Failed to hide community", error);
-    await replyWithAutoCleanup(ctx, VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
+    suppressCommunityFailure("/hide", "internal_error", ctx, error);
   }
 }
 
@@ -609,15 +650,19 @@ export async function handleUnhideCommunityCommand(
 
   try {
     const db = getDatabase();
-    await assertWhitelistedAdminOrThrow(db, telegramUserId, "UNHIDE");
+    if (!(await isWhitelistedAdmin(db, telegramUserId))) {
+      suppressCommunityFailure("/unhide", "unauthorized", ctx);
+      return;
+    }
 
-    const existingCommunity = await findActiveCommunityOrReply(ctx, db);
+    const existingCommunity = await findActiveCommunity(ctx, db);
     if (!existingCommunity) {
+      suppressCommunityFailure("/unhide", "not_activated", ctx);
       return;
     }
 
     if (existingCommunity.isPublic) {
-      await replyWithAutoCleanup(ctx, "This community is already visible.");
+      suppressCommunityFailure("/unhide", "already_visible", ctx);
       return;
     }
 
@@ -626,18 +671,11 @@ export async function handleUnhideCommunityCommand(
       .set({ isPublic: true, updatedAt: new Date() })
       .where(eq(communities.id, existingCommunity.id));
 
-    await replyWithAutoCleanup(
+    await replyCommunitySuccess(
       ctx,
       "Community is now visible in public summaries."
     );
   } catch (error) {
-    if (isUnauthorizedVisibilityError(error)) {
-      console.warn("Unauthorized /unhide command attempt", error);
-      await replyWithAutoCleanup(ctx, UNAUTHORIZED_VISIBILITY_REPLY_TEXT);
-      return;
-    }
-
-    console.error("Failed to unhide community", error);
-    await replyWithAutoCleanup(ctx, VISIBILITY_UPDATE_ERROR_REPLY_TEXT);
+    suppressCommunityFailure("/unhide", "internal_error", ctx, error);
   }
 }

--- a/app/src/lib/telegram/bot-api/helper-message-cleanup.ts
+++ b/app/src/lib/telegram/bot-api/helper-message-cleanup.ts
@@ -1,0 +1,82 @@
+import type { CommandContext, Context } from "grammy";
+
+import { getDatabase } from "@/lib/core/database";
+import { telegramHelperMessageCleanup } from "@/lib/core/schema";
+import { isCommunityChat } from "@/lib/telegram/utils";
+
+const DEFAULT_HELPER_MESSAGE_TTL_MS = 60_000;
+
+type ReplyContext = Pick<CommandContext<Context>, "chat" | "reply">;
+type ReplyOptions = Parameters<ReplyContext["reply"]>[1];
+type SendMessageApi = Pick<Context["api"], "sendMessage">;
+type SendMessageOptions = Parameters<SendMessageApi["sendMessage"]>[2];
+
+export async function scheduleHelperMessageDeletion(
+  chatId: bigint | number | string,
+  messageId: number,
+  ttlMs: number = DEFAULT_HELPER_MESSAGE_TTL_MS
+): Promise<void> {
+  try {
+    const db = getDatabase();
+    const now = Date.now();
+    const deleteAfter = new Date(now + Math.max(ttlMs, 0));
+
+    await db
+      .insert(telegramHelperMessageCleanup)
+      .values({
+        chatId: BigInt(chatId),
+        deleteAfter,
+        messageId,
+      })
+      .onConflictDoNothing();
+  } catch (error) {
+    console.error("Failed to schedule helper message cleanup", {
+      chatId: String(chatId),
+      error: error instanceof Error ? error.message : String(error),
+      messageId,
+      ttlMs,
+    });
+  }
+}
+
+export async function replyWithAutoCleanup(
+  ctx: ReplyContext,
+  text: string,
+  options?: ReplyOptions
+): Promise<void> {
+  const message = await ctx.reply(text, options);
+  if (!message || typeof message.message_id !== "number") {
+    return;
+  }
+
+  if (!ctx.chat || !isCommunityChat(ctx.chat.type)) {
+    return;
+  }
+
+  await scheduleHelperMessageDeletion(ctx.chat.id, message.message_id);
+}
+
+export async function sendMessageWithAutoCleanup(
+  params: {
+    api: SendMessageApi;
+    chatId: number | string;
+    chatType: string;
+    options?: SendMessageOptions;
+    text: string;
+  }
+): Promise<void> {
+  const message = await params.api.sendMessage(
+    params.chatId,
+    params.text,
+    params.options
+  );
+  if (!message || typeof message.message_id !== "number") {
+    return;
+  }
+
+  if (!isCommunityChat(params.chatType)) {
+    return;
+  }
+
+  await scheduleHelperMessageDeletion(params.chatId, message.message_id);
+}

--- a/app/src/lib/telegram/bot-api/notification-settings.ts
+++ b/app/src/lib/telegram/bot-api/notification-settings.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/core/schema";
 
 import { isMessageNotModifiedError } from "./callback-query-utils";
+import { replyWithAutoCleanup } from "./helper-message-cleanup";
 
 export const NOTIFICATION_SETTINGS_CALLBACK_PREFIX = "notif";
 export const NOTIFICATION_SETTINGS_CONTEXT = "settings";
@@ -125,7 +126,10 @@ export function buildNotificationSettingsKeyboard(
 ): InlineKeyboard {
   return new InlineKeyboard()
     .text(
-      renderButtonLabel("⏱ Off", community.summaryNotificationTimeHours === null),
+      renderButtonLabel(
+        "⏱ Off",
+        community.summaryNotificationTimeHours === null
+      ),
       encodeNotificationSettingsCallbackData({
         communityId: community.id,
         dimension: "time",
@@ -199,7 +203,7 @@ export async function sendNotificationSettingsMessage(
   ctx: CommandContext<Context>,
   community: NotificationSettingsState
 ): Promise<void> {
-  await ctx.reply(buildNotificationSettingsMessageText(), {
+  await replyWithAutoCleanup(ctx, buildNotificationSettingsMessageText(), {
     parse_mode: "HTML",
     reply_markup: buildNotificationSettingsKeyboard(community),
   });
@@ -208,7 +212,9 @@ export async function sendNotificationSettingsMessage(
 export async function handleNotificationSettingsCallback(
   ctx: CallbackQueryContext<Context>
 ): Promise<void> {
-  const callbackData = parseNotificationSettingsCallbackData(ctx.callbackQuery.data);
+  const callbackData = parseNotificationSettingsCallbackData(
+    ctx.callbackQuery.data
+  );
   if (!callbackData) {
     await ctx.answerCallbackQuery();
     return;

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,6 +1,10 @@
 {
   "crons": [
     {
+      "path": "/api/cron/telegram-helper-cleanup",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/summaries",
       "schedule": "0 6 * * *"
     }

--- a/docs/miniapp/database.md
+++ b/docs/miniapp/database.md
@@ -119,3 +119,4 @@ export type InsertUser = typeof users.$inferInsert;
 | `businessConnections` | Telegram Business bot connections to user accounts                                     |
 | `botThreads`          | Bot conversation sessions (supports Telegram threaded messages)                        |
 | `botMessages`         | Individual encrypted messages within bot threads                                       |
+| `telegramHelperMessageCleanup` | Queue of helper/community bot messages scheduled for delayed deletion (idempotent by chat + message id) |

--- a/docs/onboarding/add-bot-and-activate-community.md
+++ b/docs/onboarding/add-bot-and-activate-community.md
@@ -62,7 +62,8 @@ The webhook handles this by creating or updating the community row as:
 - `isActive = false`
 - `isPublic = false`
 
-The bot also sends a short onboarding message in chat with next steps.
+The bot also sends a short onboarding message in chat with next steps.  
+In community chats, this onboarding helper message is auto-cleaned after a short delay (typically within 1-2 minutes).
 
 ## Activate Community
 
@@ -140,5 +141,6 @@ After successful activation:
 ## Notes
 
 - Summary generation/delivery is scheduled via `/api/cron/summaries`, not immediate at activation time.
+- Helper message cleanup is handled by `/api/cron/telegram-helper-cleanup` (every minute) and uses the same `CRON_SECRET` bearer auth pattern.
 - Activation only enables tracking and eligibility for subsequent summary runs.
 - `/summary` and scheduled summary notifications both respect the community notification master switch.

--- a/docs/onboarding/notifications.md
+++ b/docs/onboarding/notifications.md
@@ -12,6 +12,7 @@ This guide explains how admins configure summary notification settings for an ac
 
 1. In the activated community chat, run `/notifications`.
 2. The bot sends an inline settings panel for that community.
+3. The settings panel is a helper message and is auto-cleaned from community chats after a short delay (typically within 1-2 minutes).
 
 If the community is not activated, expected response is:
 
@@ -22,7 +23,6 @@ If the community is not activated, expected response is:
 Use the inline buttons in the panel:
 
 - Time trigger: `Off`, `24h`, `48h`
-- Message trigger: `Off`, `500`, `1000`
 - Master switch: `Off`, `On`
 
 Each successful change updates the panel and shows:
@@ -47,10 +47,11 @@ Each successful change updates the panel and shows:
 1. Confirm `/notifications` works in the target community.
 2. Toggle each setting once to verify update path.
 3. Ensure the final setting combination matches community preference.
-4. Re-run `/notifications` if Telegram shows a stale panel.
+4. Re-run `/notifications` if Telegram shows a stale panel or if the helper panel was already auto-cleaned.
 
 ## Notes
 
 - Keep this as an admin-only operation controlled by the whitelist.
 - Notification configuration is per-community and can be changed any time.
 - If the master switch is `Off`, the bot will not post summary messages to that community chat, including `/summary` command responses and scheduled notifications.
+- Helper/command UI messages in community chats are auto-cleaned via queue + cron; summary delivery posts are not part of that cleanup path.


### PR DESCRIPTION
This change applies a success-only reply policy for community chat commands to reduce group spam, while preserving logging for suppressed outcomes. It also gates /notifications at command entry for whitelisted admins and adds tests for suppression behavior and activation race handling.