### PR TITLE
fix(app/wallet): enable secure balance autoreload. fix secure send Max button

### DIFF
--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -2117,7 +2117,14 @@ export default function Home() {
           (holdings) => {
             if (isCancelled) return;
             holdingsFetchIdRef.current += 1;
-            setTokenHoldings(holdings);
+            // Preserve secured entries managed by the secure balance
+            // subscription — fetchTokenHoldings only returns regular holdings.
+            setTokenHoldings((prev) => {
+              const existingSecured = prev.filter((h) => h.isSecured);
+              return existingSecured.length > 0
+                ? [...holdings, ...existingSecured]
+                : holdings;
+            });
             hasLoadedHoldingsRef.current = true;
             setIsHoldingsLoading(false);
           },

--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -1351,9 +1351,10 @@ export default function SendSheet({
                 <button
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
+                    const isSecured = selectedToken?.isSecured === true;
                     if (currency === "SOL") {
                       const maxVal = truncateDecimals(
-                        Math.max(0, balanceInSol - SOLANA_FEE_SOL),
+                        Math.max(0, isSecured ? balanceInSol : balanceInSol - SOLANA_FEE_SOL),
                         4
                       ).replace(/\.?0+$/, "");
                       handlePresetAmount(maxVal || "0");
@@ -1364,7 +1365,7 @@ export default function SendSheet({
                       const maxVal =
                         balanceInUsd !== null
                           ? truncateDecimals(
-                              Math.max(0, balanceInUsd - feeUsd),
+                              Math.max(0, isSecured ? balanceInUsd : balanceInUsd - feeUsd),
                               2
                             ).replace(/\.?0+$/, "")
                           : "0";


### PR DESCRIPTION
- Secure balance now changes after Shield/Unshield
- Send Max button do not deduct fees for Secure assets