### PR TITLE
feat(telegram): add mtcute userbot worker foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ docs/plans
 docs/scopes
 
 .entire/
+
+# userbot worker local storage overrides
+/.data/userbot/
+/workers/userbot/.data/
+/workers/userbot/node_modules/

--- a/docs/workers/README.md
+++ b/docs/workers/README.md
@@ -1,0 +1,13 @@
+# Worker Documentation
+
+Operational guides for background workers in this monorepo.
+
+## Current Workers
+
+| Worker | Purpose | Runtime |
+|--------|---------|---------|
+| `userbot` | Telegram MTProto userbot foundation with persistent SQLite session storage | Render Worker |
+
+## Quick Links
+
+- [Userbot on Render](./userbot-on-render.md) - Setup, bootstrap, run, and recovery flow

--- a/docs/workers/userbot-on-render.md
+++ b/docs/workers/userbot-on-render.md
@@ -1,0 +1,77 @@
+# Userbot Worker on Render
+
+This guide explains how to run the mtcute userbot worker with persistent SQLite session storage on Render.
+
+## Scope
+
+- Session storage is file-based (`SQLite`) on Render persistent disk.
+- No database session storage is used.
+- Single account per worker instance (`TELEGRAM_USERBOT_ACCOUNT_KEY`, default `primary`).
+
+## Prerequisites
+
+- Render Worker service pointing to this repository
+- Persistent disk attached to the worker service
+- Telegram API credentials (`api_id`, `api_hash`)
+
+## Required Environment Variables
+
+- `TELEGRAM_USERBOT_API_ID`
+- `TELEGRAM_USERBOT_API_HASH`
+
+## Optional Environment Variables
+
+- `TELEGRAM_USERBOT_ACCOUNT_KEY` (default: `primary`)
+- `USERBOT_STORAGE_DIR` (default: `/var/data/userbot`)
+- `TELEGRAM_USERBOT_PHONE` (used as default phone in bootstrap flow)
+
+## Render Service Setup
+
+1. Create a Render **Worker** service.
+2. Mount persistent disk to `/var/data/userbot`.
+3. Set environment variables above.
+4. Use start command:
+
+```bash
+cd workers/userbot && bun install && bun run start
+```
+
+## One-Time Authentication Bootstrap
+
+Open Render Shell for the worker service and run:
+
+```bash
+cd workers/userbot
+bun install
+bun run auth:bootstrap
+```
+
+Then complete Telegram login prompts (code + 2FA if enabled).
+
+## Validate Session
+
+```bash
+cd workers/userbot
+bun run auth:status
+```
+
+- Exit code `0`: session is valid
+- Exit code `1`: session missing/invalid (re-bootstrap needed)
+
+## Session Recovery Flow
+
+If the session becomes invalid:
+
+```bash
+cd workers/userbot
+bun run auth:clear
+bun run auth:bootstrap
+```
+
+Then restart the Render worker.
+
+## Operational Rules
+
+- Keep worker replicas at `1` per `TELEGRAM_USERBOT_ACCOUNT_KEY`.
+- Use a different `TELEGRAM_USERBOT_ACCOUNT_KEY` if you intentionally run multiple accounts.
+- Keep `USERBOT_STORAGE_DIR` on persistent disk (not ephemeral filesystem).

--- a/workers/userbot/README.md
+++ b/workers/userbot/README.md
@@ -1,0 +1,46 @@
+# Userbot Worker (mtcute)
+
+Standalone worker package for Telegram userbot foundations.
+
+## What this package does
+
+- Uses `@mtcute/bun`.
+- Persists session state in local SQLite storage.
+- Targets Render persistent disk (recommended mount: `/var/data/userbot`).
+- Provides script-driven auth/bootstrap primitives.
+- Runs a minimal long-lived worker with graceful shutdown.
+
+## Required environment variables
+
+- `TELEGRAM_USERBOT_API_ID`
+- `TELEGRAM_USERBOT_API_HASH`
+
+## Optional environment variables
+
+- `TELEGRAM_USERBOT_ACCOUNT_KEY` (default: `primary`)
+- `USERBOT_STORAGE_DIR` (default: `/var/data/userbot`)
+- `TELEGRAM_USERBOT_PHONE` (used by `auth:bootstrap` as default phone)
+
+## Commands
+
+Run from `workers/userbot`.
+
+```bash
+bun install
+bun run auth:bootstrap
+bun run auth:status
+bun run auth:clear
+bun run start
+```
+
+## Render operational flow
+
+1. Mount persistent disk and set `USERBOT_STORAGE_DIR=/var/data/userbot`.
+2. Run one-time `bun run auth:bootstrap` in the worker service environment.
+3. Start service with `bun run start`.
+4. Keep replicas at `1` per `TELEGRAM_USERBOT_ACCOUNT_KEY`.
+
+## Notes
+
+- Session files are account-scoped: `mtcute-<account-key>.sqlite`.
+- `auth:clear` removes `sqlite`, `-wal`, `-shm`, and `-journal` files for the active account key.

--- a/workers/userbot/bun.lock
+++ b/workers/userbot/bun.lock
@@ -1,0 +1,71 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@loyal-labs/userbot-worker",
+      "dependencies": {
+        "@mtcute/bun": "^0.28.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^20.19.0",
+        "typescript": "^5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@fuman/bun": ["@fuman/bun@0.0.19", "", { "dependencies": { "@fuman/io": "^0.0.19", "@fuman/net": "^0.0.19", "@fuman/utils": "^0.0.19" } }, "sha512-Q9SV77a9cEzx7FI3DalwOFktN1eHkby4yiJoS7cw0HWg7xLZ5lGBJPcyn19R8qc9JhpcByNbKocmrSC4/WbCeQ=="],
+
+    "@fuman/io": ["@fuman/io@0.0.19", "", { "dependencies": { "@fuman/utils": "^0.0.19" } }, "sha512-B+2n3GVa9PCYMJ9xfsdXUlUV9yXO4gKLYfxm815PeJ+MGOw5TbEp166drRmBq1AtxVnP0efy6Oz9rYpKVODgow=="],
+
+    "@fuman/net": ["@fuman/net@0.0.19", "", { "dependencies": { "@fuman/io": "^0.0.19", "@fuman/utils": "^0.0.19" } }, "sha512-yISM+JcZEWBpBYn0v2mUY/Zst4SsicTRaVTvRkVhMiZhgMzdXalfvRwRV/vsgwwL31bntwowCTDW4iilCJLbXg=="],
+
+    "@fuman/utils": ["@fuman/utils@0.0.19", "", {}, "sha512-4qVrZ9AjKYztLJsNr1Tp7kL48b22dvVLN1iVW+Me8ZSQ0ILN0qknoxjsczVPReF7+GDWgknNxR2l6ggrA4SZyw=="],
+
+    "@mtcute/bun": ["@mtcute/bun@0.28.1", "", { "dependencies": { "@fuman/bun": "0.0.19", "@fuman/io": "0.0.19", "@fuman/net": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/core": "^0.28.1", "@mtcute/html-parser": "^0.28.1", "@mtcute/markdown-parser": "^0.28.1", "@mtcute/wasm": "^0.27.8" } }, "sha512-PmMooPNWcqWRM4dJHdbz7eZkfkTBwQ6OTClI30rTc9+7KGeJSMPOLsqEczwI6kk+76xVXJpX9t3G5JmXxSrGBw=="],
+
+    "@mtcute/core": ["@mtcute/core@0.28.1", "", { "dependencies": { "@fuman/io": "0.0.19", "@fuman/net": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/file-id": "^0.28.1", "@mtcute/tl": "^222.0.0", "@mtcute/tl-runtime": "^0.24.3", "@types/events": "3.0.0", "long": "5.2.3" } }, "sha512-ahpY3HxTfVvhhFao73P7SLF4nUkxfoRRtCGyWgZr8bjcBMs2fcVP0+EiiTZkUc4qJf+9wdUasUxq3caqIqdCHw=="],
+
+    "@mtcute/file-id": ["@mtcute/file-id@0.28.1", "", { "dependencies": { "@fuman/utils": "0.0.19", "@mtcute/tl-runtime": "^0.24.3", "long": "5.2.3" } }, "sha512-OtjJEk/NF1+uKxf9D+IYtIrfglUzmg4KYoy21FrnbLgnqHw0EZbocgDDmJy/5/j5GVAHC/SHp7AGw4RkWCd9rw=="],
+
+    "@mtcute/html-parser": ["@mtcute/html-parser@0.28.1", "", { "dependencies": { "@mtcute/core": "^0.28.1", "htmlparser2": "^10.0.0", "long": "5.2.3" } }, "sha512-Kw1mANUtlb6+u1/qj3CItJSI0gb6sSRAaZAOAKDmcYlPo3g1jT0tms3Rxjxd0un5owzCx0W8VpIk3ep7AXyaow=="],
+
+    "@mtcute/markdown-parser": ["@mtcute/markdown-parser@0.28.1", "", { "dependencies": { "@mtcute/core": "^0.28.1", "long": "5.2.3" } }, "sha512-wKNPG9BcuAD9GB3O4FFXhGo2ciM6lioL0uldDMDZm1GugcdBp0mKhT+h8QJyDDrRM9l+XW01MROTc1KZbItAZQ=="],
+
+    "@mtcute/tl": ["@mtcute/tl@222.0.0", "", { "dependencies": { "long": "5.2.3" } }, "sha512-zg64rX2V7GPrQBJcZ2QX6Z+bLxkF7n1V2HxKQUB+mBkTPElmqMY9dE1lbzcwQw7Dys8lo9h3WlTOnfa1LeNyvw=="],
+
+    "@mtcute/tl-runtime": ["@mtcute/tl-runtime@0.24.3", "", { "dependencies": { "@fuman/utils": "0.0.15", "long": "5.2.3" } }, "sha512-61J3cgYgNOQT532GdIiuezRrSC7v6cc9MfvWv9GO27bRGf7JUKWVbFt4U0KzQ9Tp0J1uMOUfi1EbQKkYKacIKQ=="],
+
+    "@mtcute/wasm": ["@mtcute/wasm@0.27.8", "", {}, "sha512-3z1v1WtkAAW95l5t8LB3Ul+Y8dQNMez5YF16cHE3mAHX5RRrfgE+rgVk+wRQJHa24CugfuEEBSi6QpdZuTRBIw=="],
+
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/events": ["@types/events@3.0.0", "", {}, "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="],
+
+    "@types/node": ["@types/node@20.19.34", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "long": ["long@5.2.3", "", {}, "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@mtcute/tl-runtime/@fuman/utils": ["@fuman/utils@0.0.15", "", {}, "sha512-3H3WzkfG7iLKCa/yNV4s80lYD4yr5hgiNzU13ysLY2BcDqFjM08XGYuLd5wFVp4V8+DA/fe8gIDW96To/JwDyA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+  }
+}

--- a/workers/userbot/package.json
+++ b/workers/userbot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@loyal-labs/userbot-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/worker.ts",
+    "auth:bootstrap": "bun run src/commands/auth-bootstrap.ts",
+    "auth:status": "bun run src/commands/auth-status.ts",
+    "auth:clear": "bun run src/commands/auth-clear.ts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@mtcute/bun": "^0.28.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^20.19.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/workers/userbot/src/__tests__/auth-commands.test.ts
+++ b/workers/userbot/src/__tests__/auth-commands.test.ts
@@ -1,0 +1,203 @@
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { runAuthBootstrap } from "../commands/auth-bootstrap";
+import { runAuthClear } from "../commands/auth-clear";
+import { runAuthStatus } from "../commands/auth-status";
+import type { UserbotConfig } from "../lib/env";
+
+type FakeLogger = {
+  error: (..._args: unknown[]) => void;
+  info: (..._args: unknown[]) => void;
+  warn: (..._args: unknown[]) => void;
+};
+
+function createLogger(): FakeLogger {
+  return {
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  };
+}
+
+function createConfig(storageDir: string): UserbotConfig {
+  return {
+    accountKey: "primary",
+    apiHash: "hash",
+    apiId: 123,
+    storageDir,
+  };
+}
+
+describe("auth command primitives", () => {
+  test("auth-bootstrap succeeds and destroys client", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-bootstrap-"));
+    const sessionPath = join(storageDir, "mtcute-primary.sqlite");
+
+    let destroyCalls = 0;
+
+    try {
+      await runAuthBootstrap({
+        createClient: async (config) => ({
+          config,
+          sessionPath,
+          client: {
+            destroy: async () => {
+              destroyCalls += 1;
+            },
+            start: async () => {
+              await writeFile(sessionPath, "sqlite");
+              return { id: 999n, username: "test_user" };
+            },
+          } as any,
+        }),
+        createPrompt: () => ({
+          ask: async () => "noop",
+          close: () => undefined,
+        }),
+        loadConfig: () => createConfig(storageDir),
+        logger: createLogger(),
+      });
+
+      await stat(sessionPath);
+      expect(destroyCalls).toBe(1);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-bootstrap failure still destroys client", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-bootstrap-fail-"));
+
+    let destroyCalls = 0;
+
+    try {
+      await expect(
+        runAuthBootstrap({
+          createClient: async (config) => ({
+            config,
+            sessionPath: join(storageDir, "mtcute-primary.sqlite"),
+            client: {
+              destroy: async () => {
+                destroyCalls += 1;
+              },
+              start: async () => {
+                throw new Error("invalid code");
+              },
+            } as any,
+          }),
+          createPrompt: () => ({
+            ask: async () => "noop",
+            close: () => undefined,
+          }),
+          loadConfig: () => createConfig(storageDir),
+          logger: createLogger(),
+        })
+      ).rejects.toThrow("invalid code");
+
+      expect(destroyCalls).toBe(1);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-status returns false quickly when session file is missing", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-status-missing-"));
+
+    let createClientCalls = 0;
+
+    try {
+      const authenticated = await runAuthStatus({
+        createClient: async (config) => {
+          createClientCalls += 1;
+          return {
+            config,
+            sessionPath: join(storageDir, "mtcute-primary.sqlite"),
+            client: {
+              destroy: async () => undefined,
+              start: async () => ({ id: 1 }),
+            } as any,
+          };
+        },
+        loadConfig: () => createConfig(storageDir),
+        logger: createLogger(),
+      });
+
+      expect(authenticated).toBe(false);
+      expect(createClientCalls).toBe(0);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-status uses non-interactive callbacks for invalid sessions", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-status-invalid-"));
+    const sessionPath = join(storageDir, "mtcute-primary.sqlite");
+
+    let callbackErrorMessage = "";
+
+    try {
+      await writeFile(sessionPath, "sqlite");
+
+      const authenticated = await runAuthStatus({
+        createClient: async (config) => ({
+          config,
+          sessionPath,
+          client: {
+            destroy: async () => undefined,
+            start: async (params?: { phone?: () => Promise<string> }) => {
+              if (params?.phone) {
+                try {
+                  await params.phone();
+                } catch (error) {
+                  callbackErrorMessage =
+                    error instanceof Error ? error.message : String(error);
+                }
+              }
+              throw new Error("session invalid");
+            },
+          } as any,
+        }),
+        loadConfig: () => createConfig(storageDir),
+        logger: createLogger(),
+      });
+
+      expect(authenticated).toBe(false);
+      expect(callbackErrorMessage).toContain("Run bun run auth:bootstrap");
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-clear removes only targeted account session files", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-clear-"));
+    const basePath = join(storageDir, "mtcute-primary.sqlite");
+    const siblingPath = join(storageDir, "mtcute-other.sqlite");
+
+    try {
+      await writeFile(basePath, "db");
+      await writeFile(`${basePath}-wal`, "wal");
+      await writeFile(`${basePath}-shm`, "shm");
+      await writeFile(siblingPath, "other");
+
+      const removed = await runAuthClear({
+        loadConfig: () => createConfig(storageDir),
+        logger: createLogger(),
+      });
+
+      expect(removed).toContain(basePath);
+      expect(removed).toContain(`${basePath}-wal`);
+      expect(removed).toContain(`${basePath}-shm`);
+
+      await expect(stat(basePath)).rejects.toThrow();
+      await expect(stat(`${basePath}-wal`)).rejects.toThrow();
+      await expect(stat(`${basePath}-shm`)).rejects.toThrow();
+      await stat(siblingPath);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/workers/userbot/src/__tests__/env.test.ts
+++ b/workers/userbot/src/__tests__/env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_ACCOUNT_KEY,
+  DEFAULT_STORAGE_DIR,
+  loadUserbotConfig,
+} from "../lib/env";
+
+describe("loadUserbotConfig", () => {
+  test("throws deterministic error when TELEGRAM_USERBOT_API_ID is missing", () => {
+    expect(() =>
+      loadUserbotConfig({
+        TELEGRAM_USERBOT_API_HASH: "hash",
+      })
+    ).toThrow("TELEGRAM_USERBOT_API_ID is not set");
+  });
+
+  test("throws deterministic error when TELEGRAM_USERBOT_API_HASH is missing", () => {
+    expect(() =>
+      loadUserbotConfig({
+        TELEGRAM_USERBOT_API_ID: "123",
+      })
+    ).toThrow("TELEGRAM_USERBOT_API_HASH is not set");
+  });
+
+  test("applies defaults for account key and storage dir", () => {
+    const config = loadUserbotConfig({
+      TELEGRAM_USERBOT_API_HASH: "hash",
+      TELEGRAM_USERBOT_API_ID: "123",
+    });
+
+    expect(config.accountKey).toBe(DEFAULT_ACCOUNT_KEY);
+    expect(config.storageDir).toBe(DEFAULT_STORAGE_DIR);
+  });
+
+  test("parses explicit account key and storage dir", () => {
+    const config = loadUserbotConfig({
+      TELEGRAM_USERBOT_ACCOUNT_KEY: "ops_userbot",
+      TELEGRAM_USERBOT_API_HASH: "hash",
+      TELEGRAM_USERBOT_API_ID: "123",
+      USERBOT_STORAGE_DIR: "./.data/userbot",
+    });
+
+    expect(config.accountKey).toBe("ops_userbot");
+    expect(config.storageDir.endsWith("/.data/userbot")).toBe(true);
+  });
+});

--- a/workers/userbot/src/__tests__/storage.test.ts
+++ b/workers/userbot/src/__tests__/storage.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ensureStorageReady,
+  resolveSessionSqlitePath,
+  resolveStorageDir,
+} from "../lib/storage";
+
+describe("storage primitives", () => {
+  test("ensureStorageReady is idempotent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "userbot-storage-"));
+
+    try {
+      const first = await ensureStorageReady(dir);
+      const second = await ensureStorageReady(dir);
+
+      expect(first).toBe(second);
+      expect(resolveStorageDir(dir)).toBe(first);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
+  });
+
+  test("resolveSessionSqlitePath is account-scoped and stable", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "userbot-storage-"));
+
+    try {
+      const primary = resolveSessionSqlitePath("primary", dir);
+      const secondary = resolveSessionSqlitePath("secondary", dir);
+
+      expect(primary.endsWith("mtcute-primary.sqlite")).toBe(true);
+      expect(secondary.endsWith("mtcute-secondary.sqlite")).toBe(true);
+      expect(primary === secondary).toBe(false);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/workers/userbot/src/__tests__/worker.test.ts
+++ b/workers/userbot/src/__tests__/worker.test.ts
@@ -1,0 +1,201 @@
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createUserbotWorker, registerShutdownHandlers } from "../worker";
+import type { UserbotConfig } from "../lib/env";
+
+type FakeLogger = {
+  error: (..._args: unknown[]) => void;
+  info: (..._args: unknown[]) => void;
+  warn: (..._args: unknown[]) => void;
+};
+
+function createLogger(): FakeLogger {
+  return {
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  };
+}
+
+function createConfig(): UserbotConfig {
+  return {
+    accountKey: "primary",
+    apiHash: "hash",
+    apiId: 123,
+    storageDir: "/tmp/userbot",
+  };
+}
+
+describe("worker runtime", () => {
+  test("fails fast when session file is missing", async () => {
+    let createClientCalls = 0;
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => {
+        createClientCalls += 1;
+        return {
+          config,
+          sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+          client: {
+            destroy: async () => undefined,
+            onRawUpdate: { add: () => undefined },
+            start: async () => ({ id: 1 }),
+          } as any,
+        };
+      },
+      hasFile: async () => false,
+      loadConfig: () => createConfig(),
+      logger: createLogger(),
+    });
+
+    await expect(worker.start()).rejects.toThrow("Missing session file");
+    expect(createClientCalls).toBe(0);
+  });
+
+  test("startup error destroys created client", async () => {
+    let destroyCalls = 0;
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => ({
+        config,
+        sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+        client: {
+          destroy: async () => {
+            destroyCalls += 1;
+          },
+          onRawUpdate: { add: () => undefined },
+          start: async () => {
+            throw new Error("invalid session");
+          },
+        } as any,
+      }),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      logger: createLogger(),
+    });
+
+    await expect(worker.start()).rejects.toThrow("invalid session");
+    expect(destroyCalls).toBe(1);
+  });
+
+  test("worker start uses non-interactive auth callbacks", async () => {
+    let callbackErrorMessage = "";
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => ({
+        config,
+        sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+        client: {
+          destroy: async () => undefined,
+          onRawUpdate: { add: () => undefined },
+          start: async (params?: { phone?: () => Promise<string> }) => {
+            if (params?.phone) {
+              try {
+                await params.phone();
+              } catch (error) {
+                callbackErrorMessage =
+                  error instanceof Error ? error.message : String(error);
+              }
+            }
+            throw new Error("invalid session");
+          },
+        } as any,
+      }),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      logger: createLogger(),
+    });
+
+    await expect(worker.start()).rejects.toThrow("invalid session");
+    expect(callbackErrorMessage).toContain("Run bun run auth:bootstrap");
+  });
+
+  test("shutdown handler is idempotent across repeated signals", async () => {
+    let destroyCalls = 0;
+    let exitCalls = 0;
+
+    const fakeProcess = new EventEmitter() as EventEmitter & {
+      once: (event: string, handler: () => void) => EventEmitter;
+    };
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => ({
+        config,
+        sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+        client: {
+          destroy: async () => {
+            destroyCalls += 1;
+          },
+          onRawUpdate: { add: () => undefined },
+          start: async () => ({ id: 7 }),
+        } as any,
+      }),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      logger: createLogger(),
+    });
+
+    await worker.start();
+
+    registerShutdownHandlers(worker, {
+      exit: () => {
+        exitCalls += 1;
+      },
+      logger: createLogger(),
+      processLike: fakeProcess,
+    });
+
+    fakeProcess.emit("SIGTERM");
+    fakeProcess.emit("SIGINT");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(destroyCalls).toBe(1);
+    expect(exitCalls).toBe(1);
+  });
+
+  test("signal during startup still destroys startup bundle", async () => {
+    let destroyCalls = 0;
+    let exitCalls = 0;
+
+    const fakeProcess = new EventEmitter() as EventEmitter & {
+      once: (event: string, handler: () => void) => EventEmitter;
+    };
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => ({
+        config,
+        sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+        client: {
+          destroy: async () => {
+            destroyCalls += 1;
+          },
+          onRawUpdate: { add: () => undefined },
+          start: async () => new Promise(() => undefined),
+        } as any,
+      }),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      logger: createLogger(),
+    });
+
+    registerShutdownHandlers(worker, {
+      exit: () => {
+        exitCalls += 1;
+      },
+      logger: createLogger(),
+      processLike: fakeProcess,
+    });
+
+    void worker.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fakeProcess.emit("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(destroyCalls).toBe(1);
+    expect(exitCalls).toBe(1);
+  });
+});

--- a/workers/userbot/src/commands/auth-bootstrap.ts
+++ b/workers/userbot/src/commands/auth-bootstrap.ts
@@ -1,0 +1,141 @@
+import { createInterface } from "node:readline/promises";
+
+import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
+import { loadUserbotConfig, readBootstrapPhone, type UserbotConfig } from "../lib/env";
+
+type EnvRecord = Record<string, string | undefined>;
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type Prompt = {
+  ask(question: string): Promise<string>;
+  close(): void;
+};
+
+type AuthBootstrapDeps = {
+  createClient: (config: UserbotConfig) => Promise<UserbotClientBundle>;
+  createPrompt: () => Prompt;
+  env: EnvRecord;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  logger: Logger;
+};
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+function createPrompt(): Prompt {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return {
+    ask: async (question: string) => {
+      const answer = await rl.question(question);
+      return answer.trim();
+    },
+    close: () => {
+      rl.close();
+    },
+  };
+}
+
+function resolveDeps(overrides: Partial<AuthBootstrapDeps>): AuthBootstrapDeps {
+  return {
+    createClient: overrides.createClient ?? createUserbotClient,
+    createPrompt: overrides.createPrompt ?? createPrompt,
+    env: overrides.env ?? process.env,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    logger: overrides.logger ?? console,
+  };
+}
+
+function getIdentityLabel(user: unknown): string {
+  if (!user || typeof user !== "object") {
+    return "unknown";
+  }
+
+  const candidate = user as {
+    id?: unknown;
+    username?: unknown;
+  };
+
+  const id =
+    typeof candidate.id === "string"
+      ? candidate.id
+      : typeof candidate.id === "number"
+      ? String(candidate.id)
+      : typeof candidate.id === "bigint"
+      ? candidate.id.toString()
+      : undefined;
+
+  const username =
+    typeof candidate.username === "string" && candidate.username.trim().length > 0
+      ? candidate.username.trim()
+      : undefined;
+
+  if (id && username) {
+    return `${id} (@${username})`;
+  }
+
+  if (id) {
+    return id;
+  }
+
+  if (username) {
+    return `@${username}`;
+  }
+
+  return "unknown";
+}
+
+export async function runAuthBootstrap(
+  overrides: Partial<AuthBootstrapDeps> = {}
+): Promise<void> {
+  const deps = resolveDeps(overrides);
+  const config = deps.loadConfig(deps.env);
+  const phoneFromEnv = readBootstrapPhone(deps.env);
+  const prompt = deps.createPrompt();
+
+  deps.logger.info(
+    `[userbot] Starting interactive auth bootstrap for account '${config.accountKey}'.`
+  );
+
+  const bundle = await deps.createClient(config);
+  deps.logger.info(`[userbot] Session storage: ${bundle.sessionPath}`);
+
+  try {
+    const user = await bundle.client.start({
+      code: async () => prompt.ask("Telegram code: "),
+      password: async () => prompt.ask("2FA password (if enabled): "),
+      phone: async () => phoneFromEnv ?? prompt.ask("Phone number (+...): "),
+    });
+
+    deps.logger.info(
+      `[userbot] Auth bootstrap complete for account '${config.accountKey}' as ${getIdentityLabel(user)}.`
+    );
+  } finally {
+    prompt.close();
+    await bundle.client.destroy();
+  }
+}
+
+export async function runAuthBootstrapCli(
+  overrides: Partial<AuthBootstrapDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+
+  try {
+    await runAuthBootstrap(overrides);
+    return 0;
+  } catch (error) {
+    logger.error("[userbot] Auth bootstrap failed", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("auth-bootstrap.ts")) {
+  process.exit(await runAuthBootstrapCli());
+}

--- a/workers/userbot/src/commands/auth-clear.ts
+++ b/workers/userbot/src/commands/auth-clear.ts
@@ -1,0 +1,82 @@
+import { unlink } from "node:fs/promises";
+
+import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
+import { resolveSessionSqlitePath } from "../lib/storage";
+
+type EnvRecord = Record<string, string | undefined>;
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type AuthClearDeps = {
+  env: EnvRecord;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  logger: Logger;
+  removeFile: (path: string) => Promise<void>;
+};
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+function resolveDeps(overrides: Partial<AuthClearDeps>): AuthClearDeps {
+  return {
+    env: overrides.env ?? process.env,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    logger: overrides.logger ?? console,
+    removeFile: overrides.removeFile ?? unlink,
+  };
+}
+
+export async function runAuthClear(
+  overrides: Partial<AuthClearDeps> = {}
+): Promise<string[]> {
+  const deps = resolveDeps(overrides);
+  const config = deps.loadConfig(deps.env);
+  const sessionPath = resolveSessionSqlitePath(config.accountKey, config.storageDir);
+
+  const candidates = [
+    sessionPath,
+    `${sessionPath}-journal`,
+    `${sessionPath}-shm`,
+    `${sessionPath}-wal`,
+  ];
+
+  const removed: string[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      await deps.removeFile(candidate);
+      removed.push(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  deps.logger.info(
+    `[userbot] Cleared ${removed.length} session file(s) for '${config.accountKey}'.`
+  );
+  deps.logger.info(`[userbot] Session base path: ${sessionPath}`);
+
+  return removed;
+}
+
+export async function runAuthClearCli(
+  overrides: Partial<AuthClearDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+
+  try {
+    await runAuthClear(overrides);
+    return 0;
+  } catch (error) {
+    logger.error("[userbot] Failed to clear session", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("auth-clear.ts")) {
+  process.exit(await runAuthClearCli());
+}

--- a/workers/userbot/src/commands/auth-status.ts
+++ b/workers/userbot/src/commands/auth-status.ts
@@ -1,0 +1,106 @@
+import { stat } from "node:fs/promises";
+
+import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
+import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
+import { createNonInteractiveAuthCallbacks } from "../lib/non-interactive-auth";
+import { resolveSessionSqlitePath } from "../lib/storage";
+
+type EnvRecord = Record<string, string | undefined>;
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type AuthStatusDeps = {
+  createClient: (config: UserbotConfig) => Promise<UserbotClientBundle>;
+  env: EnvRecord;
+  hasFile: (path: string) => Promise<boolean>;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  logger: Logger;
+};
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+async function hasFile(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function resolveDeps(overrides: Partial<AuthStatusDeps>): AuthStatusDeps {
+  return {
+    createClient: overrides.createClient ?? createUserbotClient,
+    env: overrides.env ?? process.env,
+    hasFile: overrides.hasFile ?? hasFile,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    logger: overrides.logger ?? console,
+  };
+}
+
+export async function runAuthStatus(
+  overrides: Partial<AuthStatusDeps> = {}
+): Promise<boolean> {
+  const deps = resolveDeps(overrides);
+  const config = deps.loadConfig(deps.env);
+  const sessionPath = resolveSessionSqlitePath(
+    config.accountKey,
+    config.storageDir
+  );
+
+  if (!(await deps.hasFile(sessionPath))) {
+    deps.logger.info(
+      `[userbot] No session found for '${config.accountKey}'. Run auth:bootstrap first.`
+    );
+    deps.logger.info(`[userbot] Expected session file: ${sessionPath}`);
+    return false;
+  }
+
+  const bundle = await deps.createClient(config);
+
+  try {
+    await bundle.client.start(
+      createNonInteractiveAuthCallbacks(
+        `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
+      )
+    );
+
+    deps.logger.info(
+      `[userbot] Session is valid for account '${config.accountKey}'.`
+    );
+
+    return true;
+  } catch (error) {
+    deps.logger.error(
+      `[userbot] Session check failed for '${config.accountKey}'. Re-run auth:bootstrap.`,
+      error
+    );
+    return false;
+  } finally {
+    await bundle.client.destroy();
+  }
+}
+
+export async function runAuthStatusCli(
+  overrides: Partial<AuthStatusDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+
+  try {
+    return (await runAuthStatus(overrides)) ? 0 : 1;
+  } catch (error) {
+    logger.error("[userbot] Auth status check crashed", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("auth-status.ts")) {
+  process.exit(await runAuthStatusCli());
+}

--- a/workers/userbot/src/lib/client.ts
+++ b/workers/userbot/src/lib/client.ts
@@ -1,0 +1,34 @@
+import { TelegramClient } from "@mtcute/bun";
+
+import type { UserbotConfig } from "./env";
+import { loadUserbotConfig } from "./env";
+import { ensureStorageReady, resolveSessionSqlitePath } from "./storage";
+
+export type UserbotClientBundle = {
+  client: TelegramClient;
+  config: UserbotConfig;
+  sessionPath: string;
+};
+
+export async function createUserbotClient(
+  config: UserbotConfig = loadUserbotConfig()
+): Promise<UserbotClientBundle> {
+  await ensureStorageReady(config.storageDir);
+
+  const sessionPath = resolveSessionSqlitePath(
+    config.accountKey,
+    config.storageDir
+  );
+
+  const client = new TelegramClient({
+    apiHash: config.apiHash,
+    apiId: config.apiId,
+    storage: sessionPath,
+  });
+
+  return {
+    client,
+    config,
+    sessionPath,
+  };
+}

--- a/workers/userbot/src/lib/env.ts
+++ b/workers/userbot/src/lib/env.ts
@@ -1,0 +1,77 @@
+import { resolve } from "node:path";
+
+export const DEFAULT_ACCOUNT_KEY = "primary";
+export const DEFAULT_STORAGE_DIR = "/var/data/userbot";
+
+const ACCOUNT_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+type EnvRecord = Record<string, string | undefined>;
+
+export type UserbotConfig = {
+  accountKey: string;
+  apiHash: string;
+  apiId: number;
+  storageDir: string;
+};
+
+function normalizeOptionalValue(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getRequiredEnv(name: string, env: EnvRecord): string {
+  const value = normalizeOptionalValue(env[name]);
+  if (!value) {
+    throw new Error(`${name} is not set`);
+  }
+
+  return value;
+}
+
+function parseApiId(rawApiId: string): number {
+  const parsed = Number.parseInt(rawApiId, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("TELEGRAM_USERBOT_API_ID must be a positive integer");
+  }
+
+  return parsed;
+}
+
+function parseAccountKey(rawAccountKey: string | undefined): string {
+  const normalized = normalizeOptionalValue(rawAccountKey) ?? DEFAULT_ACCOUNT_KEY;
+
+  if (!ACCOUNT_KEY_PATTERN.test(normalized)) {
+    throw new Error(
+      "TELEGRAM_USERBOT_ACCOUNT_KEY must match /^[A-Za-z0-9_-]+$/"
+    );
+  }
+
+  return normalized;
+}
+
+function parseStorageDir(rawStorageDir: string | undefined): string {
+  const normalized = normalizeOptionalValue(rawStorageDir) ?? DEFAULT_STORAGE_DIR;
+  return resolve(normalized);
+}
+
+export function loadUserbotConfig(env: EnvRecord = process.env): UserbotConfig {
+  const apiId = parseApiId(getRequiredEnv("TELEGRAM_USERBOT_API_ID", env));
+  const apiHash = getRequiredEnv("TELEGRAM_USERBOT_API_HASH", env);
+
+  return {
+    accountKey: parseAccountKey(env.TELEGRAM_USERBOT_ACCOUNT_KEY),
+    apiHash,
+    apiId,
+    storageDir: parseStorageDir(env.USERBOT_STORAGE_DIR),
+  };
+}
+
+export function readBootstrapPhone(
+  env: EnvRecord = process.env
+): string | undefined {
+  return normalizeOptionalValue(env.TELEGRAM_USERBOT_PHONE);
+}

--- a/workers/userbot/src/lib/non-interactive-auth.ts
+++ b/workers/userbot/src/lib/non-interactive-auth.ts
@@ -1,0 +1,22 @@
+const DEFAULT_NON_INTERACTIVE_MESSAGE =
+  "Session is missing or invalid. Run bun run auth:bootstrap to re-authenticate.";
+
+export type NonInteractiveAuthCallbacks = {
+  code: () => Promise<string>;
+  password: () => Promise<string>;
+  phone: () => Promise<string>;
+};
+
+export function createNonInteractiveAuthCallbacks(
+  message: string = DEFAULT_NON_INTERACTIVE_MESSAGE
+): NonInteractiveAuthCallbacks {
+  const throwAuthError = async (): Promise<string> => {
+    throw new Error(message);
+  };
+
+  return {
+    code: throwAuthError,
+    password: throwAuthError,
+    phone: throwAuthError,
+  };
+}

--- a/workers/userbot/src/lib/storage.ts
+++ b/workers/userbot/src/lib/storage.ts
@@ -1,0 +1,34 @@
+import { mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { DEFAULT_STORAGE_DIR } from "./env";
+
+function normalizeStorageDir(storageDir: string | undefined): string {
+  const normalized = storageDir?.trim();
+  if (!normalized) {
+    return resolve(DEFAULT_STORAGE_DIR);
+  }
+
+  return resolve(normalized);
+}
+
+export function resolveStorageDir(
+  storageDir: string | undefined = process.env.USERBOT_STORAGE_DIR
+): string {
+  return normalizeStorageDir(storageDir);
+}
+
+export function resolveSessionSqlitePath(
+  accountKey: string,
+  storageDir: string | undefined = process.env.USERBOT_STORAGE_DIR
+): string {
+  return join(resolveStorageDir(storageDir), `mtcute-${accountKey}.sqlite`);
+}
+
+export async function ensureStorageReady(
+  storageDir: string | undefined = process.env.USERBOT_STORAGE_DIR
+): Promise<string> {
+  const resolved = resolveStorageDir(storageDir);
+  await mkdir(resolved, { recursive: true });
+  return resolved;
+}

--- a/workers/userbot/src/worker.ts
+++ b/workers/userbot/src/worker.ts
@@ -1,0 +1,254 @@
+import { stat } from "node:fs/promises";
+
+import { createUserbotClient, type UserbotClientBundle } from "./lib/client";
+import { loadUserbotConfig, type UserbotConfig } from "./lib/env";
+import { createNonInteractiveAuthCallbacks } from "./lib/non-interactive-auth";
+import { resolveSessionSqlitePath } from "./lib/storage";
+
+type EnvRecord = Record<string, string | undefined>;
+type SignalName = "SIGINT" | "SIGTERM";
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type ProcessSignalLike = {
+  once(event: SignalName, listener: () => void): unknown;
+};
+
+type WorkerDeps = {
+  createClient: (config: UserbotConfig) => Promise<UserbotClientBundle>;
+  env: EnvRecord;
+  hasFile: (path: string) => Promise<boolean>;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  logger: Logger;
+};
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+async function hasFile(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function resolveWorkerDeps(overrides: Partial<WorkerDeps>): WorkerDeps {
+  return {
+    createClient: overrides.createClient ?? createUserbotClient,
+    env: overrides.env ?? process.env,
+    hasFile: overrides.hasFile ?? hasFile,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    logger: overrides.logger ?? console,
+  };
+}
+
+function getIdentityLabel(user: unknown): string {
+  if (!user || typeof user !== "object") {
+    return "unknown";
+  }
+
+  const candidate = user as {
+    id?: unknown;
+    username?: unknown;
+  };
+
+  const id =
+    typeof candidate.id === "string"
+      ? candidate.id
+      : typeof candidate.id === "number"
+      ? String(candidate.id)
+      : typeof candidate.id === "bigint"
+      ? candidate.id.toString()
+      : undefined;
+
+  const username =
+    typeof candidate.username === "string" && candidate.username.trim().length > 0
+      ? candidate.username.trim()
+      : undefined;
+
+  if (id && username) {
+    return `${id} (@${username})`;
+  }
+
+  if (id) {
+    return id;
+  }
+
+  if (username) {
+    return `@${username}`;
+  }
+
+  return "unknown";
+}
+
+export function createUserbotWorker(overrides: Partial<WorkerDeps> = {}) {
+  const deps = resolveWorkerDeps(overrides);
+
+  let activeBundle: UserbotClientBundle | null = null;
+  let startupBundle: UserbotClientBundle | null = null;
+  let startPromise: Promise<void> | null = null;
+  let shutdownPromise: Promise<void> | null = null;
+
+  async function destroyBundle(
+    bundle: UserbotClientBundle,
+    context: string
+  ): Promise<void> {
+    try {
+      await bundle.client.destroy();
+    } catch (error) {
+      deps.logger.error(`[userbot] Failed to destroy client (${context})`, error);
+    }
+  }
+
+  async function start(): Promise<void> {
+    if (startPromise) {
+      return startPromise;
+    }
+
+    startPromise = (async () => {
+      const config = deps.loadConfig(deps.env);
+      const sessionPath = resolveSessionSqlitePath(
+        config.accountKey,
+        config.storageDir
+      );
+
+      if (!(await deps.hasFile(sessionPath))) {
+        throw new Error(
+          `[userbot] Missing session file for '${config.accountKey}'. Run auth:bootstrap first. Expected: ${sessionPath}`
+        );
+      }
+
+      const bundle = await deps.createClient(config);
+      startupBundle = bundle;
+
+      try {
+        const user = await bundle.client.start(
+          createNonInteractiveAuthCallbacks(
+            `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
+          )
+        );
+
+        bundle.client.onRawUpdate.add(() => {
+          // Intentionally noop in foundation PR.
+        });
+
+        activeBundle = bundle;
+        deps.logger.info(`[userbot] Worker started for '${config.accountKey}'.`);
+        deps.logger.info(`[userbot] Session path: ${bundle.sessionPath}`);
+        deps.logger.info(`[userbot] Account: ${getIdentityLabel(user)}`);
+      } catch (error) {
+        await destroyBundle(bundle, "startup_error");
+        throw error;
+      } finally {
+        startupBundle = null;
+      }
+    })().finally(() => {
+      startPromise = null;
+    });
+
+    return startPromise;
+  }
+
+  async function shutdown(reason: string): Promise<void> {
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    shutdownPromise = (async () => {
+      const bundlesToClose = new Set<UserbotClientBundle>();
+
+      if (startupBundle) {
+        bundlesToClose.add(startupBundle);
+      }
+      if (activeBundle) {
+        bundlesToClose.add(activeBundle);
+      }
+
+      startupBundle = null;
+      activeBundle = null;
+
+      for (const bundle of bundlesToClose) {
+        await destroyBundle(bundle, reason);
+      }
+
+      deps.logger.info(`[userbot] Worker stopped (${reason}).`);
+    })().finally(() => {
+      shutdownPromise = null;
+    });
+
+    return shutdownPromise;
+  }
+
+  return {
+    shutdown,
+    start,
+  };
+}
+
+export function registerShutdownHandlers(
+  worker: { shutdown(reason: string): Promise<void> },
+  options: {
+    exit?: (code: number) => void;
+    logger?: Logger;
+    processLike?: ProcessSignalLike;
+  } = {}
+): void {
+  const logger = options.logger ?? console;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const processLike = options.processLike ?? process;
+
+  let hasHandledSignal = false;
+
+  const handleSignal = (signal: SignalName) => {
+    if (hasHandledSignal) {
+      return;
+    }
+    hasHandledSignal = true;
+
+    logger.info(`[userbot] Received ${signal}, shutting down...`);
+    void worker
+      .shutdown(signal)
+      .then(() => exit(0))
+      .catch((error) => {
+        logger.error("[userbot] Shutdown failed", error);
+        exit(1);
+      });
+  };
+
+  processLike.once("SIGINT", () => handleSignal("SIGINT"));
+  processLike.once("SIGTERM", () => handleSignal("SIGTERM"));
+}
+
+export async function runWorkerCli(
+  overrides: Partial<WorkerDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+  const worker = createUserbotWorker(overrides);
+
+  try {
+    registerShutdownHandlers(worker, { logger });
+    await worker.start();
+
+    await new Promise<never>(() => {
+      // intentionally unresolved; process exits through signal handlers
+    });
+  } catch (error) {
+    logger.error("[userbot] Worker failed to start", error);
+    await worker.shutdown("startup_error");
+    return 1;
+  }
+
+  return 0;
+}
+
+if (isDirectExecution("worker.ts")) {
+  process.exit(await runWorkerCli());
+}

--- a/workers/userbot/tsconfig.json
+++ b/workers/userbot/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "types": ["bun", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Add a standalone mtcute userbot worker package with Render-persistent SQLite session primitives and hardened auth/runtime lifecycle handling. Include worker documentation and a Render runbook under docs/workers.