### PR TITLE
fix(ui): guard touchmove preventDefault with cancelable check

### DIFF
--- a/app/src/app/telegram/summaries/direct/page.tsx
+++ b/app/src/app/telegram/summaries/direct/page.tsx
@@ -442,7 +442,7 @@ function DirectFeedContent() {
 
       // Only handle horizontal swipes
       if (isHorizontalSwipeRef.current) {
-        e.preventDefault();
+        if (e.cancelable) e.preventDefault();
         setSwipeX(deltaX);
 
         // Haptic feedback at threshold

--- a/app/src/app/telegram/wallet/hooks/usePullToRefresh.ts
+++ b/app/src/app/telegram/wallet/hooks/usePullToRefresh.ts
@@ -79,7 +79,7 @@ export function usePullToRefresh({
         return;
       }
 
-      e.preventDefault();
+      if (e.cancelable) e.preventDefault();
       isPullingRef.current = true;
 
       const distance = Math.min(deltaY * RESISTANCE, MAX_PULL);

--- a/app/src/components/summaries/ChatSummarySheet.tsx
+++ b/app/src/components/summaries/ChatSummarySheet.tsx
@@ -215,7 +215,7 @@ const ChatSummarySheet = forwardRef<ChatSummarySheetRef, ChatSummarySheetProps>(
 
     // Only handle horizontal swipes
     if (isHorizontalSwipeRef.current) {
-      e.preventDefault();
+      if (e.cancelable) e.preventDefault();
       setSwipeX(deltaX);
 
       // Haptic feedback at threshold


### PR DESCRIPTION
Guard `e.preventDefault()` calls on touchmove events with `e.cancelable` check to silence the `IgnoredEventCancel` browser intervention triggered when scrolling is already in progress.

Fixes ASK-521