### PR TITLE
docs(user-docs): clean up private transactions docs

### DIFF
--- a/user-docs/docs.json
+++ b/user-docs/docs.json
@@ -18,7 +18,7 @@
         "tab": "Developers",
         "groups": [
           {
-            "group": "Private Transactions SDK",
+            "group": "Private Transactions",
             "pages": [
               "sdk/private-transactions/quick-start",
               "sdk/private-transactions/how-it-works",

--- a/user-docs/sdk/private-transactions/cli.mdx
+++ b/user-docs/sdk/private-transactions/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Usage"
+title: "CLI"
 description: "Use the repository private-transfer CLI script for delegate/send/claim flows"
 ---
 

--- a/user-docs/sdk/private-transactions/how-it-works.mdx
+++ b/user-docs/sdk/private-transactions/how-it-works.mdx
@@ -11,6 +11,22 @@ The flow spans two execution domains:
 2. **MagicBlock PER** — execute private balance updates (transfers, claims) with sub-second latency inside TEE.
 3. **Commit back to base** — undelegate to finalize PER state on the base chain.
 
+## Lifecycle Diagram
+
+```
+┌─────────────── Base Solana ────────────────┐     ┌────── MagicBlock PER (TEE) ──────┐
+│                                            │     │                                   │
+│  1. initializeDeposit                      │     │                                   │
+│  2. modifyBalance (tokens → vault)         │     │                                   │
+│  3. createPermission                       │     │                                   │
+│  4. delegate ─────────────────────────────────►  │  5. transferDeposit               │
+│                                            │     │     transferToUsernameDeposit     │
+│                                            │     │     claimUsernameDepositToDeposit │
+│  7. modifyBalance (vault → tokens)   ◄────────── │  6. undelegate (commit)           │
+│                                            │     │                                   │
+└────────────────────────────────────────────┘     └───────────────────────────────────┘
+```
+
 ## Source of Truth
 
 | Component | Location |
@@ -109,22 +125,6 @@ All transfer operations happen on delegated accounts inside PER:
 - **Claim**: `claimUsernameDepositToDeposit` — recipient proves Telegram identity and claims to their deposit
 
 These only update `amount` fields — no actual token movement occurs until unshield.
-
-## Lifecycle Diagram
-
-```
-┌─────────────── Base Solana ────────────────┐     ┌────── MagicBlock PER (TEE) ──────┐
-│                                            │     │                                   │
-│  1. initializeDeposit                      │     │                                   │
-│  2. modifyBalance (tokens → vault)         │     │                                   │
-│  3. createPermission                       │     │                                   │
-│  4. delegate ─────────────────────────────────►  │  5. transferDeposit               │
-│                                            │     │     transferToUsernameDeposit     │
-│                                            │     │     claimUsernameDepositToDeposit │
-│  7. modifyBalance (vault → tokens)   ◄────────── │  6. undelegate (commit)           │
-│                                            │     │                                   │
-└────────────────────────────────────────────┘     └───────────────────────────────────┘
-```
 
 ## MagicBlock PER Integration
 

--- a/user-docs/sdk/private-transactions/quick-start.mdx
+++ b/user-docs/sdk/private-transactions/quick-start.mdx
@@ -3,8 +3,6 @@ title: "Quick Start"
 description: "Quick start guide for Loyal's Private Transactions SDK"
 ---
 
-`@loyal-labs/private-transactions` is the SDK for private SPL token transfer flows backed by the `telegram-private-transfer` program and [MagicBlock Private Ephemeral Rollups (PER)](https://docs.magicblock.gg/pages/private-ephemeral-rollups-pers/introduction/authorization).
-
 ## Installation
 
 ```bash
@@ -86,7 +84,7 @@ await client.delegateDeposit({
 
 Your deposit is now private — only you can see it inside PER.
 
-## Private Transfer on PER
+## Private Transfers
 
 Transfer to another user by Telegram username. The destination username deposit must already exist and be delegated.
 
@@ -158,4 +156,4 @@ await client.modifyBalance({
 
 - Read [How It Works](/sdk/private-transactions/how-it-works) for the full base-layer + PER lifecycle and smart contract details.
 - See [API Reference](/sdk/private-transactions/reference) for all method signatures and types.
-- Use [CLI Guide](/sdk/private-transactions/cli) to execute the same flow via `bun scripts/telegram-private-transfer.ts`.
+- Use [CLI](/sdk/private-transactions/cli) to execute the same flow via `bun scripts/telegram-private-transfer.ts`.

--- a/user-docs/sdk/transactions/errors.mdx
+++ b/user-docs/sdk/transactions/errors.mdx
@@ -12,5 +12,5 @@ Use the new docs:
 - [Quick Start](/sdk/private-transactions/quick-start)
 - [How It Works](/sdk/private-transactions/how-it-works)
 - [API Reference](/sdk/private-transactions/reference)
-- [CLI Usage](/sdk/private-transactions/cli)
+- [CLI](/sdk/private-transactions/cli)
 - [Error Handling](/sdk/private-transactions/errors)

--- a/user-docs/sdk/transactions/quick-start.mdx
+++ b/user-docs/sdk/transactions/quick-start.mdx
@@ -12,5 +12,5 @@ Use the new docs:
 - [Quick Start](/sdk/private-transactions/quick-start)
 - [How It Works](/sdk/private-transactions/how-it-works)
 - [API Reference](/sdk/private-transactions/reference)
-- [CLI Usage](/sdk/private-transactions/cli)
+- [CLI](/sdk/private-transactions/cli)
 - [Error Handling](/sdk/private-transactions/errors)

--- a/user-docs/sdk/transactions/reference.mdx
+++ b/user-docs/sdk/transactions/reference.mdx
@@ -12,5 +12,5 @@ Use the new docs:
 - [Quick Start](/sdk/private-transactions/quick-start)
 - [How It Works](/sdk/private-transactions/how-it-works)
 - [API Reference](/sdk/private-transactions/reference)
-- [CLI Usage](/sdk/private-transactions/cli)
+- [CLI](/sdk/private-transactions/cli)
 - [Error Handling](/sdk/private-transactions/errors)

--- a/user-docs/sdk/transactions/usage.mdx
+++ b/user-docs/sdk/transactions/usage.mdx
@@ -12,5 +12,5 @@ Use the new docs:
 - [Quick Start](/sdk/private-transactions/quick-start)
 - [How It Works](/sdk/private-transactions/how-it-works)
 - [API Reference](/sdk/private-transactions/reference)
-- [CLI Usage](/sdk/private-transactions/cli)
+- [CLI](/sdk/private-transactions/cli)
 - [Error Handling](/sdk/private-transactions/errors)


### PR DESCRIPTION
Refines the Mintlify private transactions docs by tightening labels, moving the lifecycle diagram earlier, and cleaning up CLI naming across the docs set.

Also updates legacy redirect links so the navigation reads consistently.