### PR TITLE
feat(ui): constrain content width on wallet and summaries pages

### DIFF
--- a/app/src/app/telegram/summaries/direct/page.tsx
+++ b/app/src/app/telegram/summaries/direct/page.tsx
@@ -543,7 +543,7 @@ function DirectFeedContent() {
 
   return (
     <main
-      className="font-sans overflow-hidden relative flex flex-col"
+      className="font-sans overflow-hidden relative flex flex-col max-w-md mx-auto w-full"
       style={{ background: "#ffffff", height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Header */}

--- a/app/src/app/telegram/summaries/page.tsx
+++ b/app/src/app/telegram/summaries/page.tsx
@@ -408,7 +408,7 @@ export default function SummariesPage() {
 
   return (
     <main
-      className="text-foreground font-sans overflow-y-auto relative flex flex-col"
+      className="text-foreground font-sans overflow-y-auto relative flex flex-col max-w-md mx-auto w-full"
       style={{ background: "#fff", height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Header - fixed at top */}

--- a/app/src/app/telegram/wallet/page.tsx
+++ b/app/src/app/telegram/wallet/page.tsx
@@ -971,7 +971,7 @@ export default function Home() {
         />
       )}
       <main
-        className="min-h-screen font-sans overflow-hidden relative flex flex-col"
+        className="min-h-screen font-sans overflow-hidden relative flex flex-col max-w-md mx-auto w-full"
         style={{ background: "#fff" }}
       >
         <StickyBalancePill

--- a/app/src/components/telegram/BottomButtonBar.tsx
+++ b/app/src/components/telegram/BottomButtonBar.tsx
@@ -49,7 +49,7 @@ export function BottomButtonBar() {
   return createPortal(
     <div
       id={BUTTON_BAR_ID}
-      className="pointer-events-none fixed bottom-0 left-0 right-0 z-[10000]"
+      className="pointer-events-none fixed bottom-0 left-0 right-0 z-[10000] max-w-md mx-auto"
       style={{ display: hasButtons ? "flex" : "none" }}
     >
       <div

--- a/app/src/components/wallet/ActivitySheet.tsx
+++ b/app/src/components/wallet/ActivitySheet.tsx
@@ -286,7 +286,7 @@ export default function ActivitySheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/BalanceBackgroundPicker.tsx
+++ b/app/src/components/wallet/BalanceBackgroundPicker.tsx
@@ -339,7 +339,7 @@ export default function BalanceBackgroundPicker({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/ReceiveSheet.tsx
+++ b/app/src/components/wallet/ReceiveSheet.tsx
@@ -396,7 +396,7 @@ export default function ReceiveSheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -793,7 +793,7 @@ export default function SendSheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/SwapSheet.tsx
+++ b/app/src/components/wallet/SwapSheet.tsx
@@ -897,7 +897,7 @@ export default function SwapSheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/TokensSheet.tsx
+++ b/app/src/components/wallet/TokensSheet.tsx
@@ -201,7 +201,7 @@ export default function TokensSheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",

--- a/app/src/components/wallet/TransactionDetailsSheet.tsx
+++ b/app/src/components/wallet/TransactionDetailsSheet.tsx
@@ -522,7 +522,7 @@ export default function TransactionDetailsSheet({
       <div
         ref={sheetRef}
         onTransitionEnd={handleTransitionEnd}
-        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans"
+        className="fixed left-0 right-0 bottom-0 z-[9999] flex flex-col bg-white rounded-t-[38px] font-sans max-w-md mx-auto"
         style={{
           top: sheetTopOffset,
           transform: show ? "translateY(0)" : "translateY(100%)",


### PR DESCRIPTION
Adds max-w-md centered constraint to wallet page, summaries pages, all wallet sheet modals, and the bottom button bar to match the profile page layout on wide screens.