### PR TITLE
chore: add Turborepo for parallel workspace package builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ docs/scopes
 /workers/userbot/.data/
 /workers/userbot/node_modules/
 
+# turbo
+.turbo/
+
 # internal workspace package build outputs
 /packages/*/dist/
 /sdk/*/dist/

--- a/admin/package.json
+++ b/admin/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "bun run --cwd .. build:db-packages",
+    "predev": "bun run --cwd .. build:packages",
     "dev": "next dev --turbopack",
-    "prebuild": "bun run --cwd .. build:db-packages",
+    "prebuild": "bun run --cwd .. build:packages",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/app/package.json
+++ b/app/package.json
@@ -5,10 +5,10 @@
   "packageManager": "bun@1.2.17",
   "scripts": {
     "check:drizzle-singleton": "node scripts/check-drizzle-singleton.mjs",
-    "predev": "bun run --cwd .. build:db-packages && bun run --cwd .. build:llm-packages && bun run --cwd .. build:solana-packages && bun run --cwd .. build:shared-packages && bun run check:drizzle-singleton",
+    "predev": "bun run --cwd .. build:packages && bun run check:drizzle-singleton",
     "dev": "next dev --turbopack",
     "dev:http": "next dev --experimental-https",
-    "prebuild": "bun run --cwd .. build:db-packages && bun run --cwd .. build:llm-packages && bun run --cwd .. build:solana-packages && bun run --cwd .. build:shared-packages && bun run check:drizzle-singleton",
+    "prebuild": "bun run --cwd .. build:packages && bun run check:drizzle-singleton",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -21,6 +22,7 @@
         "mocha": "^9.0.3",
         "prettier": "^2.6.2",
         "ts-mocha": "^10.0.0",
+        "turbo": "^2.8.20",
         "tweetnacl": "^1.0.3",
         "typescript": "^5.7.3",
       },
@@ -146,7 +148,7 @@
     },
     "extension": {
       "name": "@loyal-labs/extension",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-react": "^0.15.39",
@@ -1978,6 +1980,18 @@
     "@trezor/websocket-client": ["@trezor/websocket-client@1.3.0", "", { "dependencies": { "@trezor/utils": "9.5.0", "ws": "^8.18.0" }, "peerDependencies": { "tslib": "^2.6.2" } }, "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.19.0", "", { "dependencies": { "fast-glob": "^3.2.12", "minimatch": "^7.4.3", "mkdirp": "^2.1.6", "path-browserify": "^1.0.1" } }, "sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.8.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.8.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.8.20", "", { "os": "linux", "cpu": "x64" }, "sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.8.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.8.20", "", { "os": "win32", "cpu": "x64" }, "sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.8.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw=="],
 
     "@turnkey/crypto": ["@turnkey/crypto@2.8.3", "", { "dependencies": { "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.0", "@noble/hashes": "1.8.0", "@peculiar/webcrypto": "1.5.0", "@peculiar/x509": "1.12.3", "@turnkey/encoding": "0.6.0", "@turnkey/sdk-types": "0.6.3", "borsh": "2.0.0", "cbor-js": "0.1.0" } }, "sha512-UfRZrF7xTineWTW6iwRXqsDcyAtXhJNPlGs5+dnfOWRdLrlzVb7J4S2UVdn659TgLHyorh8dE3NJoxIfVUfU9g=="],
 
@@ -4706,6 +4720,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
+    "turbo": ["turbo@2.8.20", "", { "optionalDependencies": { "@turbo/darwin-64": "2.8.20", "@turbo/darwin-arm64": "2.8.20", "@turbo/linux-64": "2.8.20", "@turbo/linux-arm64": "2.8.20", "@turbo/windows-64": "2.8.20", "@turbo/windows-arm64": "2.8.20" }, "bin": { "turbo": "bin/turbo" } }, "sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "bun run --cwd .. build:grid-packages && bun run --cwd .. build:llm-packages && bun run --cwd .. build:solana-packages && bun run --cwd .. build:wallet-packages && bun run --cwd .. build:db-packages && bun run --cwd .. build:shared-packages",
+    "predev": "bun run --cwd .. build:packages",
     "dev": "next dev --turbopack",
     "generate-grpc": "buf generate src/lib/proto",
-    "prebuild": "bun run --cwd .. build:grid-packages && bun run --cwd .. build:llm-packages && bun run --cwd .. build:solana-packages && bun run --cwd .. build:wallet-packages && bun run --cwd .. build:db-packages && bun run --cwd .. build:shared-packages",
+    "prebuild": "bun run --cwd .. build:packages",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "license": "ISC",
   "type": "module",
+  "packageManager": "bun@1.3.11",
   "workspaces": [
     "admin",
     "app",
@@ -30,6 +31,7 @@
     "passkey:dev": "bun run --cwd passkey dev",
     "passkey:build": "bun run --cwd passkey build",
     "passkey:lint": "bun run --cwd passkey lint",
+    "build:packages": "turbo run build --filter='./packages/*'",
     "build:grid-packages": "bun run --cwd packages/grid-core build && bun run --cwd packages/auth-core build",
     "typecheck:grid-packages": "bun run --cwd packages/grid-core typecheck && bun run --cwd packages/auth-core typecheck",
     "build:solana-packages": "bun run --cwd packages/solana-rpc build && bun run --cwd packages/solana-wallet build",
@@ -60,19 +62,20 @@
     "lightningcss": "^1.30.2"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "@types/chai": "^4.3.0",
-    "@types/mocha": "^9.0.0",
+    "@commitlint/cli": "^20.1.0",
+    "@commitlint/config-conventional": "^20.0.0",
     "@magicblock-labs/ephemeral-rollups-sdk": "0.8.0",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.0",
-    "tweetnacl": "^1.0.3",
-    "@commitlint/cli": "^20.1.0",
-    "@commitlint/config-conventional": "^20.0.0",
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
     "mocha": "^9.0.3",
     "prettier": "^2.6.2",
     "ts-mocha": "^10.0.0",
+    "turbo": "^2.8.20",
+    "tweetnacl": "^1.0.3",
     "typescript": "^5.7.3"
   }
 }

--- a/passkey/package.json
+++ b/passkey/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "packageManager": "bun@1.2.17",
   "scripts": {
-    "predev": "bun run --cwd .. build:grid-packages",
+    "predev": "bun run --cwd .. build:packages",
     "dev": "next dev --turbopack",
-    "pretest": "bun run --cwd .. build:grid-packages",
-    "prebuild": "bun run --cwd .. build:grid-packages",
+    "pretest": "bun run --cwd .. build:packages",
+    "prebuild": "bun run --cwd .. build:packages",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["*"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Replaces sequential `predev`/`prebuild` package build chains across all apps with `turbo run build --filter='./packages/*'`, which parallelizes builds based on the workspace dependency graph and caches unchanged packages. First run builds in ~8s (vs sequential), cached runs complete in ~2.5s.