### PR TITLE
fix(wallet): hide explorer link and fix share for private sends

### DIFF
--- a/frontend/src/components/wallet-sidebar/index.tsx
+++ b/frontend/src/components/wallet-sidebar/index.tsx
@@ -488,6 +488,7 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
               )}
               {displayTab === "send" && (
                 <SendContent
+                  addLocalActivity={props.walletDesktopData.addLocalActivity}
                   onClose={props.onClose}
                   onDone={() => props.onTabChange("portfolio")}
                   onNavigate={setSubView}

--- a/frontend/src/components/wallet-sidebar/send-content.tsx
+++ b/frontend/src/components/wallet-sidebar/send-content.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePrivateSend } from "@/hooks/use-private-send";
 import { useSend } from "@/hooks/use-send";
 
-import type { SubView, SwapToken } from "./types";
+import type { ActivityRow, SubView, SwapToken, TransactionDetail } from "./types";
 
 const font = "var(--font-geist-sans), sans-serif";
 const secondary = "rgba(60, 60, 67, 0.6)";
@@ -224,6 +224,7 @@ function SendTransactionDetail({
   isTgRecipient,
   usdValue,
   signature,
+  isPrivate,
   onClose,
   onDone,
 }: {
@@ -233,6 +234,7 @@ function SendTransactionDetail({
   isTgRecipient: boolean;
   usdValue: string;
   signature?: string;
+  isPrivate?: boolean;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -287,22 +289,30 @@ function SendTransactionDetail({
 
         {/* Action buttons */}
         <div style={{ display: "flex", alignItems: "center", paddingTop: "20px", paddingBottom: "16px", width: "100%" }}>
+          {!isPrivate && (
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
+              <button
+                className="send-tx-action-btn"
+                onClick={() => signature && window.open(`https://explorer.solana.com/tx/${signature}`, "_blank")}
+                style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: signature ? "pointer" : "default", opacity: signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
+                type="button"
+              >
+                <Globe size={24} style={{ color: "#3C3C43" }} />
+              </button>
+              <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, textAlign: "center" }}>View in explorer</span>
+            </div>
+          )}
           <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
             <button
               className="send-tx-action-btn"
-              onClick={() => signature && window.open(`https://explorer.solana.com/tx/${signature}`, "_blank")}
-              style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: signature ? "pointer" : "default", opacity: signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
-              type="button"
-            >
-              <Globe size={24} style={{ color: "#3C3C43" }} />
-            </button>
-            <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, textAlign: "center" }}>View in explorer</span>
-          </div>
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
-            <button
-              className="send-tx-action-btn"
-              onClick={() => signature && void navigator.clipboard.writeText(`https://explorer.solana.com/tx/${signature}`)}
-              style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: signature ? "pointer" : "default", opacity: signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
+              onClick={() => {
+                if (isPrivate) {
+                  void navigator.clipboard.writeText(`Sent ${amount} ${token.symbol} to ${displayRecipient} (${usdValue})`);
+                } else if (signature) {
+                  void navigator.clipboard.writeText(`https://explorer.solana.com/tx/${signature}`);
+                }
+              }}
+              style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: isPrivate || signature ? "pointer" : "default", opacity: isPrivate || signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
               type="button"
             >
               <Share size={24} style={{ color: "#3C3C43" }} />
@@ -332,11 +342,13 @@ export function SendContent({
   onDone,
   onNavigate,
   token,
+  addLocalActivity,
 }: {
   onClose: () => void;
   onDone: () => void;
   onNavigate: (view: SubView) => void;
   token: SwapToken;
+  addLocalActivity?: (row: ActivityRow, detail: TransactionDetail) => void;
 }) {
   const { executeSend } = useSend();
   const { executePrivateSend } = usePrivateSend();
@@ -427,11 +439,34 @@ export function SendContent({
       setPhase("success");
       setAmount("");
       setRecipient("");
+
+      if (isPrivate && addLocalActivity) {
+        const now = new Date();
+        const syntheticRow: ActivityRow = {
+          id: result.signature ?? `private-${Date.now()}`,
+          type: "sent",
+          counterparty: cleanRecipient,
+          amount: `-${currentAmount} ${token.symbol}`,
+          timestamp: now.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true }),
+          date: now.toLocaleDateString("en-US", { month: "long", day: "numeric" }),
+          icon: "/hero-new/Shield_40.svg",
+          isPrivate: true,
+        };
+        const syntheticDetail: TransactionDetail = {
+          activity: syntheticRow,
+          usdValue: currentUsd,
+          status: "Completed",
+          networkFee: "0.00005 SOL",
+          networkFeeUsd: "$0.00",
+          isPrivate: true,
+        };
+        addLocalActivity(syntheticRow, syntheticDetail);
+      }
     } else {
       setErrorMessage(result.error);
       setPhase("error");
     }
-  }, [hasAmount, numericAmount, token.price, token.symbol, token.mint, recipientTrimmed, isTg, isPrivate, executeSend, executePrivateSend]);
+  }, [hasAmount, numericAmount, token.price, token.symbol, token.mint, recipientTrimmed, isTg, isPrivate, executeSend, executePrivateSend, addLocalActivity]);
 
   // Cross-fade between phases
   const [phaseOpacity, setPhaseOpacity] = useState(1);
@@ -472,6 +507,7 @@ export function SendContent({
       return (
         <SendTransactionDetail
           amount={resultAmount}
+          isPrivate={isPrivate}
           isTgRecipient={resultIsTg}
           onClose={onClose}
           onDone={onDone}

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -22,7 +22,14 @@ function SwapShieldTabs({
   onClose: () => void;
 }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px" }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px",
+      }}
+    >
       <div
         style={{
           display: "flex",
@@ -78,7 +85,11 @@ function SwapShieldTabs({
           type="button"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img alt="" src="/hero-new/Shield.png" style={{ width: "20px", height: "20px" }} />
+          <img
+            alt=""
+            src="/hero-new/Shield.png"
+            style={{ width: "20px", height: "20px" }}
+          />
           Shield
         </button>
       </div>
@@ -118,16 +129,50 @@ function StatusHeader({
   onClose: () => void;
 }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px" }}>
-      <div style={{ flex: 1, paddingLeft: "12px", paddingTop: "4px", paddingBottom: "4px" }}>
-        <span style={{ fontFamily: font, fontSize: "18px", fontWeight: 600, lineHeight: "28px", color: "#000" }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px",
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          paddingLeft: "12px",
+          paddingTop: "4px",
+          paddingBottom: "4px",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: font,
+            fontSize: "18px",
+            fontWeight: 600,
+            lineHeight: "28px",
+            color: "#000",
+          }}
+        >
           {title}
         </span>
       </div>
       <button
         className="shield-close"
         onClick={onClose}
-        style={{ width: "36px", height: "36px", display: "flex", justifyContent: "center", alignItems: "center", background: "rgba(0, 0, 0, 0.04)", border: "none", borderRadius: "9999px", cursor: "pointer", transition: "all 0.2s ease", color: "#3C3C43" }}
+        style={{
+          width: "36px",
+          height: "36px",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          background: "rgba(0, 0, 0, 0.04)",
+          border: "none",
+          borderRadius: "9999px",
+          cursor: "pointer",
+          transition: "all 0.2s ease",
+          color: "#3C3C43",
+        }}
         type="button"
       >
         <X size={24} />
@@ -146,18 +191,56 @@ function ShieldedTokenPill({ token }: { token: SwapToken }) {
         flexShrink: 0,
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", padding: "4px 14px 4px 4px", position: "relative" }}>
-        <div style={{ width: "28px", height: "28px", borderRadius: "9999px", overflow: "hidden", marginRight: "-8px" }}>
-          <Image alt={token.symbol} height={28} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={28} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "4px 14px 4px 4px",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "9999px",
+            overflow: "hidden",
+            marginRight: "-8px",
+          }}
+        >
+          <Image
+            alt={token.symbol}
+            height={28}
+            src={token.icon}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            width={28}
+          />
         </div>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           alt="Shielded"
           src="/hero-new/Shield.png"
-          style={{ width: "16px", height: "16px", position: "absolute", bottom: "2px", right: "2px" }}
+          style={{
+            width: "16px",
+            height: "16px",
+            position: "absolute",
+            bottom: "2px",
+            right: "2px",
+          }}
         />
       </div>
-      <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 500, lineHeight: "20px", color: "#000", letterSpacing: "-0.176px", whiteSpace: "nowrap", padding: "8px 0" }}>
+      <span
+        style={{
+          fontFamily: font,
+          fontSize: "16px",
+          fontWeight: 500,
+          lineHeight: "20px",
+          color: "#000",
+          letterSpacing: "-0.176px",
+          whiteSpace: "nowrap",
+          padding: "8px 0",
+        }}
+      >
         {token.symbol}
       </span>
     </div>
@@ -186,15 +269,54 @@ function SelectableTokenPill({
       }}
       type="button"
     >
-      <div style={{ display: "flex", alignItems: "center", paddingRight: "6px", padding: "4px 6px 4px 4px" }}>
-        <div style={{ width: "28px", height: "28px", borderRadius: "9999px", overflow: "hidden" }}>
-          <Image alt={token.symbol} height={28} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={28} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          paddingRight: "6px",
+          padding: "4px 6px 4px 4px",
+        }}
+      >
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "9999px",
+            overflow: "hidden",
+          }}
+        >
+          <Image
+            alt={token.symbol}
+            height={28}
+            src={token.icon}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            width={28}
+          />
         </div>
       </div>
-      <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 500, lineHeight: "20px", color: "#000", letterSpacing: "-0.176px", whiteSpace: "nowrap", padding: "8px 0" }}>
+      <span
+        style={{
+          fontFamily: font,
+          fontSize: "16px",
+          fontWeight: 500,
+          lineHeight: "20px",
+          color: "#000",
+          letterSpacing: "-0.176px",
+          whiteSpace: "nowrap",
+          padding: "8px 0",
+        }}
+      >
         {token.symbol}
       </span>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "36px", padding: "8px 0" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "36px",
+          padding: "8px 0",
+        }}
+      >
         <ChevronRight size={16} style={{ color: "#3C3C43" }} />
       </div>
     </button>
@@ -223,21 +345,67 @@ function ShieldedSelectableTokenPill({
       }}
       type="button"
     >
-      <div style={{ display: "flex", alignItems: "center", padding: "4px 14px 4px 4px", position: "relative" }}>
-        <div style={{ width: "28px", height: "28px", borderRadius: "9999px", overflow: "hidden", marginRight: "-8px" }}>
-          <Image alt={token.symbol} height={28} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={28} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "4px 14px 4px 4px",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "9999px",
+            overflow: "hidden",
+            marginRight: "-8px",
+          }}
+        >
+          <Image
+            alt={token.symbol}
+            height={28}
+            src={token.icon}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            width={28}
+          />
         </div>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           alt="Shielded"
           src="/hero-new/Shield.png"
-          style={{ width: "16px", height: "16px", position: "absolute", bottom: "2px", right: "2px" }}
+          style={{
+            width: "16px",
+            height: "16px",
+            position: "absolute",
+            bottom: "2px",
+            right: "2px",
+          }}
         />
       </div>
-      <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 500, lineHeight: "20px", color: "#000", letterSpacing: "-0.176px", whiteSpace: "nowrap", padding: "8px 0" }}>
+      <span
+        style={{
+          fontFamily: font,
+          fontSize: "16px",
+          fontWeight: 500,
+          lineHeight: "20px",
+          color: "#000",
+          letterSpacing: "-0.176px",
+          whiteSpace: "nowrap",
+          padding: "8px 0",
+        }}
+      >
         {token.symbol}
       </span>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "36px", padding: "8px 0" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "36px",
+          padding: "8px 0",
+        }}
+      >
         <ChevronRight size={16} style={{ color: "#3C3C43" }} />
       </div>
     </button>
@@ -292,23 +460,30 @@ export function ShieldContent({
   const insufficientFunds = numericAmount > sourceBalance;
 
   const usdValue = useMemo(
-    () => (numericAmount * token.price).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-    [numericAmount, token.price],
+    () =>
+      (numericAmount * token.price).toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    [numericAmount, token.price]
   );
 
   const exchangeRate = useMemo(
     () =>
-      `1 ${token.symbol} ≈ $${token.price.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`,
-    [token.symbol, token.price],
+      `1 ${token.symbol} ≈ $${token.price.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 4,
+      })}`,
+    [token.symbol, token.price]
   );
 
   const buttonLabel = !hasAmount
     ? "Enter Amount"
     : insufficientFunds
-      ? "Insufficient Funds"
-      : direction === "shield"
-        ? "Confirm and Shield"
-        : "Confirm and Unshield";
+    ? "Insufficient Funds"
+    : direction === "shield"
+    ? "Confirm and Shield"
+    : "Confirm and Unshield";
   const buttonDisabled = !hasAmount || insufficientFunds;
   const amountColor = insufficientFunds && hasAmount ? red : "#000";
 
@@ -322,14 +497,19 @@ export function ShieldContent({
       const val = pct === 100 ? bal : bal * (pct / 100);
       setAmount(val > 0 ? String(Number(val.toFixed(6))) : "");
     },
-    [sourceBalance],
+    [sourceBalance]
   );
 
   const handleConfirm = useCallback(async () => {
     if (!hasAmount || insufficientFunds) return;
 
     setResultAmount(String(numericAmount));
-    setResultUsd(`$${(numericAmount * token.price).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
+    setResultUsd(
+      `$${(numericAmount * token.price).toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`
+    );
     setErrorMessage(undefined);
     setPhase("processing");
 
@@ -339,9 +519,10 @@ export function ShieldContent({
       tokenMint: token.mint,
     };
 
-    const result = direction === "shield"
-      ? await shieldFn(params)
-      : await unshieldFn(params);
+    const result =
+      direction === "shield"
+        ? await shieldFn(params)
+        : await unshieldFn(params);
 
     if (result.success) {
       setPhase("success");
@@ -350,7 +531,17 @@ export function ShieldContent({
       setErrorMessage(result.error);
       setPhase("error");
     }
-  }, [hasAmount, insufficientFunds, numericAmount, token.price, token.symbol, token.mint, direction, shieldFn, unshieldFn]);
+  }, [
+    hasAmount,
+    insufficientFunds,
+    numericAmount,
+    token.price,
+    token.symbol,
+    token.mint,
+    direction,
+    shieldFn,
+    unshieldFn,
+  ]);
 
   // Report form button props to parent when chrome is managed externally
   useEffect(() => {
@@ -359,7 +550,11 @@ export function ShieldContent({
       onFormButtonChange(null);
       return;
     }
-    onFormButtonChange({ label: buttonLabel, disabled: buttonDisabled, onClick: handleConfirm });
+    onFormButtonChange({
+      label: buttonLabel,
+      disabled: buttonDisabled,
+      onClick: handleConfirm,
+    });
   });
 
   // Cross-fade between phases
@@ -381,37 +576,113 @@ export function ShieldContent({
   const renderPhaseContent = (p: ShieldPhase) => {
     if (p === "processing") {
       return (
-        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
           <style jsx>{`
-            .shield-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
+            .shield-close:hover {
+              background: rgba(0, 0, 0, 0.08) !important;
+            }
             @keyframes chevronBounce {
-              0%, 100% { transform: translateX(0); }
-              50% { transform: translateX(4px); }
+              0%,
+              100% {
+                transform: translateX(0);
+              }
+              50% {
+                transform: translateX(4px);
+              }
             }
           `}</style>
 
-          <StatusHeader onClose={onClose} title={direction === "shield" ? "Shield" : "Unshield"} />
+          <StatusHeader
+            onClose={onClose}
+            title={direction === "shield" ? "Shield" : "Unshield"}
+          />
 
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: "20px", alignItems: "center", padding: "24px 32px" }}>
-              <div style={{ display: "flex", gap: "16px", alignItems: "center", padding: "8px 0" }}>
-                <div style={{ width: "64px", height: "64px", borderRadius: "9999px", overflow: "hidden", flexShrink: 0 }}>
-                  <Image alt={token.symbol} height={64} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={64} />
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "20px",
+                alignItems: "center",
+                padding: "24px 32px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  gap: "16px",
+                  alignItems: "center",
+                  padding: "8px 0",
+                }}
+              >
+                <div
+                  style={{
+                    width: "64px",
+                    height: "64px",
+                    borderRadius: "9999px",
+                    overflow: "hidden",
+                    flexShrink: 0,
+                  }}
+                >
+                  <Image
+                    alt={token.symbol}
+                    height={64}
+                    src={token.icon}
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                    }}
+                    width={64}
+                  />
                 </div>
-                <ChevronRight size={16} style={{ color: secondary, animation: "chevronBounce 1s ease-in-out infinite" }} />
+                <ChevronRight
+                  size={16}
+                  style={{
+                    color: secondary,
+                    animation: "chevronBounce 1s ease-in-out infinite",
+                  }}
+                />
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   alt={direction === "shield" ? "Shield" : "Unshield"}
-                  src={direction === "shield" ? "/hero-new/Shield.png" : "/hero-new/Unshield.svg"}
+                  src={
+                    direction === "shield"
+                      ? "/hero-new/Shield.png"
+                      : "/hero-new/Unshield.svg"
+                  }
                   style={{ width: "64px", height: "64px", flexShrink: 0 }}
                 />
               </div>
-              <div style={{ display: "flex", flexDirection: "column", gap: "4px", alignItems: "center", textAlign: "center" }}>
-                <span style={{ fontFamily: font, fontSize: "20px", fontWeight: 600, lineHeight: "24px", color: "#000" }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "4px",
+                  alignItems: "center",
+                  textAlign: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "20px",
+                    fontWeight: 600,
+                    lineHeight: "24px",
+                    color: "#000",
+                  }}
+                >
                   {direction === "shield" ? "Shielding..." : "Unshielding..."}
-                </span>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, maxWidth: "285px" }}>
-                  You can close this screen and continue using the app
                 </span>
               </div>
             </div>
@@ -420,7 +691,20 @@ export function ShieldContent({
           <div style={{ padding: "16px 20px" }}>
             <button
               disabled
-              style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#CCCDCD", border: "none", cursor: "default", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center" }}
+              style={{
+                width: "100%",
+                padding: "12px 16px",
+                borderRadius: "9999px",
+                background: "#CCCDCD",
+                border: "none",
+                cursor: "default",
+                fontFamily: font,
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#fff",
+                textAlign: "center",
+              }}
               type="button"
             >
               In progress...
@@ -433,61 +717,164 @@ export function ShieldContent({
     if (p === "success" || p === "error") {
       const isSuccess = p === "success";
       return (
-        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
           <style jsx>{`
-            .shield-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-            .shield-done-btn:hover { background: #333 !important; }
-            .shield-done-secondary-btn:hover { background: rgba(0, 0, 0, 0.08) !important; }
+            .shield-close:hover {
+              background: rgba(0, 0, 0, 0.08) !important;
+            }
+            .shield-done-btn:hover {
+              background: #333 !important;
+            }
+            .shield-done-secondary-btn:hover {
+              background: rgba(0, 0, 0, 0.08) !important;
+            }
             @keyframes mascotNod {
-              0%, 100% { transform: rotate(0deg); }
-              25% { transform: rotate(4deg); }
-              75% { transform: rotate(-4deg); }
+              0%,
+              100% {
+                transform: rotate(0deg);
+              }
+              25% {
+                transform: rotate(4deg);
+              }
+              75% {
+                transform: rotate(-4deg);
+              }
             }
           `}</style>
 
           <StatusHeader
             onClose={onClose}
-            title={isSuccess
-              ? (direction === "shield" ? "Shield" : "Unshield")
-              : "Shield/Unshield"}
+            title={
+              isSuccess
+                ? direction === "shield"
+                  ? "Shield"
+                  : "Unshield"
+                : "Shield/Unshield"
+            }
           />
 
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: "20px", alignItems: "center", padding: "24px 32px" }}>
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "20px",
+                alignItems: "center",
+                padding: "24px 32px",
+              }}
+            >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 alt={isSuccess ? "Success" : "Error"}
-                src={isSuccess ? "/hero-new/success.svg" : "/hero-new/error.svg"}
-                style={{ width: "100px", height: "80px", animation: "mascotNod 0.6s ease-in-out 2", transformOrigin: "center bottom" }}
+                src={
+                  isSuccess ? "/hero-new/success.svg" : "/hero-new/error.svg"
+                }
+                style={{
+                  width: "100px",
+                  height: "80px",
+                  animation: "mascotNod 0.6s ease-in-out 2",
+                  transformOrigin: "center bottom",
+                }}
               />
-              <div style={{ display: "flex", flexDirection: "column", gap: "4px", alignItems: "center", textAlign: "center" }}>
-                <span style={{ fontFamily: font, fontSize: "20px", fontWeight: 600, lineHeight: "24px", color: "#000" }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "4px",
+                  alignItems: "center",
+                  textAlign: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "20px",
+                    fontWeight: 600,
+                    lineHeight: "24px",
+                    color: "#000",
+                  }}
+                >
                   {isSuccess
-                    ? `${token.symbol} ${direction === "shield" ? "Shielded" : "Unshielded"}`
-                    : (direction === "shield" ? "Shielding Failed" : "Unshielding Failed")}
+                    ? `${token.symbol} ${
+                        direction === "shield" ? "Shielded" : "Unshielded"
+                      }`
+                    : direction === "shield"
+                    ? "Shielding Failed"
+                    : "Unshielding Failed"}
                 </span>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, maxWidth: "255px" }}>
-                  {isSuccess
-                    ? (<><span style={{ color: "#000" }}>{resultAmount} {token.symbol}</span>{` moved to your ${direction === "shield" ? "secure" : "main"} balance`}</>)
-                    : (errorMessage || "Something went wrong. Please try again.")}
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                    maxWidth: "255px",
+                  }}
+                >
+                  {isSuccess ? (
+                    <>
+                      <span style={{ color: "#000" }}>
+                        {resultAmount} {token.symbol}
+                      </span>
+                      {` moved to your ${
+                        direction === "shield" ? "secure" : "main"
+                      } balance`}
+                    </>
+                  ) : (
+                    errorMessage || "Something went wrong. Please try again."
+                  )}
                 </span>
               </div>
             </div>
           </div>
 
-          <div style={{ padding: "16px 20px", display: "flex", flexDirection: "column", gap: "8px" }}>
+          <div
+            style={{
+              padding: "16px 20px",
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+            }}
+          >
             {isSuccess && (
               <button
                 className="shield-done-btn"
                 onClick={() => setPhase("details")}
-                style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#000", border: "none", cursor: "pointer", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center", transition: "background 0.15s ease" }}
+                style={{
+                  width: "100%",
+                  padding: "12px 16px",
+                  borderRadius: "9999px",
+                  background: "#000",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: "#fff",
+                  textAlign: "center",
+                  transition: "background 0.15s ease",
+                }}
                 type="button"
               >
                 Transaction Details
               </button>
             )}
             <button
-              className={isSuccess ? "shield-done-secondary-btn" : "shield-done-btn"}
+              className={
+                isSuccess ? "shield-done-secondary-btn" : "shield-done-btn"
+              }
               onClick={() => {
                 setPhase("form");
                 onDone();
@@ -518,53 +905,180 @@ export function ShieldContent({
 
     if (p === "details") {
       const now = new Date();
-      const dateStr = now.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-      const timeStr = now.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+      const dateStr = now.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+      const timeStr = now.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
 
       return (
-        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
           <style jsx>{`
-            .shield-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-            .shield-done-btn:hover { background: #333 !important; }
+            .shield-close:hover {
+              background: rgba(0, 0, 0, 0.08) !important;
+            }
+            .shield-done-btn:hover {
+              background: #333 !important;
+            }
           `}</style>
 
-          <StatusHeader onClose={onClose} title={direction === "shield" ? "Shielded" : "Unshielded"} />
+          <StatusHeader
+            onClose={onClose}
+            title={direction === "shield" ? "Shielded" : "Unshielded"}
+          />
 
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "8px", overflowY: "auto" }}>
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              padding: "8px",
+              overflowY: "auto",
+            }}
+          >
             {/* Token icon with badge */}
             <div style={{ padding: "8px 12px 0" }}>
-              <div style={{ position: "relative", width: "48px", height: "56px" }}>
-                <div style={{ width: "48px", height: "48px", borderRadius: "9999px", overflow: "hidden" }}>
-                  <Image alt={token.symbol} height={48} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={48} />
+              <div
+                style={{ position: "relative", width: "48px", height: "56px" }}
+              >
+                <div
+                  style={{
+                    width: "48px",
+                    height: "48px",
+                    borderRadius: "9999px",
+                    overflow: "hidden",
+                  }}
+                >
+                  <Image
+                    alt={token.symbol}
+                    height={48}
+                    src={token.icon}
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                    }}
+                    width={48}
+                  />
                 </div>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   alt={direction === "shield" ? "Shielded" : "Unshielded"}
-                  src={direction === "shield" ? "/hero-new/Shield.png" : "/hero-new/Unshield.svg"}
-                  style={{ width: "24px", height: "24px", position: "absolute", bottom: "0", left: "16px" }}
+                  src={
+                    direction === "shield"
+                      ? "/hero-new/Shield.png"
+                      : "/hero-new/Unshield.svg"
+                  }
+                  style={{
+                    width: "24px",
+                    height: "24px",
+                    position: "absolute",
+                    bottom: "0",
+                    left: "16px",
+                  }}
                 />
               </div>
             </div>
 
             {/* Amount hero */}
             <div style={{ padding: "12px 12px 24px" }}>
-              <div style={{ display: "flex", alignItems: "baseline", gap: "8px", fontFamily: font, fontWeight: 600, whiteSpace: "nowrap" }}>
-                <span style={{ fontSize: "40px", lineHeight: "48px", color: "#000" }}>{resultAmount}</span>
-                <span style={{ fontSize: "28px", lineHeight: "32px", color: "rgba(60, 60, 67, 0.4)", letterSpacing: "0.4px" }}>{token.symbol}</span>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: "8px",
+                  fontFamily: font,
+                  fontWeight: 600,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "40px",
+                    lineHeight: "48px",
+                    color: "#000",
+                  }}
+                >
+                  {resultAmount}
+                </span>
+                <span
+                  style={{
+                    fontSize: "28px",
+                    lineHeight: "32px",
+                    color: "rgba(60, 60, 67, 0.4)",
+                    letterSpacing: "0.4px",
+                  }}
+                >
+                  {token.symbol}
+                </span>
               </div>
-              <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, display: "block", marginTop: "4px" }}>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: secondary,
+                  display: "block",
+                  marginTop: "4px",
+                }}
+              >
                 ≈{resultUsd}
               </span>
-              <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, display: "block" }}>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: secondary,
+                  display: "block",
+                }}
+              >
                 {dateStr}, {timeStr}
               </span>
             </div>
 
             {/* Status card */}
-            <div style={{ background: "rgba(0, 0, 0, 0.04)", borderRadius: "16px", padding: "4px 0" }}>
+            <div
+              style={{
+                background: "rgba(0, 0, 0, 0.04)",
+                borderRadius: "16px",
+                padding: "4px 0",
+              }}
+            >
               <div style={{ padding: "9px 12px" }}>
-                <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Status</span>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#000", display: "block", marginTop: "2px" }}>Completed</span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 400,
+                    lineHeight: "16px",
+                    color: secondary,
+                    display: "block",
+                  }}
+                >
+                  Status
+                </span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: "#000",
+                    display: "block",
+                    marginTop: "2px",
+                  }}
+                >
+                  Completed
+                </span>
               </div>
             </div>
           </div>
@@ -577,7 +1091,21 @@ export function ShieldContent({
                 setPhase("form");
                 onDone();
               }}
-              style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#000", border: "none", cursor: "pointer", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center", transition: "background 0.15s ease" }}
+              style={{
+                width: "100%",
+                padding: "12px 16px",
+                borderRadius: "9999px",
+                background: "#000",
+                border: "none",
+                cursor: "pointer",
+                fontFamily: font,
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#fff",
+                textAlign: "center",
+                transition: "background 0.15s ease",
+              }}
               type="button"
             >
               Done
@@ -591,32 +1119,145 @@ export function ShieldContent({
     return (
       <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
         <style jsx>{`
-          .shield-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-          .pct-btn:hover { opacity: 0.7; }
-          .swap-circle:hover { background: #333 !important; }
-          .confirm-btn:not(:disabled):hover { background: #333 !important; }
+          .shield-close:hover {
+            background: rgba(0, 0, 0, 0.08) !important;
+          }
+          .pct-btn:hover {
+            opacity: 0.7;
+          }
+          .swap-circle:hover {
+            background: #333 !important;
+          }
+          .confirm-btn:not(:disabled):hover {
+            background: #333 !important;
+          }
         `}</style>
 
         {/* Header with tabs — hidden when parent owns chrome */}
-        {!hideFormChrome && <SwapShieldTabs mode={swapMode} onClose={onClose} onModeChange={onSwapModeChange} />}
+        {!hideFormChrome && (
+          <SwapShieldTabs
+            mode={swapMode}
+            onClose={onClose}
+            onModeChange={onSwapModeChange}
+          />
+        )}
 
         {/* Body */}
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0", overflow: "auto", padding: "8px 8px 16px" }}>
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: "0",
+            overflow: "auto",
+            padding: "8px 8px 16px",
+          }}
+        >
           {/* Input cards container */}
-          <div style={{ display: "flex", flexDirection: "column", gap: "8px", position: "relative", isolation: "isolate", overflow: "visible" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+              position: "relative",
+              isolation: "isolate",
+              overflow: "visible",
+            }}
+          >
             {/* From card */}
-            <div style={{ background: "#fff", borderRadius: "16px", padding: "10px 12px", position: "relative", zIndex: 2 }}>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", fontFamily: font, fontWeight: 400, lineHeight: "20px", whiteSpace: "nowrap" }}>
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "16px",
+                padding: "10px 12px",
+                position: "relative",
+                zIndex: 2,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontFamily: font,
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  whiteSpace: "nowrap",
+                }}
+              >
                 <span style={{ fontSize: "16px", color: secondary }}>
                   {direction === "shield" ? "You shield" : "You unshield"}
                 </span>
-                <div style={{ display: "flex", gap: "16px", alignItems: "center", fontSize: "14px", color: red }}>
-                  <button className="pct-btn" onClick={() => handlePercentage(25)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">25%</button>
-                  <button className="pct-btn" onClick={() => handlePercentage(50)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">50%</button>
-                  <button className="pct-btn" onClick={() => handlePercentage(100)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">Max</button>
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "16px",
+                    alignItems: "center",
+                    fontSize: "14px",
+                    color: red,
+                  }}
+                >
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(25)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    25%
+                  </button>
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(50)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    50%
+                  </button>
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(100)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    Max
+                  </button>
                 </div>
               </div>
-              <div style={{ display: "flex", gap: "4px", height: "48px", alignItems: "center" }}>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "4px",
+                  height: "48px",
+                  alignItems: "center",
+                }}
+              >
                 <input
                   inputMode="decimal"
                   onChange={(e) => {
@@ -624,26 +1265,81 @@ export function ShieldContent({
                     if (v === "" || /^\d*\.?\d*$/.test(v)) setAmount(v);
                   }}
                   placeholder="0"
-                  style={{ flex: 1, fontFamily: font, fontSize: "32px", fontWeight: 600, lineHeight: "36px", color: amountColor, background: "none", border: "none", outline: "none", padding: 0, minWidth: 0 }}
+                  style={{
+                    flex: 1,
+                    fontFamily: font,
+                    fontSize: "32px",
+                    fontWeight: 600,
+                    lineHeight: "36px",
+                    color: amountColor,
+                    background: "none",
+                    border: "none",
+                    outline: "none",
+                    padding: 0,
+                    minWidth: 0,
+                  }}
                   type="text"
                   value={amount}
                 />
                 {direction === "shield" ? (
-                  <SelectableTokenPill onClick={() => onNavigate({ type: "shieldTokenSelect" })} token={token} />
+                  <SelectableTokenPill
+                    onClick={() => onNavigate({ type: "shieldTokenSelect" })}
+                    token={token}
+                  />
                 ) : (
-                  <ShieldedSelectableTokenPill onClick={() => onNavigate({ type: "shieldTokenSelect" })} token={token} />
+                  <ShieldedSelectableTokenPill
+                    onClick={() => onNavigate({ type: "shieldTokenSelect" })}
+                    token={token}
+                  />
                 )}
               </div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
-                  <div style={{ width: "20px", height: "20px", borderRadius: "9999px", background: "#F5F5F5", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <ArrowDownUp size={12} style={{ color: secondary, opacity: 0.4 }} />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <div
+                  style={{ display: "flex", gap: "6px", alignItems: "center" }}
+                >
+                  <div
+                    style={{
+                      width: "20px",
+                      height: "20px",
+                      borderRadius: "9999px",
+                      background: "#F5F5F5",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <ArrowDownUp
+                      size={12}
+                      style={{ color: secondary, opacity: 0.4 }}
+                    />
                   </div>
-                  <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+                  <span
+                    style={{
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      lineHeight: "20px",
+                      color: secondary,
+                    }}
+                  >
                     {exchangeRate}
                   </span>
                 </div>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
                   Balance: {sourceBalance.toLocaleString()}{" "}
                 </span>
               </div>
@@ -676,34 +1372,137 @@ export function ShieldContent({
             </div>
 
             {/* To card */}
-            <div style={{ border: "1px solid rgba(0, 0, 0, 0.08)", borderRadius: "16px", padding: "12px", zIndex: 1 }}>
+            <div
+              style={{
+                border: "1px solid rgba(0, 0, 0, 0.08)",
+                borderRadius: "16px",
+                padding: "12px",
+                zIndex: 1,
+              }}
+            >
               <div style={{ display: "flex", alignItems: "center" }}>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary }}>You receive</span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
+                  You receive
+                </span>
               </div>
-              <div style={{ display: "flex", gap: "4px", height: "48px", alignItems: "center" }}>
-                <span style={{ flex: 1, fontFamily: font, fontSize: "32px", fontWeight: 600, lineHeight: "36px", color: insufficientFunds && hasAmount ? red : hasAmount ? "#000" : "rgba(60, 60, 67, 0.4)", minWidth: 0 }}>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "4px",
+                  height: "48px",
+                  alignItems: "center",
+                }}
+              >
+                <span
+                  style={{
+                    flex: 1,
+                    fontFamily: font,
+                    fontSize: "32px",
+                    fontWeight: 600,
+                    lineHeight: "36px",
+                    color:
+                      insufficientFunds && hasAmount
+                        ? red
+                        : hasAmount
+                        ? "#000"
+                        : "rgba(60, 60, 67, 0.4)",
+                    minWidth: 0,
+                  }}
+                >
                   {hasAmount ? amount : "0"}
                 </span>
                 {direction === "shield" ? (
                   <ShieldedTokenPill token={token} />
                 ) : (
-                  <div style={{ display: "flex", alignItems: "center", padding: "0 4px", flexShrink: 0 }}>
-                    <div style={{ display: "flex", alignItems: "center", paddingRight: "6px", padding: "4px 6px 4px 4px" }}>
-                      <div style={{ width: "28px", height: "28px", borderRadius: "9999px", overflow: "hidden" }}>
-                        <Image alt={token.symbol} height={28} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={28} />
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      padding: "0 4px",
+                      flexShrink: 0,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        paddingRight: "6px",
+                        padding: "4px 6px 4px 4px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: "28px",
+                          height: "28px",
+                          borderRadius: "9999px",
+                          overflow: "hidden",
+                        }}
+                      >
+                        <Image
+                          alt={token.symbol}
+                          height={28}
+                          src={token.icon}
+                          style={{
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
+                          }}
+                          width={28}
+                        />
                       </div>
                     </div>
-                    <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 500, lineHeight: "20px", color: "#000", letterSpacing: "-0.176px", whiteSpace: "nowrap", padding: "8px 0" }}>
+                    <span
+                      style={{
+                        fontFamily: font,
+                        fontSize: "16px",
+                        fontWeight: 500,
+                        lineHeight: "20px",
+                        color: "#000",
+                        letterSpacing: "-0.176px",
+                        whiteSpace: "nowrap",
+                        padding: "8px 0",
+                      }}
+                    >
                       {token.symbol}
                     </span>
                   </div>
                 )}
               </div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
                   ${hasAmount ? usdValue : "0"}
                 </span>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
                   Balance: {destBalance.toLocaleString()}{" "}
                 </span>
               </div>
@@ -715,17 +1514,64 @@ export function ShieldContent({
 
           {/* Info card about shielded assets */}
           <div style={{ padding: "0 12px" }}>
-            <div style={{ background: "rgba(0, 0, 0, 0.04)", borderRadius: "16px", display: "flex", alignItems: "center", padding: "0 12px", overflow: "hidden" }}>
-              <div style={{ display: "flex", alignItems: "center", paddingRight: "12px", padding: "4px 12px 4px 0", flexShrink: 0 }}>
+            <div
+              style={{
+                background: "rgba(0, 0, 0, 0.04)",
+                borderRadius: "16px",
+                display: "flex",
+                alignItems: "center",
+                padding: "0 12px",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  paddingRight: "12px",
+                  padding: "4px 12px 4px 0",
+                  flexShrink: 0,
+                }}
+              >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img alt="" src="/hero-new/Shield.png" style={{ width: "40px", height: "40px" }} />
+                <img
+                  alt=""
+                  src="/hero-new/Shield.png"
+                  style={{ width: "40px", height: "40px" }}
+                />
               </div>
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "2px", padding: "10px 0" }}>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#000" }}>
+              <div
+                style={{
+                  flex: 1,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "2px",
+                  padding: "10px 0",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: "#000",
+                  }}
+                >
                   What are Shielded Assets?
                 </span>
-                <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary }}>
-                  When you shield assets, they move to your private balance. This enables private transactions without revealing your address or sensitive data on-chain.
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 400,
+                    lineHeight: "16px",
+                    color: secondary,
+                  }}
+                >
+                  When you shield assets, they move to your private balance.
+                  This enables private transactions without revealing your
+                  address or sensitive data on-chain.
                 </span>
               </div>
             </div>

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -37,15 +37,54 @@ function TokenPill({
       }}
       type="button"
     >
-      <div style={{ display: "flex", alignItems: "center", paddingRight: "6px", padding: "4px 6px 4px 4px" }}>
-        <div style={{ width: "28px", height: "28px", borderRadius: "9999px", overflow: "hidden" }}>
-          <Image alt={token.symbol} height={28} src={token.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={28} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          paddingRight: "6px",
+          padding: "4px 6px 4px 4px",
+        }}
+      >
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "9999px",
+            overflow: "hidden",
+          }}
+        >
+          <Image
+            alt={token.symbol}
+            height={28}
+            src={token.icon}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            width={28}
+          />
         </div>
       </div>
-      <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 500, lineHeight: "20px", color: "#000", letterSpacing: "-0.176px", whiteSpace: "nowrap", padding: "8px 0" }}>
+      <span
+        style={{
+          fontFamily: font,
+          fontSize: "16px",
+          fontWeight: 500,
+          lineHeight: "20px",
+          color: "#000",
+          letterSpacing: "-0.176px",
+          whiteSpace: "nowrap",
+          padding: "8px 0",
+        }}
+      >
         {token.symbol}
       </span>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "36px", padding: "8px 0" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "36px",
+          padding: "8px 0",
+        }}
+      >
         <ChevronRight size={16} style={{ color: "#3C3C43" }} />
       </div>
     </button>
@@ -64,16 +103,50 @@ function SwapStatusHeader({
   onClose: () => void;
 }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px" }}>
-      <div style={{ flex: 1, paddingLeft: "12px", paddingTop: "4px", paddingBottom: "4px" }}>
-        <span style={{ fontFamily: font, fontSize: "18px", fontWeight: 600, lineHeight: "28px", color: "#000" }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px",
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          paddingLeft: "12px",
+          paddingTop: "4px",
+          paddingBottom: "4px",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: font,
+            fontSize: "18px",
+            fontWeight: 600,
+            lineHeight: "28px",
+            color: "#000",
+          }}
+        >
           Swap {fromToken.symbol} to {toToken.symbol}
         </span>
       </div>
       <button
         className="swap-status-close"
         onClick={onClose}
-        style={{ width: "36px", height: "36px", display: "flex", justifyContent: "center", alignItems: "center", background: "rgba(0, 0, 0, 0.04)", border: "none", borderRadius: "9999px", cursor: "pointer", transition: "all 0.2s ease", color: "#3C3C43" }}
+        style={{
+          width: "36px",
+          height: "36px",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          background: "rgba(0, 0, 0, 0.04)",
+          border: "none",
+          borderRadius: "9999px",
+          cursor: "pointer",
+          transition: "all 0.2s ease",
+          color: "#3C3C43",
+        }}
         type="button"
       >
         <X size={24} />
@@ -94,30 +167,113 @@ function SwapProcessing({
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <style jsx>{`
-        .swap-status-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
+        .swap-status-close:hover {
+          background: rgba(0, 0, 0, 0.08) !important;
+        }
         @keyframes chevronBounce {
-          0%, 100% { transform: translateX(0); }
-          50% { transform: translateX(4px); }
+          0%,
+          100% {
+            transform: translateX(0);
+          }
+          50% {
+            transform: translateX(4px);
+          }
         }
       `}</style>
 
-      <SwapStatusHeader fromToken={fromToken} onClose={onClose} toToken={toToken} />
+      <SwapStatusHeader
+        fromToken={fromToken}
+        onClose={onClose}
+        toToken={toToken}
+      />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: "20px", alignItems: "center", padding: "24px 32px" }}>
-          <div style={{ display: "flex", gap: "16px", alignItems: "center", padding: "8px 0" }}>
-            <div style={{ width: "64px", height: "64px", borderRadius: "9999px", overflow: "hidden", flexShrink: 0 }}>
-              <Image alt={fromToken.symbol} height={64} src={fromToken.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={64} />
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+            alignItems: "center",
+            padding: "24px 32px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: "16px",
+              alignItems: "center",
+              padding: "8px 0",
+            }}
+          >
+            <div
+              style={{
+                width: "64px",
+                height: "64px",
+                borderRadius: "9999px",
+                overflow: "hidden",
+                flexShrink: 0,
+              }}
+            >
+              <Image
+                alt={fromToken.symbol}
+                height={64}
+                src={fromToken.icon}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                width={64}
+              />
             </div>
-            <ChevronRight size={16} style={{ color: secondary, animation: "chevronBounce 1s ease-in-out infinite" }} />
-            <div style={{ width: "64px", height: "64px", borderRadius: "9999px", overflow: "hidden", flexShrink: 0 }}>
-              <Image alt={toToken.symbol} height={64} src={toToken.icon} style={{ width: "100%", height: "100%", objectFit: "cover" }} width={64} />
+            <ChevronRight
+              size={16}
+              style={{
+                color: secondary,
+                animation: "chevronBounce 1s ease-in-out infinite",
+              }}
+            />
+            <div
+              style={{
+                width: "64px",
+                height: "64px",
+                borderRadius: "9999px",
+                overflow: "hidden",
+                flexShrink: 0,
+              }}
+            >
+              <Image
+                alt={toToken.symbol}
+                height={64}
+                src={toToken.icon}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                width={64}
+              />
             </div>
           </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: "4px", alignItems: "center", textAlign: "center" }}>
-            <span style={{ fontFamily: font, fontSize: "20px", fontWeight: 600, lineHeight: "24px", color: "#000" }}>Swapping...</span>
-            <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, maxWidth: "285px" }}>
-              You can close this screen and continue using the app
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "4px",
+              alignItems: "center",
+              textAlign: "center",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "20px",
+                fontWeight: 600,
+                lineHeight: "24px",
+                color: "#000",
+              }}
+            >
+              Swapping...
             </span>
           </div>
         </div>
@@ -126,7 +282,20 @@ function SwapProcessing({
       <div style={{ padding: "16px 20px" }}>
         <button
           disabled
-          style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#CCCDCD", border: "none", cursor: "default", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center" }}
+          style={{
+            width: "100%",
+            padding: "12px 16px",
+            borderRadius: "9999px",
+            background: "#CCCDCD",
+            border: "none",
+            cursor: "default",
+            fontFamily: font,
+            fontSize: "16px",
+            fontWeight: 400,
+            lineHeight: "20px",
+            color: "#fff",
+            textAlign: "center",
+          }}
           type="button"
         >
           In progress...
@@ -160,37 +329,111 @@ function SwapResult({
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <style jsx>{`
-        .swap-status-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-        .done-btn:hover { background: #333 !important; }
-        .done-secondary-btn:hover { background: rgba(0, 0, 0, 0.08) !important; }
+        .swap-status-close:hover {
+          background: rgba(0, 0, 0, 0.08) !important;
+        }
+        .done-btn:hover {
+          background: #333 !important;
+        }
+        .done-secondary-btn:hover {
+          background: rgba(0, 0, 0, 0.08) !important;
+        }
         @keyframes mascotNod {
-          0%, 100% { transform: rotate(0deg); }
-          25% { transform: rotate(4deg); }
-          75% { transform: rotate(-4deg); }
+          0%,
+          100% {
+            transform: rotate(0deg);
+          }
+          25% {
+            transform: rotate(4deg);
+          }
+          75% {
+            transform: rotate(-4deg);
+          }
         }
       `}</style>
 
-      <SwapStatusHeader fromToken={fromToken} onClose={onClose} toToken={toToken} />
+      <SwapStatusHeader
+        fromToken={fromToken}
+        onClose={onClose}
+        toToken={toToken}
+      />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: "20px", alignItems: "center", padding: "24px 32px" }}>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+            alignItems: "center",
+            padding: "24px 32px",
+          }}
+        >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             alt={isSuccess ? "Success" : "Error"}
             src={isSuccess ? "/hero-new/success.svg" : "/hero-new/error.svg"}
-            style={{ width: "100px", height: "80px", animation: "mascotNod 0.6s ease-in-out 2", transformOrigin: "center bottom" }}
+            style={{
+              width: "100px",
+              height: "80px",
+              animation: "mascotNod 0.6s ease-in-out 2",
+              transformOrigin: "center bottom",
+            }}
           />
-          <div style={{ display: "flex", flexDirection: "column", gap: "4px", alignItems: "center", textAlign: "center" }}>
-            <span style={{ fontFamily: font, fontSize: "20px", fontWeight: 600, lineHeight: "24px", color: "#000" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "4px",
+              alignItems: "center",
+              textAlign: "center",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "20px",
+                fontWeight: 600,
+                lineHeight: "24px",
+                color: "#000",
+              }}
+            >
               {isSuccess ? "Swap Completed" : "Swap Failed"}
             </span>
             {isSuccess ? (
-              <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, maxWidth: "255px" }}>
-                <span style={{ color: "#000" }}>{receivedAmount} {toToken.symbol}</span>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: secondary,
+                  maxWidth: "255px",
+                }}
+              >
+                <span style={{ color: "#000" }}>
+                  {receivedAmount} {toToken.symbol}
+                </span>
                 {" has been deposited to your wallet"}
               </span>
             ) : (
-              <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary, maxWidth: "255px" }}>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: secondary,
+                  maxWidth: "255px",
+                }}
+              >
                 {errorMessage || "Something went wrong. Please try again."}
               </span>
             )}
@@ -198,12 +441,33 @@ function SwapResult({
         </div>
       </div>
 
-      <div style={{ padding: "16px 20px", display: "flex", flexDirection: "column", gap: "8px" }}>
+      <div
+        style={{
+          padding: "16px 20px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+        }}
+      >
         {isSuccess && (
           <button
             className="done-btn"
             onClick={onDetails}
-            style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#000", border: "none", cursor: "pointer", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center", transition: "background 0.15s ease" }}
+            style={{
+              width: "100%",
+              padding: "12px 16px",
+              borderRadius: "9999px",
+              background: "#000",
+              border: "none",
+              cursor: "pointer",
+              fontFamily: font,
+              fontSize: "16px",
+              fontWeight: 400,
+              lineHeight: "20px",
+              color: "#fff",
+              textAlign: "center",
+              transition: "background 0.15s ease",
+            }}
             type="button"
           >
             Transaction Details
@@ -254,42 +518,183 @@ function SwapTransactionDetail({
   onDone: () => void;
 }) {
   const now = new Date();
-  const dateStr = now.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-  const timeStr = now.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  const dateStr = now.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const timeStr = now.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <style jsx>{`
-        .swap-status-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-        .swap-tx-action-btn:hover { background: rgba(249, 54, 60, 0.22) !important; }
-        .swap-tx-done-btn:hover { background: #333 !important; }
+        .swap-status-close:hover {
+          background: rgba(0, 0, 0, 0.08) !important;
+        }
+        .swap-tx-action-btn:hover {
+          background: rgba(249, 54, 60, 0.22) !important;
+        }
+        .swap-tx-done-btn:hover {
+          background: #333 !important;
+        }
       `}</style>
 
-      <SwapStatusHeader fromToken={fromToken} onClose={onClose} toToken={toToken} />
+      <SwapStatusHeader
+        fromToken={fromToken}
+        onClose={onClose}
+        toToken={toToken}
+      />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", padding: "8px", overflowY: "auto" }}>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          padding: "8px",
+          overflowY: "auto",
+        }}
+      >
         {/* Amount hero */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "32px 12px 24px", width: "100%" }}>
-          <div style={{ display: "flex", flexDirection: "column", gap: "4px", width: "100%" }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: "8px", fontFamily: font, fontWeight: 600, whiteSpace: "nowrap" }}>
-              <span style={{ fontSize: "40px", lineHeight: "48px", color: "#34C759" }}>+{receivedAmount}</span>
-              <span style={{ fontSize: "28px", lineHeight: "32px", color: "rgba(60, 60, 67, 0.4)", letterSpacing: "0.4px" }}>{toToken.symbol}</span>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "32px 12px 24px",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "4px",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: "8px",
+                fontFamily: font,
+                fontWeight: 600,
+                whiteSpace: "nowrap",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: "40px",
+                  lineHeight: "48px",
+                  color: "#34C759",
+                }}
+              >
+                +{receivedAmount}
+              </span>
+              <span
+                style={{
+                  fontSize: "28px",
+                  lineHeight: "32px",
+                  color: "rgba(60, 60, 67, 0.4)",
+                  letterSpacing: "0.4px",
+                }}
+              >
+                {toToken.symbol}
+              </span>
             </div>
-            <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary }}>≈{usdValue}</span>
-            <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary }}>{dateStr}, {timeStr}</span>
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: secondary,
+              }}
+            >
+              ≈{usdValue}
+            </span>
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: secondary,
+              }}
+            >
+              {dateStr}, {timeStr}
+            </span>
           </div>
         </div>
 
         {/* Details card */}
         <div style={{ width: "100%" }}>
-          <div style={{ background: "rgba(0, 0, 0, 0.04)", borderRadius: "16px", padding: "4px 0", display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              background: "rgba(0, 0, 0, 0.04)",
+              borderRadius: "16px",
+              padding: "4px 0",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
             <div style={{ padding: "9px 12px" }}>
-              <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Status</span>
-              <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#000", display: "block", marginTop: "2px" }}>Completed</span>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "13px",
+                  fontWeight: 400,
+                  lineHeight: "16px",
+                  color: secondary,
+                  display: "block",
+                }}
+              >
+                Status
+              </span>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: "#000",
+                  display: "block",
+                  marginTop: "2px",
+                }}
+              >
+                Completed
+              </span>
             </div>
             <div style={{ padding: "9px 12px" }}>
-              <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Network Fee</span>
-              <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "2px", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px" }}>
+              <span
+                style={{
+                  fontFamily: font,
+                  fontSize: "13px",
+                  fontWeight: 400,
+                  lineHeight: "16px",
+                  color: secondary,
+                  display: "block",
+                }}
+              >
+                Network Fee
+              </span>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  marginTop: "2px",
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                }}
+              >
                 <span style={{ color: "#000" }}>0.00005 SOL</span>
                 <span style={{ color: secondary }}>≈ $0.00</span>
               </div>
@@ -298,28 +703,109 @@ function SwapTransactionDetail({
         </div>
 
         {/* Action buttons */}
-        <div style={{ display: "flex", alignItems: "center", paddingTop: "20px", paddingBottom: "16px", width: "100%" }}>
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            paddingTop: "20px",
+            paddingBottom: "16px",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
             <button
               className="swap-tx-action-btn"
-              onClick={() => signature && window.open(`https://explorer.solana.com/tx/${signature}`, "_blank")}
-              style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: signature ? "pointer" : "default", opacity: signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
+              onClick={() =>
+                signature &&
+                window.open(
+                  `https://explorer.solana.com/tx/${signature}`,
+                  "_blank"
+                )
+              }
+              style={{
+                width: "48px",
+                height: "48px",
+                borderRadius: "9999px",
+                background: "rgba(249, 54, 60, 0.14)",
+                border: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: signature ? "pointer" : "default",
+                opacity: signature ? 1 : 0.5,
+                transition: "background-color 0.15s ease",
+              }}
               type="button"
             >
               <Globe size={24} style={{ color: "#3C3C43" }} />
             </button>
-            <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, textAlign: "center" }}>View in explorer</span>
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "13px",
+                fontWeight: 400,
+                lineHeight: "16px",
+                color: secondary,
+                textAlign: "center",
+              }}
+            >
+              View in explorer
+            </span>
           </div>
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
             <button
               className="swap-tx-action-btn"
-              onClick={() => signature && void navigator.clipboard.writeText(`https://explorer.solana.com/tx/${signature}`)}
-              style={{ width: "48px", height: "48px", borderRadius: "9999px", background: "rgba(249, 54, 60, 0.14)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: signature ? "pointer" : "default", opacity: signature ? 1 : 0.5, transition: "background-color 0.15s ease" }}
+              onClick={() =>
+                signature &&
+                void navigator.clipboard.writeText(
+                  `https://explorer.solana.com/tx/${signature}`
+                )
+              }
+              style={{
+                width: "48px",
+                height: "48px",
+                borderRadius: "9999px",
+                background: "rgba(249, 54, 60, 0.14)",
+                border: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: signature ? "pointer" : "default",
+                opacity: signature ? 1 : 0.5,
+                transition: "background-color 0.15s ease",
+              }}
               type="button"
             >
               <Share size={24} style={{ color: "#3C3C43" }} />
             </button>
-            <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, textAlign: "center" }}>Share</span>
+            <span
+              style={{
+                fontFamily: font,
+                fontSize: "13px",
+                fontWeight: 400,
+                lineHeight: "16px",
+                color: secondary,
+                textAlign: "center",
+              }}
+            >
+              Share
+            </span>
           </div>
         </div>
       </div>
@@ -329,7 +815,21 @@ function SwapTransactionDetail({
         <button
           className="swap-tx-done-btn"
           onClick={onDone}
-          style={{ width: "100%", padding: "12px 16px", borderRadius: "9999px", background: "#000", border: "none", cursor: "pointer", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#fff", textAlign: "center", transition: "background 0.15s ease" }}
+          style={{
+            width: "100%",
+            padding: "12px 16px",
+            borderRadius: "9999px",
+            background: "#000",
+            border: "none",
+            cursor: "pointer",
+            fontFamily: font,
+            fontSize: "16px",
+            fontWeight: 400,
+            lineHeight: "20px",
+            color: "#fff",
+            textAlign: "center",
+            transition: "background 0.15s ease",
+          }}
           type="button"
         >
           Done
@@ -366,7 +866,15 @@ export function SwapContent({
   onFormActiveChange?: (isForm: boolean) => void;
   onFormButtonChange?: (props: FormButtonProps | null) => void;
 }) {
-  const { getQuote, executeSwap, resetQuote, quote, isAvailable, unavailableReason, error: swapError } = useSwap();
+  const {
+    getQuote,
+    executeSwap,
+    resetQuote,
+    quote,
+    isAvailable,
+    unavailableReason,
+    error: swapError,
+  } = useSwap();
   const [fromAmount, setFromAmount] = useState("");
   const [phase, setPhase] = useState<SwapPhase>("form");
   const [resultAmount, setResultAmount] = useState("");
@@ -414,26 +922,38 @@ export function SwapContent({
         fromToken.symbol,
         toToken.symbol,
         String(numericFrom),
-        fromToken.mint,
+        fromToken.mint
       ).finally(() => setIsQuoting(false));
     }, 500);
     return () => {
       if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     };
-  }, [fromAmount, fromToken.symbol, fromToken.mint, toToken.symbol, hasAmount, insufficientFunds, phase, getQuote, resetQuote, numericFrom]);
+  }, [
+    fromAmount,
+    fromToken.symbol,
+    fromToken.mint,
+    toToken.symbol,
+    hasAmount,
+    insufficientFunds,
+    phase,
+    getQuote,
+    resetQuote,
+    numericFrom,
+  ]);
 
   const buttonLabel = !isAvailable
-    ? (unavailableReason ?? "Swap unavailable")
+    ? unavailableReason ?? "Swap unavailable"
     : !hasAmount
-      ? "Enter Amount"
-      : insufficientFunds
-        ? "Insufficient Funds"
-        : isQuoting
-          ? "Getting quote..."
-          : !quote
-            ? "Enter Amount"
-            : "Confirm and Swap";
-  const buttonDisabled = !isAvailable || !hasAmount || insufficientFunds || isQuoting || !quote;
+    ? "Enter Amount"
+    : insufficientFunds
+    ? "Insufficient Funds"
+    : isQuoting
+    ? "Getting quote..."
+    : !quote
+    ? "Enter Amount"
+    : "Confirm and Swap";
+  const buttonDisabled =
+    !isAvailable || !hasAmount || insufficientFunds || isQuoting || !quote;
   const amountColor = insufficientFunds && hasAmount ? red : "#000";
 
   const handleSwapTokens = useCallback(() => {
@@ -453,7 +973,16 @@ export function SwapContent({
   const handleConfirm = useCallback(async () => {
     if (!quote) return;
     setResultAmount(hasAmount ? Number(toAmount.toFixed(6)).toString() : "0");
-    setResultUsd(`$${hasAmount ? (toAmount * toToken.price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "0"}`);
+    setResultUsd(
+      `$${
+        hasAmount
+          ? (toAmount * toToken.price).toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })
+          : "0"
+      }`
+    );
     setResultSignature(undefined);
     setErrorMessage(undefined);
     setPhase("processing");
@@ -478,7 +1007,11 @@ export function SwapContent({
       onFormButtonChange(null);
       return;
     }
-    onFormButtonChange({ label: buttonLabel, disabled: buttonDisabled, onClick: handleConfirm });
+    onFormButtonChange({
+      label: buttonLabel,
+      disabled: buttonDisabled,
+      onClick: handleConfirm,
+    });
   });
 
   // Cross-fade between phases
@@ -499,49 +1032,192 @@ export function SwapContent({
 
   const handlePercentage = useCallback(
     (pct: number) => {
-      const val = pct === 100 ? fromToken.balance : fromToken.balance * (pct / 100);
+      const val =
+        pct === 100 ? fromToken.balance : fromToken.balance * (pct / 100);
       setFromAmount(val > 0 ? String(Number(val.toFixed(6))) : "");
     },
-    [fromToken.balance],
+    [fromToken.balance]
   );
 
   const renderPhaseContent = (p: SwapPhase) => {
     if (p === "processing") {
-      return <SwapProcessing fromToken={fromToken} onClose={onClose} toToken={toToken} />;
+      return (
+        <SwapProcessing
+          fromToken={fromToken}
+          onClose={onClose}
+          toToken={toToken}
+        />
+      );
     }
     if (p === "success" || p === "error") {
-      return <SwapResult errorMessage={errorMessage} fromToken={fromToken} onClose={onClose} onDetails={() => setPhase("details")} onDone={onDone} receivedAmount={resultAmount} toToken={toToken} variant={p} />;
+      return (
+        <SwapResult
+          errorMessage={errorMessage}
+          fromToken={fromToken}
+          onClose={onClose}
+          onDetails={() => setPhase("details")}
+          onDone={onDone}
+          receivedAmount={resultAmount}
+          toToken={toToken}
+          variant={p}
+        />
+      );
     }
     if (p === "details") {
-      return <SwapTransactionDetail fromToken={fromToken} onClose={onClose} onDone={onDone} receivedAmount={resultAmount} signature={resultSignature} toToken={toToken} usdValue={resultUsd} />;
+      return (
+        <SwapTransactionDetail
+          fromToken={fromToken}
+          onClose={onClose}
+          onDone={onDone}
+          receivedAmount={resultAmount}
+          signature={resultSignature}
+          toToken={toToken}
+          usdValue={resultUsd}
+        />
+      );
     }
     return (
       <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
         <style jsx>{`
-          .swap-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
-          .pct-btn:hover { opacity: 0.7; }
-          .swap-circle:hover { background: #333 !important; }
-          .confirm-btn:not(:disabled):hover { background: #333 !important; }
+          .swap-close:hover {
+            background: rgba(0, 0, 0, 0.08) !important;
+          }
+          .pct-btn:hover {
+            opacity: 0.7;
+          }
+          .swap-circle:hover {
+            background: #333 !important;
+          }
+          .confirm-btn:not(:disabled):hover {
+            background: #333 !important;
+          }
         `}</style>
 
         {/* Header with tabs — hidden when parent owns chrome */}
-        {!hideFormChrome && <SwapShieldTabs mode={swapMode} onClose={onClose} onModeChange={onSwapModeChange} />}
+        {!hideFormChrome && (
+          <SwapShieldTabs
+            mode={swapMode}
+            onClose={onClose}
+            onModeChange={onSwapModeChange}
+          />
+        )}
 
         {/* Body */}
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "16px", overflow: "auto", padding: "8px 8px 16px" }}>
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            overflow: "auto",
+            padding: "8px 8px 16px",
+          }}
+        >
           {/* Swap inputs container */}
-          <div style={{ display: "flex", flexDirection: "column", gap: "8px", position: "relative", isolation: "isolate", overflow: "visible" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+              position: "relative",
+              isolation: "isolate",
+              overflow: "visible",
+            }}
+          >
             {/* From card */}
-            <div style={{ background: "#fff", borderRadius: "16px", padding: "10px 12px", position: "relative", zIndex: 2 }}>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", fontFamily: font, fontWeight: 400, lineHeight: "20px", whiteSpace: "nowrap" }}>
-                <span style={{ fontSize: "16px", color: secondary }}>You swap</span>
-                <div style={{ display: "flex", gap: "16px", alignItems: "center", fontSize: "14px", color: red }}>
-                  <button className="pct-btn" onClick={() => handlePercentage(25)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">25%</button>
-                  <button className="pct-btn" onClick={() => handlePercentage(50)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">50%</button>
-                  <button className="pct-btn" onClick={() => handlePercentage(100)} style={{ background: "none", border: "none", cursor: "pointer", color: red, fontFamily: font, fontSize: "14px", fontWeight: 400, padding: 0 }} type="button">Max</button>
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "16px",
+                padding: "10px 12px",
+                position: "relative",
+                zIndex: 2,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontFamily: font,
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span style={{ fontSize: "16px", color: secondary }}>
+                  You swap
+                </span>
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "16px",
+                    alignItems: "center",
+                    fontSize: "14px",
+                    color: red,
+                  }}
+                >
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(25)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    25%
+                  </button>
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(50)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    50%
+                  </button>
+                  <button
+                    className="pct-btn"
+                    onClick={() => handlePercentage(100)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: red,
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      padding: 0,
+                    }}
+                    type="button"
+                  >
+                    Max
+                  </button>
                 </div>
               </div>
-              <div style={{ display: "flex", gap: "4px", height: "48px", alignItems: "center" }}>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "4px",
+                  height: "48px",
+                  alignItems: "center",
+                }}
+              >
                 <input
                   inputMode="decimal"
                   onChange={(e) => {
@@ -549,22 +1225,81 @@ export function SwapContent({
                     if (v === "" || /^\d*\.?\d*$/.test(v)) setFromAmount(v);
                   }}
                   placeholder="0"
-                  style={{ flex: 1, fontFamily: font, fontSize: "32px", fontWeight: 600, lineHeight: "36px", color: amountColor, background: "none", border: "none", outline: "none", padding: 0, minWidth: 0 }}
+                  style={{
+                    flex: 1,
+                    fontFamily: font,
+                    fontSize: "32px",
+                    fontWeight: 600,
+                    lineHeight: "36px",
+                    color: amountColor,
+                    background: "none",
+                    border: "none",
+                    outline: "none",
+                    padding: 0,
+                    minWidth: 0,
+                  }}
                   type="text"
                   value={fromAmount}
                 />
-                <TokenPill onClick={() => onNavigate({ type: "tokenSelect", field: "from" })} token={fromToken} variant="from" />
+                <TokenPill
+                  onClick={() =>
+                    onNavigate({ type: "tokenSelect", field: "from" })
+                  }
+                  token={fromToken}
+                  variant="from"
+                />
               </div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
-                  <div style={{ width: "20px", height: "20px", borderRadius: "9999px", background: "#F5F5F5", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <ArrowDownUp size={12} style={{ color: secondary, opacity: 0.4 }} />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <div
+                  style={{ display: "flex", gap: "6px", alignItems: "center" }}
+                >
+                  <div
+                    style={{
+                      width: "20px",
+                      height: "20px",
+                      borderRadius: "9999px",
+                      background: "#F5F5F5",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <ArrowDownUp
+                      size={12}
+                      style={{ color: secondary, opacity: 0.4 }}
+                    />
                   </div>
-                  <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
-                    1 {fromToken.symbol} ≈ ${fromToken.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 })}
+                  <span
+                    style={{
+                      fontFamily: font,
+                      fontSize: "14px",
+                      fontWeight: 400,
+                      lineHeight: "20px",
+                      color: secondary,
+                    }}
+                  >
+                    1 {fromToken.symbol} ≈ $
+                    {fromToken.price.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 4,
+                    })}
                   </span>
                 </div>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
                   Balance: {fromToken.balance.toLocaleString()}{" "}
                 </span>
               </div>
@@ -597,21 +1332,94 @@ export function SwapContent({
             </div>
 
             {/* To card */}
-            <div style={{ background: "#fff", borderRadius: "16px", padding: "12px", zIndex: 1 }}>
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "16px",
+                padding: "12px",
+                zIndex: 1,
+              }}
+            >
               <div style={{ display: "flex", alignItems: "center" }}>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: secondary }}>You receive</span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
+                  You receive
+                </span>
               </div>
-              <div style={{ display: "flex", gap: "4px", height: "48px", alignItems: "center" }}>
-                <span style={{ flex: 1, fontFamily: font, fontSize: "32px", fontWeight: 600, lineHeight: "36px", color: insufficientFunds && hasAmount ? red : hasAmount ? "#000" : secondary, minWidth: 0 }}>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "4px",
+                  height: "48px",
+                  alignItems: "center",
+                }}
+              >
+                <span
+                  style={{
+                    flex: 1,
+                    fontFamily: font,
+                    fontSize: "32px",
+                    fontWeight: 600,
+                    lineHeight: "36px",
+                    color:
+                      insufficientFunds && hasAmount
+                        ? red
+                        : hasAmount
+                        ? "#000"
+                        : secondary,
+                    minWidth: 0,
+                  }}
+                >
                   {hasAmount ? Number(toAmount.toFixed(6)).toString() : "0"}
                 </span>
-                <TokenPill onClick={() => onNavigate({ type: "tokenSelect", field: "to" })} token={toToken} variant="to" />
+                <TokenPill
+                  onClick={() =>
+                    onNavigate({ type: "tokenSelect", field: "to" })
+                  }
+                  token={toToken}
+                  variant="to"
+                />
               </div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
-                  ${hasAmount ? Number(toUsd).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "0"}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
+                  $
+                  {hasAmount
+                    ? Number(toUsd).toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })
+                    : "0"}
                 </span>
-                <span style={{ fontFamily: font, fontSize: "14px", fontWeight: 400, lineHeight: "20px", color: secondary }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "14px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: secondary,
+                  }}
+                >
                   Balance: {toToken.balance.toLocaleString()}{" "}
                 </span>
               </div>
@@ -620,21 +1428,99 @@ export function SwapContent({
 
           {/* Details card (only when amount entered) */}
           {hasAmount && (
-            <div style={{ background: "rgba(0, 0, 0, 0.04)", borderRadius: "16px", padding: "4px 0" }}>
+            <div
+              style={{
+                background: "rgba(0, 0, 0, 0.04)",
+                borderRadius: "16px",
+                padding: "4px 0",
+              }}
+            >
               <div style={{ padding: "10px 12px" }}>
-                <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Rate</span>
-                <div style={{ display: "flex", gap: "4px", alignItems: "center", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", marginTop: "2px" }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 400,
+                    lineHeight: "16px",
+                    color: secondary,
+                    display: "block",
+                  }}
+                >
+                  Rate
+                </span>
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "4px",
+                    alignItems: "center",
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    marginTop: "2px",
+                  }}
+                >
                   <span style={{ color: "#000" }}>1 {toToken.symbol}</span>
-                  <span style={{ color: secondary }}>≈ {fromToken.price > 0 ? (toToken.price / fromToken.price).toFixed(2) : "—"}</span>
+                  <span style={{ color: secondary }}>
+                    ≈{" "}
+                    {fromToken.price > 0
+                      ? (toToken.price / fromToken.price).toFixed(2)
+                      : "—"}
+                  </span>
                 </div>
               </div>
               <div style={{ padding: "10px 12px" }}>
-                <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Slippage</span>
-                <span style={{ fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", color: "#000", display: "block", marginTop: "2px" }}>1%</span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 400,
+                    lineHeight: "16px",
+                    color: secondary,
+                    display: "block",
+                  }}
+                >
+                  Slippage
+                </span>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    color: "#000",
+                    display: "block",
+                    marginTop: "2px",
+                  }}
+                >
+                  1%
+                </span>
               </div>
               <div style={{ padding: "10px 12px" }}>
-                <span style={{ fontFamily: font, fontSize: "13px", fontWeight: 400, lineHeight: "16px", color: secondary, display: "block" }}>Network Fee</span>
-                <div style={{ display: "flex", gap: "4px", alignItems: "center", fontFamily: font, fontSize: "16px", fontWeight: 400, lineHeight: "20px", marginTop: "2px" }}>
+                <span
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 400,
+                    lineHeight: "16px",
+                    color: secondary,
+                    display: "block",
+                  }}
+                >
+                  Network Fee
+                </span>
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "4px",
+                    alignItems: "center",
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    lineHeight: "20px",
+                    marginTop: "2px",
+                  }}
+                >
                   <span style={{ color: "#000" }}>0.00005 SOL</span>
                   <span style={{ color: secondary }}>≈ $0.00</span>
                 </div>

--- a/frontend/src/components/wallet-sidebar/transaction-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/transaction-detail-view.tsx
@@ -24,6 +24,7 @@ export function TransactionDetailView({
   const isSent = detail.activity.type === "sent";
   const isShielded = detail.activity.type === "shielded";
   const isUnshielded = detail.activity.type === "unshielded";
+  const isPrivate = detail.isPrivate || detail.activity.isPrivate;
   const isShieldType = isShielded || isUnshielded;
   const title = isShielded ? "Shielded" : isUnshielded ? "Unshielded" : isSent ? "Sent" : "Received";
   // Strip the +/− prefix for the large display
@@ -247,47 +248,49 @@ export function TransactionDetailView({
           }}
         >
           {/* View in explorer */}
-          <div
-            style={{
-              flex: 1,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "8px",
-            }}
-          >
-            <button
-              className="tx-action-btn"
-              onClick={() => window.open(`https://explorer.solana.com/tx/${detail.activity.id}`, "_blank")}
+          {!isPrivate && (
+            <div
               style={{
-                width: "48px",
-                height: "48px",
-                borderRadius: "9999px",
-                background: "rgba(249, 54, 60, 0.14)",
-                border: "none",
+                flex: 1,
                 display: "flex",
+                flexDirection: "column",
                 alignItems: "center",
-                justifyContent: "center",
-                cursor: "pointer",
-                transition: "background-color 0.15s ease",
-              }}
-              type="button"
-            >
-              <Globe size={24} style={{ color: "#3C3C43" }} />
-            </button>
-            <span
-              style={{
-                fontFamily: "var(--font-geist-sans), sans-serif",
-                fontSize: "13px",
-                fontWeight: 400,
-                lineHeight: "16px",
-                color: "rgba(60, 60, 67, 0.6)",
-                textAlign: "center",
+                gap: "8px",
               }}
             >
-              View in explorer
-            </span>
-          </div>
+              <button
+                className="tx-action-btn"
+                onClick={() => window.open(`https://explorer.solana.com/tx/${detail.activity.id}`, "_blank")}
+                style={{
+                  width: "48px",
+                  height: "48px",
+                  borderRadius: "9999px",
+                  background: "rgba(249, 54, 60, 0.14)",
+                  border: "none",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  cursor: "pointer",
+                  transition: "background-color 0.15s ease",
+                }}
+                type="button"
+              >
+                <Globe size={24} style={{ color: "#3C3C43" }} />
+              </button>
+              <span
+                style={{
+                  fontFamily: "var(--font-geist-sans), sans-serif",
+                  fontSize: "13px",
+                  fontWeight: 400,
+                  lineHeight: "16px",
+                  color: "rgba(60, 60, 67, 0.6)",
+                  textAlign: "center",
+                }}
+              >
+                View in explorer
+              </span>
+            </div>
+          )}
 
           {/* Share */}
           <div
@@ -302,9 +305,11 @@ export function TransactionDetailView({
             <button
               className="tx-action-btn"
               onClick={() => {
-                const text = isShieldType
-                  ? `${title} ${rawAmount} ${amountToken} (${detail.usdValue})\nhttps://explorer.solana.com/tx/${detail.activity.id}`
-                  : `${title} ${rawAmount} ${amountToken} (${detail.usdValue}) ${isSent ? "to" : "from"} ${truncateAddress(detail.activity.counterparty)}\nhttps://explorer.solana.com/tx/${detail.activity.id}`;
+                const text = isPrivate
+                  ? `Sent ${rawAmount} ${amountToken} (${detail.usdValue}) to ${truncateAddress(detail.activity.counterparty)}`
+                  : isShieldType
+                    ? `${title} ${rawAmount} ${amountToken} (${detail.usdValue})\nhttps://explorer.solana.com/tx/${detail.activity.id}`
+                    : `${title} ${rawAmount} ${amountToken} (${detail.usdValue}) ${isSent ? "to" : "from"} ${truncateAddress(detail.activity.counterparty)}\nhttps://explorer.solana.com/tx/${detail.activity.id}`;
                 void navigator.clipboard.writeText(text).then(() => {
                   setCopied(true);
                   setTimeout(() => setCopied(false), 2000);

--- a/frontend/src/components/wallet-sidebar/types.ts
+++ b/frontend/src/components/wallet-sidebar/types.ts
@@ -20,6 +20,7 @@ export interface ActivityRow {
   timestamp: string;
   date: string;
   icon: string;
+  isPrivate?: boolean;
 }
 
 export interface TransactionDetail {
@@ -28,6 +29,7 @@ export interface TransactionDetail {
   status: string;
   networkFee: string;
   networkFeeUsd: string;
+  isPrivate?: boolean;
 }
 
 export interface SwapToken {

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -6,7 +6,7 @@ import {
   type WalletActivity,
 } from "@loyal-labs/solana-wallet";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   ActivityRow,
@@ -37,6 +37,7 @@ export type WalletDesktopData = {
   transactionDetails: Record<string, TransactionDetail>;
   positions: PortfolioPosition[];
   balanceHistory: BalanceHistoryPoint[];
+  addLocalActivity: (row: ActivityRow, detail: TransactionDetail) => void;
 };
 
 const EMPTY_POSITIONS: PortfolioPosition[] = [];
@@ -320,6 +321,49 @@ export function useWalletDesktopData(): WalletDesktopData {
     useState<PortfolioSnapshot | null>(null);
   const [activities, setActivities] = useState<WalletActivity[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [localRows, setLocalRows] = useState<ActivityRow[]>([]);
+  const [localDetails, setLocalDetails] = useState<Record<string, TransactionDetail>>({});
+
+  // Load local activity from localStorage when wallet connects
+  useEffect(() => {
+    if (!walletAddress) {
+      setLocalRows([]);
+      setLocalDetails({});
+      return;
+    }
+    try {
+      const stored = localStorage.getItem(`loyal:local-activity:${walletAddress}`);
+      if (stored) {
+        const parsed = JSON.parse(stored) as { rows: ActivityRow[]; details: Record<string, TransactionDetail> };
+        setLocalRows(parsed.rows ?? []);
+        setLocalDetails(parsed.details ?? {});
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }, [walletAddress]);
+
+  const addLocalActivity = useCallback(
+    (row: ActivityRow, detail: TransactionDetail) => {
+      setLocalRows((prev) => {
+        const next = [row, ...prev];
+        if (walletAddress) {
+          try {
+            const nextDetails = { ...localDetails, [row.id]: detail };
+            localStorage.setItem(
+              `loyal:local-activity:${walletAddress}`,
+              JSON.stringify({ rows: next, details: nextDetails }),
+            );
+          } catch {
+            // ignore quota errors
+          }
+        }
+        return next;
+      });
+      setLocalDetails((prev) => ({ ...prev, [row.id]: detail }));
+    },
+    [walletAddress, localDetails],
+  );
 
   useEffect(() => {
     console.log("[wallet-data] effect fired", {
@@ -500,6 +544,15 @@ export function useWalletDesktopData(): WalletDesktopData {
     return { rows, details };
   }, [activities, positions, totals.effectiveSolPriceUsd]);
 
+  // Merge local (private send) rows with on-chain activity, deduping by id
+  const mergedActivityData = useMemo(() => {
+    const onChainIds = new Set(activityData.rows.map((r) => r.id));
+    const uniqueLocalRows = localRows.filter((r) => !onChainIds.has(r.id));
+    const rows = [...uniqueLocalRows, ...activityData.rows];
+    const details = { ...activityData.details, ...localDetails };
+    return { rows, details };
+  }, [activityData, localRows, localDetails]);
+
   // Lock balance history to the initial fetch so WebSocket subscription
   // updates don't cause jarring redraws of the sparkline.
   const balanceHistoryRef = useRef<BalanceHistoryPoint[]>([]);
@@ -569,10 +622,11 @@ export function useWalletDesktopData(): WalletDesktopData {
     walletLabel,
     tokenRows: allTokenRows.slice(0, 3),
     allTokenRows,
-    activityRows: activityData.rows.slice(0, 5),
-    allActivityRows: activityData.rows,
-    transactionDetails: activityData.details,
+    activityRows: mergedActivityData.rows.slice(0, 5),
+    allActivityRows: mergedActivityData.rows,
+    transactionDetails: mergedActivityData.details,
     positions,
     balanceHistory,
+    addLocalActivity,
   };
 }


### PR DESCRIPTION
## Summary
- Hide "View in explorer" button for private sends in both SendTransactionDetail and TransactionDetailView
- Share button copies human-readable text instead of explorer URL for private transactions
- Add local activity persistence via localStorage so private sends appear in wallet activity immediately

## Test plan
- [ ] Send a private transaction and verify explorer button is hidden in the details view
- [ ] Verify share copies text like "Sent 1 SOL to @user ($X.XX)" without explorer URL
- [ ] Verify private send appears in activity list after completion
- [ ] Verify regular (non-private) sends still show explorer button and share explorer URL