### PR TITLE
feat(frontend/roadmap): mark Q1 2026 completed and Q2 in progress

### DIFF
--- a/frontend/src/components/roadmap-section.tsx
+++ b/frontend/src/components/roadmap-section.tsx
@@ -7,13 +7,13 @@ import { roadmapEvents } from "@/data/roadmap";
 const GEIST = "var(--font-geist-sans), sans-serif";
 
 function RoadmapSectionComponent() {
-  const q1_2026Index = roadmapEvents.findIndex(
+  const q2_2026Index = roadmapEvents.findIndex(
     (item) =>
       item.year === 2026 &&
       item.periodType === "Q" &&
-      item.periodNumber === 1
+      item.periodNumber === 2
   );
-  const initialRoadmapIndex = q1_2026Index >= 0 ? q1_2026Index : 0;
+  const initialRoadmapIndex = q2_2026Index >= 0 ? q2_2026Index : 0;
   const [currentIndex, setCurrentIndex] = useState(initialRoadmapIndex);
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(true);
 
@@ -561,7 +561,9 @@ function RoadmapSectionComponent() {
                                             borderRadius: "50%",
                                             background: event.isChecked
                                               ? "#34C759"
-                                              : "#F9363C",
+                                              : item.isChecked
+                                                ? "#FFCC00"
+                                                : "#F9363C",
                                           }}
                                         />
                                       </div>

--- a/frontend/src/data/roadmap.ts
+++ b/frontend/src/data/roadmap.ts
@@ -31,10 +31,9 @@ export const roadmapEvents: RoadmapEvent[] = [
     year: 2026,
     periodType: "Q" as const,
     periodNumber: 1,
-    isChecked: false,
-    isActive: true,
+    isChecked: true,
     events: [
-      { title: "Squads multisig interoperability", isChecked: false },
+      { title: "Squads multisig interoperability", isChecked: true },
       { title: "LP management & staking automation", isChecked: false },
       { title: "Knowledge graph data visualization", isChecked: false },
       { title: "Fiat on-/off-ramping", isChecked: false },
@@ -45,6 +44,7 @@ export const roadmapEvents: RoadmapEvent[] = [
     periodType: "Q" as const,
     periodNumber: 2,
     isChecked: false,
+    isActive: true,
     events: [
       { title: "Workflow builder & executor", isChecked: false },
       { title: "Data connectors for email & calendar", isChecked: false },


### PR DESCRIPTION
## Summary
- Marks Q1 2026 as completed; Squads multisig shipped (green) and remaining Q1 items render yellow as carry-over.
- Sets Q2 2026 as the active in-progress quarter and defaults the carousel to land on Q2.