### PR TITLE
feat(telegram): add inline summary query handler

### DIFF
--- a/app/src/app/api/telegram/webhook/route.ts
+++ b/app/src/app/api/telegram/webhook/route.ts
@@ -14,7 +14,11 @@ import {
   handleUnhideCommunityCommand,
 } from "@/lib/telegram/bot-api/commands";
 import { handleBusinessConnection } from "@/lib/telegram/bot-api/handle-business-connection";
-import { handleInlineQuery } from "@/lib/telegram/bot-api/inline";
+import {
+  handleInlineQuery,
+  handleSummaryInlineQuery,
+  SUMMARY_INLINE_QUERY_REGEX,
+} from "@/lib/telegram/bot-api/inline";
 import {
   handleCommunityMessage,
   handleGLoyalReaction,
@@ -93,6 +97,10 @@ bot.command("summary", async (ctx: CommandContext<Context>) => {
 
 bot.command("notifications", async (ctx: CommandContext<Context>) => {
   await handleNotificationsCommand(ctx);
+});
+
+bot.inlineQuery(SUMMARY_INLINE_QUERY_REGEX, async (ctx) => {
+  await handleSummaryInlineQuery(ctx as InlineQueryContext<Context>);
 });
 
 bot.on("inline_query", async (ctx) => {

--- a/app/src/lib/telegram/bot-api/__tests__/inline.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/inline.test.ts
@@ -1,0 +1,268 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context, InlineQueryContext } from "grammy";
+import type { InlineQueryResultArticle } from "grammy/types";
+
+import { MINI_APP_LINK } from "@/lib/telegram/constants";
+import { buildSummaryFeedMiniAppUrl } from "@/lib/telegram/mini-app/start-param";
+
+mock.module("server-only", () => ({}));
+
+type CommunityRecord = {
+  chatId: bigint;
+  chatTitle: string;
+  id: string;
+  isActive: boolean;
+};
+
+type SummaryRecord = {
+  createdAt: Date;
+  id: string;
+  oneliner: string;
+  topics: Array<{
+    content: string;
+    sources: string[];
+    title: string;
+  }>;
+};
+
+let communityRecord: CommunityRecord | null = null;
+let summaryRecords: SummaryRecord[] = [];
+let summaryVoteTotalsResult = { dislikes: 1, likes: 3 };
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => ({
+    query: {
+      communities: {
+        findFirst: async () => communityRecord,
+      },
+      summaries: {
+        findMany: async (options?: { limit?: number }) =>
+          typeof options?.limit === "number"
+            ? summaryRecords.slice(0, options.limit)
+            : summaryRecords,
+      },
+    },
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            groupBy: async () => [summaryVoteTotalsResult],
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+mock.module("@/lib/redpill", () => ({
+  chatCompletion: async () => {
+    throw new Error("chatCompletion should not be called in inline tests");
+  },
+}));
+
+let handleInlineQuery: typeof import("../inline").handleInlineQuery;
+let handleSummaryInlineQuery: typeof import("../inline").handleSummaryInlineQuery;
+let SUMMARY_INLINE_QUERY_REGEX: typeof import("../inline").SUMMARY_INLINE_QUERY_REGEX;
+
+function createSummaryRecord(id: string, createdAt: string): SummaryRecord {
+  return {
+    createdAt: new Date(createdAt),
+    id,
+    oneliner: `Summary ${id}`,
+    topics: [
+      {
+        content: "Team discussed launch scope. Second sentence should not appear.",
+        sources: ["Alice", "Bob"],
+        title: "Launch",
+      },
+      {
+        content: "Finalized rollout timeline! More context not shown.",
+        sources: ["Alice"],
+        title: "Rollout",
+      },
+    ],
+  };
+}
+
+function createInlineContext(match?: unknown) {
+  const answerInlineQueryCalls: unknown[][] = [];
+
+  const ctx = {
+    answerInlineQuery: async (...args: unknown[]) => {
+      answerInlineQueryCalls.push(args);
+    },
+    match,
+  } as unknown as InlineQueryContext<Context>;
+
+  return { answerInlineQueryCalls, ctx };
+}
+
+describe("inline query handlers", () => {
+  beforeAll(async () => {
+    const inlineModule = await import("../inline");
+    handleInlineQuery = inlineModule.handleInlineQuery;
+    handleSummaryInlineQuery = inlineModule.handleSummaryInlineQuery;
+    SUMMARY_INLINE_QUERY_REGEX = inlineModule.SUMMARY_INLINE_QUERY_REGEX;
+  });
+
+  beforeEach(() => {
+    communityRecord = {
+      chatId: BigInt("-1001234567890"),
+      chatTitle: "Loyal Alpha",
+      id: "community-1",
+      isActive: true,
+    };
+    summaryRecords = [
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174000", "2026-02-12T00:00:00Z"),
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174001", "2026-02-11T00:00:00Z"),
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174002", "2026-02-10T00:00:00Z"),
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174003", "2026-02-09T00:00:00Z"),
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174004", "2026-02-08T00:00:00Z"),
+      createSummaryRecord("123e4567-e89b-12d3-a456-426614174005", "2026-02-07T00:00:00Z"),
+    ];
+    summaryVoteTotalsResult = { dislikes: 1, likes: 3 };
+  });
+
+  test("summary inline regex matches summary:<chat_id> queries", () => {
+    const match = "summary:-1001234567890".match(SUMMARY_INLINE_QUERY_REGEX);
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe("-1001234567890");
+    expect("summary:{-1001234567890}".match(SUMMARY_INLINE_QUERY_REGEX)).toBeNull();
+    expect("hello world".match(SUMMARY_INLINE_QUERY_REGEX)).toBeNull();
+  });
+
+  test("handleSummaryInlineQuery returns up to five summaries with summary payload formatting", async () => {
+    const match = "summary:-1001234567890".match(SUMMARY_INLINE_QUERY_REGEX);
+    const { answerInlineQueryCalls, ctx } = createInlineContext(match);
+
+    await handleSummaryInlineQuery(ctx);
+
+    expect(answerInlineQueryCalls).toHaveLength(1);
+    const [results, options] = answerInlineQueryCalls[0] as [
+      InlineQueryResultArticle[],
+      {
+        button: {
+          text: string;
+          web_app: { url: string };
+        };
+      },
+    ];
+
+    expect(options.button.text).toBe("Loyal Wallet");
+    expect(options.button.web_app.url).toBe(MINI_APP_LINK);
+    expect(results).toHaveLength(5);
+
+    const firstResult = results[0];
+    expect(firstResult.type).toBe("article");
+    expect(firstResult.id).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(firstResult.title).toBe("Loyal Alpha • 2026-02-12");
+
+    const inputMessageContent = firstResult.input_message_content as {
+      link_preview_options?: { prefer_large_media?: boolean };
+      message_text: string;
+      parse_mode?: string;
+    };
+    expect(inputMessageContent.parse_mode).toBe("HTML");
+    expect(inputMessageContent.link_preview_options?.prefer_large_media).toBe(true);
+    expect(inputMessageContent.message_text).toContain(
+      '<tg-emoji emoji-id="5255883309841422076">🔹</tg-emoji> Team discussed launch scope.'
+    );
+    expect(inputMessageContent.message_text).toContain(
+      '<tg-emoji emoji-id="5255883309841422076">🔹</tg-emoji> Finalized rollout timeline!'
+    );
+    expect(inputMessageContent.message_text).not.toContain(
+      "Second sentence should not appear."
+    );
+
+    const keyboard = firstResult.reply_markup as {
+      inline_keyboard: Array<
+        Array<{
+          callback_data?: string;
+          text?: string;
+          url?: string;
+        }>
+      >;
+    };
+
+    expect(keyboard.inline_keyboard[0]?.[0]?.callback_data).toBe(
+      "sv:u:123e4567-e89b-12d3-a456-426614174000:-1001234567890"
+    );
+    expect(keyboard.inline_keyboard[0]?.[1]?.text).toBe("Score: 2");
+    expect(keyboard.inline_keyboard[0]?.[2]?.callback_data).toBe(
+      "sv:d:123e4567-e89b-12d3-a456-426614174000:-1001234567890"
+    );
+    expect(keyboard.inline_keyboard[1]?.[0]?.url).toBe(
+      buildSummaryFeedMiniAppUrl(
+        BigInt("-1001234567890"),
+        "123e4567-e89b-12d3-a456-426614174000"
+      )
+    );
+  });
+
+  test("handleSummaryInlineQuery returns empty results when community is missing", async () => {
+    communityRecord = null;
+    const match = "summary:-1001234567890".match(SUMMARY_INLINE_QUERY_REGEX);
+    const { answerInlineQueryCalls, ctx } = createInlineContext(match);
+
+    await handleSummaryInlineQuery(ctx);
+
+    expect(answerInlineQueryCalls).toHaveLength(1);
+    const [results, options] = answerInlineQueryCalls[0] as [
+      InlineQueryResultArticle[],
+      {
+        button: {
+          text: string;
+          web_app: { url: string };
+        };
+      },
+    ];
+
+    expect(results).toEqual([]);
+    expect(options.button.text).toBe("Loyal Wallet");
+    expect(options.button.web_app.url).toBe(MINI_APP_LINK);
+  });
+
+  test("handleSummaryInlineQuery returns empty results when no summaries are found", async () => {
+    summaryRecords = [];
+    const match = "summary:-1001234567890".match(SUMMARY_INLINE_QUERY_REGEX);
+    const { answerInlineQueryCalls, ctx } = createInlineContext(match);
+
+    await handleSummaryInlineQuery(ctx);
+
+    expect(answerInlineQueryCalls).toHaveLength(1);
+    const [results, options] = answerInlineQueryCalls[0] as [
+      InlineQueryResultArticle[],
+      {
+        button: {
+          text: string;
+          web_app: { url: string };
+        };
+      },
+    ];
+
+    expect(results).toEqual([]);
+    expect(options.button.text).toBe("Loyal Wallet");
+    expect(options.button.web_app.url).toBe(MINI_APP_LINK);
+  });
+
+  test("handleInlineQuery keeps fallback behavior for non-matching queries", async () => {
+    const { answerInlineQueryCalls, ctx } = createInlineContext();
+
+    await handleInlineQuery(ctx);
+
+    expect(answerInlineQueryCalls).toHaveLength(1);
+    const [results, options] = answerInlineQueryCalls[0] as [
+      InlineQueryResultArticle[],
+      {
+        button: {
+          text: string;
+          web_app: { url: string };
+        };
+      },
+    ];
+
+    expect(results).toEqual([]);
+    expect(options.button.text).toBe("Loyal Wallet");
+    expect(options.button.web_app.url).toBe(MINI_APP_LINK);
+  });
+});

--- a/app/src/lib/telegram/bot-api/inline.ts
+++ b/app/src/lib/telegram/bot-api/inline.ts
@@ -1,12 +1,69 @@
+import { communities, summaries, type Summary } from "@loyal-labs/db-core/schema";
+import { and, desc, eq } from "drizzle-orm";
 import type { Context, InlineQueryContext } from "grammy";
-import { InlineQueryResult } from "grammy/types";
+import {
+  type InlineQueryResult,
+  type InlineQueryResultArticle,
+} from "grammy/types";
 
+import { getDatabase } from "@/lib/core/database";
+import { buildSummaryMessagePayload } from "@/lib/telegram/bot-api/summaries";
 import { MINI_APP_LINK } from "@/lib/telegram/constants";
 
-//TODO: implement results
-export const handleInlineQuery = async (ctx: InlineQueryContext<Context>) => {
-  const results: InlineQueryResult[] = [];
+const SUMMARY_INLINE_QUERY_RESULTS_LIMIT = 5;
 
+export const SUMMARY_INLINE_QUERY_REGEX = /^summary:\s*(-?\d+)\s*$/;
+
+export const handleInlineQuery = async (ctx: InlineQueryContext<Context>) => {
+  await answerInlineQueryWithWalletButton(ctx, []);
+};
+
+export const handleSummaryInlineQuery = async (
+  ctx: InlineQueryContext<Context>
+) => {
+  const communityChatId = parseCommunityChatId(ctx.match);
+  if (communityChatId === null) {
+    await answerInlineQueryWithWalletButton(ctx, []);
+    return;
+  }
+
+  const db = getDatabase();
+  const community = await db.query.communities.findFirst({
+    where: and(
+      eq(communities.chatId, communityChatId),
+      eq(communities.isActive, true)
+    ),
+  });
+
+  if (!community) {
+    await answerInlineQueryWithWalletButton(ctx, []);
+    return;
+  }
+
+  const latestSummaries = await db.query.summaries.findMany({
+    where: eq(summaries.communityId, community.id),
+    orderBy: [desc(summaries.createdAt)],
+    limit: SUMMARY_INLINE_QUERY_RESULTS_LIMIT,
+  });
+
+  if (latestSummaries.length === 0) {
+    await answerInlineQueryWithWalletButton(ctx, []);
+    return;
+  }
+
+  const results = await Promise.all(
+    latestSummaries.map((summary) =>
+      toInlineSummaryResult(summary, community.chatId, community.chatTitle)
+    )
+  );
+
+  await answerInlineQueryWithWalletButton(ctx, results);
+};
+
+async function answerInlineQueryWithWalletButton(
+  ctx: InlineQueryContext<Context>,
+  results: InlineQueryResult[]
+) {
   await ctx.answerInlineQuery(results, {
     button: {
       text: "Loyal Wallet",
@@ -15,4 +72,47 @@ export const handleInlineQuery = async (ctx: InlineQueryContext<Context>) => {
       },
     },
   });
-};
+}
+
+function parseCommunityChatId(match: unknown): bigint | null {
+  const capturedValue =
+    Array.isArray(match) && typeof match[1] === "string" ? match[1] : null;
+
+  if (!capturedValue) {
+    return null;
+  }
+
+  try {
+    return BigInt(capturedValue);
+  } catch {
+    return null;
+  }
+}
+
+async function toInlineSummaryResult(
+  summary: Pick<Summary, "createdAt" | "id" | "oneliner" | "topics">,
+  sourceCommunityChatId: bigint,
+  sourceCommunityTitle: string
+): Promise<InlineQueryResultArticle> {
+  const messagePayload = await buildSummaryMessagePayload(
+    summary,
+    sourceCommunityChatId
+  );
+
+  return {
+    description: summary.oneliner,
+    id: summary.id,
+    input_message_content: {
+      link_preview_options: messagePayload.messageOptions.link_preview_options,
+      message_text: messagePayload.messageText,
+      parse_mode: messagePayload.messageOptions.parse_mode,
+    },
+    reply_markup: messagePayload.messageOptions.reply_markup,
+    title: `${sourceCommunityTitle} • ${formatSummaryDate(summary.createdAt)}`,
+    type: "article",
+  };
+}
+
+function formatSummaryDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/app/src/lib/telegram/bot-api/summaries.ts
+++ b/app/src/lib/telegram/bot-api/summaries.ts
@@ -64,6 +64,15 @@ type SummaryWithCommunity = Summary & {
   };
 };
 
+export type SummaryMessagePayload = {
+  messageOptions: {
+    parse_mode: "HTML";
+    link_preview_options: { prefer_large_media: boolean };
+    reply_markup: ReturnType<typeof buildSummaryVoteKeyboard>;
+  };
+  messageText: string;
+};
+
 export async function generateOrGetSummaryForRun(input: {
   chatTitle: string;
   communityId: string;
@@ -403,15 +412,10 @@ function buildSummaryInput(
   return output;
 }
 
-async function sendSummaryToChat(
-  bot: Bot,
+export async function buildSummaryMessagePayload(
   summary: Pick<Summary, "createdAt" | "id" | "oneliner" | "topics">,
-  options: {
-    destinationChatId: bigint;
-    sourceCommunityChatId: bigint;
-    replyToMessageId?: number;
-  }
-): Promise<SummaryDeliveredMessage> {
+  sourceCommunityChatId: bigint
+): Promise<SummaryMessagePayload> {
   const { firstBulletContent, messageBody } = buildSummaryMessageBody(summary.topics);
   const ogText = buildSummaryOgText(summary.oneliner, firstBulletContent);
 
@@ -423,22 +427,40 @@ async function sendSummaryToChat(
 
   const voteTotals = await getSummaryVoteTotals(summary.id);
   const keyboard = buildSummaryVoteKeyboard(
-    options.sourceCommunityChatId,
+    sourceCommunityChatId,
     summary.id,
     voteTotals.likes,
     voteTotals.dislikes
   );
 
-  const messageOptions = {
-    parse_mode: "HTML" as const,
-    link_preview_options: { prefer_large_media: true },
-    reply_markup: keyboard,
+  return {
+    messageOptions: {
+      parse_mode: "HTML",
+      link_preview_options: { prefer_large_media: true },
+      reply_markup: keyboard,
+    },
+    messageText: messageWithPreview,
   };
+}
+
+async function sendSummaryToChat(
+  bot: Bot,
+  summary: Pick<Summary, "createdAt" | "id" | "oneliner" | "topics">,
+  options: {
+    destinationChatId: bigint;
+    sourceCommunityChatId: bigint;
+    replyToMessageId?: number;
+  }
+): Promise<SummaryDeliveredMessage> {
+  const messagePayload = await buildSummaryMessagePayload(
+    summary,
+    options.sourceCommunityChatId
+  );
 
   const sentMessage = await sendSummaryMessage(bot, {
     destinationChatId: options.destinationChatId,
-    messageOptions,
-    messageText: messageWithPreview,
+    messageOptions: messagePayload.messageOptions,
+    messageText: messagePayload.messageText,
     replyToMessageId: options.replyToMessageId,
   });
 


### PR DESCRIPTION
Add a filtered grammY inline query flow for summary:<chat_id> that returns the latest five community summaries. Reuse the shared summary payload builder so inline results match group summary message formatting and vote keyboard behavior.