### PR TITLE
feat(api): add CORS headers to summaries endpoint

### DIFF
--- a/app/src/app/api/summaries/route.ts
+++ b/app/src/app/api/summaries/route.ts
@@ -9,6 +9,16 @@ type CommunityPhotoSettings = {
   photoMimeType?: string;
 };
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
 export async function GET(req: Request): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(req.url);
@@ -49,12 +59,15 @@ export async function GET(req: Request): Promise<NextResponse> {
       };
     });
 
-    return NextResponse.json({ summaries: transformedSummaries });
+    return NextResponse.json(
+      { summaries: transformedSummaries },
+      { headers: corsHeaders }
+    );
   } catch (error) {
     console.error("[api/summaries] Failed to fetch summaries:", error);
     return NextResponse.json(
       { error: "Failed to fetch summaries" },
-      { status: 500 }
+      { status: 500, headers: corsHeaders }
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add CORS headers (`Access-Control-Allow-Origin: *`) to the summaries API route
- Add `OPTIONS` preflight handler for cross-origin requests
- Include CORS headers in both success and error responses