### PR TITLE
feat(auth): add WalletConnect and mobile wallet deep-link support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -180,6 +180,7 @@
         "@sqds/grid": "^3.1.2",
         "@tabler/icons-react": "^3.35.0",
         "@vercel/speed-insights": "^1.2.0",
+        "@walletconnect/solana-adapter": "^0.0.8",
         "ai": "^5.0.13",
         "bs58": "^6.0.0",
         "class-variance-authority": "^0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@sqds/grid": "^3.1.2",
     "@tabler/icons-react": "^3.35.0",
     "@vercel/speed-insights": "^1.2.0",
+    "@walletconnect/solana-adapter": "^0.0.8",
     "ai": "^5.0.13",
     "bs58": "^6.0.0",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/components/auth/use-wallet-proof-auth.ts
+++ b/frontend/src/components/auth/use-wallet-proof-auth.ts
@@ -77,7 +77,12 @@ export function useWalletProofAuth({
   const verifyAttemptedForAddressRef = useRef<string | null>(null);
 
   const installedWallets = useMemo(
-    () => wallets.filter((candidate) => candidate.readyState === "Installed"),
+    () =>
+      wallets.filter(
+        (candidate) =>
+          candidate.readyState === "Installed" ||
+          candidate.adapter.name === "WalletConnect"
+      ),
     [wallets]
   );
 

--- a/frontend/src/components/auth/wallet-tab.tsx
+++ b/frontend/src/components/auth/wallet-tab.tsx
@@ -1,8 +1,57 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useWalletProofAuth } from "./use-wallet-proof-auth";
+
+const MOBILE_WALLETS = [
+  {
+    name: "Phantom",
+    icon: "https://phantom.app/favicon.ico",
+    browseUrl: (url: string) =>
+      `https://phantom.app/ul/browse/${encodeURIComponent(url)}?ref=${encodeURIComponent(url)}`,
+  },
+  {
+    name: "Solflare",
+    icon: "https://solflare.com/favicon.ico",
+    browseUrl: (url: string) =>
+      `https://solflare.com/ul/v1/browse/${encodeURIComponent(url)}?ref=${encodeURIComponent(url)}`,
+  },
+] as const;
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    setIsMobile(/Android|iPhone|iPad|iPod/i.test(navigator.userAgent));
+  }, []);
+  return isMobile;
+}
+
+function MobileWalletList() {
+  const currentUrl = useMemo(
+    () => (typeof window !== "undefined" ? window.location.href : ""),
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-neutral-500 text-sm">
+        Open this page in your wallet&apos;s built-in browser:
+      </p>
+      {MOBILE_WALLETS.map((wallet) => (
+        <a
+          className="flex items-center gap-3 rounded-lg border border-neutral-200 px-4 py-3 text-neutral-900 text-sm transition hover:bg-neutral-50"
+          href={wallet.browseUrl(currentUrl)}
+          key={wallet.name}
+          rel="noopener noreferrer"
+        >
+          <img alt={wallet.name} className="h-6 w-6" src={wallet.icon} />
+          <span>Open in {wallet.name}</span>
+        </a>
+      ))}
+    </div>
+  );
+}
 
 export function WalletTab({ onFlowStart }: { onFlowStart?: () => void }) {
   const {
@@ -16,6 +65,8 @@ export function WalletTab({ onFlowStart }: { onFlowStart?: () => void }) {
   } = useWalletProofAuth({
     onFlowStart,
   });
+
+  const isMobile = useIsMobile();
 
   // Delay showing errors so transient failures during connection don't flash
   const isErrorState =
@@ -104,9 +155,11 @@ export function WalletTab({ onFlowStart }: { onFlowStart?: () => void }) {
               <span>{installedWallet.adapter.name}</span>
             </button>
           ))}
-          {installedWallets.length === 0 && (
+          {installedWallets.length === 0 && isMobile && <MobileWalletList />}
+          {installedWallets.length === 0 && !isMobile && (
             <p className="py-4 text-center text-neutral-500 text-sm">
-              No wallet extensions detected.
+              No wallet extensions detected. Install a Solana wallet extension
+              to continue.
             </p>
           )}
         </div>

--- a/frontend/src/components/solana/wallet-provider.tsx
+++ b/frontend/src/components/solana/wallet-provider.tsx
@@ -4,14 +4,27 @@ import {
   ConnectionProvider,
   WalletProvider,
 } from "@solana/wallet-adapter-react";
-import {
-  PhantomWalletAdapter,
-  SolflareWalletAdapter,
-} from "@solana/wallet-adapter-wallets";
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
+import { WalletConnectWalletAdapter } from "@walletconnect/solana-adapter";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+
+const WALLETCONNECT_PROJECT_ID = "9d9f57c5553496b42ac1b9977066559d";
+
+function toWalletAdapterNetwork(env: SolanaEnv): WalletAdapterNetwork {
+  switch (env) {
+    case "mainnet":
+      return WalletAdapterNetwork.Mainnet;
+    case "devnet":
+    case "localnet":
+      return WalletAdapterNetwork.Devnet;
+    case "testnet":
+      return WalletAdapterNetwork.Testnet;
+  }
+}
 
 type WalletConnectionProviderProps = {
   children: ReactNode;
@@ -20,12 +33,19 @@ type WalletConnectionProviderProps = {
 export const WalletConnectionProvider: FC<WalletConnectionProviderProps> = ({
   children,
 }) => {
-  const { solanaRpcEndpoint } = usePublicEnv();
+  const { solanaRpcEndpoint, solanaEnv } = usePublicEnv();
   const endpoint = useMemo(() => solanaRpcEndpoint, [solanaRpcEndpoint]);
 
   const wallets = useMemo(
-    () => [new PhantomWalletAdapter(), new SolflareWalletAdapter()],
-    []
+    () => [
+      new WalletConnectWalletAdapter({
+        network: toWalletAdapterNetwork(solanaEnv),
+        options: {
+          projectId: WALLETCONNECT_PROJECT_ID,
+        },
+      }),
+    ],
+    [solanaEnv]
   );
 
   return (

--- a/frontend/src/components/solana/wallet-provider.tsx
+++ b/frontend/src/components/solana/wallet-provider.tsx
@@ -14,16 +14,12 @@ import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 
 const WALLETCONNECT_PROJECT_ID = "9d9f57c5553496b42ac1b9977066559d";
 
-function toWalletAdapterNetwork(env: SolanaEnv): WalletAdapterNetwork {
-  switch (env) {
-    case "mainnet":
-      return WalletAdapterNetwork.Mainnet;
-    case "devnet":
-    case "localnet":
-      return WalletAdapterNetwork.Devnet;
-    case "testnet":
-      return WalletAdapterNetwork.Testnet;
-  }
+function toWalletConnectNetwork(
+  env: SolanaEnv
+): WalletAdapterNetwork.Mainnet | WalletAdapterNetwork.Devnet {
+  return env === "mainnet"
+    ? WalletAdapterNetwork.Mainnet
+    : WalletAdapterNetwork.Devnet;
 }
 
 type WalletConnectionProviderProps = {
@@ -39,7 +35,7 @@ export const WalletConnectionProvider: FC<WalletConnectionProviderProps> = ({
   const wallets = useMemo(
     () => [
       new WalletConnectWalletAdapter({
-        network: toWalletAdapterNetwork(solanaEnv),
+        network: toWalletConnectNetwork(solanaEnv),
         options: {
           projectId: WALLETCONNECT_PROJECT_ID,
         },


### PR DESCRIPTION
## Summary
- Replace static Phantom/Solflare wallet adapters with WalletConnect protocol + Wallet Standard auto-detection
- Add mobile deep-link fallback (open in Phantom/Solflare in-app browser) when no extensions detected
- Remove `@solana/wallet-adapter-wallets` dependency in favor of `@walletconnect/solana-adapter`

## Test plan
- [ ] Desktop: verify browser extension wallets still appear and connect
- [ ] Desktop: verify WalletConnect option appears and shows QR code
- [ ] Mobile browser: verify mobile deep-link buttons appear when no extensions detected
- [ ] Mobile in-app browser (Phantom/Solflare): verify wallet auto-injects and connects