### PR TITLE
fix(telegram): harden webhook ingest and add reliability guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,27 @@ Use `/app/src/lib` for cross-slice infrastructure and integration primitives. Ex
 - Promote code into `/app/src/lib` only after it is proven reusable across multiple slices.
 - Refactor incrementally by slice (wallet, summaries, telegram, etc.), not by file type alone.
 
+### Mobile App-Specific Guardrails (`/mobile`)
+
+These complement the command list above and mirror guidance in `mobile/CLAUDE.md`.
+
+- **Architecture and boundaries**:
+  - Routes live in `mobile/app` (Expo Router); reusable UI/hook/service logic lives in `mobile/src`.
+  - Keep network calls centralized in `mobile/src/services/api.ts` (avoid ad-hoc fetches in UI components).
+  - Use `@/` alias for imports under `mobile/src`.
+  - Shared cross-app types/utilities belong in `@loyal-labs/shared` (do not duplicate between `/app` and `/mobile`).
+- **Environment config**:
+  - Client-exposed vars must use `EXPO_PUBLIC_` prefix.
+  - For cloud builds, `eas.json` env is source of truth; `.env` is local-only.
+  - Keep fallback behavior in `mobile/src/config/env.ts` aligned with production API expectations.
+- **Build/runtime constraints**:
+  - Maintain Metro monorepo + SVG transformer settings in `mobile/metro.config.js` (watchFolders for shared package, svg as source extension).
+  - Keep typed routes and New Architecture settings compatible with Expo SDK/React Native versions already pinned.
+- **Testing and validation**:
+  - Lint mobile changes with `cd mobile && npx expo lint`.
+  - Run mobile unit tests with `cd mobile && npm test` when touching shared mobile logic.
+  - Do not start Expo dev server unless explicitly requested by user.
+
 ### Admin Guardrails (`/admin`)
 
 - Use shared DB modules only:
@@ -254,6 +275,54 @@ Service layer patterns:
 ### Troubleshooting
 
 - **Runtime vs Code Mismatch**: If logs/stack traces reference code that no longer matches current file contents, restart the local dev server or worker process. Stale processes can keep executing old code after edits.
+
+### Webhook + Drizzle Reliability Guardrails
+
+- **Context-bound method safety (critical)**:
+  - Never detach Drizzle/SDK methods that may rely on `this` (for example `db.query.*.findFirst`, `findMany`, or SDK instance methods).
+  - Prefer direct invocation from owning object: `db.query.communities.findFirst({...})`.
+  - If extraction is unavoidable, explicitly bind method context and add a regression test for bound behavior.
+- **Webhook failure policy**:
+  - Classify logic in webhook handlers as either `critical` or `best-effort`.
+  - `critical` ingest/storage/auth failures must bubble and fail the webhook request to allow upstream retries.
+  - `best-effort` side effects (reactions, analytics, forwarding) must never block webhook acknowledgment.
+  - For best-effort paths, use fire-and-catch (`void task().catch(...)`) with structured logs.
+- **Error logging standard**:
+  - Log structured context (`chatId`, `messageId`, `telegramUserId`, `updateId`) without message text.
+  - Include both normalized error fields (`errorName`, `errorMessage`) and stack/raw error for debugging.
+- **Test design requirements**:
+  - When wrappers call ORM methods, include context-sensitive mocks that would fail if method context is detached.
+  - For webhook ingest, include retry/idempotency tests that simulate partial write failure then successful retry.
+  - Include non-blocking tests for best-effort side effects to ensure handler completion does not await them.
+- **Required validation after webhook/ingest changes**:
+  - `cd app && bun lint`
+  - Run targeted tests for touched webhook/ingest modules
+  - `cd app && bun run build`
+  - Manual canary in Telegram + verify new `messages` rows are written
+- **On-call detection runbook**:
+  - If cron summary stats suddenly show high `skippedNotEnoughMessages` for historically active communities, assume ingest regression until disproven.
+  - Verify webhook errors and message freshness immediately.
+  - SQL templates:
+    ```sql
+    -- Freshness by active community
+    SELECT c.chat_title, c.chat_id, MAX(m.created_at) AS latest_message_at, COUNT(m.id) AS total_messages
+    FROM communities c
+    LEFT JOIN messages m ON m.community_id = c.id
+    WHERE c.is_active = true
+    GROUP BY c.id, c.chat_title, c.chat_id
+    ORDER BY latest_message_at DESC NULLS LAST;
+    ```
+    ```sql
+    -- 24h ingest volume by active community
+    SELECT c.chat_title, c.chat_id, COUNT(m.id) AS messages_24h
+    FROM communities c
+    LEFT JOIN messages m
+      ON m.community_id = c.id
+     AND m.created_at >= NOW() - INTERVAL '24 hours'
+    WHERE c.is_active = true
+    GROUP BY c.id, c.chat_title, c.chat_id
+    ORDER BY messages_24h DESC;
+    ```
 
 ### Telegram SDK + Cloud Storage Guardrails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,54 @@ Service layer patterns:
 
 - **Runtime vs Code Mismatch**: If logs/stack traces reference code that no longer matches current file contents, restart the local dev server or worker process. Stale processes can keep executing old code after edits.
 
+### Webhook + Drizzle Reliability Guardrails
+
+- **Context-bound method safety (critical)**:
+  - Never detach Drizzle/SDK methods that may rely on `this` (for example `db.query.*.findFirst`, `findMany`, or SDK instance methods).
+  - Prefer direct invocation from owning object: `db.query.communities.findFirst({...})`.
+  - If extraction is unavoidable, explicitly bind method context and add a regression test for bound behavior.
+- **Webhook failure policy**:
+  - Classify logic in webhook handlers as either `critical` or `best-effort`.
+  - `critical` ingest/storage/auth failures must bubble and fail the webhook request to allow upstream retries.
+  - `best-effort` side effects (reactions, analytics, forwarding) must never block webhook acknowledgment.
+  - For best-effort paths, use fire-and-catch (`void task().catch(...)`) with structured logs.
+- **Error logging standard**:
+  - Log structured context (`chatId`, `messageId`, `telegramUserId`, `updateId`) without message text.
+  - Include both normalized error fields (`errorName`, `errorMessage`) and stack/raw error for debugging.
+- **Test design requirements**:
+  - When wrappers call ORM methods, include context-sensitive mocks that would fail if method context is detached.
+  - For webhook ingest, include retry/idempotency tests that simulate partial write failure then successful retry.
+  - Include non-blocking tests for best-effort side effects to ensure handler completion does not await them.
+- **Required validation after webhook/ingest changes**:
+  - `cd app && bun lint`
+  - Run targeted tests for touched webhook/ingest modules
+  - `cd app && bun run build`
+  - Manual canary in Telegram + verify new `messages` rows are written
+- **On-call detection runbook**:
+  - If cron summary stats suddenly show high `skippedNotEnoughMessages` for historically active communities, assume ingest regression until disproven.
+  - Verify webhook errors and message freshness immediately.
+  - SQL templates:
+    ```sql
+    -- Freshness by active community
+    SELECT c.chat_title, c.chat_id, MAX(m.created_at) AS latest_message_at, COUNT(m.id) AS total_messages
+    FROM communities c
+    LEFT JOIN messages m ON m.community_id = c.id
+    WHERE c.is_active = true
+    GROUP BY c.id, c.chat_title, c.chat_id
+    ORDER BY latest_message_at DESC NULLS LAST;
+    ```
+    ```sql
+    -- 24h ingest volume by active community
+    SELECT c.chat_title, c.chat_id, COUNT(m.id) AS messages_24h
+    FROM communities c
+    LEFT JOIN messages m
+      ON m.community_id = c.id
+     AND m.created_at >= NOW() - INTERVAL '24 hours'
+    WHERE c.is_active = true
+    GROUP BY c.id, c.chat_title, c.chat_id
+    ORDER BY messages_24h DESC;
+    ```
+
 ### Telegram SDK + Cloud Storage Guardrails
 
 - Keep `app/src/app/layout.tsx` free of Telegram SDK/UI imports. Telegram wrappers/providers belong under `app/src/app/telegram/*` route scope only.

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -40,7 +40,14 @@ const eslintConfig = [
   },
   {
     files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
     rules: {
+      "@typescript-eslint/unbound-method": "error",
       "no-restricted-syntax": [
         "error",
         {
@@ -66,6 +73,7 @@ const eslintConfig = [
     ],
     rules: {
       "no-restricted-syntax": "off",
+      "@typescript-eslint/unbound-method": "off",
     },
   },
   {

--- a/app/src/app/api/telegram/webhook/message-text-handler.test.ts
+++ b/app/src/app/api/telegram/webhook/message-text-handler.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { Bot, Context } from "grammy";
+
+import type { WebhookTextMessageHandlerDeps } from "./message-text-handler";
+
+let handleWebhookTextMessage: typeof import("./message-text-handler").handleWebhookTextMessage;
+
+let handleCommunityMessageCalls = 0;
+let handleDirectMessageCalls = 0;
+let handleGLoyalReactionCalls = 0;
+let handleCommunityMessageImpl: WebhookTextMessageHandlerDeps["handleCommunityMessage"];
+let handleDirectMessageImpl: WebhookTextMessageHandlerDeps["handleDirectMessage"];
+let handleGLoyalReactionImpl: WebhookTextMessageHandlerDeps["handleGLoyalReaction"];
+
+const fakeBot = {} as Bot;
+
+function createDeps(): WebhookTextMessageHandlerDeps {
+  return {
+    handleCommunityMessage: async (ctx) => {
+      handleCommunityMessageCalls += 1;
+      await handleCommunityMessageImpl(ctx);
+    },
+    handleDirectMessage: async (ctx, bot) => {
+      handleDirectMessageCalls += 1;
+      await handleDirectMessageImpl(ctx, bot);
+    },
+    handleGLoyalReaction: async (ctx, bot) => {
+      handleGLoyalReactionCalls += 1;
+      await handleGLoyalReactionImpl(ctx, bot);
+    },
+    isPrivateChat: (chatType) => chatType === "private",
+  };
+}
+
+function createCommunityContext(): Context {
+  return {
+    chat: {
+      id: -1001234567890,
+      type: "supergroup",
+    },
+    message: {
+      message_id: 1234,
+      text: "hello group",
+    },
+    update: {
+      update_id: 123,
+    },
+  } as unknown as Context;
+}
+
+describe("webhook text message handler", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("./message-text-handler");
+    handleWebhookTextMessage = loadedModule.handleWebhookTextMessage;
+  });
+
+  beforeEach(() => {
+    handleCommunityMessageCalls = 0;
+    handleDirectMessageCalls = 0;
+    handleGLoyalReactionCalls = 0;
+    handleCommunityMessageImpl = async () => {};
+    handleDirectMessageImpl = async () => {};
+    handleGLoyalReactionImpl = async () => {};
+  });
+
+  test("rejects when community ingest fails", async () => {
+    const ingestFailure = new Error("ingest failed");
+    handleCommunityMessageImpl = async () => {
+      throw ingestFailure;
+    };
+    const context = createCommunityContext();
+
+    await expect(
+      handleWebhookTextMessage(context, fakeBot, createDeps())
+    ).rejects.toThrow("ingest failed");
+
+    expect(handleCommunityMessageCalls).toBe(1);
+    expect(handleGLoyalReactionCalls).toBe(0);
+  });
+
+  test("continues successfully when reaction handling fails", async () => {
+    handleGLoyalReactionImpl = async () => {
+      throw new Error("reaction failed");
+    };
+    const context = createCommunityContext();
+
+    const previousConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      await expect(
+        handleWebhookTextMessage(context, fakeBot, createDeps())
+      ).resolves.toBeUndefined();
+      await Promise.resolve();
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(handleCommunityMessageCalls).toBe(1);
+    expect(handleGLoyalReactionCalls).toBe(1);
+    expect(consoleErrorCalls).toHaveLength(1);
+    expect(consoleErrorCalls[0]?.[0]).toBe("Failed to handle gLoyal reaction");
+    expect(consoleErrorCalls[0]?.[2]).toBeInstanceOf(Error);
+  });
+
+  test("does not await slow reaction handling before resolving", async () => {
+    let resolveReaction: (() => void) | null = null;
+    let reactionSettled = false;
+
+    handleGLoyalReactionImpl = async () => {
+      await new Promise<void>((resolve) => {
+        resolveReaction = resolve;
+      });
+      reactionSettled = true;
+    };
+
+    const context = createCommunityContext();
+    await expect(
+      handleWebhookTextMessage(context, fakeBot, createDeps())
+    ).resolves.toBeUndefined();
+
+    expect(handleCommunityMessageCalls).toBe(1);
+    expect(handleGLoyalReactionCalls).toBe(1);
+    expect(reactionSettled).toBe(false);
+
+    resolveReaction?.();
+    await Promise.resolve();
+    expect(reactionSettled).toBe(true);
+  });
+
+  test("routes private non-command text to direct-message handler", async () => {
+    const privateContext = {
+      chat: {
+        id: 777,
+        type: "private",
+      },
+      message: {
+        message_id: 77,
+        text: "hello bot",
+      },
+      update: {
+        update_id: 124,
+      },
+    } as unknown as Context;
+
+    await handleWebhookTextMessage(privateContext, fakeBot, createDeps());
+
+    expect(handleDirectMessageCalls).toBe(1);
+    expect(handleCommunityMessageCalls).toBe(0);
+    expect(handleGLoyalReactionCalls).toBe(0);
+  });
+});

--- a/app/src/app/api/telegram/webhook/message-text-handler.ts
+++ b/app/src/app/api/telegram/webhook/message-text-handler.ts
@@ -1,0 +1,43 @@
+import type { Bot, Context } from "grammy";
+
+import { logWebhookHandlerError } from "@/lib/telegram/bot-api/webhook-error-log";
+
+export type WebhookTextMessageHandlerDeps = {
+  handleCommunityMessage: (ctx: Context) => Promise<void>;
+  handleDirectMessage: (ctx: Context, bot: Bot) => Promise<void>;
+  handleGLoyalReaction: (ctx: Context, bot: Bot) => Promise<void>;
+  isPrivateChat: (chatType: string) => boolean;
+};
+
+export async function handleWebhookTextMessage(
+  ctx: Context,
+  bot: Bot,
+  deps: WebhookTextMessageHandlerDeps
+): Promise<void> {
+  const chatType = ctx.chat?.type;
+
+  if (chatType && deps.isPrivateChat(chatType)) {
+    // Commands are handled by bot.command() handlers.
+    if (!ctx.message?.text?.startsWith("/")) {
+      await deps.handleDirectMessage(ctx, bot);
+    }
+    return;
+  }
+
+  // Community ingest is critical and must fail webhook processing for retries.
+  await deps.handleCommunityMessage(ctx);
+
+  // Reactions are non-critical and should not block message ingestion.
+  void deps.handleGLoyalReaction(ctx, bot).catch((error) => {
+    const updateId =
+      "update_id" in ctx.update && typeof ctx.update.update_id === "number"
+        ? ctx.update.update_id
+        : undefined;
+
+    logWebhookHandlerError("Failed to handle gLoyal reaction", error, {
+      chatId: ctx.chat ? String(ctx.chat.id) : undefined,
+      messageId: ctx.message?.message_id,
+      updateId,
+    });
+  });
+}

--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -43,7 +43,15 @@ import {
 } from "@/lib/telegram/conversation-service";
 import { isPrivateChat } from "@/lib/telegram/utils";
 
+import { handleWebhookTextMessage } from "./message-text-handler";
+
 const bot = await getBot();
+const webhookTextMessageHandlerDeps = {
+  handleCommunityMessage,
+  handleDirectMessage,
+  handleGLoyalReaction,
+  isPrivateChat,
+} as const;
 
 bot.command("start", async (ctx: CommandContext<Context>) => {
   await handleStartCommand(ctx, bot);
@@ -135,22 +143,7 @@ bot.on("message:forum_topic_created", async (ctx) => {
 });
 
 bot.on("message:text", async (ctx) => {
-  const chatType = ctx.chat?.type;
-
-  // Route private DMs to conversation handler (skip commands)
-  if (chatType && isPrivateChat(chatType)) {
-    // Commands are handled by bot.command() handlers above
-    if (!ctx.message?.text?.startsWith("/")) {
-      await handleDirectMessage(ctx, bot);
-    }
-    return;
-  }
-
-  // Handle group/community messages
-  await Promise.all([
-    handleGLoyalReaction(ctx, bot),
-    handleCommunityMessage(ctx),
-  ]);
+  await handleWebhookTextMessage(ctx, bot, webhookTextMessageHandlerDeps);
 });
 
 export const POST = webhookCallback(bot, "std/http");

--- a/app/src/lib/telegram/bot-api/__tests__/active-community-cache.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/active-community-cache.test.ts
@@ -8,17 +8,14 @@ import {
 type CommunityRecord = {
   id: string;
   parserType: "bot" | "userbot";
-} | null;
+} | null | undefined;
 
 type CacheDb = Parameters<typeof resolveActiveBotCommunityId>[0];
 
-function createDb(sequence: CommunityRecord[]): CacheDb & { calls: number } {
+function createDb(sequence: CommunityRecord[]): CacheDb {
   let index = 0;
 
   return {
-    get calls() {
-      return index;
-    },
     query: {
       communities: {
         findFirst: async () => sequence[index++] ?? null,
@@ -34,34 +31,31 @@ describe("active community cache", () => {
     evictActiveCommunityCache(chatId);
   });
 
-  test("reuses cached bot community after revalidation", async () => {
-    const db = createDb([
-      { id: "community-1", parserType: "bot" },
-      { id: "community-1", parserType: "bot" },
-    ]);
+  test("returns community id for active bot community", async () => {
+    const db = createDb([{ id: "community-1", parserType: "bot" }]);
 
-    const first = await resolveActiveBotCommunityId(db, chatId);
-    const second = await resolveActiveBotCommunityId(db, chatId);
+    const resolved = await resolveActiveBotCommunityId(db, chatId);
 
-    expect(first).toBe("community-1");
-    expect(second).toBe("community-1");
-    expect(db.calls).toBe(2);
+    expect(resolved).toBe("community-1");
   });
 
-  test("invalidates cache when parser flips away from bot", async () => {
-    const db = createDb([
-      { id: "community-1", parserType: "bot" },
-      { id: "community-1", parserType: "userbot" },
-      { id: "community-1", parserType: "userbot" },
-    ]);
+  test("returns null when no active community exists", async () => {
+    const db = createDb([null]);
 
-    const initial = await resolveActiveBotCommunityId(db, chatId);
-    const afterFlip = await resolveActiveBotCommunityId(db, chatId);
-    const subsequent = await resolveActiveBotCommunityId(db, chatId);
+    const resolved = await resolveActiveBotCommunityId(db, chatId);
 
-    expect(initial).toBe("community-1");
-    expect(afterFlip).toBeNull();
-    expect(subsequent).toBeNull();
-    expect(db.calls).toBe(3);
+    expect(resolved).toBeNull();
+  });
+
+  test("returns null when resolved community parser is not bot", async () => {
+    const db = createDb([{ id: "community-1", parserType: "userbot" }]);
+
+    const resolved = await resolveActiveBotCommunityId(db, chatId);
+
+    expect(resolved).toBeNull();
+  });
+
+  test("evictActiveCommunityCache remains safe no-op for compatibility", () => {
+    expect(() => evictActiveCommunityCache(chatId)).not.toThrow();
   });
 });

--- a/app/src/lib/telegram/bot-api/__tests__/message-handlers.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/message-handlers.test.ts
@@ -1,0 +1,177 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "grammy";
+
+mock.module("server-only", () => ({}));
+
+type InsertValues = Record<string, unknown>;
+
+let mockDb: {
+  insert: () => {
+    values: (values: InsertValues) => {
+      onConflictDoNothing: () => Promise<void>;
+    };
+  };
+};
+
+let resolveActiveBotCommunityIdImpl: (
+  db: unknown,
+  chatId: bigint
+) => Promise<string | null>;
+let getOrCreateUserImpl: (
+  telegramUserId: bigint,
+  input: { displayName: string; username: string | null }
+) => Promise<string>;
+
+let membershipPersistedKeys: Set<string>;
+let messagePersistedKeys: Set<string>;
+let failMessageInsertOnce = false;
+let getOrCreateUserCalls = 0;
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => mockDb,
+}));
+
+mock.module("../active-community-cache", () => ({
+  evictActiveCommunityCache: () => {},
+  resolveActiveBotCommunityId: (db: unknown, chatId: bigint) =>
+    resolveActiveBotCommunityIdImpl(db, chatId),
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: (
+    telegramUserId: bigint,
+    input: { displayName: string; username: string | null }
+  ) => {
+    getOrCreateUserCalls += 1;
+    return getOrCreateUserImpl(telegramUserId, input);
+  },
+}));
+
+let handleCommunityMessage: typeof import("../message-handlers").handleCommunityMessage;
+
+function isMessageInsert(values: InsertValues): boolean {
+  return (
+    "content" in values &&
+    "telegramMessageId" in values &&
+    "communityId" in values &&
+    "userId" in values
+  );
+}
+
+function createCommunityTextMessageContext(): Context {
+  return {
+    chat: {
+      id: -1001234567890,
+      type: "supergroup",
+    },
+    message: {
+      from: {
+        first_name: "Taylor",
+        id: 777,
+        username: "taylor",
+      },
+      message_id: 1234,
+      text: "hello group",
+    },
+    update: {
+      update_id: 9001,
+    },
+  } as unknown as Context;
+}
+
+describe("message handlers", () => {
+  beforeAll(async () => {
+    const loadedModule = await import("../message-handlers");
+    handleCommunityMessage = loadedModule.handleCommunityMessage;
+  });
+
+  beforeEach(() => {
+    membershipPersistedKeys = new Set();
+    messagePersistedKeys = new Set();
+    failMessageInsertOnce = false;
+    getOrCreateUserCalls = 0;
+    resolveActiveBotCommunityIdImpl = async () => "community-1";
+    getOrCreateUserImpl = async () => "user-1";
+
+    mockDb = {
+      insert: () => ({
+        values: (values: InsertValues) => ({
+          onConflictDoNothing: async () => {
+            if (isMessageInsert(values)) {
+              if (failMessageInsertOnce) {
+                failMessageInsertOnce = false;
+                throw new Error("message insert failed once");
+              }
+
+              const messageKey = `${String(values.communityId)}:${String(values.userId)}:${String(values.telegramMessageId)}`;
+              if (!messagePersistedKeys.has(messageKey)) {
+                messagePersistedKeys.add(messageKey);
+              }
+              return;
+            }
+
+            const membershipKey = `${String(values.communityId)}:${String(values.userId)}`;
+            if (!membershipPersistedKeys.has(membershipKey)) {
+              membershipPersistedKeys.add(membershipKey);
+            }
+          },
+        }),
+      }),
+    };
+  });
+
+  test("rethrows community ingest failures with structured and stack-bearing logs", async () => {
+    const context = createCommunityTextMessageContext();
+    const failure = new Error("findFirst failed");
+    resolveActiveBotCommunityIdImpl = async () => {
+      throw failure;
+    };
+
+    const previousConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      await expect(handleCommunityMessage(context)).rejects.toThrow(
+        "findFirst failed"
+      );
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(consoleErrorCalls).toHaveLength(1);
+    expect(consoleErrorCalls[0]?.[0]).toBe("Failed to handle community message");
+    expect(consoleErrorCalls[0]?.[1]).toMatchObject({
+      chatId: "-1001234567890",
+      errorMessage: "findFirst failed",
+      errorName: "Error",
+      messageId: 1234,
+      telegramUserId: "777",
+      updateId: 9001,
+    });
+    expect(consoleErrorCalls[0]?.[1]).toHaveProperty("errorStack");
+    expect(consoleErrorCalls[0]?.[2]).toBe(failure);
+  });
+
+  test("remains idempotent across retry after partial insert failure", async () => {
+    const context = createCommunityTextMessageContext();
+    failMessageInsertOnce = true;
+
+    const previousConsoleError = console.error;
+    console.error = () => {};
+    try {
+      await expect(handleCommunityMessage(context)).rejects.toThrow(
+        "message insert failed once"
+      );
+      await expect(handleCommunityMessage(context)).resolves.toBeUndefined();
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(membershipPersistedKeys.size).toBe(1);
+    expect(messagePersistedKeys.size).toBe(1);
+    expect(getOrCreateUserCalls).toBe(2);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/summaries.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries.test.ts
@@ -42,6 +42,9 @@ mock.module("@/lib/core/database", () => ({
       values: (values: unknown) => {
         insertedSummaryValues.push(values);
         return {
+          onConflictDoNothing: () => ({
+            returning: async () => insertReturningQueue.shift() ?? [],
+          }),
           returning: async () => insertReturningQueue.shift() ?? [],
         };
       },
@@ -128,6 +131,25 @@ describe("generateOrGetSummaryForRun", () => {
     expect(insertedSummaryValues).toHaveLength(0);
   });
 
+  test("falls back to legacy created-at day lookup when trigger key is absent", async () => {
+    countResult = 9;
+    summariesFindFirstResults = [null, { id: "existing-legacy", messageCount: 9 }];
+
+    const result = await generateOrGetSummaryForRun({
+      chatTitle: "General",
+      communityId: "community-1",
+      run,
+    });
+
+    expect(result).toEqual({
+      status: "existing",
+      summaryId: "existing-legacy",
+      messageCount: 9,
+    });
+    expect(chatCompletionCalls).toHaveLength(0);
+    expect(insertedSummaryValues).toHaveLength(0);
+  });
+
   test("creates a summary when enough messages exist and no summary exists for today", async () => {
     countResult = 5;
     summariesFindFirstResults = [null];
@@ -150,6 +172,10 @@ describe("generateOrGetSummaryForRun", () => {
     });
     expect(chatCompletionCalls).toHaveLength(2);
     expect(insertedSummaryValues).toHaveLength(1);
+    expect(insertedSummaryValues[0]).toMatchObject({
+      triggerKey: "daily:2026-02-13",
+      triggerType: "daily",
+    });
   });
 
   test("creates a summary when message count reaches the minimum threshold", async () => {
@@ -179,7 +205,7 @@ describe("generateOrGetSummaryForRun", () => {
 
   test("does not create duplicate summaries on repeated runs for the same day", async () => {
     countResult = 4;
-    summariesFindFirstResults = [null, { id: "existing-2", messageCount: 4 }];
+    summariesFindFirstResults = [null, null, { id: "existing-2", messageCount: 4 }];
     insertReturningQueue = [[{ id: "summary-1", messageCount: 4 }]];
     recentMessages = Array.from({ length: 4 }, (_, index) => ({
       content: `msg ${index + 1}`,
@@ -206,6 +232,30 @@ describe("generateOrGetSummaryForRun", () => {
     expect(secondRun).toEqual({
       status: "existing",
       summaryId: "existing-2",
+      messageCount: 4,
+    });
+    expect(insertedSummaryValues).toHaveLength(1);
+  });
+
+  test("returns existing summary when insert conflicts on trigger key", async () => {
+    countResult = 4;
+    summariesFindFirstResults = [null, null, { id: "existing-3", messageCount: 4 }];
+    insertReturningQueue = [[]];
+    recentMessages = Array.from({ length: 4 }, (_, index) => ({
+      content: `msg ${index + 1}`,
+      telegramMessageId: BigInt(index + 1),
+      user: { displayName: `User${index + 1}` },
+    }));
+
+    const result = await generateOrGetSummaryForRun({
+      chatTitle: "General",
+      communityId: "community-1",
+      run,
+    });
+
+    expect(result).toEqual({
+      status: "existing",
+      summaryId: "existing-3",
       messageCount: 4,
     });
     expect(insertedSummaryValues).toHaveLength(1);

--- a/app/src/lib/telegram/bot-api/active-community-cache.ts
+++ b/app/src/lib/telegram/bot-api/active-community-cache.ts
@@ -1,38 +1,30 @@
 import { communities } from "@loyal-labs/db-core/schema";
-import { and, eq } from "drizzle-orm";
-
-type CacheEntry = {
-  communityId: string;
-  parserType: "bot" | "userbot";
-};
+import { and, eq, type SQL } from "drizzle-orm";
 
 type CommunityRecord = {
   id: string;
   parserType: "bot" | "userbot";
-} | null;
+} | null | undefined;
 
 type CommunityQueryDb = {
   query: {
     communities: {
-      findFirst: unknown;
+      findFirst: (args: {
+        columns: {
+          id: true;
+          parserType: true;
+        };
+        where?: SQL<unknown>;
+      }) => Promise<CommunityRecord>;
     };
   };
 };
 
-type FindActiveCommunity = (args: {
-  columns: {
-    id: true;
-    parserType: true;
-  };
-  where: unknown;
-}) => Promise<CommunityRecord>;
-
 function findActiveCommunity(
   db: CommunityQueryDb,
-  where: unknown
+  where: SQL<unknown> | undefined
 ): Promise<CommunityRecord> {
-  const findFirst = db.query.communities.findFirst as FindActiveCommunity;
-  return findFirst({
+  return db.query.communities.findFirst({
     columns: {
       id: true,
       parserType: true,
@@ -41,61 +33,29 @@ function findActiveCommunity(
   });
 }
 
-// Cache of active community state (chatId string -> parser-aware record).
-const activeCommunities = new Map<string, CacheEntry>();
-
+// Backward-compatible no-op: active community cache was removed to reduce bug surface.
 export function evictActiveCommunityCache(
-  chatId: bigint | number | string
+  _chatId: bigint | number | string
 ): void {
-  activeCommunities.delete(String(chatId));
+  // no-op
 }
 
 export async function resolveActiveBotCommunityId(
   db: CommunityQueryDb,
   chatId: bigint
 ): Promise<string | null> {
-  const chatIdStr = String(chatId);
-  const cached = activeCommunities.get(chatIdStr);
-
-  if (cached) {
-    // Revalidate cached mapping so parser flips (bot -> userbot) are respected.
-    const stillActive = await findActiveCommunity(
-      db,
-      and(
-        eq(communities.id, cached.communityId),
-        eq(communities.chatId, chatId),
-        eq(communities.isActive, true)
-      )
-    );
-
-    if (!stillActive || stillActive.parserType !== "bot") {
-      activeCommunities.delete(chatIdStr);
-      return null;
-    }
-
-    activeCommunities.set(chatIdStr, {
-      communityId: stillActive.id,
-      parserType: stillActive.parserType,
-    });
-    return stillActive.id;
-  }
-
   const community = await findActiveCommunity(
     db,
     and(
       eq(communities.chatId, chatId),
-      eq(communities.isActive, true)
+      eq(communities.isActive, true),
+      eq(communities.parserType, "bot")
     )
   );
 
   if (!community || community.parserType !== "bot") {
-    activeCommunities.delete(chatIdStr);
     return null;
   }
 
-  activeCommunities.set(chatIdStr, {
-    communityId: community.id,
-    parserType: community.parserType,
-  });
   return community.id;
 }

--- a/app/src/lib/telegram/bot-api/message-handlers.ts
+++ b/app/src/lib/telegram/bot-api/message-handlers.ts
@@ -6,6 +6,7 @@ import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat, isGroupChat } from "@/lib/telegram/utils";
 
 import { resolveActiveBotCommunityId } from "./active-community-cache";
+import { logWebhookHandlerError } from "./webhook-error-log";
 
 export { evictActiveCommunityCache } from "./active-community-cache";
 
@@ -59,6 +60,10 @@ export async function handleCommunityMessage(ctx: Context): Promise<void> {
   const chatId = BigInt(chat.id);
   const message = ctx.message;
   if (!message?.text || !message.from) return;
+  const updateId =
+    "update_id" in ctx.update && typeof ctx.update.update_id === "number"
+      ? ctx.update.update_id
+      : undefined;
 
   try {
     const db = getDatabase();
@@ -95,6 +100,12 @@ export async function handleCommunityMessage(ctx: Context): Promise<void> {
       })
       .onConflictDoNothing();
   } catch (error) {
-    console.error("Failed to handle community message", error);
+    logWebhookHandlerError("Failed to handle community message", error, {
+      chatId: String(chatId),
+      messageId: message.message_id,
+      telegramUserId: String(message.from.id),
+      updateId,
+    });
+    throw error;
   }
 }

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -28,6 +28,7 @@ import type {
 } from "./types";
 
 export const MIN_MESSAGES_FOR_SUMMARY = 3;
+export const DAILY_SUMMARY_TRIGGER_TYPE = "daily";
 const MAX_SUMMARY_INPUT_CHARS = 12_000;
 const MAX_SUMMARY_BULLET_COUNT = 5;
 const MAX_SUMMARY_BULLET_CONTENT_CHARS = 450;
@@ -68,14 +69,16 @@ export async function generateOrGetSummaryForRun(input: {
   run: SummaryRunContext;
 }): Promise<GenerateOrGetSummaryForRunResult> {
   const db = getDatabase();
+  const triggerKey = buildDailySummaryTriggerKey(input.run.dayStartUtc);
   const messageCount = await countMessagesInWindow(input.communityId, input.run);
 
   if (messageCount < MIN_MESSAGES_FOR_SUMMARY) {
     return { status: "not_enough_messages", messageCount };
   }
 
-  const existingSummary = await findTodaySummary(
+  const existingSummary = await findExistingSummaryForRun(
     input.communityId,
+    triggerKey,
     input.run.dayStartUtc,
     input.run.dayEndUtc
   );
@@ -133,17 +136,29 @@ export async function generateOrGetSummaryForRun(input: {
       messageCount,
       oneliner,
       topics,
+      triggerKey,
+      triggerType: DAILY_SUMMARY_TRIGGER_TYPE,
     })
+    .onConflictDoNothing()
     .returning({ id: summaries.id, messageCount: summaries.messageCount });
 
-  if (insertedSummary.length === 0) {
+  if (insertedSummary.length > 0) {
+    return {
+      status: "created",
+      summaryId: insertedSummary[0].id,
+      messageCount: insertedSummary[0].messageCount,
+    };
+  }
+
+  const conflictedSummary = await findSummaryByTriggerKey(input.communityId, triggerKey);
+  if (!conflictedSummary) {
     throw new Error("Failed to create summary");
   }
 
   return {
-    status: "created",
-    summaryId: insertedSummary[0].id,
-    messageCount: insertedSummary[0].messageCount,
+    status: "existing",
+    summaryId: conflictedSummary.id,
+    messageCount: conflictedSummary.messageCount,
   };
 }
 
@@ -300,11 +315,38 @@ async function countMessagesInWindow(
   return Number(result?.count ?? 0);
 }
 
-async function findTodaySummary(
+function toUtcDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildDailySummaryTriggerKey(dayStartUtc: Date): string {
+  return `${DAILY_SUMMARY_TRIGGER_TYPE}:${toUtcDayKey(dayStartUtc)}`;
+}
+
+async function findSummaryByTriggerKey(
   communityId: string,
+  triggerKey: string
+): Promise<Summary | null> {
+  const db = getDatabase();
+  return (
+    (await db.query.summaries.findFirst({
+      where: and(eq(summaries.communityId, communityId), eq(summaries.triggerKey, triggerKey)),
+      orderBy: [desc(summaries.createdAt)],
+    })) ?? null
+  );
+}
+
+async function findExistingSummaryForRun(
+  communityId: string,
+  triggerKey: string,
   dayStartUtc: Date,
   dayEndUtc: Date
 ): Promise<Summary | null> {
+  const byTriggerKey = await findSummaryByTriggerKey(communityId, triggerKey);
+  if (byTriggerKey) {
+    return byTriggerKey;
+  }
+
   const db = getDatabase();
   return (
     (await db.query.summaries.findFirst({

--- a/app/src/lib/telegram/bot-api/webhook-error-log.ts
+++ b/app/src/lib/telegram/bot-api/webhook-error-log.ts
@@ -1,0 +1,30 @@
+type ErrorContextValue = boolean | null | number | string | undefined;
+
+export type WebhookErrorLogContext = Record<string, ErrorContextValue>;
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
+export function logWebhookHandlerError(
+  message: string,
+  error: unknown,
+  context: WebhookErrorLogContext
+): void {
+  const normalizedError = normalizeError(error);
+
+  console.error(
+    message,
+    {
+      ...context,
+      errorMessage: normalizedError.message,
+      errorName: normalizedError.name,
+      errorStack: normalizedError.stack,
+    },
+    normalizedError
+  );
+}

--- a/docs/workers/manual-summary-examples-2026-03-01-2026-03-02.md
+++ b/docs/workers/manual-summary-examples-2026-03-01-2026-03-02.md
@@ -1,0 +1,191 @@
+# Manual Summary Examples (2026-03-01 to 2026-03-02 UTC)
+
+This document captures manually curated daily summaries used as reference examples for high-quality Telegram community summarization.
+
+## Scope
+
+- Target window (UTC): `2026-03-01` and `2026-03-02`
+- Policy: only meaningful community/day pairs (skip zero-activity and spam-heavy feed cases)
+- Delivery: database records + this markdown reference
+- Notification sending: not performed
+
+## Quality Rules Applied
+
+- Oneliner is concise, specific, and non-hype (`<= 110` chars)
+- Topics are limited to 1-5 and focus on meaningful discussion
+- Greeting noise, command spam, and repetitive low-value chatter are excluded from topic shaping
+- Topic `sources` contain participants who materially contributed
+- First sentence of each topic is written to stand alone (for bullet rendering)
+
+## Best-Practice References Used
+
+- Reuters Trust Principles: <https://www.reuters.com/agency/trust-principles/>
+- GOV.UK writing guidance: <https://www.gov.uk/guidance/content-design/writing-for-gov-uk>
+- GOV.UK docs style guide: <https://docs.publishing.service.gov.uk/manual/docs-style-guide.html>
+- QAGS factual consistency framing: <https://aclanthology.org/2020.acl-main.450/>
+- US Plain Writing principles: <https://www.archives.gov/open/plain-writing/10-principles.html>
+
+## Inserted Summaries
+
+### 1) The Loyal Community — 2026-03-01
+
+- `summary_id`: `2c73e2b2-2ebb-4325-92d0-95f9d7de80a5`
+- `trigger_key`: `daily:2026-03-01`
+- `community_id`: `e2c7fb8d-119f-4fff-b3bf-8509d55dd25c`
+- `chat_id`: `-1002981429221`
+- `message_count`: `19`
+- `from_message_id`: `29244`
+- `to_message_id`: `29270`
+
+**Oneliner**
+
+`New-month check-ins turned into product talk on summary timing and where persistent storage fits next.`
+
+**Topics JSON**
+
+```json
+[
+  {
+    "title": "Community kickoff and safety check-ins",
+    "content": "Members opened the month with greetings and safety wishes as regional conflict concerns filtered into chat sentiment.",
+    "sources": ["gemhunter", "nel ogx", "ROYALREDDY", "Gaurav", "Hexx"]
+  },
+  {
+    "title": "Daily summary timing clarified",
+    "content": "A short support thread clarified why no new summary had appeared yet: the daily report is generated after the day is complete.",
+    "sources": ["裴嘉輝 裴嘉輝", "gemhunter"]
+  },
+  {
+    "title": "Persistent storage vs execution priorities",
+    "content": "Late in the day, members debated persistent storage timing versus TEE-first execution, with a direct comparison to Venice and Loyal's product focus.",
+    "sources": ["8️⃣6️⃣.eth | 0548.eth", "chris"]
+  }
+]
+```
+
+**Source excerpts used**
+
+- `29248` (`2026-03-01T04:05:47Z`, `gemhunter`): "Happy New Month, and if you're in hot zones with the ongoing war, please stay safe."
+- `29265` (`2026-03-01T17:41:10Z`, `裴嘉輝 裴嘉輝`): "Why is there no update?"
+- `29267` (`2026-03-01T17:42:01Z`, `gemhunter`): "Why would it make update for a day not spent yet?"
+- `29269` (`2026-03-01T23:52:24Z`, `8️⃣6️⃣.eth | 0548.eth`): persistent storage timing concern vs roadmap
+- `29270` (`2026-03-01T23:55:55Z`, `chris`): product-focus response and Venice comparison
+
+---
+
+### 2) The Loyal Community — 2026-03-02
+
+- `summary_id`: `498557bb-e5af-46d4-9402-45b4158de49b`
+- `trigger_key`: `daily:2026-03-02`
+- `community_id`: `e2c7fb8d-119f-4fff-b3bf-8509d55dd25c`
+- `chat_id`: `-1002981429221`
+- `message_count`: `46`
+- `from_message_id`: `29271`
+- `to_message_id`: `29327`
+
+**Oneliner**
+
+`Roadmap day at Loyal: storage priorities, private-rollup mechanics, and wallet UX questions before launch.`
+
+**Topics JSON**
+
+```json
+[
+  {
+    "title": "Persistent storage roadmap revisited",
+    "content": "A long thread revisited persistent chat memory, with the team confirming it remains planned but deferred until current launch milestones are shipped.",
+    "sources": ["8️⃣6️⃣.eth | 0548.eth", "chris"]
+  },
+  {
+    "title": "PER privacy model and documentation gaps",
+    "content": "Chris explained that actions run in MagicBlock PER and settle state back to Solana without publishing intermediate activity on mainnet, while members asked for clearer docs on the model.",
+    "sources": ["chris", "8️⃣6️⃣.eth | 0548.eth"]
+  },
+  {
+    "title": "Launch readiness and wallet UX Q&A",
+    "content": "Members asked practical questions on shielding behavior, wallet replacement safety, and multi-wallet support, receiving clear guidance on current limits and next steps.",
+    "sources": ["Will", "Hexx", "chris"]
+  },
+  {
+    "title": "Community operations and partnership routing",
+    "content": "The rest of the day focused on onboarding chatter and operations, including routing partnership outreach to main@askloyal.com.",
+    "sources": ["nel ogx", "michael", "INVESTORADESAM", "gemhunter"]
+  }
+]
+```
+
+**Source excerpts used**
+
+- `29272` (`2026-03-02T00:02:35Z`, `chris`): "how would group summaries work w/o persistent storage?.."
+- `29276` (`2026-03-02T00:13:53Z`, `chris`): storage work deferred until current priorities complete
+- `29280` (`2026-03-02T00:16:29Z`, `8️⃣6️⃣.eth | 0548.eth`): anonymity-set and rollup lifetime questions
+- `29289` (`2026-03-02T00:29:15Z`, `chris`): settlement model explanation (state updated, actions not on main ledger)
+- `29301` (`2026-03-02T07:58:26Z`, `Will`): shielded funds and multi-wallet UX questions
+- `29311` (`2026-03-02T10:35:31Z`, `Hexx`): shielding and one-wallet current-state clarification
+- `29325` (`2026-03-02T16:37:55Z`, `INVESTORADESAM`) + `29326` (`gemhunter`): partnership routing to `main@askloyal.com`
+
+---
+
+### 3) turbine.cash — 2026-03-02
+
+- `summary_id`: `1b5a2d13-3253-4f8b-9b5e-b2cd8af6813f`
+- `trigger_key`: `daily:2026-03-02`
+- `community_id`: `04ccb37c-aead-42b9-864c-6012537cc8e1`
+- `chat_id`: `-1002735351372`
+- `message_count`: `7`
+- `from_message_id`: `9824`
+- `to_message_id`: `9847`
+
+**Oneliner**
+
+`Quiet day in turbine.cash: partnership routing and a practical integration Q&A carried the chat.`
+
+**Topics JSON**
+
+```json
+[
+  {
+    "title": "Partnership inquiry triage",
+    "content": "A partnership request was acknowledged quickly, with moderators moving the discussion to direct messages for follow-up.",
+    "sources": ["INVESTORADESAM", "Mango"]
+  },
+  {
+    "title": "Integration interest from community",
+    "content": "A member asked whether Turbine is integrating other projects, and moderators invited a direct conversation to scope requirements.",
+    "sources": ["alby", "Mango"]
+  },
+  {
+    "title": "Low-volume social check-ins",
+    "content": "Morning greetings and brief check-ins set a light, low-traffic tone for the day.",
+    "sources": ["Asad Sohail || BD at CoinUp", "Mango"]
+  }
+]
+```
+
+**Source excerpts used**
+
+- `9841` (`2026-03-02T16:15:28Z`, `INVESTORADESAM`): partnership contact request
+- `9842` (`2026-03-02T16:17:28Z`, `Mango`): "Replied to you in dms ;)"
+- `9846` (`2026-03-02T19:48:10Z`, `alby`): integration question
+- `9847` (`2026-03-02T20:10:53Z`, `Mango`): invitation to continue in DM
+- `9824` / `9827`: brief morning check-ins
+
+## Excluded Community-Day Pairs (with reason)
+
+- `Loyal News` — `2026-03-01`: high-volume single-sender headline feed; excluded for example quality
+- `Loyal News` — `2026-03-02`: high-volume single-sender headline feed; excluded for example quality
+- `Offerwall group testing` — `2026-03-01`: `0` messages
+- `Offerwall group testing` — `2026-03-02`: `0` messages
+- `Unitaware: AI & inference` — `2026-03-01`: `0` messages
+- `Unitaware: AI & inference` — `2026-03-02`: `0` messages
+- `turbine.cash` — `2026-03-01`: `0` messages
+
+## Verification Snapshot
+
+- Inserted `daily:*` summaries in target window: `3`
+- Inserted pairs:
+  - `The Loyal Community` → `daily:2026-03-01`
+  - `The Loyal Community` → `daily:2026-03-02`
+  - `turbine.cash` → `daily:2026-03-02`
+- Topic counts: `3`, `4`, `3` (all within 1-5)
+- Oneliner lengths are within the `<= 110` limit

--- a/docs/workers/userbot-on-render.md
+++ b/docs/workers/userbot-on-render.md
@@ -25,6 +25,8 @@ This guide explains how to run the mtcute userbot worker with persistent SQLite 
 - `TELEGRAM_USERBOT_ACCOUNT_KEY` (default: `primary`)
 - `USERBOT_STORAGE_DIR` (default: `/var/data/userbot`)
 - `TELEGRAM_USERBOT_PHONE` (used as default phone in bootstrap flow)
+- `TELEGRAM_USERBOT_BOT_TOKEN` (preferred bot auth token)
+- `ASKLOYAL_TGBOT_KEY` (fallback bot auth token, compatible with app env)
 
 ## Render Service Setup
 
@@ -49,6 +51,9 @@ bun run auth:bootstrap
 
 Then complete Telegram login prompts (code + 2FA if enabled).
 
+If bot token auth is configured (`TELEGRAM_USERBOT_BOT_TOKEN` or `ASKLOYAL_TGBOT_KEY`),
+`auth:bootstrap` logs in non-interactively as a bot and does not prompt for phone/code.
+
 ## Validate Session
 
 ```bash
@@ -65,6 +70,12 @@ Configure a Render cron job with:
 
 ```bash
 cd workers/userbot && bun install && bun run sync:once
+```
+
+Optional recovery flags for targeted backfill:
+
+```bash
+cd workers/userbot && bun install && bun run sync:once --parser-types=bot,userbot --lookback-days=2
 ```
 
 ## Session Recovery Flow

--- a/workers/userbot/README.md
+++ b/workers/userbot/README.md
@@ -21,6 +21,8 @@ Standalone worker package for Telegram userbot foundations.
 - `TELEGRAM_USERBOT_ACCOUNT_KEY` (default: `primary`)
 - `USERBOT_STORAGE_DIR` (default: `/var/data/userbot`)
 - `TELEGRAM_USERBOT_PHONE` (used by `auth:bootstrap` as default phone)
+- `TELEGRAM_USERBOT_BOT_TOKEN` (preferred bot auth token)
+- `ASKLOYAL_TGBOT_KEY` (fallback bot auth token, compatible with app env)
 
 ## Commands
 
@@ -34,6 +36,18 @@ bun run auth:clear
 bun run sync:once
 bun run start
 ```
+
+`auth:bootstrap` auto-selects login mode:
+
+- If `TELEGRAM_USERBOT_BOT_TOKEN` (or `ASKLOYAL_TGBOT_KEY`) is set, it signs in as a bot without phone/code prompts.
+- Otherwise, it uses interactive user login (phone/code/2FA).
+
+`sync:once` supports optional recovery flags:
+
+- `--parser-types=userbot` (default)
+- `--parser-types=bot,userbot` (include activated bot-parser communities)
+- `--lookback-days=2` (scan history for previous full UTC days)
+- `--chat-ids=-100123,-100456` (scope to specific chat IDs)
 
 ## Render operational flow
 

--- a/workers/userbot/src/__tests__/auth-commands.test.ts
+++ b/workers/userbot/src/__tests__/auth-commands.test.ts
@@ -23,12 +23,18 @@ function createLogger(): FakeLogger {
   };
 }
 
-function createConfig(storageDir: string): UserbotConfig {
+function createConfig(
+  storageDir: string,
+  overrides: Partial<UserbotConfig> = {}
+): UserbotConfig {
   return {
     accountKey: "primary",
+    authMode: "user",
     apiHash: "hash",
     apiId: 123,
+    botToken: null,
     storageDir,
+    ...overrides,
   };
 }
 
@@ -99,6 +105,49 @@ describe("auth command primitives", () => {
       ).rejects.toThrow("invalid code");
 
       expect(destroyCalls).toBe(1);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-bootstrap uses bot token mode without interactive prompts", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-bootstrap-bot-"));
+    const sessionPath = join(storageDir, "mtcute-primary.sqlite");
+
+    let promptCreated = false;
+    let receivedBotToken = "";
+
+    try {
+      await runAuthBootstrap({
+        createClient: async (config) => ({
+          config,
+          sessionPath,
+          client: {
+            destroy: async () => undefined,
+            start: async (params?: { botToken?: string }) => {
+              receivedBotToken = params?.botToken ?? "";
+              await writeFile(sessionPath, "sqlite");
+              return { id: 321n, username: "askloyal_bot" };
+            },
+          } as any,
+        }),
+        createPrompt: () => {
+          promptCreated = true;
+          return {
+            ask: async () => "noop",
+            close: () => undefined,
+          };
+        },
+        loadConfig: () =>
+          createConfig(storageDir, {
+            authMode: "bot",
+            botToken: "bot-token-123",
+          }),
+        logger: createLogger(),
+      });
+
+      expect(promptCreated).toBe(false);
+      expect(receivedBotToken).toBe("bot-token-123");
     } finally {
       await rm(storageDir, { force: true, recursive: true });
     }
@@ -196,6 +245,44 @@ describe("auth command primitives", () => {
       await expect(stat(`${basePath}-wal`)).rejects.toThrow();
       await expect(stat(`${basePath}-shm`)).rejects.toThrow();
       await stat(siblingPath);
+    } finally {
+      await rm(storageDir, { force: true, recursive: true });
+    }
+  });
+
+  test("auth-status in bot mode can validate token login without session file", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "userbot-status-bot-"));
+
+    let createClientCalls = 0;
+    let receivedBotToken = "";
+
+    try {
+      const authenticated = await runAuthStatus({
+        createClient: async (config) => {
+          createClientCalls += 1;
+          return {
+            config,
+            sessionPath: join(storageDir, "mtcute-primary.sqlite"),
+            client: {
+              destroy: async () => undefined,
+              start: async (params?: { botToken?: string }) => {
+                receivedBotToken = params?.botToken ?? "";
+                return { id: 1 };
+              },
+            } as any,
+          };
+        },
+        loadConfig: () =>
+          createConfig(storageDir, {
+            authMode: "bot",
+            botToken: "bot-token-456",
+          }),
+        logger: createLogger(),
+      });
+
+      expect(authenticated).toBe(true);
+      expect(createClientCalls).toBe(1);
+      expect(receivedBotToken).toBe("bot-token-456");
     } finally {
       await rm(storageDir, { force: true, recursive: true });
     }

--- a/workers/userbot/src/__tests__/env.test.ts
+++ b/workers/userbot/src/__tests__/env.test.ts
@@ -30,6 +30,8 @@ describe("loadUserbotConfig", () => {
     });
 
     expect(config.accountKey).toBe(DEFAULT_ACCOUNT_KEY);
+    expect(config.authMode).toBe("user");
+    expect(config.botToken).toBeNull();
     expect(config.storageDir).toBe(DEFAULT_STORAGE_DIR);
   });
 
@@ -42,6 +44,31 @@ describe("loadUserbotConfig", () => {
     });
 
     expect(config.accountKey).toBe("ops_userbot");
+    expect(config.authMode).toBe("user");
+    expect(config.botToken).toBeNull();
     expect(config.storageDir.endsWith("/.data/userbot")).toBe(true);
+  });
+
+  test("prefers TELEGRAM_USERBOT_BOT_TOKEN for bot auth mode", () => {
+    const config = loadUserbotConfig({
+      ASKLOYAL_TGBOT_KEY: "fallback-token",
+      TELEGRAM_USERBOT_API_HASH: "hash",
+      TELEGRAM_USERBOT_API_ID: "123",
+      TELEGRAM_USERBOT_BOT_TOKEN: "preferred-token",
+    });
+
+    expect(config.authMode).toBe("bot");
+    expect(config.botToken).toBe("preferred-token");
+  });
+
+  test("falls back to ASKLOYAL_TGBOT_KEY for bot auth mode", () => {
+    const config = loadUserbotConfig({
+      ASKLOYAL_TGBOT_KEY: "fallback-token",
+      TELEGRAM_USERBOT_API_HASH: "hash",
+      TELEGRAM_USERBOT_API_ID: "123",
+    });
+
+    expect(config.authMode).toBe("bot");
+    expect(config.botToken).toBe("fallback-token");
   });
 });

--- a/workers/userbot/src/__tests__/history-source.test.ts
+++ b/workers/userbot/src/__tests__/history-source.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { fetchUnseenMessages } from "../lib/sync/history-source";
+import {
+  fetchMessagesSince,
+  fetchUnseenMessages,
+  fetchUnseenMessagesByIdBatches,
+} from "../lib/sync/history-source";
 
 describe("history source", () => {
   test("first sync returns the latest 200 batch in ascending id order", async () => {
@@ -11,6 +15,7 @@ describe("history source", () => {
         }
         return [];
       },
+      getMessages: async () => [],
       iterHistory: async function* () {
         yield { id: 999 };
       },
@@ -29,6 +34,7 @@ describe("history source", () => {
 
     const client = {
       getHistory: async () => [],
+      getMessages: async () => [],
       iterHistory: () => ({
         [Symbol.asyncIterator]() {
           return {
@@ -55,5 +61,116 @@ describe("history source", () => {
     const second = await iterator.next();
     expect(second.value).toEqual({ id: 102 });
     expect(nextCalls).toBe(2);
+  });
+
+  test("lookback mode stops once history crosses the UTC cutoff", async () => {
+    const client = {
+      getHistory: async () => [],
+      getMessages: async () => [],
+      iterHistory: () => {
+        const messages = [
+          { date: new Date("2026-03-01T12:00:00.000Z"), id: 12 },
+          { date: new Date("2026-03-01T00:00:00.000Z"), id: 11 },
+          { date: new Date("2026-02-28T23:59:59.999Z"), id: 10 },
+          { date: new Date("2026-02-28T12:00:00.000Z"), id: 9 },
+        ];
+
+        return (async function* () {
+          for (const message of messages) {
+            yield message;
+          }
+        })();
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const message of fetchMessagesSince(
+      client,
+      1,
+      new Date("2026-03-01T00:00:00.000Z")
+    )) {
+      seen.push((message as { id: number }).id);
+    }
+
+    expect(seen).toEqual([12, 11]);
+  });
+
+  test("id-batch mode requests 200 ids from last stored+1 and yields ascending non-null messages", async () => {
+    const requestedStarts: number[] = [];
+    const client = {
+      getHistory: async () => [],
+      getMessages: async (_chatId: number, messageIds: number[]) => {
+        requestedStarts.push(messageIds[0] ?? -1);
+        if (messageIds[0] === 11) {
+          return [{ id: 13 }, null, { id: 11 }, { id: 12 }];
+        }
+
+        return [];
+      },
+      iterHistory: async function* () {
+        yield { id: 999 };
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const message of fetchUnseenMessagesByIdBatches(client, 1, 10)) {
+      seen.push((message as { id: number }).id);
+    }
+
+    expect(requestedStarts).toEqual([11, 211]);
+    expect(seen).toEqual([11, 12, 13]);
+  });
+
+  test("id-batch mode stops after first empty batch", async () => {
+    let calls = 0;
+    const client = {
+      getHistory: async () => [],
+      getMessages: async () => {
+        calls += 1;
+        return [];
+      },
+      iterHistory: async function* () {
+        yield { id: 999 };
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const message of fetchUnseenMessagesByIdBatches(client, 1, null)) {
+      seen.push((message as { id: number }).id);
+    }
+
+    expect(calls).toBe(1);
+    expect(seen).toEqual([]);
+  });
+
+  test("id-batch mode waits and retries when flood-wait is returned", async () => {
+    let calls = 0;
+    const sleepCalls: number[] = [];
+    const client = {
+      getHistory: async () => [],
+      getMessages: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("A wait of 2 seconds is required");
+        }
+        return [];
+      },
+      iterHistory: async function* () {
+        yield { id: 999 };
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const message of fetchUnseenMessagesByIdBatches(client, 1, null, {
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    })) {
+      seen.push((message as { id: number }).id);
+    }
+
+    expect(calls).toBe(2);
+    expect(sleepCalls).toEqual([3000]);
+    expect(seen).toEqual([]);
   });
 });

--- a/workers/userbot/src/__tests__/sync-once.test.ts
+++ b/workers/userbot/src/__tests__/sync-once.test.ts
@@ -35,6 +35,8 @@ type FakeState = {
   existingMembershipKeys: Set<string>;
   existingMessageKeys: Set<string>;
   getHistoryCalls: Array<{ chatId: number; limit: number }>;
+  getMessagesCalls: Array<{ chatId: number; firstId: number; size: number }>;
+  getMessagesResponsesByFirstId: Map<number, Array<unknown | null>>;
   getHistoryLimitOneFailCount: number;
   incrementalHistory: unknown[];
   initialHistory: unknown[];
@@ -58,8 +60,10 @@ function createLogger(): FakeLogger {
 function createConfig(): UserbotConfig {
   return {
     accountKey: "primary",
+    authMode: "user",
     apiHash: "hash",
     apiId: 123,
+    botToken: null,
     storageDir: "/tmp/userbot",
   };
 }
@@ -71,6 +75,7 @@ function createFakeState(
       | "existingMembershipKeys"
       | "existingMessageKeys"
       | "getHistoryCalls"
+      | "getMessagesCalls"
       | "insertedMembershipRows"
       | "insertedMessageRows"
       | "insertedUserRows"
@@ -84,6 +89,9 @@ function createFakeState(
     existingMembershipKeys: new Set<string>(),
     existingMessageKeys: new Set<string>(),
     getHistoryCalls: [],
+    getMessagesCalls: [],
+    getMessagesResponsesByFirstId:
+      overrides.getMessagesResponsesByFirstId ?? new Map<number, Array<unknown | null>>(),
     getHistoryLimitOneFailCount: overrides.getHistoryLimitOneFailCount ?? 0,
     incrementalHistory: overrides.incrementalHistory ?? [],
     initialHistory: overrides.initialHistory ?? [],
@@ -107,8 +115,7 @@ function createFakeDb(state: FakeState): any {
   return {
     query: {
       communities: {
-        findMany: async () =>
-          state.communities.filter((community) => community.parserType === "userbot"),
+        findMany: async () => state.communities,
       },
       messages: {
         findFirst: async () =>
@@ -188,7 +195,10 @@ function createFakeDb(state: FakeState): any {
   };
 }
 
-function createFakeBundle(state: FakeState): any {
+function createFakeBundle(
+  state: FakeState,
+  config: UserbotConfig = createConfig()
+): any {
   return {
     client: {
       destroy: async () => undefined,
@@ -219,6 +229,16 @@ function createFakeBundle(state: FakeState): any {
 
         return [];
       },
+      getMessages: async (chatId: number, messageIds: number[]) => {
+        const firstId = messageIds[0] ?? 0;
+        state.getMessagesCalls.push({
+          chatId,
+          firstId,
+          size: messageIds.length,
+        });
+
+        return state.getMessagesResponsesByFirstId.get(firstId) ?? [];
+      },
       iterHistory: (_chatId: number, params?: { minId?: number }) => {
         state.iterHistoryCalls.push({
           chatId: _chatId,
@@ -234,7 +254,7 @@ function createFakeBundle(state: FakeState): any {
       },
       start: async () => ({ id: 1 }),
     },
-    config: createConfig(),
+    config,
     sessionPath: "/tmp/userbot/mtcute-primary.sqlite",
   };
 }
@@ -257,6 +277,118 @@ describe("sync:once command", () => {
 
     expect(statusCode).toBe(1);
     expect(createClientCalls).toBe(0);
+  });
+
+  test("bot mode can start sync without a pre-existing session file", async () => {
+    const state = createFakeState();
+    let receivedBotToken = "";
+    const baseBundle = createFakeBundle(state);
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => ({
+          config: baseBundle.config,
+          sessionPath: baseBundle.sessionPath,
+          client: {
+            ...(baseBundle.client as any),
+            start: async (params?: { botToken?: string }) => {
+              receivedBotToken = params?.botToken ?? "";
+              return { id: 1 };
+            },
+          } as any,
+        }),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => false,
+        loadConfig: () => ({
+          ...createConfig(),
+          authMode: "bot",
+          botToken: "bot-token-999",
+        }),
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { parserTypes: ["bot", "userbot"] }
+    );
+
+    expect(result.stats.communitiesScanned).toBe(0);
+    expect(receivedBotToken).toBe("bot-token-999");
+  });
+
+  test("bot mode uses getMessages id batches and avoids getHistory", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000099),
+          chatTitle: "Bot Community",
+          id: "community-bot",
+          parserType: "bot",
+        },
+      ],
+      latestStoredMessageId: BigInt(500),
+      getMessagesResponsesByFirstId: new Map<number, Array<unknown | null>>([
+        [
+          501,
+          [
+            {
+              date: new Date("2026-03-01T12:00:00.000Z"),
+              id: 501,
+              isService: false,
+              media: null,
+              sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+              text: "message 1",
+            } satisfies MessageRecord,
+            {
+              date: new Date("2026-03-01T12:01:00.000Z"),
+              id: 502,
+              isService: false,
+              media: null,
+              sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+              text: "message 2",
+            } satisfies MessageRecord,
+          ],
+        ],
+        [701, []],
+      ]),
+    });
+    const botConfig: UserbotConfig = {
+      ...createConfig(),
+      authMode: "bot",
+      botToken: "bot-token-999",
+    };
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state, botConfig),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => botConfig,
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { parserTypes: ["bot", "userbot"] }
+    );
+
+    expect(result.stats.authMode).toBe("bot");
+    expect(result.stats.botUsedIdBatchFetch).toBe(true);
+    expect(result.stats.botBatchSize).toBe(200);
+    expect(result.stats.botBatchRequests).toBe(2);
+    expect(result.stats.botEmptyBatches).toBe(1);
+    expect(result.stats.insertedMessages).toBe(2);
+    expect(state.getHistoryCalls).toEqual([]);
+    expect(state.getMessagesCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000099)),
+        firstId: 501,
+        size: 200,
+      },
+      {
+        chatId: Number(BigInt(-1000000000099)),
+        firstId: 701,
+        size: 200,
+      },
+    ]);
   });
 
   test("returns zero-work stats when no userbot communities exist", async () => {
@@ -303,6 +435,81 @@ describe("sync:once command", () => {
     expect(result.stats.communitiesScanned).toBe(0);
     expect(result.stats.communitiesProcessed).toBe(0);
     expect(result.stats.insertedMessages).toBe(0);
+  });
+
+  test("includes bot communities when parser types include bot", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000011),
+          chatTitle: "Bot Community",
+          id: "community-bot",
+          parserType: "bot",
+        },
+      ],
+      latestStoredMessageId: BigInt(4),
+      latestTelegramMessageId: 4,
+    });
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => createConfig(),
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { parserTypes: ["bot", "userbot"] }
+    );
+
+    expect(result.stats.communitiesScanned).toBe(1);
+    expect(result.stats.communitiesProcessed).toBe(1);
+    expect(result.stats.selectedParserTypes).toEqual(["bot", "userbot"]);
+  });
+
+  test("filters communities by explicit chat ids when provided", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000012),
+          chatTitle: "Keep",
+          id: "community-keep",
+          parserType: "userbot",
+        },
+        {
+          chatId: BigInt(-1000000000013),
+          chatTitle: "Skip",
+          id: "community-skip",
+          parserType: "userbot",
+        },
+      ],
+      latestStoredMessageId: BigInt(4),
+      latestTelegramMessageId: 4,
+    });
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => createConfig(),
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { chatIds: [BigInt(-1000000000012)] }
+    );
+
+    expect(result.stats.communitiesScanned).toBe(1);
+    expect(result.stats.communitiesProcessed).toBe(1);
+    expect(state.getHistoryCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000012)),
+        limit: 1,
+      },
+    ]);
   });
 
   test("skips insertion when no new Telegram messages are available", async () => {
@@ -537,5 +744,82 @@ describe("sync:once command", () => {
     expect(result.stats.retryCount).toBe(1);
     expect(result.stats.communitiesFailed).toBe(0);
     expect(result.stats.communitiesUpToDate).toBe(1);
+  });
+
+  test("lookback mode in bot auth inserts only messages inside UTC recovery window", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000014),
+          chatTitle: "Lookback",
+          id: "community-1",
+          parserType: "bot",
+        },
+      ],
+      latestStoredMessageId: BigInt(100),
+      getMessagesResponsesByFirstId: new Map<number, Array<unknown | null>>([
+        [
+          101,
+          [
+            {
+              date: new Date("2026-03-01T12:00:00.000Z"),
+              id: 101,
+              isService: false,
+              media: null,
+              sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+              text: "inside window",
+            } satisfies MessageRecord,
+            {
+              date: new Date("2026-03-03T01:00:00.000Z"),
+              id: 102,
+              isService: false,
+              media: null,
+              sender: { displayName: "Bob", id: 2, type: "user", username: "bob" },
+              text: "outside window end",
+            } satisfies MessageRecord,
+          ],
+        ],
+      ]),
+    });
+    const botConfig: UserbotConfig = {
+      ...createConfig(),
+      authMode: "bot",
+      botToken: "bot-token-999",
+    };
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state, botConfig),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => botConfig,
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      {
+        lookbackDays: 2,
+        now: new Date("2026-03-03T12:00:00.000Z"),
+        parserTypes: ["bot", "userbot"],
+      }
+    );
+
+    expect(result.stats.lookbackDays).toBe(2);
+    expect(result.stats.lookbackWindowStartUtc).toBe("2026-03-01T00:00:00.000Z");
+    expect(result.stats.lookbackWindowEndExclusiveUtc).toBe(
+      "2026-03-03T00:00:00.000Z"
+    );
+    expect(result.stats.botUsedLookbackFilter).toBe(true);
+    expect(result.stats.insertedMessages).toBe(1);
+    expect(result.stats.communitiesUpToDate).toBe(0);
+    expect(state.getHistoryCalls).toEqual([]);
+    expect(state.iterHistoryCalls).toEqual([]);
+    expect(state.getMessagesCalls).toEqual([
+      {
+        chatId: Number(BigInt(-1000000000014)),
+        firstId: 101,
+        size: 200,
+      },
+    ]);
   });
 });

--- a/workers/userbot/src/__tests__/worker.test.ts
+++ b/workers/userbot/src/__tests__/worker.test.ts
@@ -20,12 +20,15 @@ function createLogger(): FakeLogger {
   };
 }
 
-function createConfig(): UserbotConfig {
+function createConfig(overrides: Partial<UserbotConfig> = {}): UserbotConfig {
   return {
     accountKey: "primary",
+    authMode: "user",
     apiHash: "hash",
     apiId: 123,
+    botToken: null,
     storageDir: "/tmp/userbot",
+    ...overrides,
   };
 }
 
@@ -111,6 +114,35 @@ describe("worker runtime", () => {
 
     await expect(worker.start()).rejects.toThrow("invalid session");
     expect(callbackErrorMessage).toContain("Run bun run auth:bootstrap");
+  });
+
+  test("bot mode starts without pre-existing session file", async () => {
+    let receivedBotToken = "";
+
+    const worker = createUserbotWorker({
+      createClient: async (config) => ({
+        config,
+        sessionPath: join(config.storageDir, "mtcute-primary.sqlite"),
+        client: {
+          destroy: async () => undefined,
+          onRawUpdate: { add: () => undefined },
+          start: async (params?: { botToken?: string }) => {
+            receivedBotToken = params?.botToken ?? "";
+            return { id: 999 };
+          },
+        } as any,
+      }),
+      hasFile: async () => false,
+      loadConfig: () =>
+        createConfig({
+          authMode: "bot",
+          botToken: "bot-token-789",
+        }),
+      logger: createLogger(),
+    });
+
+    await expect(worker.start()).resolves.toBeUndefined();
+    expect(receivedBotToken).toBe("bot-token-789");
   });
 
   test("shutdown handler is idempotent across repeated signals", async () => {

--- a/workers/userbot/src/commands/auth-bootstrap.ts
+++ b/workers/userbot/src/commands/auth-bootstrap.ts
@@ -2,6 +2,10 @@ import { createInterface } from "node:readline/promises";
 
 import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
 import { loadUserbotConfig, readBootstrapPhone, type UserbotConfig } from "../lib/env";
+import {
+  buildReauthGuidance,
+  createBotTokenStartParams,
+} from "../lib/non-interactive-auth";
 
 type EnvRecord = Record<string, string | undefined>;
 
@@ -96,28 +100,39 @@ export async function runAuthBootstrap(
 ): Promise<void> {
   const deps = resolveDeps(overrides);
   const config = deps.loadConfig(deps.env);
-  const phoneFromEnv = readBootstrapPhone(deps.env);
-  const prompt = deps.createPrompt();
 
   deps.logger.info(
-    `[userbot] Starting interactive auth bootstrap for account '${config.accountKey}'.`
+    `[userbot] Starting auth bootstrap for account '${config.accountKey}' (authMode=${config.authMode}).`
   );
 
   const bundle = await deps.createClient(config);
   deps.logger.info(`[userbot] Session storage: ${bundle.sessionPath}`);
 
   try {
-    const user = await bundle.client.start({
-      code: async () => prompt.ask("Telegram code: "),
-      password: async () => prompt.ask("2FA password (if enabled): "),
-      phone: async () => phoneFromEnv ?? prompt.ask("Phone number (+...): "),
-    });
+    const user = await (async () => {
+      if (config.authMode === "bot") {
+        return bundle.client.start(createBotTokenStartParams(config));
+      }
+
+      const phoneFromEnv = readBootstrapPhone(deps.env);
+      const prompt = deps.createPrompt();
+      try {
+        return bundle.client.start({
+          code: async () => prompt.ask("Telegram code: "),
+          password: async () =>
+            prompt.ask("2FA password (if enabled): "),
+          phone: async () =>
+            phoneFromEnv ?? prompt.ask("Phone number (+...): "),
+        });
+      } finally {
+        prompt.close();
+      }
+    })();
 
     deps.logger.info(
       `[userbot] Auth bootstrap complete for account '${config.accountKey}' as ${getIdentityLabel(user)}.`
     );
   } finally {
-    prompt.close();
     await bundle.client.destroy();
   }
 }
@@ -126,12 +141,20 @@ export async function runAuthBootstrapCli(
   overrides: Partial<AuthBootstrapDeps> = {}
 ): Promise<number> {
   const logger = overrides.logger ?? console;
+  const loadConfig = overrides.loadConfig ?? loadUserbotConfig;
+  const env = overrides.env ?? process.env;
 
   try {
     await runAuthBootstrap(overrides);
     return 0;
   } catch (error) {
-    logger.error("[userbot] Auth bootstrap failed", error);
+    let guidance = "Run bun run auth:bootstrap.";
+    try {
+      guidance = buildReauthGuidance(loadConfig(env));
+    } catch {
+      // Keep default guidance when config cannot be loaded.
+    }
+    logger.error(`[userbot] Auth bootstrap failed. ${guidance}`, error);
     return 1;
   }
 }

--- a/workers/userbot/src/commands/auth-status.ts
+++ b/workers/userbot/src/commands/auth-status.ts
@@ -2,7 +2,10 @@ import { stat } from "node:fs/promises";
 
 import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
 import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
-import { createNonInteractiveAuthCallbacks } from "../lib/non-interactive-auth";
+import {
+  buildReauthGuidance,
+  createNonInteractiveStartParams,
+} from "../lib/non-interactive-auth";
 import { resolveSessionSqlitePath } from "../lib/storage";
 
 type EnvRecord = Record<string, string | undefined>;
@@ -50,12 +53,16 @@ export async function runAuthStatus(
 ): Promise<boolean> {
   const deps = resolveDeps(overrides);
   const config = deps.loadConfig(deps.env);
+  deps.logger.info(
+    `[userbot] Checking auth status for '${config.accountKey}' (authMode=${config.authMode}).`
+  );
   const sessionPath = resolveSessionSqlitePath(
     config.accountKey,
     config.storageDir
   );
 
-  if (!(await deps.hasFile(sessionPath))) {
+  const sessionExists = await deps.hasFile(sessionPath);
+  if (!sessionExists && config.authMode === "user") {
     deps.logger.info(
       `[userbot] No session found for '${config.accountKey}'. Run auth:bootstrap first.`
     );
@@ -63,23 +70,25 @@ export async function runAuthStatus(
     return false;
   }
 
+  if (!sessionExists && config.authMode === "bot") {
+    deps.logger.info(
+      `[userbot] No session found for '${config.accountKey}' in bot mode; validating token login directly.`
+    );
+  }
+
   const bundle = await deps.createClient(config);
 
   try {
-    await bundle.client.start(
-      createNonInteractiveAuthCallbacks(
-        `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
-      )
-    );
+    await bundle.client.start(createNonInteractiveStartParams(config));
 
     deps.logger.info(
-      `[userbot] Session is valid for account '${config.accountKey}'.`
+      `[userbot] Session is valid for account '${config.accountKey}' (authMode=${config.authMode}).`
     );
 
     return true;
   } catch (error) {
     deps.logger.error(
-      `[userbot] Session check failed for '${config.accountKey}'. Re-run auth:bootstrap.`,
+      `[userbot] Session check failed for '${config.accountKey}'. ${buildReauthGuidance(config)}`,
       error
     );
     return false;

--- a/workers/userbot/src/commands/sync-once.ts
+++ b/workers/userbot/src/commands/sync-once.ts
@@ -1,13 +1,27 @@
 import { stat } from "node:fs/promises";
 
-import { communities, messages } from "@loyal-labs/db-core/schema";
-import { and, desc, eq } from "drizzle-orm";
+import {
+  communities,
+  messages,
+  type CommunityParserType,
+} from "@loyal-labs/db-core/schema";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
 import { createWorkerDatabase, loadDatabaseUrl, type UserbotDb } from "../lib/database";
 import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
-import { createNonInteractiveAuthCallbacks } from "../lib/non-interactive-auth";
-import { fetchUnseenMessages, getLatestTelegramMessageId } from "../lib/sync/history-source";
+import {
+  buildReauthGuidance,
+  createNonInteractiveStartParams,
+} from "../lib/non-interactive-auth";
+import {
+  BOT_EMPTY_BATCH_STOP_COUNT,
+  BOT_ID_BATCH_SIZE,
+  fetchMessagesSince,
+  fetchUnseenMessagesByIdBatches,
+  fetchUnseenMessages,
+  getLatestTelegramMessageId,
+} from "../lib/sync/history-source";
 import { toIngestibleMessage } from "../lib/sync/message-filter";
 import { persistEligibleMessage } from "../lib/sync/persistence";
 import { resolveSessionSqlitePath } from "../lib/storage";
@@ -27,10 +41,26 @@ type SyncOnceDeps = {
   sleep: (ms: number) => Promise<void>;
 };
 
-type ActiveUserbotCommunity = {
+type SyncOnceOptions = {
+  chatIds?: bigint[];
+  lookbackDays?: number | null;
+  now?: Date;
+  parserTypes?: CommunityParserType[];
+};
+
+type ResolvedSyncOnceOptions = {
+  chatIds: bigint[] | null;
+  lookbackDays: number | null;
+  lookbackWindowEndExclusiveUtc: Date | null;
+  lookbackWindowStartUtc: Date | null;
+  parserTypes: CommunityParserType[];
+};
+
+type ActiveSyncCommunity = {
   chatId: bigint;
   chatTitle: string;
   id: string;
+  parserType: CommunityParserType;
 };
 
 type CommunitySyncError = {
@@ -40,6 +70,14 @@ type CommunitySyncError = {
 };
 
 export type SyncOnceStats = {
+  authMode: UserbotConfig["authMode"];
+  botBatchRequests: number;
+  botEmptyBatches: number;
+  botStopAfterEmptyBatches: number | null;
+  botUsedIdBatchFetch: boolean;
+  botUsedLookbackFilter: boolean;
+  botBatchSize: number | null;
+  chatIdFilterCount: number | null;
   communitiesFailed: number;
   communitiesProcessed: number;
   communitiesScanned: number;
@@ -58,6 +96,10 @@ export type SyncOnceStats = {
   telegramMessagesConsidered: number;
   telegramMessagesFetched: number;
   userMetadataUpdates: number;
+  lookbackDays: number | null;
+  lookbackWindowEndExclusiveUtc: string | null;
+  lookbackWindowStartUtc: string | null;
+  selectedParserTypes: CommunityParserType[];
 };
 
 export type SyncOnceResult = {
@@ -67,6 +109,7 @@ export type SyncOnceResult = {
 
 const RETRY_BASE_DELAY_MS = 250;
 const RETRY_MAX_ATTEMPTS = 3;
+const SUPPORTED_PARSER_TYPES: CommunityParserType[] = ["bot", "userbot"];
 
 function isDirectExecution(scriptName: string): boolean {
   const entrypoint = process.argv[1];
@@ -90,6 +133,122 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function toUtcDayStart(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+}
+
+function resolveSyncOptions(options: SyncOnceOptions = {}): ResolvedSyncOnceOptions {
+  const parserTypes: CommunityParserType[] = options.parserTypes?.length
+    ? [...new Set(options.parserTypes)]
+    : ["userbot"];
+  const invalidParserTypes = parserTypes.filter(
+    (entry) => !SUPPORTED_PARSER_TYPES.includes(entry)
+  );
+  if (invalidParserTypes.length > 0) {
+    throw new Error(
+      `Unsupported parser type(s): ${invalidParserTypes.join(", ")}. Supported values: ${SUPPORTED_PARSER_TYPES.join(", ")}`
+    );
+  }
+
+  const lookbackDays = options.lookbackDays ?? null;
+  if (lookbackDays !== null && (!Number.isInteger(lookbackDays) || lookbackDays <= 0)) {
+    throw new Error("lookbackDays must be a positive integer");
+  }
+
+  if (lookbackDays === null) {
+    return {
+      chatIds: options.chatIds?.length ? options.chatIds : null,
+      lookbackDays: null,
+      lookbackWindowEndExclusiveUtc: null,
+      lookbackWindowStartUtc: null,
+      parserTypes,
+    };
+  }
+
+  const now = options.now ?? new Date();
+  const lookbackWindowEndExclusiveUtc = toUtcDayStart(now);
+  const lookbackWindowStartUtc = new Date(
+    lookbackWindowEndExclusiveUtc.getTime() - lookbackDays * 24 * 60 * 60 * 1_000
+  );
+
+  return {
+    chatIds: options.chatIds?.length ? options.chatIds : null,
+    lookbackDays,
+    lookbackWindowEndExclusiveUtc,
+    lookbackWindowStartUtc,
+    parserTypes,
+  };
+}
+
+function parseParserTypes(value: string): CommunityParserType[] {
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (parsed.length === 0) {
+    throw new Error("--parser-types must include at least one parser type");
+  }
+
+  const invalid = parsed.filter(
+    (entry) => !SUPPORTED_PARSER_TYPES.includes(entry as CommunityParserType)
+  );
+  if (invalid.length > 0) {
+    throw new Error(
+      `Unsupported parser type(s): ${invalid.join(", ")}. Supported values: ${SUPPORTED_PARSER_TYPES.join(", ")}`
+    );
+  }
+
+  return [...new Set(parsed as CommunityParserType[])];
+}
+
+function parseChatIds(value: string): bigint[] {
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (parsed.length === 0) {
+    throw new Error("--chat-ids must include at least one chat id");
+  }
+
+  return parsed.map((entry) => {
+    try {
+      return BigInt(entry);
+    } catch {
+      throw new Error(`Invalid --chat-ids value: '${entry}'`);
+    }
+  });
+}
+
+function parseSyncOnceCliOptions(argv: string[]): SyncOnceOptions {
+  const options: SyncOnceOptions = {};
+
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith("--parser-types=")) {
+      options.parserTypes = parseParserTypes(arg.slice("--parser-types=".length));
+      continue;
+    }
+
+    if (arg.startsWith("--lookback-days=")) {
+      const value = Number.parseInt(arg.slice("--lookback-days=".length), 10);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error("--lookback-days must be a positive integer");
+      }
+      options.lookbackDays = value;
+      continue;
+    }
+
+    if (arg.startsWith("--chat-ids=")) {
+      options.chatIds = parseChatIds(arg.slice("--chat-ids=".length));
+      continue;
+    }
+  }
+
+  return options;
+}
+
 function resolveDeps(overrides: Partial<SyncOnceDeps>): SyncOnceDeps {
   return {
     createClient: overrides.createClient ?? createUserbotClient,
@@ -103,8 +262,22 @@ function resolveDeps(overrides: Partial<SyncOnceDeps>): SyncOnceDeps {
   };
 }
 
-function createInitialStats(communitiesScanned: number): SyncOnceStats {
+function createInitialStats(
+  communitiesScanned: number,
+  options: ResolvedSyncOnceOptions,
+  config: UserbotConfig
+): SyncOnceStats {
+  const isBotAuthMode = config.authMode === "bot";
+
   return {
+    authMode: config.authMode,
+    botBatchRequests: 0,
+    botBatchSize: isBotAuthMode ? BOT_ID_BATCH_SIZE : null,
+    botEmptyBatches: 0,
+    botStopAfterEmptyBatches: isBotAuthMode ? BOT_EMPTY_BATCH_STOP_COUNT : null,
+    botUsedIdBatchFetch: isBotAuthMode,
+    botUsedLookbackFilter: isBotAuthMode && options.lookbackWindowStartUtc !== null,
+    chatIdFilterCount: options.chatIds?.length ?? null,
     communitiesFailed: 0,
     communitiesProcessed: 0,
     communitiesScanned,
@@ -123,6 +296,11 @@ function createInitialStats(communitiesScanned: number): SyncOnceStats {
     telegramMessagesConsidered: 0,
     telegramMessagesFetched: 0,
     userMetadataUpdates: 0,
+    lookbackDays: options.lookbackDays,
+    lookbackWindowEndExclusiveUtc:
+      options.lookbackWindowEndExclusiveUtc?.toISOString() ?? null,
+    lookbackWindowStartUtc: options.lookbackWindowStartUtc?.toISOString() ?? null,
+    selectedParserTypes: options.parserTypes,
   };
 }
 
@@ -189,29 +367,175 @@ async function destroyBundle(
   }
 }
 
-async function syncCommunity(
+async function getLatestStoredMessageId(
   db: UserbotDb,
-  bundle: UserbotClientBundle,
-  community: ActiveUserbotCommunity,
-  stats: SyncOnceStats,
-  userIdCache: Map<string, string>,
-  membershipCache: Set<string>
-): Promise<void> {
+  communityId: string
+): Promise<number | null> {
   const latestStored = await db.query.messages.findFirst({
     columns: { telegramMessageId: true },
     orderBy: [desc(messages.telegramMessageId)],
-    where: eq(messages.communityId, community.id),
+    where: eq(messages.communityId, communityId),
   });
-  const latestStoredMessageId =
-    latestStored?.telegramMessageId !== undefined
-      ? Number(latestStored.telegramMessageId)
-      : null;
+
+  return latestStored?.telegramMessageId !== undefined
+    ? Number(latestStored.telegramMessageId)
+    : null;
+}
+
+async function syncCommunityWithBotIdBatches(
+  db: UserbotDb,
+  bundle: UserbotClientBundle,
+  community: ActiveSyncCommunity,
+  stats: SyncOnceStats,
+  options: ResolvedSyncOnceOptions,
+  userIdCache: Map<string, string>,
+  membershipCache: Set<string>
+): Promise<void> {
+  const chatPeerId = Number(community.chatId);
+  const latestStoredMessageId = await getLatestStoredMessageId(db, community.id);
 
   if (latestStoredMessageId === null) {
     stats.communitiesWithNoStoredMessages += 1;
   }
 
+  let fetchedMessages = 0;
+  for await (const rawMessage of fetchUnseenMessagesByIdBatches(
+    bundle.client,
+    chatPeerId,
+    latestStoredMessageId,
+    {
+      batchSize: BOT_ID_BATCH_SIZE,
+      onBatch: (payload) => {
+        stats.botBatchRequests += 1;
+        if (payload.wasEmpty) {
+          stats.botEmptyBatches += 1;
+        }
+      },
+      stopAfterEmptyBatches: BOT_EMPTY_BATCH_STOP_COUNT,
+    }
+  )) {
+    fetchedMessages += 1;
+    stats.telegramMessagesFetched += 1;
+    stats.telegramMessagesConsidered += 1;
+
+    const message = toIngestibleMessage(rawMessage, stats);
+    if (!message) {
+      continue;
+    }
+
+    if (
+      latestStoredMessageId !== null &&
+      message.messageId <= latestStoredMessageId
+    ) {
+      stats.skippedOldOrEqual += 1;
+      continue;
+    }
+
+    if (
+      options.lookbackWindowEndExclusiveUtc &&
+      message.createdAt >= options.lookbackWindowEndExclusiveUtc
+    ) {
+      break;
+    }
+
+    if (
+      options.lookbackWindowStartUtc &&
+      message.createdAt < options.lookbackWindowStartUtc
+    ) {
+      continue;
+    }
+
+    await persistEligibleMessage({
+      communityId: community.id,
+      db,
+      membershipCache,
+      message,
+      stats,
+      userIdCache,
+    });
+  }
+
+  if (fetchedMessages === 0) {
+    if (latestStoredMessageId === null) {
+      stats.communitiesWithNoTelegramHistory += 1;
+      return;
+    }
+
+    stats.communitiesUpToDate += 1;
+  }
+}
+
+async function syncCommunity(
+  db: UserbotDb,
+  bundle: UserbotClientBundle,
+  authMode: UserbotConfig["authMode"],
+  community: ActiveSyncCommunity,
+  stats: SyncOnceStats,
+  options: ResolvedSyncOnceOptions,
+  userIdCache: Map<string, string>,
+  membershipCache: Set<string>
+): Promise<void> {
+  if (authMode === "bot") {
+    await syncCommunityWithBotIdBatches(
+      db,
+      bundle,
+      community,
+      stats,
+      options,
+      userIdCache,
+      membershipCache
+    );
+    return;
+  }
+
   const chatPeerId = Number(community.chatId);
+
+  if (options.lookbackWindowStartUtc) {
+    let fetchedMessages = 0;
+
+    for await (const rawMessage of fetchMessagesSince(
+      bundle.client,
+      chatPeerId,
+      options.lookbackWindowStartUtc
+    )) {
+      fetchedMessages += 1;
+      stats.telegramMessagesFetched += 1;
+      stats.telegramMessagesConsidered += 1;
+
+      const message = toIngestibleMessage(rawMessage, stats);
+      if (!message) {
+        continue;
+      }
+
+      if (
+        options.lookbackWindowEndExclusiveUtc &&
+        message.createdAt >= options.lookbackWindowEndExclusiveUtc
+      ) {
+        continue;
+      }
+
+      await persistEligibleMessage({
+        communityId: community.id,
+        db,
+        membershipCache,
+        message,
+        stats,
+        userIdCache,
+      });
+    }
+
+    if (fetchedMessages === 0) {
+      stats.communitiesUpToDate += 1;
+    }
+    return;
+  }
+
+  const latestStoredMessageId = await getLatestStoredMessageId(db, community.id);
+
+  if (latestStoredMessageId === null) {
+    stats.communitiesWithNoStoredMessages += 1;
+  }
+
   const latestTelegramMessageId = await getLatestTelegramMessageId(
     bundle.client,
     chatPeerId
@@ -262,18 +586,34 @@ async function syncCommunity(
 }
 
 export async function runSyncOnce(
-  overrides: Partial<SyncOnceDeps> = {}
+  overrides: Partial<SyncOnceDeps> = {},
+  options: SyncOnceOptions = {}
 ): Promise<SyncOnceResult> {
   const deps = resolveDeps(overrides);
+  const resolvedOptions = resolveSyncOptions(options);
   const config = deps.loadConfig(deps.env);
+  deps.logger.info(
+    `[userbot] Starting sync:once for '${config.accountKey}' (authMode=${config.authMode}).`
+  );
+  deps.logger.info(
+    `[userbot] sync:once fetch strategy: ${
+      config.authMode === "bot" ? "getMessages-id-batch" : "history"
+    }`
+  );
   const sessionPath = resolveSessionSqlitePath(
     config.accountKey,
     config.storageDir
   );
 
-  if (!(await deps.hasFile(sessionPath))) {
+  const sessionExists = await deps.hasFile(sessionPath);
+  if (!sessionExists && config.authMode === "user") {
     throw new Error(
       `[userbot] Missing session file for '${config.accountKey}'. Run auth:bootstrap first. Expected: ${sessionPath}`
+    );
+  }
+  if (!sessionExists && config.authMode === "bot") {
+    deps.logger.info(
+      `[userbot] No session found for '${config.accountKey}' in bot mode; proceeding with token-based startup.`
     );
   }
 
@@ -282,31 +622,54 @@ export async function runSyncOnce(
   const membershipCache = new Set<string>();
 
   try {
-    await bundle.client.start(
-      createNonInteractiveAuthCallbacks(
-        `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
-      )
-    );
+    await bundle.client.start(createNonInteractiveStartParams(config));
 
     const databaseUrl = deps.loadDatabaseUrl(deps.env);
     const db = deps.createDb(databaseUrl);
 
-    const userbotCommunities = await db.query.communities.findMany({
+    const whereClauses = [
+      eq(communities.isActive, true),
+      inArray(communities.parserType, resolvedOptions.parserTypes),
+    ];
+    if (resolvedOptions.chatIds) {
+      whereClauses.push(inArray(communities.chatId, resolvedOptions.chatIds));
+    }
+
+    const queriedCommunities = await db.query.communities.findMany({
       columns: {
         chatId: true,
         chatTitle: true,
         id: true,
+        parserType: true,
       },
-      where: and(
-        eq(communities.isActive, true),
-        eq(communities.parserType, "userbot")
-      ),
+      where: and(...whereClauses),
     });
 
-    const stats = createInitialStats(userbotCommunities.length);
+    // Keep runtime filtering explicit for auditability in tests and logs.
+    const chatIdFilter =
+      resolvedOptions.chatIds === null
+        ? null
+        : new Set(resolvedOptions.chatIds.map((chatId) => chatId.toString()));
+    const selectedCommunities = queriedCommunities.filter((community) => {
+      if (!resolvedOptions.parserTypes.includes(community.parserType)) {
+        return false;
+      }
+
+      if (!chatIdFilter) {
+        return true;
+      }
+
+      return chatIdFilter.has(community.chatId.toString());
+    });
+
+    const stats = createInitialStats(
+      selectedCommunities.length,
+      resolvedOptions,
+      config
+    );
     const errors: CommunitySyncError[] = [];
 
-    for (const community of userbotCommunities) {
+    for (const community of selectedCommunities) {
       stats.communitiesProcessed += 1;
 
       try {
@@ -318,8 +681,10 @@ export async function runSyncOnce(
             await syncCommunity(
               db,
               bundle,
+              config.authMode,
               community,
               stats,
+              resolvedOptions,
               userIdCache,
               membershipCache
             );
@@ -351,12 +716,23 @@ export async function runSyncOnceCli(
   overrides: Partial<SyncOnceDeps> = {}
 ): Promise<number> {
   const logger = overrides.logger ?? console;
+  const argv = process.argv;
+  const loadConfig = overrides.loadConfig ?? loadUserbotConfig;
+  const env = overrides.env ?? process.env;
 
   try {
-    await runSyncOnce(overrides);
+    const config = loadConfig(env);
+    const options = parseSyncOnceCliOptions(argv);
+    await runSyncOnce(overrides, options);
     return 0;
   } catch (error) {
-    logger.error("[userbot] sync:once failed to start", error);
+    let guidance = "Run bun run auth:bootstrap.";
+    try {
+      guidance = buildReauthGuidance(loadConfig(env));
+    } catch {
+      // Keep default guidance when config cannot be loaded.
+    }
+    logger.error(`[userbot] sync:once failed to start. ${guidance}`, error);
     return 1;
   }
 }

--- a/workers/userbot/src/lib/env.ts
+++ b/workers/userbot/src/lib/env.ts
@@ -7,10 +7,14 @@ const ACCOUNT_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 type EnvRecord = Record<string, string | undefined>;
 
+export type UserbotAuthMode = "bot" | "user";
+
 export type UserbotConfig = {
   accountKey: string;
+  authMode: UserbotAuthMode;
   apiHash: string;
   apiId: number;
+  botToken: string | null;
   storageDir: string;
 };
 
@@ -58,14 +62,31 @@ function parseStorageDir(rawStorageDir: string | undefined): string {
   return resolve(normalized);
 }
 
+function parseBotToken(env: EnvRecord): string | null {
+  const explicitBotToken = normalizeOptionalValue(env.TELEGRAM_USERBOT_BOT_TOKEN);
+  if (explicitBotToken) {
+    return explicitBotToken;
+  }
+
+  const askLoyalBotToken = normalizeOptionalValue(env.ASKLOYAL_TGBOT_KEY);
+  if (askLoyalBotToken) {
+    return askLoyalBotToken;
+  }
+
+  return null;
+}
+
 export function loadUserbotConfig(env: EnvRecord = process.env): UserbotConfig {
   const apiId = parseApiId(getRequiredEnv("TELEGRAM_USERBOT_API_ID", env));
   const apiHash = getRequiredEnv("TELEGRAM_USERBOT_API_HASH", env);
+  const botToken = parseBotToken(env);
 
   return {
     accountKey: parseAccountKey(env.TELEGRAM_USERBOT_ACCOUNT_KEY),
+    authMode: botToken ? "bot" : "user",
     apiHash,
     apiId,
+    botToken,
     storageDir: parseStorageDir(env.USERBOT_STORAGE_DIR),
   };
 }

--- a/workers/userbot/src/lib/non-interactive-auth.ts
+++ b/workers/userbot/src/lib/non-interactive-auth.ts
@@ -1,15 +1,21 @@
+import type { UserbotConfig } from "./env";
+
 const DEFAULT_NON_INTERACTIVE_MESSAGE =
   "Session is missing or invalid. Run bun run auth:bootstrap to re-authenticate.";
 
-export type NonInteractiveAuthCallbacks = {
+export type UserNonInteractiveAuthCallbacks = {
   code: () => Promise<string>;
   password: () => Promise<string>;
   phone: () => Promise<string>;
 };
 
+export type AuthStartParams =
+  | { botToken: string }
+  | UserNonInteractiveAuthCallbacks;
+
 export function createNonInteractiveAuthCallbacks(
   message: string = DEFAULT_NON_INTERACTIVE_MESSAGE
-): NonInteractiveAuthCallbacks {
+): UserNonInteractiveAuthCallbacks {
   const throwAuthError = async (): Promise<string> => {
     throw new Error(message);
   };
@@ -19,4 +25,37 @@ export function createNonInteractiveAuthCallbacks(
     password: throwAuthError,
     phone: throwAuthError,
   };
+}
+
+export function createBotTokenStartParams(
+  config: UserbotConfig
+): { botToken: string } {
+  if (!config.botToken) {
+    throw new Error(
+      "Bot auth mode selected but bot token is missing. Set TELEGRAM_USERBOT_BOT_TOKEN or ASKLOYAL_TGBOT_KEY."
+    );
+  }
+
+  return {
+    botToken: config.botToken,
+  };
+}
+
+export function createNonInteractiveStartParams(
+  config: UserbotConfig,
+  userModeMessage: string = DEFAULT_NON_INTERACTIVE_MESSAGE
+): AuthStartParams {
+  if (config.authMode === "bot") {
+    return createBotTokenStartParams(config);
+  }
+
+  return createNonInteractiveAuthCallbacks(userModeMessage);
+}
+
+export function buildReauthGuidance(config: UserbotConfig): string {
+  if (config.authMode === "bot") {
+    return "Check TELEGRAM_USERBOT_BOT_TOKEN or ASKLOYAL_TGBOT_KEY.";
+  }
+
+  return "Run bun run auth:bootstrap.";
 }

--- a/workers/userbot/src/lib/sync/history-source.ts
+++ b/workers/userbot/src/lib/sync/history-source.ts
@@ -2,6 +2,8 @@ import type { TelegramHistoryClient } from "./types";
 
 const INITIAL_BACKFILL_LIMIT = 200;
 const HISTORY_CHUNK_SIZE = 200;
+export const BOT_ID_BATCH_SIZE = 200;
+export const BOT_EMPTY_BATCH_STOP_COUNT = 1;
 
 function readMessageId(message: unknown): number | null {
   if (!message || typeof message !== "object") {
@@ -14,6 +16,15 @@ function readMessageId(message: unknown): number | null {
   }
 
   return id as number;
+}
+
+function readMessageDate(message: unknown): Date | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+
+  const value = (message as { date?: unknown }).date;
+  return value instanceof Date && Number.isFinite(value.getTime()) ? value : null;
 }
 
 export async function getLatestTelegramMessageId(
@@ -56,5 +67,137 @@ export async function* fetchUnseenMessages(
     minId: lastStoredMessageId,
   })) {
     yield message;
+  }
+}
+
+export async function* fetchMessagesSince(
+  client: TelegramHistoryClient,
+  chatId: number,
+  startUtcInclusive: Date
+): AsyncGenerator<unknown> {
+  const cutoffTime = startUtcInclusive.getTime();
+
+  for await (const message of client.iterHistory(chatId, {
+    chunkSize: HISTORY_CHUNK_SIZE,
+  })) {
+    const messageDate = readMessageDate(message);
+    if (messageDate && messageDate.getTime() < cutoffTime) {
+      break;
+    }
+
+    yield message;
+  }
+}
+
+type BotBatchObserverPayload = {
+  fromMessageId: number;
+  requestedMessageIds: number;
+  returnedMessages: number;
+  wasEmpty: boolean;
+};
+
+type BotBatchFetchOptions = {
+  batchSize?: number;
+  onBatch?: (payload: BotBatchObserverPayload) => void;
+  sleep?: (ms: number) => Promise<void>;
+  stopAfterEmptyBatches?: number;
+};
+
+function buildMessageIdBatch(startId: number, batchSize: number): number[] {
+  return Array.from({ length: batchSize }, (_, index) => startId + index);
+}
+
+function resolveIdBatchMessageOrder(
+  messages: Array<unknown | null>
+): Array<unknown> {
+  return messages
+    .filter((message): message is unknown => message !== null)
+    .sort((left, right) => {
+      const leftId = readMessageId(left);
+      const rightId = readMessageId(right);
+      if (leftId === null || rightId === null) {
+        return 0;
+      }
+
+      return leftId - rightId;
+    });
+}
+
+function parseFloodWaitSeconds(error: unknown): number | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = /wait of\s+(\d+)\s+seconds/i.exec(message);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(match[1] ?? "", 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export async function* fetchUnseenMessagesByIdBatches(
+  client: TelegramHistoryClient,
+  chatId: number,
+  lastStoredMessageId: number | null,
+  options: BotBatchFetchOptions = {}
+): AsyncGenerator<unknown> {
+  const batchSize = options.batchSize ?? BOT_ID_BATCH_SIZE;
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error("batchSize must be a positive integer");
+  }
+
+  const stopAfterEmptyBatches =
+    options.stopAfterEmptyBatches ?? BOT_EMPTY_BATCH_STOP_COUNT;
+  if (!Number.isInteger(stopAfterEmptyBatches) || stopAfterEmptyBatches <= 0) {
+    throw new Error("stopAfterEmptyBatches must be a positive integer");
+  }
+
+  const sleep =
+    options.sleep ??
+    (async (ms: number): Promise<void> => {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+    });
+
+  let consecutiveEmptyBatches = 0;
+  let nextMessageId = lastStoredMessageId === null ? 1 : lastStoredMessageId + 1;
+
+  while (consecutiveEmptyBatches < stopAfterEmptyBatches) {
+    const requestedIds = buildMessageIdBatch(nextMessageId, batchSize);
+    let fetchedMessages: Array<unknown | null>;
+    while (true) {
+      try {
+        fetchedMessages = await client.getMessages(chatId, requestedIds);
+        break;
+      } catch (error) {
+        const waitSeconds = parseFloodWaitSeconds(error);
+        if (waitSeconds === null) {
+          throw error;
+        }
+
+        await sleep((waitSeconds + 1) * 1_000);
+      }
+    }
+
+    const orderedMessages = resolveIdBatchMessageOrder(fetchedMessages);
+    const wasEmpty = orderedMessages.length === 0;
+
+    options.onBatch?.({
+      fromMessageId: nextMessageId,
+      requestedMessageIds: requestedIds.length,
+      returnedMessages: orderedMessages.length,
+      wasEmpty,
+    });
+
+    if (wasEmpty) {
+      consecutiveEmptyBatches += 1;
+      nextMessageId += batchSize;
+      continue;
+    }
+
+    consecutiveEmptyBatches = 0;
+    for (const message of orderedMessages) {
+      yield message;
+    }
+
+    nextMessageId += batchSize;
   }
 }

--- a/workers/userbot/src/lib/sync/types.ts
+++ b/workers/userbot/src/lib/sync/types.ts
@@ -1,4 +1,8 @@
 export type TelegramHistoryClient = {
+  getMessages: (
+    chatId: number,
+    messageIds: number[]
+  ) => Promise<Array<unknown | null>>;
   getHistory: (chatId: number, params?: { limit?: number }) => Promise<unknown[]>;
   iterHistory: (
     chatId: number,

--- a/workers/userbot/src/worker.ts
+++ b/workers/userbot/src/worker.ts
@@ -2,7 +2,10 @@ import { stat } from "node:fs/promises";
 
 import { createUserbotClient, type UserbotClientBundle } from "./lib/client";
 import { loadUserbotConfig, type UserbotConfig } from "./lib/env";
-import { createNonInteractiveAuthCallbacks } from "./lib/non-interactive-auth";
+import {
+  buildReauthGuidance,
+  createNonInteractiveStartParams,
+} from "./lib/non-interactive-auth";
 import { resolveSessionSqlitePath } from "./lib/storage";
 
 type EnvRecord = Record<string, string | undefined>;
@@ -120,9 +123,15 @@ export function createUserbotWorker(overrides: Partial<WorkerDeps> = {}) {
         config.storageDir
       );
 
-      if (!(await deps.hasFile(sessionPath))) {
+      const sessionExists = await deps.hasFile(sessionPath);
+      if (!sessionExists && config.authMode === "user") {
         throw new Error(
           `[userbot] Missing session file for '${config.accountKey}'. Run auth:bootstrap first. Expected: ${sessionPath}`
+        );
+      }
+      if (!sessionExists && config.authMode === "bot") {
+        deps.logger.info(
+          `[userbot] No session found for '${config.accountKey}' in bot mode; proceeding with token-based startup.`
         );
       }
 
@@ -130,18 +139,16 @@ export function createUserbotWorker(overrides: Partial<WorkerDeps> = {}) {
       startupBundle = bundle;
 
       try {
-        const user = await bundle.client.start(
-          createNonInteractiveAuthCallbacks(
-            `Session for '${config.accountKey}' is invalid. Run bun run auth:bootstrap.`
-          )
-        );
+        const user = await bundle.client.start(createNonInteractiveStartParams(config));
 
         bundle.client.onRawUpdate.add(() => {
           // Intentionally noop in foundation PR.
         });
 
         activeBundle = bundle;
-        deps.logger.info(`[userbot] Worker started for '${config.accountKey}'.`);
+        deps.logger.info(
+          `[userbot] Worker started for '${config.accountKey}' (authMode=${config.authMode}).`
+        );
         deps.logger.info(`[userbot] Session path: ${bundle.sessionPath}`);
         deps.logger.info(`[userbot] Account: ${getIdentityLabel(user)}`);
       } catch (error) {
@@ -232,6 +239,8 @@ export async function runWorkerCli(
 ): Promise<number> {
   const logger = overrides.logger ?? console;
   const worker = createUserbotWorker(overrides);
+  const loadConfig = overrides.loadConfig ?? loadUserbotConfig;
+  const env = overrides.env ?? process.env;
 
   try {
     registerShutdownHandlers(worker, { logger });
@@ -241,7 +250,13 @@ export async function runWorkerCli(
       // intentionally unresolved; process exits through signal handlers
     });
   } catch (error) {
-    logger.error("[userbot] Worker failed to start", error);
+    let guidance = "Run bun run auth:bootstrap.";
+    try {
+      guidance = buildReauthGuidance(loadConfig(env));
+    } catch {
+      // Keep default guidance when config cannot be loaded.
+    }
+    logger.error(`[userbot] Worker failed to start. ${guidance}`, error);
     await worker.shutdown("startup_error");
     return 1;
   }


### PR DESCRIPTION
Hardens Telegram webhook ingest so critical community-message failures fail for retry and best-effort reactions do not block processing. Also adds guardrails/tests/docs updates to prevent context-bound Drizzle method regressions and improve observability.