### PR TITLE
feat(wallet): add Jupiter price fallback for unpriced tokens

### DIFF
--- a/app/src/lib/jupiter/price.ts
+++ b/app/src/lib/jupiter/price.ts
@@ -1,0 +1,28 @@
+import { fetchJson } from "../core/http";
+import { JUPITER_API_BASE_URL } from "./constants";
+
+type JupiterPriceResponse = {
+  data: Record<string, { id: string; price: string } | undefined>;
+};
+
+export async function fetchTokenPricesByMints(
+  mints: string[],
+): Promise<Map<string, number>> {
+  if (mints.length === 0) return new Map();
+
+  const url = `${JUPITER_API_BASE_URL}/price/v2?ids=${mints.join(",")}`;
+  const response = await fetchJson<JupiterPriceResponse>(url, {
+    method: "GET",
+  });
+
+  const prices = new Map<string, number>();
+  for (const [mint, data] of Object.entries(response.data)) {
+    if (data?.price) {
+      const price = Number(data.price);
+      if (Number.isFinite(price) && price > 0) {
+        prices.set(mint, price);
+      }
+    }
+  }
+  return prices;
+}

--- a/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
+++ b/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
@@ -2,6 +2,7 @@ import { getSolanaEndpoints } from "@loyal-labs/solana-rpc";
 import { PublicKey } from "@solana/web3.js";
 
 import { NATIVE_SOL_DECIMALS, NATIVE_SOL_MINT } from "@/lib/constants";
+import { fetchTokenPricesByMints } from "@/lib/jupiter/price";
 
 import { fetchJson } from "../../core/http";
 import { fetchLoyalDeposits } from "../deposits/loyal-deposits";
@@ -137,6 +138,36 @@ async function fetchHoldingsFromHelius(
   return holdings;
 }
 
+async function enrichHoldingsWithJupiterPrices(
+  holdings: TokenHolding[],
+): Promise<TokenHolding[]> {
+  const unpricedMints = holdings
+    .filter((h) => h.priceUsd === null && h.mint !== NATIVE_SOL_MINT)
+    .map((h) => h.mint);
+
+  if (unpricedMints.length === 0) return holdings;
+
+  const uniqueMints = [...new Set(unpricedMints)];
+
+  let prices: Map<string, number>;
+  try {
+    prices = await fetchTokenPricesByMints(uniqueMints);
+  } catch {
+    return holdings;
+  }
+
+  return holdings.map((h) => {
+    if (h.priceUsd !== null) return h;
+    const price = prices.get(h.mint);
+    if (!price) return h;
+    return {
+      ...h,
+      priceUsd: price,
+      valueUsd: h.balance * price,
+    };
+  });
+}
+
 // Fetch holdings from Helius and from Magic Block PER (Secure deposits)
 async function fetchCombinedHoldings(
   rpcUrl: string,
@@ -176,7 +207,8 @@ async function fetchCombinedHoldings(
     }
   }
 
-  return [...holdingsFromHelius, ...securedHoldings];
+  const allHoldings = [...holdingsFromHelius, ...securedHoldings];
+  return enrichHoldingsWithJupiterPrices(allHoldings);
 }
 
 export async function fetchTokenHoldings(

--- a/packages/solana-wallet/src/providers/default-asset-provider.ts
+++ b/packages/solana-wallet/src/providers/default-asset-provider.ts
@@ -66,6 +66,55 @@ const TOKEN_2022_PROGRAM_ID = new PublicKey(
   "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 );
 
+const JUPITER_PRICE_API_URL = "https://api.jup.ag/price/v2";
+
+type JupiterPriceResponse = {
+  data: Record<string, { id: string; price: string } | undefined>;
+};
+
+async function enrichAssetsWithJupiterPrices(
+  fetchImpl: typeof fetch,
+  assets: AssetBalance[]
+): Promise<AssetBalance[]> {
+  const unpricedMints = assets
+    .filter((a) => a.priceUsd === null && a.asset.mint !== NATIVE_SOL_MINT)
+    .map((a) => a.asset.mint);
+
+  if (unpricedMints.length === 0) return assets;
+
+  const uniqueMints = [...new Set(unpricedMints)];
+
+  let prices: Map<string, number>;
+  try {
+    const url = `${JUPITER_PRICE_API_URL}?ids=${uniqueMints.join(",")}`;
+    const response = await fetchJson<JupiterPriceResponse>(fetchImpl, url, {
+      method: "GET",
+    });
+    prices = new Map<string, number>();
+    for (const [mint, data] of Object.entries(response.data)) {
+      if (data?.price) {
+        const price = Number(data.price);
+        if (Number.isFinite(price) && price > 0) {
+          prices.set(mint, price);
+        }
+      }
+    }
+  } catch {
+    return assets;
+  }
+
+  return assets.map((a) => {
+    if (a.priceUsd !== null) return a;
+    const price = prices.get(a.asset.mint);
+    if (!price) return a;
+    return {
+      ...a,
+      priceUsd: price,
+      valueUsd: a.balance * price,
+    };
+  });
+}
+
 function getSafeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -244,10 +293,12 @@ export function createHeliusAssetProvider(args: {
         }
       }
 
+      const enrichedAssets = await enrichAssetsWithJupiterPrices(args.fetchImpl, assets);
+
       return {
         owner: owner.toBase58(),
         nativeBalanceLamports: response.result.nativeBalance?.lamports ?? 0,
-        assets,
+        assets: enrichedAssets,
         fetchedAt: Date.now(),
       };
     },


### PR DESCRIPTION
Tokens not tracked by Helius (like LOYAL) showed $0.00 in the portfolio. Adds a Jupiter Price API v2 enrichment step that batch-fetches prices for any token with null priceUsd after Helius returns holdings.