### PR TITLE
fix(summaries): move Ax validation to retry layer and default to GLM-4.7

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -16,7 +16,7 @@ TELEGRAM_SETUP_SECRET=
 CRON_SECRET=
 REDPILL_AI_API_KEY=
 # Optional Ax summary runtime overrides
-# AX_SUMMARY_MODEL_DEFAULT defaults to deepseek/deepseek-v3.2
+# AX_SUMMARY_MODEL_DEFAULT defaults to z-ai/glm-4.7
 AX_SUMMARY_MODEL_DEFAULT=
 # Legacy fallback still supported
 SUMMARY_AX_MODEL=

--- a/app/src/app/api/cron/summaries/route.ts
+++ b/app/src/app/api/cron/summaries/route.ts
@@ -1,4 +1,5 @@
 import { communities, pushTokens } from "@loyal-labs/db-core/schema";
+import { LlmRetryExhaustedError } from "@loyal-labs/llm-core";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -32,8 +33,12 @@ type ActiveCommunityRecord = {
 type CommunityProcessingError = {
   chatId?: string;
   communityId?: string;
+  errorDetails?: Record<string, string>;
   error: string;
+  errorName?: string;
+  failureReasons?: string[];
   scope: "delivery" | "generation";
+  stack?: string;
   summaryId?: string;
 };
 
@@ -195,12 +200,15 @@ export async function runDailyCommunitySummaries(
       );
     } catch (error) {
       stats.errors += 1;
-      errors.push({
-        chatId: String(community.chatId),
+      const generationError = buildCommunityProcessingError({
+        chatId: community.chatId,
         communityId: community.id,
-        error: error instanceof Error ? error.message : String(error),
+        error,
         scope: "generation",
       });
+
+      errors.push(generationError);
+      logCommunityProcessingFailure(generationError);
       continue;
     }
 
@@ -258,13 +266,16 @@ export async function runDailyCommunitySummaries(
     } catch (error) {
       stats.deliveryFailed += 1;
       stats.errors += 1;
-      errors.push({
-        chatId: String(community.chatId),
+      const deliveryError = buildCommunityProcessingError({
+        chatId: community.chatId,
         communityId: community.id,
-        error: error instanceof Error ? error.message : String(error),
+        error,
         scope: "delivery",
         summaryId: generationResult.summaryId,
       });
+
+      errors.push(deliveryError);
+      logCommunityProcessingFailure(deliveryError);
     }
   }
 
@@ -304,4 +315,112 @@ function logQualityControlForwardFailure(
     sourceCommunityChatId: String(deliveredMessage.sourceCommunityChatId),
     summaryId,
   });
+}
+
+type BuildCommunityProcessingErrorOptions = {
+  chatId: bigint;
+  communityId: string;
+  error: unknown;
+  scope: CommunityProcessingError["scope"];
+  summaryId?: string;
+};
+
+function buildCommunityProcessingError(
+  options: BuildCommunityProcessingErrorOptions
+): CommunityProcessingError {
+  const baseError: CommunityProcessingError = {
+    chatId: String(options.chatId),
+    communityId: options.communityId,
+    error: options.error instanceof Error ? options.error.message : String(options.error),
+    scope: options.scope,
+    summaryId: options.summaryId,
+  };
+
+  if (!(options.error instanceof Error)) {
+    return baseError;
+  }
+
+  baseError.errorName = options.error.name;
+  if (options.error.stack) {
+    baseError.stack = options.error.stack.split("\n").slice(0, 6).join("\n");
+  }
+
+  const errorDetails = extractErrorDetails(options.error);
+  if (Object.keys(errorDetails).length > 0) {
+    baseError.errorDetails = errorDetails;
+  }
+
+  if (options.error instanceof LlmRetryExhaustedError) {
+    baseError.failureReasons = options.error.failureReasons;
+  }
+
+  return baseError;
+}
+
+function logCommunityProcessingFailure(error: CommunityProcessingError): void {
+  console.error("[cron/summaries] Community summary processing failed", error);
+}
+
+function extractErrorDetails(error: Error): Record<string, string> {
+  const details: Record<string, string> = {};
+  const errorRecord = error as Error & Record<string, unknown>;
+  const keys = ["code", "status", "statusCode", "type", "param", "requestId"];
+
+  for (const key of keys) {
+    const value = errorRecord[key];
+    if (value !== undefined) {
+      details[key] = stringifyErrorField(value);
+    }
+  }
+
+  const response = errorRecord.response;
+  if (response !== undefined) {
+    details.response = stringifyErrorField(response);
+  }
+
+  const cause = (error as Error & { cause?: unknown }).cause;
+  if (cause !== undefined) {
+    details.cause = stringifyErrorField(cause);
+  }
+
+  return details;
+}
+
+function stringifyErrorField(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    value === null
+  ) {
+    return String(value);
+  }
+
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  try {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (_key, currentValue) => {
+      if (typeof currentValue === "bigint") {
+        return currentValue.toString();
+      }
+
+      if (typeof currentValue === "object" && currentValue !== null) {
+        if (seen.has(currentValue)) {
+          return "[Circular]";
+        }
+        seen.add(currentValue);
+      }
+
+      return currentValue;
+    });
+  } catch {
+    return String(value);
+  }
 }

--- a/app/src/lib/ai/ax/programs/summaries/__tests__/generate.test.ts
+++ b/app/src/lib/ai/ax/programs/summaries/__tests__/generate.test.ts
@@ -56,7 +56,7 @@ describe("createAxSummaryGenerationService", () => {
 
     const service = createAxSummaryGenerationService({
       ai: {} as never,
-      defaultModel: "deepseek/deepseek-v3.2",
+      defaultModel: "z-ai/glm-4.7",
       maxAttempts: 3,
       spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
       testPrograms: {
@@ -95,7 +95,34 @@ describe("createAxSummaryGenerationService", () => {
 
     const service = createAxSummaryGenerationService({
       ai: {} as never,
-      defaultModel: "deepseek/deepseek-v3.2",
+      defaultModel: "z-ai/glm-4.7",
+      maxAttempts: 3,
+      spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
+      testPrograms: {
+        onelinerProgram: onelinerStub.program,
+        topicProgram: topicStub.program,
+      },
+    });
+
+    const result = await service.generate(BASE_REQUEST);
+
+    expect(result.topics).toEqual(VALID_TOPIC_OUTPUT.topics);
+    expect(topicStub.getCallCount()).toBe(2);
+    expect(onelinerStub.getCallCount()).toBe(1);
+  });
+
+  test("retries when topics is not an array and succeeds later", async () => {
+    const topicStub = createProgramStub<TopicExtractionInput, TopicExtractionOutput>([
+      { topics: { title: "wrong-shape" } },
+      VALID_TOPIC_OUTPUT,
+    ]);
+    const onelinerStub = createProgramStub<OnelinerGenerationInput, OnelinerGenerationOutput>([
+      { oneliner: "Daily thread focused on launch risks and mitigations." },
+    ]);
+
+    const service = createAxSummaryGenerationService({
+      ai: {} as never,
+      defaultModel: "z-ai/glm-4.7",
       maxAttempts: 3,
       spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
       testPrograms: {
@@ -121,7 +148,7 @@ describe("createAxSummaryGenerationService", () => {
 
     const service = createAxSummaryGenerationService({
       ai: {} as never,
-      defaultModel: "deepseek/deepseek-v3.2",
+      defaultModel: "z-ai/glm-4.7",
       maxAttempts: 3,
       spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
       testPrograms: {
@@ -155,7 +182,7 @@ describe("createAxSummaryGenerationService", () => {
 
     const service = createAxSummaryGenerationService({
       ai: {} as never,
-      defaultModel: "deepseek/deepseek-v3.2",
+      defaultModel: "z-ai/glm-4.7",
       maxAttempts: 1,
       spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
       testPrograms: {
@@ -180,7 +207,7 @@ describe("createAxSummaryGenerationService", () => {
 
     const service = createAxSummaryGenerationService({
       ai: {} as never,
-      defaultModel: "deepseek/deepseek-v3.2",
+      defaultModel: "z-ai/glm-4.7",
       maxAttempts: 3,
       spec: DEFAULT_SUMMARY_PROGRAM_SPEC,
       testPrograms: {

--- a/app/src/lib/ai/ax/programs/summaries/generate.ts
+++ b/app/src/lib/ai/ax/programs/summaries/generate.ts
@@ -193,9 +193,8 @@ function createTopicProgram(
   });
 
   program.setExamples(spec.topicExtraction.examples);
-  for (const assertion of spec.topicExtraction.assertions) {
-    program.addAssert((values) => assertion(values as TopicExtractionOutput));
-  }
+  // Runtime assertions are enforced in runAxProgram() via `asserts` + normalizeOutput.
+  // Keeping Ax internal addAssert() disabled avoids brittle provider-side repair loops.
 
   return program;
 }
@@ -211,9 +210,8 @@ function createOnelinerProgram(
   });
 
   program.setExamples(spec.oneliner.examples);
-  for (const assertion of spec.oneliner.assertions) {
-    program.addAssert((values) => assertion(values as OnelinerGenerationOutput));
-  }
+  // Runtime assertions are enforced in runAxProgram() via `asserts` + normalizeOutput.
+  // Keeping Ax internal addAssert() disabled avoids brittle provider-side repair loops.
 
   return program;
 }

--- a/app/src/lib/core/config/__tests__/server.test.ts
+++ b/app/src/lib/core/config/__tests__/server.test.ts
@@ -118,7 +118,7 @@ describe("server config", () => {
   });
 
   test("returns Ax summary defaults when env values are not set", () => {
-    expect(serverEnv.axSummaryModelDefault).toBe("deepseek/deepseek-v3.2");
+    expect(serverEnv.axSummaryModelDefault).toBe("z-ai/glm-4.7");
     expect(serverEnv.axSummaryMaxAttempts).toBe(3);
     expect(serverEnv.axSummaryExamplesVersion).toBe("v1");
     expect(serverEnv.axSummaryEnableTelemetry).toBe(true);

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -81,7 +81,7 @@ export const serverEnv = {
     return (
       getOptionalEnv("AX_SUMMARY_MODEL_DEFAULT") ??
       getOptionalEnv("SUMMARY_AX_MODEL") ??
-      "deepseek/deepseek-v3.2"
+      "z-ai/glm-4.7"
     );
   },
   get axSummaryMaxAttempts(): number {

--- a/app/src/lib/telegram/bot-api/__tests__/summaries.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summaries.test.ts
@@ -84,7 +84,7 @@ describe("generateOrGetSummaryForRun", () => {
             diagnostics: {
               attempts: 2,
               failureReasons: [],
-              finalModel: "deepseek/deepseek-v3.2",
+              finalModel: "z-ai/glm-4.7",
               latencyMs: 120,
               usedExampleSet: "summaries/examples/v1",
             },
@@ -99,7 +99,7 @@ describe("generateOrGetSummaryForRun", () => {
           };
         },
       },
-      summaryModelResolver: () => "deepseek/deepseek-v3.2",
+      summaryModelResolver: () => "z-ai/glm-4.7",
     });
   });
 
@@ -178,7 +178,7 @@ describe("generateOrGetSummaryForRun", () => {
     expect(summaryGenerationCalls).toHaveLength(1);
     expect(summaryGenerationCalls[0]).toMatchObject({
       dayKeyUtc: "2026-02-13",
-      modelKey: "deepseek/deepseek-v3.2",
+      modelKey: "z-ai/glm-4.7",
       participants: ["User1", "User2", "User3", "User4", "User5"],
     });
     expect(insertedSummaryValues).toHaveLength(1);

--- a/docs/miniapp/environment-vars.md
+++ b/docs/miniapp/environment-vars.md
@@ -25,7 +25,7 @@ Environment access is centralized in:
 | `NEXT_PUBLIC_SERVER_HOST` | `core/api.ts` | Base URL for API endpoints |
 | `DEPLOYMENT_PK` | `solana/wallet/gasless-keypair.server.ts` | Gasless payer keypair (required for gasless claim flow) |
 | `NEXT_PUBLIC_GAS_PUBLIC_KEY` | `solana/wallet/` | Public key for gasless payer |
-| `AX_SUMMARY_MODEL_DEFAULT` | `core/config/server.ts` | Default Ax summary model (fallback: `SUMMARY_AX_MODEL`, then `deepseek/deepseek-v3.2`) |
+| `AX_SUMMARY_MODEL_DEFAULT` | `core/config/server.ts` | Default Ax summary model (fallback: `SUMMARY_AX_MODEL`, then `z-ai/glm-4.7`) |
 | `AX_SUMMARY_MAX_ATTEMPTS` | `core/config/server.ts` | Max bounded attempts for Ax summary generation (default: `3`) |
 | `AX_SUMMARY_EXAMPLES_VERSION` | `core/config/server.ts` | Version key for summary example/rule assets (default: `v1`) |
 | `AX_SUMMARY_ENABLE_TELEMETRY` | `core/config/server.ts` | Enables runtime telemetry logging for Ax summary runs (default: `true`) |
@@ -71,12 +71,12 @@ NEXT_PUBLIC_SOLANA_ENV=devnet
 # AI
 REDPILL_AI_API_KEY=your_api_key
 # Optional - Ax summary runtime tuning
-# AX_SUMMARY_MODEL_DEFAULT=deepseek/deepseek-v3.2
+# AX_SUMMARY_MODEL_DEFAULT=z-ai/glm-4.7
 # AX_SUMMARY_MAX_ATTEMPTS=3
 # AX_SUMMARY_EXAMPLES_VERSION=v1
 # AX_SUMMARY_ENABLE_TELEMETRY=true
 # Legacy alias still supported
-# SUMMARY_AX_MODEL=deepseek/deepseek-v3.2
+# SUMMARY_AX_MODEL=z-ai/glm-4.7
 
 # Database
 DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/dbname?sslmode=require

--- a/packages/llm-server/README.md
+++ b/packages/llm-server/README.md
@@ -29,7 +29,7 @@ const result = await runAxProgram({
   ai,
   input,
   label: "feature.program",
-  model: "deepseek/deepseek-v3.2",
+  model: "z-ai/glm-4.7",
   normalizeOutput: (output) => output,
   program,
   retryPolicy: { maxAttempts: 3 },

--- a/packages/llm-server/src/__tests__/program-runner.test.ts
+++ b/packages/llm-server/src/__tests__/program-runner.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { LlmProviderError, LlmValidationError } from "@loyal-labs/llm-core";
+import {
+  LlmProviderError,
+  LlmRetryExhaustedError,
+  LlmValidationError,
+} from "@loyal-labs/llm-core";
 
 import { runAxProgram } from "../program-runner";
 
@@ -66,5 +70,73 @@ describe("runAxProgram", () => {
     ).rejects.toBeInstanceOf(LlmProviderError);
 
     expect(callCount).toBe(1);
+  });
+
+  test("preserves wrapped error cause/details and emits telemetry diagnostics", async () => {
+    const telemetryEvents: Array<Record<string, unknown>> = [];
+    const underlyingError = new Error("Generate failed", {
+      cause: new Error("Unable to fix validation error: topics must be an array"),
+    }) as Error & {
+      details?: Record<string, unknown>;
+    };
+    underlyingError.name = "AxGenerateError";
+    underlyingError.details = {
+      model: "z-ai/glm-4.7",
+      streaming: true,
+    };
+
+    let thrown: unknown;
+
+    await runAxProgram({
+      ai: {} as never,
+      input: { foo: "bar" },
+      label: "test.program",
+      model: "test-model",
+      normalizeOutput: (output: { value: string }) => output.value,
+      program: {
+        forward: async () => {
+          throw underlyingError;
+        },
+      },
+      retryPolicy: {
+        initialDelayMs: 0,
+        jitterRatio: 0,
+        maxAttempts: 1,
+      },
+      telemetry: (event) => telemetryEvents.push(event as unknown as Record<string, unknown>),
+    }).catch((error) => {
+      thrown = error;
+    });
+
+    expect(thrown).toBeInstanceOf(LlmRetryExhaustedError);
+    expect((thrown as Error).message).toContain("Generate failed");
+    expect((thrown as LlmRetryExhaustedError).failureReasons).toEqual([
+      "Generate failed",
+    ]);
+
+    expect(telemetryEvents.length).toBe(1);
+    expect(telemetryEvents[0]).toMatchObject({
+      attempt: 1,
+      errorCauseMessage: "Generate failed",
+      errorMessage: "Generate failed",
+      errorName: LlmProviderError.name,
+      event: "llm_attempt_failed",
+      model: "test-model",
+      program: "test.program",
+    });
+
+    const llmErrorDetails = (
+      telemetryEvents[0].errorDetails as { llmErrorDetails?: string } | undefined
+    )?.llmErrorDetails;
+    expect(llmErrorDetails).toContain('"program":"test.program"');
+    expect(llmErrorDetails).toContain(
+      '"cause":"Unable to fix validation error: topics must be an array"'
+    );
+    const parsedLlmErrorDetails = JSON.parse(llmErrorDetails ?? "{}") as {
+      errorDetails?: { details?: string };
+    };
+    expect(parsedLlmErrorDetails.errorDetails?.details).toContain(
+      '"model":"z-ai/glm-4.7"'
+    );
   });
 });

--- a/packages/llm-server/src/program-runner.ts
+++ b/packages/llm-server/src/program-runner.ts
@@ -3,6 +3,7 @@ import {
   getErrorMessage,
   isRetryableLlmError,
   LlmAssertionError,
+  LlmError,
   LlmProviderError,
   LlmValidationError,
   runWithRetryPolicy,
@@ -10,7 +11,7 @@ import {
   type RetryPolicy,
 } from "@loyal-labs/llm-core";
 
-import type { LlmTelemetrySink } from "./telemetry";
+import type { LlmTelemetryEvent, LlmTelemetrySink } from "./telemetry";
 
 export type AxProgramLike<TInput, TOutput> = {
   forward: (
@@ -48,9 +49,12 @@ export async function runAxProgram<TInput, TOutput, TResult>(
   const runResult = await runWithRetryPolicy({
     label: params.label,
     onAttemptFailure: (failure) => {
+      const errorFields = buildTelemetryErrorFields(failure.error);
+
       params.telemetry?.({
         attempt: failure.attempt,
         errorMessage: failure.reason,
+        ...errorFields,
         event: "llm_attempt_failed",
         latencyMs: Date.now() - startTimeMs,
         model: params.model,
@@ -81,12 +85,33 @@ export async function runAxProgram<TInput, TOutput, TResult>(
           throw error;
         }
 
-        throw new LlmProviderError(getErrorMessage(error), {
-          details: {
-            program: params.label,
-          },
+        const wrappedErrorDetails: Record<string, unknown> = {
+          program: params.label,
+        };
+
+        if (error instanceof Error) {
+          const errorDetails = extractErrorDetails(error);
+          const errorCauseMessage = getErrorCauseMessage(error);
+
+          if (Object.keys(errorDetails).length > 0) {
+            wrappedErrorDetails.errorDetails = errorDetails;
+          }
+
+          if (errorCauseMessage) {
+            wrappedErrorDetails.cause = errorCauseMessage;
+          }
+        }
+
+        const wrappedProviderError = new LlmProviderError(getErrorMessage(error), {
+          details: wrappedErrorDetails,
           retryable: true,
         });
+
+        if (error instanceof Error) {
+          (wrappedProviderError as Error & { cause?: unknown }).cause = error;
+        }
+
+        throw wrappedProviderError;
       }
 
       try {
@@ -121,4 +146,125 @@ export async function runAxProgram<TInput, TOutput, TResult>(
     diagnostics,
     value: runResult.value,
   };
+}
+
+const MAX_ERROR_FIELD_LENGTH = 2_000;
+
+function buildTelemetryErrorFields(error: unknown): Pick<
+  LlmTelemetryEvent,
+  "errorCauseMessage" | "errorDetails" | "errorName" | "errorStack"
+> {
+  if (!(error instanceof Error)) {
+    return {
+      errorDetails: {
+        nonErrorValue: truncateValue(stringifyUnknown(error)),
+      },
+    };
+  }
+
+  const details = extractErrorDetails(error);
+  const errorStack = error.stack
+    ? truncateValue(error.stack.split("\n").slice(0, 6).join("\n"))
+    : undefined;
+
+  return {
+    errorCauseMessage: getErrorCauseMessage(error),
+    errorDetails: Object.keys(details).length > 0 ? details : undefined,
+    errorName: error.name,
+    errorStack,
+  };
+}
+
+function extractErrorDetails(error: Error): Record<string, string> {
+  const details: Record<string, string> = {};
+  const baseRecord = error as Error & Record<string, unknown>;
+
+  if (error instanceof LlmError && error.details) {
+    details.llmErrorDetails = truncateValue(stringifyUnknown(error.details));
+  }
+
+  if (baseRecord.details !== undefined) {
+    details.details = truncateValue(stringifyUnknown(baseRecord.details));
+  }
+
+  const directKeys = ["code", "status", "statusCode", "type", "param", "requestId"];
+  for (const key of directKeys) {
+    const value = baseRecord[key];
+    if (value !== undefined) {
+      details[key] = truncateValue(stringifyUnknown(value));
+    }
+  }
+
+  const response = baseRecord.response;
+  if (response !== undefined) {
+    details.response = truncateValue(stringifyUnknown(response));
+  }
+
+  return details;
+}
+
+function getErrorCauseMessage(error: Error): string | undefined {
+  const maybeErrorWithCause = error as Error & {
+    cause?: unknown;
+  };
+
+  if (maybeErrorWithCause.cause === undefined) {
+    return undefined;
+  }
+
+  if (maybeErrorWithCause.cause instanceof Error) {
+    return truncateValue(maybeErrorWithCause.cause.message);
+  }
+
+  return truncateValue(stringifyUnknown(maybeErrorWithCause.cause));
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return String(value);
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  try {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (_key, currentValue) => {
+      if (typeof currentValue === "bigint") {
+        return currentValue.toString();
+      }
+
+      if (typeof currentValue === "function") {
+        return `[Function ${currentValue.name || "anonymous"}]`;
+      }
+
+      if (typeof currentValue === "object" && currentValue !== null) {
+        if (seen.has(currentValue)) {
+          return "[Circular]";
+        }
+        seen.add(currentValue);
+      }
+
+      return currentValue;
+    });
+  } catch {
+    return String(value);
+  }
+}
+
+function truncateValue(value: string): string {
+  if (value.length <= MAX_ERROR_FIELD_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_ERROR_FIELD_LENGTH)}…(truncated)`;
 }

--- a/packages/llm-server/src/telemetry.ts
+++ b/packages/llm-server/src/telemetry.ts
@@ -1,6 +1,10 @@
 export type LlmTelemetryEvent = {
   attempt?: number;
+  errorCauseMessage?: string;
+  errorDetails?: Record<string, string>;
   errorMessage?: string;
+  errorName?: string;
+  errorStack?: string;
   event: "llm_attempt_failed" | "llm_completed";
   latencyMs: number;
   model: string;
@@ -15,11 +19,24 @@ export function createConsoleTelemetrySink(enabled: boolean): LlmTelemetrySink {
   }
 
   return (event) => {
+    const payload = safeStringify(event);
+
     if (event.event === "llm_attempt_failed") {
-      console.warn("[llm-server]", JSON.stringify(event));
+      console.warn("[llm-server]", payload);
       return;
     }
 
-    console.info("[llm-server]", JSON.stringify(event));
+    console.info("[llm-server]", payload);
   };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return JSON.stringify({
+      event: "llm_telemetry_serialization_failed",
+      fallbackValue: String(value),
+    });
+  }
 }


### PR DESCRIPTION
Move summary runtime validation out of Ax internal asserts and enforce it in runAxProgram retries to prevent topic extraction repair-loop failures. Also improve llm-server error telemetry/cause propagation and switch the default summary model to z-ai/glm-4.7 with aligned tests/docs.