### PR TITLE
feat(admin): make community active status one-click editable

### DIFF
--- a/admin/src/app/(admin)/communities/community-active-checkbox.tsx
+++ b/admin/src/app/(admin)/communities/community-active-checkbox.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+
+import { setCommunityActiveStatus } from "./community-list-actions";
+
+type CommunityActiveCheckboxProps = {
+  communityId: string;
+  initialChecked: boolean;
+  ariaLabel?: string;
+};
+
+export function CommunityActiveCheckbox({
+  communityId,
+  initialChecked,
+  ariaLabel = "Toggle community active status",
+}: CommunityActiveCheckboxProps) {
+  const router = useRouter();
+  const [checked, setChecked] = useState(initialChecked);
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setChecked(initialChecked);
+  }, [initialChecked]);
+
+  function handleChange(nextChecked: boolean) {
+    const previousChecked = checked;
+    setChecked(nextChecked);
+
+    startTransition(async () => {
+      const result = await setCommunityActiveStatus(communityId, nextChecked);
+      if ("error" in result) {
+        setChecked(previousChecked);
+        return;
+      }
+
+      router.refresh();
+    });
+  }
+
+  return (
+    <input
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      disabled={pending}
+      onChange={(event) => handleChange(event.target.checked)}
+      className="size-4 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+    />
+  );
+}

--- a/admin/src/app/(admin)/communities/community-list-actions.ts
+++ b/admin/src/app/(admin)/communities/community-list-actions.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { revalidatePath, revalidateTag } from "next/cache";
+import { eq } from "drizzle-orm";
+
+import { getDatabase } from "@/lib/core/database";
+import { CACHE_TAGS, communityTag } from "@/lib/data-cache";
+import { communities } from "@loyal-labs/db-core/schema";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type CommunityActionResult = { success: true } | { error: string };
+
+export async function setCommunityActiveStatus(
+  communityId: string,
+  nextIsActive: boolean,
+): Promise<CommunityActionResult> {
+  if (!UUID_PATTERN.test(communityId)) {
+    return { error: "Invalid community ID" };
+  }
+
+  const db = getDatabase();
+
+  try {
+    const updatedRows = nextIsActive
+      ? await db
+          .update(communities)
+          .set({
+            isActive: true,
+            updatedAt: new Date(),
+          })
+          .where(eq(communities.id, communityId))
+          .returning({ id: communities.id })
+      : await db
+          .update(communities)
+          .set({
+            isActive: false,
+            summaryNotificationsEnabled: false,
+            updatedAt: new Date(),
+          })
+          .where(eq(communities.id, communityId))
+          .returning({ id: communities.id });
+
+    if (updatedRows.length === 0) {
+      return { error: "Community not found" };
+    }
+  } catch {
+    return { error: "Failed to update community status" };
+  }
+
+  revalidateTag(communityTag(communityId));
+  revalidateTag(CACHE_TAGS.communitiesList);
+  revalidateTag(CACHE_TAGS.overview);
+  revalidatePath(`/communities/${communityId}`);
+
+  return { success: true };
+}

--- a/admin/src/app/(admin)/communities/page.tsx
+++ b/admin/src/app/(admin)/communities/page.tsx
@@ -28,6 +28,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CommunityActiveCheckbox } from "./community-active-checkbox";
 
 export const dynamic = "force-dynamic";
 
@@ -315,11 +316,11 @@ export default async function Home({ searchParams }: HomePageProps) {
                   </TableCell>
                   <TableCell>{String(community.chatId)}</TableCell>
                   <TableCell>
-                    {community.isActive ? (
-                      <CheckIcon aria-label="Active" className="size-4 text-foreground" />
-                    ) : (
-                      <XIcon aria-label="Inactive" className="size-4 text-muted-foreground" />
-                    )}
+                    <CommunityActiveCheckbox
+                      communityId={community.id}
+                      initialChecked={community.isActive}
+                      ariaLabel={`Set ${community.chatTitle} active`}
+                    />
                   </TableCell>
                   <TableCell>
                     {community.summaryNotificationsEnabled ? (


### PR DESCRIPTION
Replaces the Communities table Active tick/cross with a one-click checkbox in admin. Keeps Notifications and Public as read-only icons while preserving existing behavior that disabling Active also disables summary notifications.