### PR TITLE
fix(wallet): fix claim success state, refresh cache, and stale closure

### DIFF
--- a/app/src/app/telegram/wallet/hooks/useIncomingDeposits.ts
+++ b/app/src/app/telegram/wallet/hooks/useIncomingDeposits.ts
@@ -153,6 +153,7 @@ export function useIncomingDeposits(params: {
 
         // Trigger confetti celebration
         setShowConfetti(true);
+        setShowClaimSuccess(true);
 
         // Extended intense haptic pattern for celebration
         if (hapticFeedback.impactOccurred.isAvailable()) {


### PR DESCRIPTION
## Summary
- Fix `showClaimSuccess` never being set to `true` after a successful deposit claim, so the Done button and success UI in TransactionDetailsSheet now render correctly
- Replace inline deposit mapping in pull-to-refresh with shared `mapDepositToIncomingTransaction` utility and update the incoming transactions cache
- Add `refreshBalance` to `handleSubmitSecure` dependency array to prevent stale closure