### PR TITLE
feat(wallet): show current Solana network in balance card

### DIFF
--- a/app/src/app/telegram/wallet/components/BalanceCard.tsx
+++ b/app/src/app/telegram/wallet/components/BalanceCard.tsx
@@ -6,6 +6,7 @@ import { Brush, Copy, RefreshCcw } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
 
+import { getSolanaEnv } from "@/lib/solana/rpc/connection";
 import { formatAddress } from "@/lib/solana/wallet/formatters";
 
 interface BalanceCardProps {
@@ -42,6 +43,7 @@ export function BalanceCard({
   onOpenBgPicker,
 }: BalanceCardProps) {
   const [addressCopied, setAddressCopied] = useState(false);
+  const solanaEnv = getSolanaEnv();
 
   return (
     <div className="flex flex-col items-center pt-5 px-4">
@@ -117,48 +119,60 @@ export function BalanceCard({
             </div>
           ) : (
             <>
-              {/* Top: Wallet address */}
-              {isLoading || !walletAddress ? (
-            <div className="flex items-center gap-1">
-              <div className="w-4 h-4 bg-white/20 animate-pulse rounded" />
-              <div className="w-24 h-5 bg-white/20 animate-pulse rounded" />
-            </div>
-          ) : (
-            <button
-              onClick={() => {
-                if (hapticFeedback.impactOccurred.isAvailable()) {
-                  hapticFeedback.impactOccurred("light");
-                }
-                if (walletAddress) {
-                  if (navigator?.clipboard?.writeText) {
-                    navigator.clipboard.writeText(walletAddress);
-                    setAddressCopied(true);
-                    setTimeout(() => setAddressCopied(false), 2000);
-                  }
-                  if (hapticFeedback.notificationOccurred.isAvailable()) {
-                    hapticFeedback.notificationOccurred("success");
-                  }
-                }
-              }}
-              className="flex items-center gap-1 active:opacity-70 transition-opacity self-start"
-            >
-              <Copy
-                className="w-5 h-5"
-                strokeWidth={1.5}
-                style={{
-                  color: balanceBg ? "white" : "rgba(60, 60, 67, 0.6)",
-                }}
-              />
-              <span
-                className="text-[17px] leading-[22px]"
-                style={{
-                  color: balanceBg ? "white" : "rgba(60, 60, 67, 0.6)",
-                }}
-              >
-                {addressCopied ? "Copied!" : formatAddress(walletAddress)}
-              </span>
-            </button>
-          )}
+              {/* Top: Wallet address + network */}
+              <div className="flex flex-col gap-0.5">
+                {isLoading || !walletAddress ? (
+                  <div className="flex items-center gap-1">
+                    <div className="w-4 h-4 bg-white/20 animate-pulse rounded" />
+                    <div className="w-24 h-5 bg-white/20 animate-pulse rounded" />
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => {
+                      if (hapticFeedback.impactOccurred.isAvailable()) {
+                        hapticFeedback.impactOccurred("light");
+                      }
+                      if (walletAddress) {
+                        if (navigator?.clipboard?.writeText) {
+                          navigator.clipboard.writeText(walletAddress);
+                          setAddressCopied(true);
+                          setTimeout(() => setAddressCopied(false), 2000);
+                        }
+                        if (hapticFeedback.notificationOccurred.isAvailable()) {
+                          hapticFeedback.notificationOccurred("success");
+                        }
+                      }
+                    }}
+                    className="flex items-center gap-1 active:opacity-70 transition-opacity self-start"
+                  >
+                    <Copy
+                      className="w-5 h-5"
+                      strokeWidth={1.5}
+                      style={{
+                        color: balanceBg ? "white" : "rgba(60, 60, 67, 0.6)",
+                      }}
+                    />
+                    <span
+                      className="text-[17px] leading-[22px]"
+                      style={{
+                        color: balanceBg ? "white" : "rgba(60, 60, 67, 0.6)",
+                      }}
+                    >
+                      {addressCopied ? "Copied!" : formatAddress(walletAddress)}
+                    </span>
+                  </button>
+                )}
+                <span
+                  className="text-[13px] leading-[18px] capitalize pl-0.5"
+                  style={{
+                    color: balanceBg
+                      ? "rgba(255, 255, 255, 0.7)"
+                      : "rgba(60, 60, 67, 0.45)",
+                  }}
+                >
+                  Solana {solanaEnv}
+                </span>
+              </div>
 
           {/* Bottom: Balance + USD value */}
           <div className="flex flex-col gap-1.5">

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -34,6 +34,7 @@ import { track } from "@/lib/core/analytics";
 import { refundDeposit, topUpDeposit } from "@/lib/solana/deposits";
 import { fetchDeposits } from "@/lib/solana/fetch-deposits";
 import { fetchSolUsdPrice } from "@/lib/solana/fetch-sol-price";
+import { getSolanaEnv } from "@/lib/solana/rpc/connection";
 import { getTelegramTransferProgram } from "@/lib/solana/solana-helpers";
 import { computePortfolioTotals } from "@/lib/solana/token-holdings";
 import { formatAddress } from "@/lib/solana/wallet/formatters";
@@ -1107,17 +1108,29 @@ export default function Home() {
           const decimalStr = String(decimalDigits).padStart(decimals, "0");
           return (
             <>
-              <div className="flex items-center gap-1">
-                <Copy
-                  className="w-5 h-5"
-                  strokeWidth={1.5}
-                  style={{ color: decimalColor }}
-                />
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-1">
+                  <Copy
+                    className="w-5 h-5"
+                    strokeWidth={1.5}
+                    style={{ color: decimalColor }}
+                  />
+                  <span
+                    className="text-[17px] leading-[22px]"
+                    style={{ color: decimalColor }}
+                  >
+                    {walletAddress ? formatAddress(walletAddress) : "Loading..."}
+                  </span>
+                </div>
                 <span
-                  className="text-[17px] leading-[22px]"
-                  style={{ color: decimalColor }}
+                  className="text-[13px] leading-[18px] capitalize pl-0.5"
+                  style={{
+                    color: previewBg
+                      ? "rgba(255, 255, 255, 0.7)"
+                      : "rgba(60, 60, 67, 0.45)",
+                  }}
                 >
-                  {walletAddress ? formatAddress(walletAddress) : "Loading..."}
+                  Solana {getSolanaEnv()}
                 </span>
               </div>
               <div className="flex-1" />


### PR DESCRIPTION
## Summary
- Adds a "Solana {network}" label below the wallet address in the Balance card and the background picker preview
- Uses muted 13px text that adapts to the card background, smaller than the 17px wallet address