### PR TITLE
feat(wallet): add pull-to-refresh to wallet page

### DIFF
--- a/app/src/app/telegram/wallet/components/PullToRefreshIndicator.tsx
+++ b/app/src/app/telegram/wallet/components/PullToRefreshIndicator.tsx
@@ -1,0 +1,36 @@
+interface PullToRefreshIndicatorProps {
+  pullDistance: number;
+  isRefreshing: boolean;
+  threshold: number;
+}
+
+export function PullToRefreshIndicator({
+  pullDistance,
+  isRefreshing,
+  threshold,
+}: PullToRefreshIndicatorProps) {
+  if (pullDistance === 0 && !isRefreshing) return null;
+
+  const progress = Math.min(pullDistance / threshold, 1);
+
+  return (
+    <div
+      className="absolute left-0 right-0 flex justify-center pointer-events-none"
+      style={{
+        top: -40,
+        opacity: isRefreshing ? 1 : progress,
+      }}
+    >
+      {isRefreshing ? (
+        <div className="w-6 h-6 border-2 border-black/10 border-t-black/40 rounded-full animate-spin" />
+      ) : (
+        <div
+          className="w-6 h-6 border-2 border-black/10 border-t-black/40 rounded-full"
+          style={{
+            transform: `rotate(${progress * 360}deg)`,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/src/app/telegram/wallet/hooks/usePullToRefresh.ts
+++ b/app/src/app/telegram/wallet/hooks/usePullToRefresh.ts
@@ -1,0 +1,128 @@
+import { hapticFeedback } from "@telegram-apps/sdk-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const PULL_THRESHOLD = 80;
+const MAX_PULL = 140;
+const REFRESH_HOLD_DISTANCE = 60;
+const RESISTANCE = 0.45;
+const AXIS_LOCK_RATIO = 1.5;
+
+interface UsePullToRefreshOptions {
+  onRefresh: () => Promise<void>;
+  disabled?: boolean;
+}
+
+export function usePullToRefresh({
+  onRefresh,
+  disabled = false,
+}: UsePullToRefreshOptions) {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const startYRef = useRef(0);
+  const startXRef = useRef(0);
+  const isPullingRef = useRef(false);
+  const axisLockedRef = useRef<"vertical" | "horizontal" | null>(null);
+  const crossedThresholdRef = useRef(false);
+
+  const handleRefreshEnd = useCallback(() => {
+    setIsRefreshing(false);
+    setPullDistance(0);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || disabled) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (isRefreshing) return;
+      if (window.scrollY > 0) return;
+
+      const touch = e.touches[0];
+      startYRef.current = touch.clientY;
+      startXRef.current = touch.clientX;
+      isPullingRef.current = false;
+      axisLockedRef.current = null;
+      crossedThresholdRef.current = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (isRefreshing) return;
+
+      const touch = e.touches[0];
+      const deltaY = touch.clientY - startYRef.current;
+      const deltaX = touch.clientX - startXRef.current;
+
+      // Lock axis on first significant movement
+      if (axisLockedRef.current === null) {
+        const absY = Math.abs(deltaY);
+        const absX = Math.abs(deltaX);
+        if (absY < 5 && absX < 5) return;
+
+        if (absY > absX * AXIS_LOCK_RATIO) {
+          axisLockedRef.current = "vertical";
+        } else {
+          axisLockedRef.current = "horizontal";
+          return;
+        }
+      }
+
+      if (axisLockedRef.current === "horizontal") return;
+
+      // Only activate when at top of page and pulling down
+      if (deltaY <= 0 || window.scrollY > 0) {
+        if (isPullingRef.current) {
+          isPullingRef.current = false;
+          setPullDistance(0);
+        }
+        return;
+      }
+
+      e.preventDefault();
+      isPullingRef.current = true;
+
+      const distance = Math.min(deltaY * RESISTANCE, MAX_PULL);
+      setPullDistance(distance);
+
+      // Haptic on threshold crossing
+      if (
+        !crossedThresholdRef.current &&
+        distance >= PULL_THRESHOLD &&
+        hapticFeedback.impactOccurred.isAvailable()
+      ) {
+        crossedThresholdRef.current = true;
+        hapticFeedback.impactOccurred("light");
+      }
+      if (crossedThresholdRef.current && distance < PULL_THRESHOLD) {
+        crossedThresholdRef.current = false;
+      }
+    };
+
+    const onTouchEnd = () => {
+      if (isRefreshing || !isPullingRef.current) return;
+      isPullingRef.current = false;
+      axisLockedRef.current = null;
+
+      if (pullDistance >= PULL_THRESHOLD) {
+        setIsRefreshing(true);
+        setPullDistance(REFRESH_HOLD_DISTANCE);
+        onRefresh().finally(handleRefreshEnd);
+      } else {
+        setPullDistance(0);
+      }
+    };
+
+    container.addEventListener("touchstart", onTouchStart, { passive: true });
+    container.addEventListener("touchmove", onTouchMove, { passive: false });
+    container.addEventListener("touchend", onTouchEnd, { passive: true });
+
+    return () => {
+      container.removeEventListener("touchstart", onTouchStart);
+      container.removeEventListener("touchmove", onTouchMove);
+      container.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [disabled, isRefreshing, pullDistance, onRefresh, handleRefreshEnd]);
+
+  return { pullDistance, isRefreshing, containerRef };
+}


### PR DESCRIPTION
## Summary
- Custom pull-to-refresh with touch gesture detection, rubber-band resistance, axis locking (avoids banner swipe conflicts), and haptic feedback
- Activates the existing unused `_handleRefresh` callback to refresh balance, tokens, SOL price, transactions, and incoming deposits
- Disabled when any sheet is open to prevent gesture conflicts