### PR TITLE
fix(wallet): reserve network fees in max send flows

### DIFF
--- a/app/src/components/wallet/SendSheet.tsx
+++ b/app/src/components/wallet/SendSheet.tsx
@@ -24,7 +24,6 @@ import {
   MAX_RECENT_RECIPIENTS,
   RECENT_RECIPIENTS_KEY,
   SOL_PRICE_USD,
-  SOLANA_FEE_SOL,
 } from "@/lib/constants";
 import { fetchSolUsdPrice } from "@/lib/solana/fetch-sol-price";
 import { resolveTokenIcon } from "@/lib/solana/token-holdings";
@@ -34,6 +33,13 @@ import {
   getCloudValue,
   setCloudValue,
 } from "@/lib/telegram/mini-app/cloud-storage";
+
+import {
+  getMaxAmountWithFeeReserve,
+  getSendFeeReserveSol,
+  hasEnoughSolForFee,
+  type WalletSendFlow,
+} from "./fee-reserve";
 
 // iOS-style sheet timing (shared with other sheets)
 const SHEET_TRANSITION = "transform 0.4s cubic-bezier(0.32, 0.72, 0, 1)";
@@ -384,7 +390,22 @@ export default function SendSheet({
     ? isSolPriceLoadingProp ?? solPriceUsd === null
     : isSolPriceLoadingState;
   const balanceInUsd = solPriceUsd ? balanceInSol * solPriceUsd : null;
-  const solanaFeeUsd = solPriceUsd ? SOLANA_FEE_SOL * solPriceUsd : null;
+  const tokenSymbol = selectedToken?.symbol || "SOL";
+  const isSecuredTransfer = selectedToken?.isSecured === true;
+  const recipientTrimmed = recipient.trim();
+  const sendFlow: WalletSendFlow =
+    isValidTelegramUsername(recipientTrimmed) || isSecuredTransfer
+      ? "private-send"
+      : "direct-sol-send";
+  const sendFeeReserveSol = getSendFeeReserveSol(sendFlow);
+  const sendFeeUsd = solPriceUsd ? sendFeeReserveSol * solPriceUsd : null;
+  const maxSendAmountInSol = getMaxAmountWithFeeReserve({
+    assetBalance: balanceInSol,
+    feePayerSolBalance: walletBalanceInSol,
+    feeReserveSol: sendFeeReserveSol,
+    amountAndFeeUseSameSolBalance: sendFlow === "direct-sol-send",
+  });
+  const maxSendAmountInUsd = solPriceUsd ? maxSendAmountInSol * solPriceUsd : 0;
 
   useEffect(() => {
     setMounted(true);
@@ -565,7 +586,6 @@ export default function SendSheet({
       return;
     }
 
-    const recipientTrimmed = recipient.trim();
     const isRecipientValid =
       isValidSolanaAddress(recipientTrimmed) ||
       isValidTelegramUsername(recipientTrimmed);
@@ -586,31 +606,30 @@ export default function SendSheet({
 
     const amountInSol =
       currency === "SOL" ? amount : solPriceUsd ? amount / solPriceUsd : NaN;
-    const hasEnoughBalance = !isNaN(amountInSol) && amountInSol <= balanceInSol;
+    const hasEnoughBalance =
+      !isNaN(amountInSol) && amountInSol <= maxSendAmountInSol;
+    const canCoverNetworkFees = hasEnoughSolForFee(
+      walletBalanceInSol,
+      sendFeeReserveSol
+    );
 
     if (step === 3) {
       const isValid =
         isAmountValid &&
         isRecipientValid &&
         hasEnoughBalance &&
+        canCoverNetworkFees &&
         (currency === "SOL" || !!solPriceUsd);
       onValidationChange?.(isValid);
       return;
     }
 
     if (step === 4) {
-      // Secured token tx fees are paid from the regular SOL wallet,
-      // not the token balance. For regular SOL, both come from the same balance.
-      const isSecuredTransfer = selectedToken?.isSecured === true;
-      const hasEnoughSolForFee = isSecuredTransfer
-        ? walletBalanceInSol >= SOLANA_FEE_SOL
-        : balanceInSol >= amountInSol + SOLANA_FEE_SOL;
-
       const isValid =
         isAmountValid &&
         isRecipientValid &&
         hasEnoughBalance &&
-        hasEnoughSolForFee &&
+        canCoverNetworkFees &&
         (currency === "SOL" || !!solPriceUsd);
       onValidationChange?.(isValid);
       return;
@@ -624,10 +643,11 @@ export default function SendSheet({
     open,
     onValidationChange,
     currency,
-    balanceInSol,
+    maxSendAmountInSol,
     walletBalanceInSol,
-    selectedToken,
     solPriceUsd,
+    recipientTrimmed,
+    sendFeeReserveSol,
   ]);
 
   const handleRecipientSelect = (selected: string) => {
@@ -660,17 +680,14 @@ export default function SendSheet({
     setTokenSearchQuery("");
     onStepChange(2);
   };
-
-  const tokenSymbol = selectedToken?.symbol || "SOL";
-
   // Insufficient balance check
   const insufficientBalance = useMemo(() => {
     const val = parseFloat(amountStr);
     if (isNaN(val) || val <= 0) return false;
     const amountInSol =
       currency === "SOL" ? val : solPriceUsd ? val / solPriceUsd : NaN;
-    return amountInSol > balanceInSol;
-  }, [amountStr, currency, solPriceUsd, balanceInSol]);
+    return amountInSol > maxSendAmountInSol;
+  }, [amountStr, currency, maxSendAmountInSol, solPriceUsd]);
 
   // Sheet animation handlers
   const unmount = useCallback(() => {
@@ -1361,32 +1378,17 @@ export default function SendSheet({
                 <button
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
-                    const isSecured = selectedToken?.isSecured === true;
                     if (currency === "SOL") {
                       const maxVal = truncateDecimals(
-                        Math.max(
-                          0,
-                          isSecured
-                            ? balanceInSol
-                            : balanceInSol - SOLANA_FEE_SOL
-                        ),
+                        Math.max(0, maxSendAmountInSol),
                         4
                       ).replace(/\.?0+$/, "");
                       handlePresetAmount(maxVal || "0");
                     } else {
-                      const feeUsd = solPriceUsd
-                        ? SOLANA_FEE_SOL * solPriceUsd
-                        : 0;
-                      const maxVal =
-                        balanceInUsd !== null
-                          ? truncateDecimals(
-                              Math.max(
-                                0,
-                                isSecured ? balanceInUsd : balanceInUsd - feeUsd
-                              ),
-                              2
-                            ).replace(/\.?0+$/, "")
-                          : "0";
+                      const maxVal = truncateDecimals(
+                        Math.max(0, maxSendAmountInUsd),
+                        2
+                      ).replace(/\.?0+$/, "");
                       handlePresetAmount(maxVal || "0");
                     }
                   }}
@@ -1533,12 +1535,11 @@ export default function SendSheet({
                   </p>
                   <div className="flex items-baseline text-base leading-5">
                     <span className="text-black">
-                      {SOLANA_FEE_SOL.toFixed(6).replace(/\.?0+$/, "")}{" "}
-                      {tokenSymbol}
+                      {sendFeeReserveSol.toFixed(6).replace(/\.?0+$/, "")} SOL
                     </span>
                     <span style={{ color: "rgba(60, 60, 67, 0.6)" }}>
-                      {solanaFeeUsd !== null
-                        ? ` ≈ $${solanaFeeUsd.toFixed(2)}`
+                      {sendFeeUsd !== null
+                        ? ` ≈ $${sendFeeUsd.toFixed(2)}`
                         : " ≈ $—"}
                     </span>
                   </div>
@@ -1561,12 +1562,14 @@ export default function SendSheet({
                     <span className="text-black">
                       {(() => {
                         const val = parseFloat(amountStr);
-                        const feeStr = SOLANA_FEE_SOL.toFixed(6).replace(
+                        const feeStr = sendFeeReserveSol.toFixed(6).replace(
                           /\.?0+$/,
                           ""
                         );
                         if (isNaN(val)) {
-                          return `${feeStr} ${tokenSymbol}`;
+                          return sendFlow === "direct-sol-send"
+                            ? `${feeStr} ${tokenSymbol}`
+                            : `${feeStr} SOL`;
                         }
                         const solVal =
                           currency === "SOL"
@@ -1574,19 +1577,25 @@ export default function SendSheet({
                             : solPriceUsd
                             ? val / solPriceUsd
                             : NaN;
-                        const total = solVal + SOLANA_FEE_SOL;
+                        if (sendFlow !== "direct-sol-send") {
+                          if (isNaN(solVal)) return `${feeStr} SOL`;
+                          const amountLabel =
+                            currency === "SOL"
+                              ? `${solVal.toFixed(6).replace(/\.?0+$/, "")} ${tokenSymbol}`
+                              : `${val.toFixed(2).replace(/\.?0+$/, "")} USD`;
+                          return `${amountLabel} + ${feeStr} SOL`;
+                        }
+                        const total = solVal + sendFeeReserveSol;
                         if (isNaN(total)) return `${feeStr} ${tokenSymbol}`;
-                        return `${total
-                          .toFixed(6)
-                          .replace(/\.?0+$/, "")} ${tokenSymbol}`;
+                        return `${total.toFixed(6).replace(/\.?0+$/, "")} ${tokenSymbol}`;
                       })()}
                     </span>
                     <span style={{ color: "rgba(60, 60, 67, 0.6)" }}>
                       {(() => {
                         const val = parseFloat(amountStr);
                         if (isNaN(val)) {
-                          return solanaFeeUsd !== null
-                            ? ` ≈ $${solanaFeeUsd.toFixed(2)}`
+                          return sendFeeUsd !== null
+                            ? ` ≈ $${sendFeeUsd.toFixed(2)}`
                             : " ≈ $—";
                         }
                         const usdVal =
@@ -1599,8 +1608,8 @@ export default function SendSheet({
                           return " ≈ $—";
                         }
                         const totalUsd =
-                          solanaFeeUsd !== null
-                            ? usdVal + solanaFeeUsd
+                          sendFeeUsd !== null
+                            ? usdVal + sendFeeUsd
                             : usdVal;
                         return ` ≈ $${totalUsd.toLocaleString("en-US", {
                           minimumFractionDigits: 2,

--- a/app/src/components/wallet/SwapSheet.tsx
+++ b/app/src/components/wallet/SwapSheet.tsx
@@ -10,7 +10,6 @@ import { useTelegramSafeArea } from "@/hooks/useTelegramSafeArea";
 import {
   NATIVE_SOL_MINT,
   SOL_PRICE_USD,
-  SOLANA_FEE_SOL,
   SOLANA_USDC_MINT_DEVNET,
   SOLANA_USDC_MINT_MAINNET,
   SOLANA_USDT_MINT_MAINNET,
@@ -23,6 +22,12 @@ import {
   type TokenHolding,
 } from "@/lib/solana/token-holdings";
 import { hideAllButtons } from "@/lib/telegram/mini-app/buttons";
+
+import {
+  getMaxAmountWithFeeReserve,
+  getSwapFeeReserveSol,
+  getSwapFlowFeeProfile,
+} from "./fee-reserve";
 
 // iOS-style sheet timing (shared with other sheets)
 const SHEET_TRANSITION = "transform 0.4s cubic-bezier(0.32, 0.72, 0, 1)";
@@ -293,6 +298,10 @@ export default function SwapSheet({
     }
     return tokenHoldings.map(holdingToToken);
   }, [tokenHoldings]);
+  const regularSolBalance =
+    availableTokens.find(
+      (token) => token.mint === NATIVE_SOL_MINT && token.isSecured !== true
+    )?.balance ?? 0;
 
   // Secure mode state
   const [secureToken, setSecureToken] = useState<Token>(
@@ -534,21 +543,48 @@ export default function SwapSheet({
     return receiveAmount * toToken.priceUsd;
   }, [receiveAmount, toToken.priceUsd]);
 
+  const swapFeeProfile = getSwapFlowFeeProfile({
+    activeTab: "swap",
+    secureDirection,
+    amountMint: fromToken.mint,
+  });
+  const swapFeeReserveSol = getSwapFeeReserveSol(swapFeeProfile.flow);
+  const maxSwapAmount = getMaxAmountWithFeeReserve({
+    assetBalance: fromToken.balance,
+    feePayerSolBalance: regularSolBalance,
+    feeReserveSol: swapFeeReserveSol,
+    amountAndFeeUseSameSolBalance:
+      swapFeeProfile.amountAndFeeUseSameSolBalance,
+  });
+  const secureFeeProfile = getSwapFlowFeeProfile({
+    activeTab: "secure",
+    secureDirection,
+    amountMint: secureToken.mint,
+  });
+  const secureFeeReserveSol = getSwapFeeReserveSol(secureFeeProfile.flow);
+  const maxSecureAmount = getMaxAmountWithFeeReserve({
+    assetBalance: secureToken.balance,
+    feePayerSolBalance: regularSolBalance,
+    feeReserveSol: secureFeeReserveSol,
+    amountAndFeeUseSameSolBalance:
+      secureFeeProfile.amountAndFeeUseSameSolBalance,
+  });
+
   // Check if swap is valid
   const isSwapValid = useMemo(() => {
     const val = parseFloat(amountStr);
     if (isNaN(val) || val <= 0) return false;
-    if (val > fromToken.balance) return false;
+    if (val > maxSwapAmount) return false;
     return true;
-  }, [amountStr, fromToken.balance]);
+  }, [amountStr, maxSwapAmount]);
 
   // Check if secure is valid
   const isSecureValid = useMemo(() => {
     const val = parseFloat(secureAmountStr);
     if (isNaN(val) || val <= 0) return false;
-    if (val > secureToken.balance) return false;
+    if (val > maxSecureAmount) return false;
     return true;
-  }, [secureAmountStr, secureToken.balance]);
+  }, [secureAmountStr, maxSecureAmount]);
 
   // Calculate secure USD value
   const secureUsdValue = useMemo(() => {
@@ -610,11 +646,13 @@ export default function SwapSheet({
   const insufficientBalance = useMemo(() => {
     const val = parseFloat(amountStr);
     if (isNaN(val) || val <= 0) return false;
-    if (fromToken.symbol === "SOL") {
-      return val + SOLANA_FEE_SOL > fromToken.balance;
-    }
-    return val > fromToken.balance;
-  }, [amountStr, fromToken.balance, fromToken.symbol]);
+    return val > maxSwapAmount;
+  }, [amountStr, maxSwapAmount]);
+  const secureInsufficientBalance = useMemo(() => {
+    const val = parseFloat(secureAmountStr);
+    if (isNaN(val) || val <= 0) return false;
+    return val > maxSecureAmount;
+  }, [maxSecureAmount, secureAmountStr]);
 
   // Swap from/to tokens
   const handleSwapTokens = useCallback(() => {
@@ -680,10 +718,8 @@ export default function SwapSheet({
   const handlePresetPercentage = useCallback(
     (percentage: number) => {
       hapticFeedback.impactOccurred("light");
-      let amount = fromToken.balance * (percentage / 100);
-      if (percentage === 100 && fromToken.symbol === "SOL") {
-        amount = Math.max(0, amount - SOLANA_FEE_SOL);
-      }
+      const amount =
+        percentage === 100 ? maxSwapAmount : fromToken.balance * (percentage / 100);
       const formatted =
         amount
           .toFixed(getMaxDecimals(fromToken.symbol))
@@ -691,7 +727,7 @@ export default function SwapSheet({
       setAmountStr(formatted);
       amountInputRef.current?.focus({ preventScroll: true });
     },
-    [fromToken.balance, fromToken.symbol]
+    [fromToken.balance, fromToken.symbol, maxSwapAmount]
   );
 
   // Open secure token selector
@@ -722,14 +758,10 @@ export default function SwapSheet({
   const handleSecurePresetPercentage = useCallback(
     (percentage: number) => {
       hapticFeedback.impactOccurred("light");
-      let amount = secureToken.balance * (percentage / 100);
-      if (
-        percentage === 100 &&
-        secureToken.symbol === "SOL" &&
-        secureDirection === "shield"
-      ) {
-        amount = Math.max(0, amount - SOLANA_FEE_SOL);
-      }
+      const amount =
+        percentage === 100
+          ? maxSecureAmount
+          : secureToken.balance * (percentage / 100);
       const formatted =
         amount
           .toFixed(getMaxDecimals(secureToken.symbol))
@@ -737,7 +769,7 @@ export default function SwapSheet({
       setSecureAmountStr(formatted);
       secureAmountInputRef.current?.focus({ preventScroll: true });
     },
-    [secureToken.balance, secureToken.symbol, secureDirection]
+    [maxSecureAmount, secureToken.balance, secureToken.symbol]
   );
 
   // Handler wrappers for TokenSelectView callbacks
@@ -1523,21 +1555,14 @@ export default function SwapSheet({
                 </div>
 
                 {/* Insufficient balance error */}
-                {(() => {
-                  const val = parseFloat(secureAmountStr);
-                  if (isNaN(val) || val <= 0) return null;
-                  if (val > secureToken.balance) {
-                    return (
-                      <p
-                        className="text-[13px] leading-4 px-1"
-                        style={{ color: "#f9363c" }}
-                      >
-                        Insufficient balance
-                      </p>
-                    );
-                  }
-                  return null;
-                })()}
+                {secureInsufficientBalance && (
+                  <p
+                    className="text-[13px] leading-4 px-1"
+                    style={{ color: "#f9363c" }}
+                  >
+                    Insufficient balance
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/app/src/components/wallet/__tests__/fee-reserve.test.ts
+++ b/app/src/components/wallet/__tests__/fee-reserve.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import { NATIVE_SOL_MINT, SOLANA_FEE_SOL } from "@/lib/constants";
+
+import {
+  getMaxAmountWithFeeReserve,
+  getSendFeeReserveSol,
+  getSwapFeeReserveSol,
+  getSwapFlowFeeProfile,
+  hasEnoughSolForFee,
+} from "../fee-reserve";
+
+describe("wallet fee reserve helpers", () => {
+  test("uses a single fee for direct SOL sends", () => {
+    expect(getSendFeeReserveSol("direct-sol-send")).toBe(SOLANA_FEE_SOL);
+  });
+
+  test("reserves three fees for private sends", () => {
+    expect(getSendFeeReserveSol("private-send")).toBe(SOLANA_FEE_SOL * 3);
+  });
+
+  test("maps secure native SOL shield flow to the highest fee reserve path", () => {
+    expect(
+      getSwapFlowFeeProfile({
+        activeTab: "secure",
+        secureDirection: "shield",
+        amountMint: NATIVE_SOL_MINT,
+      })
+    ).toEqual({
+      flow: "shield-native-sol",
+      amountAndFeeUseSameSolBalance: true,
+    });
+    expect(getSwapFeeReserveSol("shield-native-sol")).toBe(SOLANA_FEE_SOL * 6);
+  });
+
+  test("treats unshielded native SOL fees as coming from the regular wallet", () => {
+    expect(
+      getSwapFlowFeeProfile({
+        activeTab: "secure",
+        secureDirection: "unshield",
+        amountMint: NATIVE_SOL_MINT,
+      })
+    ).toEqual({
+      flow: "unshield-native-sol",
+      amountAndFeeUseSameSolBalance: false,
+    });
+    expect(getSwapFeeReserveSol("unshield-native-sol")).toBe(
+      SOLANA_FEE_SOL * 5
+    );
+  });
+
+  test("subtracts the fee reserve when amount and fees use the same SOL balance", () => {
+    expect(
+      getMaxAmountWithFeeReserve({
+        assetBalance: 1,
+        feePayerSolBalance: 1,
+        feeReserveSol: SOLANA_FEE_SOL * 2,
+        amountAndFeeUseSameSolBalance: true,
+      })
+    ).toBe(1 - SOLANA_FEE_SOL * 2);
+  });
+
+  test("caps max amount at zero when a separate SOL fee payer cannot cover fees", () => {
+    expect(
+      getMaxAmountWithFeeReserve({
+        assetBalance: 25,
+        feePayerSolBalance: SOLANA_FEE_SOL * 2,
+        feeReserveSol: SOLANA_FEE_SOL * 3,
+        amountAndFeeUseSameSolBalance: false,
+      })
+    ).toBe(0);
+    expect(hasEnoughSolForFee(SOLANA_FEE_SOL * 2, SOLANA_FEE_SOL * 3)).toBe(
+      false
+    );
+  });
+
+  test("allows the full asset balance when fees are paid from a separate SOL balance", () => {
+    expect(
+      getMaxAmountWithFeeReserve({
+        assetBalance: 25,
+        feePayerSolBalance: SOLANA_FEE_SOL * 4,
+        feeReserveSol: SOLANA_FEE_SOL * 3,
+        amountAndFeeUseSameSolBalance: false,
+      })
+    ).toBe(25);
+  });
+});

--- a/app/src/components/wallet/fee-reserve.ts
+++ b/app/src/components/wallet/fee-reserve.ts
@@ -1,0 +1,82 @@
+import { NATIVE_SOL_MINT, SOLANA_FEE_SOL } from "@/lib/constants";
+
+export type WalletSendFlow = "direct-sol-send" | "private-send";
+
+export type WalletSwapFlow =
+  | "swap"
+  | "shield-native-sol"
+  | "shield-token"
+  | "unshield-native-sol"
+  | "unshield-token";
+
+const FEE_TX_COUNT_BY_SEND_FLOW: Record<WalletSendFlow, number> = {
+  "direct-sol-send": 1,
+  "private-send": 3,
+};
+
+const FEE_TX_COUNT_BY_SWAP_FLOW: Record<WalletSwapFlow, number> = {
+  swap: 1,
+  "shield-native-sol": 6,
+  "shield-token": 4,
+  "unshield-native-sol": 5,
+  "unshield-token": 3,
+};
+
+export function getSendFeeReserveSol(flow: WalletSendFlow): number {
+  return FEE_TX_COUNT_BY_SEND_FLOW[flow] * SOLANA_FEE_SOL;
+}
+
+export function getSwapFeeReserveSol(flow: WalletSwapFlow): number {
+  return FEE_TX_COUNT_BY_SWAP_FLOW[flow] * SOLANA_FEE_SOL;
+}
+
+export function getSwapFlowFeeProfile(params: {
+  activeTab: "swap" | "secure";
+  secureDirection: "shield" | "unshield";
+  amountMint?: string | null;
+}): {
+  flow: WalletSwapFlow;
+  amountAndFeeUseSameSolBalance: boolean;
+} {
+  if (params.activeTab === "swap") {
+    return {
+      flow: "swap",
+      amountAndFeeUseSameSolBalance: params.amountMint === NATIVE_SOL_MINT,
+    };
+  }
+
+  const isNativeSol = params.amountMint === NATIVE_SOL_MINT;
+  if (params.secureDirection === "shield") {
+    return {
+      flow: isNativeSol ? "shield-native-sol" : "shield-token",
+      amountAndFeeUseSameSolBalance: isNativeSol,
+    };
+  }
+
+  return {
+    flow: isNativeSol ? "unshield-native-sol" : "unshield-token",
+    amountAndFeeUseSameSolBalance: false,
+  };
+}
+
+export function hasEnoughSolForFee(
+  feePayerSolBalance: number,
+  feeReserveSol: number
+): boolean {
+  return feePayerSolBalance >= feeReserveSol;
+}
+
+export function getMaxAmountWithFeeReserve(params: {
+  assetBalance: number;
+  feePayerSolBalance: number;
+  feeReserveSol: number;
+  amountAndFeeUseSameSolBalance: boolean;
+}): number {
+  if (params.amountAndFeeUseSameSolBalance) {
+    return Math.max(0, params.assetBalance - params.feeReserveSol);
+  }
+
+  return hasEnoughSolForFee(params.feePayerSolBalance, params.feeReserveSol)
+    ? params.assetBalance
+    : 0;
+}


### PR DESCRIPTION
Reserve enough SOL for network fees across the Telegram mini-app wallet MAX actions and validation paths. This centralizes fee reserve logic for send, swap, shield, and unshield flows and adds focused fee-cap tests.