### PR TITLE
refactor(frontend): share llm chat provider config via llm-core

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@irys/upload-solana": "^0.1.8",
     "@irys/web-upload": "^0.0.15",
     "@irys/web-upload-solana": "^0.1.8",
+    "@loyal-labs/llm-core": "workspace:*",
     "@loyal-labs/transactions": "workspace:*",
     "@nillion/nilai-ts": "^0.2.0",
     "@nillion/nuc": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "generate-grpc": "buf generate src/lib/proto",
+    "prebuild": "bun run --cwd .. build:llm-packages",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/frontend/src/app/api/chat/route.ts
+++ b/frontend/src/app/api/chat/route.ts
@@ -1,22 +1,16 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { resolveLlmProviderConfig } from "@loyal-labs/llm-core";
 import { convertToModelMessages, streamText, type UIMessage } from "ai";
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
-const customProvider = createOpenAICompatible({
-  baseURL: "https://api.redpill.ai/v1/",
-  name: "loyal-oracle",
-  headers: {
-    Authorization: `Bearer ${process.env.PHALA_API_KEY}`,
-  },
-});
-
-const MODEL_ID = process.env.PHALA_MODEL_ID?.trim() || "loyal-oracle";
-const loyalOracleModel = customProvider.languageModel(MODEL_ID);
+const DEFAULT_MODEL_ID = "loyal-oracle";
+const LOYAL_ORACLE_PROVIDER_NAME = "loyal-oracle";
+const REDPILL_API_BASE_URL = "https://api.redpill.ai/v1/";
 
 export async function POST(req: Request) {
-  if (!process.env.PHALA_API_KEY) {
+  if (!process.env.PHALA_API_KEY?.trim()) {
     console.error("Missing PHALA_API_KEY environment variable.");
     return new Response("Server misconfiguration", { status: 500 });
   }
@@ -26,8 +20,31 @@ export async function POST(req: Request) {
     return new Response("Invalid request payload", { status: 400 });
   }
 
+  const { config, model } = resolveLlmProviderConfig({
+    defaults: {
+      apiKey: process.env.PHALA_API_KEY,
+      model: DEFAULT_MODEL_ID,
+    },
+    overrides: {
+      model: process.env.PHALA_MODEL_ID,
+    },
+    provider: {
+      apiURL: REDPILL_API_BASE_URL,
+      name: "openai",
+    },
+  });
+
+  const customProvider = createOpenAICompatible({
+    baseURL: config.apiURL,
+    name: LOYAL_ORACLE_PROVIDER_NAME,
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      ...(config.headers ?? {}),
+    },
+  });
+
   const result = streamText({
-    model: loyalOracleModel,
+    model: customProvider.languageModel(model),
     system:
       "You are a helpful AI assistant for Loyal, a private intelligence platform.",
     messages: convertToModelMessages(messages),

--- a/packages/llm-core/src/__tests__/provider-config.test.ts
+++ b/packages/llm-core/src/__tests__/provider-config.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import { LlmValidationError } from "../errors";
+import { resolveLlmProviderConfig } from "../provider-config";
+
+describe("resolveLlmProviderConfig", () => {
+  test("returns normalized config using overrides", () => {
+    const result = resolveLlmProviderConfig({
+      defaults: {
+        apiKey: "default-key",
+        model: "default-model",
+      },
+      overrides: {
+        apiKey: "  override-key  ",
+        model: "  override-model  ",
+      },
+      provider: {
+        apiURL: " https://api.example.com/v1 ",
+        headers: {
+          "X-Test": "1",
+        },
+        name: "openai",
+      },
+    });
+
+    expect(result).toEqual({
+      config: {
+        apiKey: "override-key",
+        apiURL: "https://api.example.com/v1",
+        headers: {
+          "X-Test": "1",
+        },
+        name: "openai",
+      },
+      model: "override-model",
+    });
+  });
+
+  test("falls back to default model and provider api key", () => {
+    const result = resolveLlmProviderConfig({
+      defaults: {
+        apiKey: "default-key",
+        model: "default-model",
+      },
+      provider: {
+        apiKey: "provider-key",
+        apiURL: "https://api.example.com/v1",
+      },
+    });
+
+    expect(result.config.apiKey).toBe("provider-key");
+    expect(result.model).toBe("default-model");
+  });
+
+  test("throws LlmValidationError when no api key is resolvable", () => {
+    expect(() =>
+      resolveLlmProviderConfig({
+        defaults: {
+          apiKey: "   ",
+          model: "default-model",
+        },
+        overrides: {
+          apiKey: "",
+        },
+        provider: {
+          apiURL: "https://api.example.com/v1",
+        },
+      })
+    ).toThrow(LlmValidationError);
+
+    expect(() =>
+      resolveLlmProviderConfig({
+        defaults: {
+          apiKey: "   ",
+          model: "default-model",
+        },
+        provider: {
+          apiURL: "https://api.example.com/v1",
+        },
+      })
+    ).toThrow("LLM provider apiKey is required");
+  });
+
+  test("throws LlmValidationError when default model is empty", () => {
+    expect(() =>
+      resolveLlmProviderConfig({
+        defaults: {
+          apiKey: "default-key",
+          model: "   ",
+        },
+        provider: {
+          apiURL: "https://api.example.com/v1",
+        },
+      })
+    ).toThrow(LlmValidationError);
+  });
+
+  test("throws LlmValidationError when provider apiURL is empty", () => {
+    expect(() =>
+      resolveLlmProviderConfig({
+        defaults: {
+          apiKey: "default-key",
+          model: "default-model",
+        },
+        provider: {
+          apiURL: "",
+        },
+      })
+    ).toThrow("LLM provider apiURL is required");
+  });
+});

--- a/packages/llm-core/src/index.ts
+++ b/packages/llm-core/src/index.ts
@@ -20,6 +20,11 @@ export type {
   RetryPolicy,
 } from "./types";
 export {
+  resolveLlmProviderConfig,
+  type ResolvedLlmProviderConfig,
+  type ResolveLlmProviderConfigParams,
+} from "./provider-config";
+export {
   assertValidationResult,
   getErrorMessage,
   normalizeWhitespace,

--- a/packages/llm-core/src/provider-config.ts
+++ b/packages/llm-core/src/provider-config.ts
@@ -1,0 +1,75 @@
+import { LlmValidationError } from "./errors";
+import type { LlmProviderConfig } from "./types";
+
+type OptionalString = string | null | undefined;
+
+export type ResolveLlmProviderConfigParams = {
+  defaults: {
+    apiKey?: OptionalString;
+    model: OptionalString;
+  };
+  overrides?: {
+    apiKey?: OptionalString;
+    model?: OptionalString;
+  };
+  provider: Omit<LlmProviderConfig, "apiKey"> & {
+    apiKey?: OptionalString;
+  };
+};
+
+export type ResolvedLlmProviderConfig = {
+  config: LlmProviderConfig;
+  model: string;
+};
+
+export function resolveLlmProviderConfig(
+  params: ResolveLlmProviderConfigParams
+): ResolvedLlmProviderConfig {
+  const apiURL = toNonEmptyString(params.provider.apiURL);
+  if (!apiURL) {
+    throw new LlmValidationError("LLM provider apiURL is required", {
+      field: "provider.apiURL",
+    });
+  }
+
+  const defaultModel = toNonEmptyString(params.defaults.model);
+  if (!defaultModel) {
+    throw new LlmValidationError("LLM default model is required", {
+      field: "defaults.model",
+    });
+  }
+
+  const resolvedApiKey =
+    toNonEmptyString(params.overrides?.apiKey) ??
+    toNonEmptyString(params.provider.apiKey) ??
+    toNonEmptyString(params.defaults.apiKey);
+
+  if (!resolvedApiKey) {
+    throw new LlmValidationError("LLM provider apiKey is required", {
+      field: "apiKey",
+    });
+  }
+
+  return {
+    config: {
+      apiKey: resolvedApiKey,
+      apiURL,
+      headers: params.provider.headers,
+      name: params.provider.name,
+    },
+    model: toNonEmptyString(params.overrides?.model) ?? defaultModel,
+  };
+}
+
+function toNonEmptyString(value: OptionalString): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
Moves frontend chat provider/model normalization into @loyal-labs/llm-core while keeping the AI SDK chat transport and route contract unchanged. This reduces duplication in /frontend and adds shared validation-backed config resolution with tests.