### PR TITLE
ci(vercel): skip deploys for unrelated monorepo changes

### DIFF
--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../packages",
   "installCommand": "rm -rf node_modules && cd .. && bun install --frozen-lockfile",
   "buildCommand": "bun run build"
 }

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../packages",
   "installCommand": "rm -rf node_modules && cd .. && bun install --frozen-lockfile",
   "buildCommand": "bun run build && bash scripts/upload-sourcemaps.sh",
   "crons": [


### PR DESCRIPTION
Adds `ignoreCommand` to both `app/vercel.json` and `admin/vercel.json` so each Vercel project only builds when its own directory or shared `packages/` change. Changes to `mobile/`, `programs/`, etc. no longer trigger unnecessary deployments.