### PR TITLE
fix(datadog): skip initialization on localhost

### DIFF
--- a/app/src/lib/core/datadog.ts
+++ b/app/src/lib/core/datadog.ts
@@ -26,6 +26,12 @@ let initialized = false;
 
 export function initDatadog() {
   if (initialized) return;
+
+  if (typeof window !== "undefined") {
+    const { hostname } = window.location;
+    if (hostname === "localhost" || hostname === "127.0.0.1") return;
+  }
+
   initialized = true;
 
   datadogRum.init({


### PR DESCRIPTION
Skip Datadog RUM and Logs SDK initialization when running locally (localhost/127.0.0.1) to prevent spam errors in the local network.

Closes ASK-519