### PR TITLE
fix(wallet): remove broken clipboard paste button from import wallet

### DIFF
--- a/app/src/app/telegram/profile/keys/page.tsx
+++ b/app/src/app/telegram/profile/keys/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Keypair } from "@solana/web3.js";
-import { backButton, readTextFromClipboard } from "@telegram-apps/sdk";
-import { hapticFeedback, retrieveLaunchParams } from "@telegram-apps/sdk-react";
+import { backButton } from "@telegram-apps/sdk";
+import { hapticFeedback } from "@telegram-apps/sdk-react";
 import bs58 from "bs58";
 import {
   CircleAlert,
@@ -437,14 +437,6 @@ function ImportWalletSheet({
   const [error, setError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
 
-  const [isAndroid] = useState(() => {
-    try {
-      return retrieveLaunchParams().tgWebAppPlatform === "android";
-    } catch {
-      return false;
-    }
-  });
-
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -552,40 +544,6 @@ function ImportWalletSheet({
       hapticFeedback.impactOccurred("medium");
     }
     setStep("input");
-  }, []);
-
-  const handlePasteFromClipboard = useCallback(() => {
-    const applyText = (text: string) => {
-      setInputKey(text.trim());
-      setError(null);
-      if (hapticFeedback.impactOccurred.isAvailable()) {
-        hapticFeedback.impactOccurred("light");
-      }
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tgWebApp = (window as any).Telegram?.WebApp;
-
-    if (tgWebApp?.readTextFromClipboard) {
-      tgWebApp.readTextFromClipboard((text: string | null) => {
-        if (text) applyText(text);
-      });
-      return;
-    }
-
-    if (readTextFromClipboard.isAvailable()) {
-      readTextFromClipboard()
-        .then((text) => { if (text) applyText(text); })
-        .catch(() => {});
-      return;
-    }
-
-    if (navigator?.clipboard?.readText) {
-      navigator.clipboard
-        .readText()
-        .then((text) => { if (text) applyText(text); })
-        .catch(() => {});
-    }
   }, []);
 
   const validatePrivateKey = useCallback(
@@ -880,22 +838,9 @@ function ImportWalletSheet({
                   )}
                 </div>
 
-                {isAndroid ? (
-                  <p className="text-[13px] font-normal leading-4 text-[rgba(60,60,67,0.6)] text-center px-4">
-                    Long-press the text field and select Paste.
-                  </p>
-                ) : (
-                  <button
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={handlePasteFromClipboard}
-                    className="px-4 py-2 rounded-full flex items-center justify-center active:opacity-80 transition-opacity"
-                    style={{ background: "rgba(249, 54, 60, 0.14)" }}
-                  >
-                    <span className="text-[15px] font-normal leading-5 text-black text-center">
-                      Paste From Clipboard
-                    </span>
-                  </button>
-                )}
+                <p className="text-[13px] font-normal leading-4 text-[rgba(60,60,67,0.6)] text-center px-4">
+                  Long-press the text field and select Paste.
+                </p>
               </div>
             </div>
 


### PR DESCRIPTION
Clipboard paste via Telegram SDK doesn't work on iOS or Android. Removes the platform-conditional paste button and shows a universal long-press to paste hint on all platforms.