### PR TITLE
feat(extension): add show/hide toggle for private key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -146,7 +146,7 @@
     },
     "extension": {
       "name": "@loyal-labs/extension",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-react": "^0.15.39",
@@ -159,6 +159,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "text-security": "^3.2.1",
         "tweetnacl": "1.0.3",
       },
       "devDependencies": {
@@ -4641,6 +4642,8 @@
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
 
     "text-encoding-utf-8": ["text-encoding-utf-8@1.0.2", "", {}, "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="],
+
+    "text-security": ["text-security@3.2.1", "", {}, "sha512-MjDQ3lyLeLqcGqZfQCZ6kvjQiuNfJaicdgIczPJDtD4tj0vIPT8WwIOKTi8wgXCVS/F1WJmapO3SppXemrwbIA=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 

--- a/extension/assets/tailwind.css
+++ b/extension/assets/tailwind.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@import "text-security/text-security-disc.css";

--- a/extension/package.json
+++ b/extension/package.json
@@ -26,6 +26,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "text-security": "^3.2.1",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/extension/src/components/wallet/settings.tsx
+++ b/extension/src/components/wallet/settings.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, ChevronDown, ChevronRight, ChevronUp, Copy, Eye, Globe, KeyRound, Lock, PanelRight, Plus, Square, Timer } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, ChevronRight, ChevronUp, Copy, Eye, EyeOff, Globe, KeyRound, Lock, PanelRight, Plus, Square, Timer } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import { useWalletContext } from "~/src/components/wallet/wallet-provider";
@@ -200,6 +200,7 @@ function SegmentedControl<T extends string | number>({
 export function Settings({ onBack }: { onBack: () => void }) {
   const { network, setNetwork, publicKey, lock, resetWallet, getSecretKey } = useWalletContext();
   const [showPrivateKey, setShowPrivateKey] = useState(false);
+  const [revealKey, setRevealKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAddress, setCopiedAddress] = useState(false);
   const [resetAction, setResetAction] = useState<"create" | "import" | null>(null);
@@ -317,7 +318,7 @@ export function Settings({ onBack }: { onBack: () => void }) {
           <SettingsRow
             icon={<Eye size={18} />}
             title="Private Key"
-            onClick={() => setShowPrivateKey(!showPrivateKey)}
+            onClick={() => { setShowPrivateKey(!showPrivateKey); setRevealKey(false); }}
           >
             {showPrivateKey
               ? <ChevronUp size={14} style={{ color: chevronColor }} />
@@ -349,9 +350,10 @@ export function Settings({ onBack }: { onBack: () => void }) {
               </span>
               <div
                 style={{
+                  position: "relative",
                   background: "rgba(0, 0, 0, 0.04)",
                   borderRadius: "8px",
-                  padding: "10px 12px",
+                  padding: "10px 36px 10px 12px",
                   fontFamily: "monospace",
                   fontSize: "11px",
                   lineHeight: "16px",
@@ -361,7 +363,28 @@ export function Settings({ onBack }: { onBack: () => void }) {
                   overflowY: "auto",
                 }}
               >
-                {Array.from(getSecretKey() ?? []).map((b) => b.toString(16).padStart(2, "0")).join("")}
+                {revealKey
+                  ? Array.from(getSecretKey() ?? []).map((b) => b.toString(16).padStart(2, "0")).join("")
+                  : "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"}
+                <button
+                  type="button"
+                  onClick={() => setRevealKey(!revealKey)}
+                  style={{
+                    position: "absolute",
+                    right: "8px",
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    padding: "2px",
+                    display: "flex",
+                    alignItems: "center",
+                    color: "rgba(60, 60, 67, 0.6)",
+                  }}
+                >
+                  {revealKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
               </div>
               <div style={{ display: "flex", gap: "8px" }}>
                 <button

--- a/extension/src/components/wallet/wallet-app.tsx
+++ b/extension/src/components/wallet/wallet-app.tsx
@@ -4,6 +4,8 @@ import {
   ArrowDownLeft,
   ArrowLeftRight,
   ArrowUpRight,
+  Eye,
+  EyeOff,
   Settings as SettingsIcon,
   Shield,
   Wallet,
@@ -173,6 +175,7 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [secretKeyInput, setSecretKeyInput] = useState("");
+  const [showImportKey, setShowImportKey] = useState(false);
   const [mode, setMode] = useState<"create" | "import">(initialMode);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -332,28 +335,49 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
         />
 
         {mode === "import" && (
-          <textarea
-            placeholder="Private key (hex)"
-            value={secretKeyInput}
-            onChange={(e) => setSecretKeyInput(e.target.value)}
-            rows={4}
-            style={{
-              width: "100%",
-              background: "#fff",
-              border: "none",
-              borderRadius: "16px",
-              padding: "12px 16px",
-              fontFamily: "monospace",
-              fontSize: "13px",
-              fontWeight: 400,
-              lineHeight: "18px",
-              color: "#000",
-              outline: "none",
-              resize: "none",
-              boxSizing: "border-box",
-              wordBreak: "break-all",
-            }}
-          />
+          <div style={{ position: "relative", width: "100%" }}>
+            <textarea
+              placeholder="Private key (hex)"
+              value={secretKeyInput}
+              onChange={(e) => setSecretKeyInput(e.target.value)}
+              rows={4}
+              style={{
+                width: "100%",
+                background: "#fff",
+                border: "none",
+                borderRadius: "16px",
+                padding: "12px 40px 12px 16px",
+                fontFamily: showImportKey ? "monospace" : "'text-security-disc', monospace",
+                fontSize: "13px",
+                fontWeight: 400,
+                lineHeight: "18px",
+                color: "#000",
+                outline: "none",
+                resize: "none",
+                boxSizing: "border-box",
+                wordBreak: "break-all",
+                ...(showImportKey ? {} : { WebkitTextSecurity: "disc" as never }),
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setShowImportKey(!showImportKey)}
+              style={{
+                position: "absolute",
+                right: "12px",
+                top: "12px",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: "2px",
+                display: "flex",
+                alignItems: "center",
+                color: "rgba(60, 60, 67, 0.6)",
+              }}
+            >
+              {showImportKey ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
Add eye icon toggle to mask/reveal private key in settings export view and import wallet textarea. Hidden by default with bullet masking, cross-browser via text-security font.