### PR TITLE
perf(frontend): switch bento animations to lottie-web light with viewport pause

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -222,7 +222,7 @@
         "highlight.js": "^11.11.1",
         "jose": "^6.0.13",
         "katex": "^0.16.22",
-        "lottie-react": "^2.4.1",
+        "lottie-web": "^5.13.0",
         "lucide-react": "^0.553.0",
         "magic-router-sdk": "^1.0.10",
         "motion": "^12.23.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "highlight.js": "^11.11.1",
     "jose": "^6.0.13",
     "katex": "^0.16.22",
-    "lottie-react": "^2.4.1",
+    "lottie-web": "^5.13.0",
     "lucide-react": "^0.553.0",
     "magic-router-sdk": "^1.0.10",
     "motion": "^12.23.24",

--- a/frontend/src/components/bento-grid-section.tsx
+++ b/frontend/src/components/bento-grid-section.tsx
@@ -1,68 +1,102 @@
 "use client";
-import Lottie from "lottie-react";
-import { memo, useEffect, useRef, useState } from "react";
+import type { AnimationItem } from "lottie-web";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 
 import { type BentoItem, bentoItems } from "@/data/bento";
 import { BentoGrid, BentoGridItem } from "./ui/bento-grid";
 
-function BentoAnimation({ item, delay }: { item: BentoItem; delay: number }) {
-  const [animationData, setAnimationData] = useState<unknown>(null);
-  const [isVisible, setIsVisible] = useState(false);
-  const [shouldPlay, setShouldPlay] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+async function loadLottieLight() {
+  const mod = await import("lottie-web/build/player/lottie_light");
+  return mod.default ?? mod;
+}
 
-  useEffect(() => {
-    fetch(item.animationPath)
-      .then((res) => res.json())
-      .then(setAnimationData)
-      .catch(console.error);
+function BentoAnimation({ item, delay }: { item: BentoItem; delay: number }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animRef = useRef<AnimationItem | null>(null);
+  const startedRef = useRef(false);
+  const [hasStarted, setHasStarted] = useState(false);
+
+  const initAnimation = useCallback(async () => {
+    const el = containerRef.current;
+    if (!el || startedRef.current) return;
+    startedRef.current = true;
+
+    const lottie = await loadLottieLight();
+    const anim = lottie.loadAnimation({
+      container: el,
+      renderer: "svg",
+      loop: true,
+      autoplay: true,
+      path: item.animationPath,
+    });
+    animRef.current = anim;
+    el.style.opacity = "1";
+    el.style.animation = "bentoFadeIn 0.6s ease-out";
+    setHasStarted(true);
   }, [item.animationPath]);
 
+  // Start animation after delay when first visible
   useEffect(() => {
-    const el = ref.current;
+    const el = containerRef.current;
     if (!el) return;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
+        if (entry.isIntersecting && !startedRef.current) {
           observer.disconnect();
+          timer = setTimeout(initAnimation, delay);
         }
       },
       { threshold: 0.3 }
     );
 
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, [delay, initAnimation]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      animRef.current?.destroy();
+    };
   }, []);
 
+  // Pause/play based on viewport visibility
   useEffect(() => {
-    if (!isVisible) return;
-    const timer = setTimeout(() => setShouldPlay(true), delay);
-    return () => clearTimeout(timer);
-  }, [isVisible, delay]);
+    const el = containerRef.current;
+    if (!el || !hasStarted) return;
 
-  const aspectRatio = item.colSpan === 2 ? "795 / 389" : "1 / 1";
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const anim = animRef.current;
+        if (!anim) return;
+        if (entry.isIntersecting) {
+          anim.play();
+        } else {
+          anim.pause();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasStarted]);
+
+  const aspectRatio =
+    item.aspectRatio ?? (item.colSpan === 2 ? "795 / 389" : "1 / 1");
 
   return (
     <div
-      ref={ref}
+      ref={containerRef}
       className="shrink-0 w-full overflow-hidden"
-      style={{ aspectRatio, background: "#F5F5F5" }}
-    >
-      {animationData !== null && shouldPlay && (
-        <Lottie
-          animationData={animationData}
-          loop
-          style={{
-            width: "100%",
-            height: "100%",
-            opacity: 1,
-            animation: "bentoFadeIn 0.6s ease-out",
-          }}
-        />
-      )}
-    </div>
+      style={{ aspectRatio, background: "#F5F5F5", opacity: 0 }}
+    />
   );
 }
 

--- a/frontend/src/data/bento.ts
+++ b/frontend/src/data/bento.ts
@@ -3,6 +3,7 @@ export type BentoItem = {
   description: string;
   animationPath: string;
   colSpan: 1 | 2;
+  aspectRatio?: string;
 };
 
 export const bentoItems: BentoItem[] = [
@@ -26,6 +27,7 @@ export const bentoItems: BentoItem[] = [
       "Now you can privately send Solana and SPL tokens with minimal fees. Don't doxx your wallet address either — just use their Telegram username instead.",
     animationPath: "/bento/03-Private-transactions.json",
     colSpan: 1,
+    aspectRatio: "1 / 0.95",
   },
   {
     title: "Community agents",


### PR DESCRIPTION
Replace lottie-react with lottie-web light build for smaller bundle. Animations now pause when scrolled out of view and resume on re-entry. Also adjusts the third bento card aspect ratio so all three cards in the first row have even heights.