### PR TITLE
feat(extension): replace password auth with 4-digit PIN input

### DIFF
--- a/extension/src/components/wallet/shared.tsx
+++ b/extension/src/components/wallet/shared.tsx
@@ -1,4 +1,194 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowLeft, Search, X } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// PIN Input — 4-digit code with filled dots, auto-advance, shake on error
+// ---------------------------------------------------------------------------
+
+const PIN_LENGTH = 4;
+const DOT_SIZE = 56;
+const DOT_GAP = 12;
+
+export function PinInput({
+  value,
+  onChange,
+  onComplete,
+  error,
+  disabled,
+  label,
+}: {
+  value: string;
+  onChange: (pin: string) => void;
+  onComplete?: (pin: string) => void;
+  error?: boolean;
+  disabled?: boolean;
+  label?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [shake, setShake] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  // Trigger shake animation on error
+  useEffect(() => {
+    if (error) {
+      setShake(true);
+      const t = setTimeout(() => setShake(false), 500);
+      return () => clearTimeout(t);
+    }
+  }, [error]);
+
+  const handleInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (disabled) return;
+      const raw = e.target.value.replace(/\D/g, "").slice(0, PIN_LENGTH);
+      onChange(raw);
+      if (raw.length === PIN_LENGTH) {
+        onComplete?.(raw);
+      }
+    },
+    [disabled, onChange, onComplete],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (disabled) return;
+      if (e.key === "Backspace" && value.length === 0) {
+        e.preventDefault();
+      }
+    },
+    [disabled, value],
+  );
+
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Hint text for the first empty box
+  const hintText = !focused && value.length === 0 ? "Click" : focused && value.length === 0 ? "Type" : null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "16px",
+      }}
+    >
+      {label && (
+        <span
+          style={{
+            fontFamily: "var(--font-geist-sans), sans-serif",
+            fontSize: "15px",
+            fontWeight: 500,
+            lineHeight: "20px",
+            color: "rgba(60, 60, 67, 0.6)",
+          }}
+        >
+          {label}
+        </span>
+      )}
+
+      {/* Dot row — tap to focus hidden input */}
+      <div
+        onClick={focusInput}
+        style={{
+          display: "flex",
+          gap: `${DOT_GAP}px`,
+          cursor: value.length === 0 && !focused ? "pointer" : "default",
+          animation: shake ? "pin-shake 0.5s ease" : undefined,
+        }}
+      >
+        {Array.from({ length: PIN_LENGTH }).map((_, i) => {
+          const isFilled = i < value.length;
+          const isActive = i === value.length && focused && !disabled;
+          const showHint = i === 0 && hintText;
+          return (
+            <div
+              key={i}
+              style={{
+                width: `${DOT_SIZE}px`,
+                height: `${DOT_SIZE}px`,
+                borderRadius: "16px",
+                background: isFilled
+                  ? "#000"
+                  : isActive
+                    ? "rgba(249, 54, 60, 0.06)"
+                    : "#fff",
+                border: isActive
+                  ? "2px solid #000"
+                  : isFilled
+                    ? "2px solid #000"
+                    : "2px solid rgba(0, 0, 0, 0.06)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "all 0.15s cubic-bezier(0.4, 0, 0.2, 1)",
+                boxSizing: "border-box",
+              }}
+            >
+              {showHint ? (
+                <span
+                  style={{
+                    fontFamily: "var(--font-geist-sans), sans-serif",
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    color: "rgba(60, 60, 67, 0.35)",
+                    userSelect: "none",
+                    transition: "opacity 0.15s ease",
+                  }}
+                >
+                  {hintText}
+                </span>
+              ) : (
+                <div
+                  style={{
+                    width: isFilled ? "14px" : "0px",
+                    height: isFilled ? "14px" : "0px",
+                    borderRadius: "9999px",
+                    background: "#fff",
+                    transition: "all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1)",
+                  }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Off-screen input — captures keyboard */}
+      <input
+        ref={inputRef}
+        type="tel"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        maxLength={PIN_LENGTH}
+        value={value}
+        onChange={handleInput}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        disabled={disabled}
+        tabIndex={-1}
+        style={{
+          position: "fixed",
+          left: "-9999px",
+          top: "-9999px",
+          opacity: 0,
+        }}
+      />
+
+      {/* Keyframe for shake animation */}
+      <style>{`
+        @keyframes pin-shake {
+          0%, 100% { transform: translateX(0); }
+          10%, 50%, 90% { transform: translateX(-6px); }
+          30%, 70% { transform: translateX(6px); }
+        }
+      `}</style>
+    </div>
+  );
+}
 
 export function SearchInput({
   value,

--- a/extension/src/components/wallet/wallet-app.tsx
+++ b/extension/src/components/wallet/wallet-app.tsx
@@ -15,6 +15,7 @@ import confettiAnimationData from "~/assets/confetti.json";
 import type { SubView, SwapMode, SwapToken } from "@loyal-labs/wallet-core/types";
 import { LOYL_TOKEN } from "@loyal-labs/wallet-core/types";
 import { useWalletContext, WalletProvider } from "./wallet-provider";
+import { PinInput } from "./shared";
 
 import { PortfolioContent } from "./portfolio-content";
 import { SendContent } from "./send-content";
@@ -172,43 +173,52 @@ function Logotype() {
 
 function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create" | "import" }) {
   const { createWallet, importWallet } = useWalletContext();
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [pin, setPin] = useState("");
+  const [confirmPin, setConfirmPin] = useState("");
+  const [step, setStep] = useState<"enter" | "confirm">("enter");
   const [secretKeyInput, setSecretKeyInput] = useState("");
   const [showImportKey, setShowImportKey] = useState(false);
   const [mode, setMode] = useState<"create" | "import">(initialMode);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleCreate = async () => {
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters");
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
-    setError(null);
-    setLoading(true);
-    try {
-      await createWallet(password);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create wallet");
-    } finally {
-      setLoading(false);
-    }
-  };
+  const handleCreateWithPin = useCallback(
+    async (finalPin: string) => {
+      setLoading(true);
+      try {
+        await createWallet(finalPin);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to create wallet");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [createWallet],
+  );
+
+  const handlePinComplete = useCallback(
+    (enteredPin: string) => {
+      if (step === "enter") {
+        setPin(enteredPin);
+        setStep("confirm");
+        setConfirmPin("");
+        setError(null);
+      } else {
+        if (enteredPin !== pin) {
+          setError("PINs don't match");
+          setConfirmPin("");
+          return;
+        }
+        setConfirmPin(enteredPin);
+        setError(null);
+        if (mode === "import") return;
+        void handleCreateWithPin(enteredPin);
+      }
+    },
+    [step, pin, mode, handleCreateWithPin],
+  );
 
   const handleImport = async () => {
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters");
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
     try {
       const hex = secretKeyInput.trim().replace(/^0x/, "");
       if (!hex) throw new Error("Private key cannot be empty");
@@ -217,13 +227,23 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
       const bytes = new Uint8Array(pairs.map((b) => parseInt(b, 16)));
       setError(null);
       setLoading(true);
-      await importWallet(bytes, password);
+      await importWallet(bytes, pin);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Invalid secret key or import failed");
     } finally {
       setLoading(false);
     }
   };
+
+  const handleBack = useCallback(() => {
+    setStep("enter");
+    setConfirmPin("");
+    setPin("");
+    setError(null);
+  }, []);
+
+  const pinLabel = step === "enter" ? "Create a PIN" : "Confirm your PIN";
+  const showImportField = mode === "import" && step === "confirm" && confirmPin.length === 4 && confirmPin === pin;
 
   return (
     <div
@@ -242,11 +262,11 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
         <Logotype />
       </div>
 
-      {/* Tab toggle — matches frontend quick-action 12px radius, 6px gap */}
-      <div style={{ display: "flex", gap: "6px", width: "100%", marginBottom: "16px" }}>
+      {/* Tab toggle */}
+      <div style={{ display: "flex", gap: "6px", width: "100%", marginBottom: "24px" }}>
         <button
           type="button"
-          onClick={() => { setMode("create"); setError(null); }}
+          onClick={() => { setMode("create"); setError(null); setStep("enter"); setPin(""); setConfirmPin(""); }}
           style={{
             flex: 1,
             display: "flex",
@@ -269,7 +289,7 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
         </button>
         <button
           type="button"
-          onClick={() => { setMode("import"); setError(null); }}
+          onClick={() => { setMode("import"); setError(null); setStep("enter"); setPin(""); setConfirmPin(""); }}
           style={{
             flex: 1,
             display: "flex",
@@ -292,49 +312,49 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
         </button>
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: "8px", width: "100%" }}>
-        <input
-          type="password"
-          placeholder="Password (min 8 characters)"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          style={{
-            width: "100%",
-            background: "#fff",
-            border: "none",
-            borderRadius: "16px",
-            padding: "15px 16px",
-            fontFamily: "var(--font-geist-sans), sans-serif",
-            fontSize: "16px",
-            fontWeight: 400,
-            lineHeight: "20px",
-            color: "#000",
-            outline: "none",
-            boxSizing: "border-box",
-          }}
-        />
-        <input
-          type="password"
-          placeholder="Confirm password"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          style={{
-            width: "100%",
-            background: "#fff",
-            border: "none",
-            borderRadius: "16px",
-            padding: "15px 16px",
-            fontFamily: "var(--font-geist-sans), sans-serif",
-            fontSize: "16px",
-            fontWeight: 400,
-            lineHeight: "20px",
-            color: "#000",
-            outline: "none",
-            boxSizing: "border-box",
-          }}
-        />
+      {/* PIN input — don't pass disabled during create loading to prevent layout shift */}
+      <PinInput
+        value={step === "enter" ? pin : confirmPin}
+        onChange={step === "enter" ? setPin : setConfirmPin}
+        onComplete={handlePinComplete}
+        error={!!error}
+        label={pinLabel}
+      />
 
-        {mode === "import" && (
+      {/* Back button — always rendered to reserve space and prevent layout shift */}
+      <button
+        type="button"
+        onClick={handleBack}
+        style={{
+          marginTop: "12px",
+          background: "none",
+          border: "none",
+          cursor: step === "confirm" ? "pointer" : "default",
+          fontFamily: "var(--font-geist-sans), sans-serif",
+          fontSize: "13px",
+          fontWeight: 500,
+          lineHeight: "16px",
+          color: "rgba(60, 60, 67, 0.6)",
+          padding: "4px 8px",
+          opacity: step === "confirm" && !showImportField ? 1 : 0,
+          pointerEvents: step === "confirm" && !showImportField ? "auto" : "none",
+          transition: "opacity 0.15s ease",
+        }}
+      >
+        Re-enter PIN
+      </button>
+
+      {/* Import key field + button — animated reveal after PIN is confirmed */}
+      <div
+        style={{
+          width: "100%",
+          overflow: "hidden",
+          maxHeight: showImportField ? "300px" : "0px",
+          opacity: showImportField ? 1 : 0,
+          transition: "max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease",
+        }}
+      >
+        <div style={{ width: "100%", marginTop: "16px" }}>
           <div style={{ position: "relative", width: "100%" }}>
             <textarea
               placeholder="Private key (hex)"
@@ -378,7 +398,40 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
               {showImportKey ? <EyeOff size={16} /> : <Eye size={16} />}
             </button>
           </div>
-        )}
+        </div>
+
+        {/* Import button */}
+        {(() => {
+          const isDisabled = loading || !secretKeyInput.trim();
+          return (
+            <button
+              type="button"
+              disabled={isDisabled}
+              onClick={handleImport}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "12px 16px",
+                marginTop: "16px",
+                borderRadius: "9999px",
+                border: "none",
+                cursor: isDisabled ? "default" : "pointer",
+                background: isDisabled ? "#CCCDCD" : "#000",
+                fontFamily: "var(--font-geist-sans), sans-serif",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: "20px",
+                color: "#fff",
+                textAlign: "center",
+                transition: "background 0.15s ease",
+              }}
+            >
+              {loading ? "Working..." : "Import Wallet"}
+            </button>
+          );
+        })()}
       </div>
 
       {error && (
@@ -396,42 +449,6 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
         </p>
       )}
 
-      {(() => {
-        const isFormValid = password.length >= 8 && password === confirmPassword && (mode === "create" || secretKeyInput.trim().length > 0);
-        const isDisabled = loading || !isFormValid;
-        return (
-          <button
-            type="button"
-            disabled={isDisabled}
-            onClick={mode === "create" ? handleCreate : handleImport}
-            style={{
-              width: "100%",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              padding: "12px 16px",
-              marginTop: "16px",
-              borderRadius: "9999px",
-              border: "none",
-              cursor: isDisabled ? "default" : "pointer",
-              background: isDisabled ? "#CCCDCD" : "#000",
-              fontFamily: "var(--font-geist-sans), sans-serif",
-              fontSize: "16px",
-              fontWeight: 400,
-              lineHeight: "20px",
-              color: "#fff",
-              textAlign: "center",
-              transition: "background 0.15s ease",
-            }}
-          >
-            {loading
-              ? "Working..."
-              : mode === "create"
-                ? "Create Wallet"
-                : "Import Wallet"}
-          </button>
-        );
-      })()}
     </div>
   );
 }
@@ -442,22 +459,26 @@ function CreateWalletScreen({ initialMode = "create" }: { initialMode?: "create"
 
 function UnlockScreen() {
   const { unlock, publicKey, resetWallet } = useWalletContext();
-  const [password, setPassword] = useState("");
+  const [pin, setPin] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [resetAction, setResetAction] = useState<"create" | "import" | null>(null);
 
-  const handleUnlock = async () => {
-    setError(null);
-    setLoading(true);
-    try {
-      await unlock(password);
-    } catch {
-      setError("Invalid password");
-    } finally {
-      setLoading(false);
-    }
-  };
+  const handleUnlock = useCallback(
+    async (enteredPin: string) => {
+      setError(null);
+      setLoading(true);
+      try {
+        await unlock(enteredPin);
+      } catch {
+        setError("Wrong PIN");
+        setPin("");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [unlock],
+  );
 
   const truncatedKey = publicKey
     ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
@@ -493,28 +514,14 @@ function UnlockScreen() {
         )}
       </div>
 
-      <input
-        type="password"
-        placeholder="Enter password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") handleUnlock();
-        }}
-        style={{
-          width: "100%",
-          background: "#fff",
-          border: "none",
-          borderRadius: "16px",
-          padding: "15px 16px",
-          fontFamily: "var(--font-geist-sans), sans-serif",
-          fontSize: "16px",
-          fontWeight: 400,
-          lineHeight: "20px",
-          color: "#000",
-          outline: "none",
-          boxSizing: "border-box",
-        }}
+      {/* PIN input */}
+      <PinInput
+        value={pin}
+        onChange={setPin}
+        onComplete={handleUnlock}
+        error={!!error}
+        disabled={loading}
+        label="Enter your PIN"
       />
 
       {error && (
@@ -525,39 +532,27 @@ function UnlockScreen() {
             lineHeight: "16px",
             color: "#FF3B30",
             textAlign: "center",
-            marginTop: "8px",
+            marginTop: "12px",
           }}
         >
           {error}
         </p>
       )}
 
-      <button
-        type="button"
-        disabled={loading}
-        onClick={handleUnlock}
-        style={{
-          width: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: "12px 16px",
-          marginTop: "16px",
-          borderRadius: "9999px",
-          border: "none",
-          cursor: loading ? "default" : "pointer",
-          background: loading ? "#CCCDCD" : "#000",
-          fontFamily: "var(--font-geist-sans), sans-serif",
-          fontSize: "16px",
-          fontWeight: 400,
-          lineHeight: "20px",
-          color: "#fff",
-          textAlign: "center",
-          transition: "background 0.15s ease",
-        }}
-      >
-        {loading ? "Unlocking..." : "Unlock"}
-      </button>
+      {loading && (
+        <p
+          style={{
+            fontFamily: "var(--font-geist-sans), sans-serif",
+            fontSize: "14px",
+            lineHeight: "20px",
+            color: "rgba(60, 60, 67, 0.6)",
+            textAlign: "center",
+            marginTop: "12px",
+          }}
+        >
+          Unlocking...
+        </p>
+      )}
 
       {/* Reset wallet options */}
       <div style={{ display: "flex", gap: "8px", width: "100%", marginTop: "24px" }}>
@@ -1086,15 +1081,29 @@ function WalletAppInner() {
   const { state, resetMode } = useWalletContext();
   const prevStateRef = useRef(state);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [transitioning, setTransitioning] = useState(false);
+  const [displayState, setDisplayState] = useState(state);
 
   useEffect(() => {
-    if (prevStateRef.current === "noWallet" && state === "unlocked") {
-      setShowConfetti(true);
-    }
+    const prev = prevStateRef.current;
     prevStateRef.current = state;
+
+    // Cross-fade when unlocking (locked→unlocked or noWallet→unlocked)
+    if (state === "unlocked" && (prev === "locked" || prev === "noWallet")) {
+      setTransitioning(true);
+      // Fade out the old screen, then swap content + fade in + confetti
+      const t = setTimeout(() => {
+        setDisplayState(state);
+        setTransitioning(false);
+        setShowConfetti(true);
+      }, 250);
+      return () => clearTimeout(t);
+    }
+
+    setDisplayState(state);
   }, [state]);
 
-  if (state === "loading") {
+  if (displayState === "loading") {
     return (
       <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%" }}>
         <div
@@ -1111,15 +1120,23 @@ function WalletAppInner() {
     );
   }
 
-  const screen = state === "noWallet"
+  const screen = displayState === "noWallet"
     ? <CreateWalletScreen initialMode={resetMode} />
-    : state === "locked"
+    : displayState === "locked"
       ? <UnlockScreen />
       : <WalletInterface />;
 
   return (
     <>
-      {screen}
+      <div
+        style={{
+          height: "100%",
+          opacity: transitioning ? 0 : 1,
+          transition: "opacity 0.25s ease",
+        }}
+      >
+        {screen}
+      </div>
       {showConfetti && <ConfettiOverlay onComplete={() => setShowConfetti(false)} />}
     </>
   );

--- a/extension/src/components/wallet/wallet-provider.tsx
+++ b/extension/src/components/wallet/wallet-provider.tsx
@@ -62,9 +62,9 @@ interface WalletContextValue {
   publicKey: string | null;
 
   // Actions
-  createWallet: (password: string) => Promise<void>;
-  importWallet: (secretKey: Uint8Array, password: string) => Promise<void>;
-  unlock: (password: string) => Promise<void>;
+  createWallet: (pin: string) => Promise<void>;
+  importWallet: (secretKey: Uint8Array, pin: string) => Promise<void>;
+  unlock: (pin: string) => Promise<void>;
   lock: () => void;
   /** Wipe stored keypair and return to the create wallet screen */
   resetWallet: (initialMode?: "create" | "import") => Promise<void>;
@@ -218,26 +218,26 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   );
 
   const createWallet = useCallback(
-    async (password: string) => {
-      const keypair = await generateKeypair(password);
+    async (pin: string) => {
+      const keypair = await generateKeypair(pin);
       buildSigner(keypair);
     },
     [buildSigner],
   );
 
   const importWallet = useCallback(
-    async (secretKey: Uint8Array, password: string) => {
-      const keypair = await importKeypair(secretKey, password);
+    async (secretKey: Uint8Array, pin: string) => {
+      const keypair = await importKeypair(secretKey, pin);
       buildSigner(keypair);
     },
     [buildSigner],
   );
 
   const unlock = useCallback(
-    async (password: string) => {
-      const keypair = await loadKeypair(password);
+    async (pin: string) => {
+      const keypair = await loadKeypair(pin);
       if (!keypair) {
-        throw new Error("Invalid password or no stored keypair");
+        throw new Error("Invalid PIN or no stored keypair");
       }
       buildSigner(keypair);
     },

--- a/extension/src/lib/keypair-storage.ts
+++ b/extension/src/lib/keypair-storage.ts
@@ -10,22 +10,22 @@ const walletPublicKey = storage.defineItem<string | null>("local:walletPublicKey
   fallback: null,
 });
 
-export async function generateKeypair(password: string): Promise<Keypair> {
+export async function generateKeypair(pin: string): Promise<Keypair> {
   const keypair = Keypair.generate();
-  await storeKeypair(keypair, password);
+  await storeKeypair(keypair, pin);
   return keypair;
 }
 
-export async function importKeypair(secretKey: Uint8Array, password: string): Promise<Keypair> {
+export async function importKeypair(secretKey: Uint8Array, pin: string): Promise<Keypair> {
   const keypair = Keypair.fromSecretKey(secretKey);
-  await storeKeypair(keypair, password);
+  await storeKeypair(keypair, pin);
   return keypair;
 }
 
-export async function loadKeypair(password: string): Promise<Keypair | null> {
+export async function loadKeypair(pin: string): Promise<Keypair | null> {
   const encrypted = await encryptedKeypair.getValue();
   if (!encrypted) return null;
-  const decrypted = await decrypt(encrypted, password);
+  const decrypted = await decrypt(encrypted, pin);
   if (!decrypted) return null;
   return Keypair.fromSecretKey(new Uint8Array(JSON.parse(decrypted)));
 }
@@ -43,18 +43,18 @@ export async function clearStoredKeypair(): Promise<void> {
   await walletPublicKey.setValue(null);
 }
 
-async function storeKeypair(keypair: Keypair, password: string): Promise<void> {
+async function storeKeypair(keypair: Keypair, pin: string): Promise<void> {
   const serialized = JSON.stringify(Array.from(keypair.secretKey));
-  const encrypted = await encrypt(serialized, password);
+  const encrypted = await encrypt(serialized, pin);
   await encryptedKeypair.setValue(encrypted);
   await walletPublicKey.setValue(keypair.publicKey.toBase58());
 }
 
 // AES-GCM encryption/decryption using Web Crypto API
-async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+async function deriveKey(pin: string, salt: Uint8Array): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
-    new TextEncoder().encode(password),
+    new TextEncoder().encode(pin),
     "PBKDF2",
     false,
     ["deriveKey"],
@@ -68,10 +68,10 @@ async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey>
   );
 }
 
-async function encrypt(plaintext: string, password: string): Promise<string> {
+async function encrypt(plaintext: string, pin: string): Promise<string> {
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const iv = crypto.getRandomValues(new Uint8Array(12));
-  const key = await deriveKey(password, salt);
+  const key = await deriveKey(pin, salt);
   const encrypted = await crypto.subtle.encrypt(
     { name: "AES-GCM", iv },
     key,
@@ -84,10 +84,10 @@ async function encrypt(plaintext: string, password: string): Promise<string> {
   });
 }
 
-async function decrypt(ciphertext: string, password: string): Promise<string | null> {
+async function decrypt(ciphertext: string, pin: string): Promise<string | null> {
   try {
     const { salt, iv, data } = JSON.parse(ciphertext);
-    const key = await deriveKey(password, new Uint8Array(salt));
+    const key = await deriveKey(pin, new Uint8Array(salt));
     const decrypted = await crypto.subtle.decrypt(
       { name: "AES-GCM", iv: new Uint8Array(iv) },
       key,


### PR DESCRIPTION
## Summary
- Replace password fields with a 4-digit PIN input component featuring visual dot indicators, shake animation on error, and click/type hint UX for extension popup focus limitations
- Add smooth cross-fade transitions between create/unlock/wallet screens with confetti on unlock
- Animated reveal of import key field after PIN confirmation
- Rename all `password` params to `pin` across keypair-storage and wallet-provider