### PR TITLE
docs(team): add Linear MCP defaults to AGENTS and CLAUDE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,12 @@ git worktree prune
 - Run `git worktree list` if unsure which worktrees exist
 - After merging a PR, clean up the worktree
 
+## Linear MCP Defaults
+
+- When creating Linear issues via MCP, set status to `Todo` by default unless the user explicitly requests another status.
+- Assess task impact/scope and set an explicit priority during issue creation (`Urgent`, `High`, `Normal`, `Low`).
+- Choose appropriate labels and assignees based on ownership and domain before finalizing the issue.
+
 ## Commit Conventions
 
 This project enforces [Conventional Commits](https://www.conventionalcommits.org/) via `commitlint` with `@commitlint/config-conventional`. A CI workflow (`.github/workflows/commit-style.yml`) validates all commit messages in a PR and the PR title itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,12 @@ Example: `ask-328-fix-wrong-token-history-processing`
 
 To find the correct branch name for a Linear issue, use the issue identifier (e.g., ASK-123).
 
+## Linear MCP Defaults
+
+- When creating Linear issues via MCP, set status to `Todo` by default unless the user explicitly requests another status.
+- Assess task impact/scope and set an explicit priority during issue creation (`Urgent`, `High`, `Normal`, `Low`).
+- Choose appropriate labels and assignees based on ownership and domain before finalizing the issue.
+
 ## Commit Conventions
 
 This project enforces [Conventional Commits](https://www.conventionalcommits.org/) via `commitlint` with `@commitlint/config-conventional`. A CI workflow (`.github/workflows/commit-style.yml`) validates all commit messages in a PR and the PR title itself.


### PR DESCRIPTION
Add concise Linear MCP defaults to AGENTS.md and CLAUDE.md for issue status, priority, and ownership. This standardizes how issues are created so task triage is consistent across the team.