### PR TITLE
feat(analytics): unify Mixpanel workspace attribution

### DIFF
--- a/app/src/lib/core/__tests__/analytics.test.ts
+++ b/app/src/lib/core/__tests__/analytics.test.ts
@@ -12,12 +12,19 @@ const createClientCalls: Array<Record<string, unknown>> = [];
 const trackCalls: Array<{ event: string; properties?: Record<string, unknown> }> = [];
 const identifyCalls: string[] = [];
 const setUserProfileCalls: Array<Record<string, unknown>> = [];
+const setUserProfileOnceCalls: Array<Record<string, unknown>> = [];
+const unionUserProfileCalls: Array<Record<string, unknown>> = [];
 
 let currentEventContext: Record<string, unknown> = {};
+let currentDefaultEventProperties: Record<string, unknown> = {};
 
 mock.module("@loyal-labs/shared/analytics", () => ({
   createMixpanelBrowserClient: (config: Record<string, unknown>) => {
     createClientCalls.push(config);
+    currentDefaultEventProperties = {
+      ...((config.defaultEventProperties as Record<string, unknown> | undefined) ??
+        {}),
+    };
     return {
       init: async () => {},
       setContext: (properties: Record<string, unknown>) => {
@@ -30,6 +37,7 @@ mock.module("@loyal-labs/shared/analytics", () => ({
         trackCalls.push({
           event,
           properties: {
+            ...currentDefaultEventProperties,
             ...currentEventContext,
             ...(properties ?? {}),
           },
@@ -42,12 +50,31 @@ mock.module("@loyal-labs/shared/analytics", () => ({
       setUserProfile: (properties: Record<string, unknown>) => {
         setUserProfileCalls.push(properties);
       },
-      setUserProfileOnce: () => {},
+      setUserProfileOnce: (properties: Record<string, unknown>) => {
+        setUserProfileOnceCalls.push(properties);
+      },
+      unionUserProfile: (properties: Record<string, unknown>) => {
+        unionUserProfileCalls.push(properties);
+      },
       __resetForTests: () => {
         currentEventContext = {};
+        currentDefaultEventProperties = {};
       },
     };
   },
+  createWorkspaceProfileUpdate: (workspace: string) => ({
+    set: {
+      last_workspace: workspace,
+      [`${workspace}_last_seen_at`]: "2026-03-26T00:00:00.000Z",
+    },
+    setOnce: {
+      first_workspace: workspace,
+      [`${workspace}_first_seen_at`]: "2026-03-26T00:00:00.000Z",
+    },
+    union: {
+      workspaces: [workspace],
+    },
+  }),
 }));
 
 mock.module("@/lib/core/config/public", () => ({
@@ -76,7 +103,10 @@ describe("app analytics facade", () => {
     trackCalls.length = 0;
     identifyCalls.length = 0;
     setUserProfileCalls.length = 0;
+    setUserProfileOnceCalls.length = 0;
+    unionUserProfileCalls.length = 0;
     currentEventContext = {};
+    currentDefaultEventProperties = {};
     analytics.__resetAnalyticsStateForTests();
   });
 
@@ -93,7 +123,11 @@ describe("app analytics facade", () => {
         apiHost: "https://loyal.example/ingest",
         debug: true,
         persistence: "localStorage",
+        defaultEventProperties: {
+          workspace: "miniapp",
+        },
         registerProperties: {
+          workspace: "miniapp",
           app_mode: "demo",
           app_solana_env: "devnet",
         },
@@ -116,13 +150,28 @@ describe("app analytics facade", () => {
     analytics.identifyTelegramUser(identity);
 
     expect(identifyCalls).toEqual(["tg:123456789"]);
-    expect(setUserProfileCalls).toHaveLength(1);
+    expect(setUserProfileCalls).toHaveLength(2);
     expect(setUserProfileCalls[0]).toMatchObject({
       telegram_id: "123456789",
       telegram_username: "ada",
       telegram_language_code: "en",
       telegram_is_premium: true,
     });
+    expect(setUserProfileCalls[1]).toEqual({
+      last_workspace: "miniapp",
+      miniapp_last_seen_at: "2026-03-26T00:00:00.000Z",
+    });
+    expect(setUserProfileOnceCalls).toEqual([
+      {
+        first_workspace: "miniapp",
+        miniapp_first_seen_at: "2026-03-26T00:00:00.000Z",
+      },
+    ]);
+    expect(unionUserProfileCalls).toEqual([
+      {
+        workspaces: ["miniapp"],
+      },
+    ]);
   });
 
   test("refreshes the Telegram profile when tracked fields change", () => {
@@ -140,8 +189,12 @@ describe("app analytics facade", () => {
     });
 
     expect(identifyCalls).toEqual(["tg:123456789"]);
-    expect(setUserProfileCalls).toHaveLength(2);
+    expect(setUserProfileCalls).toHaveLength(3);
     expect(setUserProfileCalls[1]).toMatchObject({
+      last_workspace: "miniapp",
+      miniapp_last_seen_at: "2026-03-26T00:00:00.000Z",
+    });
+    expect(setUserProfileCalls[2]).toMatchObject({
       telegram_language_code: "es",
     });
   });
@@ -159,6 +212,7 @@ describe("app analytics facade", () => {
       {
         event: "Page View",
         properties: {
+          workspace: "miniapp",
           start_param_raw: VALID_START_PARAM,
           group_chat_id: GROUP_CHAT_ID,
           summary_id: SUMMARY_ID,
@@ -180,6 +234,7 @@ describe("app analytics facade", () => {
       {
         event: "Page View",
         properties: {
+          workspace: "miniapp",
           start_param_raw: "none",
           group_chat_id: "none",
           summary_id: "none",
@@ -203,6 +258,7 @@ describe("app analytics facade", () => {
       {
         event: "Page View",
         properties: {
+          workspace: "miniapp",
           path: "/telegram/wallet",
         },
       },

--- a/app/src/lib/core/analytics.ts
+++ b/app/src/lib/core/analytics.ts
@@ -4,6 +4,7 @@ import {
   type AnalyticsClient,
   type AnalyticsProperties,
   createMixpanelBrowserClient,
+  createWorkspaceProfileUpdate,
 } from "@loyal-labs/shared/analytics";
 
 import { publicEnv } from "@/lib/core/config/public";
@@ -19,6 +20,7 @@ let lastProfiledDistinctId: string | null = null;
 let lastProfileFingerprint: string | null = null;
 
 const TELEGRAM_IDENTITY_PROVIDER = "telegram" as const;
+const MINIAPP_WORKSPACE = "miniapp" as const;
 
 function normalizeOptionalString(value: string | undefined): string | null {
   if (!value) {
@@ -49,12 +51,18 @@ function getAnalyticsClient(): AnalyticsClient {
     apiHost: getApiHost(),
     debug: isDevnetDemoMode,
     persistence: "localStorage",
-    registerProperties: isDevnetDemoMode
-      ? {
-          app_mode: "demo",
-          app_solana_env: "devnet",
-        }
-      : undefined,
+    defaultEventProperties: {
+      workspace: MINIAPP_WORKSPACE,
+    },
+    registerProperties: {
+      workspace: MINIAPP_WORKSPACE,
+      ...(isDevnetDemoMode
+        ? {
+            app_mode: "demo",
+            app_solana_env: "devnet",
+          }
+        : {}),
+    },
   });
 
   return analyticsClient;
@@ -144,8 +152,9 @@ export function identifyTelegramUser(identity: TelegramIdentity | null): void {
   const client = getAnalyticsClient();
   const distinctId = `tg:${identity.telegramId}`;
   const profileFingerprint = buildTelegramProfileFingerprint(identity);
+  const shouldRefreshWorkspaceProfile = lastIdentifiedDistinctId !== distinctId;
 
-  if (lastIdentifiedDistinctId !== distinctId) {
+  if (shouldRefreshWorkspaceProfile) {
     client.identify(distinctId);
     lastIdentifiedDistinctId = distinctId;
   }
@@ -157,6 +166,14 @@ export function identifyTelegramUser(identity: TelegramIdentity | null): void {
     client.setUserProfile(buildTelegramProfileProperties(identity));
     lastProfiledDistinctId = distinctId;
     lastProfileFingerprint = profileFingerprint;
+  }
+
+  if (shouldRefreshWorkspaceProfile) {
+    const workspaceProfileUpdate =
+      createWorkspaceProfileUpdate(MINIAPP_WORKSPACE);
+    client.unionUserProfile(workspaceProfileUpdate.union);
+    client.setUserProfileOnce(workspaceProfileUpdate.setOnce);
+    client.setUserProfile(workspaceProfileUpdate.set);
   }
 }
 

--- a/app/src/lib/telegram/bot-api/__tests__/analytics.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/analytics.test.ts
@@ -1,0 +1,171 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const mixpanelInitTokens: string[] = [];
+const mixpanelTrackCalls: Array<{
+  eventName: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleSetCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleSetOnceCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleUnionCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+
+mock.module("mixpanel", () => ({
+  default: {
+    init: (token: string) => {
+      mixpanelInitTokens.push(token);
+      return {
+        track: (
+          eventName: string,
+          properties: Record<string, unknown>,
+          callback?: (error?: unknown) => void
+        ) => {
+          mixpanelTrackCalls.push({ eventName, properties });
+          callback?.();
+        },
+        people: {
+          set: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          set_once: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetOnceCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          union: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleUnionCalls.push({ distinctId, properties });
+            callback?.();
+          },
+        },
+      };
+    },
+  },
+}));
+
+let analytics: typeof import("../analytics");
+
+describe("bot analytics helpers", () => {
+  beforeAll(async () => {
+    analytics = await import("../analytics");
+  });
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_MIXPANEL_TOKEN = "test-mixpanel-token";
+    mixpanelInitTokens.length = 0;
+    mixpanelTrackCalls.length = 0;
+    mixpanelPeopleSetCalls.length = 0;
+    mixpanelPeopleSetOnceCalls.length = 0;
+    mixpanelPeopleUnionCalls.length = 0;
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+  });
+
+  test("tracks bot events with workspace and updates profile adoption for users", () => {
+    analytics.trackBotEvent(
+      "Bot /start Command",
+      analytics.createBotTrackingProperties({
+        chatId: -1009876543210,
+        chatType: "supergroup",
+        userId: 123456789,
+      })
+    );
+
+    expect(mixpanelInitTokens).toEqual(["test-mixpanel-token"]);
+    expect(mixpanelTrackCalls).toEqual([
+      {
+        eventName: "Bot /start Command",
+        properties: {
+          workspace: "bot",
+          distinct_id: "tg:123456789",
+          telegram_chat_id: "-1009876543210",
+          telegram_chat_type: "supergroup",
+          telegram_user_id: "123456789",
+        },
+      },
+    ]);
+    expect(mixpanelPeopleUnionCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          workspaces: ["bot"],
+        },
+      },
+    ]);
+    expect(mixpanelPeopleSetOnceCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          first_workspace: "bot",
+          bot_first_seen_at: expect.any(String),
+        },
+      },
+    ]);
+    expect(mixpanelPeopleSetCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          last_workspace: "bot",
+          bot_last_seen_at: expect.any(String),
+        },
+      },
+    ]);
+  });
+
+  test("skips profile adoption updates when only a chat fallback distinct id exists", () => {
+    analytics.trackBotEvent(
+      "Bot Added to Group",
+      analytics.createBotTrackingProperties({
+        chatId: -1009876543210,
+        chatType: "supergroup",
+      })
+    );
+
+    expect(mixpanelTrackCalls).toEqual([
+      {
+        eventName: "Bot Added to Group",
+        properties: {
+          workspace: "bot",
+          distinct_id: "tg-chat:-1009876543210",
+          telegram_chat_id: "-1009876543210",
+          telegram_chat_type: "supergroup",
+          telegram_user_id: null,
+        },
+      },
+    ]);
+    expect(mixpanelPeopleUnionCalls).toHaveLength(0);
+    expect(mixpanelPeopleSetOnceCalls).toHaveLength(0);
+    expect(mixpanelPeopleSetCalls).toHaveLength(0);
+  });
+});

--- a/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/commands-summary.test.ts
@@ -26,6 +26,18 @@ const mixpanelTrackCalls: Array<{
   eventName: string;
   properties: Record<string, unknown>;
 }> = [];
+const mixpanelPeopleSetCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleSetOnceCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleUnionCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
 let sendStartCarouselShouldThrow = false;
 let sendStartCarouselCalls = 0;
 let autoCleanupReplyTexts: string[] = [];
@@ -42,6 +54,32 @@ mock.module("mixpanel", () => ({
         ) => {
           mixpanelTrackCalls.push({ eventName, properties });
           callback?.();
+        },
+        people: {
+          set: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          set_once: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetOnceCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          union: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleUnionCalls.push({ distinctId, properties });
+            callback?.();
+          },
         },
       };
     },
@@ -95,10 +133,12 @@ mock.module("../helper-message-cleanup", () => ({
     autoCleanupReplyTexts.push(text);
     await ctx.reply(text, options as never);
   },
+  sendMessageWithAutoCleanup: async () => {},
 }));
 
 let handleStartCommand: typeof import("../commands").handleStartCommand;
 let handleSummaryCommand: typeof import("../commands").handleSummaryCommand;
+let resetBotAnalyticsStateForTests: typeof import("../analytics").__resetBotAnalyticsStateForTests;
 
 function createStartCommandContext() {
   const ctx = {
@@ -142,6 +182,8 @@ describe("commands analytics tracking", () => {
     const loadedModule = await import("../commands");
     handleStartCommand = loadedModule.handleStartCommand;
     handleSummaryCommand = loadedModule.handleSummaryCommand;
+    ({ __resetBotAnalyticsStateForTests: resetBotAnalyticsStateForTests } =
+      await import("../analytics"));
   });
 
   beforeEach(() => {
@@ -151,9 +193,13 @@ describe("commands analytics tracking", () => {
     sendLatestSummaryCalls.length = 0;
     mixpanelInitTokens.length = 0;
     mixpanelTrackCalls.length = 0;
+    mixpanelPeopleSetCalls.length = 0;
+    mixpanelPeopleSetOnceCalls.length = 0;
+    mixpanelPeopleUnionCalls.length = 0;
     sendStartCarouselCalls = 0;
     sendStartCarouselShouldThrow = false;
     autoCleanupReplyTexts = [];
+    resetBotAnalyticsStateForTests();
   });
 
   afterEach(() => {
@@ -171,10 +217,37 @@ describe("commands analytics tracking", () => {
       {
         eventName: "Bot /start Command",
         properties: {
+          workspace: "bot",
           distinct_id: "tg:123456789",
           telegram_chat_id: "-1009876543210",
           telegram_chat_type: "supergroup",
           telegram_user_id: "123456789",
+        },
+      },
+    ]);
+    expect(mixpanelPeopleUnionCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          workspaces: ["bot"],
+        },
+      },
+    ]);
+    expect(mixpanelPeopleSetOnceCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          first_workspace: "bot",
+          bot_first_seen_at: expect.any(String),
+        },
+      },
+    ]);
+    expect(mixpanelPeopleSetCalls).toEqual([
+      {
+        distinctId: "tg:123456789",
+        properties: {
+          last_workspace: "bot",
+          bot_last_seen_at: expect.any(String),
         },
       },
     ]);
@@ -202,6 +275,7 @@ describe("commands analytics tracking", () => {
       {
         eventName: "Bot /summary Command",
         properties: {
+          workspace: "bot",
           distinct_id: "tg:123456789",
           summary_destination_chat_id: "-1009876543210",
           summary_source_chat_id: "-1009876543210",

--- a/app/src/lib/telegram/bot-api/__tests__/my-chat-member.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/my-chat-member.test.ts
@@ -44,6 +44,18 @@ const mixpanelTrackCalls: Array<{
   eventName: string;
   properties: Record<string, unknown>;
 }> = [];
+const mixpanelPeopleSetCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleSetOnceCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleUnionCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
 const getOrCreateUserCalls: Array<{
   telegramId: bigint;
   userData: {
@@ -78,6 +90,32 @@ mock.module("mixpanel", () => ({
         ) => {
           mixpanelTrackCalls.push({ eventName, properties });
           callback?.();
+        },
+        people: {
+          set: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          set_once: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetOnceCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          union: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleUnionCalls.push({ distinctId, properties });
+            callback?.();
+          },
         },
       };
     },
@@ -128,6 +166,7 @@ mock.module("../helper-message-cleanup", () => ({
 }));
 
 let handleMyChatMemberUpdate: (ctx: Context) => Promise<void>;
+let resetBotAnalyticsStateForTests: typeof import("../analytics").__resetBotAnalyticsStateForTests;
 
 const COMMUNITY_CHAT_ID = -1009876543210;
 const ONBOARDING_MESSAGE =
@@ -197,6 +236,8 @@ describe("my chat member onboarding", () => {
   beforeAll(async () => {
     const loadedModule = await import("../my-chat-member");
     handleMyChatMemberUpdate = loadedModule.handleMyChatMemberUpdate;
+    ({ __resetBotAnalyticsStateForTests: resetBotAnalyticsStateForTests } =
+      await import("../analytics"));
   });
 
   beforeEach(() => {
@@ -211,9 +252,13 @@ describe("my chat member onboarding", () => {
     removalWhereCalls = 0;
     mixpanelInitTokens.length = 0;
     mixpanelTrackCalls.length = 0;
+    mixpanelPeopleSetCalls.length = 0;
+    mixpanelPeopleSetOnceCalls.length = 0;
+    mixpanelPeopleUnionCalls.length = 0;
     getOrCreateUserCalls.length = 0;
     privateUserSettingsDisableValuesCaptured = [];
     sendMessageWithAutoCleanupCalls = [];
+    resetBotAnalyticsStateForTests();
 
     mockDb = {
       insert: () => ({
@@ -300,6 +345,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_ADDED_TO_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "supergroup",
@@ -327,6 +373,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_ADDED_TO_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "channel",
@@ -390,6 +437,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_BLOCKED_BY_USER_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "private",
@@ -422,6 +470,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_UNBLOCKED_BY_USER_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "private",
@@ -504,6 +553,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_ADDED_TO_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "group",
@@ -554,6 +604,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_REMOVED_FROM_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "supergroup",
@@ -582,6 +633,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_REMOVED_FROM_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "channel",
@@ -610,6 +662,7 @@ describe("my chat member onboarding", () => {
       {
         eventName: BOT_REMOVED_FROM_GROUP_EVENT,
         properties: {
+          workspace: "bot",
           distinct_id: "tg:777",
           telegram_chat_id: String(COMMUNITY_CHAT_ID),
           telegram_chat_type: "supergroup",

--- a/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
+++ b/app/src/lib/telegram/bot-api/__tests__/summary-votes.test.ts
@@ -38,6 +38,18 @@ const mixpanelTrackCalls: Array<{
   eventName: string;
   properties: Record<string, unknown>;
 }> = [];
+const mixpanelPeopleSetCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleSetOnceCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const mixpanelPeopleUnionCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
 
 mock.module("mixpanel", () => ({
   default: {
@@ -51,6 +63,32 @@ mock.module("mixpanel", () => ({
         ) => {
           mixpanelTrackCalls.push({ eventName, properties });
           callback?.();
+        },
+        people: {
+          set: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          set_once: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleSetOnceCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          union: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            mixpanelPeopleUnionCalls.push({ distinctId, properties });
+            callback?.();
+          },
         },
       };
     },
@@ -104,6 +142,7 @@ let encodeSummaryVoteCallbackData: typeof import("../summary-votes").encodeSumma
 let handleSummaryVoteCallback: typeof import("../summary-votes").handleSummaryVoteCallback;
 let parseSummaryVoteCallbackData: typeof import("../summary-votes").parseSummaryVoteCallbackData;
 let SUMMARY_VOTE_CALLBACK_DATA_REGEX: typeof import("../summary-votes").SUMMARY_VOTE_CALLBACK_DATA_REGEX;
+let resetBotAnalyticsStateForTests: typeof import("../analytics").__resetBotAnalyticsStateForTests;
 
 beforeAll(async () => {
   const loadedModule = await import("../summary-votes");
@@ -112,6 +151,8 @@ beforeAll(async () => {
   handleSummaryVoteCallback = loadedModule.handleSummaryVoteCallback;
   parseSummaryVoteCallbackData = loadedModule.parseSummaryVoteCallbackData;
   SUMMARY_VOTE_CALLBACK_DATA_REGEX = loadedModule.SUMMARY_VOTE_CALLBACK_DATA_REGEX;
+  ({ __resetBotAnalyticsStateForTests: resetBotAnalyticsStateForTests } =
+    await import("../analytics"));
 });
 
 beforeEach(() => {
@@ -123,6 +164,10 @@ beforeEach(() => {
   userIdResult = "user-1";
   mixpanelInitTokens.length = 0;
   mixpanelTrackCalls.length = 0;
+  mixpanelPeopleSetCalls.length = 0;
+  mixpanelPeopleSetOnceCalls.length = 0;
+  mixpanelPeopleUnionCalls.length = 0;
+  resetBotAnalyticsStateForTests();
 });
 
 afterEach(() => {
@@ -351,6 +396,7 @@ describe("handleSummaryVoteCallback", () => {
       {
         eventName: "Bot Summary Like",
         properties: {
+          workspace: "bot",
           distinct_id: "tg:123",
           group_chat_id: GROUP_CHAT_ID,
           summary_id: SUMMARY_ID,
@@ -390,6 +436,7 @@ describe("handleSummaryVoteCallback", () => {
       {
         eventName: "Bot Summary Dislike",
         properties: {
+          workspace: "bot",
           distinct_id: "tg:123",
           group_chat_id: GROUP_CHAT_ID,
           summary_id: SUMMARY_ID,
@@ -505,6 +552,7 @@ describe("handleSummaryVoteCallback", () => {
       {
         eventName: "Bot Summary Like",
         properties: {
+          workspace: "bot",
           distinct_id: "tg:123",
           group_chat_id: GROUP_CHAT_ID,
           summary_id: SUMMARY_ID,

--- a/app/src/lib/telegram/bot-api/analytics.ts
+++ b/app/src/lib/telegram/bot-api/analytics.ts
@@ -1,4 +1,8 @@
-import Mixpanel from "mixpanel";
+import {
+  __resetServerAnalyticsClientsForTests,
+  createMixpanelServerClient,
+  type ServerAnalyticsClient,
+} from "@loyal-labs/shared/analytics-server";
 
 import { serverEnv } from "@/lib/core/config/server";
 
@@ -6,6 +10,10 @@ type MixpanelTrackPrimitive = boolean | null | number | string;
 type TrackingIdentifier = bigint | number | string;
 
 export type MixpanelTrackProperties = Record<string, MixpanelTrackPrimitive>;
+
+const BOT_WORKSPACE = "bot" as const;
+let analyticsClient: ServerAnalyticsClient | null = null;
+let analyticsClientToken: string | null = null;
 
 type BotTrackingInput = {
   chatId?: TrackingIdentifier | null;
@@ -37,6 +45,19 @@ function resolveDistinctId(input: BotTrackingInput): string {
   return "tg:unknown";
 }
 
+function getAnalyticsClient(token: string): ServerAnalyticsClient {
+  if (analyticsClient && analyticsClientToken === token) {
+    return analyticsClient;
+  }
+
+  analyticsClient = createMixpanelServerClient({
+    token,
+    workspace: BOT_WORKSPACE,
+  });
+  analyticsClientToken = token;
+  return analyticsClient;
+}
+
 export function createBotTrackingProperties(
   input: BotTrackingInput
 ): MixpanelTrackProperties {
@@ -58,13 +79,22 @@ export function trackBotEvent(
   }
 
   try {
-    const mixpanel = Mixpanel.init(token);
-    mixpanel.track(eventName, properties, (error: unknown) => {
-      if (error) {
-        console.error(`Failed to track Mixpanel event: ${eventName}`, error);
-      }
-    });
+    const client = getAnalyticsClient(token);
+    client.track(eventName, properties);
+
+    if (
+      typeof properties.distinct_id === "string" &&
+      typeof properties.telegram_user_id === "string"
+    ) {
+      client.updateWorkspaceProfile(properties.distinct_id);
+    }
   } catch (error) {
     console.error(`Failed to track Mixpanel event: ${eventName}`, error);
   }
+}
+
+export function __resetBotAnalyticsStateForTests(): void {
+  analyticsClient = null;
+  analyticsClientToken = null;
+  __resetServerAnalyticsClientsForTests();
 }

--- a/app/src/lib/telegram/bot-api/summary-votes.ts
+++ b/app/src/lib/telegram/bot-api/summary-votes.ts
@@ -6,14 +6,13 @@ import {
 import { eq, sql } from "drizzle-orm";
 import type { CallbackQueryContext, Context } from "grammy";
 import { InlineKeyboard } from "grammy";
-import Mixpanel from "mixpanel";
 
-import { serverEnv } from "@/lib/core/config/server";
 import { getDatabase } from "@/lib/core/database";
 import { buildSummaryFeedMiniAppUrl } from "@/lib/telegram/mini-app/start-param";
 import { getOrCreateUser } from "@/lib/telegram/user-service";
 import { getTelegramDisplayName } from "@/lib/telegram/utils";
 
+import { trackBotEvent } from "./analytics";
 import { isMessageNotModifiedError } from "./callback-query-utils";
 
 type SummaryVoteAction = "u" | "d" | "s";
@@ -58,33 +57,16 @@ function getVoteEventName(
   return null;
 }
 
-async function trackSummaryVoteEvent(
+function trackSummaryVoteEvent(
   voteAction: PersistedSummaryVoteAction,
   properties: MixpanelTrackProperties
-): Promise<void> {
+): void {
   const eventName = getVoteEventName(voteAction);
   if (!eventName) {
     return;
   }
 
-  const token = serverEnv.mixpanelToken;
-  if (!token) {
-    return;
-  }
-
-  try {
-    const mixpanel = Mixpanel.init(token);
-    await new Promise<void>((resolve) => {
-      mixpanel.track(eventName, properties, (error: unknown) => {
-        if (error) {
-          console.error(`Failed to track Mixpanel event: ${eventName}`, error);
-        }
-        resolve();
-      });
-    });
-  } catch (error) {
-    console.error(`Failed to track Mixpanel event: ${eventName}`, error);
-  }
+  trackBotEvent(eventName, properties);
 }
 
 export const SUMMARY_VOTE_CALLBACK_DATA_REGEX = new RegExp(
@@ -304,7 +286,7 @@ export async function handleSummaryVoteCallback(
       return;
     }
 
-    await trackSummaryVoteEvent(voteAction, {
+    trackSummaryVoteEvent(voteAction, {
       distinct_id: `tg:${ctx.from.id}`,
       group_chat_id: callbackData.groupChatId,
       summary_id: callbackData.summaryId,

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -22,6 +22,7 @@
       "@/*": ["./src/*"],
       "@loyal-labs/shared": ["../packages/shared/src/index.ts"],
       "@loyal-labs/shared/analytics": ["../packages/shared/src/analytics.ts"],
+      "@loyal-labs/shared/analytics-server": ["../packages/shared/src/analytics-server.ts"],
       "@loyal-labs/solana-rpc": ["../packages/solana-rpc/src/index.ts"],
       "@loyal-labs/solana-wallet": ["../packages/solana-wallet/src/index.ts"]
     }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -344,6 +343,7 @@
       "name": "@loyal-labs/shared",
       "version": "0.1.0",
       "dependencies": {
+        "mixpanel": "^0.20.0",
         "mixpanel-browser": "^2.74.0",
       },
       "devDependencies": {

--- a/frontend/src/app/api/chat/route.ts
+++ b/frontend/src/app/api/chat/route.ts
@@ -35,6 +35,37 @@ type SubmittedChatTurn = {
   turnId: string;
 };
 
+function getRequestClientIp(req: Request): string | undefined {
+  const cfConnectingIp = req.headers.get("cf-connecting-ip")?.trim();
+  if (cfConnectingIp) {
+    return cfConnectingIp;
+  }
+
+  const xForwardedFor = req.headers.get("x-forwarded-for");
+  if (xForwardedFor) {
+    const forwardedIp = xForwardedFor
+      .split(",")
+      .map((part) => part.trim())
+      .find((part) => part.length > 0);
+
+    if (forwardedIp) {
+      return forwardedIp;
+    }
+  }
+
+  const xRealIp = req.headers.get("x-real-ip")?.trim();
+  if (xRealIp) {
+    return xRealIp;
+  }
+
+  const xVercelForwardedFor = req.headers.get("x-vercel-forwarded-for")?.trim();
+  if (xVercelForwardedFor) {
+    return xVercelForwardedFor;
+  }
+
+  return undefined;
+}
+
 function isChatRequestBody(value: unknown): value is ChatRequestBody {
   if (!value || typeof value !== "object") {
     return false;
@@ -184,6 +215,7 @@ export async function POST(req: Request) {
       chatId,
       initialMessageLength: submittedTurn.text.length,
       source: "main_chat_input",
+      clientIp: getRequestClientIp(req),
     });
   }
 

--- a/frontend/src/app/ingest/[...path]/route.test.ts
+++ b/frontend/src/app/ingest/[...path]/route.test.ts
@@ -39,8 +39,48 @@ describe("Mixpanel ingest proxy route", () => {
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
       method: "GET",
     });
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toBeInstanceOf(Headers);
+    expect(
+      (fetchMock.mock.calls[0]?.[1]?.headers as Headers).get("accept")
+    ).toBe("application/json");
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
+  });
+
+  test("forwards client IP headers so Mixpanel can geolocate the end user", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("ok", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+        },
+      })
+    );
+
+    const { POST } = await import("./route");
+    await POST(
+      new Request("https://askloyal.com/ingest/track/", {
+        method: "POST",
+        body: "payload-body",
+        headers: {
+          "cf-connecting-ip": "203.0.113.10",
+          "x-forwarded-for": "203.0.113.10, 198.51.100.1",
+          "x-real-ip": "203.0.113.10",
+          "x-vercel-forwarded-for": "203.0.113.10",
+        },
+      }),
+      { params: Promise.resolve({ path: ["track", ""] }) }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toBeInstanceOf(Headers);
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+
+    expect(headers.get("cf-connecting-ip")).toBe("203.0.113.10");
+    expect(headers.get("x-forwarded-for")).toBe("203.0.113.10, 198.51.100.1");
+    expect(headers.get("x-real-ip")).toBe("203.0.113.10");
+    expect(headers.get("x-vercel-forwarded-for")).toBe("203.0.113.10");
   });
 
   test("forwards POST requests with body and content type", async () => {

--- a/frontend/src/app/ingest/[...path]/route.ts
+++ b/frontend/src/app/ingest/[...path]/route.ts
@@ -2,10 +2,15 @@ const MIXPANEL_API_ORIGIN = "https://api-js.mixpanel.com";
 const FORWARDED_REQUEST_HEADERS = [
   "accept",
   "accept-language",
+  "cf-connecting-ip",
   "content-type",
+  "forwarded",
   "origin",
   "referer",
   "user-agent",
+  "x-forwarded-for",
+  "x-real-ip",
+  "x-vercel-forwarded-for",
 ] as const;
 const FORWARDED_RESPONSE_HEADERS = [
   "cache-control",

--- a/frontend/src/features/chat/server/__tests__/chat-analytics.test.ts
+++ b/frontend/src/features/chat/server/__tests__/chat-analytics.test.ts
@@ -32,12 +32,14 @@ describe("chat analytics", () => {
       chatId: "chat-123",
       initialMessageLength: 21,
       source: "main_chat_input",
+      clientIp: "203.0.113.10",
     });
 
     expect(trackServerAnalyticsEvent).toHaveBeenCalledWith(
       "chat_thread_created",
       {
         distinct_id: "wallet:wallet-address",
+        ip: "203.0.113.10",
         workspace: "frontend",
         auth_method: "wallet",
         provider: "solana",

--- a/frontend/src/features/chat/server/__tests__/chat-analytics.test.ts
+++ b/frontend/src/features/chat/server/__tests__/chat-analytics.test.ts
@@ -40,7 +40,6 @@ describe("chat analytics", () => {
       {
         distinct_id: "wallet:wallet-address",
         ip: "203.0.113.10",
-        workspace: "frontend",
         auth_method: "wallet",
         provider: "solana",
         wallet_address: "wallet-address",

--- a/frontend/src/features/chat/server/chat-analytics.ts
+++ b/frontend/src/features/chat/server/chat-analytics.ts
@@ -9,9 +9,11 @@ export function trackChatThreadCreatedServer(args: {
   chatId: string;
   initialMessageLength: number;
   source: string;
+  clientIp?: string;
 }): void {
   trackServerAnalyticsEvent(FRONTEND_ANALYTICS_EVENTS.chatThreadCreated, {
     distinct_id: `wallet:${args.principal.walletAddress}`,
+    ...(args.clientIp ? { ip: args.clientIp } : {}),
     workspace: "frontend",
     auth_method: args.principal.authMethod,
     provider: args.principal.provider,

--- a/frontend/src/features/chat/server/chat-analytics.ts
+++ b/frontend/src/features/chat/server/chat-analytics.ts
@@ -14,7 +14,6 @@ export function trackChatThreadCreatedServer(args: {
   trackServerAnalyticsEvent(FRONTEND_ANALYTICS_EVENTS.chatThreadCreated, {
     distinct_id: `wallet:${args.principal.walletAddress}`,
     ...(args.clientIp ? { ip: args.clientIp } : {}),
-    workspace: "frontend",
     auth_method: args.principal.authMethod,
     provider: args.principal.provider,
     wallet_address: args.principal.walletAddress,

--- a/frontend/src/lib/core/__tests__/analytics-server.test.ts
+++ b/frontend/src/lib/core/__tests__/analytics-server.test.ts
@@ -1,0 +1,55 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const track = mock();
+const updateWorkspaceProfile = mock();
+const createMixpanelServerClient = mock(() => ({
+  track,
+  updateWorkspaceProfile,
+}));
+
+mock.module("@loyal-labs/shared/analytics-server", () => ({
+  createMixpanelServerClient,
+}));
+
+mock.module("@/lib/core/config/server", () => ({
+  getServerEnv: () => ({
+    mixpanelToken: "frontend-server-token",
+  }),
+}));
+
+let analyticsServer: typeof import("../analytics-server");
+
+describe("frontend server analytics wrapper", () => {
+  beforeAll(async () => {
+    analyticsServer = await import("../analytics-server");
+  });
+
+  beforeEach(() => {
+    createMixpanelServerClient.mockClear();
+    track.mockClear();
+    updateWorkspaceProfile.mockClear();
+  });
+
+  test("configures website workspace and refreshes workspace adoption for distinct ids", () => {
+    analyticsServer.trackServerAnalyticsEvent("chat_thread_created", {
+      distinct_id: "wallet:wallet-address",
+      chat_id: "chat-123",
+      source: "main_chat_input",
+    });
+
+    expect(createMixpanelServerClient).toHaveBeenCalledWith({
+      token: "frontend-server-token",
+      workspace: "website",
+    });
+    expect(track).toHaveBeenCalledWith("chat_thread_created", {
+      distinct_id: "wallet:wallet-address",
+      chat_id: "chat-123",
+      source: "main_chat_input",
+    });
+    expect(updateWorkspaceProfile).toHaveBeenCalledWith(
+      "wallet:wallet-address"
+    );
+  });
+});

--- a/frontend/src/lib/core/__tests__/analytics.test.ts
+++ b/frontend/src/lib/core/__tests__/analytics.test.ts
@@ -11,16 +11,29 @@ import {
 const createClientCalls: Array<Record<string, unknown>> = [];
 const identifyCalls: string[] = [];
 const setUserProfileCalls: Array<Record<string, unknown>> = [];
+const setUserProfileOnceCalls: Array<Record<string, unknown>> = [];
+const unionUserProfileCalls: Array<Record<string, unknown>> = [];
 const resetCalls: Array<undefined> = [];
 const trackCalls: Array<{ event: string; properties?: Record<string, unknown> }> = [];
+let currentDefaultEventProperties: Record<string, unknown> = {};
 
 mock.module("@loyal-labs/shared/analytics", () => ({
   createMixpanelBrowserClient: (config: Record<string, unknown>) => {
     createClientCalls.push(config);
+    currentDefaultEventProperties = {
+      ...((config.defaultEventProperties as Record<string, unknown> | undefined) ??
+        {}),
+    };
     return {
       init: async () => {},
       track: (event: string, properties?: Record<string, unknown>) => {
-        trackCalls.push({ event, properties });
+        trackCalls.push({
+          event,
+          properties: {
+            ...currentDefaultEventProperties,
+            ...(properties ?? {}),
+          },
+        });
       },
       identify: (distinctId: string) => {
         identifyCalls.push(distinctId);
@@ -33,10 +46,28 @@ mock.module("@loyal-labs/shared/analytics", () => ({
       setUserProfile: (properties: Record<string, unknown>) => {
         setUserProfileCalls.push(properties);
       },
-      setUserProfileOnce: () => {},
+      setUserProfileOnce: (properties: Record<string, unknown>) => {
+        setUserProfileOnceCalls.push(properties);
+      },
+      unionUserProfile: (properties: Record<string, unknown>) => {
+        unionUserProfileCalls.push(properties);
+      },
       __resetForTests: () => {},
     };
   },
+  createWorkspaceProfileUpdate: (workspace: string) => ({
+    set: {
+      last_workspace: workspace,
+      [`${workspace}_last_seen_at`]: "2026-03-26T00:00:00.000Z",
+    },
+    setOnce: {
+      first_workspace: workspace,
+      [`${workspace}_first_seen_at`]: "2026-03-26T00:00:00.000Z",
+    },
+    union: {
+      workspaces: [workspace],
+    },
+  }),
 }));
 
 let analytics: typeof import("../analytics");
@@ -78,8 +109,11 @@ describe("frontend analytics adapter", () => {
     createClientCalls.length = 0;
     identifyCalls.length = 0;
     setUserProfileCalls.length = 0;
+    setUserProfileOnceCalls.length = 0;
+    unionUserProfileCalls.length = 0;
     resetCalls.length = 0;
     trackCalls.length = 0;
+    currentDefaultEventProperties = {};
     analytics.__resetAnalyticsStateForTests();
   });
 
@@ -96,12 +130,15 @@ describe("frontend analytics adapter", () => {
         apiHost: "https://askloyal.com/ingest",
         debug: false,
         persistence: "localStorage",
+        defaultEventProperties: {
+          workspace: "website",
+        },
         registerProperties: {
           app_environment: "prod",
           app_solana_env: "devnet",
           git_branch: "feature-branch",
           git_commit_hash: "abc1234",
-          workspace: "frontend",
+          workspace: "website",
         },
       },
     ]);
@@ -114,6 +151,7 @@ describe("frontend analytics adapter", () => {
       {
         event: "View /wallet",
         properties: {
+          workspace: "website",
           path: "/wallet",
         },
       },
@@ -143,6 +181,21 @@ describe("frontend analytics adapter", () => {
         display_address: "display-address",
         wallet_address: "wallet-address",
         smart_account_address: "smart-account-address",
+      },
+      {
+        last_workspace: "website",
+        website_last_seen_at: "2026-03-26T00:00:00.000Z",
+      },
+    ]);
+    expect(setUserProfileOnceCalls).toEqual([
+      {
+        first_workspace: "website",
+        website_first_seen_at: "2026-03-26T00:00:00.000Z",
+      },
+    ]);
+    expect(unionUserProfileCalls).toEqual([
+      {
+        workspaces: ["website"],
       },
     ]);
   });
@@ -177,8 +230,8 @@ describe("frontend analytics adapter", () => {
     });
 
     expect(identifyCalls).toEqual(["wallet:wallet-address"]);
-    expect(setUserProfileCalls).toHaveLength(2);
-    expect(setUserProfileCalls[1]).toMatchObject({
+    expect(setUserProfileCalls).toHaveLength(3);
+    expect(setUserProfileCalls[2]).toMatchObject({
       email: "user@example.com",
       $email: "user@example.com",
     });
@@ -198,6 +251,7 @@ describe("frontend analytics adapter", () => {
       {
         event: analytics.FRONTEND_ANALYTICS_EVENTS.authLogout,
         properties: {
+          workspace: "website",
           path: "/wallet",
           auth_method: "wallet",
           grid_user_id: "grid-user-1",
@@ -219,6 +273,7 @@ describe("frontend analytics adapter", () => {
       {
         event: analytics.FRONTEND_ANALYTICS_EVENTS.chatThreadCreated,
         properties: {
+          workspace: "website",
           path: "/wallet",
           chat_id: "chat-123",
           source: "main_chat_input",

--- a/frontend/src/lib/core/analytics-server.ts
+++ b/frontend/src/lib/core/analytics-server.ts
@@ -1,22 +1,27 @@
 import "server-only";
 
-import Mixpanel from "mixpanel";
+import {
+  createMixpanelServerClient,
+  type ServerAnalyticsClient,
+  type ServerAnalyticsProperties,
+} from "@loyal-labs/shared/analytics-server";
 
 import { getServerEnv } from "@/lib/core/config/server";
 
-type ServerAnalyticsPrimitive = boolean | null | number | string;
+const WEBSITE_WORKSPACE = "website" as const;
 
-export type ServerAnalyticsProperties = Record<string, ServerAnalyticsPrimitive>;
-
-let serverClient: ReturnType<typeof Mixpanel.init> | null = null;
+let serverClient: ServerAnalyticsClient | null = null;
 let serverClientToken: string | null = null;
 
-function getServerAnalyticsClient(token: string): ReturnType<typeof Mixpanel.init> {
+function getServerAnalyticsClient(token: string): ServerAnalyticsClient {
   if (serverClient && serverClientToken === token) {
     return serverClient;
   }
 
-  serverClient = Mixpanel.init(token);
+  serverClient = createMixpanelServerClient({
+    token,
+    workspace: WEBSITE_WORKSPACE,
+  });
   serverClientToken = token;
   return serverClient;
 }
@@ -32,11 +37,11 @@ export function trackServerAnalyticsEvent(
 
   try {
     const client = getServerAnalyticsClient(mixpanelToken);
-    client.track(eventName, properties, (error: unknown) => {
-      if (error) {
-        console.error(`Failed to track Mixpanel event: ${eventName}`, error);
-      }
-    });
+    client.track(eventName, properties);
+
+    if (typeof properties.distinct_id === "string") {
+      client.updateWorkspaceProfile(properties.distinct_id);
+    }
   } catch (error) {
     console.error(`Failed to track Mixpanel event: ${eventName}`, error);
   }

--- a/frontend/src/lib/core/analytics/client.ts
+++ b/frontend/src/lib/core/analytics/client.ts
@@ -2,9 +2,10 @@
 
 import type { AuthSessionUser } from "@loyal-labs/auth-core";
 import {
-  createMixpanelBrowserClient,
   type AnalyticsClient,
   type AnalyticsProperties,
+  createMixpanelBrowserClient,
+  createWorkspaceProfileUpdate,
 } from "@loyal-labs/shared/analytics";
 
 import type { PublicEnv } from "@/lib/core/config/public";
@@ -19,6 +20,7 @@ let analyticsClientKey: string | null = null;
 let lastIdentifiedDistinctId: string | null = null;
 let lastProfiledDistinctId: string | null = null;
 let lastProfileFingerprint: string | null = null;
+const WEBSITE_WORKSPACE = "website" as const;
 
 function getCurrentPathname(): string | undefined {
   if (typeof window === "undefined") {
@@ -73,12 +75,15 @@ function getAnalyticsClient(publicEnv: PublicEnv): AnalyticsClient {
     apiHost: getApiHost(publicEnv),
     debug: publicEnv.appEnvironment !== "prod",
     persistence: "localStorage",
+    defaultEventProperties: {
+      workspace: WEBSITE_WORKSPACE,
+    },
     registerProperties: {
       app_environment: publicEnv.appEnvironment,
       app_solana_env: publicEnv.solanaEnv,
       git_branch: publicEnv.gitBranch,
       git_commit_hash: publicEnv.gitCommitHash,
-      workspace: "frontend",
+      workspace: WEBSITE_WORKSPACE,
     },
   });
 
@@ -172,8 +177,9 @@ export function identifyAuthenticatedUser(
 
   const client = getAnalyticsClient(publicEnv);
   const profileFingerprint = buildFrontendProfileFingerprint(user);
+  const shouldRefreshWorkspaceProfile = lastIdentifiedDistinctId !== distinctId;
 
-  if (lastIdentifiedDistinctId !== distinctId) {
+  if (shouldRefreshWorkspaceProfile) {
     client.identify(distinctId);
     lastIdentifiedDistinctId = distinctId;
   }
@@ -185,6 +191,14 @@ export function identifyAuthenticatedUser(
     client.setUserProfile(buildFrontendProfileProperties(user));
     lastProfiledDistinctId = distinctId;
     lastProfileFingerprint = profileFingerprint;
+  }
+
+  if (shouldRefreshWorkspaceProfile) {
+    const workspaceProfileUpdate =
+      createWorkspaceProfileUpdate(WEBSITE_WORKSPACE);
+    client.unionUserProfile(workspaceProfileUpdate.union);
+    client.setUserProfileOnce(workspaceProfileUpdate.setOnce);
+    client.setUserProfile(workspaceProfileUpdate.set);
   }
 }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,6 +22,7 @@
       "@/*": ["./src/*"],
       "@loyal-labs/shared": ["../packages/shared/src/index.ts"],
       "@loyal-labs/shared/analytics": ["../packages/shared/src/analytics.ts"],
+      "@loyal-labs/shared/analytics-server": ["../packages/shared/src/analytics-server.ts"],
       "@loyal-labs/solana-rpc": ["../packages/solana-rpc/src/index.ts"],
       "@loyal-labs/solana-wallet": ["../packages/solana-wallet/src/index.ts"]
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/analytics.js",
       "default": "./dist/analytics.js",
       "types": "./dist/analytics.d.ts"
+    },
+    "./analytics-server": {
+      "import": "./dist/analytics-server.js",
+      "default": "./dist/analytics-server.js",
+      "types": "./dist/analytics-server.d.ts"
     }
   },
   "files": [
@@ -27,6 +32,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "mixpanel": "^0.20.0",
     "mixpanel-browser": "^2.74.0"
   },
   "devDependencies": {

--- a/packages/shared/src/__tests__/analytics-server.test.ts
+++ b/packages/shared/src/__tests__/analytics-server.test.ts
@@ -1,0 +1,162 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const initCalls: string[] = [];
+const trackCalls: Array<{
+  eventName: string;
+  properties: Record<string, unknown>;
+}> = [];
+const peopleSetCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const peopleSetOnceCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+const peopleUnionCalls: Array<{
+  distinctId: string;
+  properties: Record<string, unknown>;
+}> = [];
+
+mock.module("mixpanel", () => ({
+  default: {
+    init: (token: string) => {
+      initCalls.push(token);
+      return {
+        track: (
+          eventName: string,
+          properties: Record<string, unknown>,
+          callback?: (error?: unknown) => void
+        ) => {
+          trackCalls.push({ eventName, properties });
+          callback?.();
+        },
+        people: {
+          set: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            peopleSetCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          set_once: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            peopleSetOnceCalls.push({ distinctId, properties });
+            callback?.();
+          },
+          union: (
+            distinctId: string,
+            properties: Record<string, unknown>,
+            callback?: (error?: unknown) => void
+          ) => {
+            peopleUnionCalls.push({ distinctId, properties });
+            callback?.();
+          },
+        },
+      };
+    },
+  },
+}));
+
+let analyticsServer: typeof import("../analytics-server");
+
+describe("shared server analytics client", () => {
+  beforeAll(async () => {
+    analyticsServer = await import("../analytics-server");
+  });
+
+  beforeEach(() => {
+    initCalls.length = 0;
+    trackCalls.length = 0;
+    peopleSetCalls.length = 0;
+    peopleSetOnceCalls.length = 0;
+    peopleUnionCalls.length = 0;
+    analyticsServer.__resetServerAnalyticsClientsForTests();
+  });
+
+  test("stamps workspace on every tracked event and caches the sdk client", () => {
+    const client = analyticsServer.createMixpanelServerClient({
+      token: "server-token",
+      workspace: "website",
+    });
+
+    client.track("chat_thread_created", {
+      distinct_id: "wallet:user-1",
+      chat_id: "chat-123",
+    });
+    client.track("chat_thread_created", {
+      distinct_id: "wallet:user-1",
+      chat_id: "chat-456",
+    });
+
+    expect(initCalls).toEqual(["server-token"]);
+    expect(trackCalls).toEqual([
+      {
+        eventName: "chat_thread_created",
+        properties: {
+          workspace: "website",
+          distinct_id: "wallet:user-1",
+          chat_id: "chat-123",
+        },
+      },
+      {
+        eventName: "chat_thread_created",
+        properties: {
+          workspace: "website",
+          distinct_id: "wallet:user-1",
+          chat_id: "chat-456",
+        },
+      },
+    ]);
+  });
+
+  test("updates workspace adoption profile fields", () => {
+    const client = analyticsServer.createMixpanelServerClient({
+      token: "server-token",
+      workspace: "bot",
+    });
+    const occurredAt = new Date("2026-03-26T12:00:00.000Z");
+
+    client.updateWorkspaceProfile("tg:123", occurredAt);
+
+    expect(peopleUnionCalls).toEqual([
+      {
+        distinctId: "tg:123",
+        properties: {
+          workspaces: ["bot"],
+        },
+      },
+    ]);
+    expect(peopleSetOnceCalls).toEqual([
+      {
+        distinctId: "tg:123",
+        properties: {
+          first_workspace: "bot",
+          bot_first_seen_at: "2026-03-26T12:00:00.000Z",
+        },
+      },
+    ]);
+    expect(peopleSetCalls).toEqual([
+      {
+        distinctId: "tg:123",
+        properties: {
+          last_workspace: "bot",
+          bot_last_seen_at: "2026-03-26T12:00:00.000Z",
+        },
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/__tests__/analytics.test.ts
+++ b/packages/shared/src/__tests__/analytics.test.ts
@@ -15,6 +15,7 @@ const resetCalls: Array<undefined> = [];
 const registerCalls: Array<Record<string, unknown>> = [];
 const peopleSetOnceCalls: Array<Record<string, unknown>> = [];
 const peopleSetCalls: Array<Record<string, unknown>> = [];
+const peopleUnionCalls: Array<Record<string, unknown>> = [];
 let shouldFailLoad = false;
 
 const mixpanelMock = {
@@ -39,6 +40,9 @@ const mixpanelMock = {
     },
     set_once: (properties: Record<string, unknown>) => {
       peopleSetOnceCalls.push(properties);
+    },
+    union: (properties: Record<string, unknown>) => {
+      peopleUnionCalls.push(properties);
     },
   },
 };
@@ -69,6 +73,7 @@ describe("shared analytics client factory", () => {
     registerCalls.length = 0;
     peopleSetCalls.length = 0;
     peopleSetOnceCalls.length = 0;
+    peopleUnionCalls.length = 0;
     shouldFailLoad = false;
   });
 
@@ -81,8 +86,11 @@ describe("shared analytics client factory", () => {
       token: "test-mixpanel-token",
       apiHost: "https://loyal.example/ingest",
       persistence: "localStorage",
+      defaultEventProperties: {
+        workspace: "website",
+      },
       registerProperties: {
-        workspace: "app",
+        workspace: "website",
       },
     });
 
@@ -100,7 +108,7 @@ describe("shared analytics client factory", () => {
         },
       ],
     ]);
-    expect(registerCalls).toEqual([{ workspace: "app" }]);
+    expect(registerCalls).toEqual([{ workspace: "website" }]);
   });
 
   test("missing token makes calls no-op", async () => {
@@ -127,6 +135,9 @@ describe("shared analytics client factory", () => {
       token: "test-mixpanel-token",
       apiHost: "https://loyal.example/ingest",
       persistence: "localStorage",
+      defaultEventProperties: {
+        workspace: "bot",
+      },
     });
 
     await client.init();
@@ -141,11 +152,13 @@ describe("shared analytics client factory", () => {
       token: "test-mixpanel-token",
       apiHost: "https://loyal.example/ingest",
       persistence: "localStorage",
+      defaultEventProperties: {
+        workspace: "website",
+      },
     });
 
     await client.init();
     client.setContext({
-      workspace: "frontend",
       path_group: "wallet",
     });
     client.track("Page View", { path: "/wallet" });
@@ -155,7 +168,7 @@ describe("shared analytics client factory", () => {
       {
         event: "Page View",
         properties: {
-          workspace: "frontend",
+          workspace: "website",
           path_group: "wallet",
           path: "/wallet",
         },
@@ -168,18 +181,23 @@ describe("shared analytics client factory", () => {
       token: "test-mixpanel-token",
       apiHost: "https://loyal.example/ingest",
       persistence: "localStorage",
+      defaultEventProperties: {
+        workspace: "miniapp",
+      },
     });
 
     await client.init();
     client.identify("grid:user-1");
     client.setUserProfile({ email: "user@example.com" });
     client.setUserProfileOnce({ auth_method: "wallet" });
+    client.unionUserProfile({ workspaces: ["miniapp"] });
     client.reset();
     await Promise.resolve();
 
     expect(identifyCalls).toEqual(["grid:user-1"]);
     expect(peopleSetCalls).toEqual([{ email: "user@example.com" }]);
     expect(peopleSetOnceCalls).toEqual([{ auth_method: "wallet" }]);
+    expect(peopleUnionCalls).toEqual([{ workspaces: ["miniapp"] }]);
     expect(resetCalls).toHaveLength(1);
   });
 });

--- a/packages/shared/src/analytics-core.ts
+++ b/packages/shared/src/analytics-core.ts
@@ -1,0 +1,51 @@
+export type AnalyticsPrimitive = boolean | null | number | string;
+
+export type AnalyticsListPrimitive = boolean | number | string;
+
+export type AnalyticsProperties = Record<string, unknown>;
+
+export type AnalyticsWorkspace = "miniapp" | "bot" | "website";
+
+export type AnalyticsProfileProperties = Record<string, AnalyticsPrimitive>;
+
+export type AnalyticsProfileUnionProperties = Record<
+  string,
+  AnalyticsListPrimitive[]
+>;
+
+export type AnalyticsWorkspaceProfileUpdate = {
+  set: AnalyticsProfileProperties;
+  setOnce: AnalyticsProfileProperties;
+  union: AnalyticsProfileUnionProperties;
+};
+
+export function withWorkspaceProperties(
+  workspace: AnalyticsWorkspace,
+  properties?: AnalyticsProperties
+): AnalyticsProperties {
+  return {
+    workspace,
+    ...(properties ?? {}),
+  };
+}
+
+export function createWorkspaceProfileUpdate(
+  workspace: AnalyticsWorkspace,
+  occurredAt: Date = new Date()
+): AnalyticsWorkspaceProfileUpdate {
+  const timestamp = occurredAt.toISOString();
+
+  return {
+    set: {
+      last_workspace: workspace,
+      [`${workspace}_last_seen_at`]: timestamp,
+    },
+    setOnce: {
+      first_workspace: workspace,
+      [`${workspace}_first_seen_at`]: timestamp,
+    },
+    union: {
+      workspaces: [workspace],
+    },
+  };
+}

--- a/packages/shared/src/analytics-server.ts
+++ b/packages/shared/src/analytics-server.ts
@@ -1,0 +1,162 @@
+import "server-only";
+
+import Mixpanel from "mixpanel";
+
+import {
+  createWorkspaceProfileUpdate,
+  type AnalyticsProfileProperties,
+  type AnalyticsProfileUnionProperties,
+  type AnalyticsWorkspace,
+  withWorkspaceProperties,
+} from "./analytics-core";
+
+export type ServerAnalyticsPrimitive = boolean | null | number | string;
+
+export type ServerAnalyticsProperties = Record<
+  string,
+  ServerAnalyticsPrimitive
+>;
+
+type ServerAnalyticsConfig = {
+  token?: string;
+  workspace: AnalyticsWorkspace;
+};
+
+export type ServerAnalyticsClient = {
+  track: (
+    eventName: string,
+    properties?: ServerAnalyticsProperties
+  ) => void;
+  setUserProfile: (
+    distinctId: string,
+    properties: AnalyticsProfileProperties
+  ) => void;
+  setUserProfileOnce: (
+    distinctId: string,
+    properties: AnalyticsProfileProperties
+  ) => void;
+  unionUserProfile: (
+    distinctId: string,
+    properties: AnalyticsProfileUnionProperties
+  ) => void;
+  updateWorkspaceProfile: (distinctId: string, occurredAt?: Date) => void;
+};
+
+const serverClients = new Map<string, ReturnType<typeof Mixpanel.init>>();
+
+function getServerClient(token: string): ReturnType<typeof Mixpanel.init> {
+  const existingClient = serverClients.get(token);
+  if (existingClient) {
+    return existingClient;
+  }
+
+  const nextClient = Mixpanel.init(token);
+  serverClients.set(token, nextClient);
+  return nextClient;
+}
+
+function logMixpanelError(action: string, target: string, error: unknown): void {
+  console.error(`Failed to ${action} Mixpanel ${target}`, error);
+}
+
+export function createMixpanelServerClient(
+  config: ServerAnalyticsConfig
+): ServerAnalyticsClient {
+  function withClient(
+    action: string,
+    target: string,
+    callback: (client: ReturnType<typeof Mixpanel.init>) => void
+  ): void {
+    if (!config.token) {
+      return;
+    }
+
+    try {
+      callback(getServerClient(config.token));
+    } catch (error) {
+      logMixpanelError(action, target, error);
+    }
+  }
+
+  function track(
+    eventName: string,
+    properties?: ServerAnalyticsProperties
+  ): void {
+    withClient("track", `event: ${eventName}`, (client) => {
+      client.track(
+        eventName,
+        withWorkspaceProperties(
+          config.workspace,
+          properties
+        ) as ServerAnalyticsProperties,
+        (error: unknown) => {
+          if (error) {
+            logMixpanelError("track", `event: ${eventName}`, error);
+          }
+        }
+      );
+    });
+  }
+
+  function setUserProfile(
+    distinctId: string,
+    properties: AnalyticsProfileProperties
+  ): void {
+    withClient("set", `profile: ${distinctId}`, (client) => {
+      client.people.set(distinctId, properties, (error: unknown) => {
+        if (error) {
+          logMixpanelError("set", `profile: ${distinctId}`, error);
+        }
+      });
+    });
+  }
+
+  function setUserProfileOnce(
+    distinctId: string,
+    properties: AnalyticsProfileProperties
+  ): void {
+    withClient("set_once", `profile: ${distinctId}`, (client) => {
+      client.people.set_once(distinctId, properties, (error: unknown) => {
+        if (error) {
+          logMixpanelError("set_once", `profile: ${distinctId}`, error);
+        }
+      });
+    });
+  }
+
+  function unionUserProfile(
+    distinctId: string,
+    properties: AnalyticsProfileUnionProperties
+  ): void {
+    withClient("union", `profile: ${distinctId}`, (client) => {
+      client.people.union(distinctId, properties, (error: unknown) => {
+        if (error) {
+          logMixpanelError("union", `profile: ${distinctId}`, error);
+        }
+      });
+    });
+  }
+
+  function updateWorkspaceProfile(
+    distinctId: string,
+    occurredAt: Date = new Date()
+  ): void {
+    const update = createWorkspaceProfileUpdate(config.workspace, occurredAt);
+
+    unionUserProfile(distinctId, update.union);
+    setUserProfileOnce(distinctId, update.setOnce);
+    setUserProfile(distinctId, update.set);
+  }
+
+  return {
+    track,
+    setUserProfile,
+    setUserProfileOnce,
+    unionUserProfile,
+    updateWorkspaceProfile,
+  };
+}
+
+export function __resetServerAnalyticsClientsForTests(): void {
+  serverClients.clear();
+}

--- a/packages/shared/src/analytics.ts
+++ b/packages/shared/src/analytics.ts
@@ -3,13 +3,28 @@
 import type MixpanelType from "mixpanel-browser";
 import type { Persistence } from "mixpanel-browser";
 
-export type AnalyticsProperties = Record<string, unknown>;
+import {
+  type AnalyticsProfileUnionProperties,
+  type AnalyticsProperties,
+} from "./analytics-core";
+
+export {
+  createWorkspaceProfileUpdate,
+  type AnalyticsPrimitive,
+  type AnalyticsProfileProperties,
+  type AnalyticsProfileUnionProperties,
+  type AnalyticsProperties,
+  type AnalyticsWorkspace,
+  type AnalyticsWorkspaceProfileUpdate,
+  withWorkspaceProperties,
+} from "./analytics-core";
 
 export type AnalyticsConfig = {
   token?: string;
   apiHost?: string;
   debug?: boolean;
   persistence?: Persistence;
+  defaultEventProperties?: AnalyticsProperties;
   registerProperties?: AnalyticsProperties;
 };
 
@@ -22,6 +37,7 @@ export type AnalyticsClient = {
   clearContext: () => void;
   setUserProfile: (properties: AnalyticsProperties) => void;
   setUserProfileOnce: (properties: AnalyticsProperties) => void;
+  unionUserProfile: (properties: AnalyticsProfileUnionProperties) => void;
   __resetForTests: () => void;
 };
 
@@ -120,6 +136,7 @@ export function createMixpanelBrowserClient(
 
       try {
         mixpanel.track(event, {
+          ...(config.defaultEventProperties ?? {}),
           ...currentEventContext,
           ...(properties ?? {}),
         });
@@ -201,6 +218,24 @@ export function createMixpanelBrowserClient(
     });
   }
 
+  function unionUserProfile(properties: AnalyticsProfileUnionProperties): void {
+    if (!canTrack()) {
+      return;
+    }
+
+    void init().then(() => {
+      if (!isInitialized || !mixpanel) {
+        return;
+      }
+
+      try {
+        mixpanel.people.union(properties);
+      } catch (error) {
+        console.error("Failed to union Mixpanel profile", error);
+      }
+    });
+  }
+
   function resetForTests(): void {
     mixpanel = null;
     isInitialized = false;
@@ -217,6 +252,7 @@ export function createMixpanelBrowserClient(
     clearContext,
     setUserProfile,
     setUserProfileOnce,
+    unionUserProfile,
     __resetForTests: resetForTests,
   };
 }


### PR DESCRIPTION
Unify Mixpanel workspace attribution across miniapp, bot, and website with shared browser/server helpers.

Add durable workspace adoption profile fields and centralize the bot and website server emitters.