### PR TITLE
feat(telegram): migrate community summary avatars to cloudflare cdn

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint",
     "telegram:setup-commands": "bun run --conditions react-server scripts/telegram/setup-commands.ts",
     "telegram:setup-chat-commands": "bun run --conditions react-server scripts/telegram/setup-chat-commands.ts",
+    "telegram:backfill-community-photos": "bun run --conditions react-server scripts/telegram/backfill-community-photos-to-cdn.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"

--- a/app/scripts/telegram/backfill-community-photos-to-cdn.ts
+++ b/app/scripts/telegram/backfill-community-photos-to-cdn.ts
@@ -1,0 +1,203 @@
+import { communities } from "@loyal-labs/db-core/schema";
+import { eq, sql } from "drizzle-orm";
+
+import { getCloudflareCdnUrlClientFromEnv } from "@/lib/core/cdn-url";
+import { getDatabase } from "@/lib/core/database";
+import {
+  getCloudflareR2UploadClientFromEnv,
+  isCloudflareR2UploadConfigured,
+} from "@/lib/core/r2-upload";
+import {
+  resolveCommunityPhotoObjectKey,
+} from "@/lib/telegram/photo-path";
+
+type CommunitySettings = Record<string, unknown> & {
+  photoUrl?: string;
+  photoBase64?: string;
+  photoMimeType?: string;
+  photoUpdatedAt?: string;
+};
+
+type BackfillStats = {
+  scanned: number;
+  skippedAlreadyMigrated: number;
+  skippedInvalidBase64: number;
+  dryRunCandidates: number;
+  uploaded: number;
+  updated: number;
+  failed: number;
+};
+
+function normalizePhotoContentType(value: unknown): string {
+  if (typeof value !== "string") {
+    return "image/jpeg";
+  }
+
+  const normalized = value.split(";")[0]?.trim().toLowerCase();
+  if (!normalized || !normalized.startsWith("image/")) {
+    return "image/jpeg";
+  }
+
+  return normalized;
+}
+
+function decodeStrictBase64(value: string): Buffer | null {
+  const normalized = value.trim().replace(/\s+/g, "");
+  if (!normalized || normalized.length % 4 !== 0) {
+    return null;
+  }
+
+  // Telegram photo blobs are standard base64, not URL-safe base64.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    return null;
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.length === 0) {
+    return null;
+  }
+
+  const canonicalInput = normalized.replace(/=+$/, "");
+  const canonicalOutput = decoded.toString("base64").replace(/=+$/, "");
+  return canonicalInput === canonicalOutput ? decoded : null;
+}
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+export async function runBackfillCommunityPhotosToCdn(
+  options?: { apply?: boolean }
+): Promise<BackfillStats> {
+  const shouldApply = options?.apply ?? false;
+
+  if (!isCloudflareR2UploadConfigured()) {
+    throw new Error("Cloudflare R2 upload is not configured");
+  }
+
+  const db = getDatabase();
+  const uploadClient = getCloudflareR2UploadClientFromEnv();
+  const cdnClient = getCloudflareCdnUrlClientFromEnv();
+  const stats: BackfillStats = {
+    scanned: 0,
+    skippedAlreadyMigrated: 0,
+    skippedInvalidBase64: 0,
+    dryRunCandidates: 0,
+    uploaded: 0,
+    updated: 0,
+    failed: 0,
+  };
+
+  const rows = await db
+    .select({
+      id: communities.id,
+      chatId: communities.chatId,
+      settings: communities.settings,
+    })
+    .from(communities)
+    .where(sql`${communities.settings} ? 'photoBase64'`);
+
+  stats.scanned = rows.length;
+
+  for (const row of rows) {
+    try {
+      const settings =
+        row.settings && typeof row.settings === "object"
+          ? ({ ...row.settings } as CommunitySettings)
+          : ({} as CommunitySettings);
+
+      if (typeof settings.photoUrl === "string" && settings.photoUrl.length > 0) {
+        stats.skippedAlreadyMigrated += 1;
+        continue;
+      }
+
+      if (typeof settings.photoBase64 !== "string" || settings.photoBase64.length === 0) {
+        stats.skippedInvalidBase64 += 1;
+        continue;
+      }
+
+      const body = decodeStrictBase64(settings.photoBase64);
+      if (!body) {
+        stats.skippedInvalidBase64 += 1;
+        continue;
+      }
+
+      const contentType = normalizePhotoContentType(settings.photoMimeType);
+      const key = resolveCommunityPhotoObjectKey(String(row.chatId), contentType);
+      const photoUrl = cdnClient.resolveUrl({ key });
+
+      if (!shouldApply) {
+        stats.dryRunCandidates += 1;
+        console.info("[backfill-community-photos] dry-run candidate", {
+          communityId: row.id,
+          chatId: String(row.chatId),
+          key,
+          photoUrl,
+        });
+        continue;
+      }
+
+      await uploadClient.uploadImage({
+        key,
+        body,
+        contentType,
+      });
+      stats.uploaded += 1;
+
+      const photoUpdatedAt = new Date().toISOString();
+      await db
+        .update(communities)
+        .set({
+          // Update only photo fields in JSONB to avoid clobbering concurrent settings writes.
+          settings: sql`jsonb_set(
+            jsonb_set(
+              ${communities.settings} - 'photoBase64' - 'photoMimeType',
+              '{photoUrl}',
+              to_jsonb(${photoUrl}::text),
+              true
+            ),
+            '{photoUpdatedAt}',
+            to_jsonb(${photoUpdatedAt}::text),
+            true
+          )`,
+          updatedAt: new Date(),
+        })
+        .where(eq(communities.id, row.id));
+
+      stats.updated += 1;
+    } catch (error) {
+      stats.failed += 1;
+      console.error("[backfill-community-photos] failed row", {
+        communityId: row.id,
+        chatId: String(row.chatId),
+        error,
+      });
+    }
+  }
+
+  return stats;
+}
+
+export async function runBackfillCommunityPhotosToCdnCli(): Promise<number> {
+  const shouldApply = process.argv.includes("--apply");
+
+  try {
+    const stats = await runBackfillCommunityPhotosToCdn({
+      apply: shouldApply,
+    });
+
+    console.info("[backfill-community-photos] complete", {
+      mode: shouldApply ? "apply" : "dry-run",
+      ...stats,
+    });
+    return 0;
+  } catch (error) {
+    console.error("[backfill-community-photos] failed", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("backfill-community-photos-to-cdn.ts")) {
+  process.exit(await runBackfillCommunityPhotosToCdnCli());
+}

--- a/app/src/app/api/summaries/route.ts
+++ b/app/src/app/api/summaries/route.ts
@@ -5,6 +5,8 @@ import { NextResponse } from "next/server";
 import { getDatabase } from "@/lib/core/database";
 
 type CommunityPhotoSettings = {
+  photoUrl?: string;
+  // Deprecated compatibility fields; kept temporarily for clients still migrating.
   photoBase64?: string;
   photoMimeType?: string;
 };
@@ -47,6 +49,8 @@ export async function GET(req: Request): Promise<NextResponse> {
         title: item.chatTitle,
         messageCount: item.messageCount,
         oneliner: item.oneliner,
+        photoUrl: settings?.photoUrl,
+        // Deprecated compatibility fields; remove after migration window.
         photoBase64: settings?.photoBase64,
         photoMimeType: settings?.photoMimeType,
         topics: item.topics.map((topic, index) => ({

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -239,7 +239,14 @@ export default function SummariesPage() {
   const { summaries: cachedSummaries, setSummaries, hasCachedData } = useSummaries();
 
   // Transform summaries to unique group chats format (deduplicate by group chat id)
-  const transformToGroupChats = (summaries: Array<{ chatId?: string; title: string; photoBase64?: string; photoMimeType?: string; topics?: Array<{ content: string }> }>) => {
+  const transformToGroupChats = (summaries: Array<{
+    chatId?: string;
+    title: string;
+    photoUrl?: string;
+    photoBase64?: string;
+    photoMimeType?: string;
+    topics?: Array<{ content: string }>;
+  }>) => {
     const groupMap = new Map<string, GroupChat>();
 
     for (const summary of summaries) {
@@ -251,6 +258,7 @@ export default function SummariesPage() {
           id: groupKey,
           title: summary.title,
           subtitle: summary.topics?.[0]?.content || "",
+          photoUrl: summary.photoUrl,
           photoBase64: summary.photoBase64,
           photoMimeType: summary.photoMimeType,
         });

--- a/app/src/components/summaries/SummaryFeed.tsx
+++ b/app/src/components/summaries/SummaryFeed.tsx
@@ -26,6 +26,8 @@ export type ChatSummary = {
   title: string;
   messageCount?: number;
   createdAt?: string;
+  photoUrl?: string;
+  // Deprecated compatibility fields; remove after migration window.
   photoBase64?: string;
   photoMimeType?: string;
   topics: Array<{
@@ -218,11 +220,11 @@ export default function SummaryFeed({
   const groupPhoto = useMemo(() => {
     if (summaries.length === 0) return null;
     const first = summaries[0];
+    if (first.photoUrl) {
+      return first.photoUrl;
+    }
     if (first.photoBase64) {
-      return {
-        base64: first.photoBase64,
-        mimeType: first.photoMimeType || "image/jpeg",
-      };
+      return `data:${first.photoMimeType || "image/jpeg"};base64,${first.photoBase64}`;
     }
     return null;
   }, [summaries]);
@@ -657,7 +659,7 @@ export default function SummaryFeed({
           {groupPhoto ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
-              src={`data:${groupPhoto.mimeType};base64,${groupPhoto.base64}`}
+              src={groupPhoto}
               alt={groupTitle}
               className="rounded-full object-cover shrink-0"
               style={{ width: 44, height: 44 }}

--- a/app/src/lib/telegram/__tests__/community-photo-service.test.ts
+++ b/app/src/lib/telegram/__tests__/community-photo-service.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const uploadCalls: Array<{
+  key: string;
+  body: Buffer;
+  contentType: string;
+}> = [];
+const resolveUrlCalls: string[] = [];
+const getChatCalls: Array<bigint | number | string> = [];
+const downloadCalls: string[] = [];
+
+let isR2Configured = true;
+let hasCdnBaseUrl = true;
+let getChatImpl: (chatId: bigint | number | string) => Promise<{
+  photo?: { small_file_id?: string };
+}> = async () => ({});
+let downloadFileImpl: (fileId: string) => Promise<{
+  body: Buffer;
+  contentType: string;
+}> = async () => ({
+  body: Buffer.from("img"),
+  contentType: "image/jpeg",
+});
+
+mock.module("@/lib/core/r2-upload", () => ({
+  isCloudflareR2UploadConfigured: () => isR2Configured,
+  getCloudflareR2UploadClientFromEnv: () => ({
+    uploadImage: async (input: {
+      key: string;
+      body: Buffer;
+      contentType: string;
+    }) => {
+      uploadCalls.push(input);
+      return { key: input.key, bucket: "bucket" };
+    },
+  }),
+}));
+
+mock.module("@/lib/core/cdn-url", () => ({
+  getCloudflareCdnBaseUrlFromEnv: () =>
+    hasCdnBaseUrl ? "https://cdn.example.com" : null,
+  getCloudflareCdnUrlClientFromEnv: () => ({
+    resolveUrl: ({ key }: { key: string }) => {
+      resolveUrlCalls.push(key);
+      return `https://cdn.example.com/${key}`;
+    },
+  }),
+}));
+
+mock.module("@/lib/telegram/bot-api/get-chat", () => ({
+  getChat: async (chatId: bigint | number | string) => {
+    getChatCalls.push(chatId);
+    return getChatImpl(chatId);
+  },
+}));
+
+mock.module("@/lib/telegram/bot-api/get-file", () => ({
+  downloadTelegramFile: async (fileId: string) => {
+    downloadCalls.push(fileId);
+    return downloadFileImpl(fileId);
+  },
+}));
+
+let captureCommunityPhotoToCdn: typeof import("../community-photo-service").captureCommunityPhotoToCdn;
+let resolveCommunityPhotoObjectKey: typeof import("../community-photo-service").resolveCommunityPhotoObjectKey;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("community-photo-service", () => {
+  beforeAll(async () => {
+    const loaded = await import("../community-photo-service");
+    captureCommunityPhotoToCdn = loaded.captureCommunityPhotoToCdn;
+    resolveCommunityPhotoObjectKey = loaded.resolveCommunityPhotoObjectKey;
+  });
+
+  beforeEach(() => {
+    uploadCalls.length = 0;
+    resolveUrlCalls.length = 0;
+    getChatCalls.length = 0;
+    downloadCalls.length = 0;
+    isR2Configured = true;
+    hasCdnBaseUrl = true;
+    getChatImpl = async () => ({});
+    downloadFileImpl = async () => ({
+      body: Buffer.from("img"),
+      contentType: "image/jpeg",
+    });
+  });
+
+  test("builds key from chat ID hash", () => {
+    const chatId = "-1001234567890";
+    const hash = createHash("sha256").update(chatId, "utf8").digest("hex");
+
+    expect(resolveCommunityPhotoObjectKey(chatId, "image/png")).toBe(
+      `telegram/communities/${hash}/profile.png`
+    );
+  });
+
+  test("uploads chat photo and returns CDN URL", async () => {
+    const chatId = "-1009876543210";
+    const hash = createHash("sha256").update(chatId, "utf8").digest("hex");
+
+    getChatImpl = async () => ({
+      photo: { small_file_id: "chat-photo-file-1" },
+    });
+    downloadFileImpl = async () => ({
+      body: Buffer.from("png-bytes"),
+      contentType: "image/png",
+    });
+
+    const result = await captureCommunityPhotoToCdn(chatId);
+
+    expect(result).toBe(
+      `https://cdn.example.com/telegram/communities/${hash}/profile.png`
+    );
+    expect(getChatCalls).toEqual([chatId]);
+    expect(downloadCalls).toEqual(["chat-photo-file-1"]);
+    expect(uploadCalls).toHaveLength(1);
+    expect(uploadCalls[0]?.key).toBe(
+      `telegram/communities/${hash}/profile.png`
+    );
+  });
+
+  test("returns null when chat photo is missing", async () => {
+    getChatImpl = async () => ({});
+
+    const result = await captureCommunityPhotoToCdn("-10042");
+
+    expect(result).toBeNull();
+    expect(uploadCalls).toHaveLength(0);
+  });
+
+  test("returns null when CDN/R2 config is missing", async () => {
+    isR2Configured = false;
+    hasCdnBaseUrl = false;
+
+    const result = await captureCommunityPhotoToCdn("-100777");
+
+    expect(result).toBeNull();
+    expect(getChatCalls).toHaveLength(0);
+    expect(uploadCalls).toHaveLength(0);
+  });
+
+  test("returns null when capture exceeds timeout", async () => {
+    getChatImpl = async () => {
+      await sleep(20);
+      return { photo: { small_file_id: "chat-photo-file-2" } };
+    };
+
+    const result = await captureCommunityPhotoToCdn("-1001010", {
+      timeoutMs: 1,
+    });
+
+    expect(result).toBeNull();
+    expect(uploadCalls).toHaveLength(0);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-admin-auth.test.ts
@@ -23,7 +23,8 @@ let mockDb: {
   };
 };
 
-let getChatCalls = 0;
+let captureCommunityPhotoCalls: Array<bigint | number | string> = [];
+let captureCommunityPhotoResult: string | null = null;
 let evictCalls: Array<bigint | number | string> = [];
 let autoCleanupReplyTexts: string[] = [];
 let notificationSettingsCalls: Array<{
@@ -35,18 +36,11 @@ mock.module("@/lib/core/database", () => ({
   getDatabase: () => mockDb,
 }));
 
-mock.module("../get-chat", () => ({
-  getChat: async () => {
-    getChatCalls += 1;
-    return {};
+mock.module("@/lib/telegram/community-photo-service", () => ({
+  captureCommunityPhotoToCdn: async (chatId: bigint | number | string) => {
+    captureCommunityPhotoCalls.push(chatId);
+    return captureCommunityPhotoResult;
   },
-}));
-
-mock.module("../get-file", () => ({
-  downloadTelegramFile: async () => ({
-    body: Buffer.from(""),
-    contentType: "image/jpeg",
-  }),
 }));
 
 mock.module("@/lib/telegram/user-service", () => ({
@@ -160,7 +154,8 @@ describe("commands admin authorization", () => {
     communityResult = null;
     communityFindResults = [];
     insertReturningRows = [{ id: "new-community" }];
-    getChatCalls = 0;
+    captureCommunityPhotoCalls = [];
+    captureCommunityPhotoResult = "https://cdn.example.com/community-avatar.jpg";
     evictCalls = [];
     autoCleanupReplyTexts = [];
     notificationSettingsCalls = [];
@@ -202,14 +197,24 @@ describe("commands admin authorization", () => {
 
   test("activate succeeds for whitelisted user without requiring Telegram chat-admin check", async () => {
     adminResult = { id: "admin-1" };
-    communityResult = createCommunity({ isActive: true });
+    communityResult = createCommunity({
+      isActive: true,
+      settings: {
+        photoBase64: "old-base64",
+        photoMimeType: "image/jpeg",
+      },
+    });
     const { ctx, replyCalls } = createCommandContext();
 
     await handleActivateCommunityCommand(ctx);
 
-    expect(getChatCalls).toBe(1);
+    expect(captureCommunityPhotoCalls).toEqual([ctx.chat.id]);
     expect(updateValuesCaptured).toHaveLength(1);
     expect(updateValuesCaptured[0]?.updatedAt).toBeInstanceOf(Date);
+    const settings = updateValuesCaptured[0]?.settings as Record<string, unknown>;
+    expect(settings?.photoUrl).toBe(captureCommunityPhotoResult);
+    expect(settings?.photoBase64).toBeUndefined();
+    expect(settings?.photoMimeType).toBeUndefined();
     expect(replyCalls).toContain(
       "Community is already activated. Data updated!"
     );
@@ -235,10 +240,14 @@ describe("commands admin authorization", () => {
 
     await handleActivateCommunityCommand(ctx);
 
-    expect(getChatCalls).toBe(1);
+    expect(captureCommunityPhotoCalls).toEqual([ctx.chat.id]);
     expect(updateValuesCaptured).toHaveLength(0);
     expect(insertValuesCaptured).toHaveLength(1);
     expect(insertValuesCaptured[0]?.isPublic).toBe(false);
+    const settings = insertValuesCaptured[0]?.settings as Record<string, unknown>;
+    expect(settings?.photoUrl).toBe(captureCommunityPhotoResult);
+    expect(settings?.photoBase64).toBeUndefined();
+    expect(settings?.photoMimeType).toBeUndefined();
     expect(replyCalls).toContain("Community activated for message tracking!");
   });
 

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -4,6 +4,7 @@ import type { CommandContext, Context } from "grammy";
 import { Bot, InlineKeyboard } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
+import { captureCommunityPhotoToCdn } from "@/lib/telegram/community-photo-service";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat } from "@/lib/telegram/utils";
 
@@ -13,8 +14,6 @@ import {
   trackBotEvent,
 } from "./analytics";
 import { CA_COMMAND_CHAT_ID } from "./constants";
-import { getChat } from "./get-chat";
-import { downloadTelegramFile } from "./get-file";
 import { replyWithAutoCleanup } from "./helper-message-cleanup";
 import { evictActiveCommunityCache } from "./message-handlers";
 import { sendNotificationSettingsMessage } from "./notification-settings";
@@ -22,11 +21,6 @@ import { sendStartCarousel } from "./start-carousel";
 import { sendLatestSummary } from "./summaries";
 import type { HandleSummaryCommandOptions } from "./types";
 import { sendUserSettingsMessage } from "./user-settings";
-
-interface CommunityPhoto {
-  base64: string;
-  mimeType: string;
-}
 
 const SETTINGS_LOAD_ERROR_REPLY_TEXT =
   "Unable to load your settings right now. Please try again.";
@@ -49,29 +43,6 @@ function createCommandTrackingProperties(
     chatType: ctx.chat?.type,
     userId: ctx.from?.id,
   });
-}
-
-/**
- * Fetches community profile photo and converts to base64.
- * Returns undefined if photo is unavailable or fetch fails.
- */
-async function fetchCommunityPhoto(
-  chatId: number | string
-): Promise<CommunityPhoto | undefined> {
-  try {
-    const chatInfo = await getChat(chatId);
-    if (!chatInfo.photo?.small_file_id) {
-      return undefined;
-    }
-    const photo = await downloadTelegramFile(chatInfo.photo.small_file_id);
-    return {
-      base64: photo.body.toString("base64"),
-      mimeType: photo.contentType,
-    };
-  } catch (error) {
-    console.warn("Failed to fetch community photo:", error);
-    return undefined;
-  }
 }
 
 async function isWhitelistedAdmin(
@@ -149,10 +120,17 @@ function mergeCommunitySettings(
       ? (existingSettings as Record<string, unknown>)
       : {};
 
-  return {
+  const mergedSettings: Record<string, unknown> = {
     ...current,
     ...nextSettings,
   };
+
+  if (typeof nextSettings.photoUrl === "string" && nextSettings.photoUrl.length > 0) {
+    delete mergedSettings.photoBase64;
+    delete mergedSettings.photoMimeType;
+  }
+
+  return mergedSettings;
 }
 
 async function syncActivationForExistingCommunity(params: {
@@ -314,11 +292,10 @@ export async function handleActivateCommunityCommand(
     const chatId = BigInt(ctx.chat.id);
 
     // Fetch community photo (non-blocking on failure)
-    const photo = await fetchCommunityPhoto(ctx.chat.id);
-    const settings = photo
+    const photoUrl = await captureCommunityPhotoToCdn(ctx.chat.id);
+    const settings = photoUrl
       ? {
-          photoBase64: photo.base64,
-          photoMimeType: photo.mimeType,
+          photoUrl,
           photoUpdatedAt: new Date().toISOString(),
         }
       : {};

--- a/app/src/lib/telegram/community-photo-service.ts
+++ b/app/src/lib/telegram/community-photo-service.ts
@@ -3,24 +3,22 @@ import {
   getCloudflareR2UploadClientFromEnv,
   isCloudflareR2UploadConfigured,
 } from "@/lib/core/r2-upload";
-import { getBot } from "@/lib/telegram/bot-api/bot";
+import { getChat } from "@/lib/telegram/bot-api/get-chat";
 import { downloadTelegramFile } from "@/lib/telegram/bot-api/get-file";
-import {
-  resolveUserAvatarObjectKey,
-} from "@/lib/telegram/photo-path";
+import { resolveCommunityPhotoObjectKey as resolveCommunityPhotoObjectKeyFromPath } from "@/lib/telegram/photo-path";
 
-const PROFILE_CAPTURE_TIMEOUT_MS = 2500;
+const COMMUNITY_CAPTURE_TIMEOUT_MS = 2500;
 
-type CaptureProfilePhotoOptions = {
+type CaptureCommunityPhotoOptions = {
   timeoutMs?: number;
 };
 
-export function resolveAvatarObjectKey(
-  telegramId: bigint,
+export function resolveCommunityPhotoObjectKey(
+  chatId: number | string,
   contentType: string
 ): string {
   // Backward-compatible wrapper kept for existing tests/import sites.
-  return resolveUserAvatarObjectKey(telegramId, contentType);
+  return resolveCommunityPhotoObjectKeyFromPath(chatId, contentType);
 }
 
 async function withTimeout<T>(
@@ -31,7 +29,7 @@ async function withTimeout<T>(
 
   const timeout = new Promise<never>((_, reject) => {
     timeoutHandle = setTimeout(() => {
-      reject(new Error(`Telegram profile photo capture timed out after ${timeoutMs}ms`));
+      reject(new Error(`Telegram community photo capture timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
 
@@ -44,30 +42,22 @@ async function withTimeout<T>(
   }
 }
 
-async function captureTelegramProfilePhotoToCdnInternal(
-  telegramId: bigint
+async function captureCommunityPhotoToCdnInternal(
+  chatId: number | string
 ): Promise<string | null> {
   if (!isCloudflareR2UploadConfigured() || !getCloudflareCdnBaseUrlFromEnv()) {
     return null;
   }
 
-  const userIdAsNumber = Number(telegramId);
-  if (!Number.isSafeInteger(userIdAsNumber)) {
+  const chatInfo = await getChat(chatId);
+  const smallFileId = chatInfo.photo?.small_file_id;
+
+  if (!smallFileId) {
     return null;
   }
 
-  const bot = await getBot();
-  const profilePhotos = await bot.api.getUserProfilePhotos(userIdAsNumber, {
-    limit: 1,
-  });
-  const firstPhoto = profilePhotos.photos[0]?.[0];
-
-  if (!firstPhoto?.file_id) {
-    return null;
-  }
-
-  const photoFile = await downloadTelegramFile(firstPhoto.file_id);
-  const key = resolveAvatarObjectKey(telegramId, photoFile.contentType);
+  const photoFile = await downloadTelegramFile(smallFileId);
+  const key = resolveCommunityPhotoObjectKeyFromPath(chatId, photoFile.contentType);
 
   await getCloudflareR2UploadClientFromEnv().uploadImage({
     key,
@@ -78,20 +68,20 @@ async function captureTelegramProfilePhotoToCdnInternal(
   return getCloudflareCdnUrlClientFromEnv().resolveUrl({ key });
 }
 
-export async function captureTelegramProfilePhotoToCdn(
-  telegramId: bigint,
-  options?: CaptureProfilePhotoOptions
+export async function captureCommunityPhotoToCdn(
+  chatId: number | string,
+  options?: CaptureCommunityPhotoOptions
 ): Promise<string | null> {
-  const timeoutMs = options?.timeoutMs ?? PROFILE_CAPTURE_TIMEOUT_MS;
+  const timeoutMs = options?.timeoutMs ?? COMMUNITY_CAPTURE_TIMEOUT_MS;
 
   try {
     return await withTimeout(
-      captureTelegramProfilePhotoToCdnInternal(telegramId),
+      captureCommunityPhotoToCdnInternal(chatId),
       timeoutMs
     );
   } catch (error) {
-    console.warn("Failed to capture Telegram profile photo", {
-      telegramId: String(telegramId),
+    console.warn("Failed to capture Telegram community photo", {
+      chatId: String(chatId),
       error,
     });
     return null;

--- a/app/src/lib/telegram/photo-path.ts
+++ b/app/src/lib/telegram/photo-path.ts
@@ -1,0 +1,40 @@
+import { createHash } from "node:crypto";
+
+export function hashIdentifier(value: bigint | number | string): string {
+  return createHash("sha256").update(String(value), "utf8").digest("hex");
+}
+
+export function resolveImageExtensionFromContentType(contentType: string): string {
+  const normalized = contentType.split(";")[0]?.trim().toLowerCase();
+
+  switch (normalized) {
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    case "image/jpeg":
+    case "image/jpg":
+    default:
+      return "jpg";
+  }
+}
+
+export function resolveUserAvatarObjectKey(
+  telegramId: bigint,
+  contentType: string
+): string {
+  const telegramIdHash = hashIdentifier(telegramId);
+  const extension = resolveImageExtensionFromContentType(contentType);
+  return `telegram/users/${telegramIdHash}/profile.${extension}`;
+}
+
+export function resolveCommunityPhotoObjectKey(
+  chatId: number | string,
+  contentType: string
+): string {
+  const chatIdHash = hashIdentifier(chatId);
+  const extension = resolveImageExtensionFromContentType(contentType);
+  return `telegram/communities/${chatIdHash}/profile.${extension}`;
+}

--- a/mobile/app/+not-found.tsx
+++ b/mobile/app/+not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFoundScreen() {
     <>
       <Stack.Screen options={{ title: "Not Found" }} />
       <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-        <Text>This screen doesn't exist.</Text>
+        <Text>This screen doesn&apos;t exist.</Text>
         <Link href="/" style={{ marginTop: 16, color: "#007AFF" }}>
           <Text>Go to home screen</Text>
         </Link>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -139,6 +139,7 @@ export default function SummariesListScreen() {
           key={group.id}
           title={group.title}
           subtitle={group.subtitle}
+          photoUrl={group.photoUrl}
           photoBase64={group.photoBase64}
           photoMimeType={group.photoMimeType}
           onPress={() => handleGroupPress(group)}

--- a/mobile/app/summaries/[groupChatId].tsx
+++ b/mobile/app/summaries/[groupChatId].tsx
@@ -284,12 +284,11 @@ export default function SummaryFeedScreen() {
     );
   }
 
-  const groupPhoto = summaries[0]?.photoBase64
-    ? {
-        base64: summaries[0].photoBase64,
-        mimeType: summaries[0].photoMimeType ?? "image/jpeg",
-      }
-    : null;
+  const groupPhoto =
+    summaries[0]?.photoUrl ??
+    (summaries[0]?.photoBase64
+      ? `data:${summaries[0].photoMimeType ?? "image/jpeg"};base64,${summaries[0].photoBase64}`
+      : null);
   const avatarColor = getAvatarColor(groupTitle);
   const firstLetter = getFirstLetter(groupTitle);
 
@@ -304,9 +303,7 @@ export default function SummaryFeedScreen() {
         <View className="px-4 pt-4 pb-2 flex-row items-center gap-3">
           {groupPhoto ? (
             <Image
-              source={{
-                uri: `data:${groupPhoto.mimeType};base64,${groupPhoto.base64}`,
-              }}
+              source={{ uri: groupPhoto }}
               className="w-11 h-11 rounded-full object-cover"
             />
           ) : (

--- a/mobile/src/components/summaries/ChatItem.tsx
+++ b/mobile/src/components/summaries/ChatItem.tsx
@@ -8,6 +8,8 @@ import { getAvatarColor, getFirstLetter } from "./avatar-utils";
 type ChatItemProps = {
   title: string;
   subtitle?: string;
+  photoUrl?: string;
+  // Deprecated compatibility fields; remove after migration window.
   photoBase64?: string;
   photoMimeType?: string;
   onPress: () => void;
@@ -16,6 +18,7 @@ type ChatItemProps = {
 export function ChatItem({
   title,
   subtitle,
+  photoUrl,
   photoBase64,
   photoMimeType,
   onPress,
@@ -23,9 +26,11 @@ export function ChatItem({
   const avatarColor = getAvatarColor(title);
   const firstLetter = getFirstLetter(title);
 
-  const photoUri = photoBase64
-    ? `data:${photoMimeType ?? "image/jpeg"};base64,${photoBase64}`
-    : null;
+  const photoUri =
+    photoUrl ??
+    (photoBase64
+      ? `data:${photoMimeType ?? "image/jpeg"};base64,${photoBase64}`
+      : null);
 
   return (
     <Pressable

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -6,6 +6,8 @@ export type GroupChat = {
   id: string;
   title: string;
   subtitle: string;
+  photoUrl?: string;
+  // Deprecated compatibility fields; remove after migration window.
   photoBase64?: string;
   photoMimeType?: string;
 };
@@ -54,6 +56,7 @@ export function transformSummariesToGroups(
         id: groupKey,
         title: summary.title,
         subtitle: summary.topics[0]?.content ?? "",
+        photoUrl: summary.photoUrl,
         photoBase64: summary.photoBase64,
         photoMimeType: summary.photoMimeType,
       });

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -12,6 +12,8 @@ export type ChatSummary = {
   messageCount?: number;
   createdAt?: string;
   oneliner?: string;
+  photoUrl?: string;
+  // Deprecated compatibility fields; remove after migration window.
   photoBase64?: string;
   photoMimeType?: string;
   topics: Topic[];


### PR DESCRIPTION
Migrate community summary avatars from DB base64 blobs to Cloudflare CDN URLs across write paths, API contracts, and web/mobile consumers with backward-compatible fallbacks. Adds a one-time dry-run/apply backfill script and tests for the new community photo capture flow.