### PR TITLE
fix(ui): set white overscroll background on iOS Safari

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -153,6 +153,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    background-color: white;
+  }
   body {
     @apply bg-background text-foreground font-sans;
   }


### PR DESCRIPTION
Sets html background-color to white so iOS Safari overscroll (rubber-band) areas show white instead of black.