### PR TITLE
fix(wallet): switch Jupiter price API to token search endpoint and fix sidebar bugs

### DIFF
--- a/app/src/lib/jupiter/price.ts
+++ b/app/src/lib/jupiter/price.ts
@@ -1,8 +1,9 @@
 import { fetchJson } from "../core/http";
-import { JUPITER_API_BASE_URL } from "./constants";
+import { JUPITER_TOKENS_V2_BASE_URL } from "./constants";
 
-type JupiterPriceResponse = {
-  data: Record<string, { id: string; price: string } | undefined>;
+type JupiterTokenSearchResult = {
+  id: string;
+  usdPrice?: number;
 };
 
 export async function fetchTokenPricesByMints(
@@ -10,18 +11,21 @@ export async function fetchTokenPricesByMints(
 ): Promise<Map<string, number>> {
   if (mints.length === 0) return new Map();
 
-  const url = `${JUPITER_API_BASE_URL}/price/v2?ids=${mints.join(",")}`;
-  const response = await fetchJson<JupiterPriceResponse>(url, {
-    method: "GET",
-  });
+  const results = await Promise.all(
+    mints.map(async (mint) => {
+      const url = `${JUPITER_TOKENS_V2_BASE_URL}/search?query=${mint}`;
+      const tokens = await fetchJson<JupiterTokenSearchResult[]>(url, {
+        method: "GET",
+      });
+      const match = tokens.find((t) => t.id === mint);
+      return { mint, price: match?.usdPrice ?? null };
+    }),
+  );
 
   const prices = new Map<string, number>();
-  for (const [mint, data] of Object.entries(response.data)) {
-    if (data?.price) {
-      const price = Number(data.price);
-      if (Number.isFinite(price) && price > 0) {
-        prices.set(mint, price);
-      }
+  for (const { mint, price } of results) {
+    if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+      prices.set(mint, price);
     }
   }
   return prices;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -15,6 +15,14 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "avatars.githubusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "cdn.instadapp.io",
+      },
+      {
+        protocol: "https",
+        hostname: "**",
+      },
     ],
   },
 };

--- a/frontend/src/components/wallet-sidebar/send-content.tsx
+++ b/frontend/src/components/wallet-sidebar/send-content.tsx
@@ -451,6 +451,7 @@ export function SendContent({
           date: now.toLocaleDateString("en-US", { month: "long", day: "numeric" }),
           icon: "/hero-new/Shield_40.svg",
           isPrivate: true,
+          rawTimestamp: now.getTime(),
         };
         const syntheticDetail: TransactionDetail = {
           activity: syntheticRow,

--- a/frontend/src/components/wallet-sidebar/types.ts
+++ b/frontend/src/components/wallet-sidebar/types.ts
@@ -21,6 +21,8 @@ export interface ActivityRow {
   date: string;
   icon: string;
   isPrivate?: boolean;
+  /** Epoch milliseconds for sort order — absent in legacy localStorage rows */
+  rawTimestamp?: number;
 }
 
 export interface TransactionDetail {

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -41,8 +41,18 @@ export type WalletDesktopData = {
 };
 
 const EMPTY_POSITIONS: PortfolioPosition[] = [];
+const LOYL_MINT = "LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta";
+const JUPITER_TOKEN_SEARCH_URL = "https://lite-api.jup.ag/tokens/v2/search";
+
+const LOYL_ICON_URL = "https://avatars.githubusercontent.com/u/210601628?s=200&v=4";
 
 function resolveTokenIcon(position: PortfolioPosition): string {
+  if (position.asset.imageUrl) {
+    return position.asset.imageUrl;
+  }
+  if (position.asset.mint === LOYL_MINT) {
+    return LOYL_ICON_URL;
+  }
   return getTokenIconUrl(position.asset.symbol);
 }
 
@@ -272,6 +282,7 @@ function mapActivityToRowAndDetail(
     icon: activity.type === "secure" ? "/hero-new/Shield.png"
       : activity.type === "unshield" ? "/hero-new/Unshield.svg"
       : display.icon,
+    rawTimestamp: activity.timestamp ?? undefined,
   };
 
   return {
@@ -483,6 +494,24 @@ export function useWalletDesktopData(): WalletDesktopData {
     };
   }, [client, wallet.connected, wallet.publicKey]);
 
+  // Fetch LOYAL token price from Jupiter for the always-visible placeholder row
+  const [loylPriceUsd, setLoylPriceUsd] = useState<number | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${JUPITER_TOKEN_SEARCH_URL}?query=${LOYL_MINT}`)
+      .then((res) => res.json())
+      .then((tokens: { id: string; usdPrice?: number }[]) => {
+        if (cancelled) return;
+        const match = tokens.find((t) => t.id === LOYL_MINT);
+        const price = match?.usdPrice;
+        if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+          setLoylPriceUsd(price);
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
   const positions = portfolioSnapshot?.positions ?? EMPTY_POSITIONS;
   const totals = portfolioSnapshot?.totals ?? {
     totalUsd: 0,
@@ -502,25 +531,32 @@ export function useWalletDesktopData(): WalletDesktopData {
       }
     }
 
-    // Ensure LOYL appears at 3rd position if not already present
-    const LOYL_MINT = "LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta";
-    if (!rows.some((r) => r.id === LOYL_MINT)) {
+    // Ensure LOYL appears at 3rd position (index 2) always
+    const existingLoylIndex = rows.findIndex((r) => r.id === LOYL_MINT);
+    if (existingLoylIndex >= 0) {
+      // Already in rows (has balance) — move to index 2 if not there
+      if (existingLoylIndex !== 2) {
+        const [loylRow] = rows.splice(existingLoylIndex, 1);
+        rows.splice(Math.min(2, rows.length), 0, loylRow);
+      }
+    } else {
+      // Not in rows — create placeholder with Jupiter price
       const loylPosition = positions.find((p) => p.asset.mint === LOYL_MINT);
       const loylRow: TokenRow = loylPosition
         ? mapPositionToTokenRow(loylPosition)
         : {
             id: LOYL_MINT,
             symbol: "LOYAL",
-            price: "$0.00",
+            price: formatUsd(loylPriceUsd),
             amount: "0",
             value: "$0.00",
-            icon: "https://avatars.githubusercontent.com/u/210601628?s=200&v=4",
+            icon: LOYL_ICON_URL,
           };
-      rows.splice(2, 0, loylRow);
+      rows.splice(Math.min(2, rows.length), 0, loylRow);
     }
 
     return rows;
-  }, [positions]);
+  }, [positions, loylPriceUsd]);
 
   const activityData = useMemo(() => {
     const details: Record<string, TransactionDetail> = {};
@@ -545,10 +581,13 @@ export function useWalletDesktopData(): WalletDesktopData {
   }, [activities, positions, totals.effectiveSolPriceUsd]);
 
   // Merge local (private send) rows with on-chain activity, deduping by id
+  // and sorting by rawTimestamp descending so newest activity appears first
   const mergedActivityData = useMemo(() => {
     const onChainIds = new Set(activityData.rows.map((r) => r.id));
     const uniqueLocalRows = localRows.filter((r) => !onChainIds.has(r.id));
-    const rows = [...uniqueLocalRows, ...activityData.rows];
+    const rows = [...uniqueLocalRows, ...activityData.rows].sort(
+      (a, b) => (b.rawTimestamp ?? 0) - (a.rawTimestamp ?? 0)
+    );
     const details = { ...activityData.details, ...localDetails };
     return { rows, details };
   }, [activityData, localRows, localDetails]);

--- a/packages/solana-wallet/src/providers/default-asset-provider.ts
+++ b/packages/solana-wallet/src/providers/default-asset-provider.ts
@@ -66,10 +66,11 @@ const TOKEN_2022_PROGRAM_ID = new PublicKey(
   "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 );
 
-const JUPITER_PRICE_API_URL = "https://api.jup.ag/price/v2";
+const JUPITER_TOKEN_SEARCH_URL = "https://lite-api.jup.ag/tokens/v2/search";
 
-type JupiterPriceResponse = {
-  data: Record<string, { id: string; price: string } | undefined>;
+type JupiterTokenSearchResult = {
+  id: string;
+  usdPrice?: number;
 };
 
 async function enrichAssetsWithJupiterPrices(
@@ -86,17 +87,23 @@ async function enrichAssetsWithJupiterPrices(
 
   let prices: Map<string, number>;
   try {
-    const url = `${JUPITER_PRICE_API_URL}?ids=${uniqueMints.join(",")}`;
-    const response = await fetchJson<JupiterPriceResponse>(fetchImpl, url, {
-      method: "GET",
-    });
+    // Fetch prices in parallel using the token search endpoint (no auth required)
+    const results = await Promise.all(
+      uniqueMints.map(async (mint) => {
+        const url = `${JUPITER_TOKEN_SEARCH_URL}?query=${mint}`;
+        const tokens = await fetchJson<JupiterTokenSearchResult[]>(
+          fetchImpl,
+          url,
+          { method: "GET" }
+        );
+        const match = tokens.find((t) => t.id === mint);
+        return { mint, price: match?.usdPrice ?? null };
+      })
+    );
     prices = new Map<string, number>();
-    for (const [mint, data] of Object.entries(response.data)) {
-      if (data?.price) {
-        const price = Number(data.price);
-        if (Number.isFinite(price) && price > 0) {
-          prices.set(mint, price);
-        }
+    for (const { mint, price } of results) {
+      if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+        prices.set(mint, price);
       }
     }
   } catch {


### PR DESCRIPTION
## Summary
- Jupiter Price API v2 now returns 401 — switched all price fetching (solana-wallet package, app/, frontend/) to the lite token search endpoint which requires no auth
- LOYAL token always pinned to 3rd position in token list regardless of balance
- Token icons now resolved from Helius `imageUrl` before falling back to logo.dev
- Activity sort order fixed for merged local (private send) + on-chain rows using numeric `rawTimestamp`
- Added wildcard `next/image` remote pattern for arbitrary token icon hostnames from Helius