### PR TITLE
feat(telegram): add verify biometrics Mixpanel tracking

### DIFF
--- a/app/src/app/telegram/verify/__tests__/verify-analytics.test.ts
+++ b/app/src/app/telegram/verify/__tests__/verify-analytics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  VERIFY_ANALYTICS_EVENTS,
+  VERIFY_ANALYTICS_PATH,
+  VERIFY_BIOMETRICS_OUTCOMES,
+} from "../verify-analytics";
+
+describe("verify analytics constants", () => {
+  test("uses the verify path expected by event tracking", () => {
+    expect(VERIFY_ANALYTICS_PATH).toBe("/telegram/verify");
+  });
+
+  test("keeps verify event names stable", () => {
+    expect(VERIFY_ANALYTICS_EVENTS).toEqual({
+      openEnableBiometrics: 'Open "Enable Biometrics"',
+      openVerify: 'Open "Verify"',
+      verifyBiometrics: "Verify Biometrics",
+      verifyBiometricsFailed: "Verify Biometrics Failed",
+    });
+  });
+
+  test("keeps biometrics outcomes stable", () => {
+    expect(VERIFY_BIOMETRICS_OUTCOMES).toEqual({
+      authorized: "authorized",
+      denied: "denied",
+      error: "error",
+      not_available: "not_available",
+    });
+  });
+});

--- a/app/src/app/telegram/verify/verify-analytics.ts
+++ b/app/src/app/telegram/verify/verify-analytics.ts
@@ -1,0 +1,18 @@
+export const VERIFY_ANALYTICS_PATH = "/telegram/verify";
+
+export const VERIFY_ANALYTICS_EVENTS = {
+  openEnableBiometrics: 'Open "Enable Biometrics"',
+  openVerify: 'Open "Verify"',
+  verifyBiometrics: "Verify Biometrics",
+  verifyBiometricsFailed: "Verify Biometrics Failed",
+} as const;
+
+export const VERIFY_BIOMETRICS_OUTCOMES = {
+  authorized: "authorized",
+  denied: "denied",
+  error: "error",
+  not_available: "not_available",
+} as const;
+
+export type VerifyBiometricsOutcome =
+  (typeof VERIFY_BIOMETRICS_OUTCOMES)[keyof typeof VERIFY_BIOMETRICS_OUTCOMES];


### PR DESCRIPTION
Add Mixpanel analytics for /telegram/verify biometrics actions, including enable access and verify attempt/outcome events.\n\nThis introduces verify analytics constants and tests to keep event names and outcome keys stable.