### PR TITLE
docs(smart-accounts): add smart account SDK docs

### DIFF
--- a/user-docs/docs.json
+++ b/user-docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Developers",
+        "tab": "DeFi",
         "groups": [
           {
             "group": "Private Transactions",
@@ -37,6 +37,26 @@
             "group": "Resources",
             "pages": [
               "resources/links"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Smart Accounts",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "smart-accounts/overview",
+              "smart-accounts/concepts",
+              "smart-accounts/policies-and-execution"
+            ]
+          },
+          {
+            "group": "SDKs",
+            "pages": [
+              "smart-accounts/typescript-sdk",
+              "smart-accounts/rust-sdk"
             ]
           }
         ]

--- a/user-docs/smart-accounts/concepts.mdx
+++ b/user-docs/smart-accounts/concepts.mdx
@@ -1,0 +1,101 @@
+---
+title: "Concepts"
+description: "The core smart-account vocabulary and the invariants developers need before using the SDKs."
+---
+
+This page covers the terms that show up immediately in the SDK examples. It is intentionally narrow.
+
+## Settings
+
+`Settings` is the root account for configuration.
+
+Why it matters: threshold, time lock, signer list, and policy state all hang off this account.
+
+<Note>
+Do not treat the `Settings` PDA as the place to hold assets. It is the control account, not the treasury address.
+</Note>
+
+## Sub-Accounts
+
+Sub-accounts are the derived addresses that hold funds and execute transactions. In practice, this is the address most developers think of as the smart account itself.
+
+Why it matters: if you derive the wrong account, you can point users at the wrong address for deposits or execution.
+
+<Warning>
+Fund the smart-account sub-account or vault address, not the `Settings` address. Sending funds to the wrong address is one of the easiest mistakes to make.
+</Warning>
+
+## Signer Permissions
+
+Signers carry a permission bitmask. The core permissions are:
+
+- `Initiate`
+- `Vote`
+- `Execute`
+
+Why it matters: the program enforces capability, not just membership.
+
+<Note>
+The program requires at least one signer that can initiate, one that can vote, and one that can execute. A valid signer set still fails if those capabilities are missing.
+</Note>
+
+## Threshold
+
+Threshold is the number of voting signers required to approve governance actions.
+
+Why it matters: it defines the difference between a simple shared wallet and an actual multisig workflow.
+
+<Note>
+Threshold must be greater than zero and cannot exceed the number of signers with vote permission.
+</Note>
+
+## `settings_authority`
+
+`settings_authority` controls whether the smart account is autonomous or directly managed.
+
+Why it matters: this changes how configuration updates happen.
+
+| Mode | Meaning |
+| --- | --- |
+| `Pubkey::default()` or `null` equivalent | Autonomous. Config changes go through governance. |
+| Explicit pubkey | Controlled. That authority can change settings directly. |
+
+<Note>
+Use a controlled account when you want an operator or platform authority to manage config. Use autonomous mode when the account should govern itself.
+</Note>
+
+## Time Lock
+
+Time lock is the delay between approval and execution.
+
+Why it matters: it determines whether a flow can settle immediately or must wait.
+
+<Note>
+`time_lock = 0` enables the synchronous path. Non-zero time lock pushes you into the proposal-based lifecycle.
+</Note>
+
+## Autonomous Vs Controlled
+
+These are the two most important operating modes to understand before integrating.
+
+### Autonomous
+
+The account governs itself through signers, threshold, and proposal flow.
+
+Why it matters: this is the cleanest model when no outside operator should be able to rewrite configuration.
+
+### Controlled
+
+A separate authority can change settings directly.
+
+Why it matters: this is often the better fit for managed systems, custodial products, or rollout phases where governance is not fully decentralized yet.
+
+## The Invariants Worth Remembering
+
+- Funds belong in a smart-account sub-account, not the `Settings` account
+- Permissions matter as much as signer count
+- Threshold is counted against voters, not against every signer
+- Time lock changes the execution path, not just the speed
+- Policy design is part of account design, not an afterthought
+
+Next: [Policies and Execution](/smart-accounts/policies-and-execution)

--- a/user-docs/smart-accounts/overview.mdx
+++ b/user-docs/smart-accounts/overview.mdx
@@ -1,0 +1,65 @@
+---
+title: "Overview"
+description: "What Loyal Smart Accounts are, when to use them, and the mental model behind the SDKs."
+---
+
+Loyal Smart Accounts are programmable Solana accounts for teams and apps that need shared control, policy-based execution, or safer operational flows than a single wallet can provide.
+
+Under the hood, Loyal’s SDKs target the Squads Smart Account Program, but the docs here stay focused on the Loyal developer surface and the concepts you need to use it well.
+
+## When To Use This
+
+Use Loyal Smart Accounts when you need one or more of these:
+
+- Multiple signers with an approval threshold
+- A controlled separation between configuration and funds
+- Proposal-based execution with an optional delay
+- Rules around what can be spent or executed
+- A TS SDK today, with a narrower Rust parity surface for create flows
+
+<Info>
+If you only need a single signer wallet with no policy logic, Smart Accounts are probably unnecessary overhead.
+</Info>
+
+## Mental Model
+
+Think about the system in five pieces:
+
+| Piece | What it does |
+| --- | --- |
+| `Settings` | The configuration root for a smart account |
+| Sub-accounts / vaults | The addresses that actually hold assets and execute |
+| Signers + permissions | Who can initiate, vote, and execute |
+| Transactions + proposals | The async governance path |
+| Policies | Scoped rules for what can happen and under what limits |
+
+### 1. Settings
+
+The `Settings` account is the control plane. It stores signer configuration, threshold, time lock, and other governance state.
+
+### 2. Sub-accounts
+
+Assets live in derived smart-account addresses, sometimes easiest to think of as vaults. `account_index = 0` is usually the primary one.
+
+### 3. Signers
+
+Each signer has a permission mask. The important permissions are:
+
+- Initiate
+- Vote
+- Execute
+
+### 4. Transactions and proposals
+
+If you want review and approval before execution, you create transactions and proposals, collect votes, then execute once the threshold and time-lock rules are satisfied.
+
+### 5. Policies
+
+Policies let you express narrower execution rules without giving the whole settings authority away. That is useful for spend controls, constrained program calls, and delegated operational flows.
+
+## Start Here
+
+- Read [Concepts](/smart-accounts/concepts) if you are new to the model
+- Read [Policies and Execution](/smart-accounts/policies-and-execution) if you need the lifecycle and rule system
+- Read [TypeScript SDK](/smart-accounts/typescript-sdk) if you are integrating from an app today
+- Read [Rust SDK](/smart-accounts/rust-sdk) if you need the current parity-first Rust surface

--- a/user-docs/smart-accounts/policies-and-execution.mdx
+++ b/user-docs/smart-accounts/policies-and-execution.mdx
@@ -1,0 +1,97 @@
+---
+title: "Policies and Execution"
+description: "How smart-account execution works, and where policies fit into the lifecycle."
+---
+
+This is a mental model for using the SDKs. It is not a full contract specification.
+
+## Two Execution Modes
+
+### Consensus Transactions
+
+This is the async governance path.
+
+Flow:
+
+```text
+Create transaction -> create proposal -> collect votes -> wait through time lock -> execute
+```
+
+Use it when:
+
+- Signers are not online at the same time
+- You want review and approval before execution
+- You want the time lock to act as a safety buffer
+
+### Synchronous Transactions
+
+This is the immediate path when the required signers are present together and the account allows it.
+
+Flow:
+
+```text
+Single transaction with the required signers -> validate -> execute
+```
+
+Use it when:
+
+- `time_lock = 0`
+- Your signers can coordinate in one flow
+- You want the most direct operational path
+
+<Note>
+The point of the time lock is not just delay. It decides whether the account can use the synchronous path at all.
+</Note>
+
+## Why The Lifecycle Is Split
+
+The split between settings, transactions, proposals, and execution is what lets the program do three useful things at once:
+
+- Keep assets separate from configuration
+- Separate proposal state from executable state
+- Apply policy and permission checks at execution time
+
+That structure is why the SDK surface is organized by feature instead of as one giant client.
+
+## What Policies Are
+
+Policies are scoped rule sets with their own execution boundaries. They are useful when a smart account needs narrower permissions than the full settings-level governance model.
+
+## Policy Types You Should Know
+
+### Program Interaction
+
+Use this when a smart account should only call specific programs or instruction shapes.
+
+Why it matters: this is the policy type behind constrained automation and rule-based execution.
+
+### Spending Limits
+
+Use this when a smart account can spend, but only within quantity and time constraints.
+
+Why it matters: it is the simplest way to express operational budgets.
+
+### Internal Fund Transfers
+
+Use this when funds should move between a smart account’s own sub-accounts under defined rules.
+
+Why it matters: it supports internal treasury structure without broad external transfer authority.
+
+### Settings Change
+
+Use this when some configuration changes should be delegated without handing over full control of the entire smart account.
+
+Why it matters: it gives you a middle ground between rigid governance and unrestricted authority.
+
+## Practical Guidance
+
+- Start with the account model first: signer set, threshold, time lock, and whether the account is autonomous or controlled
+- Add policies only where they remove risk or operational friction
+- Use async governance for human approval workflows
+- Use synchronous execution for coordinated or automated flows
+
+<Info>
+If a policy model feels more complicated than the operational problem you are solving, keep the first version simpler. Smart-account design compounds quickly.
+</Info>
+
+Next: [TypeScript SDK](/smart-accounts/typescript-sdk)

--- a/user-docs/smart-accounts/rust-sdk.mdx
+++ b/user-docs/smart-accounts/rust-sdk.mdx
@@ -1,0 +1,105 @@
+---
+title: "Rust SDK"
+description: "How to use Loyal’s Rust Smart Accounts crate for the current creation-focused public surface."
+---
+
+The Rust crate is `loyal-smart-accounts-rs`, imported in code as `loyal_smart_accounts_rs`.
+
+## Scope
+
+This crate is parity-first, but intentionally narrower than the TypeScript SDK today.
+
+The stable public flow to rely on right now is:
+
+- `smart_accounts::instructions::create`
+- `smart_accounts::prepare::create`
+- `client.smart_accounts().create(...)`
+
+<Info>
+Do not assume the Rust crate currently matches the full TS feature surface. Today the documented, trustworthy path is the smart-account create flow.
+</Info>
+
+## Create A Client
+
+```rust
+use std::sync::Arc;
+
+use loyal_smart_accounts_rs::{
+    create_loyal_smart_accounts_client,
+    LoyalSmartAccountsClientConfig,
+};
+use solana_client::nonblocking::rpc_client::RpcClient;
+
+let rpc = Arc::new(RpcClient::new("https://api.devnet.solana.com".into()));
+
+let client = create_loyal_smart_accounts_client(LoyalSmartAccountsClientConfig {
+    rpc,
+    program_id: None,
+    default_commitment: None,
+    sender: None,
+    confirmer: None,
+});
+```
+
+## Build The Request
+
+```rust
+use loyal_smart_accounts_rs::smart_accounts::CreateSmartAccountRequest;
+use loyal_smart_accounts_rs::types::{Permissions, SmartAccountSigner};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer};
+
+let creator = Keypair::new();
+
+let request = CreateSmartAccountRequest {
+    treasury: Pubkey::new_unique(),
+    creator: creator.pubkey(),
+    settings: None,
+    settings_authority: None,
+    threshold: 1,
+    signers: vec![SmartAccountSigner {
+        key: creator.pubkey(),
+        permissions: Permissions::all(),
+    }],
+    time_lock: 0,
+    rent_collector: None,
+    memo: None,
+    program_id: None,
+    remaining_accounts: vec![],
+};
+```
+
+## Two Useful Entry Points
+
+### Raw Instruction
+
+Use `smart_accounts::instructions::create(...)` when you want to assemble and send the transaction yourself.
+
+```rust
+use loyal_smart_accounts_rs::{smart_accounts, PROGRAM_ID};
+
+let instruction = smart_accounts::instructions::create(&request, PROGRAM_ID)?;
+```
+
+### Prepare First
+
+Use `smart_accounts::prepare::create(...)` when you want a prepared operation before send.
+
+```rust
+use loyal_smart_accounts_rs::{smart_accounts, PROGRAM_ID};
+
+let prepared = smart_accounts::prepare::create(&request, PROGRAM_ID)?;
+```
+
+### Send Through The Client
+
+Use `client.smart_accounts().create(...)` for the direct path.
+
+```rust
+let signature = client.smart_accounts().create(request, &creator).await?;
+```
+
+## What This Means In Practice
+
+- Rust is already useful for creation workflows
+- The TS SDK is still the broader integration surface today
+- If you need the fullest feature coverage right now, start from [TypeScript SDK](/smart-accounts/typescript-sdk)

--- a/user-docs/smart-accounts/typescript-sdk.mdx
+++ b/user-docs/smart-accounts/typescript-sdk.mdx
@@ -1,0 +1,168 @@
+---
+title: "TypeScript SDK"
+description: "How to use Loyal’s TypeScript Smart Accounts SDK, from raw instructions to prepared and client-send flows."
+---
+
+The TypeScript package is [`@loyal-labs/loyal-smart-accounts`](https://www.npmjs.com/package/@loyal-labs/loyal-smart-accounts).
+
+## What It Exposes
+
+The public surface is split by feature namespace instead of one flat API:
+
+- `programConfig`
+- `smartAccounts`
+- `proposals`
+- `transactions`
+- `batches`
+- `policies`
+- `spendingLimits`
+- `execution`
+
+It also exports lower-level protocol helpers:
+
+- `generated`
+- `accounts`
+- `pda`
+- `codecs`
+- `errors`
+
+## Install
+
+```bash
+bun add @loyal-labs/loyal-smart-accounts @solana/web3.js
+# or
+npm install @loyal-labs/loyal-smart-accounts @solana/web3.js
+```
+
+## Create A Client
+
+```ts
+import {
+  createLoyalSmartAccountsClient,
+  pda,
+} from "@loyal-labs/loyal-smart-accounts";
+import { Connection } from "@solana/web3.js";
+
+const connection = new Connection("https://api.devnet.solana.com");
+const client = createLoyalSmartAccountsClient({ connection });
+
+const [settingsPda] = pda.getSettingsPda({
+  accountIndex: 1n,
+});
+```
+
+## Three Ways To Work
+
+This is the most important pattern in the SDK:
+
+1. Build a raw instruction
+2. Build a prepared operation
+3. Use the client send flow
+
+### 1. Raw Instruction
+
+Use `smartAccounts.instructions.create(...)` when you want full transaction assembly control.
+
+```ts
+import {
+  codecs,
+  smartAccounts,
+} from "@loyal-labs/loyal-smart-accounts";
+import { Keypair } from "@solana/web3.js";
+
+const creator = Keypair.generate();
+
+const instruction = smartAccounts.instructions.create({
+  treasury: creator.publicKey,
+  creator: creator.publicKey,
+  settings: settingsPda,
+  settingsAuthority: null,
+  threshold: 1,
+  signers: [
+    {
+      key: creator.publicKey,
+      permissions: codecs.Permissions.all(),
+    },
+  ],
+  timeLock: 0,
+  rentCollector: null,
+});
+```
+
+### 2. Prepared Operation
+
+Use `smartAccounts.prepare.create(...)` when you want the SDK to package the operation cleanly before sending it yourself.
+
+```ts
+const prepared = await smartAccounts.prepare.create({
+  treasury: creator.publicKey,
+  creator: creator.publicKey,
+  settings: settingsPda,
+  settingsAuthority: null,
+  threshold: 1,
+  signers: [
+    {
+      key: creator.publicKey,
+      permissions: codecs.Permissions.all(),
+    },
+  ],
+  timeLock: 0,
+  rentCollector: null,
+});
+
+await client.send(prepared, {
+  signers: [creator],
+});
+```
+
+### 3. Client Send Flow
+
+Use `client.smartAccounts.create(...)` when you want the highest-level path.
+
+```ts
+await client.smartAccounts.create({
+  treasury: creator.publicKey,
+  creator,
+  settings: settingsPda,
+  settingsAuthority: null,
+  threshold: 1,
+  signers: [
+    {
+      key: creator.publicKey,
+      permissions: codecs.Permissions.all(),
+    },
+  ],
+  timeLock: 0,
+  rentCollector: null,
+});
+```
+
+## Choosing The Right Level
+
+| Use this | When you want |
+| --- | --- |
+| `instructions.*` | Full control over transaction composition |
+| `prepare.*` | A reusable prepared operation before send |
+| `client.*` | The shortest path from request to signature |
+
+## PDA Helpers You Will Use Early
+
+Two helpers matter immediately:
+
+- `pda.getSettingsPda({ accountIndex })`
+- `pda.getSmartAccountPda({ settingsPda, accountIndex })`
+
+The first derives the configuration root. The second derives a sub-account that can actually hold assets and execute.
+
+<Warning>
+Do not send funds to the settings PDA by accident. In most integrations, the sub-account or vault PDA is the address users should treat as the asset-holding account.
+</Warning>
+
+## What To Read Next
+
+- [Concepts](/smart-accounts/concepts) for the vocabulary behind the fields
+- [Policies and Execution](/smart-accounts/policies-and-execution) for the governance and execution model
+
+<Info>
+The TS SDK already exposes the broader feature namespaces listed above. This page stays centered on the create flow and the main integration pattern so it remains useful instead of turning into a dump of every operation.
+</Info>


### PR DESCRIPTION
Add a new Smart Accounts docs section in Mintlify, rename the Developers tab to DeFi, and document the TS and Rust SDK surfaces with a concise concepts and execution model.