### PR TITLE
fix(telegram): use Jupiter token data for /ca

### DIFF
--- a/app/src/lib/jupiter/__tests__/tokens-v2.server.test.ts
+++ b/app/src/lib/jupiter/__tests__/tokens-v2.server.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let fetchTokenMetricsByMint: typeof import("../tokens-v2.server").fetchTokenMetricsByMint;
+const originalFetch = globalThis.fetch;
+
+describe("fetchTokenMetricsByMint", () => {
+  beforeAll(async () => {
+    ({ fetchTokenMetricsByMint } = await import("../tokens-v2.server"));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restore();
+  });
+
+  test("returns metrics for the exact mint match", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        "https://lite-api.jup.ag/tokens/v2/search?query=target-mint"
+      );
+
+      return new Response(
+        JSON.stringify([
+          {
+            id: "other-mint",
+            mcap: 123,
+            name: "Other",
+            symbol: "OTR",
+            usdPrice: 0.1,
+          },
+          {
+            fdv: 3341945.8167783576,
+            holderCount: 1572,
+            id: "target-mint",
+            liquidity: 402595.3191460919,
+            mcap: 2029828.3193513064,
+            name: "Loyal",
+            symbol: "LOYAL",
+            updatedAt: "2026-03-10T21:57:59.390765983Z",
+            usdPrice: 0.1624529794720929,
+          },
+        ]),
+        { status: 200 }
+      );
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(fetchTokenMetricsByMint("target-mint")).resolves.toEqual({
+      fdvUsd: 3341945.8167783576,
+      holderCount: 1572,
+      liquidityUsd: 402595.3191460919,
+      marketCapUsd: 2029828.3193513064,
+      priceUsd: 0.1624529794720929,
+      updatedAt: "2026-03-10T21:57:59.390765983Z",
+    });
+  });
+
+  test("throws when the exact mint is missing from search results", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify([
+          {
+            id: "similar-mint",
+            mcap: 1,
+            name: "Loyal",
+            symbol: "LOYAL",
+            usdPrice: 1,
+          },
+        ]),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    await expect(fetchTokenMetricsByMint("target-mint")).rejects.toThrow(
+      "Invalid Jupiter token response."
+    );
+  });
+
+  test("throws when Jupiter returns a non-OK response", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("bad gateway", { status: 502, statusText: "Bad Gateway" });
+    }) as typeof fetch;
+
+    await expect(fetchTokenMetricsByMint("target-mint")).rejects.toThrow(
+      "HTTP 502: Bad Gateway"
+    );
+  });
+});

--- a/app/src/lib/jupiter/constants.ts
+++ b/app/src/lib/jupiter/constants.ts
@@ -1,4 +1,6 @@
 export const JUPITER_API_BASE_URL = "https://api.jup.ag";
+export const JUPITER_LITE_API_BASE_URL = "https://lite-api.jup.ag";
+export const JUPITER_TOKENS_V2_BASE_URL = `${JUPITER_LITE_API_BASE_URL}/tokens/v2`;
 
 /** Jupiter V6 Aggregator program — used for deterministic on-chain swap detection */
 export const JUPITER_PROGRAM_ID = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
@@ -20,4 +22,8 @@ export const SWAP_ERRORS = {
   MISSING_API_KEY: "Swap service is not configured.",
   ORDER_EXPIRED: "Swap order expired. Please try again.",
   EXECUTION_FAILED: "Swap execution failed. Please try again.",
+} as const;
+
+export const TOKEN_DATA_ERRORS = {
+  INVALID_RESPONSE: "Invalid Jupiter token response.",
 } as const;

--- a/app/src/lib/jupiter/server.ts
+++ b/app/src/lib/jupiter/server.ts
@@ -2,3 +2,4 @@ import "server-only";
 
 export { executeOrder, fetchOrder } from "./api.server";
 export { convertFromBaseUnits, convertToBaseUnits } from "./client";
+export { fetchTokenMetricsByMint } from "./tokens-v2.server";

--- a/app/src/lib/jupiter/tokens-v2.server.ts
+++ b/app/src/lib/jupiter/tokens-v2.server.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { fetchJson } from "../core/http";
+import { JUPITER_TOKENS_V2_BASE_URL, TOKEN_DATA_ERRORS } from "./constants";
+import type {
+  JupiterTokenMetrics,
+  JupiterTokenSearchResult,
+} from "./types";
+
+function mapTokenMetrics(token: JupiterTokenSearchResult): JupiterTokenMetrics {
+  return {
+    fdvUsd: token.fdv,
+    holderCount: token.holderCount,
+    liquidityUsd: token.liquidity,
+    marketCapUsd: token.mcap,
+    priceUsd: token.usdPrice,
+    updatedAt: token.updatedAt,
+  };
+}
+
+export async function fetchTokenMetricsByMint(
+  mint: string
+): Promise<JupiterTokenMetrics> {
+  const params = new URLSearchParams({ query: mint });
+  const url = `${JUPITER_TOKENS_V2_BASE_URL}/search?${params.toString()}`;
+
+  const response = await fetchJson<JupiterTokenSearchResult[]>(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  const token = response.find((item) => item.id === mint);
+  if (!token) {
+    throw new Error(TOKEN_DATA_ERRORS.INVALID_RESPONSE);
+  }
+
+  if (!Number.isFinite(token.usdPrice) || !Number.isFinite(token.mcap)) {
+    throw new Error(TOKEN_DATA_ERRORS.INVALID_RESPONSE);
+  }
+
+  return mapTokenMetrics(token);
+}

--- a/app/src/lib/jupiter/types.ts
+++ b/app/src/lib/jupiter/types.ts
@@ -51,6 +51,27 @@ export type JupiterOrderErrorResponse = {
   code?: number;
 };
 
+export type JupiterTokenSearchResult = {
+  id: string;
+  name: string;
+  symbol: string;
+  usdPrice: number;
+  mcap: number;
+  fdv?: number;
+  holderCount?: number;
+  liquidity?: number;
+  updatedAt?: string;
+};
+
+export type JupiterTokenMetrics = {
+  priceUsd: number;
+  marketCapUsd: number;
+  fdvUsd?: number;
+  holderCount?: number;
+  liquidityUsd?: number;
+  updatedAt?: string;
+};
+
 /** POST /ultra/v1/execute request */
 export type JupiterExecuteRequest = {
   signedTransaction: string;

--- a/app/src/lib/telegram/bot-api/__tests__/commands-ca.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-ca.test.ts
@@ -1,0 +1,170 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Bot, CommandContext, Context } from "grammy";
+
+mock.module("server-only", () => ({}));
+
+const fetchTokenMetricsByMintMock = mock(async () => ({
+  fdvUsd: 3341945.8167783576,
+  holderCount: 1572,
+  liquidityUsd: 402595.3191460919,
+  marketCapUsd: 2029828.3193513064,
+  priceUsd: 0.1624529794720929,
+  updatedAt: "2026-03-10T21:57:59.390765983Z",
+}));
+
+mock.module("@/lib/jupiter/server", () => ({
+  fetchTokenMetricsByMint: fetchTokenMetricsByMintMock,
+}));
+
+mock.module("mixpanel", () => ({
+  default: {
+    init: () => ({
+      track: (
+        _eventName: string,
+        _properties: Record<string, unknown>,
+        callback?: (error?: unknown) => void
+      ) => {
+        callback?.();
+      },
+    }),
+  },
+}));
+
+mock.module("@/lib/core/database", () => ({
+  getDatabase: () => ({}),
+}));
+
+mock.module("@/lib/telegram/community-photo-service", () => ({
+  captureCommunityPhotoToCdn: async () => null,
+}));
+
+mock.module("@/lib/telegram/user-service", () => ({
+  getOrCreateUser: async () => "user-1",
+}));
+
+mock.module("../message-handlers", () => ({
+  evictActiveCommunityCache: () => {},
+}));
+
+mock.module("../notification-settings", () => ({
+  sendNotificationSettingsMessage: async () => {},
+}));
+
+mock.module("../start-carousel", () => ({
+  sendStartCarousel: async () => {},
+}));
+
+mock.module("../summaries", () => ({
+  sendLatestSummary: async () => ({ sent: true as const }),
+}));
+
+mock.module("../helper-message-cleanup", () => ({
+  replyWithAutoCleanup: async () => {},
+}));
+
+let handleCaCommand: typeof import("../commands").handleCaCommand;
+
+function createContext(chatId: number | undefined = -1002981429221) {
+  return {
+    chat:
+      chatId === undefined
+        ? undefined
+        : {
+            id: chatId,
+            type: "supergroup",
+          },
+  } as unknown as CommandContext<Context>;
+}
+
+function createBot() {
+  const sendMessage = mock(async () => ({}));
+
+  return {
+    bot: {
+      api: {
+        sendMessage,
+      },
+    } as unknown as Bot,
+    sendMessage,
+  };
+}
+
+describe("/ca command", () => {
+  beforeAll(async () => {
+    ({ handleCaCommand } = await import("../commands"));
+  });
+
+  beforeEach(() => {
+    fetchTokenMetricsByMintMock.mockReset();
+    fetchTokenMetricsByMintMock.mockImplementation(async () => ({
+      fdvUsd: 3341945.8167783576,
+      holderCount: 1572,
+      liquidityUsd: 402595.3191460919,
+      marketCapUsd: 2029828.3193513064,
+      priceUsd: 0.1624529794720929,
+      updatedAt: "2026-03-10T21:57:59.390765983Z",
+    }));
+  });
+
+  test("sends the CA message with Jupiter token metrics", async () => {
+    const ctx = createContext();
+    const { bot, sendMessage } = createBot();
+
+    await handleCaCommand(ctx, bot);
+
+    expect(fetchTokenMetricsByMintMock).toHaveBeenCalledWith(
+      "LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta"
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [chatId, text, options] = sendMessage.mock.calls[0] ?? [];
+
+    expect(chatId).toBe(-1002981429221);
+    expect(text).toContain("Price: **$0.162**");
+    expect(text).toContain("Market cap: **$2,029,828.319**");
+    expect(text).toContain("FDV: **$3,341,945.817**");
+    expect(text).toContain("Holders: **1,572**");
+    expect(text).toContain("Liquidity: **$402,595.319**");
+    expect(text).toContain("Updated: **2026-03-10T21:57:59.390765983Z**");
+    expect(options).toEqual(
+      expect.objectContaining({
+        parse_mode: "Markdown",
+      })
+    );
+  });
+
+  test("falls back to N/A values when Jupiter lookup fails", async () => {
+    fetchTokenMetricsByMintMock.mockImplementation(async () => {
+      throw new Error("Jupiter unavailable");
+    });
+    const ctx = createContext();
+    const { bot, sendMessage } = createBot();
+    const consoleErrorMock = mock(() => undefined);
+    const previousConsoleError = console.error;
+    console.error = consoleErrorMock;
+
+    try {
+      await handleCaCommand(ctx, bot);
+    } finally {
+      console.error = previousConsoleError;
+    }
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [chatId, text] = sendMessage.mock.calls[0] ?? [];
+
+    expect(chatId).toBe(-1002981429221);
+    expect(text).toContain("Price: **N/A**");
+    expect(text).toContain("Market cap: **N/A**");
+    expect(text).toContain("Updated: **N/A**");
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does nothing outside the designated CA chat", async () => {
+    const ctx = createContext(-1001234567890);
+    const { bot, sendMessage } = createBot();
+
+    await handleCaCommand(ctx, bot);
+
+    expect(fetchTokenMetricsByMintMock).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/commands-ca.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-ca.test.ts
@@ -124,7 +124,7 @@ describe("/ca command", () => {
     expect(text).toContain("FDV: **$3,341,945.817**");
     expect(text).toContain("Holders: **1,572**");
     expect(text).toContain("Liquidity: **$402,595.319**");
-    expect(text).toContain("Updated: **2026-03-10T21:57:59.390765983Z**");
+    expect(text).toContain("Updated: **2026-03-10 21:57:59**");
     expect(options).toEqual(
       expect.objectContaining({
         parse_mode: "Markdown",

--- a/app/src/lib/telegram/bot-api/ca-command.ts
+++ b/app/src/lib/telegram/bot-api/ca-command.ts
@@ -1,0 +1,51 @@
+import { InlineKeyboard } from "grammy";
+
+import type { JupiterTokenMetrics } from "@/lib/jupiter";
+
+export const LOYAL_CA_ADDRESS = "LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta";
+
+function formatUsdValue(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "N/A";
+  }
+
+  return `$${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 3,
+    minimumFractionDigits: 3,
+  }).format(value)}`;
+}
+
+function formatIntegerValue(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "N/A";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function createCaCommandKeyboard(caAddress: string): InlineKeyboard {
+  return new InlineKeyboard()
+    .url("Jupiter", `https://jup.ag/tokens/${caAddress}`)
+    .url("Dexscreener", `https://dexscreener.com/solana/${caAddress}`)
+    .row()
+    .copyText("Copy CA to clipboard", caAddress);
+}
+
+export function formatCaCommandMessage(
+  caAddress: string,
+  metrics?: JupiterTokenMetrics | null
+): string {
+  const caAddressMarkdown = `\`${caAddress}\``;
+  const tokenInfoLines = [
+    `Price: **${formatUsdValue(metrics?.priceUsd)}**`,
+    `Market cap: **${formatUsdValue(metrics?.marketCapUsd)}**`,
+    `FDV: **${formatUsdValue(metrics?.fdvUsd)}**`,
+    `Holders: **${formatIntegerValue(metrics?.holderCount)}**`,
+    `Liquidity: **${formatUsdValue(metrics?.liquidityUsd)}**`,
+    `Updated: **${metrics?.updatedAt ?? "N/A"}**`,
+  ].join("\n");
+
+  return `$LOYAL's CA: ${caAddressMarkdown}\n\n${tokenInfoLines}`;
+}

--- a/app/src/lib/telegram/bot-api/ca-command.ts
+++ b/app/src/lib/telegram/bot-api/ca-command.ts
@@ -25,6 +25,15 @@ function formatIntegerValue(value: number | undefined): string {
   }).format(value);
 }
 
+function formatUpdatedAt(value: string | undefined): string {
+  if (typeof value !== "string" || value.length < 19) {
+    return "N/A";
+  }
+
+  const normalized = value.slice(0, 19).replace("T", " ");
+  return normalized.length === 19 ? normalized : "N/A";
+}
+
 export function createCaCommandKeyboard(caAddress: string): InlineKeyboard {
   return new InlineKeyboard()
     .url("Jupiter", `https://jup.ag/tokens/${caAddress}`)
@@ -44,7 +53,7 @@ export function formatCaCommandMessage(
     `FDV: **${formatUsdValue(metrics?.fdvUsd)}**`,
     `Holders: **${formatIntegerValue(metrics?.holderCount)}**`,
     `Liquidity: **${formatUsdValue(metrics?.liquidityUsd)}**`,
-    `Updated: **${metrics?.updatedAt ?? "N/A"}**`,
+    `Updated: **${formatUpdatedAt(metrics?.updatedAt)}**`,
   ].join("\n");
 
   return `$LOYAL's CA: ${caAddressMarkdown}\n\n${tokenInfoLines}`;

--- a/app/src/lib/telegram/bot-api/commands.ts
+++ b/app/src/lib/telegram/bot-api/commands.ts
@@ -1,9 +1,10 @@
 import { admins, communities, type Community, userSettings } from "@loyal-labs/db-core/schema";
 import { eq } from "drizzle-orm";
 import type { CommandContext, Context } from "grammy";
-import { Bot, InlineKeyboard } from "grammy";
+import { Bot } from "grammy";
 
 import { getDatabase } from "@/lib/core/database";
+import { fetchTokenMetricsByMint } from "@/lib/jupiter/server";
 import { captureCommunityPhotoToCdn } from "@/lib/telegram/community-photo-service";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName, isCommunityChat } from "@/lib/telegram/utils";
@@ -13,6 +14,11 @@ import {
   type MixpanelTrackProperties,
   trackBotEvent,
 } from "./analytics";
+import {
+  createCaCommandKeyboard,
+  formatCaCommandMessage,
+  LOYAL_CA_ADDRESS,
+} from "./ca-command";
 import { CA_COMMAND_CHAT_ID } from "./constants";
 import { replyWithAutoCleanup } from "./helper-message-cleanup";
 import { evictActiveCommunityCache } from "./message-handlers";
@@ -187,20 +193,8 @@ export async function handleCaCommand(
   ctx: CommandContext<Context>,
   bot: Bot
 ): Promise<void> {
-  const caAddress = "LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta";
-  const caAddressMarkdown = `\`${caAddress}\``;
-  const cmcEndpoint =
-    "https://api.coinmarketcap.com/data-api/v3.3/cryptocurrency/detail/chart?id=39037&interval=3h&convertId=2781&range=All";
-  const currencyFormatter = new Intl.NumberFormat("en-US", {
-    minimumFractionDigits: 3,
-    maximumFractionDigits: 3,
-  });
-
-  const keyboard = new InlineKeyboard()
-    .url("Jupiter", `https://jup.ag/tokens/${caAddress}`)
-    .url("Dexscreener", `https://dexscreener.com/solana/${caAddress}`)
-    .row()
-    .copyText("Copy CA to clipboard", caAddress);
+  const caAddress = LOYAL_CA_ADDRESS;
+  const keyboard = createCaCommandKeyboard(caAddress);
 
   const chatId = ctx.chat?.id;
   if (!chatId) {
@@ -213,45 +207,17 @@ export async function handleCaCommand(
     return;
   }
 
-  let priceValue = "N/A";
-  let marketCapValue = "N/A";
+  let metrics = null;
 
   try {
-    const response = await fetch(cmcEndpoint);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch CMC data: ${response.status} ${response.statusText}`
-      );
-    }
-    const data = await response.json();
-    const points = data?.data?.points;
-    const latestPoint =
-      Array.isArray(points) && points.length > 0
-        ? points[points.length - 1]
-        : null;
-    const latestValues = latestPoint?.v;
-    const latestPrice = Array.isArray(latestValues)
-      ? Number(latestValues[0])
-      : NaN;
-    const latestMarketCap = Array.isArray(latestValues)
-      ? Number(latestValues[2])
-      : NaN;
-
-    if (Number.isFinite(latestPrice)) {
-      priceValue = `$${currencyFormatter.format(latestPrice)}`;
-    }
-    if (Number.isFinite(latestMarketCap)) {
-      marketCapValue = `$${currencyFormatter.format(latestMarketCap)}`;
-    }
+    metrics = await fetchTokenMetricsByMint(caAddress);
   } catch (error) {
-    console.error("Failed to fetch CMC data for ca command", error);
+    console.error("Failed to fetch Jupiter data for ca command", error);
   }
-
-  const priceLine = `\n\nPrice: **${priceValue}**\nMarket cap: **${marketCapValue}**`;
 
   await bot.api.sendMessage(
     chatId,
-    `$LOYAL's CA: ${caAddressMarkdown}${priceLine}`,
+    formatCaCommandMessage(caAddress, metrics),
     {
       parse_mode: "Markdown",
       reply_markup: keyboard,


### PR DESCRIPTION
Switch the  bot response from a stale CoinMarketCap chart tail to Jupiter Tokens V2 and include price, market cap, FDV, holders, liquidity, and updated time. This also extracts the CA message formatting into a dedicated helper and adds focused tests for the Jupiter fetcher and bot command.