### PR TITLE
fix(monitoring): disable session replay recording

### DIFF
--- a/app/src/lib/core/datadog.ts
+++ b/app/src/lib/core/datadog.ts
@@ -32,7 +32,7 @@ export function initDatadog() {
     ...sharedConfig,
     applicationId: "67ad7dc6-b0d4-4ef4-9dec-3ded01bf7a9a",
     sessionSampleRate: 100,
-    sessionReplaySampleRate: 20,
+    sessionReplaySampleRate: 0,
     trackUserInteractions: true,
     trackResources: true,
     trackLongTasks: true,


### PR DESCRIPTION
## Summary
- Set `sessionReplaySampleRate` to 0 to disable DOM-based session replay recordings