### PR TITLE
fix(api): remove invalid "use server" from route handlers and fix URL resolution

### DIFF
--- a/app/src/app/api/gasless/claim/route.ts
+++ b/app/src/app/api/gasless/claim/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
 import {
   Ed25519Program,

--- a/app/src/app/api/jupiter/execute/route.ts
+++ b/app/src/app/api/jupiter/execute/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { NextResponse } from "next/server";
 
 import { SWAP_ERRORS } from "@/lib/jupiter/constants";

--- a/app/src/app/api/jupiter/order/route.ts
+++ b/app/src/app/api/jupiter/order/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { PublicKey } from "@solana/web3.js";
 import { NextResponse } from "next/server";
 

--- a/app/src/app/api/telegram/settings/route.ts
+++ b/app/src/app/api/telegram/settings/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 

--- a/app/src/app/api/telegram/share/route.ts
+++ b/app/src/app/api/telegram/share/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { NextResponse } from "next/server";
 
 import { resolveEndpoint } from "@/lib/core/api";
@@ -8,14 +6,15 @@ import { createValidationBytesFromRawInitData } from "@/lib/telegram/mini-app/in
 import { cleanInitData } from "@/lib/telegram/mini-app/init-data-transform";
 import { verifyInitData } from "@/lib/telegram/mini-app/verify-init-data";
 
-const getPhotoUrl = async (
+const getPhotoUrl = (
+  requestUrl: string,
   senderUsername: string,
   receiverUsername: string,
   solAmount: number,
   usdAmount: number
 ) => {
-  const endpoint = resolveEndpoint("api/og/share");
-  const url = new URL(endpoint);
+  const endpoint = resolveEndpoint("/api/og/share");
+  const url = new URL(endpoint, requestUrl);
   url.searchParams.set("sender", senderUsername);
   url.searchParams.set("receiver", receiverUsername);
   url.searchParams.set("solAmount", solAmount.toString());
@@ -78,7 +77,8 @@ export async function POST(req: Request) {
     }
 
     const userId = user.id;
-    const photoUrl = await getPhotoUrl(
+    const photoUrl = getPhotoUrl(
+      req.url,
       senderUsername,
       receiverUsername,
       solAmount,

--- a/app/src/app/api/telegram/verify/emoji/route.ts
+++ b/app/src/app/api/telegram/verify/emoji/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { NextResponse } from "next/server";
 
 import { hasCustomEmoji } from "@/lib/telegram/bot-api/check-custom-emoji";

--- a/app/src/app/api/telegram/verify/join/route.ts
+++ b/app/src/app/api/telegram/verify/join/route.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { NextResponse } from "next/server";
 
 import { checkChatParticipation } from "@/lib/telegram/bot-api/check-chat-participation";

--- a/app/src/app/telegram/profile/page.tsx
+++ b/app/src/app/telegram/profile/page.tsx
@@ -237,7 +237,7 @@ export default function ProfilePage() {
   useEffect(() => {
     if (!rawInitData) return;
     const endpoint = resolveEndpoint(
-      `api/telegram/settings?initData=${encodeURIComponent(rawInitData)}`,
+      `/api/telegram/settings?initData=${encodeURIComponent(rawInitData)}`,
     );
     fetch(endpoint)
       .then((res) => (res.ok ? res.json() : null))
@@ -453,7 +453,7 @@ export default function ProfilePage() {
                 onChange: (checked) => {
                   setBotNotifications(checked);
                   if (!rawInitData) return;
-                  const endpoint = resolveEndpoint("api/telegram/settings");
+                  const endpoint = resolveEndpoint("/api/telegram/settings");
                   fetch(endpoint, {
                     method: "PATCH",
                     headers: { "Content-Type": "application/json" },

--- a/app/src/lib/telegram/mini-app/share-message.ts
+++ b/app/src/lib/telegram/mini-app/share-message.ts
@@ -15,9 +15,7 @@ export const createShareMessage = async (
   solAmount: number,
   usdAmount: number
 ): Promise<string> => {
-  const endpoint = resolveEndpoint("api/telegram/share");
-  console.log("endpoint", endpoint);
-  //put all the data into the body
+  const endpoint = resolveEndpoint("/api/telegram/share");
   const body = JSON.stringify({
     rawInitData,
     receiverUsername,


### PR DESCRIPTION
## Summary
- Removed `"use server"` directive from 7 route handler files — this directive is only for Server Actions and prevents Next.js from registering HTTP exports, causing 404s
- Fixed missing leading `/` in `resolveEndpoint()` calls that caused relative URL resolution failures in client-side fetches and server-side `new URL()` construction