### PR TITLE
fix(wallet): notify balance listeners on first load to enable Send button

### DIFF
--- a/app/src/app/telegram/wallet/hooks/useWalletInit.ts
+++ b/app/src/app/telegram/wallet/hooks/useWalletInit.ts
@@ -59,6 +59,7 @@ export function useWalletInit(): {
       } else {
         const balanceLamports = await getWalletBalance();
         setCachedWalletBalance(publicKeyBase58, balanceLamports);
+        walletBalanceListeners.forEach((listener) => listener(balanceLamports));
         setIsLoading(false);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- On first page load (no cached balance), the `else` branch in `useWalletInit` fetched the balance and cached it but never notified `walletBalanceListeners`, leaving `solBalanceLamports` stuck at `null` and the Send button permanently disabled despite having funds.

## Test plan
- [ ] Open wallet on a fresh page load (hard refresh) with SOL balance > 0 and verify Send button is enabled