### PR TITLE
feat(passkey): share passkeys across askloyal subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the Loyal web frontend, shared packages/SDKs, and worker services.
 | [`app/`](./app) | Next.js Telegram mini-app and API routes | [`app/README.md`](./app/README.md) |
 | [`frontend/`](./frontend) | Next.js Loyal web frontend | [`frontend/README.md`](./frontend/README.md) |
 | [`admin/`](./admin) | Internal Next.js admin dashboard | [`admin/README.md`](./admin/README.md) |
+| [`passkey/`](./passkey) | Next.js passkey proxy app for Squads Grid custom-domain WebAuthn flow | [`passkey/README.md`](./passkey/README.md) |
 | [`programs/`](./programs) | Anchor smart contracts (`telegram-transfer`, `telegram-verification`, `telegram-private-transfer`) | [`programs/`](./programs) |
 | [`tests/`](./tests) | Anchor integration tests and fixtures | [`tests/`](./tests) |
 | [`packages/`](./packages) | Shared workspace libraries (`db-core`, `db-adapter-neon`, `llm-core`, `llm-server`) | [`packages/`](./packages) |
@@ -60,6 +61,9 @@ bun run admin:build
 bun run frontend:dev
 bun run frontend:lint
 bun run frontend:build
+bun run passkey:dev
+bun run passkey:lint
+bun run passkey:build
 ```
 
 ### Telegram App (`/app`)

--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,8 @@
     "ai:eval:summaries": "bun run --cwd .. build:llm-packages && bun run src/lib/ai/ax/evals/runner.ts"
   },
   "dependencies": {
-    "@ax-llm/ax": "^14.0.32",
     "@aws-sdk/client-s3": "^3.918.0",
+    "@ax-llm/ax": "^14.0.32",
     "@coral-xyz/anchor": "^0.32.1",
     "@datadog/browser-logs": "^6.27.1",
     "@datadog/browser-rum": "^6.27.1",
@@ -39,6 +39,7 @@
     "@number-flow/react": "^0.5.10",
     "@solana/wallet-adapter-react": "^0.15.39",
     "@solana/web3.js": "1",
+    "@sqds/grid": "^3.1.2",
     "@telegram-apps/bridge": "^2.11.0",
     "@telegram-apps/sdk": "^3.11.8",
     "@telegram-apps/sdk-react": "^3.3.9",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -71,7 +70,7 @@
         "@loyal-labs/db-core": "workspace:*",
         "@loyal-labs/llm-core": "workspace:*",
         "@loyal-labs/llm-server": "workspace:*",
-        "@loyal-labs/private-transactions": "^0.2.2",
+        "@loyal-labs/private-transactions": "^0.2.4",
         "@magicblock-labs/ephemeral-rollups-sdk": "^0.8.5",
         "@neondatabase/serverless": "^1.0.2",
         "@noble/ed25519": "^3.0.0",
@@ -79,6 +78,7 @@
         "@number-flow/react": "^0.5.10",
         "@solana/wallet-adapter-react": "^0.15.39",
         "@solana/web3.js": "1",
+        "@sqds/grid": "^3.1.2",
         "@telegram-apps/bridge": "^2.11.0",
         "@telegram-apps/sdk": "^3.11.8",
         "@telegram-apps/sdk-react": "^3.3.9",
@@ -155,6 +155,7 @@
         "@irys/upload-solana": "^0.1.8",
         "@irys/web-upload": "^0.0.15",
         "@irys/web-upload-solana": "^0.1.8",
+        "@loyal-labs/llm-core": "workspace:*",
         "@loyal-labs/transactions": "workspace:*",
         "@nillion/nilai-ts": "^0.2.0",
         "@nillion/nuc": "^1.0.0",
@@ -171,6 +172,7 @@
         "@solana/wallet-standard-features": "^1.3.0",
         "@solana/wallet-standard-util": "^1.1.2",
         "@solana/web3.js": "^1.98.4",
+        "@sqds/grid": "^3.1.2",
         "@tabler/icons-react": "^3.35.0",
         "@vercel/speed-insights": "^1.2.0",
         "ai": "^5.0.13",
@@ -269,9 +271,28 @@
       "name": "@loyal-labs/shared",
       "version": "0.1.0",
     },
+    "passkey": {
+      "name": "passkey",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sqds/grid": "^3.1.2",
+        "bs58": "^6.0.0",
+        "next": "^15.5.7",
+        "react": "^19.1.2",
+        "react-dom": "^19.1.2",
+        "server-only": "^0.0.1",
+        "zod": "^4.0.17",
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "typescript": "^5",
+      },
+    },
     "sdk/private-transactions": {
       "name": "@loyal-labs/private-transactions",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "dependencies": {
         "tweetnacl": "^1.0.3",
       },
@@ -832,6 +853,12 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
+    "@hpke/chacha20poly1305": ["@hpke/chacha20poly1305@1.7.1", "", { "dependencies": { "@hpke/common": "^1.8.1" } }, "sha512-Zp8IwRIkdCucu877wCNqDp3B8yOhAnAah/YDDkO94pPr/KKV7IGnBbpwIjDB3BsAySWBMrhhdE0JKYw3N4FCag=="],
+
+    "@hpke/common": ["@hpke/common@1.10.0", "", {}, "sha512-uVq9pTNERQ1GcFlHZzQx+a0ZMC81wQzkbNzJPEyR/l3AWM7fASd/qYN2Cnq6uL1NPEfwcD4lgOmfjjZfx2k2XA=="],
+
+    "@hpke/core": ["@hpke/core@1.7.5", "", { "dependencies": { "@hpke/common": "^1.8.1" } }, "sha512-4xfckZuPaIodeu0HpuTRIdtmajhRHXM/6rjS2N62Ns9aOCkGbbeYRwktqR3bUScuhCwyEBsEQqtIh9f0iLP3WQ=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -1081,6 +1108,32 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pfx": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.6.0", "", { "dependencies": { "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
+
+    "@peculiar/json-schema": ["@peculiar/json-schema@1.1.12", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w=="],
+
+    "@peculiar/webcrypto": ["@peculiar/webcrypto@1.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.8", "@peculiar/json-schema": "^1.1.12", "pvtsutils": "^1.3.5", "tslib": "^2.6.2", "webcrypto-core": "^1.8.0" } }, "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.12.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.3.13", "@peculiar/asn1-csr": "^2.3.13", "@peculiar/asn1-ecc": "^2.3.14", "@peculiar/asn1-pkcs9": "^2.3.13", "@peculiar/asn1-rsa": "^2.3.13", "@peculiar/asn1-schema": "^2.3.13", "@peculiar/asn1-x509": "^2.3.13", "pvtsutils": "^1.3.5", "reflect-metadata": "^0.2.2", "tslib": "^2.7.0", "tsyringe": "^4.8.0" } }, "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.3", "", {}, "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g=="],
 
@@ -1478,6 +1531,10 @@
 
     "@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
 
+    "@sqds/grid": ["@sqds/grid@3.1.2", "", { "dependencies": { "@hpke/chacha20poly1305": "1.7.1", "@hpke/core": "1.7.5", "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@solana/web3.js": "1.98.4", "@sqds/grid-crypto": "0.1.5", "@turnkey/crypto": "2.8.3", "asn1js": "3.0.6", "bs58": "6.0.0", "canonicalize": "2.1.0", "fast-text-encoding": "1.0.6", "jose": "6.0.13", "sha256-uint8array": "0.10.7", "text-encoding-utf-8": "1.0.2", "uuid": "11.1.0" } }, "sha512-k6Th+h5x6XQtTw36T64tQy98MxZleCkNDDRjjjBc825lrQzn1W2tM7Rcwa50x2K8uYp5lnFNk76vy2nSChazEg=="],
+
+    "@sqds/grid-crypto": ["@sqds/grid-crypto@0.1.5", "", { "dependencies": { "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@turnkey/crypto": "2.8.7", "buffer": "6.0.3", "canonicalize": "2.1.0", "sha256-uint8array": "0.10.7" } }, "sha512-eu/TolOZZFNa6nvQ9byiRd6nEdGAPoTMKzLd6Fu6RznaqFGR+di/Y+H2eO5gn5HY3KluNmvfykziP7BcPjIZPQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@suchipi/femver": ["@suchipi/femver@1.0.0", "", {}, "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="],
@@ -1541,6 +1598,12 @@
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.19.0", "", { "dependencies": { "fast-glob": "^3.2.12", "minimatch": "^7.4.3", "mkdirp": "^2.1.6", "path-browserify": "^1.0.1" } }, "sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ=="],
+
+    "@turnkey/crypto": ["@turnkey/crypto@2.8.3", "", { "dependencies": { "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.0", "@noble/hashes": "1.8.0", "@peculiar/webcrypto": "1.5.0", "@peculiar/x509": "1.12.3", "@turnkey/encoding": "0.6.0", "@turnkey/sdk-types": "0.6.3", "borsh": "2.0.0", "cbor-js": "0.1.0" } }, "sha512-UfRZrF7xTineWTW6iwRXqsDcyAtXhJNPlGs5+dnfOWRdLrlzVb7J4S2UVdn659TgLHyorh8dE3NJoxIfVUfU9g=="],
+
+    "@turnkey/encoding": ["@turnkey/encoding@0.6.0", "", { "dependencies": { "bs58": "6.0.0", "bs58check": "4.0.0" } }, "sha512-IC8qXvy36+iGAeiaVIuJvB35uU2Ld/RAWI/DRTKS+ttBej0GXhOn48Ouu5mlca4jt8ZEuwXmDVv74A8uBQclsA=="],
+
+    "@turnkey/sdk-types": ["@turnkey/sdk-types@0.6.3", "", {}, "sha512-H/JeypsTeTXA6uh8MyeHpinsaKMagQEwkIrsOEyY6tSVtZDNiaCx3iZLnA3iov9p74ZjjCYVt0nXM5Z6muck7Q=="],
 
     "@twa-dev/types": ["@twa-dev/types@7.10.0", "", {}, "sha512-BXHyNLXy+cPbOZ2qQq5ArPKcP4kUfuX3YBSFT0XUxtMNWAzvyMuYAiq59UTfQ8OnELXlfChrAoIT3c2pujBtcQ=="],
 
@@ -1860,6 +1923,8 @@
 
     "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
 
+    "asn1js": ["asn1js@3.0.6", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA=="],
+
     "assertion-error": ["assertion-error@1.1.0", "", {}, "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
@@ -1952,7 +2017,7 @@
 
     "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
-    "bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
+    "bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
@@ -1984,7 +2049,11 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
+    "canonicalize": ["canonicalize@2.1.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ=="],
+
     "cardinal": ["cardinal@2.1.1", "", { "dependencies": { "ansicolors": "~0.3.2", "redeyed": "~2.1.0" }, "bin": { "cdl": "./bin/cdl.js" } }, "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw=="],
+
+    "cbor-js": ["cbor-js@0.1.0", "", {}, "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -2438,6 +2507,8 @@
 
     "fast-stable-stringify": ["fast-stable-stringify@1.0.0", "", {}, "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="],
 
+    "fast-text-encoding": ["fast-text-encoding@1.0.6", "", {}, "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.0.0", "", {}, "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ=="],
@@ -2846,7 +2917,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.0.13", "", {}, "sha512-Yms4GpbmdANamS51kKK6w4hRlKx8KTxbWyAAKT/MhUMtqbIqh5mb2HjhTNUbk7TFL8/MBB5zWSDohL7ed4k/UA=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
@@ -3334,6 +3405,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "passkey": ["passkey@workspace:passkey"],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
@@ -3436,6 +3509,10 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
@@ -3499,6 +3576,8 @@
     "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "redeyed": ["redeyed@2.1.1", "", { "dependencies": { "esprima": "~4.0.0" } }, "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -3627,6 +3706,8 @@
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sha256-uint8array": ["sha256-uint8array@0.10.7", "", {}, "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ=="],
 
     "shadcn": ["shadcn@3.8.5", "", { "dependencies": { "@antfu/ni": "^25.0.0", "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-jPRx44e+eyeV7xwY3BLJXcfrks00+M0h5BGB9l6DdcBW4BpAj4x3lVmVy0TXPEs2iHEisxejr62sZAAw6B1EVA=="],
 
@@ -3840,6 +3921,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "tween-functions": ["tween-functions@1.2.0", "", {}, "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="],
@@ -3926,7 +4009,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "valibot": ["valibot@1.0.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw=="],
 
@@ -3967,6 +4050,8 @@
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webcrypto-core": ["webcrypto-core@1.8.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.13", "@peculiar/json-schema": "^1.1.12", "asn1js": "^3.0.5", "pvtsutils": "^1.3.5", "tslib": "^2.7.0" } }, "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -4208,6 +4293,8 @@
 
     "@nillion/nuc/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
+    "@nillion/secretvaults/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
     "@phantom/browser-sdk/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@phantom/browser-sdk/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
@@ -4434,6 +4521,8 @@
 
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
+    "@sqds/grid-crypto/@turnkey/crypto": ["@turnkey/crypto@2.8.7", "", { "dependencies": { "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.0", "@noble/hashes": "1.8.0", "@peculiar/x509": "1.12.3", "@turnkey/encoding": "0.6.0", "@turnkey/sdk-types": "0.10.0", "borsh": "2.0.0", "cbor-js": "0.1.0" } }, "sha512-6/wKlP6tum2yZ5jnMrxZ9mUWzoOkMFssTTpB/8YyIyzQm+qYFDqAd53S5seOPGBZWWryA+nsAEsAQMBw9ieYFQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -4453,6 +4542,10 @@
     "@ts-morph/common/minimatch": ["minimatch@7.4.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw=="],
 
     "@ts-morph/common/mkdirp": ["mkdirp@2.1.6", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="],
+
+    "@turnkey/crypto/@noble/curves": ["@noble/curves@1.9.0", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg=="],
+
+    "@turnkey/crypto/borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
 
     "@types/bn.js/@types/node": ["@types/node@24.8.1", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q=="],
 
@@ -4510,6 +4603,8 @@
 
     "bitcoinjs-lib/bech32": ["bech32@2.0.0", "", {}, "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="],
 
+    "bitcoinjs-lib/bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
+
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -4519,8 +4614,6 @@
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "borsh/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
-
-    "bs58check/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "bun-types/@types/node": ["@types/node@24.8.1", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q=="],
 
@@ -4630,6 +4723,8 @@
 
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "flags/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "frontend/@magicblock-labs/ephemeral-rollups-sdk": ["@magicblock-labs/ephemeral-rollups-sdk@0.8.5", "", { "dependencies": { "@phala/dcap-qvl-web": "^0.2.7", "@solana/spl-token": "^0.4.9", "@solana/web3.js": "^1.98.0", "bs58": "^6.0.0", "rpc-websockets": "^9.0.4", "typescript": "^5.3.0" } }, "sha512-W+k38iQ6XSllc4xV0kehTyWSx+j4juozfTxcA3tmZQD61lWzYm9n0m2iyclSxF/KEi3phUwF73Z0+ZE2aIpy1Q=="],
 
     "gel/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -4735,8 +4830,6 @@
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "merge-options/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
-
-    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4938,6 +5031,8 @@
 
     "tsconfig-paths/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ultracite/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -5090,8 +5185,6 @@
 
     "@nillion/nilai-ts/@nillion/nuc/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@nillion/nilai-ts/@nillion/secretvaults/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
-
     "@nillion/nilai-ts/@nillion/secretvaults/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@phantom/crypto/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
@@ -5190,6 +5283,12 @@
 
     "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
+    "@sqds/grid-crypto/@turnkey/crypto/@noble/curves": ["@noble/curves@1.9.0", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg=="],
+
+    "@sqds/grid-crypto/@turnkey/crypto/@turnkey/sdk-types": ["@turnkey/sdk-types@0.10.0", "", {}, "sha512-j/bV1qapTXoTfcsK8dH/KrO4+hBPsFJrebWUU1uPVtTBcPDghWPXn/9mAUUXafD+nSPPqZ5NoiKyOC+xxuDULQ=="],
+
+    "@sqds/grid-crypto/@turnkey/crypto/borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
+
     "@ts-morph/common/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -5222,9 +5321,9 @@
 
     "babel-jest/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+    "bitcoinjs-lib/bs58check/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
-    "bs58check/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+    "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
@@ -5469,6 +5568,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "anchor-client-gen/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "bitcoinjs-lib/bs58check/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "cz-conventional-changelog/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@solana/wallet-standard-features": "^1.3.0",
     "@solana/wallet-standard-util": "^1.1.2",
     "@solana/web3.js": "^1.98.4",
+    "@sqds/grid": "^3.1.2",
     "@tabler/icons-react": "^3.35.0",
     "@vercel/speed-insights": "^1.2.0",
     "ai": "^5.0.13",

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -168,6 +168,7 @@ start_workspace_pipeline() {
 start_workspace_pipeline "app" "app" "app"
 start_workspace_pipeline "admin" "admin" "admin"
 start_workspace_pipeline "frontend" "frontend" "frontend"
+start_workspace_pipeline "passkey" "passkey" "passkey"
 
 any_failed=0
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "admin",
     "app",
     "frontend",
+    "passkey",
     "packages/*",
     "sdk/*",
     "workers/*"
@@ -17,6 +18,9 @@
     "frontend:dev": "bun run --cwd frontend dev",
     "frontend:build": "bun run --cwd frontend build",
     "frontend:lint": "bun run --cwd frontend lint",
+    "passkey:dev": "bun run --cwd passkey dev",
+    "passkey:build": "bun run --cwd passkey build",
+    "passkey:lint": "bun run --cwd passkey lint",
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
     "commitlint:head": "commitlint --from HEAD~1 --to HEAD --verbose",

--- a/passkey/.env.example
+++ b/passkey/.env.example
@@ -1,0 +1,6 @@
+PASSKEY_GRID_ENVIRONMENT=sandbox
+PASSKEY_CUSTOM_DOMAIN_BASE_URL=https://passkey.example.com
+PASSKEY_GRID_API_BASE_URL=https://grid.squads.xyz
+PASSKEY_APP_NAME=askloyal
+# Optional: use API key when your Grid app requires authenticated server requests
+# PASSKEY_GRID_API_KEY=your_grid_api_key

--- a/passkey/.env.example
+++ b/passkey/.env.example
@@ -1,5 +1,7 @@
 PASSKEY_GRID_ENVIRONMENT=sandbox
-PASSKEY_CUSTOM_DOMAIN_BASE_URL=https://passkey.example.com
+PASSKEY_ALLOWED_PARENT_DOMAIN=askloyal.com
+PASSKEY_ALLOW_LOCALHOST=true
+NEXT_PUBLIC_PASSKEY_RP_ID=askloyal.com
 PASSKEY_GRID_API_BASE_URL=https://grid.squads.xyz
 PASSKEY_APP_NAME=askloyal
 # Optional: use API key when your Grid app requires authenticated server requests

--- a/passkey/.eslintrc.json
+++ b/passkey/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/passkey/.gitignore
+++ b/passkey/.gitignore
@@ -1,0 +1,13 @@
+.next
+node_modules
+out
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+!.env.example
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.tsbuildinfo

--- a/passkey/README.md
+++ b/passkey/README.md
@@ -1,0 +1,45 @@
+# passkey
+
+Standalone Next.js workspace for Squads Grid passkey WebAuthn proxy flow on a custom domain.
+
+## What this workspace owns
+
+- Passkey session endpoints proxying (`create`, `authorize`, `submit`)
+- Passkey account endpoints proxying (`create`, `find`, `get`)
+- Minimal browser ceremony pages for `create` and `auth`
+- Custom-domain forwarding requirements (cookies/origin passthrough)
+
+## Environment
+
+Copy `.env.example` to `.env.local`:
+
+```bash
+PASSKEY_GRID_ENVIRONMENT=sandbox
+PASSKEY_CUSTOM_DOMAIN_BASE_URL=https://passkey.example.com
+PASSKEY_GRID_API_BASE_URL=https://grid.squads.xyz
+PASSKEY_APP_NAME=askloyal
+```
+
+Optional:
+
+```bash
+PASSKEY_GRID_API_KEY=<grid_api_key>
+```
+
+## Commands
+
+```bash
+bun dev
+bun run build
+bun run lint
+bun test
+```
+
+## API Surface
+
+- `POST /api/passkeys/session/create`
+- `POST /api/passkeys/session/authorize`
+- `POST /api/passkeys/session/submit`
+- `POST /api/passkeys/account/create`
+- `POST /api/passkeys/account/find`
+- `GET /api/passkeys/account/:passkeyAddress`

--- a/passkey/README.md
+++ b/passkey/README.md
@@ -1,13 +1,15 @@
 # passkey
 
-Standalone Next.js workspace for Squads Grid passkey WebAuthn proxy flow on a custom domain.
+Standalone Next.js workspace for Squads Grid passkey WebAuthn flows shared across
+`askloyal.com` and all `*.askloyal.com` subdomains.
 
 ## What this workspace owns
 
 - Passkey session endpoints proxying (`create`, `authorize`, `submit`)
 - Passkey account endpoints proxying (`create`, `find`, `get`)
-- Minimal browser ceremony pages for `create` and `auth`
-- Custom-domain forwarding requirements (cookies/origin passthrough)
+- Browser ceremony pages for `/continue`, `/create`, and `/auth`
+- Request-host-aware Grid forwarding (origin/cookie passthrough)
+- Explicit WebAuthn RP ID resolution for shared subdomain credentials
 
 ## Environment
 
@@ -15,7 +17,9 @@ Copy `.env.example` to `.env.local`:
 
 ```bash
 PASSKEY_GRID_ENVIRONMENT=sandbox
-PASSKEY_CUSTOM_DOMAIN_BASE_URL=https://passkey.example.com
+PASSKEY_ALLOWED_PARENT_DOMAIN=askloyal.com
+PASSKEY_ALLOW_LOCALHOST=true
+NEXT_PUBLIC_PASSKEY_RP_ID=askloyal.com
 PASSKEY_GRID_API_BASE_URL=https://grid.squads.xyz
 PASSKEY_APP_NAME=askloyal
 ```
@@ -25,6 +29,21 @@ Optional:
 ```bash
 PASSKEY_GRID_API_KEY=<grid_api_key>
 ```
+
+## Host and RP behavior
+
+- `askloyal.com` and any `*.askloyal.com` host are allowed.
+- All allowed `askloyal.com` hosts share the RP ID `askloyal.com`, so one
+  passkey can be reused across those subdomains.
+- `localhost` is supported as a separate dev-only passkey realm when
+  `PASSKEY_ALLOW_LOCALHOST=true`.
+- `localhost` passkeys do not work on `askloyal.com`, and `askloyal.com`
+  passkeys do not work on `localhost`.
+- Unrelated root domains and `127.0.0.1` are not supported by this workspace.
+
+The proxy derives `baseUrl` from the incoming request origin for allowed hosts,
+so `app.askloyal.com` and `admin.askloyal.com` each get their own callback base
+URL while still sharing the same WebAuthn RP ID.
 
 ## Commands
 

--- a/passkey/next.config.ts
+++ b/passkey/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/passkey/package.json
+++ b/passkey/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "passkey",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "bun@1.2.17",
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@sqds/grid": "^3.1.2",
+    "bs58": "^6.0.0",
+    "next": "^15.5.7",
+    "react": "^19.1.2",
+    "react-dom": "^19.1.2",
+    "server-only": "^0.0.1",
+    "zod": "^4.0.17"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/passkey/src/app/api/passkeys/account/[passkeyAddress]/route.ts
+++ b/passkey/src/app/api/passkeys/account/[passkeyAddress]/route.ts
@@ -1,0 +1,13 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ passkeyAddress: string }> }
+) {
+  const { passkeyAddress } = await context.params;
+  return proxyPasskeyOperation({
+    operation: "getAccount",
+    request,
+    passkeyAddress,
+  });
+}

--- a/passkey/src/app/api/passkeys/account/create/route.ts
+++ b/passkey/src/app/api/passkeys/account/create/route.ts
@@ -1,0 +1,8 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function POST(request: Request) {
+  return proxyPasskeyOperation({
+    operation: "createAccount",
+    request,
+  });
+}

--- a/passkey/src/app/api/passkeys/account/find/route.ts
+++ b/passkey/src/app/api/passkeys/account/find/route.ts
@@ -1,0 +1,8 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function POST(request: Request) {
+  return proxyPasskeyOperation({
+    operation: "findAccount",
+    request,
+  });
+}

--- a/passkey/src/app/api/passkeys/session/authorize/route.ts
+++ b/passkey/src/app/api/passkeys/session/authorize/route.ts
@@ -1,0 +1,8 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function POST(request: Request) {
+  return proxyPasskeyOperation({
+    operation: "authorizeSession",
+    request,
+  });
+}

--- a/passkey/src/app/api/passkeys/session/create/route.ts
+++ b/passkey/src/app/api/passkeys/session/create/route.ts
@@ -1,0 +1,8 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function POST(request: Request) {
+  return proxyPasskeyOperation({
+    operation: "createSession",
+    request,
+  });
+}

--- a/passkey/src/app/api/passkeys/session/submit/route.ts
+++ b/passkey/src/app/api/passkeys/session/submit/route.ts
@@ -1,0 +1,8 @@
+import { proxyPasskeyOperation } from "@/lib/passkeys/grid-proxy";
+
+export async function POST(request: Request) {
+  return proxyPasskeyOperation({
+    operation: "submitSession",
+    request,
+  });
+}

--- a/passkey/src/app/auth/page.tsx
+++ b/passkey/src/app/auth/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { PasskeyFlowClient } from "@/components/passkey-flow-client";
+
+export default function AuthPage() {
+  return (
+    <Suspense fallback={<p>Loading passkey auth flow...</p>}>
+      <PasskeyFlowClient mode="auth" />
+    </Suspense>
+  );
+}

--- a/passkey/src/app/continue/page.tsx
+++ b/passkey/src/app/continue/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+
+import { PasskeyContinueClient } from "@/components/passkey-continue-client";
+
+export default function ContinuePage() {
+  return (
+    <Suspense fallback={<p>Loading passkey continue flow...</p>}>
+      <PasskeyContinueClient />
+    </Suspense>
+  );
+}
+

--- a/passkey/src/app/create/page.tsx
+++ b/passkey/src/app/create/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { PasskeyFlowClient } from "@/components/passkey-flow-client";
+
+export default function CreatePage() {
+  return (
+    <Suspense fallback={<p>Loading passkey create flow...</p>}>
+      <PasskeyFlowClient mode="create" />
+    </Suspense>
+  );
+}

--- a/passkey/src/app/icon.svg
+++ b/passkey/src/app/icon.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="320" viewBox="0 0 400 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M60 280L0 140H180V0L260 140L280 0L400 320L60 280Z" fill="#F9363C"/>
+<path d="M221.359 173.036C254.451 174.77 280.059 199.425 278.555 228.105L158.72 221.824C160.223 193.145 188.268 171.302 221.359 173.036Z" fill="white"/>
+<mask id="mask0_5_1302" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="158" y="172" width="121" height="57">
+<path d="M221.36 173.036C254.452 174.77 280.059 199.425 278.556 228.105L158.721 221.824C160.224 193.145 188.268 171.302 221.36 173.036Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_5_1302)">
+<circle cx="219.998" cy="199" r="27" transform="rotate(3 219.998 199)" fill="black"/>
+</g>
+</svg>

--- a/passkey/src/app/layout.tsx
+++ b/passkey/src/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import type { CSSProperties, ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "loyal passkey",
+  description: "Custom-domain passkey proxy flow for Squads Grid",
+  icons: {
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+    apple: "/icon.svg",
+  },
+};
+
+const rootStyle: CSSProperties = {
+  margin: "0 auto",
+  maxWidth: 760,
+  padding: "32px 20px 56px",
+  fontFamily:
+    "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+  color: "#0f172a",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={rootStyle}>{children}</body>
+    </html>
+  );
+}

--- a/passkey/src/app/page.tsx
+++ b/passkey/src/app/page.tsx
@@ -14,18 +14,22 @@ export default function HomePage() {
     <main>
       <h1 style={{ fontSize: 28, marginBottom: 10 }}>Passkey Proxy Workspace</h1>
       <p style={{ lineHeight: 1.5, marginBottom: 20 }}>
-        This app owns the Squads Grid passkey WebAuthn proxy flow on a custom
-        domain.
+        This app owns the Squads Grid passkey WebAuthn proxy flow for
+        `askloyal.com`, all `*.askloyal.com` subdomains, and an optional
+        separate `localhost` dev realm.
       </p>
 
       <section style={cardStyle}>
         <h2 style={{ fontSize: 18, marginTop: 0 }}>Flow Pages</h2>
         <ul style={{ paddingLeft: 20 }}>
           <li>
-            <Link href="/create">/create</Link>
+            <Link href="/continue">/continue</Link> (primary)
           </li>
           <li>
-            <Link href="/auth">/auth</Link>
+            <Link href="/auth">/auth</Link> (legacy/debug)
+          </li>
+          <li>
+            <Link href="/create">/create</Link> (legacy/debug)
           </li>
         </ul>
       </section>

--- a/passkey/src/app/page.tsx
+++ b/passkey/src/app/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+
+const cardStyle: CSSProperties = {
+  border: "1px solid #e2e8f0",
+  borderRadius: 12,
+  padding: 16,
+  marginBottom: 12,
+  background: "#f8fafc",
+};
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1 style={{ fontSize: 28, marginBottom: 10 }}>Passkey Proxy Workspace</h1>
+      <p style={{ lineHeight: 1.5, marginBottom: 20 }}>
+        This app owns the Squads Grid passkey WebAuthn proxy flow on a custom
+        domain.
+      </p>
+
+      <section style={cardStyle}>
+        <h2 style={{ fontSize: 18, marginTop: 0 }}>Flow Pages</h2>
+        <ul style={{ paddingLeft: 20 }}>
+          <li>
+            <Link href="/create">/create</Link>
+          </li>
+          <li>
+            <Link href="/auth">/auth</Link>
+          </li>
+        </ul>
+      </section>
+
+      <section style={cardStyle}>
+        <h2 style={{ fontSize: 18, marginTop: 0 }}>API Endpoints</h2>
+        <ul style={{ paddingLeft: 20, lineHeight: 1.5 }}>
+          <li>POST /api/passkeys/session/create</li>
+          <li>POST /api/passkeys/session/authorize</li>
+          <li>POST /api/passkeys/session/submit</li>
+          <li>POST /api/passkeys/account/create</li>
+          <li>POST /api/passkeys/account/find</li>
+          <li>GET /api/passkeys/account/:passkeyAddress</li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/passkey/src/components/passkey-continue-client.tsx
+++ b/passkey/src/components/passkey-continue-client.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { startTransition, useState } from "react";
+
+import {
+  runContinueAuthFirst,
+  runCreateFallbackFromAuth,
+} from "@/lib/passkeys/continue-runner";
+import { parseAuthPasskeyQuery } from "@/lib/passkeys/query-params";
+
+export function PasskeyContinueClient() {
+  const searchParams = useSearchParams();
+  const parsed = parseAuthPasskeyQuery(searchParams);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorDetails, setErrorDetails] = useState<string[]>([]);
+  const [result, setResult] = useState<unknown>(null);
+  const [resultBranch, setResultBranch] = useState<"auth" | "create" | null>(
+    null
+  );
+  const [isChallengeExpired, setIsChallengeExpired] = useState(false);
+  const [showCreateCta, setShowCreateCta] = useState(false);
+  const [createCtaMessage, setCreateCtaMessage] = useState<string | null>(null);
+
+  async function handleContinue() {
+    if (!parsed.ok || isRunning) {
+      return;
+    }
+
+    setIsRunning(true);
+    setErrorMessage(null);
+    setErrorDetails([]);
+    setIsChallengeExpired(false);
+    setShowCreateCta(false);
+    setCreateCtaMessage(null);
+    startTransition(() => {
+      setResult(null);
+      setResultBranch(null);
+    });
+
+    const outcome = await runContinueAuthFirst(parsed.data);
+    if (outcome.type === "success") {
+      startTransition(() => {
+        setResult(outcome.body);
+        setResultBranch(outcome.branch);
+      });
+      setIsRunning(false);
+      return;
+    }
+
+    if (outcome.type === "needs_create_cta") {
+      setCreateCtaMessage(outcome.message);
+      setShowCreateCta(true);
+      setIsRunning(false);
+      return;
+    }
+
+    setErrorMessage(outcome.message);
+    setErrorDetails(outcome.details);
+    setIsChallengeExpired(outcome.challengeExpired);
+    setIsRunning(false);
+  }
+
+  async function handleCreateFallback() {
+    if (!parsed.ok || isRunning) {
+      return;
+    }
+
+    setIsRunning(true);
+    setErrorMessage(null);
+    setErrorDetails([]);
+    setIsChallengeExpired(false);
+    setShowCreateCta(false);
+    setCreateCtaMessage(null);
+    startTransition(() => {
+      setResult(null);
+      setResultBranch(null);
+    });
+
+    const outcome = await runCreateFallbackFromAuth(parsed.data);
+    if (outcome.type === "success") {
+      startTransition(() => {
+        setResult(outcome.body);
+        setResultBranch(outcome.branch);
+      });
+      setIsRunning(false);
+      return;
+    }
+
+    if (outcome.type === "needs_create_cta") {
+      setCreateCtaMessage(outcome.message);
+      setShowCreateCta(true);
+      setIsRunning(false);
+      return;
+    }
+
+    setErrorMessage(outcome.message);
+    setErrorDetails(outcome.details);
+    setIsChallengeExpired(outcome.challengeExpired);
+    setIsRunning(false);
+  }
+
+  return (
+    <section>
+      <h1 style={{ fontSize: 26, marginBottom: 8 }}>Continue with Passkey</h1>
+      <p style={{ lineHeight: 1.5, marginBottom: 18 }}>
+        Attempts passkey login first. If no account exists, it automatically
+        falls back to account creation.
+      </p>
+
+      {!parsed.ok ? (
+        <div
+          style={{
+            border: "1px solid #fca5a5",
+            borderRadius: 10,
+            background: "#fef2f2",
+            padding: 14,
+            marginBottom: 12,
+          }}
+        >
+          <strong>Missing or invalid query parameters.</strong>
+          <ul style={{ paddingLeft: 20, marginBottom: 0 }}>
+            {parsed.errors.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={isRunning}
+          onClick={handleContinue}
+          style={{
+            border: "1px solid #0f172a",
+            borderRadius: 10,
+            background: isRunning ? "#cbd5e1" : "#0f172a",
+            color: "#fff",
+            fontWeight: 600,
+            padding: "10px 14px",
+            cursor: isRunning ? "not-allowed" : "pointer",
+          }}
+        >
+          {isRunning ? "Running passkey flow..." : "Continue with Passkey"}
+        </button>
+      )}
+
+      {showCreateCta ? (
+        <div
+          style={{
+            border: "1px solid #fcd34d",
+            borderRadius: 10,
+            background: "#fffbeb",
+            padding: 14,
+            marginTop: 14,
+          }}
+        >
+          <strong>Passkey login not completed.</strong>
+          <p style={{ marginTop: 8 }}>
+            {createCtaMessage ??
+              "No existing passkey login was completed. You can register one now."}
+          </p>
+          <button
+            type="button"
+            disabled={isRunning}
+            onClick={handleCreateFallback}
+            style={{
+              border: "1px solid #92400e",
+              borderRadius: 10,
+              background: isRunning ? "#fde68a" : "#f59e0b",
+              color: "#111827",
+              fontWeight: 600,
+              padding: "10px 14px",
+              cursor: isRunning ? "not-allowed" : "pointer",
+            }}
+          >
+            {isRunning ? "Creating account..." : "Try create account"}
+          </button>
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <div
+          style={{
+            border: "1px solid #fca5a5",
+            borderRadius: 10,
+            background: "#fef2f2",
+            padding: 14,
+            marginTop: 14,
+          }}
+        >
+          <strong>Error:</strong> {errorMessage}
+          {errorDetails.length > 0 ? (
+            <ul style={{ paddingLeft: 20, marginBottom: 0 }}>
+              {errorDetails.map((detail) => (
+                <li key={detail}>{detail}</li>
+              ))}
+            </ul>
+          ) : null}
+          {isChallengeExpired ? (
+            <p style={{ marginBottom: 0 }}>
+              Challenge likely expired. Restart from session authorize and retry
+              immediately.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {result ? (
+        <section
+          style={{
+            border: "1px solid #86efac",
+            borderRadius: 10,
+            background: "#f0fdf4",
+            padding: 14,
+            marginTop: 14,
+          }}
+        >
+          <strong>
+            Success via {resultBranch === "create" ? "create fallback" : "auth"}.
+          </strong>
+          <pre
+            style={{
+              marginTop: 10,
+              padding: 14,
+              borderRadius: 10,
+              border: "1px solid #bbf7d0",
+              background: "#f8fafc",
+              overflowX: "auto",
+            }}
+          >
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+
+      <p style={{ marginTop: 18 }}>
+        <Link href="/">Back to workspace home</Link>
+      </p>
+    </section>
+  );
+}
+

--- a/passkey/src/components/passkey-flow-client.tsx
+++ b/passkey/src/components/passkey-flow-client.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { startTransition, useState } from "react";
+
+import {
+  buildPasskeyFlowRequest,
+  parsePasskeyFlowQuery,
+  type PasskeyFlowMode,
+} from "@/lib/passkeys/flow-runner";
+import { isChallengeTimeoutError } from "@/lib/passkeys/webauthn";
+
+type ApiOutcome = {
+  ok: boolean;
+  status: number;
+  body: unknown;
+};
+
+async function callApi(endpoint: string, payload: unknown): Promise<ApiOutcome> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const bodyText = await response.text();
+  let body: unknown = bodyText;
+  try {
+    body = bodyText ? JSON.parse(bodyText) : null;
+  } catch {
+    body = bodyText;
+  }
+
+  return { ok: response.ok, status: response.status, body };
+}
+
+function extractMessage(payload: unknown): string {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "object" &&
+    payload.error !== null &&
+    "message" in payload.error &&
+    typeof payload.error.message === "string"
+  ) {
+    return payload.error.message;
+  }
+
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "message" in payload &&
+    typeof payload.message === "string"
+  ) {
+    return payload.message;
+  }
+
+  return "Passkey flow failed";
+}
+
+function parseErrorDetails(payload: unknown): string[] {
+  const normalizeDetail = (detail: unknown): string | null => {
+    if (typeof detail === "string") {
+      return detail;
+    }
+
+    if (typeof detail === "object" && detail !== null) {
+      const record = detail as Record<string, unknown>;
+      const field = typeof record.field === "string" ? record.field : undefined;
+      const code = typeof record.code === "string" ? record.code : undefined;
+      const message =
+        typeof record.message === "string" ? record.message : undefined;
+
+      if (field && code && message) {
+        return `${field} (${code}): ${message}`;
+      }
+
+      if (message) {
+        return message;
+      }
+    }
+
+    return null;
+  };
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "object" &&
+    payload.error !== null &&
+    "details" in payload.error &&
+    Array.isArray(payload.error.details)
+  ) {
+    return payload.error.details
+      .map(normalizeDetail)
+      .filter((detail): detail is string => detail !== null);
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "details" in payload &&
+    Array.isArray(payload.details)
+  ) {
+    return payload.details
+      .map(normalizeDetail)
+      .filter((detail): detail is string => detail !== null);
+  }
+
+  return [];
+}
+
+export function PasskeyFlowClient({ mode }: { mode: PasskeyFlowMode }) {
+  const searchParams = useSearchParams();
+  const [isRunning, setIsRunning] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorDetails, setErrorDetails] = useState<string[]>([]);
+  const [result, setResult] = useState<unknown>(null);
+  const [isChallengeExpired, setIsChallengeExpired] = useState(false);
+
+  const parsed = parsePasskeyFlowQuery(mode, searchParams);
+
+  async function runFlow() {
+    if (!parsed.ok || isRunning) {
+      return;
+    }
+
+    setIsRunning(true);
+    setErrorMessage(null);
+    setErrorDetails([]);
+    setIsChallengeExpired(false);
+    startTransition(() => setResult(null));
+
+    try {
+      const request = await buildPasskeyFlowRequest(mode, parsed.data);
+      const outcome = await callApi(request.endpoint, request.payload);
+      if (!outcome.ok) {
+        const details = parseErrorDetails(outcome.body);
+        if (details.length > 0) {
+          setErrorDetails(details);
+        }
+        throw new Error(extractMessage(outcome.body));
+      }
+
+      startTransition(() => setResult(outcome.body));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Passkey flow failed";
+      setErrorMessage(message);
+      setIsChallengeExpired(isChallengeTimeoutError(error));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <section>
+      <h1 style={{ fontSize: 26, marginBottom: 8 }}>
+        {mode === "create" ? "Create Passkey Account" : "Authorize Passkey Session"}
+      </h1>
+      <p style={{ lineHeight: 1.5, marginBottom: 18 }}>
+        {mode === "create"
+          ? "Completes WebAuthn passkey registration and submits the create session."
+          : "Completes WebAuthn authentication and submits the passkey session."}
+      </p>
+
+      {!parsed.ok ? (
+        <div
+          style={{
+            border: "1px solid #fca5a5",
+            borderRadius: 10,
+            background: "#fef2f2",
+            padding: 14,
+            marginBottom: 12,
+          }}
+        >
+          <strong>Missing or invalid query parameters.</strong>
+          <ul style={{ paddingLeft: 20, marginBottom: 0 }}>
+            {parsed.errors.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={isRunning}
+          onClick={runFlow}
+          style={{
+            border: "1px solid #0f172a",
+            borderRadius: 10,
+            background: isRunning ? "#cbd5e1" : "#0f172a",
+            color: "#fff",
+            fontWeight: 600,
+            padding: "10px 14px",
+            cursor: isRunning ? "not-allowed" : "pointer",
+          }}
+        >
+          {isRunning
+            ? "Running WebAuthn ceremony..."
+            : mode === "create"
+              ? "Create with Passkey"
+              : "Authenticate with Passkey"}
+        </button>
+      )}
+
+      {errorMessage ? (
+        <div
+          style={{
+            border: "1px solid #fca5a5",
+            borderRadius: 10,
+            background: "#fef2f2",
+            padding: 14,
+            marginTop: 14,
+          }}
+        >
+          <strong>Error:</strong> {errorMessage}
+          {errorDetails.length > 0 ? (
+            <ul style={{ paddingLeft: 20, marginBottom: 0 }}>
+              {errorDetails.map((detail) => (
+                <li key={detail}>{detail}</li>
+              ))}
+            </ul>
+          ) : null}
+          {isChallengeExpired ? (
+            <p style={{ marginBottom: 0 }}>
+              Challenge likely expired. Restart from the session create/authorize
+              step and retry immediately.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {result ? (
+        <pre
+          style={{
+            marginTop: 14,
+            padding: 14,
+            borderRadius: 10,
+            border: "1px solid #e2e8f0",
+            background: "#f8fafc",
+            overflowX: "auto",
+          }}
+        >
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      ) : null}
+
+      <p style={{ marginTop: 18 }}>
+        <Link href="/">Back to workspace home</Link>
+      </p>
+    </section>
+  );
+}

--- a/passkey/src/components/passkey-flow-client.tsx
+++ b/passkey/src/components/passkey-flow-client.tsx
@@ -5,119 +5,16 @@ import { useSearchParams } from "next/navigation";
 import { startTransition, useState } from "react";
 
 import {
+  callPasskeyApi,
+  extractPasskeyErrorMessage,
+  parsePasskeyErrorDetails,
+} from "@/lib/passkeys/client-api";
+import {
   buildPasskeyFlowRequest,
   parsePasskeyFlowQuery,
   type PasskeyFlowMode,
 } from "@/lib/passkeys/flow-runner";
 import { isChallengeTimeoutError } from "@/lib/passkeys/webauthn";
-
-type ApiOutcome = {
-  ok: boolean;
-  status: number;
-  body: unknown;
-};
-
-async function callApi(endpoint: string, payload: unknown): Promise<ApiOutcome> {
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-
-  const bodyText = await response.text();
-  let body: unknown = bodyText;
-  try {
-    body = bodyText ? JSON.parse(bodyText) : null;
-  } catch {
-    body = bodyText;
-  }
-
-  return { ok: response.ok, status: response.status, body };
-}
-
-function extractMessage(payload: unknown): string {
-  if (
-    typeof payload === "object" &&
-    payload !== null &&
-    "error" in payload &&
-    typeof payload.error === "object" &&
-    payload.error !== null &&
-    "message" in payload.error &&
-    typeof payload.error.message === "string"
-  ) {
-    return payload.error.message;
-  }
-
-  if (typeof payload === "string") {
-    return payload;
-  }
-
-  if (
-    typeof payload === "object" &&
-    payload !== null &&
-    "message" in payload &&
-    typeof payload.message === "string"
-  ) {
-    return payload.message;
-  }
-
-  return "Passkey flow failed";
-}
-
-function parseErrorDetails(payload: unknown): string[] {
-  const normalizeDetail = (detail: unknown): string | null => {
-    if (typeof detail === "string") {
-      return detail;
-    }
-
-    if (typeof detail === "object" && detail !== null) {
-      const record = detail as Record<string, unknown>;
-      const field = typeof record.field === "string" ? record.field : undefined;
-      const code = typeof record.code === "string" ? record.code : undefined;
-      const message =
-        typeof record.message === "string" ? record.message : undefined;
-
-      if (field && code && message) {
-        return `${field} (${code}): ${message}`;
-      }
-
-      if (message) {
-        return message;
-      }
-    }
-
-    return null;
-  };
-
-  if (
-    typeof payload === "object" &&
-    payload !== null &&
-    "error" in payload &&
-    typeof payload.error === "object" &&
-    payload.error !== null &&
-    "details" in payload.error &&
-    Array.isArray(payload.error.details)
-  ) {
-    return payload.error.details
-      .map(normalizeDetail)
-      .filter((detail): detail is string => detail !== null);
-  }
-
-  if (
-    typeof payload === "object" &&
-    payload !== null &&
-    "details" in payload &&
-    Array.isArray(payload.details)
-  ) {
-    return payload.details
-      .map(normalizeDetail)
-      .filter((detail): detail is string => detail !== null);
-  }
-
-  return [];
-}
 
 export function PasskeyFlowClient({ mode }: { mode: PasskeyFlowMode }) {
   const searchParams = useSearchParams();
@@ -142,13 +39,13 @@ export function PasskeyFlowClient({ mode }: { mode: PasskeyFlowMode }) {
 
     try {
       const request = await buildPasskeyFlowRequest(mode, parsed.data);
-      const outcome = await callApi(request.endpoint, request.payload);
+      const outcome = await callPasskeyApi(request.endpoint, request.payload);
       if (!outcome.ok) {
-        const details = parseErrorDetails(outcome.body);
+        const details = parsePasskeyErrorDetails(outcome.body);
         if (details.length > 0) {
           setErrorDetails(details);
         }
-        throw new Error(extractMessage(outcome.body));
+        throw new Error(extractPasskeyErrorMessage(outcome.body));
       }
 
       startTransition(() => setResult(outcome.body));

--- a/passkey/src/lib/core/config/__tests__/schema.test.ts
+++ b/passkey/src/lib/core/config/__tests__/schema.test.ts
@@ -3,18 +3,49 @@ import { describe, expect, test } from "bun:test";
 import { parsePasskeyServerConfig } from "@/lib/core/config/schema";
 
 describe("parsePasskeyServerConfig", () => {
-  test("applies defaults for grid environment, base url, and app name", () => {
+  test("applies defaults for grid environment, base url, app name, and localhost", () => {
     const config = parsePasskeyServerConfig({
-      PASSKEY_CUSTOM_DOMAIN_BASE_URL: "https://passkey.example.com/",
+      PASSKEY_ALLOWED_PARENT_DOMAIN: "askloyal.com",
+      NEXT_PUBLIC_PASSKEY_RP_ID: "askloyal.com",
     });
 
     expect(config.gridEnvironment).toBe("sandbox");
     expect(config.gridApiBaseUrl).toBe("https://grid.squads.xyz");
     expect(config.appName).toBe("askloyal");
-    expect(config.customDomainBaseUrl).toBe("https://passkey.example.com");
+    expect(config.allowedParentDomain).toBe("askloyal.com");
+    expect(config.sharedRpId).toBe("askloyal.com");
+    expect(config.allowLocalhost).toBe(true);
   });
 
-  test("fails fast when custom domain is missing", () => {
+  test("supports disabling localhost explicitly", () => {
+    const config = parsePasskeyServerConfig({
+      PASSKEY_ALLOWED_PARENT_DOMAIN: "askloyal.com",
+      PASSKEY_ALLOW_LOCALHOST: "false",
+      NEXT_PUBLIC_PASSKEY_RP_ID: "askloyal.com",
+    });
+
+    expect(config.allowLocalhost).toBe(false);
+  });
+
+  test("fails fast when parent domain is missing", () => {
     expect(() => parsePasskeyServerConfig({})).toThrow();
+  });
+
+  test("rejects invalid parent domain values", () => {
+    expect(() =>
+      parsePasskeyServerConfig({
+        PASSKEY_ALLOWED_PARENT_DOMAIN: "https://askloyal.com",
+        NEXT_PUBLIC_PASSKEY_RP_ID: "askloyal.com",
+      })
+    ).toThrow();
+  });
+
+  test("rejects RP IDs that do not match the allowed parent domain", () => {
+    expect(() =>
+      parsePasskeyServerConfig({
+        PASSKEY_ALLOWED_PARENT_DOMAIN: "askloyal.com",
+        NEXT_PUBLIC_PASSKEY_RP_ID: "example.com",
+      })
+    ).toThrow();
   });
 });

--- a/passkey/src/lib/core/config/__tests__/schema.test.ts
+++ b/passkey/src/lib/core/config/__tests__/schema.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { parsePasskeyServerConfig } from "@/lib/core/config/schema";
+
+describe("parsePasskeyServerConfig", () => {
+  test("applies defaults for grid environment, base url, and app name", () => {
+    const config = parsePasskeyServerConfig({
+      PASSKEY_CUSTOM_DOMAIN_BASE_URL: "https://passkey.example.com/",
+    });
+
+    expect(config.gridEnvironment).toBe("sandbox");
+    expect(config.gridApiBaseUrl).toBe("https://grid.squads.xyz");
+    expect(config.appName).toBe("askloyal");
+    expect(config.customDomainBaseUrl).toBe("https://passkey.example.com");
+  });
+
+  test("fails fast when custom domain is missing", () => {
+    expect(() => parsePasskeyServerConfig({})).toThrow();
+  });
+});

--- a/passkey/src/lib/core/config/schema.ts
+++ b/passkey/src/lib/core/config/schema.ts
@@ -2,15 +2,44 @@ import { z } from "zod";
 
 import type { PasskeyServerConfig } from "@/lib/core/config/types";
 
+const hostnameSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .refine(
+    (value) =>
+      value.length > 0 &&
+      !value.includes("://") &&
+      !value.includes("/") &&
+      !value.includes(":") &&
+      value !== "localhost" &&
+      /^[a-z0-9.-]+$/.test(value),
+    "Must be a bare parent domain hostname"
+  );
+
 const serverConfigSchema = z.object({
   PASSKEY_GRID_ENVIRONMENT: z.enum(["sandbox", "production"]).default("sandbox"),
-  PASSKEY_CUSTOM_DOMAIN_BASE_URL: z.string().url(),
+  PASSKEY_ALLOWED_PARENT_DOMAIN: hostnameSchema,
+  PASSKEY_ALLOW_LOCALHOST: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((value) => value === "true"),
+  NEXT_PUBLIC_PASSKEY_RP_ID: hostnameSchema,
   PASSKEY_GRID_API_BASE_URL: z
     .string()
     .url()
     .default("https://grid.squads.xyz"),
   PASSKEY_APP_NAME: z.string().min(1).default("askloyal"),
   PASSKEY_GRID_API_KEY: z.string().min(1).optional(),
+}).superRefine((value, ctx) => {
+  if (value.PASSKEY_ALLOWED_PARENT_DOMAIN !== value.NEXT_PUBLIC_PASSKEY_RP_ID) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "NEXT_PUBLIC_PASSKEY_RP_ID must match PASSKEY_ALLOWED_PARENT_DOMAIN",
+      path: ["NEXT_PUBLIC_PASSKEY_RP_ID"],
+    });
+  }
 });
 
 function trimTrailingSlash(value: string): string {
@@ -23,7 +52,9 @@ export function parsePasskeyServerConfig(
   const parsed = serverConfigSchema.parse(env);
   return {
     gridEnvironment: parsed.PASSKEY_GRID_ENVIRONMENT,
-    customDomainBaseUrl: trimTrailingSlash(parsed.PASSKEY_CUSTOM_DOMAIN_BASE_URL),
+    allowedParentDomain: parsed.PASSKEY_ALLOWED_PARENT_DOMAIN,
+    allowLocalhost: parsed.PASSKEY_ALLOW_LOCALHOST,
+    sharedRpId: parsed.NEXT_PUBLIC_PASSKEY_RP_ID,
     gridApiBaseUrl: trimTrailingSlash(parsed.PASSKEY_GRID_API_BASE_URL),
     appName: parsed.PASSKEY_APP_NAME,
     gridApiKey: parsed.PASSKEY_GRID_API_KEY,

--- a/passkey/src/lib/core/config/schema.ts
+++ b/passkey/src/lib/core/config/schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import type { PasskeyServerConfig } from "@/lib/core/config/types";
+
+const serverConfigSchema = z.object({
+  PASSKEY_GRID_ENVIRONMENT: z.enum(["sandbox", "production"]).default("sandbox"),
+  PASSKEY_CUSTOM_DOMAIN_BASE_URL: z.string().url(),
+  PASSKEY_GRID_API_BASE_URL: z
+    .string()
+    .url()
+    .default("https://grid.squads.xyz"),
+  PASSKEY_APP_NAME: z.string().min(1).default("askloyal"),
+  PASSKEY_GRID_API_KEY: z.string().min(1).optional(),
+});
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+export function parsePasskeyServerConfig(
+  env: Record<string, string | undefined>
+): PasskeyServerConfig {
+  const parsed = serverConfigSchema.parse(env);
+  return {
+    gridEnvironment: parsed.PASSKEY_GRID_ENVIRONMENT,
+    customDomainBaseUrl: trimTrailingSlash(parsed.PASSKEY_CUSTOM_DOMAIN_BASE_URL),
+    gridApiBaseUrl: trimTrailingSlash(parsed.PASSKEY_GRID_API_BASE_URL),
+    appName: parsed.PASSKEY_APP_NAME,
+    gridApiKey: parsed.PASSKEY_GRID_API_KEY,
+  };
+}

--- a/passkey/src/lib/core/config/server.ts
+++ b/passkey/src/lib/core/config/server.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { parsePasskeyServerConfig } from "@/lib/core/config/schema";
+import type { PasskeyServerConfig } from "@/lib/core/config/types";
+
+let cachedConfig: PasskeyServerConfig | null = null;
+
+export function getServerConfig(): PasskeyServerConfig {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  cachedConfig = parsePasskeyServerConfig(process.env);
+
+  return cachedConfig;
+}
+
+export function resetServerConfigCacheForTests(): void {
+  cachedConfig = null;
+}

--- a/passkey/src/lib/core/config/types.ts
+++ b/passkey/src/lib/core/config/types.ts
@@ -1,0 +1,9 @@
+export type PasskeyGridEnvironment = "sandbox" | "production";
+
+export type PasskeyServerConfig = {
+  gridEnvironment: PasskeyGridEnvironment;
+  customDomainBaseUrl: string;
+  gridApiBaseUrl: string;
+  appName: string;
+  gridApiKey?: string;
+};

--- a/passkey/src/lib/core/config/types.ts
+++ b/passkey/src/lib/core/config/types.ts
@@ -2,7 +2,9 @@ export type PasskeyGridEnvironment = "sandbox" | "production";
 
 export type PasskeyServerConfig = {
   gridEnvironment: PasskeyGridEnvironment;
-  customDomainBaseUrl: string;
+  allowedParentDomain: string;
+  allowLocalhost: boolean;
+  sharedRpId: string;
   gridApiBaseUrl: string;
   appName: string;
   gridApiKey?: string;

--- a/passkey/src/lib/passkeys/__tests__/continue-runner.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/continue-runner.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, mock, test } from "bun:test";
+import bs58 from "bs58";
+
+import {
+  runContinueAuthFirst,
+  type ContinueRunnerResult,
+} from "@/lib/passkeys/continue-runner";
+
+const parsedAuth = {
+  challenge: "challenge-value",
+  slotNumber: 12,
+  sessionKey: bs58.encode(Uint8Array.from([1, 2, 3, 4])),
+  expirationInSeconds: 120,
+  env: "sandbox" as const,
+};
+
+describe("runContinueAuthFirst", () => {
+  test("returns auth success when the first submit succeeds", async () => {
+    const buildFlowRequest = mock(async () => ({
+      endpoint: "/api/passkeys/session/submit",
+      payload: { ceremonyType: "auth" },
+    }));
+    const callApi = mock(async () => ({
+      ok: true,
+      status: 200,
+      body: { ok: true },
+    }));
+
+    const result = await runContinueAuthFirst(parsedAuth, {
+      buildFlowRequest,
+      callApi,
+    });
+
+    expect(result).toEqual({
+      type: "success",
+      branch: "auth",
+      body: { ok: true },
+    } satisfies ContinueRunnerResult);
+  });
+
+  test("falls back to create when auth reports no passkey account", async () => {
+    const buildFlowRequest = mock(async (mode: "create" | "auth") => ({
+      endpoint: "/api/passkeys/session/submit",
+      payload: { ceremonyType: mode },
+    }));
+    const callApi = mock(async (endpoint: string) => {
+      if (endpoint === "/api/passkeys/session/submit" && callApi.mock.calls.length === 1) {
+        return {
+          ok: false,
+          status: 404,
+          body: {
+            error: {
+              message: "Passkey account not found",
+            },
+          },
+        };
+      }
+
+      if (endpoint === "/api/passkeys/session/create") {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            url: `https://app.askloyal.com/create?challenge=challenge-value&slot-num=12&session-key=${parsedAuth.sessionKey}&expiration-in-seconds=120&env=sandbox&app-name=askloyal&user-id=tg-100`,
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        body: { ok: true, branch: "create" },
+      };
+    });
+
+    const result = await runContinueAuthFirst(parsedAuth, {
+      buildFlowRequest,
+      callApi,
+    });
+
+    expect(result).toEqual({
+      type: "success",
+      branch: "create",
+      body: { ok: true, branch: "create" },
+    } satisfies ContinueRunnerResult);
+    expect(buildFlowRequest.mock.calls.map((call) => call[0])).toEqual([
+      "auth",
+      "create",
+    ]);
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/contracts.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/contracts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  authorizeSessionRequestSchema,
+  createSessionRequestSchema,
+  submitSessionRequestSchema,
+} from "@/lib/passkeys/contracts";
+
+describe("passkey contract validation", () => {
+  test("accepts valid create session payload", () => {
+    const payload = {
+      sessionKey: { key: "session-key", expiration: Date.now() + 60_000 },
+      env: "sandbox",
+      metaInfo: { appName: "Loyal" },
+    };
+
+    const parsed = createSessionRequestSchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects authorize payload without app name", () => {
+    const payload = {
+      metaInfo: {},
+    };
+
+    const parsed = authorizeSessionRequestSchema.safeParse(payload);
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects submit payload with invalid ceremony type", () => {
+    const payload = {
+      ceremonyType: "invalid",
+      slotNumber: 10,
+      sessionKey: { key: [1, 2, 3], expiration: Date.now() + 60_000 },
+      authenticatorResponse: {},
+    };
+
+    const parsed = submitSessionRequestSchema.safeParse(payload);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/flow-runner.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/flow-runner.test.ts
@@ -8,14 +8,20 @@ import {
 
 describe("buildPasskeyFlowRequest", () => {
   test("builds create flow request payload", async () => {
-    const createCredentials = mock(async () => ({
-      id: new ArrayBuffer(8),
-      publicKey: "public-key",
+    const resolveHostContext = mock(() => ({
+      hostname: "app.askloyal.com",
+      origin: "https://app.askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    })) as FlowRunnerDependencies["resolveHostContext"];
+    const runCreateCeremony = mock(async () => ({
+      rawId: "raw-credential-id",
       credentialId: "credential-id",
-    })) as FlowRunnerDependencies["createCredentials"];
-    const getCredentials = mock(async () => ({
+      publicKey: "public-key",
+    })) as FlowRunnerDependencies["runCreateCeremony"];
+    const runAuthCeremony = mock(async () => ({
       response: { signature: "sig" },
-    })) as FlowRunnerDependencies["getCredentials"];
+    })) as FlowRunnerDependencies["runAuthCeremony"];
 
     const sessionKey = bs58.encode(Uint8Array.from([1, 2, 3, 4]));
     const request = await buildPasskeyFlowRequest(
@@ -29,8 +35,9 @@ describe("buildPasskeyFlowRequest", () => {
         userId: "tg-user",
       },
       {
-        createCredentials,
-        getCredentials,
+        resolveHostContext,
+        runCreateCeremony,
+        runAuthCeremony,
       }
     );
 
@@ -40,19 +47,35 @@ describe("buildPasskeyFlowRequest", () => {
       slotNumber: 10,
       sessionKey: { expiration: 900 },
     });
-    expect(createCredentials).toHaveBeenCalledTimes(1);
-    expect(getCredentials).toHaveBeenCalledTimes(1);
+    expect(runCreateCeremony).toHaveBeenCalledTimes(1);
+    expect(runCreateCeremony.mock.calls[0]?.[0]).toMatchObject({
+      rpId: "askloyal.com",
+      appName: "askloyal",
+      userId: "tg-user",
+    });
+    expect(runAuthCeremony).toHaveBeenCalledTimes(1);
+    expect(runAuthCeremony.mock.calls[0]?.[0]).toMatchObject({
+      rpId: "askloyal.com",
+      allowCredentialId: "raw-credential-id",
+      publicKey: "public-key",
+    });
   });
 
   test("builds auth flow request payload", async () => {
-    const createCredentials = mock(async () => ({
-      id: new ArrayBuffer(8),
+    const resolveHostContext = mock(() => ({
+      hostname: "localhost",
+      origin: "http://localhost:3000",
+      rpId: "localhost",
+      isLocalhost: true,
+    })) as FlowRunnerDependencies["resolveHostContext"];
+    const runCreateCeremony = mock(async () => ({
+      rawId: "unused",
+      credentialId: "unused",
       publicKey: "public-key",
-      credentialId: "credential-id",
-    })) as FlowRunnerDependencies["createCredentials"];
-    const getCredentials = mock(async () => ({
+    })) as FlowRunnerDependencies["runCreateCeremony"];
+    const runAuthCeremony = mock(async () => ({
       response: { signature: "sig" },
-    })) as FlowRunnerDependencies["getCredentials"];
+    })) as FlowRunnerDependencies["runAuthCeremony"];
 
     const sessionKey = bs58.encode(Uint8Array.from([9, 8, 7, 6]));
     const request = await buildPasskeyFlowRequest(
@@ -64,8 +87,9 @@ describe("buildPasskeyFlowRequest", () => {
         expirationInSeconds: 1200,
       },
       {
-        createCredentials,
-        getCredentials,
+        resolveHostContext,
+        runCreateCeremony,
+        runAuthCeremony,
       }
     );
 
@@ -75,19 +99,28 @@ describe("buildPasskeyFlowRequest", () => {
       slotNumber: 99,
       sessionKey: { expiration: 1200 },
     });
-    expect(createCredentials).toHaveBeenCalledTimes(0);
-    expect(getCredentials).toHaveBeenCalledTimes(1);
+    expect(runCreateCeremony).toHaveBeenCalledTimes(0);
+    expect(runAuthCeremony).toHaveBeenCalledTimes(1);
+    expect(runAuthCeremony.mock.calls[0]?.[0]).toMatchObject({
+      rpId: "localhost",
+    });
   });
 
-  test("normalizes URL-safe challenge before passing to SDK helpers", async () => {
-    const createCredentials = mock(async () => ({
-      id: new ArrayBuffer(8),
-      publicKey: "public-key",
+  test("normalizes challenge before passing to local ceremony helpers", async () => {
+    const resolveHostContext = mock(() => ({
+      hostname: "app.askloyal.com",
+      origin: "https://app.askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    })) as FlowRunnerDependencies["resolveHostContext"];
+    const runCreateCeremony = mock(async () => ({
+      rawId: "raw-credential-id",
       credentialId: "credential-id",
-    })) as FlowRunnerDependencies["createCredentials"];
-    const getCredentials = mock(async () => ({
+      publicKey: "public-key",
+    })) as FlowRunnerDependencies["runCreateCeremony"];
+    const runAuthCeremony = mock(async () => ({
       response: { signature: "sig" },
-    })) as FlowRunnerDependencies["getCredentials"];
+    })) as FlowRunnerDependencies["runAuthCeremony"];
 
     const sessionKey = bs58.encode(Uint8Array.from([1, 2, 3, 4]));
     await buildPasskeyFlowRequest(
@@ -101,14 +134,15 @@ describe("buildPasskeyFlowRequest", () => {
         userId: "tg-user",
       },
       {
-        createCredentials,
-        getCredentials,
+        resolveHostContext,
+        runCreateCeremony,
+        runAuthCeremony,
       }
     );
 
-    const createCall = createCredentials.mock.calls[0]?.[0] as
+    const createCall = runCreateCeremony.mock.calls[0]?.[0] as
       | { challenge?: string }
       | undefined;
-    expect(createCall?.challenge).toBe("a+b/c===");
+    expect(createCall?.challenge).toBe("a-b_c");
   });
 });

--- a/passkey/src/lib/passkeys/__tests__/flow-runner.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/flow-runner.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from "bun:test";
+import bs58 from "bs58";
+
+import {
+  buildPasskeyFlowRequest,
+  type FlowRunnerDependencies,
+} from "@/lib/passkeys/flow-runner";
+
+describe("buildPasskeyFlowRequest", () => {
+  test("builds create flow request payload", async () => {
+    const createCredentials = mock(async () => ({
+      id: new ArrayBuffer(8),
+      publicKey: "public-key",
+      credentialId: "credential-id",
+    })) as FlowRunnerDependencies["createCredentials"];
+    const getCredentials = mock(async () => ({
+      response: { signature: "sig" },
+    })) as FlowRunnerDependencies["getCredentials"];
+
+    const sessionKey = bs58.encode(Uint8Array.from([1, 2, 3, 4]));
+    const request = await buildPasskeyFlowRequest(
+      "create",
+      {
+        challenge: "challenge",
+        slotNumber: 10,
+        sessionKey,
+        expirationInSeconds: 900,
+        appName: "askloyal",
+        userId: "tg-user",
+      },
+      {
+        createCredentials,
+        getCredentials,
+      }
+    );
+
+    expect(request.endpoint).toBe("/api/passkeys/session/submit");
+    expect(request.payload).toMatchObject({
+      ceremonyType: "create",
+      slotNumber: 10,
+      sessionKey: { expiration: 900 },
+    });
+    expect(createCredentials).toHaveBeenCalledTimes(1);
+    expect(getCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  test("builds auth flow request payload", async () => {
+    const createCredentials = mock(async () => ({
+      id: new ArrayBuffer(8),
+      publicKey: "public-key",
+      credentialId: "credential-id",
+    })) as FlowRunnerDependencies["createCredentials"];
+    const getCredentials = mock(async () => ({
+      response: { signature: "sig" },
+    })) as FlowRunnerDependencies["getCredentials"];
+
+    const sessionKey = bs58.encode(Uint8Array.from([9, 8, 7, 6]));
+    const request = await buildPasskeyFlowRequest(
+      "auth",
+      {
+        challenge: "challenge",
+        slotNumber: 99,
+        sessionKey,
+        expirationInSeconds: 1200,
+      },
+      {
+        createCredentials,
+        getCredentials,
+      }
+    );
+
+    expect(request.endpoint).toBe("/api/passkeys/session/submit");
+    expect(request.payload).toMatchObject({
+      ceremonyType: "auth",
+      slotNumber: 99,
+      sessionKey: { expiration: 1200 },
+    });
+    expect(createCredentials).toHaveBeenCalledTimes(0);
+    expect(getCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  test("normalizes URL-safe challenge before passing to SDK helpers", async () => {
+    const createCredentials = mock(async () => ({
+      id: new ArrayBuffer(8),
+      publicKey: "public-key",
+      credentialId: "credential-id",
+    })) as FlowRunnerDependencies["createCredentials"];
+    const getCredentials = mock(async () => ({
+      response: { signature: "sig" },
+    })) as FlowRunnerDependencies["getCredentials"];
+
+    const sessionKey = bs58.encode(Uint8Array.from([1, 2, 3, 4]));
+    await buildPasskeyFlowRequest(
+      "create",
+      {
+        challenge: "a-b_c",
+        slotNumber: 1,
+        sessionKey,
+        expirationInSeconds: 900,
+        appName: "askloyal",
+        userId: "tg-user",
+      },
+      {
+        createCredentials,
+        getCredentials,
+      }
+    );
+
+    const createCall = createCredentials.mock.calls[0]?.[0] as
+      | { challenge?: string }
+      | undefined;
+    expect(createCall?.challenge).toBe("a+b/c===");
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/grid-proxy.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/grid-proxy.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildProxyResponse,
+  preparePasskeyUpstreamRequest,
+  ProxyValidationError,
+} from "@/lib/passkeys/grid-proxy";
+
+const config = {
+  gridEnvironment: "sandbox" as const,
+  customDomainBaseUrl: "https://passkey.example.com",
+  gridApiBaseUrl: "https://grid.squads.xyz",
+  appName: "askloyal",
+};
+
+describe("preparePasskeyUpstreamRequest", () => {
+  test("maps create session operation and injects custom domain fields", () => {
+    const prepared = preparePasskeyUpstreamRequest({
+      operation: "createSession",
+      body: {
+        sessionKey: { key: "abc", expiration: 1234 },
+        env: "sandbox",
+        metaInfo: {},
+      },
+      incomingHeaders: new Headers({
+        origin: "https://passkey.example.com",
+        cookie: "session=test",
+      }),
+      config,
+    });
+
+    expect(prepared.url).toBe("https://grid.squads.xyz/api/grid/v1/passkeys");
+    expect(prepared.init.method).toBe("POST");
+    expect(prepared.normalizedBody).toMatchObject({
+      baseUrl: "https://passkey.example.com",
+      metaInfo: {
+        baseUrl: "https://passkey.example.com",
+        appName: "askloyal",
+      },
+    });
+
+    const headers = prepared.init.headers as Headers;
+    expect(headers.get("x-grid-environment")).toBe("sandbox");
+    expect(headers.get("origin")).toBe("https://passkey.example.com");
+    expect(headers.get("cookie")).toBe("session=test");
+  });
+
+  test("maps get account operation with dynamic passkey address", () => {
+    const prepared = preparePasskeyUpstreamRequest({
+      operation: "getAccount",
+      passkeyAddress: "abc123",
+      incomingHeaders: new Headers(),
+      config,
+    });
+
+    expect(prepared.url).toBe(
+      "https://grid.squads.xyz/api/grid/v1/passkeys/account/abc123"
+    );
+    expect(prepared.init.method).toBe("GET");
+  });
+
+  test("throws validation error for invalid payload", () => {
+    expect(() =>
+      preparePasskeyUpstreamRequest({
+        operation: "authorizeSession",
+        body: { metaInfo: {} },
+        incomingHeaders: new Headers(),
+        config,
+      })
+    ).toThrow(ProxyValidationError);
+  });
+});
+
+describe("buildProxyResponse", () => {
+  test("returns normalized error envelope for upstream failures", async () => {
+    const upstream = new Response(
+      JSON.stringify({
+        message: "Upstream said no",
+        details: ["bad signature"],
+      }),
+      {
+        status: 401,
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "req-123",
+          "set-cookie": "session=abc; Path=/; HttpOnly",
+        },
+      }
+    );
+
+    const response = await buildProxyResponse(upstream);
+    const payload = (await response.json()) as {
+      error: { code: string; message: string; details: string[]; requestId: string };
+    };
+
+    expect(response.status).toBe(401);
+    expect(payload.error.code).toBe("upstream_error");
+    expect(payload.error.message).toBe("Upstream said no");
+    expect(payload.error.details).toEqual(["bad signature"]);
+    expect(payload.error.requestId).toBe("req-123");
+    expect(response.headers.get("set-cookie")).toContain("session=abc");
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/grid-proxy.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/grid-proxy.test.ts
@@ -8,13 +8,15 @@ import {
 
 const config = {
   gridEnvironment: "sandbox" as const,
-  customDomainBaseUrl: "https://passkey.example.com",
+  allowedParentDomain: "askloyal.com",
+  allowLocalhost: true,
+  sharedRpId: "askloyal.com",
   gridApiBaseUrl: "https://grid.squads.xyz",
   appName: "askloyal",
 };
 
 describe("preparePasskeyUpstreamRequest", () => {
-  test("maps create session operation and injects custom domain fields", () => {
+  test("maps create session operation and injects request-derived base url", () => {
     const prepared = preparePasskeyUpstreamRequest({
       operation: "createSession",
       body: {
@@ -22,8 +24,9 @@ describe("preparePasskeyUpstreamRequest", () => {
         env: "sandbox",
         metaInfo: {},
       },
+      requestUrl: "https://app.askloyal.com/api/passkeys/session/create",
       incomingHeaders: new Headers({
-        origin: "https://passkey.example.com",
+        origin: "https://app.askloyal.com",
         cookie: "session=test",
       }),
       config,
@@ -32,23 +35,47 @@ describe("preparePasskeyUpstreamRequest", () => {
     expect(prepared.url).toBe("https://grid.squads.xyz/api/grid/v1/passkeys");
     expect(prepared.init.method).toBe("POST");
     expect(prepared.normalizedBody).toMatchObject({
-      baseUrl: "https://passkey.example.com",
+      baseUrl: "https://app.askloyal.com",
       metaInfo: {
-        baseUrl: "https://passkey.example.com",
+        baseUrl: "https://app.askloyal.com",
         appName: "askloyal",
       },
     });
 
     const headers = prepared.init.headers as Headers;
     expect(headers.get("x-grid-environment")).toBe("sandbox");
-    expect(headers.get("origin")).toBe("https://passkey.example.com");
+    expect(headers.get("origin")).toBe("https://app.askloyal.com");
     expect(headers.get("cookie")).toBe("session=test");
+  });
+
+  test("maps authorize session operation and injects request-derived base url", () => {
+    const prepared = preparePasskeyUpstreamRequest({
+      operation: "authorizeSession",
+      body: {
+        metaInfo: {
+          appName: "askloyal",
+        },
+      },
+      requestUrl: "https://admin.askloyal.com/api/passkeys/session/authorize",
+      incomingHeaders: new Headers({
+        origin: "https://admin.askloyal.com",
+      }),
+      config,
+    });
+
+    expect(prepared.normalizedBody).toMatchObject({
+      baseUrl: "https://admin.askloyal.com",
+      metaInfo: {
+        appName: "askloyal",
+      },
+    });
   });
 
   test("maps get account operation with dynamic passkey address", () => {
     const prepared = preparePasskeyUpstreamRequest({
       operation: "getAccount",
       passkeyAddress: "abc123",
+      requestUrl: "https://askloyal.com/api/passkeys/account/abc123",
       incomingHeaders: new Headers(),
       config,
     });
@@ -64,10 +91,27 @@ describe("preparePasskeyUpstreamRequest", () => {
       preparePasskeyUpstreamRequest({
         operation: "authorizeSession",
         body: { metaInfo: {} },
+        requestUrl: "https://app.askloyal.com/api/passkeys/session/authorize",
         incomingHeaders: new Headers(),
         config,
       })
     ).toThrow(ProxyValidationError);
+  });
+
+  test("rejects hosts outside the askloyal allowlist", () => {
+    expect(() =>
+      preparePasskeyUpstreamRequest({
+        operation: "createSession",
+        body: {
+          sessionKey: { key: "abc", expiration: 1234 },
+          env: "sandbox",
+          metaInfo: {},
+        },
+        requestUrl: "https://evil.example.com/api/passkeys/session/create",
+        incomingHeaders: new Headers(),
+        config,
+      })
+    ).toThrow("not allowed");
   });
 });
 

--- a/passkey/src/lib/passkeys/__tests__/host-resolution.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/host-resolution.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  PasskeyHostResolutionError,
+  resolvePasskeyHostContext,
+  resolvePasskeyRequestContext,
+} from "@/lib/passkeys/host-resolution";
+
+const options = {
+  allowedParentDomain: "askloyal.com",
+  allowLocalhost: true,
+  sharedRpId: "askloyal.com",
+} as const;
+
+describe("resolvePasskeyHostContext", () => {
+  test("accepts the root askloyal domain", () => {
+    expect(resolvePasskeyHostContext("askloyal.com", options)).toEqual({
+      hostname: "askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    });
+  });
+
+  test("accepts askloyal subdomains", () => {
+    expect(resolvePasskeyHostContext("app.askloyal.com", options)).toEqual({
+      hostname: "app.askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    });
+    expect(
+      resolvePasskeyHostContext("wallet.dev.askloyal.com", options)
+    ).toEqual({
+      hostname: "wallet.dev.askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    });
+  });
+
+  test("accepts localhost only when enabled", () => {
+    expect(resolvePasskeyHostContext("localhost", options)).toEqual({
+      hostname: "localhost",
+      rpId: "localhost",
+      isLocalhost: true,
+    });
+
+    expect(() =>
+      resolvePasskeyHostContext("localhost", {
+        ...options,
+        allowLocalhost: false,
+      })
+    ).toThrow(PasskeyHostResolutionError);
+  });
+
+  test("rejects unrelated hosts and 127.0.0.1", () => {
+    expect(() =>
+      resolvePasskeyHostContext("example.com", options)
+    ).toThrow(PasskeyHostResolutionError);
+    expect(() =>
+      resolvePasskeyHostContext("127.0.0.1", options)
+    ).toThrow(PasskeyHostResolutionError);
+  });
+});
+
+describe("resolvePasskeyRequestContext", () => {
+  test("builds origin from forwarded host and protocol", () => {
+    expect(
+      resolvePasskeyRequestContext({
+        requestUrl: "https://ignored.askloyal.com/api/passkeys/session/create",
+        headers: new Headers({
+          "x-forwarded-host": "app.askloyal.com",
+          "x-forwarded-proto": "https",
+        }),
+        options,
+      })
+    ).toEqual({
+      hostname: "app.askloyal.com",
+      origin: "https://app.askloyal.com",
+      rpId: "askloyal.com",
+      isLocalhost: false,
+    });
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/query-params.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/query-params.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseAuthPasskeyQuery,
+  parseCreatePasskeyQuery,
+} from "@/lib/passkeys/query-params";
+
+describe("parseCreatePasskeyQuery", () => {
+  test("parses a valid create ceremony query", () => {
+    const query = new URLSearchParams({
+      challenge: "challenge-value",
+      "slot-num": "42",
+      "session-key": "session-key",
+      "expiration-in-seconds": "900",
+      env: "sandbox",
+      "app-name": "Loyal",
+      "user-id": "tg-100",
+    });
+
+    const parsed = parseCreatePasskeyQuery(query);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(parsed.data.slotNumber).toBe(42);
+    expect(parsed.data.expirationInSeconds).toBe(900);
+    expect(parsed.data.appName).toBe("Loyal");
+    expect(parsed.data.userId).toBe("tg-100");
+  });
+
+  test("returns validation errors for missing required fields", () => {
+    const parsed = parseCreatePasskeyQuery(new URLSearchParams());
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("parseAuthPasskeyQuery", () => {
+  test("parses a valid auth ceremony query", () => {
+    const query = new URLSearchParams({
+      challenge: "challenge-value",
+      "slot-num": "12",
+      "session-key": "session-key",
+      "expiration-in-seconds": "120",
+      env: "production",
+    });
+
+    const parsed = parseAuthPasskeyQuery(query);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(parsed.data.slotNumber).toBe(12);
+    expect(parsed.data.env).toBe("production");
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/session-key.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/session-key.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import bs58 from "bs58";
+
+import {
+  toSessionKeyObject,
+  toSessionKeyBackendObject,
+} from "@/lib/passkeys/session-key";
+
+describe("session-key helpers", () => {
+  test("converts base58 session key into Grid session key object", () => {
+    const original = [1, 2, 3, 4, 5, 6, 7, 8];
+    const encoded = bs58.encode(Uint8Array.from(original));
+    const sessionKey = toSessionKeyObject(encoded, 123);
+    expect(sessionKey).toEqual({
+      key: original,
+      expiration: 123,
+    });
+  });
+
+  test("produces backend session key object with absolute expiration", () => {
+    const original = [1, 2, 3, 4, 5, 6, 7, 8];
+    const encoded = bs58.encode(Uint8Array.from(original));
+    const sessionKey = toSessionKeyBackendObject(encoded, 900);
+    expect(sessionKey.key.length).toBe(8);
+    expect(sessionKey.expiration).toBe(900);
+  });
+});

--- a/passkey/src/lib/passkeys/__tests__/webauthn.test.ts
+++ b/passkey/src/lib/passkeys/__tests__/webauthn.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { isChallengeTimeoutError } from "@/lib/passkeys/webauthn";
+
+describe("isChallengeTimeoutError", () => {
+  test("detects timeout and challenge expiration messages", () => {
+    expect(isChallengeTimeoutError(new Error("NotAllowedError: timeout"))).toBe(
+      true
+    );
+    expect(
+      isChallengeTimeoutError(new Error("challenge expired while authenticating"))
+    ).toBe(true);
+  });
+
+  test("does not classify unrelated errors as timeout", () => {
+    expect(isChallengeTimeoutError(new Error("network unreachable"))).toBe(false);
+  });
+});

--- a/passkey/src/lib/passkeys/client-api.ts
+++ b/passkey/src/lib/passkeys/client-api.ts
@@ -1,0 +1,138 @@
+"use client";
+
+export type ApiOutcome = {
+  ok: boolean;
+  status: number;
+  body: unknown;
+};
+
+export async function callPasskeyApi(
+  endpoint: string,
+  payload: unknown
+): Promise<ApiOutcome> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const bodyText = await response.text();
+  let body: unknown = bodyText;
+  try {
+    body = bodyText ? JSON.parse(bodyText) : null;
+  } catch {
+    body = bodyText;
+  }
+
+  return { ok: response.ok, status: response.status, body };
+}
+
+export function extractPasskeyErrorMessage(payload: unknown): string {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "object" &&
+    payload.error !== null &&
+    "message" in payload.error &&
+    typeof payload.error.message === "string"
+  ) {
+    return payload.error.message;
+  }
+
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "message" in payload &&
+    typeof payload.message === "string"
+  ) {
+    return payload.message;
+  }
+
+  return "Passkey flow failed";
+}
+
+export function parsePasskeyErrorDetails(payload: unknown): string[] {
+  const normalizeDetail = (detail: unknown): string | null => {
+    if (typeof detail === "string") {
+      return detail;
+    }
+
+    if (typeof detail === "object" && detail !== null) {
+      const record = detail as Record<string, unknown>;
+      const field = typeof record.field === "string" ? record.field : undefined;
+      const code = typeof record.code === "string" ? record.code : undefined;
+      const message =
+        typeof record.message === "string" ? record.message : undefined;
+
+      if (field && code && message) {
+        return `${field} (${code}): ${message}`;
+      }
+
+      if (message) {
+        return message;
+      }
+    }
+
+    return null;
+  };
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "object" &&
+    payload.error !== null &&
+    "details" in payload.error &&
+    Array.isArray(payload.error.details)
+  ) {
+    return payload.error.details
+      .map(normalizeDetail)
+      .filter((detail): detail is string => detail !== null);
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "details" in payload &&
+    Array.isArray(payload.details)
+  ) {
+    return payload.details
+      .map(normalizeDetail)
+      .filter((detail): detail is string => detail !== null);
+  }
+
+  return [];
+}
+
+export function extractPasskeySessionUrl(payload: unknown): string | null {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "url" in payload &&
+    typeof payload.url === "string"
+  ) {
+    return payload.url;
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "data" in payload &&
+    typeof payload.data === "object" &&
+    payload.data !== null &&
+    "url" in payload.data &&
+    typeof payload.data.url === "string"
+  ) {
+    return payload.data.url;
+  }
+
+  return null;
+}
+

--- a/passkey/src/lib/passkeys/codecs.ts
+++ b/passkey/src/lib/passkeys/codecs.ts
@@ -1,0 +1,27 @@
+export function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function base64UrlToUint8Array(base64Url: string): Uint8Array {
+  const normalized = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  return "Unknown passkey error";
+}

--- a/passkey/src/lib/passkeys/continue-runner.ts
+++ b/passkey/src/lib/passkeys/continue-runner.ts
@@ -1,0 +1,250 @@
+"use client";
+
+import {
+  callPasskeyApi,
+  extractPasskeyErrorMessage,
+  extractPasskeySessionUrl,
+  parsePasskeyErrorDetails,
+  type ApiOutcome,
+} from "@/lib/passkeys/client-api";
+import {
+  buildPasskeyFlowRequest,
+  type FlowRunnerDependencies,
+} from "@/lib/passkeys/flow-runner";
+import {
+  parseCreatePasskeyQuery,
+  type ParsedAuthPasskeyQuery,
+} from "@/lib/passkeys/query-params";
+import { toSessionKeyObject } from "@/lib/passkeys/session-key";
+import { isChallengeTimeoutError } from "@/lib/passkeys/webauthn";
+
+type ContinueRunnerDependencies = {
+  buildFlowRequest: (
+    mode: "create" | "auth",
+    parsed: unknown,
+    dependencies?: FlowRunnerDependencies
+  ) => ReturnType<typeof buildPasskeyFlowRequest>;
+  callApi: (endpoint: string, payload: unknown) => Promise<ApiOutcome>;
+};
+
+const defaultContinueRunnerDependencies: ContinueRunnerDependencies = {
+  buildFlowRequest: buildPasskeyFlowRequest as ContinueRunnerDependencies["buildFlowRequest"],
+  callApi: callPasskeyApi,
+};
+
+const knownAccountNotFoundCodes = new Set([
+  "NOVALIDEXTERNALLYSIGNEDACCOUNT",
+  "NO_VALID_EXTERNALLY_SIGNED_ACCOUNT",
+  "PASSKEY_ACCOUNT_NOT_FOUND",
+  "ACCOUNT_NOT_FOUND",
+]);
+
+export type ContinueRunnerResult =
+  | {
+      type: "success";
+      branch: "auth" | "create";
+      body: unknown;
+    }
+  | {
+      type: "needs_create_cta";
+      message: string;
+    }
+  | {
+      type: "error";
+      branch: "auth" | "create";
+      message: string;
+      details: string[];
+      challengeExpired: boolean;
+    };
+
+function normalizeCode(code: string): string {
+  return code.replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
+}
+
+function detailCodeValues(payload: unknown): string[] {
+  const records: unknown[] = [];
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "object" &&
+    payload.error !== null &&
+    "details" in payload.error &&
+    Array.isArray(payload.error.details)
+  ) {
+    records.push(...payload.error.details);
+  } else if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "details" in payload &&
+    Array.isArray(payload.details)
+  ) {
+    records.push(...payload.details);
+  }
+
+  return records
+    .map((entry) => {
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        "code" in entry &&
+        typeof entry.code === "string"
+      ) {
+        return normalizeCode(entry.code);
+      }
+
+      return null;
+    })
+    .filter((code): code is string => code !== null);
+}
+
+export function shouldFallbackToCreateFromAuthFailure(payload: unknown): boolean {
+  const normalizedCodes = detailCodeValues(payload);
+  if (normalizedCodes.some((code) => knownAccountNotFoundCodes.has(code))) {
+    return true;
+  }
+
+  const message = extractPasskeyErrorMessage(payload).toLowerCase();
+  return (
+    message.includes("account not found") ||
+    message.includes("no valid externally signed account") ||
+    message.includes("passkey account not found")
+  );
+}
+
+function isNotAllowedCredentialError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+
+  return message.includes("notallowederror");
+}
+
+function toFailure(
+  branch: "auth" | "create",
+  payload: unknown
+): ContinueRunnerResult {
+  const message = extractPasskeyErrorMessage(payload);
+  return {
+    type: "error",
+    branch,
+    message,
+    details: parsePasskeyErrorDetails(payload),
+    challengeExpired: isChallengeTimeoutError(new Error(message)),
+  };
+}
+
+export function buildCreateSessionPayloadFromAuthQuery(
+  parsedAuth: ParsedAuthPasskeyQuery
+) {
+  return {
+    env: parsedAuth.env ?? "sandbox",
+    metaInfo: {},
+    sessionKey: toSessionKeyObject(
+      parsedAuth.sessionKey,
+      parsedAuth.expirationInSeconds
+    ),
+  };
+}
+
+export async function runCreateFallbackFromAuth(
+  parsedAuth: ParsedAuthPasskeyQuery,
+  dependencies: ContinueRunnerDependencies = defaultContinueRunnerDependencies
+): Promise<ContinueRunnerResult> {
+  const createSessionOutcome = await dependencies.callApi(
+    "/api/passkeys/session/create",
+    buildCreateSessionPayloadFromAuthQuery(parsedAuth)
+  );
+
+  if (!createSessionOutcome.ok) {
+    return toFailure("create", createSessionOutcome.body);
+  }
+
+  const createSessionUrl = extractPasskeySessionUrl(createSessionOutcome.body);
+  if (!createSessionUrl) {
+    return {
+      type: "error",
+      branch: "create",
+      message: "Create session response did not include a passkey URL",
+      details: [],
+      challengeExpired: false,
+    };
+  }
+
+  const createParamsResult = parseCreatePasskeyQuery(
+    new URL(createSessionUrl).searchParams
+  );
+  if (!createParamsResult.ok) {
+    return {
+      type: "error",
+      branch: "create",
+      message: "Create session URL was missing required query parameters",
+      details: createParamsResult.errors,
+      challengeExpired: false,
+    };
+  }
+
+  const createSubmitRequest = await dependencies.buildFlowRequest(
+    "create",
+    createParamsResult.data
+  );
+  const createSubmitOutcome = await dependencies.callApi(
+    createSubmitRequest.endpoint,
+    createSubmitRequest.payload
+  );
+  if (!createSubmitOutcome.ok) {
+    return toFailure("create", createSubmitOutcome.body);
+  }
+
+  return {
+    type: "success",
+    branch: "create",
+    body: createSubmitOutcome.body,
+  };
+}
+
+export async function runContinueAuthFirst(
+  parsedAuth: ParsedAuthPasskeyQuery,
+  dependencies: ContinueRunnerDependencies = defaultContinueRunnerDependencies
+): Promise<ContinueRunnerResult> {
+  try {
+    const authRequest = await dependencies.buildFlowRequest("auth", parsedAuth);
+    const authOutcome = await dependencies.callApi(
+      authRequest.endpoint,
+      authRequest.payload
+    );
+
+    if (authOutcome.ok) {
+      return {
+        type: "success",
+        branch: "auth",
+        body: authOutcome.body,
+      };
+    }
+
+    if (shouldFallbackToCreateFromAuthFailure(authOutcome.body)) {
+      return runCreateFallbackFromAuth(parsedAuth, dependencies);
+    }
+
+    return toFailure("auth", authOutcome.body);
+  } catch (error) {
+    if (isNotAllowedCredentialError(error)) {
+      return {
+        type: "needs_create_cta",
+        message:
+          "No existing passkey login completed. Use 'Try create account' to register one now.",
+      };
+    }
+
+    const message =
+      error instanceof Error ? error.message : "Passkey continue flow failed";
+    return {
+      type: "error",
+      branch: "auth",
+      message,
+      details: [],
+      challengeExpired: isChallengeTimeoutError(error),
+    };
+  }
+}
+

--- a/passkey/src/lib/passkeys/contracts.ts
+++ b/passkey/src/lib/passkeys/contracts.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+export const gridEnvironmentSchema = z.enum(["sandbox", "production"]);
+export const sessionEnvironmentSchema = z.enum([
+  "sandbox",
+  "production",
+  "devnet",
+  "mainnet",
+  "testnet",
+]);
+
+export const sessionKeySchema = z.object({
+  key: z.unknown(),
+  expiration: z.number().int().positive(),
+});
+
+export const sessionKeyBackendSchema = z.object({
+  key: z.array(z.number().int().min(0).max(255)),
+  expiration: z.number().int().positive(),
+});
+
+export const createSessionRequestSchema = z
+  .object({
+    sessionKey: sessionKeySchema,
+    env: sessionEnvironmentSchema,
+    metaInfo: z.record(z.string(), z.unknown()).default({}),
+  })
+  .passthrough();
+
+export const authorizeSessionRequestSchema = z
+  .object({
+    sessionKey: sessionKeySchema.optional(),
+    metaInfo: z
+      .object({
+        appName: z.string().min(1),
+        redirectUrl: z.string().url().optional(),
+      })
+      .passthrough(),
+    baseUrl: z.string().url().optional(),
+    accountAddress: z.string().optional(),
+  })
+  .passthrough();
+
+export const submitSessionRequestSchema = z
+  .object({
+    ceremonyType: z.enum(["create", "auth"]),
+    sessionKey: sessionKeyBackendSchema,
+    slotNumber: z.coerce.number().int().nonnegative(),
+    authenticatorResponse: z.unknown(),
+  })
+  .passthrough();
+
+export const createAccountRequestSchema = z
+  .object({
+    sessionKey: sessionKeySchema,
+    slotNumber: z.coerce.number().int().nonnegative(),
+    authenticatorResponse: z.unknown(),
+    adminAddress: z.string().optional(),
+    memo: z.string().optional(),
+  })
+  .passthrough();
+
+export const findAccountRequestSchema = z
+  .object({
+    sessionKey: sessionKeySchema,
+    authenticatorResponse: z.unknown(),
+  })
+  .passthrough();
+
+export const passkeyAccountParamSchema = z.object({
+  passkeyAddress: z.string().min(1),
+});
+
+export const passkeyApiPaths = {
+  createSession: "/passkeys",
+  authorizeSession: "/passkeys/auth",
+  submitSession: "/passkeys/submit",
+  createAccount: "/passkeys/account",
+  getAccount: (passkeyAddress: string) => `/passkeys/account/${passkeyAddress}`,
+  findAccount: "/passkeys/find",
+} as const;
+
+export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
+export type AuthorizeSessionRequest = z.infer<
+  typeof authorizeSessionRequestSchema
+>;
+export type SubmitSessionRequest = z.infer<typeof submitSessionRequestSchema>;
+export type CreateAccountRequest = z.infer<typeof createAccountRequestSchema>;
+export type FindAccountRequest = z.infer<typeof findAccountRequestSchema>;

--- a/passkey/src/lib/passkeys/flow-runner.ts
+++ b/passkey/src/lib/passkeys/flow-runner.ts
@@ -8,7 +8,11 @@ import {
 import {
   toSessionKeyBackendObject,
 } from "@/lib/passkeys/session-key";
-import { getGridBrowserSdkClient } from "@/lib/passkeys/grid-browser-sdk";
+import { resolveCurrentPasskeyBrowserContext } from "@/lib/passkeys/host-resolution";
+import {
+  runAuthPasskeyCeremony,
+  runCreatePasskeyCeremony,
+} from "@/lib/passkeys/webauthn";
 import type { Env } from "@sqds/grid";
 
 export type PasskeyFlowMode = "create" | "auth";
@@ -39,22 +43,19 @@ const flowRegistry: {
 };
 
 export type FlowRunnerDependencies = {
-  createCredentials: ReturnType<
-    typeof getGridBrowserSdkClient
-  >["createPasskeyCredentials"];
-  getCredentials: ReturnType<typeof getGridBrowserSdkClient>["getPasskeyCredentials"];
+  resolveHostContext: typeof resolveCurrentPasskeyBrowserContext;
+  runCreateCeremony: typeof runCreatePasskeyCeremony;
+  runAuthCeremony: typeof runAuthPasskeyCeremony;
 };
 
 const defaultFlowRunnerDependencies: FlowRunnerDependencies = {
-  createCredentials: (...args) =>
-    getGridBrowserSdkClient().createPasskeyCredentials(...args),
-  getCredentials: (...args) => getGridBrowserSdkClient().getPasskeyCredentials(...args),
+  resolveHostContext: () => resolveCurrentPasskeyBrowserContext(),
+  runCreateCeremony: (...args) => runCreatePasskeyCeremony(...args),
+  runAuthCeremony: (...args) => runAuthPasskeyCeremony(...args),
 };
 
-function normalizeChallengeForSdk(challenge: string): string {
-  const urlNormalized = challenge.trim().replace(/ /g, "+").replace(/-/g, "+").replace(/_/g, "/");
-  const paddingNeeded = (4 - (urlNormalized.length % 4)) % 4;
-  return urlNormalized + "=".repeat(paddingNeeded);
+function normalizeChallenge(challenge: string): string {
+  return challenge.trim().replace(/ /g, "+");
 }
 
 function toSharedPasskeyRequest(
@@ -68,7 +69,7 @@ function toSharedPasskeyRequest(
         : "devnet";
 
   return {
-    challenge: normalizeChallengeForSdk(parsed.challenge),
+    challenge: normalizeChallenge(parsed.challenge),
     env: gridEnv,
     expirationInSeconds: String(parsed.expirationInSeconds),
     redirectUrl: parsed.redirectUrl,
@@ -90,6 +91,7 @@ export async function buildPasskeyFlowRequest(
   dependencies: FlowRunnerDependencies = defaultFlowRunnerDependencies
 ): Promise<PasskeyFlowRequest> {
   const sharedRequest = toSharedPasskeyRequest(parsed);
+  const hostContext = dependencies.resolveHostContext();
 
   if (mode === "create") {
     const createParsed = parsed as ParsedCreatePasskeyQuery;
@@ -99,11 +101,18 @@ export async function buildPasskeyFlowRequest(
       userId: createParsed.userId,
     };
 
-    const credentialData = await dependencies.createCredentials(createRequest);
-    const assertion = await dependencies.getCredentials(
-      createRequest,
-      credentialData
-    );
+    const credentialData = await dependencies.runCreateCeremony({
+      challenge: createRequest.challenge,
+      appName: createRequest.appName,
+      userId: createRequest.userId,
+      rpId: hostContext.rpId,
+    });
+    const assertion = await dependencies.runAuthCeremony({
+      challenge: createRequest.challenge,
+      rpId: hostContext.rpId,
+      allowCredentialId: credentialData.rawId,
+      publicKey: credentialData.publicKey,
+    });
 
     return {
       endpoint: "/api/passkeys/session/submit",
@@ -120,7 +129,10 @@ export async function buildPasskeyFlowRequest(
   }
 
   const authParsed = parsed as ParsedAuthPasskeyQuery;
-  const assertion = await dependencies.getCredentials(sharedRequest);
+  const assertion = await dependencies.runAuthCeremony({
+    challenge: sharedRequest.challenge,
+    rpId: hostContext.rpId,
+  });
 
   return {
     endpoint: "/api/passkeys/session/submit",

--- a/passkey/src/lib/passkeys/flow-runner.ts
+++ b/passkey/src/lib/passkeys/flow-runner.ts
@@ -1,0 +1,137 @@
+import {
+  type ParsedAuthPasskeyQuery,
+  type ParsedCreatePasskeyQuery,
+  type ParseResult,
+  parseAuthPasskeyQuery,
+  parseCreatePasskeyQuery,
+} from "@/lib/passkeys/query-params";
+import {
+  toSessionKeyBackendObject,
+} from "@/lib/passkeys/session-key";
+import { getGridBrowserSdkClient } from "@/lib/passkeys/grid-browser-sdk";
+import type { Env } from "@sqds/grid";
+
+export type PasskeyFlowMode = "create" | "auth";
+
+export type PasskeyFlowParseResult =
+  | ParseResult<ParsedCreatePasskeyQuery>
+  | ParseResult<ParsedAuthPasskeyQuery>;
+
+export type PasskeyFlowRequest = {
+  endpoint: string;
+  payload: unknown;
+};
+
+type FlowRegistryEntry<T> = {
+  parse: (query: URLSearchParams) => ParseResult<T>;
+};
+
+const flowRegistry: {
+  create: FlowRegistryEntry<ParsedCreatePasskeyQuery>;
+  auth: FlowRegistryEntry<ParsedAuthPasskeyQuery>;
+} = {
+  create: {
+    parse: parseCreatePasskeyQuery,
+  },
+  auth: {
+    parse: parseAuthPasskeyQuery,
+  },
+};
+
+export type FlowRunnerDependencies = {
+  createCredentials: ReturnType<
+    typeof getGridBrowserSdkClient
+  >["createPasskeyCredentials"];
+  getCredentials: ReturnType<typeof getGridBrowserSdkClient>["getPasskeyCredentials"];
+};
+
+const defaultFlowRunnerDependencies: FlowRunnerDependencies = {
+  createCredentials: (...args) =>
+    getGridBrowserSdkClient().createPasskeyCredentials(...args),
+  getCredentials: (...args) => getGridBrowserSdkClient().getPasskeyCredentials(...args),
+};
+
+function normalizeChallengeForSdk(challenge: string): string {
+  const urlNormalized = challenge.trim().replace(/ /g, "+").replace(/-/g, "+").replace(/_/g, "/");
+  const paddingNeeded = (4 - (urlNormalized.length % 4)) % 4;
+  return urlNormalized + "=".repeat(paddingNeeded);
+}
+
+function toSharedPasskeyRequest(
+  parsed: ParsedCreatePasskeyQuery | ParsedAuthPasskeyQuery
+) {
+  const gridEnv: Env =
+    parsed.env === "mainnet" || parsed.env === "production"
+      ? "mainnet"
+      : parsed.env === "testnet"
+        ? "testnet"
+        : "devnet";
+
+  return {
+    challenge: normalizeChallengeForSdk(parsed.challenge),
+    env: gridEnv,
+    expirationInSeconds: String(parsed.expirationInSeconds),
+    redirectUrl: parsed.redirectUrl,
+    sessionKey: parsed.sessionKey,
+    slotNumber: String(parsed.slotNumber),
+  };
+}
+
+export function parsePasskeyFlowQuery(
+  mode: PasskeyFlowMode,
+  query: URLSearchParams
+): PasskeyFlowParseResult {
+  return flowRegistry[mode].parse(query);
+}
+
+export async function buildPasskeyFlowRequest(
+  mode: PasskeyFlowMode,
+  parsed: ParsedCreatePasskeyQuery | ParsedAuthPasskeyQuery,
+  dependencies: FlowRunnerDependencies = defaultFlowRunnerDependencies
+): Promise<PasskeyFlowRequest> {
+  const sharedRequest = toSharedPasskeyRequest(parsed);
+
+  if (mode === "create") {
+    const createParsed = parsed as ParsedCreatePasskeyQuery;
+    const createRequest = {
+      ...sharedRequest,
+      appName: createParsed.appName,
+      userId: createParsed.userId,
+    };
+
+    const credentialData = await dependencies.createCredentials(createRequest);
+    const assertion = await dependencies.getCredentials(
+      createRequest,
+      credentialData
+    );
+
+    return {
+      endpoint: "/api/passkeys/session/submit",
+      payload: {
+        ceremonyType: "create",
+        sessionKey: toSessionKeyBackendObject(
+          createParsed.sessionKey,
+          createParsed.expirationInSeconds
+        ),
+        slotNumber: createParsed.slotNumber,
+        authenticatorResponse: assertion,
+      },
+    };
+  }
+
+  const authParsed = parsed as ParsedAuthPasskeyQuery;
+  const assertion = await dependencies.getCredentials(sharedRequest);
+
+  return {
+    endpoint: "/api/passkeys/session/submit",
+    payload: {
+      ceremonyType: "auth",
+      sessionKey: toSessionKeyBackendObject(
+        authParsed.sessionKey,
+        authParsed.expirationInSeconds
+      ),
+      slotNumber: authParsed.slotNumber,
+      authenticatorResponse: assertion,
+    },
+  };
+}

--- a/passkey/src/lib/passkeys/grid-browser-sdk.ts
+++ b/passkey/src/lib/passkeys/grid-browser-sdk.ts
@@ -1,0 +1,20 @@
+import { GridClient } from "@sqds/grid";
+
+let cachedGridClient: GridClient | null = null;
+
+export function getGridBrowserSdkClient(): GridClient {
+  if (cachedGridClient) {
+    return cachedGridClient;
+  }
+
+  // Browser helper methods below do not require live API calls.
+  cachedGridClient = new GridClient({
+    environment: "sandbox",
+  });
+
+  return cachedGridClient;
+}
+
+export function resetGridBrowserSdkClientForTests(): void {
+  cachedGridClient = null;
+}

--- a/passkey/src/lib/passkeys/grid-proxy.ts
+++ b/passkey/src/lib/passkeys/grid-proxy.ts
@@ -1,0 +1,439 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import type { PasskeyServerConfig } from "@/lib/core/config/types";
+import {
+  authorizeSessionRequestSchema,
+  createAccountRequestSchema,
+  createSessionRequestSchema,
+  findAccountRequestSchema,
+  passkeyAccountParamSchema,
+  passkeyApiPaths,
+  submitSessionRequestSchema,
+} from "@/lib/passkeys/contracts";
+
+type PasskeyOperation =
+  | "createSession"
+  | "authorizeSession"
+  | "submitSession"
+  | "createAccount"
+  | "findAccount"
+  | "getAccount";
+
+type OperationDefinition = {
+  method: "POST" | "GET";
+  path: (passkeyAddress?: string) => string;
+  schema?: z.ZodType<unknown>;
+};
+
+const operationDefinitions: Record<PasskeyOperation, OperationDefinition> = {
+  createSession: {
+    method: "POST",
+    path: () => passkeyApiPaths.createSession,
+    schema: createSessionRequestSchema,
+  },
+  authorizeSession: {
+    method: "POST",
+    path: () => passkeyApiPaths.authorizeSession,
+    schema: authorizeSessionRequestSchema,
+  },
+  submitSession: {
+    method: "POST",
+    path: () => passkeyApiPaths.submitSession,
+    schema: submitSessionRequestSchema,
+  },
+  createAccount: {
+    method: "POST",
+    path: () => passkeyApiPaths.createAccount,
+    schema: createAccountRequestSchema,
+  },
+  findAccount: {
+    method: "POST",
+    path: () => passkeyApiPaths.findAccount,
+    schema: findAccountRequestSchema,
+  },
+  getAccount: {
+    method: "GET",
+    path: (passkeyAddress?: string) => passkeyApiPaths.getAccount(passkeyAddress ?? ""),
+  },
+};
+
+type PrepareProxyRequestArgs = {
+  operation: PasskeyOperation;
+  body?: unknown;
+  passkeyAddress?: string;
+  incomingHeaders: Headers;
+  config: PasskeyServerConfig;
+};
+
+type PreparedProxyRequest = {
+  url: string;
+  init: RequestInit;
+  normalizedBody?: unknown;
+};
+
+type ProxyErrorCode =
+  | "invalid_request"
+  | "invalid_json"
+  | "proxy_failed"
+  | "upstream_error";
+
+type ProxyErrorEnvelope = {
+  code: ProxyErrorCode | string;
+  message: string;
+  details?: unknown;
+  requestId?: string;
+};
+
+export class ProxyValidationError extends Error {
+  readonly details: string[];
+
+  constructor(message: string, details: string[]) {
+    super(message);
+    this.name = "ProxyValidationError";
+    this.details = details;
+  }
+}
+
+function extractSchemaErrors(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.join(".") || "request";
+    return `${path}: ${issue.message}`;
+  });
+}
+
+function createProxyErrorResponse(
+  status: number,
+  error: ProxyErrorEnvelope,
+  headers?: Headers
+): NextResponse {
+  const responseHeaders = new Headers(headers);
+  if (error.requestId) {
+    responseHeaders.set("x-request-id", error.requestId);
+  }
+
+  return NextResponse.json(
+    {
+      error: {
+        code: error.code,
+        message: error.message,
+        ...(error.details !== undefined ? { details: error.details } : {}),
+        ...(error.requestId ? { requestId: error.requestId } : {}),
+      },
+    },
+    { status, headers: responseHeaders }
+  );
+}
+
+function extractRequestId(headers: Headers): string | undefined {
+  const requestId = headers.get("x-request-id");
+  return requestId && requestId.length > 0 ? requestId : undefined;
+}
+
+function parseSetCookieHeader(header: string | null): string[] {
+  if (!header) {
+    return [];
+  }
+
+  return header
+    .split(/,(?=\s*[A-Za-z0-9_-]+=)/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const withSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
+  };
+
+  if (typeof withSetCookie.getSetCookie === "function") {
+    const setCookies = withSetCookie.getSetCookie();
+    if (setCookies.length > 0) {
+      return setCookies;
+    }
+  }
+
+  if (typeof withSetCookie.raw === "function") {
+    const raw = withSetCookie.raw();
+    const setCookies = raw["set-cookie"];
+    if (Array.isArray(setCookies) && setCookies.length > 0) {
+      return setCookies;
+    }
+  }
+
+  return parseSetCookieHeader(headers.get("set-cookie"));
+}
+
+function buildForwardHeaders(
+  incomingHeaders: Headers,
+  config: PasskeyServerConfig,
+  method: "POST" | "GET"
+): Headers {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-grid-environment": config.gridEnvironment,
+  });
+
+  if (method === "POST") {
+    headers.set("x-idempotency-key", crypto.randomUUID());
+  }
+
+  if (config.gridApiKey) {
+    headers.set("authorization", `Bearer ${config.gridApiKey}`);
+  }
+
+  for (const headerName of ["origin", "cookie", "user-agent", "referer"]) {
+    const value = incomingHeaders.get(headerName);
+    if (value) {
+      headers.set(headerName, value);
+    }
+  }
+
+  return headers;
+}
+
+function withCustomDomainDefaults(
+  operation: PasskeyOperation,
+  body: unknown,
+  config: PasskeyServerConfig
+): unknown {
+  if (typeof body !== "object" || body === null) {
+    return body;
+  }
+
+  if (operation === "createSession") {
+    const payload = body as Record<string, unknown>;
+    const metaInfo =
+      typeof payload.metaInfo === "object" && payload.metaInfo !== null
+        ? (payload.metaInfo as Record<string, unknown>)
+        : {};
+    const resolvedBaseUrl =
+      typeof payload.baseUrl === "string" && payload.baseUrl.length > 0
+        ? payload.baseUrl
+        : config.customDomainBaseUrl;
+
+    return {
+      ...payload,
+      baseUrl: resolvedBaseUrl,
+      metaInfo: {
+        ...metaInfo,
+        appName:
+          typeof metaInfo.appName === "string" && metaInfo.appName.length > 0
+            ? metaInfo.appName
+            : config.appName,
+        baseUrl:
+          typeof metaInfo.baseUrl === "string" && metaInfo.baseUrl.length > 0
+            ? metaInfo.baseUrl
+            : resolvedBaseUrl,
+      },
+    };
+  }
+
+  if (operation === "authorizeSession") {
+    const payload = body as Record<string, unknown>;
+    const metaInfo =
+      typeof payload.metaInfo === "object" && payload.metaInfo !== null
+        ? (payload.metaInfo as Record<string, unknown>)
+        : {};
+
+    return {
+      ...payload,
+      baseUrl: config.customDomainBaseUrl,
+      metaInfo: {
+        ...metaInfo,
+        appName:
+          typeof metaInfo.appName === "string" && metaInfo.appName.length > 0
+            ? metaInfo.appName
+            : config.appName,
+      },
+    };
+  }
+
+  return body;
+}
+
+export function preparePasskeyUpstreamRequest(
+  args: PrepareProxyRequestArgs
+): PreparedProxyRequest {
+  const definition = operationDefinitions[args.operation];
+  if (!definition) {
+    throw new ProxyValidationError("Unknown passkey operation", [args.operation]);
+  }
+
+  let validatedBody: unknown;
+  if (definition.method === "POST") {
+    if (!definition.schema) {
+      throw new ProxyValidationError("Missing request validator", [args.operation]);
+    }
+
+    const parseResult = definition.schema.safeParse(args.body);
+    if (!parseResult.success) {
+      throw new ProxyValidationError(
+        "Invalid request payload",
+        extractSchemaErrors(parseResult.error)
+      );
+    }
+
+    validatedBody = withCustomDomainDefaults(
+      args.operation,
+      parseResult.data,
+      args.config
+    );
+  } else if (args.operation === "getAccount") {
+    const parsed = passkeyAccountParamSchema.safeParse({
+      passkeyAddress: args.passkeyAddress,
+    });
+    if (!parsed.success) {
+      throw new ProxyValidationError(
+        "Invalid passkey account parameter",
+        extractSchemaErrors(parsed.error)
+      );
+    }
+  }
+
+  const path = definition.path(args.passkeyAddress);
+  const url = `${args.config.gridApiBaseUrl}/api/grid/v1${path}`;
+  const init: RequestInit = {
+    method: definition.method,
+    headers: buildForwardHeaders(
+      args.incomingHeaders,
+      args.config,
+      definition.method
+    ),
+    body: validatedBody ? JSON.stringify(validatedBody) : undefined,
+  };
+
+  return { url, init, normalizedBody: validatedBody };
+}
+
+export async function buildProxyResponse(upstream: Response): Promise<NextResponse> {
+  const responseHeaders = new Headers();
+  for (const headerName of ["x-request-id", "x-idempotency-key"]) {
+    const value = upstream.headers.get(headerName);
+    if (value) {
+      responseHeaders.set(headerName, value);
+    }
+  }
+
+  const setCookies = getSetCookieHeaders(upstream.headers);
+  for (const setCookie of setCookies) {
+    responseHeaders.append("set-cookie", setCookie);
+  }
+
+  const requestId = extractRequestId(upstream.headers);
+  const responseText = await upstream.text();
+  const contentType = upstream.headers.get("content-type") ?? "";
+
+  if (!responseText && upstream.status < 400) {
+    return new NextResponse(null, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+  }
+
+  let parsedPayload: unknown = responseText;
+  if (contentType.includes("application/json") && responseText) {
+    try {
+      parsedPayload = JSON.parse(responseText);
+    } catch {
+      parsedPayload = { message: responseText };
+    }
+  }
+
+  if (upstream.status >= 400) {
+    const payload =
+      parsedPayload && typeof parsedPayload === "object"
+        ? (parsedPayload as Record<string, unknown>)
+        : null;
+
+    const message =
+      (payload?.message as string | undefined) ??
+      (payload?.error as string | undefined) ??
+      (typeof parsedPayload === "string" && parsedPayload.length > 0
+        ? parsedPayload
+        : "Upstream passkey request failed");
+
+    const details = payload?.details ?? payload ?? parsedPayload;
+    const code = (payload?.code as string | undefined) ?? "upstream_error";
+
+    return createProxyErrorResponse(
+      upstream.status,
+      { code, message, details, requestId },
+      responseHeaders
+    );
+  }
+
+  if (contentType.includes("application/json")) {
+    return NextResponse.json(parsedPayload, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+  }
+
+  if (typeof parsedPayload === "string") {
+    return new NextResponse(parsedPayload, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+  }
+
+  return NextResponse.json(parsedPayload, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+export async function proxyPasskeyOperation({
+  operation,
+  request,
+  passkeyAddress,
+}: {
+  operation: PasskeyOperation;
+  request: Request;
+  passkeyAddress?: string;
+}): Promise<NextResponse> {
+  try {
+    const { getServerConfig } = await import("@/lib/core/config/server");
+    const config = getServerConfig();
+    const definition = operationDefinitions[operation];
+    const body =
+      definition.method === "POST" ? await request.json() : undefined;
+
+    const prepared = preparePasskeyUpstreamRequest({
+      operation,
+      body,
+      passkeyAddress,
+      incomingHeaders: request.headers,
+      config,
+    });
+
+    const upstream = await fetch(prepared.url, prepared.init);
+    return buildProxyResponse(upstream);
+  } catch (error) {
+    if (error instanceof ProxyValidationError) {
+      return createProxyErrorResponse(400, {
+        code: "invalid_request",
+        message: error.message,
+        details: error.details,
+      });
+    }
+
+    if (error instanceof SyntaxError) {
+      return createProxyErrorResponse(400, {
+        code: "invalid_json",
+        message: "Request body must be valid JSON",
+      });
+    }
+
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Failed to proxy passkey request";
+
+    return createProxyErrorResponse(502, {
+      code: "proxy_failed",
+      message,
+    });
+  }
+}

--- a/passkey/src/lib/passkeys/grid-proxy.ts
+++ b/passkey/src/lib/passkeys/grid-proxy.ts
@@ -11,6 +11,10 @@ import {
   passkeyApiPaths,
   submitSessionRequestSchema,
 } from "@/lib/passkeys/contracts";
+import {
+  PasskeyHostResolutionError,
+  resolvePasskeyRequestContext,
+} from "@/lib/passkeys/host-resolution";
 
 type PasskeyOperation =
   | "createSession"
@@ -62,6 +66,7 @@ type PrepareProxyRequestArgs = {
   operation: PasskeyOperation;
   body?: unknown;
   passkeyAddress?: string;
+  requestUrl: string;
   incomingHeaders: Headers;
   config: PasskeyServerConfig;
 };
@@ -196,7 +201,8 @@ function buildForwardHeaders(
 function withCustomDomainDefaults(
   operation: PasskeyOperation,
   body: unknown,
-  config: PasskeyServerConfig
+  config: PasskeyServerConfig,
+  resolvedOrigin: string
 ): unknown {
   if (typeof body !== "object" || body === null) {
     return body;
@@ -211,7 +217,7 @@ function withCustomDomainDefaults(
     const resolvedBaseUrl =
       typeof payload.baseUrl === "string" && payload.baseUrl.length > 0
         ? payload.baseUrl
-        : config.customDomainBaseUrl;
+        : resolvedOrigin;
 
     return {
       ...payload,
@@ -239,7 +245,7 @@ function withCustomDomainDefaults(
 
     return {
       ...payload,
-      baseUrl: config.customDomainBaseUrl,
+      baseUrl: resolvedOrigin,
       metaInfo: {
         ...metaInfo,
         appName:
@@ -261,6 +267,16 @@ export function preparePasskeyUpstreamRequest(
     throw new ProxyValidationError("Unknown passkey operation", [args.operation]);
   }
 
+  const resolvedRequestContext = resolvePasskeyRequestContext({
+    requestUrl: args.requestUrl,
+    headers: args.incomingHeaders,
+    options: {
+      allowedParentDomain: args.config.allowedParentDomain,
+      allowLocalhost: args.config.allowLocalhost,
+      sharedRpId: args.config.sharedRpId,
+    },
+  });
+
   let validatedBody: unknown;
   if (definition.method === "POST") {
     if (!definition.schema) {
@@ -278,7 +294,8 @@ export function preparePasskeyUpstreamRequest(
     validatedBody = withCustomDomainDefaults(
       args.operation,
       parseResult.data,
-      args.config
+      args.config,
+      resolvedRequestContext.origin
     );
   } else if (args.operation === "getAccount") {
     const parsed = passkeyAccountParamSchema.safeParse({
@@ -404,6 +421,7 @@ export async function proxyPasskeyOperation({
       operation,
       body,
       passkeyAddress,
+      requestUrl: request.url,
       incomingHeaders: request.headers,
       config,
     });
@@ -416,6 +434,13 @@ export async function proxyPasskeyOperation({
         code: "invalid_request",
         message: error.message,
         details: error.details,
+      });
+    }
+
+    if (error instanceof PasskeyHostResolutionError) {
+      return createProxyErrorResponse(400, {
+        code: "invalid_request",
+        message: error.message,
       });
     }
 

--- a/passkey/src/lib/passkeys/host-resolution.ts
+++ b/passkey/src/lib/passkeys/host-resolution.ts
@@ -1,0 +1,121 @@
+export type PasskeyHostResolutionOptions = {
+  allowedParentDomain: string;
+  allowLocalhost: boolean;
+  sharedRpId: string;
+};
+
+export type ResolvedPasskeyHostContext = {
+  hostname: string;
+  origin: string;
+  rpId: string;
+  isLocalhost: boolean;
+};
+
+export class PasskeyHostResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PasskeyHostResolutionError";
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().replace(/\.$/, "").toLowerCase();
+}
+
+function getPrimaryHeaderValue(headers: Headers, name: string): string | null {
+  const value = headers.get(name);
+  if (!value) {
+    return null;
+  }
+
+  const primary = value.split(",")[0]?.trim();
+  return primary && primary.length > 0 ? primary : null;
+}
+
+export function resolvePasskeyHostContext(
+  hostname: string,
+  options: PasskeyHostResolutionOptions
+): Omit<ResolvedPasskeyHostContext, "origin"> {
+  const normalizedHostname = normalizeHostname(hostname);
+  const normalizedParentDomain = normalizeHostname(options.allowedParentDomain);
+  const normalizedRpId = normalizeHostname(options.sharedRpId);
+
+  if (!normalizedHostname) {
+    throw new PasskeyHostResolutionError("Passkey hostname is required");
+  }
+
+  if (normalizedHostname === "localhost") {
+    if (!options.allowLocalhost) {
+      throw new PasskeyHostResolutionError("Localhost is not allowed for passkeys");
+    }
+
+    return {
+      hostname: normalizedHostname,
+      rpId: "localhost",
+      isLocalhost: true,
+    };
+  }
+
+  if (
+    normalizedHostname === normalizedParentDomain ||
+    normalizedHostname.endsWith(`.${normalizedParentDomain}`)
+  ) {
+    return {
+      hostname: normalizedHostname,
+      rpId: normalizedRpId,
+      isLocalhost: false,
+    };
+  }
+
+  throw new PasskeyHostResolutionError(
+    `Host "${normalizedHostname}" is not allowed for passkeys`
+  );
+}
+
+export function resolvePasskeyRequestContext(args: {
+  requestUrl: string;
+  headers: Headers;
+  options: PasskeyHostResolutionOptions;
+}): ResolvedPasskeyHostContext {
+  const fallbackUrl = new URL(args.requestUrl);
+  const hostHeader =
+    getPrimaryHeaderValue(args.headers, "x-forwarded-host") ??
+    getPrimaryHeaderValue(args.headers, "host") ??
+    fallbackUrl.host;
+  const protocol =
+    getPrimaryHeaderValue(args.headers, "x-forwarded-proto") ??
+    fallbackUrl.protocol.replace(/:$/, "");
+  const resolvedUrl = new URL(`${protocol}://${hostHeader}`);
+  const resolvedHost = resolvePasskeyHostContext(
+    resolvedUrl.hostname,
+    args.options
+  );
+
+  return {
+    ...resolvedHost,
+    origin: resolvedUrl.origin,
+  };
+}
+
+export function resolveCurrentPasskeyBrowserContext(
+  locationLike: Pick<Location, "hostname" | "origin"> = window.location
+): ResolvedPasskeyHostContext {
+  const sharedRpId = process.env.NEXT_PUBLIC_PASSKEY_RP_ID;
+
+  if (!sharedRpId) {
+    throw new PasskeyHostResolutionError(
+      "NEXT_PUBLIC_PASSKEY_RP_ID is required for passkey flows"
+    );
+  }
+
+  const resolvedHost = resolvePasskeyHostContext(locationLike.hostname, {
+    allowedParentDomain: sharedRpId,
+    allowLocalhost: true,
+    sharedRpId,
+  });
+
+  return {
+    ...resolvedHost,
+    origin: locationLike.origin,
+  };
+}

--- a/passkey/src/lib/passkeys/query-params.ts
+++ b/passkey/src/lib/passkeys/query-params.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import { getGridBrowserSdkClient } from "@/lib/passkeys/grid-browser-sdk";
+
+type QueryLike = {
+  get(name: string): string | null;
+};
+
+const baseQuerySchema = z.object({
+  challenge: z.string().min(1),
+  slotNumber: z.coerce.number().int().nonnegative(),
+  sessionKey: z.string().min(1),
+  expirationInSeconds: z.coerce.number().int().positive(),
+  env: z.enum(["sandbox", "production", "devnet", "mainnet", "testnet"]).optional(),
+  redirectUrl: z.string().url().optional(),
+});
+
+const createQuerySchema = baseQuerySchema.extend({
+  appName: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+const authQuerySchema = baseQuerySchema;
+
+export type ParsedCreatePasskeyQuery = z.infer<typeof createQuerySchema>;
+export type ParsedAuthPasskeyQuery = z.infer<typeof authQuerySchema>;
+
+export type ParseResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; errors: string[] };
+
+function collectIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.join(".") || "query";
+    return `${path}: ${issue.message}`;
+  });
+}
+
+function mapBaseQuery(query: QueryLike) {
+  const optional = (value: string | null | undefined): string | undefined =>
+    value == null ? undefined : value;
+
+  const extracted = getGridBrowserSdkClient().extractPasskeyAuthParams(
+    query as URLSearchParams
+  );
+
+  return {
+    challenge: optional(extracted.challenge),
+    slotNumber: optional(extracted.slotNumber),
+    sessionKey: optional(extracted.sessionKey),
+    expirationInSeconds: optional(extracted.expirationInSeconds),
+    env: optional(extracted.env),
+    redirectUrl: optional(extracted.redirectUrl),
+  };
+}
+
+export function parseCreatePasskeyQuery(query: QueryLike): ParseResult<ParsedCreatePasskeyQuery> {
+  const optional = (value: string | null | undefined): string | undefined =>
+    value == null ? undefined : value;
+  const extracted = getGridBrowserSdkClient().extractPasskeyCreateParams(
+    query as URLSearchParams
+  );
+  const mapped = {
+    ...mapBaseQuery(query),
+    appName: optional(extracted.appName),
+    userId: optional(extracted.userId),
+  };
+
+  const parsed = createQuerySchema.safeParse(mapped);
+  if (!parsed.success) {
+    return { ok: false, errors: collectIssues(parsed.error) };
+  }
+
+  return { ok: true, data: parsed.data };
+}
+
+export function parseAuthPasskeyQuery(query: QueryLike): ParseResult<ParsedAuthPasskeyQuery> {
+  const parsed = authQuerySchema.safeParse(mapBaseQuery(query));
+  if (!parsed.success) {
+    return { ok: false, errors: collectIssues(parsed.error) };
+  }
+
+  return { ok: true, data: parsed.data };
+}

--- a/passkey/src/lib/passkeys/session-key.ts
+++ b/passkey/src/lib/passkeys/session-key.ts
@@ -1,0 +1,23 @@
+import type { SessionKey, SessionKeyBackend } from "@sqds/grid";
+
+import { getGridBrowserSdkClient } from "@/lib/passkeys/grid-browser-sdk";
+
+export function toSessionKeyObject(
+  sessionKey: string,
+  expirationInSeconds: number
+): SessionKey {
+  return getGridBrowserSdkClient().getSessionKeyObject(
+    sessionKey,
+    String(expirationInSeconds)
+  );
+}
+
+export function toSessionKeyBackendObject(
+  sessionKey: string,
+  expirationInSeconds: number
+): SessionKeyBackend {
+  return getGridBrowserSdkClient().getSessionKeyObject(
+    sessionKey,
+    String(expirationInSeconds)
+  );
+}

--- a/passkey/src/lib/passkeys/webauthn.ts
+++ b/passkey/src/lib/passkeys/webauthn.ts
@@ -19,32 +19,24 @@ export type PasskeyCreateCeremonyInput = {
 
 export type PasskeyAuthCeremonyInput = {
   challenge: string;
+  rpId?: string;
+  allowCredentialId?: string;
+  publicKey?: string;
   timeoutMs?: number;
 };
 
 export type NormalizedCreateAuthenticatorResponse = {
-  id: string;
   rawId: string;
-  type: string;
-  response: {
-    clientDataJSON: string;
-    attestationObject: string;
-    authenticatorData?: string;
-    publicKey?: string;
-    publicKeyAlgorithm?: number;
-    transports?: string[];
-  };
+  credentialId: string;
+  publicKey: string;
 };
 
 export type NormalizedAuthAuthenticatorResponse = {
-  id: string;
-  rawId: string;
-  type: string;
   response: {
     clientDataJSON: string;
     authenticatorData: string;
     signature: string;
-    userHandle: string | null;
+    publicKey?: string;
   };
 };
 
@@ -105,22 +97,15 @@ export async function runCreatePasskeyCeremony(
   const response =
     credential.response as unknown as AttestationResponseWithExtensions;
   const publicKey = response.getPublicKey?.();
-  const authenticatorData = response.getAuthenticatorData?.();
+
+  if (!publicKey) {
+    throw new Error("Browser did not return a passkey public key");
+  }
 
   return {
-    id: credential.id,
     rawId: arrayBufferToBase64Url(credential.rawId),
-    type: credential.type,
-    response: {
-      clientDataJSON: arrayBufferToBase64Url(response.clientDataJSON),
-      attestationObject: arrayBufferToBase64Url(response.attestationObject),
-      authenticatorData: authenticatorData
-        ? arrayBufferToBase64Url(authenticatorData)
-        : undefined,
-      publicKey: publicKey ? arrayBufferToBase64Url(publicKey) : undefined,
-      publicKeyAlgorithm: response.getPublicKeyAlgorithm?.(),
-      transports: response.getTransports?.(),
-    },
+    credentialId: credential.id,
+    publicKey: arrayBufferToBase64Url(publicKey),
   };
 }
 
@@ -132,11 +117,28 @@ export async function runAuthPasskeyCeremony(
     challengeBytes.byteOffset,
     challengeBytes.byteOffset + challengeBytes.byteLength
   ) as ArrayBuffer;
+  const allowCredentialId = input.allowCredentialId
+    ? base64UrlToUint8Array(input.allowCredentialId)
+    : null;
 
   const credential = ensurePublicKeyCredential(
     await navigator.credentials.get({
       publicKey: {
         challenge,
+        ...(allowCredentialId
+          ? {
+              allowCredentials: [
+                {
+                  id: allowCredentialId.buffer.slice(
+                    allowCredentialId.byteOffset,
+                    allowCredentialId.byteOffset + allowCredentialId.byteLength
+                  ) as ArrayBuffer,
+                  type: "public-key" as const,
+                },
+              ],
+            }
+          : {}),
+        rpId: input.rpId,
         userVerification: "required",
         timeout: input.timeoutMs ?? 60_000,
       },
@@ -145,16 +147,11 @@ export async function runAuthPasskeyCeremony(
 
   const response = credential.response as AuthenticatorAssertionResponse;
   return {
-    id: credential.id,
-    rawId: arrayBufferToBase64Url(credential.rawId),
-    type: credential.type,
     response: {
       clientDataJSON: arrayBufferToBase64Url(response.clientDataJSON),
       authenticatorData: arrayBufferToBase64Url(response.authenticatorData),
       signature: arrayBufferToBase64Url(response.signature),
-      userHandle: response.userHandle
-        ? arrayBufferToBase64Url(response.userHandle)
-        : null,
+      ...(input.publicKey ? { publicKey: input.publicKey } : {}),
     },
   };
 }

--- a/passkey/src/lib/passkeys/webauthn.ts
+++ b/passkey/src/lib/passkeys/webauthn.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { base64UrlToUint8Array, arrayBufferToBase64Url, normalizeErrorMessage } from "@/lib/passkeys/codecs";
+
+type AttestationResponseWithExtensions = AuthenticatorAttestationResponse & {
+  getAuthenticatorData?: () => ArrayBuffer | null;
+  getPublicKey?: () => ArrayBuffer | null;
+  getPublicKeyAlgorithm?: () => number;
+  getTransports?: () => string[];
+};
+
+export type PasskeyCreateCeremonyInput = {
+  challenge: string;
+  appName: string;
+  userId: string;
+  rpId?: string;
+  timeoutMs?: number;
+};
+
+export type PasskeyAuthCeremonyInput = {
+  challenge: string;
+  timeoutMs?: number;
+};
+
+export type NormalizedCreateAuthenticatorResponse = {
+  id: string;
+  rawId: string;
+  type: string;
+  response: {
+    clientDataJSON: string;
+    attestationObject: string;
+    authenticatorData?: string;
+    publicKey?: string;
+    publicKeyAlgorithm?: number;
+    transports?: string[];
+  };
+};
+
+export type NormalizedAuthAuthenticatorResponse = {
+  id: string;
+  rawId: string;
+  type: string;
+  response: {
+    clientDataJSON: string;
+    authenticatorData: string;
+    signature: string;
+    userHandle: string | null;
+  };
+};
+
+function ensurePublicKeyCredential(
+  credential: Credential | null
+): PublicKeyCredential {
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("Browser did not return a PublicKeyCredential");
+  }
+
+  return credential;
+}
+
+export function isChallengeTimeoutError(error: unknown): boolean {
+  const message = normalizeErrorMessage(error).toLowerCase();
+  return (
+    message.includes("timeout") ||
+    message.includes("notallowederror") ||
+    message.includes("expired") ||
+    message.includes("challenge")
+  );
+}
+
+export async function runCreatePasskeyCeremony(
+  input: PasskeyCreateCeremonyInput
+): Promise<NormalizedCreateAuthenticatorResponse> {
+  const challengeBytes = base64UrlToUint8Array(input.challenge);
+  const challenge = challengeBytes.buffer.slice(
+    challengeBytes.byteOffset,
+    challengeBytes.byteOffset + challengeBytes.byteLength
+  ) as ArrayBuffer;
+
+  const credential = ensurePublicKeyCredential(
+    await navigator.credentials.create({
+      publicKey: {
+        challenge,
+        rp: {
+          id: input.rpId,
+          name: input.appName,
+        },
+        user: {
+          id: new TextEncoder().encode(input.userId),
+          name: `${input.appName}#${input.userId}`,
+          displayName: input.appName,
+        },
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+        authenticatorSelection: {
+          residentKey: "required",
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        timeout: input.timeoutMs ?? 60_000,
+        attestation: "direct",
+      },
+    })
+  );
+
+  const response =
+    credential.response as unknown as AttestationResponseWithExtensions;
+  const publicKey = response.getPublicKey?.();
+  const authenticatorData = response.getAuthenticatorData?.();
+
+  return {
+    id: credential.id,
+    rawId: arrayBufferToBase64Url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: arrayBufferToBase64Url(response.clientDataJSON),
+      attestationObject: arrayBufferToBase64Url(response.attestationObject),
+      authenticatorData: authenticatorData
+        ? arrayBufferToBase64Url(authenticatorData)
+        : undefined,
+      publicKey: publicKey ? arrayBufferToBase64Url(publicKey) : undefined,
+      publicKeyAlgorithm: response.getPublicKeyAlgorithm?.(),
+      transports: response.getTransports?.(),
+    },
+  };
+}
+
+export async function runAuthPasskeyCeremony(
+  input: PasskeyAuthCeremonyInput
+): Promise<NormalizedAuthAuthenticatorResponse> {
+  const challengeBytes = base64UrlToUint8Array(input.challenge);
+  const challenge = challengeBytes.buffer.slice(
+    challengeBytes.byteOffset,
+    challengeBytes.byteOffset + challengeBytes.byteLength
+  ) as ArrayBuffer;
+
+  const credential = ensurePublicKeyCredential(
+    await navigator.credentials.get({
+      publicKey: {
+        challenge,
+        userVerification: "required",
+        timeout: input.timeoutMs ?? 60_000,
+      },
+    })
+  );
+
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: arrayBufferToBase64Url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: arrayBufferToBase64Url(response.clientDataJSON),
+      authenticatorData: arrayBufferToBase64Url(response.authenticatorData),
+      signature: arrayBufferToBase64Url(response.signature),
+      userHandle: response.userHandle
+        ? arrayBufferToBase64Url(response.userHandle)
+        : null,
+    },
+  };
+}

--- a/passkey/tsconfig.json
+++ b/passkey/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/passkey/vercel.json
+++ b/passkey/vercel.json
@@ -1,0 +1,5 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../packages ../sdk",
+  "installCommand": "rm -rf node_modules && cd .. && bun install --frozen-lockfile",
+  "buildCommand": "bun run build"
+}


### PR DESCRIPTION
Make the passkey workspace host-aware so WebAuthn credentials are shared across askloyal.com subdomains while localhost stays a separate dev realm. This also switches the browser ceremony to explicit RP ID handling, updates the passkey env/docs, and adds coverage for host resolution, continue flow fallback, and proxy behavior.