### PR TITLE
feat(wallet): show Secure SOL in share preview for shielded transfers

### DIFF
--- a/app/src/app/api/og/share/route.tsx
+++ b/app/src/app/api/og/share/route.tsx
@@ -32,14 +32,15 @@ const formatUsd = (value: string | null) => {
   })}`;
 };
 
-const formatSol = (value: string | null) => {
+const formatSol = (value: string | null, secure?: boolean) => {
   if (!value) return null;
+  const label = secure ? "Secure SOL" : "SOL";
   const parsed = Number(value);
-  if (Number.isNaN(parsed)) return `${value} SOL`;
+  if (Number.isNaN(parsed)) return `${value} ${label}`;
   return `+${parsed.toLocaleString("en-US", {
     minimumFractionDigits: 4,
     maximumFractionDigits: 4,
-  })} SOL`;
+  })} ${label}`;
 };
 
 export async function GET(request: Request) {
@@ -49,8 +50,9 @@ export async function GET(request: Request) {
     const receiver = searchParams.get("receiver") || "2fKB…Nhtj";
     const solAmount = searchParams.get("solAmount");
     const usdAmount = searchParams.get("usdAmount");
+    const secure = searchParams.get("secure") === "1";
 
-    const solText = formatSol(solAmount) || "+15.0988 SOL";
+    const solText = formatSol(solAmount, secure) || "+15.0988 SOL";
     const usdText = formatUsd(usdAmount) || "≈$2,869.77";
 
     const allText = `You receivedLoyal${solText}${usdText}FromTo${sender}${receiver}`;

--- a/app/src/app/api/telegram/share/route.ts
+++ b/app/src/app/api/telegram/share/route.ts
@@ -11,7 +11,8 @@ const getPhotoUrl = (
   senderUsername: string,
   receiverUsername: string,
   solAmount: number,
-  usdAmount: number
+  usdAmount: number,
+  isSecure?: boolean
 ) => {
   const endpoint = resolveEndpoint("/api/og/share");
   const url = new URL(endpoint, requestUrl);
@@ -19,6 +20,7 @@ const getPhotoUrl = (
   url.searchParams.set("receiver", receiverUsername);
   url.searchParams.set("solAmount", solAmount.toString());
   url.searchParams.set("usdAmount", usdAmount.toString());
+  if (isSecure) url.searchParams.set("secure", "1");
   return url.toString();
 };
 
@@ -34,7 +36,8 @@ export async function POST(req: Request) {
 
     const bodyString = new TextDecoder().decode(body);
     const bodyJson = JSON.parse(bodyString);
-    const { rawInitData, receiverUsername, solAmount, usdAmount } = bodyJson;
+    const { rawInitData, receiverUsername, solAmount, usdAmount, isSecure } =
+      bodyJson;
     if (!rawInitData || !receiverUsername || !solAmount || !usdAmount) {
       return NextResponse.json(
         { error: "Invalid request body" },
@@ -82,7 +85,8 @@ export async function POST(req: Request) {
       senderUsername,
       receiverUsername,
       solAmount,
-      usdAmount
+      usdAmount,
+      isSecure
     );
 
     const preparedInlineMessage = await prepareInlineMessage(
@@ -90,7 +94,8 @@ export async function POST(req: Request) {
       photoUrl,
       senderUsername,
       receiverUsername,
-      solAmount
+      solAmount,
+      isSecure
     );
 
     return NextResponse.json({ msgId: preparedInlineMessage.id });

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -727,12 +727,15 @@ export default function Home() {
     try {
       const amountSol = selectedTransaction.amountLamports / LAMPORTS_PER_SOL;
       const amountUsd = amountSol * solPriceUsd;
+      const isSecure = selectedTransaction.transferType === "secure" ||
+        !!selectedTransaction.secureTokenSymbol;
 
       const msgId = await createShareMessage(
         rawInitData,
         recipientUsername,
         amountSol,
-        amountUsd
+        amountUsd,
+        isSecure
       );
 
       if (msgId) {

--- a/app/src/lib/telegram/bot-api/prepared-inline-message.ts
+++ b/app/src/lib/telegram/bot-api/prepared-inline-message.ts
@@ -10,11 +10,13 @@ export const prepareInlineMessage = async (
   photoUrl: string,
   senderUsername: string,
   receiverUsername: string,
-  solAmount: number
+  solAmount: number,
+  isSecure?: boolean
 ): Promise<PreparedInlineMessage> => {
   const bot = await getBot();
   const invisibleUnicodeSymbol = String.fromCharCode(0x200b);
-  const text = `Hi ${receiverUsername}!\n\nYou received <b>${solAmount} SOL</b> from <b>${senderUsername}</b>.\n\nTap the button below the image to get your money!<a href="${photoUrl}">${invisibleUnicodeSymbol}</a>`;
+  const tokenLabel = isSecure ? "Secure SOL" : "SOL";
+  const text = `Hi ${receiverUsername}!\n\nYou received <b>${solAmount} ${tokenLabel}</b> from <b>${senderUsername}</b>.\n\nTap the button below the image to get your money!<a href="${photoUrl}">${invisibleUnicodeSymbol}</a>`;
   const buttonText = "CLICK HERE TO CLAIM";
 
   const keyboard = new InlineKeyboard()

--- a/app/src/lib/telegram/mini-app/share-message.ts
+++ b/app/src/lib/telegram/mini-app/share-message.ts
@@ -13,7 +13,8 @@ export const createShareMessage = async (
   rawInitData: string,
   receiverUsername: string,
   solAmount: number,
-  usdAmount: number
+  usdAmount: number,
+  isSecure?: boolean
 ): Promise<string> => {
   const endpoint = resolveEndpoint("/api/telegram/share");
   const body = JSON.stringify({
@@ -21,6 +22,7 @@ export const createShareMessage = async (
     receiverUsername,
     solAmount,
     usdAmount,
+    isSecure,
   });
 
   const response = await fetch(endpoint, {


### PR DESCRIPTION
## Summary
- When sharing a deposit transaction that involves a shielded/secure token, the OG preview image and inline message now display "Secure SOL" instead of "SOL"
- Plumbs an `isSecure` boolean through the entire share chain: wallet page → share-message client → share API route → OG image route + prepared inline message

Closes ASK-493