### PR TITLE
fix(frontend): match passkey icon metadata

### DIFF
--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="320" viewBox="0 0 400 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M60 280L0 140H180V0L260 140L280 0L400 320L60 280Z" fill="#F9363C"/>
+<path d="M221.359 173.036C254.451 174.77 280.059 199.425 278.555 228.105L158.72 221.824C160.223 193.145 188.268 171.302 221.359 173.036Z" fill="white"/>
+<mask id="mask0_5_1302" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="158" y="172" width="121" height="57">
+<path d="M221.36 173.036C254.452 174.77 280.059 199.425 278.556 228.105L158.721 221.824C160.224 193.145 188.268 171.302 221.36 173.036Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_5_1302)">
+<circle cx="219.998" cy="199" r="27" transform="rotate(3 219.998 199)" fill="black"/>
+</g>
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -27,9 +27,9 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   icons: {
-    icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
-    shortcut: "/favicon.svg",
-    apple: [{ url: "/favicon.svg" }],
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+    apple: "/icon.svg",
   },
   openGraph: {
     type: "website",


### PR DESCRIPTION
Aligns /frontend favicon usage with /admin and /passkey by adding shared icon.svg and updating layout metadata. Includes minor metadata-only change.