### PR TITLE
fix(datadog): filter opaque Script error noise from Telegram WebView

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -39,6 +39,7 @@ export default function RootLayout({
       <head>
         <Script
           defer
+          crossOrigin="anonymous"
           src="https://cloud.umami.is/script.js"
           data-website-id="f6491a00-a838-4c1d-aa01-4f61ff790967"
           strategy="lazyOnload"

--- a/app/src/lib/core/datadog.ts
+++ b/app/src/lib/core/datadog.ts
@@ -1,9 +1,22 @@
 import { datadogLogs } from "@datadog/browser-logs";
+import type { RumErrorEvent } from "@datadog/browser-rum";
 import { datadogRum } from "@datadog/browser-rum";
 import { reactPlugin } from "@datadog/browser-rum-react";
 
 import { publicEnv } from "@/lib/core/config/public";
 import type { TelegramIdentity } from "@/lib/telegram/mini-app/init-data-transform";
+
+declare global {
+  interface Window {
+    __dd_early_errors?: {
+      message: string;
+      source?: string;
+      lineno?: number;
+      colno?: number;
+      timestamp: number;
+    }[];
+  }
+}
 
 function getDatadogEnv(): string {
   const branch = publicEnv.gitBranch;
@@ -22,6 +35,48 @@ const sharedConfig = {
   version: publicEnv.gitCommitHash,
 } as const;
 
+/**
+ * Drop opaque "Script error." events that carry no actionable info.
+ * These are produced by cross-origin script failures (Same-Origin Policy)
+ * and are especially common in Telegram WebViews on Android.
+ */
+function isOpaqueScriptError(event: RumErrorEvent): boolean {
+  const msg = event.error.message;
+  return msg === "Script error." || msg === "Script error";
+}
+
+/**
+ * Install a global error handler BEFORE Datadog SDK loads so we can
+ * capture real error details that the browser would otherwise mask as
+ * "Script error." for cross-origin scripts.
+ */
+function installEarlyErrorCatcher() {
+  if (typeof window === "undefined") return;
+  if (window.__dd_early_errors) return;
+
+  const earlyErrors: NonNullable<typeof window.__dd_early_errors> = [];
+  window.__dd_early_errors = earlyErrors;
+
+  const originalOnError = window.onerror;
+  window.onerror = (message, source, lineno, colno, error) => {
+    const msg = typeof message === "string" ? message : String(message);
+    // Only capture non-opaque errors (ones with real info)
+    if (msg !== "Script error." && msg !== "Script error") {
+      earlyErrors.push({
+        message: error?.stack ?? msg,
+        source: source ?? undefined,
+        lineno: lineno ?? undefined,
+        colno: colno ?? undefined,
+        timestamp: Date.now(),
+      });
+    }
+    if (originalOnError) {
+      return originalOnError.call(window, message, source, lineno, colno, error);
+    }
+    return false;
+  };
+}
+
 let initialized = false;
 
 export function initDatadog() {
@@ -31,6 +86,8 @@ export function initDatadog() {
     const { hostname } = window.location;
     if (hostname === "localhost" || hostname === "127.0.0.1") return;
   }
+
+  installEarlyErrorCatcher();
 
   initialized = true;
 
@@ -44,6 +101,12 @@ export function initDatadog() {
     trackLongTasks: true,
     defaultPrivacyLevel: "mask-user-input",
     plugins: [reactPlugin({ router: false })],
+    beforeSend(event) {
+      if (event.type === "error" && isOpaqueScriptError(event as RumErrorEvent)) {
+        return false;
+      }
+      return true;
+    },
   });
 
   datadogLogs.init({
@@ -52,7 +115,27 @@ export function initDatadog() {
     forwardErrorsToLogs: true,
     forwardConsoleLogs: ["warn", "error"],
     forwardReports: "all",
+    beforeSend(event) {
+      if (event.message === "Script error." || event.message === "Script error") {
+        return false;
+      }
+      return true;
+    },
   });
+
+  // Forward any real errors captured before DD SDK initialized
+  if (window.__dd_early_errors?.length) {
+    for (const err of window.__dd_early_errors) {
+      datadogLogs.logger.error("Early boot error", {
+        message: err.message,
+        source: err.source,
+        lineno: err.lineno,
+        colno: err.colno,
+        capturedAt: err.timestamp,
+      });
+    }
+    window.__dd_early_errors = [];
+  }
 }
 
 export function identifyDatadogUser(identity: TelegramIdentity): void {

--- a/app/src/lib/core/datadog.ts
+++ b/app/src/lib/core/datadog.ts
@@ -6,15 +6,17 @@ import { reactPlugin } from "@datadog/browser-rum-react";
 import { publicEnv } from "@/lib/core/config/public";
 import type { TelegramIdentity } from "@/lib/telegram/mini-app/init-data-transform";
 
+interface EarlyError {
+  message: string;
+  source?: string;
+  lineno?: number;
+  colno?: number;
+  timestamp: number;
+}
+
 declare global {
   interface Window {
-    __dd_early_errors?: {
-      message: string;
-      source?: string;
-      lineno?: number;
-      colno?: number;
-      timestamp: number;
-    }[];
+    __dd_early_errors?: EarlyError[];
   }
 }
 
@@ -54,7 +56,7 @@ function installEarlyErrorCatcher() {
   if (typeof window === "undefined") return;
   if (window.__dd_early_errors) return;
 
-  const earlyErrors: NonNullable<typeof window.__dd_early_errors> = [];
+  const earlyErrors: EarlyError[] = [];
   window.__dd_early_errors = earlyErrors;
 
   const originalOnError = window.onerror;


### PR DESCRIPTION
## Summary
- Filter out opaque "Script error." events in Datadog RUM and Logs that provide zero debugging value (common in Telegram Android WebViews)
- Add early `window.onerror` catcher to capture real boot errors before they get masked by the browser's Same-Origin Policy
- Add `crossorigin="anonymous"` to the Umami analytics script to unmask its errors

Closes ASK-520