### PR TITLE
docs(readme): add monorepo structure navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,153 @@
-# How-tos
-## Commit Message Style
-We use Conventional Commits for commit messages and pull request titles.
+# Loyal App
+
+Loyal App is a monorepo for Telegram-native Solana products.
+It combines on-chain Anchor programs, a Telegram mini-app, an internal admin dashboard,
+shared packages/SDKs, and worker services.
+
+## Monorepo Structure
+
+| Directory | What it contains | Start here |
+| --- | --- | --- |
+| [`app/`](./app) | Next.js Telegram mini-app and API routes | [`app/README.md`](./app/README.md) |
+| [`admin/`](./admin) | Internal Next.js admin dashboard | [`admin/README.md`](./admin/README.md) |
+| [`programs/`](./programs) | Anchor smart contracts (`telegram-transfer`, `telegram-verification`, `telegram-private-transfer`) | [`programs/`](./programs) |
+| [`tests/`](./tests) | Anchor integration tests and fixtures | [`tests/`](./tests) |
+| [`packages/`](./packages) | Shared workspace libraries (`db-core`, `db-adapter-neon`) | [`packages/`](./packages) |
+| [`sdk/`](./sdk) | Publishable SDKs for deposits and private transfers | [`sdk/transactions/README.md`](./sdk/transactions/README.md), [`sdk/private-transactions/README.md`](./sdk/private-transactions/README.md) |
+| [`workers/`](./workers) | Background workers and service runtimes | [`workers/userbot/README.md`](./workers/userbot/README.md) |
+| [`docs/`](./docs) | Internal engineering and operations documentation | [`docs/README.md`](./docs/README.md) |
+| [`user-docs/`](./user-docs) | Public Mintlify documentation content | [`user-docs/README.md`](./user-docs/README.md) |
+| [`scripts/`](./scripts) | Repository automation scripts and setup helpers | [`scripts/`](./scripts) |
+| [`githooks/`](./githooks) | Git hook scripts used by local workflow checks | [`githooks/`](./githooks) |
+| [`migrations/`](./migrations) | Root-level migration artifacts and migration history | [`migrations/`](./migrations) |
+
+## Quick Start (Contributors)
 
 1. Install dependencies:
-```bash
-bun install
-```
-
-2. Enable repo hooks (one-time per clone):
-```bash
-./scripts/setup-git-hooks.sh
-```
-
-Enabled hooks:
-- `commit-msg`: validates Conventional Commit messages.
-- `pre-push`: runs lint/build checks for both `app` and `admin` before push.
-- Bypass only when necessary: `SKIP_VERIFY=1 git push`
-- CI note: app build is not run in GitHub Actions; Vercel is the build/deploy gate.
-
-3. Optional local check:
-```bash
-echo "feat(scope): short description" | bunx commitlint --verbose
-```
-
-GitHub pull requests also enforce commit messages and PR titles with the same rules.
-
-## Monorepo Apps
-- `app`: Telegram mini-app and API
-- `admin`: internal admin dashboard
+   ```bash
+   bun install
+   ```
+2. Enable repository hooks (one-time per clone):
+   ```bash
+   ./scripts/setup-git-hooks.sh
+   ```
+3. Run the main app:
+   ```bash
+   cd app
+   bun dev
+   ```
 
 For Vercel admin deploys from this monorepo, set project Root Directory to `admin`.
 
-## Documentation Structure
-- `/docs`: Internal repository and engineering documentation for contributors/operators.
-- `/user-docs`: Mintlify-hosted public/user-facing documentation.
+## Common Commands
+
+### Root
+
+```bash
+bun run lint
+bun run lint:fix
+bun run build:db-packages
+bun run typecheck:db-packages
+bun run guard:shared-boundaries
+bun run guard:admin-shared-schema
+bun run admin:dev
+bun run admin:lint
+bun run admin:build
+```
+
+### Frontend (`/app`)
+
+```bash
+bun dev
+bun run build
+bun lint
+bun db:generate
+bun db:migrate
+bun db:studio
+```
+
+### Admin (`/admin`)
+
+```bash
+bun dev
+bun run build
+bun lint
+```
+
+### Smart Contracts (`/`)
+
+```bash
+anchor build
+anchor deploy --provider.cluster devnet
+anchor deploy --provider.cluster localnet
+```
+
+## Local Solana / Anchor Testing
+
+Local tests require three terminals:
+
+1. Terminal 1: Start validator
+   ```bash
+   mb-test-validator --reset
+   ```
+2. Terminal 2: Start ephemeral validator
+   ```bash
+   RUST_LOG=info ephemeral-validator \
+       --accounts-lifecycle ephemeral \
+       --remote-cluster development \
+       --remote-url http://127.0.0.1:8899 \
+       --remote-ws-url ws://127.0.0.1:8900 \
+       --rpc-port 7799
+   ```
+3. Terminal 3: Run tests
+   ```bash
+   EPHEMERAL_PROVIDER_ENDPOINT="http://localhost:7799" \
+   EPHEMERAL_WS_ENDPOINT="ws://localhost:7800" \
+   anchor test --provider.cluster localnet --skip-local-validator --skip-build --skip-deploy
+   ```
+
+Devnet flow:
+
+```bash
+anchor build && anchor deploy --provider.cluster devnet
+EPHEMERAL_PROVIDER_ENDPOINT="http://localhost:7799" \
+EPHEMERAL_WS_ENDPOINT="ws://localhost:7800" \
+anchor test --provider.cluster devnet --skip-local-validator --skip-build --skip-deploy
+```
+
+## Documentation
+
+- Internal docs: [`/docs`](./docs) and [`docs/README.md`](./docs/README.md)
+- Public docs: [`/user-docs`](./user-docs) and [`user-docs/README.md`](./user-docs/README.md)
 
 Mintlify local preview:
+
 ```bash
 cd user-docs
 mint dev
 ```
 
-Future subtree sync from `loyal-docs`:
+Subtree sync from `loyal-docs`:
+
 ```bash
 git subtree pull --prefix=user-docs loyal-docs main --squash
 ```
 
-## Local Development
-1. Run Solana validator
+## Commit and PR Conventions
+
+We use Conventional Commits for commit messages and pull request titles.
+
+Enabled hooks:
+
+- `commit-msg`: validates Conventional Commit messages
+- `pre-push`: runs lint/build checks for both `app` and `admin` before push
+- Temporary bypass when required: `SKIP_VERIFY=1 git push`
+- CI note: app build is intentionally not run in GitHub Actions; Vercel is the build/deploy gate
+
+Optional local commit message check:
+
 ```bash
-sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
-npm install -g @magicblock-labs/ephemeral-validator@latest
-mb-test-validator --reset
+echo "feat(scope): short description" | bunx commitlint --verbose
 ```
 
-2. Upgrade and deploy the program
-```bash
-anchor build && anchor deploy --provider.cluster localnet
-```
-
-3. Run tests
-```bash
-EPHEMERAL_PROVIDER_ENDPOINT="http://localhost:7799" \
-EPHEMERAL_WS_ENDPOINT="ws://localhost:7800" \
-anchor test \
---provider.cluster localnet \
---skip-local-validator \
---skip-build \
---skip-deploy
-```
-## Devnet
-1. Upgrade and deploy
-```bash
-anchor build && anchor deploy --provider.cluster devnet
-```
-
-2. Run tests
-```bash
-EPHEMERAL_PROVIDER_ENDPOINT="http://localhost:7799" \
-EPHEMERAL_WS_ENDPOINT="ws://localhost:7800" \
-anchor test \
---provider.cluster devnet \
---skip-local-validator \
---skip-build \
---skip-deploy
-```
+GitHub pull requests also enforce commit messages and PR titles with the same rules.


### PR DESCRIPTION
Refreshes the root README for onboarding with a clear monorepo structure table and direct links to key folders/workspace docs. Preserves existing operational commands and conventions while improving discoverability for new contributors.