### PR TITLE
fix(wallet): prevent silent address loss on new device login

### DIFF
--- a/app/src/app/telegram/wallet/components/BalanceCard.tsx
+++ b/app/src/app/telegram/wallet/components/BalanceCard.tsx
@@ -2,7 +2,7 @@
 
 import NumberFlow from "@number-flow/react";
 import { hapticFeedback } from "@telegram-apps/sdk-react";
-import { Brush, Copy } from "lucide-react";
+import { Brush, Copy, RefreshCcw } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
 
@@ -12,6 +12,8 @@ interface BalanceCardProps {
   balanceRef: React.RefObject<HTMLDivElement | null>;
   walletAddress: string | null;
   isLoading: boolean;
+  walletError: string | null;
+  onRetry: () => void;
   balanceBg: string | null;
   bgLoaded: boolean;
   displayCurrency: "USD" | "SOL";
@@ -27,6 +29,8 @@ export function BalanceCard({
   balanceRef,
   walletAddress,
   isLoading,
+  walletError,
+  onRetry,
   balanceBg,
   bgLoaded,
   displayCurrency,
@@ -79,8 +83,42 @@ export function BalanceCard({
 
         {/* Card content */}
         <div className="relative flex flex-col justify-between h-full p-4">
-          {/* Top: Wallet address */}
-          {isLoading || !walletAddress ? (
+          {walletError ? (
+            <div className="flex flex-col items-center justify-center h-full gap-3 py-2">
+              <p
+                className="text-[15px] leading-[20px] text-center px-4"
+                style={{ color: balanceBg ? "white" : "#1c1c1e" }}
+              >
+                {walletError}
+              </p>
+              <button
+                onClick={onRetry}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-full active:scale-95 transition-transform"
+                style={{
+                  background: balanceBg
+                    ? "rgba(255, 255, 255, 0.2)"
+                    : "rgba(0, 0, 0, 0.06)",
+                }}
+              >
+                <RefreshCcw
+                  size={16}
+                  strokeWidth={2}
+                  style={{
+                    color: balanceBg ? "white" : "#1c1c1e",
+                  }}
+                />
+                <span
+                  className="text-[15px] font-medium"
+                  style={{ color: balanceBg ? "white" : "#1c1c1e" }}
+                >
+                  Retry
+                </span>
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Top: Wallet address */}
+              {isLoading || !walletAddress ? (
             <div className="flex items-center gap-1">
               <div className="w-4 h-4 bg-white/20 animate-pulse rounded" />
               <div className="w-24 h-5 bg-white/20 animate-pulse rounded" />
@@ -243,6 +281,8 @@ export function BalanceCard({
                 }}
               />
             </button>
+          )}
+            </>
           )}
         </div>
       </div>

--- a/app/src/app/telegram/wallet/hooks/useWalletInit.ts
+++ b/app/src/app/telegram/wallet/hooks/useWalletInit.ts
@@ -1,8 +1,14 @@
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getWalletBalance } from "@/lib/solana/wallet/wallet-details";
-import { ensureWalletKeypair } from "@/lib/solana/wallet/wallet-keypair-logic";
+import {
+  getWalletBalance,
+  resetWalletKeypairCache,
+} from "@/lib/solana/wallet/wallet-details";
+import {
+  CloudStorageUnavailableError,
+  ensureWalletKeypair,
+} from "@/lib/solana/wallet/wallet-keypair-logic";
 
 import {
   cachedWalletAddress,
@@ -18,6 +24,8 @@ export function useWalletInit(): {
   walletAddress: string | null;
   setWalletAddress: React.Dispatch<React.SetStateAction<string | null>>;
   isLoading: boolean;
+  walletError: string | null;
+  retryWalletInit: () => void;
 } {
   const [walletAddress, setWalletAddress] = useState<string | null>(() =>
     USE_MOCK_DATA ? MOCK_WALLET_ADDRESS : cachedWalletAddress
@@ -25,45 +33,67 @@ export function useWalletInit(): {
   const [isLoading, setIsLoading] = useState(() =>
     USE_MOCK_DATA ? false : !hasCachedWalletData()
   );
+  const [walletError, setWalletError] = useState<string | null>(null);
   const ensuredWalletRef = useRef(false);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const initWallet = useCallback(async () => {
+    setIsLoading(true);
+    setWalletError(null);
+
+    try {
+      const { keypair } = await ensureWalletKeypair();
+      const publicKeyBase58 = keypair.publicKey.toBase58();
+
+      setCachedWalletAddress(publicKeyBase58);
+      setWalletAddress(publicKeyBase58);
+
+      const cachedBalance = getCachedWalletBalance(publicKeyBase58);
+
+      if (cachedBalance !== null) {
+        setIsLoading(false);
+        void getWalletBalance().then((freshBalance) => {
+          setCachedWalletBalance(publicKeyBase58, freshBalance);
+          walletBalanceListeners.forEach((listener) => listener(freshBalance));
+        });
+      } else {
+        const balanceLamports = await getWalletBalance();
+        setCachedWalletBalance(publicKeyBase58, balanceLamports);
+        setIsLoading(false);
+      }
+    } catch (error) {
+      console.error("Failed to ensure wallet keypair", error);
+
+      if (error instanceof CloudStorageUnavailableError) {
+        setWalletError(
+          "Couldn't access your wallet storage. Please try again."
+        );
+      } else {
+        setWalletError("Something went wrong loading your wallet.");
+      }
+
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (USE_MOCK_DATA) return;
+
+    // On retry, reset the guard and caches
+    if (retryCount > 0) {
+      ensuredWalletRef.current = false;
+      resetWalletKeypairCache();
+    }
+
     if (ensuredWalletRef.current) return;
     ensuredWalletRef.current = true;
 
-    void (async () => {
-      try {
-        const { keypair, isNew: _isNew } = await ensureWalletKeypair();
-        const publicKeyBase58 = keypair.publicKey.toBase58();
+    void initWallet();
+  }, [retryCount, initWallet]);
 
-        // Store wallet address in module-level cache for future mounts
-        setCachedWalletAddress(publicKeyBase58);
-        setWalletAddress(publicKeyBase58);
-
-        // Check if we already have cached balance (from previous visit)
-        const cachedBalance = getCachedWalletBalance(publicKeyBase58);
-
-        if (cachedBalance !== null) {
-          // We have cache - state was already initialized from it
-          // Just refresh in background without loading state
-          setIsLoading(false);
-          void getWalletBalance().then((freshBalance) => {
-            setCachedWalletBalance(publicKeyBase58, freshBalance);
-            walletBalanceListeners.forEach((listener) => listener(freshBalance));
-          });
-        } else {
-          // First load - need to fetch balance
-          const balanceLamports = await getWalletBalance();
-          setCachedWalletBalance(publicKeyBase58, balanceLamports);
-          setIsLoading(false);
-        }
-      } catch (error) {
-        console.error("Failed to ensure wallet keypair", error);
-        setIsLoading(false);
-      }
-    })();
+  const retryWalletInit = useCallback(() => {
+    setRetryCount((c) => c + 1);
   }, []);
 
-  return { walletAddress, setWalletAddress, isLoading };
+  return { walletAddress, setWalletAddress, isLoading, walletError, retryWalletInit };
 }

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -136,7 +136,7 @@ export default function Home() {
   const [isTokensSheetOpen, setTokensSheetOpen] = useState(false);
   const [isTransactionDetailsSheetOpen, setTransactionDetailsSheetOpen] =
     useState(false);
-  const { walletAddress, setWalletAddress, isLoading } = useWalletInit();
+  const { walletAddress, setWalletAddress, isLoading, walletError, retryWalletInit } = useWalletInit();
   const { solBalanceLamports, setSolBalanceLamports, refreshBalance } = useWalletBalance(walletAddress);
   const { tokenHoldings, isHoldingsLoading, refreshTokenHoldings } = useTokenHoldings(walletAddress);
   const { walletTransactions, setWalletTransactions, isFetchingTransactions, loadWalletTransactions } = useWalletTransactions(walletAddress);
@@ -919,6 +919,8 @@ export default function Home() {
             balanceRef={balanceRef}
             walletAddress={walletAddress}
             isLoading={isLoading}
+            walletError={walletError}
+            onRetry={retryWalletInit}
             balanceBg={balanceBg}
             bgLoaded={bgLoaded}
             displayCurrency={displayCurrency}

--- a/app/src/lib/solana/wallet/__tests__/wallet-keypair-logic.test.ts
+++ b/app/src/lib/solana/wallet/__tests__/wallet-keypair-logic.test.ts
@@ -107,7 +107,7 @@ describe("ensureWalletKeypair", () => {
   test("throws CloudStorageUnavailableError after all retries return null", async () => {
     getCloudValueImpl = async () => null;
 
-    expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
+    await expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
   });
 
   test("retries when cloud storage throws, then succeeds", async () => {
@@ -132,7 +132,7 @@ describe("ensureWalletKeypair", () => {
       throw new Error("SDK not ready");
     };
 
-    expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
+    await expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
   });
 
   test("generates new keypair only when cloud storage returns empty strings on first attempt", async () => {

--- a/app/src/lib/solana/wallet/__tests__/wallet-keypair-logic.test.ts
+++ b/app/src/lib/solana/wallet/__tests__/wallet-keypair-logic.test.ts
@@ -1,0 +1,151 @@
+import { Keypair } from "@solana/web3.js";
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// --- Mock cloud-storage module ---
+
+type GetCloudValueFn = (
+  keys: string | string[]
+) => Promise<string | Record<string, string> | null>;
+type SetCloudValueFn = (key: string, value: string) => Promise<boolean>;
+type DeleteCloudValueFn = (keys: string | string[]) => Promise<boolean>;
+
+let getCloudValueImpl: GetCloudValueFn = async () => null;
+let setCloudValueImpl: SetCloudValueFn = async () => true;
+let deleteCloudValueImpl: DeleteCloudValueFn = async () => true;
+
+let getCloudValueCalls: Array<string | string[]> = [];
+
+mock.module("@/lib/telegram/mini-app/cloud-storage", () => ({
+  getCloudValue: async (keys: string | string[]) => {
+    getCloudValueCalls.push(keys);
+    return getCloudValueImpl(keys);
+  },
+  setCloudValue: async (key: string, value: string) =>
+    setCloudValueImpl(key, value),
+  deleteCloudValue: async (keys: string | string[]) =>
+    deleteCloudValueImpl(keys),
+}));
+
+let ensureWalletKeypair: typeof import("../wallet-keypair-logic").ensureWalletKeypair;
+let CloudStorageUnavailableError: typeof import("../wallet-keypair-logic").CloudStorageUnavailableError;
+
+beforeAll(async () => {
+  const mod = await import("../wallet-keypair-logic");
+  ensureWalletKeypair = mod.ensureWalletKeypair;
+  CloudStorageUnavailableError = mod.CloudStorageUnavailableError;
+});
+
+beforeEach(() => {
+  getCloudValueCalls = [];
+  getCloudValueImpl = async () => null;
+  setCloudValueImpl = async () => true;
+  deleteCloudValueImpl = async () => true;
+});
+
+// Helper: create a stored keypair in cloud storage format
+const makeStoredKeypair = () => {
+  const kp = Keypair.generate();
+  return {
+    keypair: kp,
+    stored: {
+      solana_public_key: kp.publicKey.toBase58(),
+      solana_secret_key: JSON.stringify(Array.from(kp.secretKey)),
+    },
+  };
+};
+
+describe("ensureWalletKeypair", () => {
+  test("returns existing keypair when cloud storage has valid data", async () => {
+    const { keypair, stored } = makeStoredKeypair();
+    getCloudValueImpl = async () => stored;
+
+    const result = await ensureWalletKeypair();
+
+    expect(result.isNew).toBe(false);
+    expect(result.keypair.publicKey.toBase58()).toBe(
+      keypair.publicKey.toBase58()
+    );
+  });
+
+  test("generates new keypair when cloud storage returns empty strings (new user)", async () => {
+    getCloudValueImpl = async () => ({
+      solana_public_key: "",
+      solana_secret_key: "",
+    });
+
+    const result = await ensureWalletKeypair();
+
+    expect(result.isNew).toBe(true);
+    expect(result.keypair).toBeDefined();
+  });
+
+  test("retries when cloud storage returns null, then succeeds", async () => {
+    const { keypair, stored } = makeStoredKeypair();
+    let attempt = 0;
+    getCloudValueImpl = async () => {
+      attempt += 1;
+      if (attempt <= 2) return null; // First 2 attempts fail
+      return stored;
+    };
+
+    const result = await ensureWalletKeypair();
+
+    expect(result.isNew).toBe(false);
+    expect(result.keypair.publicKey.toBase58()).toBe(
+      keypair.publicKey.toBase58()
+    );
+    expect(getCloudValueCalls.length).toBe(3);
+  });
+
+  test("throws CloudStorageUnavailableError after all retries return null", async () => {
+    getCloudValueImpl = async () => null;
+
+    expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
+  });
+
+  test("retries when cloud storage throws, then succeeds", async () => {
+    const { keypair, stored } = makeStoredKeypair();
+    let attempt = 0;
+    getCloudValueImpl = async () => {
+      attempt += 1;
+      if (attempt <= 1) throw new Error("SDK not ready");
+      return stored;
+    };
+
+    const result = await ensureWalletKeypair();
+
+    expect(result.isNew).toBe(false);
+    expect(result.keypair.publicKey.toBase58()).toBe(
+      keypair.publicKey.toBase58()
+    );
+  });
+
+  test("throws CloudStorageUnavailableError after all retries throw", async () => {
+    getCloudValueImpl = async () => {
+      throw new Error("SDK not ready");
+    };
+
+    expect(ensureWalletKeypair()).rejects.toThrow(CloudStorageUnavailableError);
+  });
+
+  test("generates new keypair only when cloud storage returns empty strings on first attempt", async () => {
+    // Empty strings on first try = genuinely new user (no retry needed)
+    getCloudValueImpl = async () => ({
+      solana_public_key: "",
+      solana_secret_key: "",
+    });
+
+    const result = await ensureWalletKeypair();
+
+    expect(result.isNew).toBe(true);
+    // Should NOT have retried — empty strings are a definitive "not found"
+    expect(getCloudValueCalls.length).toBe(1);
+  });
+});

--- a/app/src/lib/solana/wallet/wallet-details.ts
+++ b/app/src/lib/solana/wallet/wallet-details.ts
@@ -203,3 +203,8 @@ export const sendSolTransaction = async (
 
   return signature;
 };
+
+export const resetWalletKeypairCache = () => {
+  cachedWalletKeypair = null;
+  walletKeypairPromise = null;
+};


### PR DESCRIPTION
## Summary

- Add retry logic (3 attempts with backoff) to wallet keypair cloud storage reads to handle Telegram SDK initialization race conditions on new devices
- Throw `CloudStorageUnavailableError` instead of silently generating a new keypair when cloud storage is unavailable, preventing permanent wallet address replacement
- Surface error state with retry button in the balance card UI so users can recover instead of seeing an infinite loading skeleton

## Test plan

- [ ] Verify existing users on their current device see no change in behavior
- [ ] Simulate cloud storage unavailability and confirm error message + retry button appears
- [ ] Confirm retry button successfully recovers wallet after transient failures
- [ ] Run `cd app && bun test src/lib/solana/wallet/__tests__/wallet-keypair-logic.test.ts` — 7 tests pass