### PR TITLE
feat(userbot): rework summary publish with inline delivery runtime

### DIFF
--- a/docs/workers/userbot-on-render.md
+++ b/docs/workers/userbot-on-render.md
@@ -27,6 +27,8 @@ This guide explains how to run the mtcute userbot worker with persistent SQLite 
 - `TELEGRAM_USERBOT_PHONE` (used as default phone in bootstrap flow)
 - `TELEGRAM_USERBOT_BOT_TOKEN` (preferred bot auth token)
 - `ASKLOYAL_TGBOT_KEY` (fallback bot auth token, compatible with app env)
+- `TELEGRAM_SUMMARY_INLINE_BOT_USERNAME` (default: `askloyal_tgbot`)
+- `TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM` + `TELEGRAM_SUMMARY_PEER_OVERRIDE_TO` (optional summary source peer remap; both must be set together)
 
 ## Render Service Setup
 
@@ -88,6 +90,47 @@ To only sync dialogs into communities (no message ingestion), run:
 ```bash
 cd workers/userbot && bun install && bun run sync:once --dialog-sync-only
 ```
+
+## Cron Summary Publishing (Delivery-only)
+
+Configure a Render cron job with:
+
+```bash
+cd workers/userbot && bun install && bun run summary:publish:once
+```
+
+This command:
+
+- Targets active `parserType=userbot` communities with `summaryNotificationsEnabled=true`
+- Queries the Telegram bot inline endpoint with `summary:<chatId>`
+- Sends only the latest inline summary result into each group
+- Processes communities sequentially (rate-limit safe) with bounded transient retries (max `3` attempts, base backoff `250ms`)
+- Classifies failures as `inline_query` (inline fetch phase) or `delivery` (send phase)
+- Skips groups with empty inline results (`skippedNoInlineResults`) without treating them as hard errors
+
+For targeted retries, scope to specific groups:
+
+```bash
+cd workers/userbot && bun install && bun run summary:publish:once --chat-ids=-100123,-100456
+```
+
+Note: this command requires user auth mode (session login), not bot token mode.
+
+Cron exit semantics:
+
+- Exit code `0`: no delivery errors (`stats.errors = 0`)
+- Exit code `1`: one or more delivery errors (`stats.errors > 0`) or command-level failure
+
+Operational logging for each run includes:
+
+- `communitiesMatched`
+- `communitiesProcessed`
+- `deliveryAttempted`
+- `deliverySucceeded`
+- `deliveryFailed`
+- `skippedNoInlineResults`
+- `retryCount`
+- `errors`
 
 ## Session Recovery Flow
 

--- a/workers/userbot/README.md
+++ b/workers/userbot/README.md
@@ -23,6 +23,8 @@ Standalone worker package for Telegram userbot foundations.
 - `TELEGRAM_USERBOT_PHONE` (used by `auth:bootstrap` as default phone)
 - `TELEGRAM_USERBOT_BOT_TOKEN` (preferred bot auth token)
 - `ASKLOYAL_TGBOT_KEY` (fallback bot auth token, compatible with app env)
+- `TELEGRAM_SUMMARY_INLINE_BOT_USERNAME` (default: `askloyal_tgbot`)
+- `TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM` + `TELEGRAM_SUMMARY_PEER_OVERRIDE_TO` (optional summary source peer remap; both must be set together)
 
 ## Commands
 
@@ -34,6 +36,7 @@ bun run auth:bootstrap
 bun run auth:status
 bun run auth:clear
 bun run sync:once
+bun run summary:publish:once
 bun run start
 ```
 
@@ -54,6 +57,31 @@ bun run start
 Missing chats are inserted into `communities` with `parserType=userbot` and inactive defaults:
 `isActive=false`, `isPublic=false`, `summaryNotificationsEnabled=false`,
 `summaryNotificationTimeHours=null`, `summaryNotificationMessageCount=null`.
+
+`summary:publish:once` is delivery-only and reuses the existing bot inline query flow (`summary:<chatId>`):
+
+- Targets activated `parserType=userbot` communities with summary notifications enabled
+- Pulls inline summary results for each group and sends the latest result only
+- Optional `--chat-ids=-100123,-100456` filter scopes delivery to specific groups for safe retries
+- Requires user auth mode (not bot token mode)
+- Runs sequentially per community and uses bounded transient retries (max `3` attempts, base backoff `250ms`)
+- Records phase-specific failures with `scope="inline_query"` (fetch) or `scope="delivery"` (send)
+- Uses a crypto-backed Telegram `randomId` for `messages.sendInlineBotResult`
+- Returns exit code `1` when any delivery errors occur (`stats.errors > 0`), otherwise `0`
+
+`summary:publish:once` completion logs include deterministic stats:
+
+- `communitiesMatched`
+- `communitiesProcessed`
+- `deliveryAttempted` (incremented for every processed community)
+- `deliverySucceeded`
+- `deliveryFailed`
+- `skippedNoInlineResults`
+- `errors`
+- `retryCount`
+- `authMode`
+- `botUsername`
+- `chatIdFilterCount`
 
 ## Render operational flow
 

--- a/workers/userbot/package.json
+++ b/workers/userbot/package.json
@@ -8,6 +8,7 @@
     "auth:status": "bun run src/commands/auth-status.ts",
     "auth:clear": "bun run src/commands/auth-clear.ts",
     "sync:once": "bun run src/commands/sync-once.ts",
+    "summary:publish:once": "bun run src/commands/summary-publish-once.ts",
     "test": "bun test"
   },
   "dependencies": {

--- a/workers/userbot/src/__tests__/summary-publish-once.test.ts
+++ b/workers/userbot/src/__tests__/summary-publish-once.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  runSummaryPublishOnce,
+  runSummaryPublishOnceCli,
+} from "../commands/summary-publish-once";
+import type { UserbotConfig } from "../lib/env";
+
+type FakeLogger = {
+  error: (..._args: unknown[]) => void;
+  info: (..._args: unknown[]) => void;
+  warn: (..._args: unknown[]) => void;
+};
+
+type CommunityRecord = {
+  chatId: bigint;
+  chatTitle: string;
+  id: string;
+  isActive: boolean;
+  parserType: "bot" | "userbot";
+  summaryNotificationsEnabled: boolean;
+};
+
+type FakeInlineResponse = {
+  queryId: bigint;
+  resultIds: string[];
+};
+
+type FakeState = {
+  callRequests: Array<Record<string, unknown>>;
+  communities: CommunityRecord[];
+  destroyedCount: number;
+  inlineResponsesByQuery: Map<string, Array<Error | FakeInlineResponse>>;
+  resolvePeerCalls: string[];
+  resolveUserCalls: string[];
+  sendResponsesByResultId: Map<string, Array<Error | { ok: true }>>;
+  startedCount: number;
+};
+
+function createLogger(): FakeLogger {
+  return {
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  };
+}
+
+function createConfig(overrides: Partial<UserbotConfig> = {}): UserbotConfig {
+  return {
+    accountKey: "primary",
+    apiHash: "hash",
+    apiId: 123,
+    authMode: "user",
+    botToken: null,
+    storageDir: "/tmp/userbot",
+    ...overrides,
+  };
+}
+
+function createFakeState(
+  overrides: Partial<
+    Omit<
+      FakeState,
+      | "callRequests"
+      | "destroyedCount"
+      | "inlineResponsesByQuery"
+      | "resolvePeerCalls"
+      | "resolveUserCalls"
+      | "sendResponsesByResultId"
+      | "startedCount"
+    >
+  > = {}
+): FakeState {
+  return {
+    callRequests: [],
+    communities: overrides.communities ?? [],
+    destroyedCount: 0,
+    inlineResponsesByQuery: new Map(),
+    resolvePeerCalls: [],
+    resolveUserCalls: [],
+    sendResponsesByResultId: new Map(),
+    startedCount: 0,
+  };
+}
+
+function shiftQueueItem<T>(queue: T[] | undefined): T | undefined {
+  if (!queue || queue.length === 0) {
+    return undefined;
+  }
+
+  return queue.shift();
+}
+
+function createFakeDb(state: FakeState): any {
+  return {
+    query: {
+      communities: {
+        findMany: async () => {
+          // Mimic SQL filter in command: active + userbot + notifications enabled.
+          return state.communities.filter(
+            (community) =>
+              community.isActive &&
+              community.parserType === "userbot" &&
+              community.summaryNotificationsEnabled
+          );
+        },
+      },
+    },
+  };
+}
+
+function createFakeBundle(state: FakeState, config: UserbotConfig): any {
+  return {
+    client: {
+      call: async (request: Record<string, unknown>) => {
+        state.callRequests.push(request);
+
+        if (request._ === "messages.getInlineBotResults") {
+          const query = String(request.query);
+          const queued = shiftQueueItem(state.inlineResponsesByQuery.get(query));
+          if (queued instanceof Error) {
+            throw queued;
+          }
+
+          const response = queued ?? {
+            queryId: 1n,
+            resultIds: [],
+          };
+
+          return {
+            _: "messages.botResults",
+            queryId: response.queryId,
+            results: response.resultIds.map((id) => ({ id })),
+          };
+        }
+
+        if (request._ === "messages.sendInlineBotResult") {
+          const resultId = String(request.id);
+          const queued = shiftQueueItem(
+            state.sendResponsesByResultId.get(resultId)
+          );
+          if (queued instanceof Error) {
+            throw queued;
+          }
+
+          return { _: "updates" };
+        }
+
+        throw new Error(`Unexpected RPC method: ${String(request._)}`);
+      },
+      destroy: async () => {
+        state.destroyedCount += 1;
+      },
+      resolvePeer: async (chatId: string) => {
+        state.resolvePeerCalls.push(chatId);
+        return { _: "inputPeerMock", chatId };
+      },
+      resolveUser: async (username: string) => {
+        state.resolveUserCalls.push(username);
+        return { _: "inputUserMock", username };
+      },
+      start: async () => {
+        state.startedCount += 1;
+        return { id: 1n };
+      },
+    },
+    config,
+    sessionPath: "/tmp/userbot/mtcute-primary.sqlite",
+  };
+}
+
+describe("summary-publish-once", () => {
+  test("selects only eligible communities and sends first inline result", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "Eligible",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+        {
+          chatId: BigInt(-1002),
+          chatTitle: "Wrong parser",
+          id: "community-2",
+          isActive: true,
+          parserType: "bot",
+          summaryNotificationsEnabled: true,
+        },
+        {
+          chatId: BigInt(-1003),
+          chatTitle: "Notifications off",
+          id: "community-3",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: false,
+        },
+        {
+          chatId: BigInt(-1004),
+          chatTitle: "Inactive",
+          id: "community-4",
+          isActive: false,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+    state.inlineResponsesByQuery.set("summary:-2001", [
+      {
+        queryId: 77n,
+        resultIds: ["latest-summary", "older-summary"],
+      },
+    ]);
+
+    const result = await runSummaryPublishOnce(
+      {
+        createClient: async (config) => createFakeBundle(state, config),
+        createDb: () => createFakeDb(state),
+        createRandomId: () => 999n,
+        env: {
+          TELEGRAM_SUMMARY_INLINE_BOT_USERNAME: "@custom_inline_bot",
+          TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM: "-1001",
+          TELEGRAM_SUMMARY_PEER_OVERRIDE_TO: "-2001",
+        },
+        hasFile: async () => true,
+        loadConfig: () => createConfig(),
+        loadDatabaseUrl: () => "postgres://example",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      },
+      {}
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.stats.communitiesMatched).toBe(1);
+    expect(result.stats.communitiesProcessed).toBe(1);
+    expect(result.stats.deliveryAttempted).toBe(1);
+    expect(result.stats.deliverySucceeded).toBe(1);
+    expect(result.stats.deliveryFailed).toBe(0);
+    expect(result.stats.skippedNoInlineResults).toBe(0);
+    expect(state.resolveUserCalls).toEqual(["custom_inline_bot"]);
+    expect(state.resolvePeerCalls).toEqual(["-1001"]);
+
+    const getInlineCall = state.callRequests.find(
+      (request) => request._ === "messages.getInlineBotResults"
+    );
+    expect(getInlineCall?.query).toBe("summary:-2001");
+
+    const sendCall = state.callRequests.find(
+      (request) => request._ === "messages.sendInlineBotResult"
+    );
+    expect(sendCall?.id).toBe("latest-summary");
+    expect(sendCall?.queryId).toBe(77n);
+    expect(sendCall?.randomId).toBe(999n);
+  });
+
+  test("skips delivery when inline returns no results", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "Eligible",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+    state.inlineResponsesByQuery.set("summary:-1001", [
+      {
+        queryId: 88n,
+        resultIds: [],
+      },
+    ]);
+
+    const result = await runSummaryPublishOnce({
+      createClient: async (config) => createFakeBundle(state, config),
+      createDb: () => createFakeDb(state),
+      env: {},
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://example",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.stats.deliveryAttempted).toBe(1);
+    expect(result.stats.deliverySucceeded).toBe(0);
+    expect(result.stats.deliveryFailed).toBe(0);
+    expect(result.stats.skippedNoInlineResults).toBe(1);
+    expect(
+      state.callRequests.some((request) => request._ === "messages.sendInlineBotResult")
+    ).toBe(false);
+  });
+
+  test("records inline_query and delivery failures separately while continuing", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "Inline fails",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+        {
+          chatId: BigInt(-1002),
+          chatTitle: "Send fails",
+          id: "community-2",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+        {
+          chatId: BigInt(-1003),
+          chatTitle: "Success",
+          id: "community-3",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+
+    state.inlineResponsesByQuery.set("summary:-1001", [new Error("hard inline failure")]);
+    state.inlineResponsesByQuery.set("summary:-1002", [
+      {
+        queryId: 100n,
+        resultIds: ["result-send-fail"],
+      },
+    ]);
+    state.inlineResponsesByQuery.set("summary:-1003", [
+      {
+        queryId: 101n,
+        resultIds: ["result-success"],
+      },
+    ]);
+
+    state.sendResponsesByResultId.set("result-send-fail", [new Error("hard send failure")]);
+
+    const result = await runSummaryPublishOnce({
+      createClient: async (config) => createFakeBundle(state, config),
+      createDb: () => createFakeDb(state),
+      env: {},
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://example",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.communitiesProcessed).toBe(3);
+    expect(result.stats.deliveryAttempted).toBe(3);
+    expect(result.stats.deliverySucceeded).toBe(1);
+    expect(result.stats.deliveryFailed).toBe(2);
+    expect(result.stats.errors).toBe(2);
+    expect(result.errors.map((entry) => entry.scope)).toEqual([
+      "inline_query",
+      "delivery",
+    ]);
+  });
+
+  test("increments retryCount for transient failures", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "Retries",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+
+    state.inlineResponsesByQuery.set("summary:-1001", [
+      new Error("NETWORK timeout"),
+      {
+        queryId: 202n,
+        resultIds: ["retry-send"],
+      },
+    ]);
+    state.sendResponsesByResultId.set("retry-send", [
+      new Error("RPC_CALL_FAIL"),
+      { ok: true },
+    ]);
+
+    const result = await runSummaryPublishOnce({
+      createClient: async (config) => createFakeBundle(state, config),
+      createDb: () => createFakeDb(state),
+      env: {},
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://example",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(result.stats.retryCount).toBe(2);
+    expect(result.stats.deliverySucceeded).toBe(1);
+    expect(result.stats.errors).toBe(0);
+  });
+
+  test("fails fast in bot auth mode", async () => {
+    await expect(
+      runSummaryPublishOnce({
+        env: {},
+        loadConfig: () =>
+          createConfig({
+            authMode: "bot",
+            botToken: "token",
+          }),
+        logger: createLogger(),
+      })
+    ).rejects.toThrow("requires user auth mode");
+  });
+
+  test("runSummaryPublishOnceCli applies --chat-ids filter", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "First",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+        {
+          chatId: BigInt(-1002),
+          chatTitle: "Second",
+          id: "community-2",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+
+    state.inlineResponsesByQuery.set("summary:-1001", [
+      {
+        queryId: 1n,
+        resultIds: ["summary-1"],
+      },
+    ]);
+    state.inlineResponsesByQuery.set("summary:-1002", [
+      {
+        queryId: 2n,
+        resultIds: ["summary-2"],
+      },
+    ]);
+
+    const originalArgv = [...process.argv];
+    process.argv = [
+      originalArgv[0] ?? "bun",
+      originalArgv[1] ?? "summary-publish-once.ts",
+      "--chat-ids=-1002",
+    ];
+
+    try {
+      const exitCode = await runSummaryPublishOnceCli({
+        createClient: async (config) => createFakeBundle(state, config),
+        createDb: () => createFakeDb(state),
+        env: {},
+        hasFile: async () => true,
+        loadConfig: () => createConfig(),
+        loadDatabaseUrl: () => "postgres://example",
+        logger: createLogger(),
+        sleep: async () => undefined,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(state.resolvePeerCalls).toEqual(["-1002"]);
+
+      const inlineQueries = state.callRequests.filter(
+        (request) => request._ === "messages.getInlineBotResults"
+      );
+      expect(inlineQueries).toHaveLength(1);
+      expect(inlineQueries[0]?.query).toBe("summary:-1002");
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  test("runSummaryPublishOnceCli returns exit code 1 when errors are present", async () => {
+    const state = createFakeState({
+      communities: [
+        {
+          chatId: BigInt(-1001),
+          chatTitle: "Fails",
+          id: "community-1",
+          isActive: true,
+          parserType: "userbot",
+          summaryNotificationsEnabled: true,
+        },
+      ],
+    });
+
+    state.inlineResponsesByQuery.set("summary:-1001", [new Error("hard inline failure")]);
+
+    const exitCode = await runSummaryPublishOnceCli({
+      createClient: async (config) => createFakeBundle(state, config),
+      createDb: () => createFakeDb(state),
+      env: {},
+      hasFile: async () => true,
+      loadConfig: () => createConfig(),
+      loadDatabaseUrl: () => "postgres://example",
+      logger: createLogger(),
+      sleep: async () => undefined,
+    });
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/workers/userbot/src/commands/summary-publish-once.ts
+++ b/workers/userbot/src/commands/summary-publish-once.ts
@@ -1,0 +1,465 @@
+import { randomBytes } from "node:crypto";
+
+import { communities } from "@loyal-labs/db-core/schema";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { createUserbotClient, type UserbotClientBundle } from "../lib/client";
+import {
+  hasFile,
+  isTransientError,
+  parseChatIdsCsv,
+  runWithRetry,
+  sleep,
+} from "../lib/command-runtime";
+import { createWorkerDatabase, loadDatabaseUrl, type UserbotDb } from "../lib/database";
+import { loadUserbotConfig, type UserbotConfig } from "../lib/env";
+import { createNonInteractiveStartParams } from "../lib/non-interactive-auth";
+import {
+  loadSummaryPublishEnvOptions,
+  resolveSummarySourceChatId,
+  type SummaryPeerOverride,
+} from "../lib/summary-publish-env";
+import { resolveSessionSqlitePath } from "../lib/storage";
+
+type EnvRecord = Record<string, string | undefined>;
+
+type Logger = Pick<Console, "error" | "info" | "warn">;
+
+type SummaryPublishScope = "inline_query" | "delivery";
+
+type CommunityPublishError = {
+  chatId: string;
+  communityId: string;
+  error: string;
+  scope: SummaryPublishScope;
+};
+
+export type SummaryPublishOnceStats = {
+  authMode: UserbotConfig["authMode"];
+  botUsername: string;
+  chatIdFilterCount: number | null;
+  communitiesMatched: number;
+  communitiesProcessed: number;
+  deliveryAttempted: number;
+  deliveryFailed: number;
+  deliverySucceeded: number;
+  errors: number;
+  retryCount: number;
+  skippedNoInlineResults: number;
+};
+
+export type SummaryPublishOnceResult = {
+  errors: CommunityPublishError[];
+  stats: SummaryPublishOnceStats;
+};
+
+type SummaryPublishOnceOptions = {
+  chatIds?: bigint[];
+};
+
+type ResolvedSummaryPublishOnceOptions = {
+  chatIds: bigint[] | null;
+};
+
+type ActiveSummaryCommunity = {
+  chatId: bigint;
+  id: string;
+};
+
+type SummaryPublishOnceDeps = {
+  createClient: (config: UserbotConfig) => Promise<UserbotClientBundle>;
+  createDb: (databaseUrl: string) => UserbotDb;
+  createRandomId: () => bigint;
+  env: EnvRecord;
+  hasFile: (path: string) => Promise<boolean>;
+  loadConfig: (env: EnvRecord) => UserbotConfig;
+  loadDatabaseUrl: (env: EnvRecord) => string;
+  logger: Logger;
+  runWithRetry: typeof runWithRetry;
+  sleep: (ms: number) => Promise<void>;
+};
+
+const RETRY_BASE_DELAY_MS = 250;
+const RETRY_MAX_ATTEMPTS = 3;
+const RANDOM_ID_MASK = (1n << 63n) - 1n;
+
+function isDirectExecution(scriptName: string): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && entrypoint.endsWith(scriptName);
+}
+
+function parseSummaryPublishOnceCliOptions(argv: string[]): SummaryPublishOnceOptions {
+  const options: SummaryPublishOnceOptions = {};
+
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith("--chat-ids=")) {
+      options.chatIds = parseChatIdsCsv(arg.slice("--chat-ids=".length));
+    }
+  }
+
+  return options;
+}
+
+function resolveOptions(
+  options: SummaryPublishOnceOptions = {}
+): ResolvedSummaryPublishOnceOptions {
+  return {
+    chatIds: options.chatIds?.length ? [...new Set(options.chatIds)] : null,
+  };
+}
+
+function resolveDeps(overrides: Partial<SummaryPublishOnceDeps>): SummaryPublishOnceDeps {
+  return {
+    createClient: overrides.createClient ?? createUserbotClient,
+    createDb: overrides.createDb ?? createWorkerDatabase,
+    createRandomId: overrides.createRandomId ?? createRandomMessageId,
+    env: overrides.env ?? process.env,
+    hasFile: overrides.hasFile ?? hasFile,
+    loadConfig: overrides.loadConfig ?? loadUserbotConfig,
+    loadDatabaseUrl: overrides.loadDatabaseUrl ?? loadDatabaseUrl,
+    logger: overrides.logger ?? console,
+    runWithRetry: overrides.runWithRetry ?? runWithRetry,
+    sleep: overrides.sleep ?? sleep,
+  };
+}
+
+function createRandomMessageId(): bigint {
+  return randomBytes(8).readBigUInt64BE(0) & RANDOM_ID_MASK;
+}
+
+function createRetryLogger(params: {
+  deps: SummaryPublishOnceDeps;
+  stats: SummaryPublishOnceStats;
+  label: string;
+}) {
+  return async ({ delayMs, error }: { attempt: number; delayMs: number; error: unknown }) => {
+    params.stats.retryCount += 1;
+    params.deps.logger.warn(
+      `[userbot] transient error while ${params.label}; retrying in ${delayMs}ms`,
+      error
+    );
+  };
+}
+
+async function destroyBundle(
+  bundle: UserbotClientBundle,
+  logger: Logger,
+  context: string
+): Promise<void> {
+  try {
+    await bundle.client.destroy();
+  } catch (error) {
+    logger.error(`[userbot] Failed to destroy client (${context})`, error);
+  }
+}
+
+function toSummaryPublishError(
+  error: unknown,
+  context: { chatId: bigint; communityId: string; scope: SummaryPublishScope }
+): CommunityPublishError {
+  return {
+    chatId: context.chatId.toString(),
+    communityId: context.communityId,
+    error: error instanceof Error ? error.message : String(error),
+    scope: context.scope,
+  };
+}
+
+function recordCommunityFailure(params: {
+  context: { chatId: bigint; communityId: string; scope: SummaryPublishScope };
+  error: unknown;
+  errors: CommunityPublishError[];
+  stats: SummaryPublishOnceStats;
+}): void {
+  params.stats.deliveryFailed += 1;
+  params.stats.errors += 1;
+  params.errors.push(toSummaryPublishError(params.error, params.context));
+}
+
+async function fetchInlineSummaryResult(params: {
+  bundle: UserbotClientBundle;
+  community: ActiveSummaryCommunity;
+  peerOverride: SummaryPeerOverride | null;
+  botInputUser: Awaited<ReturnType<UserbotClientBundle["client"]["resolveUser"]>>;
+}): Promise<{
+  destinationPeer: Awaited<ReturnType<UserbotClientBundle["client"]["resolvePeer"]>>;
+  queryId: bigint;
+  resultId: string | null;
+}> {
+  const destinationPeer = await params.bundle.client.resolvePeer(
+    params.community.chatId.toString()
+  );
+  const sourceChatId = resolveSummarySourceChatId(
+    params.community.chatId,
+    params.peerOverride
+  );
+
+  const inlineResults = await params.bundle.client.call({
+    _: "messages.getInlineBotResults",
+    bot: params.botInputUser,
+    offset: "",
+    peer: destinationPeer,
+    query: `summary:${sourceChatId}`,
+  });
+
+  const firstResult = inlineResults.results[0];
+  const queryId = toBigIntValue(inlineResults.queryId, "inline query id");
+
+  return {
+    destinationPeer,
+    queryId,
+    resultId: firstResult && typeof firstResult.id === "string" ? firstResult.id : null,
+  };
+}
+
+async function sendInlineSummaryResult(params: {
+  bundle: UserbotClientBundle;
+  destinationPeer: Awaited<ReturnType<UserbotClientBundle["client"]["resolvePeer"]>>;
+  queryId: bigint;
+  resultId: string;
+  randomId: bigint;
+}): Promise<void> {
+  await params.bundle.client.call({
+    _: "messages.sendInlineBotResult",
+    id: params.resultId,
+    peer: params.destinationPeer,
+    queryId: params.queryId,
+    randomId: params.randomId,
+  });
+}
+
+function toBigIntValue(value: unknown, label: string): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return BigInt(value);
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return BigInt(value.trim());
+  }
+
+  if (value && typeof value === "object" && "toString" in value) {
+    const text = String((value as { toString: () => string }).toString()).trim();
+    if (text.length > 0) {
+      return BigInt(text);
+    }
+  }
+
+  throw new Error(`Invalid ${label}`);
+}
+
+export async function runSummaryPublishOnce(
+  overrides: Partial<SummaryPublishOnceDeps> = {},
+  options: SummaryPublishOnceOptions = {}
+): Promise<SummaryPublishOnceResult> {
+  const deps = resolveDeps(overrides);
+  const resolvedOptions = resolveOptions(options);
+  const config = deps.loadConfig(deps.env);
+
+  if (config.authMode === "bot") {
+    throw new Error(
+      "[userbot] summary:publish:once requires user auth mode. Remove TELEGRAM_USERBOT_BOT_TOKEN/ASKLOYAL_TGBOT_KEY and run bun run auth:bootstrap."
+    );
+  }
+
+  const envOptions = loadSummaryPublishEnvOptions(deps.env);
+  const sessionPath = resolveSessionSqlitePath(
+    config.accountKey,
+    config.storageDir
+  );
+  const sessionExists = await deps.hasFile(sessionPath);
+
+  if (!sessionExists) {
+    throw new Error(
+      `[userbot] Missing session file for '${config.accountKey}'. Run auth:bootstrap first. Expected: ${sessionPath}`
+    );
+  }
+
+  deps.logger.info(
+    `[userbot] Starting summary:publish:once for '${config.accountKey}' using @${envOptions.inlineBotUsername}.`
+  );
+
+  const bundle = await deps.createClient(config);
+
+  const stats: SummaryPublishOnceStats = {
+    authMode: config.authMode,
+    botUsername: envOptions.inlineBotUsername,
+    chatIdFilterCount: resolvedOptions.chatIds?.length ?? null,
+    communitiesMatched: 0,
+    communitiesProcessed: 0,
+    deliveryAttempted: 0,
+    deliveryFailed: 0,
+    deliverySucceeded: 0,
+    errors: 0,
+    retryCount: 0,
+    skippedNoInlineResults: 0,
+  };
+  const errors: CommunityPublishError[] = [];
+
+  try {
+    await bundle.client.start(createNonInteractiveStartParams(config));
+
+    const db = deps.createDb(deps.loadDatabaseUrl(deps.env));
+
+    const whereClauses = [
+      eq(communities.isActive, true),
+      eq(communities.parserType, "userbot"),
+      eq(communities.summaryNotificationsEnabled, true),
+    ];
+
+    if (resolvedOptions.chatIds) {
+      whereClauses.push(inArray(communities.chatId, resolvedOptions.chatIds));
+    }
+
+    const queriedCommunities = await db.query.communities.findMany({
+      columns: {
+        chatId: true,
+        id: true,
+      },
+      where: and(...whereClauses),
+    });
+
+    const chatIdFilter =
+      resolvedOptions.chatIds === null
+        ? null
+        : new Set(resolvedOptions.chatIds.map((chatId) => chatId.toString()));
+
+    const selectedCommunities = chatIdFilter
+      ? queriedCommunities.filter((community) =>
+          chatIdFilter.has(community.chatId.toString())
+        )
+      : queriedCommunities;
+
+    stats.communitiesMatched = selectedCommunities.length;
+
+    const botInputUser = await deps.runWithRetry({
+      baseDelayMs: RETRY_BASE_DELAY_MS,
+      isRetryable: isTransientError,
+      maxAttempts: RETRY_MAX_ATTEMPTS,
+      onRetry: createRetryLogger({
+        deps,
+        label: `resolving inline bot @${envOptions.inlineBotUsername}`,
+        stats,
+      }),
+      sleepFn: deps.sleep,
+      task: async () => {
+        return bundle.client.resolveUser(envOptions.inlineBotUsername);
+      },
+    });
+
+    for (const community of selectedCommunities) {
+      stats.communitiesProcessed += 1;
+      stats.deliveryAttempted += 1;
+
+      let inlineResult: {
+        destinationPeer: Awaited<ReturnType<UserbotClientBundle["client"]["resolvePeer"]>>;
+        queryId: bigint;
+        resultId: string | null;
+      };
+
+      try {
+        inlineResult = await deps.runWithRetry({
+          baseDelayMs: RETRY_BASE_DELAY_MS,
+          isRetryable: isTransientError,
+          maxAttempts: RETRY_MAX_ATTEMPTS,
+          onRetry: createRetryLogger({
+            deps,
+            label: `fetching inline summary for community ${community.id}`,
+            stats,
+          }),
+          sleepFn: deps.sleep,
+          task: async () => {
+            return fetchInlineSummaryResult({
+              botInputUser,
+              bundle,
+              community,
+              peerOverride: envOptions.peerOverride,
+            });
+          },
+        });
+      } catch (error) {
+        recordCommunityFailure({
+          context: {
+            chatId: community.chatId,
+            communityId: community.id,
+            scope: "inline_query",
+          },
+          error,
+          errors,
+          stats,
+        });
+        continue;
+      }
+
+      if (inlineResult.resultId === null) {
+        stats.skippedNoInlineResults += 1;
+        continue;
+      }
+
+      try {
+        await deps.runWithRetry({
+          baseDelayMs: RETRY_BASE_DELAY_MS,
+          isRetryable: isTransientError,
+          maxAttempts: RETRY_MAX_ATTEMPTS,
+          onRetry: createRetryLogger({
+            deps,
+            label: `sending inline summary for community ${community.id}`,
+            stats,
+          }),
+          sleepFn: deps.sleep,
+          task: async () => {
+            await sendInlineSummaryResult({
+              bundle,
+              destinationPeer: inlineResult.destinationPeer,
+              queryId: inlineResult.queryId,
+              randomId: deps.createRandomId(),
+              resultId: inlineResult.resultId,
+            });
+          },
+        });
+      } catch (error) {
+        recordCommunityFailure({
+          context: {
+            chatId: community.chatId,
+            communityId: community.id,
+            scope: "delivery",
+          },
+          error,
+          errors,
+          stats,
+        });
+        continue;
+      }
+
+      stats.deliverySucceeded += 1;
+    }
+
+    const result = { errors, stats };
+    deps.logger.info("[userbot] summary:publish:once completed", result);
+    return result;
+  } finally {
+    await destroyBundle(bundle, deps.logger, "summary_publish_once");
+  }
+}
+
+export async function runSummaryPublishOnceCli(
+  overrides: Partial<SummaryPublishOnceDeps> = {}
+): Promise<number> {
+  const logger = overrides.logger ?? console;
+
+  try {
+    const options = parseSummaryPublishOnceCliOptions(process.argv);
+    const result = await runSummaryPublishOnce(overrides, options);
+    return result.stats.errors > 0 ? 1 : 0;
+  } catch (error) {
+    logger.error("[userbot] summary:publish:once failed", error);
+    return 1;
+  }
+}
+
+if (isDirectExecution("summary-publish-once.ts")) {
+  process.exit(await runSummaryPublishOnceCli());
+}

--- a/workers/userbot/src/lib/command-runtime.ts
+++ b/workers/userbot/src/lib/command-runtime.ts
@@ -1,0 +1,104 @@
+import { stat } from "node:fs/promises";
+
+type RetryOptions<T> = {
+  baseDelayMs?: number;
+  isRetryable?: (error: unknown) => boolean;
+  maxAttempts?: number;
+  onRetry?: (params: {
+    attempt: number;
+    delayMs: number;
+    error: unknown;
+  }) => void | Promise<void>;
+  sleepFn?: (ms: number) => Promise<void>;
+  task: () => Promise<T>;
+};
+
+export async function hasFile(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+export function isTransientError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toUpperCase() : String(error).toUpperCase();
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : "";
+
+  if (["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "EAI_AGAIN"].includes(code)) {
+    return true;
+  }
+
+  return (
+    message.includes("FLOOD_WAIT") ||
+    message.includes("RPC_CALL_FAIL") ||
+    message.includes("TIMEOUT") ||
+    message.includes("NETWORK")
+  );
+}
+
+export function parseChatIdsCsv(value: string, flagName: string = "--chat-ids"): bigint[] {
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (parsed.length === 0) {
+    throw new Error(`${flagName} must include at least one chat id`);
+  }
+
+  return parsed.map((entry) => {
+    try {
+      return BigInt(entry);
+    } catch {
+      throw new Error(`Invalid ${flagName} value: '${entry}'`);
+    }
+  });
+}
+
+export async function runWithRetry<T>(options: RetryOptions<T>): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 250;
+  const isRetryable = options.isRetryable ?? isTransientError;
+  const sleepFn = options.sleepFn ?? sleep;
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
+    throw new Error("maxAttempts must be a positive integer");
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await options.task();
+    } catch (error) {
+      const shouldRetry = isRetryable(error) && attempt < maxAttempts;
+      if (!shouldRetry) {
+        throw error;
+      }
+
+      const delayMs = baseDelayMs * attempt;
+      if (options.onRetry) {
+        await options.onRetry({
+          attempt,
+          delayMs,
+          error,
+        });
+      }
+      await sleepFn(delayMs);
+    }
+  }
+
+  throw new Error("Retry loop exhausted");
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/workers/userbot/src/lib/summary-publish-env.ts
+++ b/workers/userbot/src/lib/summary-publish-env.ts
@@ -1,0 +1,92 @@
+const DEFAULT_INLINE_BOT_USERNAME = "askloyal_tgbot";
+const TELEGRAM_SUMMARY_INLINE_BOT_USERNAME =
+  "TELEGRAM_SUMMARY_INLINE_BOT_USERNAME";
+const TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM =
+  "TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM";
+const TELEGRAM_SUMMARY_PEER_OVERRIDE_TO = "TELEGRAM_SUMMARY_PEER_OVERRIDE_TO";
+
+type EnvRecord = Record<string, string | undefined>;
+
+export type SummaryPeerOverride = {
+  fromPeerId: bigint;
+  toPeerId: bigint;
+};
+
+export type SummaryPublishEnvOptions = {
+  inlineBotUsername: string;
+  peerOverride: SummaryPeerOverride | null;
+};
+
+function normalizeOptionalValue(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseTelegramPeerId(value: string, envName: string): bigint {
+  try {
+    return BigInt(value);
+  } catch {
+    throw new Error(`${envName} must be a valid integer peer ID`);
+  }
+}
+
+export function loadSummaryPublishEnvOptions(
+  env: EnvRecord = process.env
+): SummaryPublishEnvOptions {
+  const inlineBotUsernameRaw = normalizeOptionalValue(
+    env[TELEGRAM_SUMMARY_INLINE_BOT_USERNAME]
+  );
+  const strippedInlineBotUsername =
+    inlineBotUsernameRaw && inlineBotUsernameRaw.startsWith("@")
+      ? inlineBotUsernameRaw.slice(1)
+      : inlineBotUsernameRaw;
+
+  if (strippedInlineBotUsername !== undefined && strippedInlineBotUsername.length === 0) {
+    throw new Error(`${TELEGRAM_SUMMARY_INLINE_BOT_USERNAME} must not be empty`);
+  }
+
+  const inlineBotUsername = strippedInlineBotUsername ?? DEFAULT_INLINE_BOT_USERNAME;
+
+  const fromValue = normalizeOptionalValue(env[TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM]);
+  const toValue = normalizeOptionalValue(env[TELEGRAM_SUMMARY_PEER_OVERRIDE_TO]);
+
+  if (!fromValue && !toValue) {
+    return {
+      inlineBotUsername,
+      peerOverride: null,
+    };
+  }
+
+  if (!fromValue || !toValue) {
+    throw new Error(
+      `${TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM} and ${TELEGRAM_SUMMARY_PEER_OVERRIDE_TO} must both be set`
+    );
+  }
+
+  return {
+    inlineBotUsername,
+    peerOverride: {
+      fromPeerId: parseTelegramPeerId(fromValue, TELEGRAM_SUMMARY_PEER_OVERRIDE_FROM),
+      toPeerId: parseTelegramPeerId(toValue, TELEGRAM_SUMMARY_PEER_OVERRIDE_TO),
+    },
+  };
+}
+
+export function resolveSummarySourceChatId(
+  requestChatId: bigint,
+  peerOverride: SummaryPeerOverride | null
+): bigint {
+  if (!peerOverride) {
+    return requestChatId;
+  }
+
+  if (requestChatId === peerOverride.fromPeerId) {
+    return peerOverride.toPeerId;
+  }
+
+  return requestChatId;
+}


### PR DESCRIPTION
Re-implements userbot summary publishing as a delivery-only inline-query flow for activated userbot communities, with scoped retries, deterministic stats, and explicit inline_query/delivery failure classification. Updates userbot docs and Render runbook plus tests to match the v2 operational contract.