### PR TITLE
fix(wallet): persist and track wallet banner preferences

### DIFF
--- a/app/src/app/telegram/wallet/__tests__/wallet-analytics.test.ts
+++ b/app/src/app/telegram/wallet/__tests__/wallet-analytics.test.ts
@@ -23,6 +23,8 @@ describe("wallet analytics constants", () => {
       swapTokens: "Swap tokens",
       swapTokensFailed: "Swap tokens Failed",
       claimFunds: "Claim funds",
+      pressWalletBanner: 'Press "Wallet banner"',
+      closeWalletBanner: 'Close "Wallet banner"',
     });
   });
 

--- a/app/src/app/telegram/wallet/wallet-analytics.ts
+++ b/app/src/app/telegram/wallet/wallet-analytics.ts
@@ -15,6 +15,8 @@ export const WALLET_ANALYTICS_EVENTS = {
   swapTokens: "Swap tokens",
   swapTokensFailed: "Swap tokens Failed",
   claimFunds: "Claim funds",
+  pressWalletBanner: 'Press "Wallet banner"',
+  closeWalletBanner: 'Close "Wallet banner"',
 } as const;
 
 export const SEND_METHODS = {

--- a/app/src/components/wallet/__tests__/banner-analytics.test.ts
+++ b/app/src/components/wallet/__tests__/banner-analytics.test.ts
@@ -1,0 +1,55 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const trackCalls: Array<{
+  event: string;
+  properties?: Record<string, unknown>;
+}> = [];
+
+mock.module("@/lib/core/analytics", () => ({
+  track: (event: string, properties?: Record<string, unknown>) => {
+    trackCalls.push({ event, properties });
+  },
+}));
+
+let trackWalletBannerClose: typeof import("../banner-analytics").trackWalletBannerClose;
+let trackWalletBannerPress: typeof import("../banner-analytics").trackWalletBannerPress;
+
+beforeAll(async () => {
+  const loaded = await import("../banner-analytics");
+  trackWalletBannerClose = loaded.trackWalletBannerClose;
+  trackWalletBannerPress = loaded.trackWalletBannerPress;
+});
+
+beforeEach(() => {
+  trackCalls.length = 0;
+});
+
+describe("banner analytics", () => {
+  test("tracks press with expected event and properties", () => {
+    trackWalletBannerPress("emoji-status");
+
+    expect(trackCalls).toEqual([
+      {
+        event: 'Press "Wallet banner"',
+        properties: {
+          path: "/telegram/wallet",
+          banner_id: "emoji-status",
+        },
+      },
+    ]);
+  });
+
+  test("tracks close with expected event and properties", () => {
+    trackWalletBannerClose("community-summary");
+
+    expect(trackCalls).toEqual([
+      {
+        event: 'Close "Wallet banner"',
+        properties: {
+          path: "/telegram/wallet",
+          banner_id: "community-summary",
+        },
+      },
+    ]);
+  });
+});

--- a/app/src/components/wallet/__tests__/banner-dismissals.test.ts
+++ b/app/src/components/wallet/__tests__/banner-dismissals.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getCloudValueCalls: string[] = [];
+const setCloudValueCalls: Array<{ key: string; value: string }> = [];
+
+let storedCloudValue: string | null = null;
+let getCloudValueImpl: (key: string) => Promise<string | null> = async () =>
+  storedCloudValue;
+let setCloudValueImpl: (key: string, value: string) => Promise<boolean> =
+  async (_key: string, value: string) => {
+    storedCloudValue = value;
+    return true;
+  };
+
+mock.module("@/lib/telegram/mini-app/cloud-storage", () => ({
+  getCloudValue: async (key: string) => {
+    getCloudValueCalls.push(key);
+    return getCloudValueImpl(key);
+  },
+  setCloudValue: async (key: string, value: string) => {
+    setCloudValueCalls.push({ key, value });
+    return setCloudValueImpl(key, value);
+  },
+}));
+
+let loadDismissedBannerIds: typeof import("../banner-dismissals").loadDismissedBannerIds;
+let saveDismissedBannerIds: typeof import("../banner-dismissals").saveDismissedBannerIds;
+let getCachedDismissedBannerIds: typeof import("../banner-dismissals").getCachedDismissedBannerIds;
+let clearDismissedBannerIdsCacheForTests: typeof import("../banner-dismissals").clearDismissedBannerIdsCacheForTests;
+
+beforeAll(async () => {
+  const loaded = await import("../banner-dismissals");
+  loadDismissedBannerIds = loaded.loadDismissedBannerIds;
+  saveDismissedBannerIds = loaded.saveDismissedBannerIds;
+  getCachedDismissedBannerIds = loaded.getCachedDismissedBannerIds;
+  clearDismissedBannerIdsCacheForTests = loaded.clearDismissedBannerIdsCacheForTests;
+});
+
+beforeEach(() => {
+  getCloudValueCalls.length = 0;
+  setCloudValueCalls.length = 0;
+  storedCloudValue = null;
+  getCloudValueImpl = async () => storedCloudValue;
+  setCloudValueImpl = async (_key: string, value: string) => {
+    storedCloudValue = value;
+    return true;
+  };
+  clearDismissedBannerIdsCacheForTests();
+});
+
+describe("banner dismissals persistence", () => {
+  test("returns empty set when no value is stored", async () => {
+    const dismissed = await loadDismissedBannerIds();
+
+    expect([...dismissed]).toEqual([]);
+    expect(getCloudValueCalls).toHaveLength(1);
+  });
+
+  test("ignores malformed or non-array payloads", async () => {
+    getCloudValueImpl = async () => "{bad-json";
+    const malformed = await loadDismissedBannerIds();
+    expect([...malformed]).toEqual([]);
+
+    clearDismissedBannerIdsCacheForTests();
+
+    getCloudValueImpl = async () => JSON.stringify({ id: "emoji-status" });
+    const nonArray = await loadDismissedBannerIds();
+    expect([...nonArray]).toEqual([]);
+  });
+
+  test("retries read on subsequent load when the first read fails", async () => {
+    let attempts = 0;
+    getCloudValueImpl = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("temporary read failure");
+      }
+      return JSON.stringify(["home-screen"]);
+    };
+
+    const first = await loadDismissedBannerIds();
+    expect([...first]).toEqual([]);
+    expect(getCachedDismissedBannerIds()).toBeUndefined();
+    expect(getCloudValueCalls).toHaveLength(1);
+
+    const second = await loadDismissedBannerIds();
+    expect([...second]).toEqual(["home-screen"]);
+    expect(getCloudValueCalls).toHaveLength(2);
+
+    const third = await loadDismissedBannerIds();
+    expect([...third]).toEqual(["home-screen"]);
+    expect(getCloudValueCalls).toHaveLength(2);
+  });
+
+  test("deduplicates IDs and persists valid JSON", async () => {
+    await saveDismissedBannerIds([
+      "emoji-status",
+      "home-screen",
+      "emoji-status",
+    ]);
+
+    expect(setCloudValueCalls).toHaveLength(1);
+    expect(setCloudValueCalls[0]?.key).toBe("wallet_dismissed_banners_v1");
+    expect(JSON.parse(setCloudValueCalls[0]?.value ?? "[]")).toEqual([
+      "emoji-status",
+      "home-screen",
+    ]);
+  });
+
+  test("uses in-memory cache after first load", async () => {
+    getCloudValueImpl = async () => JSON.stringify(["community-summary"]);
+
+    const first = await loadDismissedBannerIds();
+    expect([...first]).toEqual(["community-summary"]);
+    expect(getCloudValueCalls).toHaveLength(1);
+
+    getCloudValueImpl = async () => JSON.stringify(["home-screen"]);
+
+    const second = await loadDismissedBannerIds();
+    expect([...second]).toEqual(["community-summary"]);
+    expect(getCloudValueCalls).toHaveLength(1);
+
+    const cached = getCachedDismissedBannerIds();
+    expect([...(cached ?? new Set())]).toEqual(["community-summary"]);
+  });
+});

--- a/app/src/components/wallet/banner-analytics.ts
+++ b/app/src/components/wallet/banner-analytics.ts
@@ -1,0 +1,19 @@
+import {
+  WALLET_ANALYTICS_EVENTS,
+  WALLET_ANALYTICS_PATH,
+} from "@/app/telegram/wallet/wallet-analytics";
+import { track } from "@/lib/core/analytics";
+
+export function trackWalletBannerPress(bannerId: string): void {
+  track(WALLET_ANALYTICS_EVENTS.pressWalletBanner, {
+    path: WALLET_ANALYTICS_PATH,
+    banner_id: bannerId,
+  });
+}
+
+export function trackWalletBannerClose(bannerId: string): void {
+  track(WALLET_ANALYTICS_EVENTS.closeWalletBanner, {
+    path: WALLET_ANALYTICS_PATH,
+    banner_id: bannerId,
+  });
+}

--- a/app/src/components/wallet/banner-dismissals.ts
+++ b/app/src/components/wallet/banner-dismissals.ts
@@ -1,0 +1,84 @@
+import {
+  getCloudValue,
+  setCloudValue,
+} from "@/lib/telegram/mini-app/cloud-storage";
+
+const DISMISSED_BANNERS_KEY = "wallet_dismissed_banners_v1";
+
+let hasLoadedDismissedBannerIds = false;
+let cachedDismissedBannerIds = new Set<string>();
+
+const cloneSet = (ids: Set<string>): Set<string> => new Set(ids);
+
+const parseDismissedBannerIds = (rawValue: string): Set<string> => {
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) return new Set();
+
+    const validIds = parsed.filter(
+      (id): id is string => typeof id === "string" && id.length > 0
+    );
+
+    return new Set(validIds);
+  } catch {
+    return new Set();
+  }
+};
+
+export const getCachedDismissedBannerIds = (): Set<string> | undefined => {
+  if (!hasLoadedDismissedBannerIds) return undefined;
+  return cloneSet(cachedDismissedBannerIds);
+};
+
+export async function loadDismissedBannerIds(): Promise<Set<string>> {
+  if (hasLoadedDismissedBannerIds) {
+    return cloneSet(cachedDismissedBannerIds);
+  }
+
+  try {
+    const stored = await getCloudValue(DISMISSED_BANNERS_KEY);
+
+    // A dismissal may have happened while cloud storage request was in-flight.
+    if (hasLoadedDismissedBannerIds) {
+      return cloneSet(cachedDismissedBannerIds);
+    }
+
+    if (typeof stored === "string" && stored.length > 0) {
+      cachedDismissedBannerIds = parseDismissedBannerIds(stored);
+    } else {
+      cachedDismissedBannerIds = new Set();
+    }
+
+    hasLoadedDismissedBannerIds = true;
+    return cloneSet(cachedDismissedBannerIds);
+  } catch (error) {
+    console.error("Failed to load dismissed wallet banners", error);
+  }
+
+  // Retry on next remount/load attempt; do not mark as loaded on failure.
+  return new Set();
+}
+
+export async function saveDismissedBannerIds(ids: Iterable<string>): Promise<void> {
+  const uniqueIds = new Set<string>();
+
+  for (const id of ids) {
+    if (typeof id === "string" && id.length > 0) {
+      uniqueIds.add(id);
+    }
+  }
+
+  cachedDismissedBannerIds = uniqueIds;
+  hasLoadedDismissedBannerIds = true;
+
+  try {
+    await setCloudValue(DISMISSED_BANNERS_KEY, JSON.stringify([...uniqueIds]));
+  } catch (error) {
+    console.error("Failed to save dismissed wallet banners", error);
+  }
+}
+
+export const clearDismissedBannerIdsCacheForTests = (): void => {
+  cachedDismissedBannerIds = new Set();
+  hasLoadedDismissedBannerIds = false;
+};


### PR DESCRIPTION
Persist wallet banner dismissals in Telegram cloud storage with race-safe caching and remount retry behavior. Add centralized banner analytics tracking for press/close events and tests covering retry behavior, analytics wrappers, and wallet analytics constants.