### PR TITLE
refactor(ui): move See All buttons inline with section titles

### DIFF
--- a/extension/src/components/wallet/portfolio-content.tsx
+++ b/extension/src/components/wallet/portfolio-content.tsx
@@ -215,12 +215,6 @@ export function PortfolioContent({
 
   return (
     <>
-      <style>{`
-        .show-all-btn:hover {
-          background: rgba(249, 54, 60, 0.22) !important;
-        }
-      `}</style>
-
       {/* SVG pixelation filters */}
       <svg
         aria-hidden="true"
@@ -458,7 +452,15 @@ export function PortfolioContent({
             width: "100%",
           }}
         >
-          <div style={{ width: "100%", padding: "12px 12px 8px" }}>
+          <div
+            style={{
+              width: "100%",
+              padding: "12px 12px 8px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
             <span
               style={{
                 fontFamily: "var(--font-geist-sans), sans-serif",
@@ -471,6 +473,23 @@ export function PortfolioContent({
             >
               Tokens
             </span>
+            <button
+              onClick={() => onNavigate("allTokens")}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontFamily: "var(--font-geist-sans), sans-serif",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#F9363C",
+              }}
+              type="button"
+            >
+              See All
+            </button>
           </div>
 
           {tokenRows.map((token) => (
@@ -480,39 +499,6 @@ export function PortfolioContent({
               token={token}
             />
           ))}
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              paddingTop: "8px",
-              width: "100%",
-            }}
-          >
-            <button
-              className="show-all-btn"
-              onClick={() => onNavigate("allTokens")}
-              style={{
-                background: "rgba(249, 54, 60, 0.14)",
-                border: "none",
-                borderRadius: "9999px",
-                padding: "8px 16px",
-                cursor: "pointer",
-                fontFamily: "var(--font-geist-sans), sans-serif",
-                fontSize: "15px",
-                fontWeight: 400,
-                lineHeight: "20px",
-                color: "#000",
-                textAlign: "center",
-                transition: "background-color 0.15s ease",
-              }}
-              type="button"
-            >
-              Show All
-            </button>
-          </div>
         </div>
 
         {/* Activity section */}
@@ -525,7 +511,15 @@ export function PortfolioContent({
             width: "100%",
           }}
         >
-          <div style={{ width: "100%", padding: "12px 12px 8px" }}>
+          <div
+            style={{
+              width: "100%",
+              padding: "12px 12px 8px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
             <span
               style={{
                 fontFamily: "var(--font-geist-sans), sans-serif",
@@ -538,6 +532,23 @@ export function PortfolioContent({
             >
               Activity
             </span>
+            <button
+              onClick={() => onNavigate("allActivity")}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontFamily: "var(--font-geist-sans), sans-serif",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#F9363C",
+              }}
+              type="button"
+            >
+              See All
+            </button>
           </div>
 
           {activityRows.map((activity) => (
@@ -568,39 +579,6 @@ export function PortfolioContent({
               No activity yet
             </div>
           )}
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              paddingTop: "8px",
-              width: "100%",
-            }}
-          >
-            <button
-              className="show-all-btn"
-              onClick={() => onNavigate("allActivity")}
-              style={{
-                background: "rgba(249, 54, 60, 0.14)",
-                border: "none",
-                borderRadius: "9999px",
-                padding: "8px 16px",
-                cursor: "pointer",
-                fontFamily: "var(--font-geist-sans), sans-serif",
-                fontSize: "15px",
-                fontWeight: 400,
-                lineHeight: "20px",
-                color: "#000",
-                textAlign: "center",
-                transition: "background-color 0.15s ease",
-              }}
-              type="button"
-            >
-              Show All
-            </button>
-          </div>
         </div>
       </div>
 

--- a/extension/src/components/wallet/portfolio-content.tsx
+++ b/extension/src/components/wallet/portfolio-content.tsx
@@ -475,6 +475,12 @@ export function PortfolioContent({
             </span>
             <button
               onClick={() => onNavigate("allTokens")}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = "0.7";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = "1";
+              }}
               style={{
                 background: "none",
                 border: "none",
@@ -534,6 +540,12 @@ export function PortfolioContent({
             </span>
             <button
               onClick={() => onNavigate("allActivity")}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = "0.7";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = "1";
+              }}
               style={{
                 background: "none",
                 border: "none",

--- a/frontend/src/components/wallet-sidebar/portfolio-content.tsx
+++ b/frontend/src/components/wallet-sidebar/portfolio-content.tsx
@@ -217,12 +217,6 @@ export function PortfolioContent({
 
   return (
     <>
-      <style jsx>{`
-        .show-all-btn:hover {
-          background: rgba(249, 54, 60, 0.22) !important;
-        }
-      `}</style>
-
       {/* SVG pixelation filters */}
       <svg
         aria-hidden="true"
@@ -460,7 +454,15 @@ export function PortfolioContent({
             width: "100%",
           }}
         >
-          <div style={{ width: "100%", padding: "12px 12px 8px" }}>
+          <div
+            style={{
+              width: "100%",
+              padding: "12px 12px 8px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
             <span
               style={{
                 fontFamily: "var(--font-geist-sans), sans-serif",
@@ -473,6 +475,23 @@ export function PortfolioContent({
             >
               Tokens
             </span>
+            <button
+              onClick={() => onNavigate("allTokens")}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontFamily: "var(--font-geist-sans), sans-serif",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#F9363C",
+              }}
+              type="button"
+            >
+              See All
+            </button>
           </div>
 
           {tokenRows.map((token) => (
@@ -482,39 +501,6 @@ export function PortfolioContent({
               token={token}
             />
           ))}
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              paddingTop: "8px",
-              width: "100%",
-            }}
-          >
-            <button
-              className="show-all-btn"
-              onClick={() => onNavigate("allTokens")}
-              style={{
-                background: "rgba(249, 54, 60, 0.14)",
-                border: "none",
-                borderRadius: "9999px",
-                padding: "8px 16px",
-                cursor: "pointer",
-                fontFamily: "var(--font-geist-sans), sans-serif",
-                fontSize: "15px",
-                fontWeight: 400,
-                lineHeight: "20px",
-                color: "#000",
-                textAlign: "center",
-                transition: "background-color 0.15s ease",
-              }}
-              type="button"
-            >
-              Show All
-            </button>
-          </div>
         </div>
 
         {/* Activity section */}
@@ -527,7 +513,15 @@ export function PortfolioContent({
             width: "100%",
           }}
         >
-          <div style={{ width: "100%", padding: "12px 12px 8px" }}>
+          <div
+            style={{
+              width: "100%",
+              padding: "12px 12px 8px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
             <span
               style={{
                 fontFamily: "var(--font-geist-sans), sans-serif",
@@ -540,6 +534,23 @@ export function PortfolioContent({
             >
               Activity
             </span>
+            <button
+              onClick={() => onNavigate("allActivity")}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontFamily: "var(--font-geist-sans), sans-serif",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#F9363C",
+              }}
+              type="button"
+            >
+              See All
+            </button>
           </div>
 
           {activityRows.map((activity) => (
@@ -570,39 +581,6 @@ export function PortfolioContent({
               No activity yet
             </div>
           )}
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              paddingTop: "8px",
-              width: "100%",
-            }}
-          >
-            <button
-              className="show-all-btn"
-              onClick={() => onNavigate("allActivity")}
-              style={{
-                background: "rgba(249, 54, 60, 0.14)",
-                border: "none",
-                borderRadius: "9999px",
-                padding: "8px 16px",
-                cursor: "pointer",
-                fontFamily: "var(--font-geist-sans), sans-serif",
-                fontSize: "15px",
-                fontWeight: 400,
-                lineHeight: "20px",
-                color: "#000",
-                textAlign: "center",
-                transition: "background-color 0.15s ease",
-              }}
-              type="button"
-            >
-              Show All
-            </button>
-          </div>
         </div>
       </div>
 

--- a/frontend/src/components/wallet-sidebar/portfolio-content.tsx
+++ b/frontend/src/components/wallet-sidebar/portfolio-content.tsx
@@ -477,6 +477,12 @@ export function PortfolioContent({
             </span>
             <button
               onClick={() => onNavigate("allTokens")}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = "0.7";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = "1";
+              }}
               style={{
                 background: "none",
                 border: "none",
@@ -536,6 +542,12 @@ export function PortfolioContent({
             </span>
             <button
               onClick={() => onNavigate("allActivity")}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = "0.7";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = "1";
+              }}
               style={{
                 background: "none",
                 border: "none",


### PR DESCRIPTION
Move Tokens and Activity "See All" links from below lists to the right side of section headers in both frontend and extension wallet sidebars, matching the Figma design.