### PR TITLE
fix(ui): refresh chat history on session auth instead of wallet connect

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function LandingPage() {
 
   // Wallet hooks
   const { connected: isConnected, connecting: isWalletLoading, publicKey } = useWallet();
-  const { isHydrated: isAuthHydrated } = useAuthSession();
+  const { isHydrated: isAuthHydrated, isAuthenticated } = useAuthSession();
   const { isSignedIn } = useAuthCapability();
 
   // Toggle body class for mobile header visibility
@@ -89,14 +89,15 @@ export default function LandingPage() {
     }
   }, [currentChatId, setMessages]);
 
-  // Sync chat history with auth state
+  // Sync chat history with auth state — use isAuthenticated (session cookie exists)
+  // rather than isSignedIn (wallet-only connection won't have a session yet)
   useEffect(() => {
-    if (isSignedIn) {
+    if (isAuthenticated) {
       void refreshUserChats();
     } else {
       clearUserChats();
     }
-  }, [isSignedIn, refreshUserChats, clearUserChats]);
+  }, [isAuthenticated, refreshUserChats, clearUserChats]);
 
   // Truncate wallet address for display (e.g., "233Q..7ABE")
   const truncatedAddress = solanaAddress


### PR DESCRIPTION
## Summary
- Use `isAuthenticated` (session cookie exists) instead of `isSignedIn` (wallet connected) to trigger chat history fetch
- Prevents empty sidebar when reconnecting wallet because the API was called before the JWT session was established