### PR TITLE
feat(telegram): harden userbot sync-once ingestion

### DIFF
--- a/app/drizzle/0009_parched_the_executioner.sql
+++ b/app/drizzle/0009_parched_the_executioner.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "communities" ADD COLUMN "parser_type" text DEFAULT 'bot' NOT NULL;--> statement-breakpoint
+CREATE INDEX "communities_is_active_parser_type_idx" ON "communities" USING btree ("is_active","parser_type");--> statement-breakpoint
+ALTER TABLE "communities" ADD CONSTRAINT "communities_parser_type_check" CHECK ("communities"."parser_type" IN ('bot', 'userbot'));

--- a/app/drizzle/meta/0009_snapshot.json
+++ b/app/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1408 @@
+{
+  "id": "1255d42a-9277-4433-8e13-702b18c6ed55",
+  "prevId": "7b53da59-a421-4f34-a028-b08f675e511d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "parser_type": {
+          "name": "parser_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_parser_type_idx": {
+          "name": "communities_is_active_parser_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parser_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_parser_type_check": {
+          "name": "communities_parser_type_check",
+          "value": "\"communities\".\"parser_type\" IN ('bot', 'userbot')"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_helper_message_cleanup": {
+      "name": "telegram_helper_message_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_helper_message_cleanup_delete_after_idx": {
+          "name": "telegram_helper_message_cleanup_delete_after_idx",
+          "columns": [
+            {
+              "expression": "delete_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_helper_message_cleanup_chat_message_uidx": {
+          "name": "telegram_helper_message_cleanup_chat_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1771479840368,
       "tag": "0008_spotty_lockheed",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1772170186484,
+      "tag": "0009_parched_the_executioner",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/lib/telegram/bot-api/__tests__/active-community-cache.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/active-community-cache.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  evictActiveCommunityCache,
+  resolveActiveBotCommunityId,
+} from "../active-community-cache";
+
+type CommunityRecord = {
+  id: string;
+  parserType: "bot" | "userbot";
+} | null;
+
+type CacheDb = Parameters<typeof resolveActiveBotCommunityId>[0];
+
+function createDb(sequence: CommunityRecord[]): CacheDb & { calls: number } {
+  let index = 0;
+
+  return {
+    get calls() {
+      return index;
+    },
+    query: {
+      communities: {
+        findFirst: async () => sequence[index++] ?? null,
+      },
+    },
+  };
+}
+
+describe("active community cache", () => {
+  const chatId = BigInt(-1001234567890);
+
+  beforeEach(() => {
+    evictActiveCommunityCache(chatId);
+  });
+
+  test("reuses cached bot community after revalidation", async () => {
+    const db = createDb([
+      { id: "community-1", parserType: "bot" },
+      { id: "community-1", parserType: "bot" },
+    ]);
+
+    const first = await resolveActiveBotCommunityId(db, chatId);
+    const second = await resolveActiveBotCommunityId(db, chatId);
+
+    expect(first).toBe("community-1");
+    expect(second).toBe("community-1");
+    expect(db.calls).toBe(2);
+  });
+
+  test("invalidates cache when parser flips away from bot", async () => {
+    const db = createDb([
+      { id: "community-1", parserType: "bot" },
+      { id: "community-1", parserType: "userbot" },
+      { id: "community-1", parserType: "userbot" },
+    ]);
+
+    const initial = await resolveActiveBotCommunityId(db, chatId);
+    const afterFlip = await resolveActiveBotCommunityId(db, chatId);
+    const subsequent = await resolveActiveBotCommunityId(db, chatId);
+
+    expect(initial).toBe("community-1");
+    expect(afterFlip).toBeNull();
+    expect(subsequent).toBeNull();
+    expect(db.calls).toBe(3);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
@@ -107,6 +107,7 @@ function createCommunity(overrides?: Partial<Community>): Community {
     chatTitle: "Test Community",
     activatedBy: BigInt("123456789"),
     isActive: true,
+    parserType: "bot",
     summaryNotificationsEnabled: true,
     summaryNotificationTimeHours: 24,
     summaryNotificationMessageCount: null,

--- a/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/notification-settings.test.ts
@@ -78,6 +78,7 @@ function createCommunity(overrides?: Partial<Community>): Community {
     chatTitle: "Test Community",
     activatedBy: BigInt("123456789"),
     isActive: true,
+    parserType: "bot",
     summaryNotificationsEnabled: true,
     summaryNotificationTimeHours: 24,
     summaryNotificationMessageCount: null,

--- a/app/src/lib/telegram/bot-api/active-community-cache.ts
+++ b/app/src/lib/telegram/bot-api/active-community-cache.ts
@@ -1,0 +1,85 @@
+import { communities } from "@loyal-labs/db-core/schema";
+import { and, eq } from "drizzle-orm";
+
+type CacheEntry = {
+  communityId: string;
+  parserType: "bot" | "userbot";
+};
+
+type CommunityRecord = {
+  id: string;
+  parserType: "bot" | "userbot";
+} | null;
+
+type CommunityQueryDb = {
+  query: {
+    communities: {
+      findFirst: (args: unknown) => Promise<CommunityRecord>;
+    };
+  };
+};
+
+// Cache of active community state (chatId string -> parser-aware record).
+const activeCommunities = new Map<string, CacheEntry>();
+
+export function evictActiveCommunityCache(
+  chatId: bigint | number | string
+): void {
+  activeCommunities.delete(String(chatId));
+}
+
+export async function resolveActiveBotCommunityId(
+  db: CommunityQueryDb,
+  chatId: bigint
+): Promise<string | null> {
+  const chatIdStr = String(chatId);
+  const cached = activeCommunities.get(chatIdStr);
+
+  if (cached) {
+    // Revalidate cached mapping so parser flips (bot -> userbot) are respected.
+    const stillActive = await db.query.communities.findFirst({
+      columns: {
+        id: true,
+        parserType: true,
+      },
+      where: and(
+        eq(communities.id, cached.communityId),
+        eq(communities.chatId, chatId),
+        eq(communities.isActive, true)
+      ),
+    });
+
+    if (!stillActive || stillActive.parserType !== "bot") {
+      activeCommunities.delete(chatIdStr);
+      return null;
+    }
+
+    activeCommunities.set(chatIdStr, {
+      communityId: stillActive.id,
+      parserType: stillActive.parserType,
+    });
+    return stillActive.id;
+  }
+
+  const community = await db.query.communities.findFirst({
+    columns: {
+      id: true,
+      parserType: true,
+    },
+    where: and(
+      eq(communities.chatId, chatId),
+      eq(communities.isActive, true)
+    ),
+  });
+
+  if (!community || community.parserType !== "bot") {
+    activeCommunities.delete(chatIdStr);
+    return null;
+  }
+
+  activeCommunities.set(chatIdStr, {
+    communityId: community.id,
+    parserType: community.parserType,
+  });
+  return community.id;
+}

--- a/app/src/lib/telegram/bot-api/message-handlers.ts
+++ b/app/src/lib/telegram/bot-api/message-handlers.ts
@@ -1,10 +1,13 @@
-import { communities, communityMembers, messages } from "@loyal-labs/db-core/schema";
-import { and, eq } from "drizzle-orm";
+import { communityMembers, messages } from "@loyal-labs/db-core/schema";
 import type { Bot, Context } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat, isGroupChat } from "@/lib/telegram/utils";
+
+import { resolveActiveBotCommunityId } from "./active-community-cache";
+
+export { evictActiveCommunityCache } from "./active-community-cache";
 
 const POSITIVE_REACTIONS = [
   "❤",
@@ -48,41 +51,20 @@ export async function handleGLoyalReaction(ctx: Context, bot: Bot): Promise<void
   ]);
 }
 
-// Cache of active community IDs (chatId string -> communityUUID)
-const activeCommunities = new Map<string, string>();
-
-export function evictActiveCommunityCache(
-  chatId: bigint | number | string
-): void {
-  activeCommunities.delete(String(chatId));
-}
-
 export async function handleCommunityMessage(ctx: Context): Promise<void> {
   const chat = ctx.chat;
   if (!chat) return;
   if (!isCommunityChat(chat.type)) return;
 
   const chatId = BigInt(chat.id);
-  const chatIdStr = String(chat.id);
   const message = ctx.message;
   if (!message?.text || !message.from) return;
 
   try {
     const db = getDatabase();
 
-    // Check if community is active (use cache first)
-    let communityId = activeCommunities.get(chatIdStr);
-    if (!communityId) {
-      const community = await db.query.communities.findFirst({
-        where: and(
-          eq(communities.chatId, chatId),
-          eq(communities.isActive, true)
-        ),
-      });
-      if (!community) return;
-      communityId = community.id;
-      activeCommunities.set(chatIdStr, communityId);
-    }
+    const communityId = await resolveActiveBotCommunityId(db, chatId);
+    if (!communityId) return;
 
     const telegramUserId = BigInt(message.from.id);
     const displayName = getTelegramDisplayName(message.from);

--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,11 @@
     "workers/userbot": {
       "name": "@loyal-labs/userbot-worker",
       "dependencies": {
+        "@loyal-labs/db-adapter-neon": "workspace:*",
+        "@loyal-labs/db-core": "workspace:*",
         "@mtcute/bun": "^0.28.1",
+        "@neondatabase/serverless": "^1.0.2",
+        "drizzle-orm": "^0.45.1",
       },
       "devDependencies": {
         "@types/bun": "latest",

--- a/docs/workers/userbot-on-render.md
+++ b/docs/workers/userbot-on-render.md
@@ -18,6 +18,7 @@ This guide explains how to run the mtcute userbot worker with persistent SQLite 
 
 - `TELEGRAM_USERBOT_API_ID`
 - `TELEGRAM_USERBOT_API_HASH`
+- `DATABASE_URL` (required for `sync:once`)
 
 ## Optional Environment Variables
 
@@ -57,6 +58,14 @@ bun run auth:status
 
 - Exit code `0`: session is valid
 - Exit code `1`: session missing/invalid (re-bootstrap needed)
+
+## Cron Sync (One-shot)
+
+Configure a Render cron job with:
+
+```bash
+cd workers/userbot && bun install && bun run sync:once
+```
 
 ## Session Recovery Flow
 

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -59,6 +59,11 @@ export type SummaryNotificationTimeHours = 24 | 48;
 export type SummaryNotificationMessageCount = 500 | 1000;
 
 /**
+ * Community ingestion parser type.
+ */
+export type CommunityParserType = "bot" | "userbot";
+
+/**
  * Encrypted message content stored as JSONB.
  * Supports text now, extensible for images/voice later.
  */
@@ -157,6 +162,10 @@ export const communities = pgTable(
     chatTitle: text("chat_title").notNull(),
     activatedBy: bigint("activated_by", { mode: "bigint" }).notNull(),
     isActive: boolean("is_active").default(true).notNull(),
+    parserType: text("parser_type")
+      .$type<CommunityParserType>()
+      .default("bot")
+      .notNull(),
     summaryNotificationsEnabled: boolean("summary_notifications_enabled")
       .default(true)
       .notNull(),
@@ -180,9 +189,17 @@ export const communities = pgTable(
   (table) => [
     uniqueIndex("communities_chat_id_idx").on(table.chatId),
     index("communities_is_active_idx").on(table.isActive),
+    index("communities_is_active_parser_type_idx").on(
+      table.isActive,
+      table.parserType
+    ),
     check(
       "communities_summary_notification_time_hours_check",
       sql`${table.summaryNotificationTimeHours} IS NULL OR ${table.summaryNotificationTimeHours} IN (24, 48)`
+    ),
+    check(
+      "communities_parser_type_check",
+      sql`${table.parserType} IN ('bot', 'userbot')`
     ),
     check(
       "communities_summary_notification_message_count_check",

--- a/workers/userbot/README.md
+++ b/workers/userbot/README.md
@@ -14,6 +14,7 @@ Standalone worker package for Telegram userbot foundations.
 
 - `TELEGRAM_USERBOT_API_ID`
 - `TELEGRAM_USERBOT_API_HASH`
+- `DATABASE_URL` (required for `sync:once`)
 
 ## Optional environment variables
 
@@ -30,6 +31,7 @@ bun install
 bun run auth:bootstrap
 bun run auth:status
 bun run auth:clear
+bun run sync:once
 bun run start
 ```
 

--- a/workers/userbot/package.json
+++ b/workers/userbot/package.json
@@ -7,10 +7,15 @@
     "auth:bootstrap": "bun run src/commands/auth-bootstrap.ts",
     "auth:status": "bun run src/commands/auth-status.ts",
     "auth:clear": "bun run src/commands/auth-clear.ts",
+    "sync:once": "bun run src/commands/sync-once.ts",
     "test": "bun test"
   },
   "dependencies": {
-    "@mtcute/bun": "^0.28.1"
+    "@loyal-labs/db-adapter-neon": "workspace:*",
+    "@loyal-labs/db-core": "workspace:*",
+    "@mtcute/bun": "^0.28.1",
+    "@neondatabase/serverless": "^1.0.2",
+    "drizzle-orm": "^0.45.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/workers/userbot/src/__tests__/history-source.test.ts
+++ b/workers/userbot/src/__tests__/history-source.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { fetchUnseenMessages } from "../lib/sync/history-source";
+
+describe("history source", () => {
+  test("first sync returns the latest 200 batch in ascending id order", async () => {
+    const client = {
+      getHistory: async (_chatId: number, params?: { limit?: number }) => {
+        if (params?.limit === 200) {
+          return [{ id: 4 }, { id: 2 }, { id: 3 }];
+        }
+        return [];
+      },
+      iterHistory: async function* () {
+        yield { id: 999 };
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const message of fetchUnseenMessages(client, 1, null)) {
+      seen.push((message as { id: number }).id);
+    }
+
+    expect(seen).toEqual([2, 3, 4]);
+  });
+
+  test("incremental sync streams messages without pre-buffering all history", async () => {
+    let nextCalls = 0;
+
+    const client = {
+      getHistory: async () => [],
+      iterHistory: () => ({
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              nextCalls += 1;
+              if (nextCalls === 1) {
+                return { done: false, value: { id: 101 } };
+              }
+              if (nextCalls === 2) {
+                return { done: false, value: { id: 102 } };
+              }
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      }),
+    };
+
+    const iterator = fetchUnseenMessages(client, 1, 100);
+    const first = await iterator.next();
+    expect(first.value).toEqual({ id: 101 });
+    expect(nextCalls).toBe(1);
+
+    const second = await iterator.next();
+    expect(second.value).toEqual({ id: 102 });
+    expect(nextCalls).toBe(2);
+  });
+});

--- a/workers/userbot/src/__tests__/sync-once.test.ts
+++ b/workers/userbot/src/__tests__/sync-once.test.ts
@@ -1,0 +1,541 @@
+import { describe, expect, test } from "bun:test";
+
+import { runSyncOnce, runSyncOnceCli } from "../commands/sync-once";
+import type { UserbotConfig } from "../lib/env";
+
+type FakeLogger = {
+  error: (..._args: unknown[]) => void;
+  info: (..._args: unknown[]) => void;
+  warn: (..._args: unknown[]) => void;
+};
+
+type CommunityRecord = {
+  chatId: bigint;
+  chatTitle: string;
+  id: string;
+  parserType: "bot" | "userbot";
+};
+
+type MessageRecord = {
+  date: Date;
+  id: number;
+  isService: boolean;
+  media: { type: string } | null;
+  sender?: {
+    displayName?: string | null;
+    id: number;
+    type: string;
+    username?: string | null;
+  } | null;
+  text: string;
+};
+
+type FakeState = {
+  communities: CommunityRecord[];
+  existingMembershipKeys: Set<string>;
+  existingMessageKeys: Set<string>;
+  getHistoryCalls: Array<{ chatId: number; limit: number }>;
+  getHistoryLimitOneFailCount: number;
+  incrementalHistory: unknown[];
+  initialHistory: unknown[];
+  insertedMembershipRows: number;
+  insertedMessageRows: number;
+  insertedUserRows: number;
+  iterHistoryCalls: Array<{ chatId: number; minId: number }>;
+  latestStoredMessageId: bigint | null;
+  latestTelegramMessageId: number | null;
+  usersByTelegramId: Map<string, { displayName: string; id: string; username: string | null }>;
+};
+
+function createLogger(): FakeLogger {
+  return {
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  };
+}
+
+function createConfig(): UserbotConfig {
+  return {
+    accountKey: "primary",
+    apiHash: "hash",
+    apiId: 123,
+    storageDir: "/tmp/userbot",
+  };
+}
+
+function createFakeState(
+  overrides: Partial<
+    Omit<
+      FakeState,
+      | "existingMembershipKeys"
+      | "existingMessageKeys"
+      | "getHistoryCalls"
+      | "insertedMembershipRows"
+      | "insertedMessageRows"
+      | "insertedUserRows"
+      | "iterHistoryCalls"
+      | "usersByTelegramId"
+    >
+  > = {}
+): FakeState {
+  return {
+    communities: overrides.communities ?? [],
+    existingMembershipKeys: new Set<string>(),
+    existingMessageKeys: new Set<string>(),
+    getHistoryCalls: [],
+    getHistoryLimitOneFailCount: overrides.getHistoryLimitOneFailCount ?? 0,
+    incrementalHistory: overrides.incrementalHistory ?? [],
+    initialHistory: overrides.initialHistory ?? [],
+    insertedMembershipRows: 0,
+    insertedMessageRows: 0,
+    insertedUserRows: 0,
+    iterHistoryCalls: [],
+    latestStoredMessageId:
+      overrides.latestStoredMessageId === undefined
+        ? null
+        : overrides.latestStoredMessageId,
+    latestTelegramMessageId:
+      overrides.latestTelegramMessageId === undefined
+        ? null
+        : overrides.latestTelegramMessageId,
+    usersByTelegramId: new Map<string, { displayName: string; id: string; username: string | null }>(),
+  };
+}
+
+function createFakeDb(state: FakeState): any {
+  return {
+    query: {
+      communities: {
+        findMany: async () =>
+          state.communities.filter((community) => community.parserType === "userbot"),
+      },
+      messages: {
+        findFirst: async () =>
+          state.latestStoredMessageId === null
+            ? null
+            : { telegramMessageId: state.latestStoredMessageId },
+      },
+      users: {
+        findFirst: async () => {
+          const first = state.usersByTelegramId.values().next();
+          if (first.done) {
+            return null;
+          }
+
+          return first.value;
+        },
+      },
+    },
+    insert: () => ({
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: () => ({
+          returning: async () => {
+            if ("telegramId" in values) {
+              const telegramId = String(values.telegramId);
+              const existing = state.usersByTelegramId.get(telegramId);
+              if (existing) {
+                return [];
+              }
+
+              const newUser = {
+                displayName: String(values.displayName),
+                id: `user-${state.usersByTelegramId.size + 1}`,
+                username:
+                  values.username === null ? null : (values.username as string | null),
+              };
+              state.usersByTelegramId.set(telegramId, newUser);
+              state.insertedUserRows += 1;
+              return [{ id: newUser.id }];
+            }
+
+            if (
+              "communityId" in values &&
+              "userId" in values &&
+              !("content" in values)
+            ) {
+              const key = `${values.communityId}:${values.userId}`;
+              if (state.existingMembershipKeys.has(key)) {
+                return [];
+              }
+
+              state.existingMembershipKeys.add(key);
+              state.insertedMembershipRows += 1;
+              return [{ id: `community-member-${state.insertedMembershipRows}` }];
+            }
+
+            if ("content" in values && "telegramMessageId" in values) {
+              const key = `${values.communityId}:${String(values.telegramMessageId)}`;
+              if (state.existingMessageKeys.has(key)) {
+                return [];
+              }
+
+              state.existingMessageKeys.add(key);
+              state.insertedMessageRows += 1;
+              return [{ id: `message-${state.insertedMessageRows}` }];
+            }
+
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: async () => undefined,
+      }),
+    }),
+  };
+}
+
+function createFakeBundle(state: FakeState): any {
+  return {
+    client: {
+      destroy: async () => undefined,
+      getHistory: async (chatId: number, params?: { limit?: number }) => {
+        const limit = params?.limit ?? 0;
+        state.getHistoryCalls.push({ chatId, limit });
+
+        if (limit === 1) {
+          if (state.getHistoryLimitOneFailCount > 0) {
+            state.getHistoryLimitOneFailCount -= 1;
+            throw new Error("timeout");
+          }
+
+          if (state.latestTelegramMessageId === null) {
+            return [];
+          }
+
+          return [
+            {
+              id: state.latestTelegramMessageId,
+            },
+          ];
+        }
+
+        if (limit === 200) {
+          return state.initialHistory;
+        }
+
+        return [];
+      },
+      iterHistory: (_chatId: number, params?: { minId?: number }) => {
+        state.iterHistoryCalls.push({
+          chatId: _chatId,
+          minId: params?.minId ?? 0,
+        });
+
+        const messages = state.incrementalHistory;
+        return (async function* () {
+          for (const message of messages) {
+            yield message;
+          }
+        })();
+      },
+      start: async () => ({ id: 1 }),
+    },
+    config: createConfig(),
+    sessionPath: "/tmp/userbot/mtcute-primary.sqlite",
+  };
+}
+
+describe("sync:once command", () => {
+  test("fails fast when session file is missing", async () => {
+    let createClientCalls = 0;
+    const statusCode = await runSyncOnceCli({
+      createClient: async () => {
+        createClientCalls += 1;
+        return createFakeBundle(createFakeState());
+      },
+      createDb: () => createFakeDb(createFakeState()),
+      hasFile: async () => false,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(statusCode).toBe(1);
+    expect(createClientCalls).toBe(0);
+  });
+
+  test("returns zero-work stats when no userbot communities exist", async () => {
+    const state = createFakeState();
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.communitiesScanned).toBe(0);
+    expect(result.stats.communitiesProcessed).toBe(0);
+    expect(result.stats.insertedMessages).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("filters out bot communities from userbot sync selection", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000009),
+          chatTitle: "Bot Community",
+          id: "community-bot",
+          parserType: "bot",
+        },
+      ],
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.communitiesScanned).toBe(0);
+    expect(result.stats.communitiesProcessed).toBe(0);
+    expect(result.stats.insertedMessages).toBe(0);
+  });
+
+  test("skips insertion when no new Telegram messages are available", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000001),
+          chatTitle: "Community",
+          id: "community-1",
+          parserType: "userbot",
+        },
+      ],
+      latestStoredMessageId: BigInt(42),
+      latestTelegramMessageId: 42,
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.communitiesUpToDate).toBe(1);
+    expect(result.stats.insertedMessages).toBe(0);
+    expect(result.stats.telegramMessagesFetched).toBe(0);
+    expect(state.getHistoryCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000001)),
+        limit: 1,
+      },
+    ]);
+  });
+
+  test("inserts unseen text messages from initial backfill", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000002),
+          chatTitle: "Community",
+          id: "community-1",
+          parserType: "userbot",
+        },
+      ],
+      initialHistory: [
+        {
+          date: new Date("2026-01-01T00:00:00.000Z"),
+          id: 3,
+          isService: true,
+          media: null,
+          sender: { displayName: "Alice", id: 1, type: "user", username: "alice" },
+          text: "service",
+        } satisfies MessageRecord,
+        {
+          date: new Date("2026-01-01T00:01:00.000Z"),
+          id: 4,
+          isService: false,
+          media: null,
+          sender: { displayName: "Alice", id: 1, type: "user", username: "alice" },
+          text: "hello",
+        } satisfies MessageRecord,
+        {
+          date: new Date("2026-01-01T00:02:00.000Z"),
+          id: 5,
+          isService: false,
+          media: { type: "webpage" },
+          sender: { displayName: "Alice", id: 1, type: "user", username: "alice" },
+          text: "link preview message",
+        } satisfies MessageRecord,
+      ],
+      latestStoredMessageId: null,
+      latestTelegramMessageId: 5,
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.communitiesWithNoStoredMessages).toBe(1);
+    expect(result.stats.telegramMessagesFetched).toBe(3);
+    expect(result.stats.skippedNonText).toBe(1);
+    expect(result.stats.insertedUsers).toBe(1);
+    expect(result.stats.insertedMemberships).toBe(1);
+    expect(result.stats.insertedMessages).toBe(2);
+    expect(state.getHistoryCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000002)),
+        limit: 1,
+      },
+      {
+        chatId: Number(BigInt(-1000000000002)),
+        limit: 200,
+      },
+    ]);
+  });
+
+  test("tracks unsupported raw message shapes explicitly", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000005),
+          chatTitle: "Community",
+          id: "community-1",
+          parserType: "userbot",
+        },
+      ],
+      latestStoredMessageId: null,
+      latestTelegramMessageId: 5,
+      initialHistory: [
+        { bad: "shape" },
+        {
+          date: new Date("2026-01-01T00:01:00.000Z"),
+          id: 4,
+          isService: false,
+          media: null,
+          sender: { displayName: "Alice", id: 1, type: "user", username: "alice" },
+          text: "hello",
+        } satisfies MessageRecord,
+      ],
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.skippedUnsupportedShape).toBe(1);
+    expect(result.stats.insertedMessages).toBe(1);
+  });
+
+  test("does not double-insert with overlap between stored and fetched history", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000003),
+          chatTitle: "Community",
+          id: "community-1",
+          parserType: "userbot",
+        },
+      ],
+      incrementalHistory: [
+        {
+          date: new Date("2026-01-02T00:00:00.000Z"),
+          id: 10,
+          isService: false,
+          media: null,
+          sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+          text: "already saved",
+        } satisfies MessageRecord,
+        {
+          date: new Date("2026-01-02T00:01:00.000Z"),
+          id: 11,
+          isService: false,
+          media: null,
+          sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+          text: "duplicate overlap",
+        } satisfies MessageRecord,
+        {
+          date: new Date("2026-01-02T00:02:00.000Z"),
+          id: 12,
+          isService: false,
+          media: null,
+          sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+          text: "fresh message",
+        } satisfies MessageRecord,
+      ],
+      latestStoredMessageId: BigInt(10),
+      latestTelegramMessageId: 12,
+    });
+    state.existingMessageKeys.add("community-1:11");
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.skippedOldOrEqual).toBe(1);
+    expect(result.stats.duplicateMessages).toBe(1);
+    expect(result.stats.insertedMessages).toBe(1);
+    expect(state.iterHistoryCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000003)),
+        minId: 10,
+      },
+    ]);
+  });
+
+  test("retries transient Telegram failures with bounded backoff", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000010),
+          chatTitle: "Community",
+          id: "community-1",
+          parserType: "userbot",
+        },
+      ],
+      getHistoryLimitOneFailCount: 1,
+      latestStoredMessageId: BigInt(7),
+      latestTelegramMessageId: 7,
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.retryCount).toBe(1);
+    expect(result.stats.communitiesFailed).toBe(0);
+    expect(result.stats.communitiesUpToDate).toBe(1);
+  });
+});

--- a/workers/userbot/src/commands/sync-once.ts
+++ b/workers/userbot/src/commands/sync-once.ts
@@ -1,0 +1,366 @@
+import { stat } from "node:fs/promises";
+
+import { communities, messages } from "@loyal-labs/db-core/schema";
+import { and, desc, eq } from "drizzle-orm";
+
+import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
+import { createWorkerDatabase, loadDatabaseUrl, type UserbotDb } from "../lib/database";
+import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
+import { createNonInteractiveAuthCallbacks } from "../lib/non-interactive-auth";
+import { fetchUnseenMessages, getLatestTelegramMessageId } from "../lib/sync/history-source";
+import { toIngestibleMessage } from "../lib/sync/message-filter";
+import { persistEligibleMessage } from "../lib/sync/persistence";
+import { resolveSessionSqlitePath } from "../lib/storage";
+
+type EnvRecord = Record<string, string | undefined>;
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type SyncOnceDeps = {
+  createClient: (config: UserbotConfig) => Promise<UserbotClientBundle>;
+  createDb: (databaseUrl: string) => UserbotDb;
+  env: EnvRecord;
+  hasFile: (path: string) => Promise<boolean>;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  loadDatabaseUrl: (env: EnvRecord) => string;
+  logger: Logger;
+  sleep: (ms: number) => Promise<void>;
+};
+
+type ActiveUserbotCommunity = {
+  chatId: bigint;
+  chatTitle: string;
+  id: string;
+};
+
+type CommunitySyncError = {
+  chatId: string;
+  communityId: string;
+  error: string;
+};
+
+export type SyncOnceStats = {
+  communitiesFailed: number;
+  communitiesProcessed: number;
+  communitiesScanned: number;
+  communitiesUpToDate: number;
+  communitiesWithNoStoredMessages: number;
+  communitiesWithNoTelegramHistory: number;
+  duplicateMessages: number;
+  insertedMemberships: number;
+  insertedMessages: number;
+  insertedUsers: number;
+  retryCount: number;
+  skippedNonText: number;
+  skippedNonUserSender: number;
+  skippedOldOrEqual: number;
+  skippedUnsupportedShape: number;
+  telegramMessagesConsidered: number;
+  telegramMessagesFetched: number;
+  userMetadataUpdates: number;
+};
+
+export type SyncOnceResult = {
+  errors: CommunitySyncError[];
+  stats: SyncOnceStats;
+};
+
+const RETRY_BASE_DELAY_MS = 250;
+const RETRY_MAX_ATTEMPTS = 3;
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+async function hasFile(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveDeps(overrides: Partial<SyncOnceDeps>): SyncOnceDeps {
+  return {
+    createClient: overrides.createClient ?? createUserbotClient,
+    createDb: overrides.createDb ?? createWorkerDatabase,
+    env: overrides.env ?? process.env,
+    hasFile: overrides.hasFile ?? hasFile,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    loadDatabaseUrl: overrides.loadDatabaseUrl ?? loadDatabaseUrl,
+    logger: overrides.logger ?? console,
+    sleep: overrides.sleep ?? sleep,
+  };
+}
+
+function createInitialStats(communitiesScanned: number): SyncOnceStats {
+  return {
+    communitiesFailed: 0,
+    communitiesProcessed: 0,
+    communitiesScanned,
+    communitiesUpToDate: 0,
+    communitiesWithNoStoredMessages: 0,
+    communitiesWithNoTelegramHistory: 0,
+    duplicateMessages: 0,
+    insertedMemberships: 0,
+    insertedMessages: 0,
+    insertedUsers: 0,
+    retryCount: 0,
+    skippedNonText: 0,
+    skippedNonUserSender: 0,
+    skippedOldOrEqual: 0,
+    skippedUnsupportedShape: 0,
+    telegramMessagesConsidered: 0,
+    telegramMessagesFetched: 0,
+    userMetadataUpdates: 0,
+  };
+}
+
+function isTransientError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toUpperCase() : String(error).toUpperCase();
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : "";
+
+  if (["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "EAI_AGAIN"].includes(code)) {
+    return true;
+  }
+
+  return (
+    message.includes("FLOOD_WAIT") ||
+    message.includes("RPC_CALL_FAIL") ||
+    message.includes("TIMEOUT") ||
+    message.includes("NETWORK")
+  );
+}
+
+async function runWithRetry<T>(
+  deps: SyncOnceDeps,
+  stats: SyncOnceStats,
+  label: string,
+  task: () => Promise<T>
+): Promise<T> {
+  let attempt = 0;
+
+  while (attempt < RETRY_MAX_ATTEMPTS) {
+    attempt += 1;
+    try {
+      return await task();
+    } catch (error) {
+      const shouldRetry = isTransientError(error) && attempt < RETRY_MAX_ATTEMPTS;
+      if (!shouldRetry) {
+        throw error;
+      }
+
+      stats.retryCount += 1;
+      const delayMs = RETRY_BASE_DELAY_MS * attempt;
+      deps.logger.warn(
+        `[userbot] transient error while ${label}; retrying in ${delayMs}ms`,
+        error
+      );
+      await deps.sleep(delayMs);
+    }
+  }
+
+  throw new Error(`Failed retry loop for ${label}`);
+}
+
+async function destroyBundle(
+  bundle: UserbotClientBundle,
+  logger: Logger,
+  context: string
+): Promise<void> {
+  try {
+    await bundle.client.destroy();
+  } catch (error) {
+    logger.error(`[userbot] Failed to destroy client (${context})`, error);
+  }
+}
+
+async function syncCommunity(
+  db: UserbotDb,
+  bundle: UserbotClientBundle,
+  community: ActiveUserbotCommunity,
+  stats: SyncOnceStats,
+  userIdCache: Map<string, string>,
+  membershipCache: Set<string>
+): Promise<void> {
+  const latestStored = await db.query.messages.findFirst({
+    columns: { telegramMessageId: true },
+    orderBy: [desc(messages.telegramMessageId)],
+    where: eq(messages.communityId, community.id),
+  });
+  const latestStoredMessageId =
+    latestStored?.telegramMessageId !== undefined
+      ? Number(latestStored.telegramMessageId)
+      : null;
+
+  if (latestStoredMessageId === null) {
+    stats.communitiesWithNoStoredMessages += 1;
+  }
+
+  const chatPeerId = Number(community.chatId);
+  const latestTelegramMessageId = await getLatestTelegramMessageId(
+    bundle.client,
+    chatPeerId
+  );
+  if (latestTelegramMessageId === null) {
+    stats.communitiesWithNoTelegramHistory += 1;
+    return;
+  }
+
+  if (
+    latestStoredMessageId !== null &&
+    latestTelegramMessageId <= latestStoredMessageId
+  ) {
+    stats.communitiesUpToDate += 1;
+    return;
+  }
+
+  for await (const rawMessage of fetchUnseenMessages(
+    bundle.client,
+    chatPeerId,
+    latestStoredMessageId
+  )) {
+    stats.telegramMessagesFetched += 1;
+    stats.telegramMessagesConsidered += 1;
+
+    const message = toIngestibleMessage(rawMessage, stats);
+    if (!message) {
+      continue;
+    }
+
+    if (
+      latestStoredMessageId !== null &&
+      message.messageId <= latestStoredMessageId
+    ) {
+      stats.skippedOldOrEqual += 1;
+      continue;
+    }
+
+    await persistEligibleMessage({
+      communityId: community.id,
+      db,
+      membershipCache,
+      message,
+      stats,
+      userIdCache,
+    });
+  }
+}
+
+export async function runSyncOnce(
+  overrides: Partial<SyncOnceDeps> = {}
+): Promise<SyncOnceResult> {
+  const deps = resolveDeps(overrides);
+  const config = deps.loadConfig(deps.env);
+  const sessionPath = resolveSessionSqlitePath(
+    config.accountKey,
+    config.storageDir
+  );
+
+  if (!(await deps.hasFile(sessionPath))) {
+    throw new Error(
+      `[userbot] Missing session file for '${config.accountKey}'. Run auth:bootstrap first. Expected: ${sessionPath}`
+    );
+  }
+
+  const bundle = await deps.createClient(config);
+  const userIdCache = new Map<string, string>();
+  const membershipCache = new Set<string>();
+
+  try {
+    await bundle.client.start(
+      createNonInteractiveAuthCallbacks(
+        `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
+      )
+    );
+
+    const databaseUrl = deps.loadDatabaseUrl(deps.env);
+    const db = deps.createDb(databaseUrl);
+
+    const userbotCommunities = await db.query.communities.findMany({
+      columns: {
+        chatId: true,
+        chatTitle: true,
+        id: true,
+      },
+      where: and(
+        eq(communities.isActive, true),
+        eq(communities.parserType, "userbot")
+      ),
+    });
+
+    const stats = createInitialStats(userbotCommunities.length);
+    const errors: CommunitySyncError[] = [];
+
+    for (const community of userbotCommunities) {
+      stats.communitiesProcessed += 1;
+
+      try {
+        await runWithRetry(
+          deps,
+          stats,
+          `syncing community ${community.id}`,
+          async () => {
+            await syncCommunity(
+              db,
+              bundle,
+              community,
+              stats,
+              userIdCache,
+              membershipCache
+            );
+          }
+        );
+      } catch (error) {
+        stats.communitiesFailed += 1;
+        errors.push({
+          chatId: community.chatId.toString(),
+          communityId: community.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const result = {
+      errors,
+      stats,
+    };
+
+    deps.logger.info("[userbot] sync:once completed", result);
+    return result;
+  } finally {
+    await destroyBundle(bundle, deps.logger, "sync_once");
+  }
+}
+
+export async function runSyncOnceCli(
+  overrides: Partial<SyncOnceDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+
+  try {
+    await runSyncOnce(overrides);
+    return 0;
+  } catch (error) {
+    logger.error("[userbot] sync:once failed to start", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("sync-once.ts")) {
+  process.exit(await runSyncOnceCli());
+}

--- a/workers/userbot/src/lib/database.ts
+++ b/workers/userbot/src/lib/database.ts
@@ -1,0 +1,31 @@
+import { createNeonDb, type NeonDb } from "@loyal-labs/db-adapter-neon";
+import * as schema from "@loyal-labs/db-core/schema";
+
+type EnvRecord = Record<string, string | undefined>;
+
+export type UserbotDb = NeonDb<typeof schema>;
+
+function normalizeOptionalValue(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function loadDatabaseUrl(env: EnvRecord = process.env): string {
+  const databaseUrl = normalizeOptionalValue(env.DATABASE_URL);
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+
+  return databaseUrl;
+}
+
+export function createWorkerDatabase(databaseUrl: string): UserbotDb {
+  return createNeonDb({
+    databaseUrl,
+    schema,
+  });
+}

--- a/workers/userbot/src/lib/sync/history-source.ts
+++ b/workers/userbot/src/lib/sync/history-source.ts
@@ -1,0 +1,60 @@
+import type { TelegramHistoryClient } from "./types";
+
+const INITIAL_BACKFILL_LIMIT = 200;
+const HISTORY_CHUNK_SIZE = 200;
+
+function readMessageId(message: unknown): number | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+
+  const id = (message as { id?: unknown }).id;
+  if (!Number.isInteger(id) || (id as number) <= 0) {
+    return null;
+  }
+
+  return id as number;
+}
+
+export async function getLatestTelegramMessageId(
+  client: TelegramHistoryClient,
+  chatId: number
+): Promise<number | null> {
+  const latestHistory = await client.getHistory(chatId, { limit: 1 });
+  return readMessageId(latestHistory[0] ?? null);
+}
+
+export async function* fetchUnseenMessages(
+  client: TelegramHistoryClient,
+  chatId: number,
+  lastStoredMessageId: number | null
+): AsyncGenerator<unknown> {
+  if (lastStoredMessageId === null) {
+    const initialBatch = await client.getHistory(chatId, {
+      limit: INITIAL_BACKFILL_LIMIT,
+    });
+
+    // Keep first-sync deterministic in ascending message-id order.
+    const orderedInitialBatch = [...initialBatch].sort((left, right) => {
+      const leftId = readMessageId(left);
+      const rightId = readMessageId(right);
+      if (leftId === null || rightId === null) {
+        return 0;
+      }
+
+      return leftId - rightId;
+    });
+
+    for (const message of orderedInitialBatch) {
+      yield message;
+    }
+    return;
+  }
+
+  for await (const message of client.iterHistory(chatId, {
+    chunkSize: HISTORY_CHUNK_SIZE,
+    minId: lastStoredMessageId,
+  })) {
+    yield message;
+  }
+}

--- a/workers/userbot/src/lib/sync/message-filter.ts
+++ b/workers/userbot/src/lib/sync/message-filter.ts
@@ -1,0 +1,134 @@
+import type { IngestibleMessage, MessageFilterStats } from "./types";
+
+type TelegramMessageLike = {
+  date: Date;
+  id: number;
+  isService: boolean;
+  media: { type: string } | null;
+  sender?: {
+    displayName?: string | null;
+    id: number;
+    type: string;
+    username?: string | null;
+  } | null;
+  text: string;
+};
+
+function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+function toTelegramMessageLike(rawMessage: unknown): TelegramMessageLike | null {
+  if (!rawMessage || typeof rawMessage !== "object") {
+    return null;
+  }
+
+  const candidate = rawMessage as {
+    date?: unknown;
+    id?: unknown;
+    isService?: unknown;
+    media?: unknown;
+    sender?: unknown;
+    text?: unknown;
+  };
+
+  if (!Number.isInteger(candidate.id) || (candidate.id as number) <= 0) {
+    return null;
+  }
+  if (!isValidDate(candidate.date)) {
+    return null;
+  }
+  if (typeof candidate.isService !== "boolean") {
+    return null;
+  }
+  if (typeof candidate.text !== "string") {
+    return null;
+  }
+
+  const normalizedMedia =
+    candidate.media === null
+      ? null
+      : candidate.media &&
+        typeof candidate.media === "object" &&
+        typeof (candidate.media as { type?: unknown }).type === "string"
+      ? ({ type: (candidate.media as { type: string }).type } as const)
+      : null;
+
+  let normalizedSender: TelegramMessageLike["sender"] = null;
+  if (candidate.sender && typeof candidate.sender === "object") {
+    const sender = candidate.sender as {
+      displayName?: unknown;
+      id?: unknown;
+      type?: unknown;
+      username?: unknown;
+    };
+
+    if (typeof sender.type === "string" && Number.isInteger(sender.id)) {
+      normalizedSender = {
+        displayName:
+          typeof sender.displayName === "string" ? sender.displayName : null,
+        id: sender.id as number,
+        type: sender.type,
+        username: typeof sender.username === "string" ? sender.username : null,
+      };
+    }
+  }
+
+  return {
+    date: candidate.date,
+    id: candidate.id as number,
+    isService: candidate.isService,
+    media: normalizedMedia,
+    sender: normalizedSender,
+    text: candidate.text,
+  };
+}
+
+function isSupportedTextMessage(message: TelegramMessageLike): boolean {
+  if (message.isService) {
+    return false;
+  }
+
+  const trimmedText = message.text.trim();
+  if (trimmedText.length === 0) {
+    return false;
+  }
+
+  return message.media === null || message.media.type === "webpage";
+}
+
+export function toIngestibleMessage(
+  rawMessage: unknown,
+  stats: MessageFilterStats
+): IngestibleMessage | null {
+  const message = toTelegramMessageLike(rawMessage);
+  if (!message) {
+    stats.skippedUnsupportedShape += 1;
+    return null;
+  }
+
+  if (!isSupportedTextMessage(message)) {
+    stats.skippedNonText += 1;
+    return null;
+  }
+
+  const sender = message.sender;
+  if (!sender || sender.type !== "user") {
+    stats.skippedNonUserSender += 1;
+    return null;
+  }
+
+  const senderDisplayName =
+    typeof sender.displayName === "string" && sender.displayName.trim().length > 0
+      ? sender.displayName.trim()
+      : `User ${sender.id}`;
+
+  return {
+    content: message.text.trim(),
+    createdAt: message.date,
+    messageId: message.id,
+    senderDisplayName,
+    senderTelegramId: BigInt(sender.id),
+    senderUsername: sender.username ?? null,
+  };
+}

--- a/workers/userbot/src/lib/sync/persistence.ts
+++ b/workers/userbot/src/lib/sync/persistence.ts
@@ -1,0 +1,163 @@
+import {
+  communityMembers,
+  messages,
+  users,
+} from "@loyal-labs/db-core/schema";
+import { eq } from "drizzle-orm";
+
+import type { UserbotDb } from "../database";
+import type { IngestibleMessage, PersistenceStats } from "./types";
+
+type PersistEligibleMessageParams = {
+  communityId: string;
+  db: UserbotDb;
+  membershipCache: Set<string>;
+  message: IngestibleMessage;
+  stats: PersistenceStats;
+  userIdCache: Map<string, string>;
+};
+
+async function resolveOrCreateUserId(
+  db: UserbotDb,
+  userIdCache: Map<string, string>,
+  message: IngestibleMessage,
+  stats: PersistenceStats
+): Promise<string> {
+  const cacheKey = message.senderTelegramId.toString();
+  const cachedUserId = userIdCache.get(cacheKey);
+  if (cachedUserId) {
+    return cachedUserId;
+  }
+
+  const insertedUser = await db
+    .insert(users)
+    .values({
+      displayName: message.senderDisplayName,
+      telegramId: message.senderTelegramId,
+      username: message.senderUsername,
+    })
+    .onConflictDoNothing()
+    .returning({ id: users.id });
+
+  if (insertedUser.length > 0) {
+    const userId = insertedUser[0].id;
+    userIdCache.set(cacheKey, userId);
+    stats.insertedUsers += 1;
+    return userId;
+  }
+
+  const existingUser = await db.query.users.findFirst({
+    columns: {
+      displayName: true,
+      id: true,
+      username: true,
+    },
+    where: eq(users.telegramId, message.senderTelegramId),
+  });
+
+  if (!existingUser) {
+    throw new Error(
+      `Failed to resolve user ${message.senderTelegramId.toString()}`
+    );
+  }
+
+  userIdCache.set(cacheKey, existingUser.id);
+
+  if (
+    existingUser.displayName !== message.senderDisplayName ||
+    existingUser.username !== message.senderUsername
+  ) {
+    await db
+      .update(users)
+      .set({
+        displayName: message.senderDisplayName,
+        updatedAt: new Date(),
+        username: message.senderUsername,
+      })
+      .where(eq(users.id, existingUser.id));
+    stats.userMetadataUpdates += 1;
+  }
+
+  return existingUser.id;
+}
+
+async function ensureCommunityMembership(
+  db: UserbotDb,
+  membershipCache: Set<string>,
+  communityId: string,
+  userId: string,
+  stats: PersistenceStats
+): Promise<void> {
+  const membershipKey = `${communityId}:${userId}`;
+  if (membershipCache.has(membershipKey)) {
+    return;
+  }
+
+  const insertedMembership = await db
+    .insert(communityMembers)
+    .values({
+      communityId,
+      userId,
+    })
+    .onConflictDoNothing()
+    .returning({ id: communityMembers.id });
+
+  membershipCache.add(membershipKey);
+  if (insertedMembership.length > 0) {
+    stats.insertedMemberships += 1;
+  }
+}
+
+async function insertMessageRecord(
+  db: UserbotDb,
+  communityId: string,
+  userId: string,
+  message: IngestibleMessage,
+  stats: PersistenceStats
+): Promise<void> {
+  const insertedMessage = await db
+    .insert(messages)
+    .values({
+      communityId,
+      content: message.content,
+      createdAt: message.createdAt,
+      telegramMessageId: BigInt(message.messageId),
+      userId,
+    })
+    .onConflictDoNothing()
+    .returning({ id: messages.id });
+
+  if (insertedMessage.length > 0) {
+    stats.insertedMessages += 1;
+    return;
+  }
+
+  stats.duplicateMessages += 1;
+}
+
+export async function persistEligibleMessage(
+  params: PersistEligibleMessageParams
+): Promise<void> {
+  const userId = await resolveOrCreateUserId(
+    params.db,
+    params.userIdCache,
+    params.message,
+    params.stats
+  );
+
+  await ensureCommunityMembership(
+    params.db,
+    params.membershipCache,
+    params.communityId,
+    userId,
+    params.stats
+  );
+
+  await insertMessageRecord(
+    params.db,
+    params.communityId,
+    userId,
+    params.message,
+    params.stats
+  );
+}

--- a/workers/userbot/src/lib/sync/types.ts
+++ b/workers/userbot/src/lib/sync/types.ts
@@ -1,0 +1,30 @@
+export type TelegramHistoryClient = {
+  getHistory: (chatId: number, params?: { limit?: number }) => Promise<unknown[]>;
+  iterHistory: (
+    chatId: number,
+    params?: { chunkSize?: number; minId?: number }
+  ) => AsyncIterable<unknown>;
+};
+
+export type IngestibleMessage = {
+  content: string;
+  createdAt: Date;
+  messageId: number;
+  senderDisplayName: string;
+  senderTelegramId: bigint;
+  senderUsername: string | null;
+};
+
+export type MessageFilterStats = {
+  skippedNonText: number;
+  skippedNonUserSender: number;
+  skippedUnsupportedShape: number;
+};
+
+export type PersistenceStats = {
+  duplicateMessages: number;
+  insertedMemberships: number;
+  insertedMessages: number;
+  insertedUsers: number;
+  userMetadataUpdates: number;
+};


### PR DESCRIPTION
Implements a reliability-focused rewrite of Plan A userbot sync:once ingestion with streaming history processing, strict parser gating, and idempotent persistence. Adds parser-type schema/migration updates, bot cache hardening, and targeted tests for sync behavior and cache invalidation.