### PR TITLE
fix(telegram): ensure user settings on user creation

### DIFF
--- a/app/src/lib/telegram/__tests__/user-service.test.ts
+++ b/app/src/lib/telegram/__tests__/user-service.test.ts
@@ -97,6 +97,16 @@ describe("getOrCreateUser", () => {
     expect(userId).toBe("user-conflict");
     expect(findFirstCalls).toHaveLength(2);
     expect(insertReturningCallCount).toBe(1);
+    expect(insertCalls).toEqual([
+      {
+        telegramId: BigInt("2001"),
+        username: "user-conflict",
+        displayName: "User Conflict",
+      },
+      {
+        userId: "user-conflict",
+      },
+    ]);
   });
 
   test("backfills avatar URL for newly inserted user", async () => {
@@ -115,6 +125,16 @@ describe("getOrCreateUser", () => {
     expect(updateCalls[0]).toMatchObject({
       avatarUrl: "https://cdn.example.com/avatar.jpg",
     });
+    expect(insertCalls).toEqual([
+      {
+        telegramId: BigInt("2002"),
+        username: "user-new",
+        displayName: "User New",
+      },
+      {
+        userId: "user-new",
+      },
+    ]);
   });
 
   test("skips avatar capture for existing user with avatar URL", async () => {
@@ -136,6 +156,11 @@ describe("getOrCreateUser", () => {
     expect(second).toBe("user-has-avatar");
     expect(findFirstCalls).toHaveLength(1);
     expect(captureCalls).toHaveLength(0);
+    expect(insertCalls).toEqual([
+      {
+        userId: "user-has-avatar",
+      },
+    ]);
   });
 
   test("deduplicates concurrent get/create requests for the same user", async () => {
@@ -159,6 +184,15 @@ describe("getOrCreateUser", () => {
     expect(first).toBe("user-inflight");
     expect(second).toBe("user-inflight");
     expect(insertReturningCallCount).toBe(1);
+    expect(insertCalls).toEqual([
+      {
+        telegramId: BigInt("2004"),
+        username: "inflight",
+        displayName: "Inflight",
+      },
+      {
+        userId: "user-inflight",
+      },
+    ]);
   });
 });
-

--- a/app/src/lib/telegram/user-service.ts
+++ b/app/src/lib/telegram/user-service.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { getDatabase } from "@/lib/core/database";
-import { userSettings, users } from "@/lib/core/schema";
+import { users, userSettings } from "@/lib/core/schema";
 import { captureTelegramProfilePhotoToCdn } from "@/lib/telegram/profile-photo-service";
 
 type KnownUser = {

--- a/app/src/lib/telegram/user-service.ts
+++ b/app/src/lib/telegram/user-service.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { getDatabase } from "@/lib/core/database";
-import { users } from "@/lib/core/schema";
+import { userSettings, users } from "@/lib/core/schema";
 import { captureTelegramProfilePhotoToCdn } from "@/lib/telegram/profile-photo-service";
 
 type KnownUser = {
@@ -56,6 +56,11 @@ async function backfillUserAvatar(
   return backfillPromise;
 }
 
+async function ensureUserSettingsForUserId(userId: string): Promise<void> {
+  const db = getDatabase();
+  await db.insert(userSettings).values({ userId }).onConflictDoNothing();
+}
+
 async function resolveOrCreateUser(
   telegramId: bigint,
   userData: {
@@ -74,6 +79,8 @@ async function resolveOrCreateUser(
   });
 
   if (existingUser) {
+    await ensureUserSettingsForUserId(existingUser.id);
+
     const hasAvatar = Boolean(existingUser.avatarUrl);
     knownUsers.set(telegramIdStr, {
       id: existingUser.id,
@@ -113,6 +120,8 @@ async function resolveOrCreateUser(
   if (!userRecord) {
     throw new Error(`Failed to resolve user ${telegramIdStr} after conflict`);
   }
+
+  await ensureUserSettingsForUserId(userRecord.id);
 
   const hasAvatar = Boolean(userRecord.avatarUrl);
   knownUsers.set(telegramIdStr, {


### PR DESCRIPTION
Ensure getOrCreateUser always creates a corresponding user_settings row before returning a user ID. Add user-service tests to verify settings creation across existing, new, conflict, and concurrent paths.