### PR TITLE
fix(og): add missing secure parameter to formatSol function

### DIFF
--- a/app/src/app/api/og/share/route.tsx
+++ b/app/src/app/api/og/share/route.tsx
@@ -38,7 +38,7 @@ const truncateAddress = (value: string, maxLength = 12) => {
   return `${value.slice(0, side)}…${value.slice(-side)}`;
 };
 
-const formatSol = (value: string | null) => {
+const formatSol = (value: string | null, secure?: boolean) => {
   if (!value) return null;
   const label = secure ? "Secure SOL" : "SOL";
   const parsed = Number(value);


### PR DESCRIPTION
Fixes Vercel build failure — `formatSol` referenced `secure` variable from outer scope instead of accepting it as a parameter.