### PR TITLE
feat(userbot): auto-discover communities and add dialog-only sync

### DIFF
--- a/docs/workers/userbot-on-render.md
+++ b/docs/workers/userbot-on-render.md
@@ -72,10 +72,21 @@ Configure a Render cron job with:
 cd workers/userbot && bun install && bun run sync:once
 ```
 
+In user auth mode, `sync:once` first discovers active group/supergroup dialogs from
+the Telegram session and inserts missing communities as `parserType=userbot` with
+inactive defaults (`isActive=false`, `isPublic=false`, notifications disabled) so they
+can be configured manually in admin.
+
 Optional recovery flags for targeted backfill:
 
 ```bash
 cd workers/userbot && bun install && bun run sync:once --parser-types=bot,userbot --lookback-days=2
+```
+
+To only sync dialogs into communities (no message ingestion), run:
+
+```bash
+cd workers/userbot && bun install && bun run sync:once --dialog-sync-only
 ```
 
 ## Session Recovery Flow

--- a/workers/userbot/README.md
+++ b/workers/userbot/README.md
@@ -48,6 +48,12 @@ bun run start
 - `--parser-types=bot,userbot` (include activated bot-parser communities)
 - `--lookback-days=2` (scan history for previous full UTC days)
 - `--chat-ids=-100123,-100456` (scope to specific chat IDs)
+- `--dialog-sync-only` (or `--dialogue-sync-only`) to run discovery/import only and skip message ingestion
+
+`sync:once` also auto-discovers group/supergroup dialogs when running in user auth mode.
+Missing chats are inserted into `communities` with `parserType=userbot` and inactive defaults:
+`isActive=false`, `isPublic=false`, `summaryNotificationsEnabled=false`,
+`summaryNotificationTimeHours=null`, `summaryNotificationMessageCount=null`.
 
 ## Render operational flow
 

--- a/workers/userbot/src/__tests__/sync-once.test.ts
+++ b/workers/userbot/src/__tests__/sync-once.test.ts
@@ -34,18 +34,33 @@ type FakeState = {
   communities: CommunityRecord[];
   existingMembershipKeys: Set<string>;
   existingMessageKeys: Set<string>;
+  existingCommunityChatIds: Set<string>;
   getHistoryCalls: Array<{ chatId: number; limit: number }>;
   getMessagesCalls: Array<{ chatId: number; firstId: number; size: number }>;
   getMessagesResponsesByFirstId: Map<number, Array<unknown | null>>;
   getHistoryLimitOneFailCount: number;
   incrementalHistory: unknown[];
   initialHistory: unknown[];
+  insertedCommunityRows: Array<{
+    activatedBy: bigint;
+    chatId: bigint;
+    chatTitle: string;
+    isActive: boolean;
+    isPublic: boolean;
+    parserType: "userbot";
+    summaryNotificationMessageCount: null;
+    summaryNotificationTimeHours: null;
+    summaryNotificationsEnabled: boolean;
+  }>;
   insertedMembershipRows: number;
   insertedMessageRows: number;
   insertedUserRows: number;
+  iterDialogsCalls: Array<{ archived: string | undefined }>;
+  iterDialogsEntries: unknown[];
   iterHistoryCalls: Array<{ chatId: number; minId: number }>;
   latestStoredMessageId: bigint | null;
   latestTelegramMessageId: number | null;
+  startedAccountId: bigint | number;
   usersByTelegramId: Map<string, { displayName: string; id: string; username: string | null }>;
 };
 
@@ -74,20 +89,28 @@ function createFakeState(
       FakeState,
       | "existingMembershipKeys"
       | "existingMessageKeys"
+      | "existingCommunityChatIds"
       | "getHistoryCalls"
       | "getMessagesCalls"
+      | "insertedCommunityRows"
       | "insertedMembershipRows"
       | "insertedMessageRows"
       | "insertedUserRows"
+      | "iterDialogsCalls"
       | "iterHistoryCalls"
       | "usersByTelegramId"
     >
   > = {}
 ): FakeState {
+  const existingCommunities = overrides.communities ?? [];
+
   return {
-    communities: overrides.communities ?? [],
+    communities: existingCommunities,
     existingMembershipKeys: new Set<string>(),
     existingMessageKeys: new Set<string>(),
+    existingCommunityChatIds: new Set(
+      existingCommunities.map((community) => community.chatId.toString())
+    ),
     getHistoryCalls: [],
     getMessagesCalls: [],
     getMessagesResponsesByFirstId:
@@ -95,9 +118,12 @@ function createFakeState(
     getHistoryLimitOneFailCount: overrides.getHistoryLimitOneFailCount ?? 0,
     incrementalHistory: overrides.incrementalHistory ?? [],
     initialHistory: overrides.initialHistory ?? [],
+    insertedCommunityRows: [],
     insertedMembershipRows: 0,
     insertedMessageRows: 0,
     insertedUserRows: 0,
+    iterDialogsCalls: [],
+    iterDialogsEntries: overrides.iterDialogsEntries ?? [],
     iterHistoryCalls: [],
     latestStoredMessageId:
       overrides.latestStoredMessageId === undefined
@@ -107,6 +133,7 @@ function createFakeState(
       overrides.latestTelegramMessageId === undefined
         ? null
         : overrides.latestTelegramMessageId,
+    startedAccountId: overrides.startedAccountId ?? 1,
     usersByTelegramId: new Map<string, { displayName: string; id: string; username: string | null }>(),
   };
 }
@@ -182,6 +209,35 @@ function createFakeDb(state: FakeState): any {
               return [{ id: `message-${state.insertedMessageRows}` }];
             }
 
+            if (
+              "chatId" in values &&
+              "activatedBy" in values &&
+              "parserType" in values &&
+              !("communityId" in values)
+            ) {
+              const chatId = BigInt(values.chatId as bigint | number | string);
+              const chatIdKey = chatId.toString();
+              if (state.existingCommunityChatIds.has(chatIdKey)) {
+                return [];
+              }
+
+              state.existingCommunityChatIds.add(chatIdKey);
+              state.insertedCommunityRows.push({
+                activatedBy: BigInt(values.activatedBy as bigint | number | string),
+                chatId,
+                chatTitle: String(values.chatTitle),
+                isActive: Boolean(values.isActive),
+                isPublic: Boolean(values.isPublic),
+                parserType: "userbot",
+                summaryNotificationMessageCount:
+                  (values.summaryNotificationMessageCount as null) ?? null,
+                summaryNotificationTimeHours:
+                  (values.summaryNotificationTimeHours as null) ?? null,
+                summaryNotificationsEnabled: Boolean(values.summaryNotificationsEnabled),
+              });
+              return [{ id: `community-${state.insertedCommunityRows.length}` }];
+            }
+
             return [];
           },
         }),
@@ -239,6 +295,18 @@ function createFakeBundle(
 
         return state.getMessagesResponsesByFirstId.get(firstId) ?? [];
       },
+      iterDialogs: (params?: { archived?: "exclude" | "keep" | "only" }) => {
+        state.iterDialogsCalls.push({
+          archived: params?.archived,
+        });
+
+        const dialogs = state.iterDialogsEntries;
+        return (async function* () {
+          for (const dialog of dialogs) {
+            yield dialog;
+          }
+        })();
+      },
       iterHistory: (_chatId: number, params?: { minId?: number }) => {
         state.iterHistoryCalls.push({
           chatId: _chatId,
@@ -252,7 +320,7 @@ function createFakeBundle(
           }
         })();
       },
-      start: async () => ({ id: 1 }),
+      start: async () => ({ id: state.startedAccountId }),
     },
     config,
     sessionPath: "/tmp/userbot/mtcute-primary.sqlite",
@@ -312,7 +380,281 @@ describe("sync:once command", () => {
     );
 
     expect(result.stats.communitiesScanned).toBe(0);
+    expect(result.stats.telegramDialogsScanned).toBe(0);
+    expect(result.stats.telegramEligibleGroupDialogs).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesDetected).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(0);
     expect(receivedBotToken).toBe("bot-token-999");
+  });
+
+  test("imports missing eligible userbot communities as inactive records", async () => {
+    const state = createFakeState({
+      iterDialogsEntries: [
+        {
+          peer: {
+            chatType: "group",
+            id: -1000000000101,
+            isMember: true,
+            title: "Group One",
+            type: "chat",
+          },
+        },
+        {
+          peer: {
+            chatType: "supergroup",
+            id: -1000000000102,
+            isMember: true,
+            title: "Super One",
+            type: "chat",
+          },
+        },
+        {
+          peer: {
+            chatType: "group",
+            id: -1000000000101,
+            isMember: true,
+            title: "Group One Duplicate",
+            type: "chat",
+          },
+        },
+        {
+          peer: {
+            id: 123456,
+            type: "user",
+          },
+        },
+        {
+          peer: {
+            chatType: "group",
+            id: -1000000000103,
+            isMember: false,
+            title: "Left Group",
+            type: "chat",
+          },
+        },
+        {
+          peer: {
+            chatType: "channel",
+            id: -1000000000104,
+            isMember: true,
+            title: "Channel",
+            type: "chat",
+          },
+        },
+      ],
+      startedAccountId: BigInt(777000),
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.telegramDialogsScanned).toBe(6);
+    expect(result.stats.telegramEligibleGroupDialogs).toBe(3);
+    expect(result.stats.missingUserbotCommunitiesDetected).toBe(2);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(2);
+    expect(result.stats.communitiesScanned).toBe(0);
+    expect(state.iterDialogsCalls).toEqual([{ archived: "exclude" }]);
+    expect(state.insertedCommunityRows).toEqual([
+      {
+        activatedBy: BigInt(777000),
+        chatId: BigInt(-1000000000101),
+        chatTitle: "Group One",
+        isActive: false,
+        isPublic: false,
+        parserType: "userbot",
+        summaryNotificationMessageCount: null,
+        summaryNotificationTimeHours: null,
+        summaryNotificationsEnabled: false,
+      },
+      {
+        activatedBy: BigInt(777000),
+        chatId: BigInt(-1000000000102),
+        chatTitle: "Super One",
+        isActive: false,
+        isPublic: false,
+        parserType: "userbot",
+        summaryNotificationMessageCount: null,
+        summaryNotificationTimeHours: null,
+        summaryNotificationsEnabled: false,
+      },
+    ]);
+  });
+
+  test("dialog-sync-only mode imports missing communities and skips message sync", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000001101),
+          chatTitle: "Active Community",
+          id: "community-active",
+          parserType: "userbot",
+        },
+      ],
+      iterDialogsEntries: [
+        {
+          peer: {
+            chatType: "group",
+            id: -1000000001102,
+            isMember: true,
+            title: "Discovery Only Group",
+            type: "chat",
+          },
+        },
+      ],
+      latestStoredMessageId: BigInt(10),
+      latestTelegramMessageId: 11,
+    });
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => createConfig(),
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { dialogSyncOnly: true }
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.stats.telegramDialogsScanned).toBe(1);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(1);
+    expect(result.stats.communitiesScanned).toBe(0);
+    expect(result.stats.communitiesProcessed).toBe(0);
+    expect(result.stats.telegramMessagesFetched).toBe(0);
+    expect(state.getHistoryCalls).toEqual([]);
+    expect(state.iterHistoryCalls).toEqual([]);
+    expect(state.getMessagesCalls).toEqual([]);
+    expect(state.insertedCommunityRows).toEqual([
+      {
+        activatedBy: BigInt(1),
+        chatId: BigInt(-1000000001102),
+        chatTitle: "Discovery Only Group",
+        isActive: false,
+        isPublic: false,
+        parserType: "userbot",
+        summaryNotificationMessageCount: null,
+        summaryNotificationTimeHours: null,
+        summaryNotificationsEnabled: false,
+      },
+    ]);
+  });
+
+  test("dialog-sync-only mode in bot auth remains a no-op and skips message sync", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000001201),
+          chatTitle: "Bot Community",
+          id: "community-bot",
+          parserType: "bot",
+        },
+      ],
+      latestStoredMessageId: BigInt(50),
+      getMessagesResponsesByFirstId: new Map<number, Array<unknown | null>>([
+        [51, [{ id: 51 }]],
+      ]),
+    });
+    const botConfig: UserbotConfig = {
+      ...createConfig(),
+      authMode: "bot",
+      botToken: "bot-token-999",
+    };
+
+    const result = await runSyncOnce(
+      {
+        createClient: async () => createFakeBundle(state, botConfig),
+        createDb: () => createFakeDb(state),
+        hasFile: async () => true,
+        loadConfig: () => botConfig,
+        loadDatabaseUrl: () => "postgres://db",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      { dialogSyncOnly: true, parserTypes: ["bot", "userbot"] }
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.stats.telegramDialogsScanned).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(0);
+    expect(result.stats.communitiesProcessed).toBe(0);
+    expect(result.stats.telegramMessagesFetched).toBe(0);
+    expect(state.iterDialogsCalls).toEqual([]);
+    expect(state.getMessagesCalls).toEqual([]);
+    expect(state.getHistoryCalls).toEqual([]);
+  });
+
+  test("does not insert discovered community when it already exists in database", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1000000000201),
+          chatTitle: "Existing Bot Community",
+          id: "community-bot-existing",
+          parserType: "bot",
+        },
+      ],
+      iterDialogsEntries: [
+        {
+          peer: {
+            chatType: "group",
+            id: -1000000000201,
+            isMember: true,
+            title: "Existing Bot Community",
+            type: "chat",
+          },
+        },
+      ],
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.missingUserbotCommunitiesDetected).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(0);
+    expect(state.insertedCommunityRows).toHaveLength(0);
+  });
+
+  test("skips non-member or non-group dialogs during community discovery", async () => {
+    const state = createFakeState({
+      iterDialogsEntries: [
+        { peer: { chatType: "channel", id: -1000000000301, isMember: true, type: "chat" } },
+        { peer: { chatType: "group", id: -1000000000302, isMember: false, type: "chat" } },
+        { peer: { id: 555, type: "user" } },
+      ],
+    });
+
+    const result = await runSyncOnce({
+      createClient: async () => createFakeBundle(state),
+      createDb: () => createFakeDb(state),
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://db",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.telegramDialogsScanned).toBe(3);
+    expect(result.stats.telegramEligibleGroupDialogs).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesDetected).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(0);
+    expect(state.insertedCommunityRows).toHaveLength(0);
   });
 
   test("bot mode uses getMessages id batches and avoids getHistory", async () => {
@@ -376,7 +718,12 @@ describe("sync:once command", () => {
     expect(result.stats.botBatchRequests).toBe(2);
     expect(result.stats.botEmptyBatches).toBe(1);
     expect(result.stats.insertedMessages).toBe(2);
+    expect(result.stats.telegramDialogsScanned).toBe(0);
+    expect(result.stats.telegramEligibleGroupDialogs).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesDetected).toBe(0);
+    expect(result.stats.missingUserbotCommunitiesInserted).toBe(0);
     expect(state.getHistoryCalls).toEqual([]);
+    expect(state.iterDialogsCalls).toEqual([]);
     expect(state.getMessagesCalls).toEqual([
       {
         chatId: Number(BigInt(-1000000000099)),

--- a/workers/userbot/src/commands/sync-once.ts
+++ b/workers/userbot/src/commands/sync-once.ts
@@ -42,6 +42,7 @@ type SyncOnceDeps = {
 };
 
 type SyncOnceOptions = {
+  dialogSyncOnly?: boolean;
   chatIds?: bigint[];
   lookbackDays?: number | null;
   now?: Date;
@@ -49,6 +50,7 @@ type SyncOnceOptions = {
 };
 
 type ResolvedSyncOnceOptions = {
+  dialogSyncOnly: boolean;
   chatIds: bigint[] | null;
   lookbackDays: number | null;
   lookbackWindowEndExclusiveUtc: Date | null;
@@ -61,6 +63,11 @@ type ActiveSyncCommunity = {
   chatTitle: string;
   id: string;
   parserType: CommunityParserType;
+};
+
+type DiscoveredUserbotCommunity = {
+  chatId: bigint;
+  chatTitle: string;
 };
 
 type CommunitySyncError = {
@@ -87,12 +94,16 @@ export type SyncOnceStats = {
   duplicateMessages: number;
   insertedMemberships: number;
   insertedMessages: number;
+  missingUserbotCommunitiesDetected: number;
+  missingUserbotCommunitiesInserted: number;
   insertedUsers: number;
   retryCount: number;
   skippedNonText: number;
   skippedNonUserSender: number;
   skippedOldOrEqual: number;
   skippedUnsupportedShape: number;
+  telegramDialogsScanned: number;
+  telegramEligibleGroupDialogs: number;
   telegramMessagesConsidered: number;
   telegramMessagesFetched: number;
   userMetadataUpdates: number;
@@ -159,6 +170,7 @@ function resolveSyncOptions(options: SyncOnceOptions = {}): ResolvedSyncOnceOpti
 
   if (lookbackDays === null) {
     return {
+      dialogSyncOnly: options.dialogSyncOnly === true,
       chatIds: options.chatIds?.length ? options.chatIds : null,
       lookbackDays: null,
       lookbackWindowEndExclusiveUtc: null,
@@ -174,6 +186,7 @@ function resolveSyncOptions(options: SyncOnceOptions = {}): ResolvedSyncOnceOpti
   );
 
   return {
+    dialogSyncOnly: options.dialogSyncOnly === true,
     chatIds: options.chatIds?.length ? options.chatIds : null,
     lookbackDays,
     lookbackWindowEndExclusiveUtc,
@@ -226,6 +239,11 @@ function parseSyncOnceCliOptions(argv: string[]): SyncOnceOptions {
   const options: SyncOnceOptions = {};
 
   for (const arg of argv.slice(2)) {
+    if (arg === "--dialog-sync-only" || arg === "--dialogue-sync-only") {
+      options.dialogSyncOnly = true;
+      continue;
+    }
+
     if (arg.startsWith("--parser-types=")) {
       options.parserTypes = parseParserTypes(arg.slice("--parser-types=".length));
       continue;
@@ -287,12 +305,16 @@ function createInitialStats(
     duplicateMessages: 0,
     insertedMemberships: 0,
     insertedMessages: 0,
+    missingUserbotCommunitiesDetected: 0,
+    missingUserbotCommunitiesInserted: 0,
     insertedUsers: 0,
     retryCount: 0,
     skippedNonText: 0,
     skippedNonUserSender: 0,
     skippedOldOrEqual: 0,
     skippedUnsupportedShape: 0,
+    telegramDialogsScanned: 0,
+    telegramEligibleGroupDialogs: 0,
     telegramMessagesConsidered: 0,
     telegramMessagesFetched: 0,
     userMetadataUpdates: 0,
@@ -380,6 +402,153 @@ async function getLatestStoredMessageId(
   return latestStored?.telegramMessageId !== undefined
     ? Number(latestStored.telegramMessageId)
     : null;
+}
+
+function toBigIntId(value: unknown): bigint | null {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return BigInt(value);
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    try {
+      return BigInt(value);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function readStartedAccountId(account: unknown): bigint | null {
+  if (!account || typeof account !== "object") {
+    return null;
+  }
+
+  const id = (account as { id?: unknown }).id;
+  return toBigIntId(id);
+}
+
+function readDiscoveredCommunity(dialog: unknown): DiscoveredUserbotCommunity | null {
+  if (!dialog || typeof dialog !== "object") {
+    return null;
+  }
+
+  const peer = (dialog as { peer?: unknown }).peer;
+  if (!peer || typeof peer !== "object") {
+    return null;
+  }
+
+  const candidate = peer as {
+    chatType?: unknown;
+    id?: unknown;
+    isMember?: unknown;
+    title?: unknown;
+    type?: unknown;
+  };
+
+  if (candidate.type !== "chat") {
+    return null;
+  }
+
+  if (candidate.chatType !== "group" && candidate.chatType !== "supergroup") {
+    return null;
+  }
+
+  if (candidate.isMember !== true) {
+    return null;
+  }
+
+  const chatId = toBigIntId(candidate.id);
+  if (chatId === null) {
+    return null;
+  }
+
+  const chatTitle =
+    typeof candidate.title === "string" && candidate.title.trim().length > 0
+      ? candidate.title.trim()
+      : "Untitled";
+
+  return {
+    chatId,
+    chatTitle,
+  };
+}
+
+async function importMissingUserbotCommunities(params: {
+  accountTelegramId: bigint;
+  bundle: UserbotClientBundle;
+  db: UserbotDb;
+  stats: SyncOnceStats;
+}): Promise<void> {
+  const discoveredByChatId = new Map<string, DiscoveredUserbotCommunity>();
+
+  for await (const dialog of params.bundle.client.iterDialogs({
+    archived: "exclude",
+  })) {
+    params.stats.telegramDialogsScanned += 1;
+    const discoveredCommunity = readDiscoveredCommunity(dialog);
+    if (!discoveredCommunity) {
+      continue;
+    }
+
+    params.stats.telegramEligibleGroupDialogs += 1;
+    const chatIdKey = discoveredCommunity.chatId.toString();
+    if (discoveredByChatId.has(chatIdKey)) {
+      continue;
+    }
+
+    discoveredByChatId.set(chatIdKey, discoveredCommunity);
+  }
+
+  if (discoveredByChatId.size === 0) {
+    return;
+  }
+
+  const discoveredChatIds = [...discoveredByChatId.values()].map(
+    (community) => community.chatId
+  );
+  const existingCommunities = await params.db.query.communities.findMany({
+    columns: {
+      chatId: true,
+    },
+    where: inArray(communities.chatId, discoveredChatIds),
+  });
+  const existingChatIds = new Set(
+    existingCommunities.map((community) => community.chatId.toString())
+  );
+
+  const missingCommunities = [...discoveredByChatId.values()].filter(
+    (community) => !existingChatIds.has(community.chatId.toString())
+  );
+  params.stats.missingUserbotCommunitiesDetected = missingCommunities.length;
+
+  for (const missingCommunity of missingCommunities) {
+    const inserted = await params.db
+      .insert(communities)
+      .values({
+        activatedBy: params.accountTelegramId,
+        chatId: missingCommunity.chatId,
+        chatTitle: missingCommunity.chatTitle,
+        isActive: false,
+        isPublic: false,
+        parserType: "userbot",
+        settings: {},
+        summaryNotificationMessageCount: null,
+        summaryNotificationTimeHours: null,
+        summaryNotificationsEnabled: false,
+      })
+      .onConflictDoNothing()
+      .returning({ id: communities.id });
+
+    if (inserted.length > 0) {
+      params.stats.missingUserbotCommunitiesInserted += 1;
+    }
+  }
 }
 
 async function syncCommunityWithBotIdBatches(
@@ -600,6 +769,9 @@ export async function runSyncOnce(
       config.authMode === "bot" ? "getMessages-id-batch" : "history"
     }`
   );
+  if (resolvedOptions.dialogSyncOnly) {
+    deps.logger.info("[userbot] dialog sync only mode is enabled.");
+  }
   const sessionPath = resolveSessionSqlitePath(
     config.accountKey,
     config.storageDir
@@ -620,12 +792,49 @@ export async function runSyncOnce(
   const bundle = await deps.createClient(config);
   const userIdCache = new Map<string, string>();
   const membershipCache = new Set<string>();
+  const stats = createInitialStats(0, resolvedOptions, config);
 
   try {
-    await bundle.client.start(createNonInteractiveStartParams(config));
+    const account = await bundle.client.start(createNonInteractiveStartParams(config));
 
     const databaseUrl = deps.loadDatabaseUrl(deps.env);
     const db = deps.createDb(databaseUrl);
+
+    if (config.authMode === "user") {
+      const accountTelegramId = readStartedAccountId(account);
+      if (accountTelegramId === null) {
+        throw new Error(
+          "Failed to read authenticated account id for userbot community discovery."
+        );
+      }
+
+      await runWithRetry(
+        deps,
+        stats,
+        "discovering and importing userbot communities",
+        async () => {
+          await importMissingUserbotCommunities({
+            accountTelegramId,
+            bundle,
+            db,
+            stats,
+          });
+        }
+      );
+    } else {
+      deps.logger.info(
+        "[userbot] Skipping community discovery because authMode=bot."
+      );
+    }
+
+    if (resolvedOptions.dialogSyncOnly) {
+      const result = {
+        errors: [] as CommunitySyncError[],
+        stats,
+      };
+      deps.logger.info("[userbot] sync:once completed (dialog-sync-only)", result);
+      return result;
+    }
 
     const whereClauses = [
       eq(communities.isActive, true),
@@ -662,11 +871,7 @@ export async function runSyncOnce(
       return chatIdFilter.has(community.chatId.toString());
     });
 
-    const stats = createInitialStats(
-      selectedCommunities.length,
-      resolvedOptions,
-      config
-    );
+    stats.communitiesScanned = selectedCommunities.length;
     const errors: CommunitySyncError[] = [];
 
     for (const community of selectedCommunities) {


### PR DESCRIPTION
This expands sync:once to discover active group/supergroup dialogs and insert missing userbot communities with inactive defaults for manual admin setup. It also adds a --dialog-sync-only flag (with --dialogue-sync-only alias) to run community discovery/import without message ingestion.