### PR TITLE
fix(ui): prioritize Vercel env vars for git branch display

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,14 +2,22 @@ import { execSync } from "child_process";
 import type { NextConfig } from "next";
 
 function getGitInfo() {
+  const vercelCommit = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7);
+  const vercelBranch = process.env.VERCEL_GIT_COMMIT_REF;
+
   try {
-    const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
-    const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+    const commitHash =
+      vercelCommit || execSync("git rev-parse --short HEAD").toString().trim();
+    const gitBranch = execSync("git rev-parse --abbrev-ref HEAD")
+      .toString()
+      .trim();
+    const branch =
+      vercelBranch || (gitBranch !== "HEAD" ? gitBranch : "unknown");
     return { commitHash, branch };
   } catch {
     return {
-      commitHash: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "unknown",
-      branch: process.env.VERCEL_GIT_COMMIT_REF ?? "unknown",
+      commitHash: vercelCommit ?? "unknown",
+      branch: vercelBranch ?? "unknown",
     };
   }
 }


### PR DESCRIPTION
Prioritize Vercel environment variables (`VERCEL_GIT_COMMIT_REF`, `VERCEL_GIT_COMMIT_SHA`) over git commands in `next.config.ts` so the profile page shows the correct branch name on deployed builds instead of "master".