### PR TITLE
fix(app/wallet): show shielded tokens when base balance is zero

### DIFF
--- a/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
+++ b/app/src/lib/solana/token-holdings/fetch-token-holdings.ts
@@ -5,7 +5,7 @@ import { NATIVE_SOL_DECIMALS, NATIVE_SOL_MINT } from "@/lib/constants";
 import { fetchTokenPricesByMints } from "@/lib/jupiter/price";
 
 import { fetchJson } from "../../core/http";
-import { fetchLoyalDeposits } from "../deposits/loyal-deposits";
+import { getPrivateClient } from "../deposits/private-client";
 import { getSolanaEnv } from "../rpc/connection";
 import { CACHE_TTL_MS } from "./constants";
 import { resolveTokenIcon } from "./resolve-token-info";
@@ -16,6 +16,12 @@ import type {
   HeliusResponse,
   TokenHolding,
 } from "./types";
+
+type HeliusSingleAssetResponse = {
+  jsonrpc: "2.0";
+  result: HeliusAsset | null;
+  id: string;
+};
 
 const holdingsCache = new Map<string, CachedHoldings>();
 const inflightRequests = new Map<string, Promise<TokenHolding[]>>();
@@ -138,6 +144,87 @@ async function fetchHoldingsFromHelius(
   return holdings;
 }
 
+/**
+ * Fetch metadata for a single mint via Helius DAS `getAsset`.
+ *
+ * Used to resolve shielded-only token holdings — i.e. tokens the user has
+ * deposited into the Loyal secure vault but no longer holds on the base
+ * chain. Since `getAssetsByOwner` omits zero-balance token accounts, a
+ * shielded-max deposit would otherwise render without any metadata.
+ */
+async function fetchAssetByMint(
+  rpcUrl: string,
+  mint: string
+): Promise<HeliusAsset | null> {
+  try {
+    const response = await fetchJson<HeliusSingleAssetResponse>(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "shielded-asset",
+        method: "getAsset",
+        params: { id: mint },
+      }),
+    });
+    return response.result ?? null;
+  } catch (error) {
+    console.warn(
+      `[token-holdings] getAsset failed for mint ${mint}`,
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Build a zero-balance TokenHolding from mint metadata, intended as the
+ * "base row" template used to derive a shielded holding when the user has
+ * no base-chain balance for the mint. The caller overwrites `balance` and
+ * `valueUsd` with shielded values.
+ */
+function buildHoldingTemplateFromAsset(asset: HeliusAsset): TokenHolding | null {
+  const tokenInfo = asset.token_info;
+  if (!tokenInfo) return null;
+
+  const { decimals, price_info } = tokenInfo;
+  const symbol = resolveSymbol(asset);
+  const name = resolveName(asset, symbol);
+
+  return {
+    mint: asset.id,
+    symbol,
+    name,
+    balance: 0,
+    decimals,
+    priceUsd: price_info?.price_per_token ?? null,
+    valueUsd: null,
+    imageUrl: resolveImageUrl(asset),
+  };
+}
+
+/**
+ * Last-resort template when metadata can't be resolved. Preserves the mint
+ * so the row still renders (icon fallback + truncated mint as symbol).
+ */
+function buildUnknownHoldingTemplate(
+  mint: string,
+  decimals: number
+): TokenHolding {
+  const short =
+    mint.length > 10 ? `${mint.slice(0, 4)}...${mint.slice(-4)}` : mint;
+  return {
+    mint,
+    symbol: short,
+    name: short,
+    balance: 0,
+    decimals,
+    priceUsd: null,
+    valueUsd: null,
+    imageUrl: null,
+  };
+}
+
 async function enrichHoldingsWithJupiterPrices(
   holdings: TokenHolding[],
 ): Promise<TokenHolding[]> {
@@ -168,43 +255,91 @@ async function enrichHoldingsWithJupiterPrices(
   });
 }
 
-// Fetch holdings from Helius and from Magic Block PER (Secure deposits)
+/**
+ * Fetch holdings from Helius (base-chain balances) and from the Loyal secure
+ * vault (shielded deposits via MagicBlock PER), then merge them into a single
+ * TokenHolding list.
+ *
+ * Shielded deposits are enumerated directly from the Loyal program (both the
+ * base and ephemeral chains) rather than derived from Helius, so a mint only
+ * held inside the secure vault — e.g. after shielding the user's full USDC
+ * balance — still renders a row.
+ */
 async function fetchCombinedHoldings(
   rpcUrl: string,
   publicKey: string
 ): Promise<TokenHolding[]> {
   const userPubkey = new PublicKey(publicKey);
-  const solMint = new PublicKey(NATIVE_SOL_MINT);
 
-  // Fetch token holdings and Secure SOL
-  const [holdingsFromHelius, loyalNativeDeposits] = await Promise.all([
+  const [holdingsFromHelius, privateClient] = await Promise.all([
     fetchHoldingsFromHelius(rpcUrl, publicKey),
-    fetchLoyalDeposits(userPubkey, [solMint]),
+    getPrivateClient(),
   ]);
 
-  // Fetch other Secure token deposits based on tokens in base chain
-  const tokenMints = holdingsFromHelius
-    .map((h) => new PublicKey(h.mint))
-    .filter((mint) => !mint.equals(solMint));
-  const loyalTokenDeposits = await fetchLoyalDeposits(userPubkey, tokenMints);
+  let userDeposits: Awaited<
+    ReturnType<typeof privateClient.getAllDepositsByUser>
+  > = [];
+  try {
+    userDeposits = await privateClient.getAllDepositsByUser(userPubkey);
+  } catch (error) {
+    console.warn(
+      "[token-holdings] getAllDepositsByUser failed; shielded rows will be hidden",
+      error
+    );
+  }
 
-  // FIXME: show Secure token holdings even if user don't have tokens on base chain
+  const nonZeroDeposits = userDeposits.filter((d) => d.amount > BigInt(0));
+
+  // Resolve metadata for any shielded mint we can't match against a
+  // base-chain row. Each unresolved mint costs one DAS getAsset request; in
+  // practice a user has only a handful of shielded tokens.
+  const heliusByMint = new Map<string, TokenHolding>();
+  for (const holding of holdingsFromHelius) {
+    heliusByMint.set(holding.mint, holding);
+  }
+
+  const unresolvedMints = nonZeroDeposits
+    .map((d) => d.tokenMint.toBase58())
+    .filter((mint) => !heliusByMint.has(mint));
+  const uniqueUnresolvedMints = [...new Set(unresolvedMints)];
+
+  const resolvedAssets = await Promise.all(
+    uniqueUnresolvedMints.map(async (mint) => {
+      const asset = await fetchAssetByMint(rpcUrl, mint);
+      return [mint, asset] as const;
+    })
+  );
+  const assetByMint = new Map(resolvedAssets);
+
   const securedHoldings: TokenHolding[] = [];
-  for (const [mint, amount] of [
-    ...loyalNativeDeposits,
-    ...loyalTokenDeposits,
-  ]) {
-    const mintStr = mint.toString();
-    const original = holdingsFromHelius.find((h) => h.mint === mintStr);
-    if (original) {
-      const securedBalance = amount / Math.pow(10, original.decimals);
-      securedHoldings.push({
-        ...original,
-        balance: securedBalance,
-        valueUsd: original.priceUsd ? securedBalance * original.priceUsd : null,
-        isSecured: true,
-      });
+  for (const deposit of nonZeroDeposits) {
+    const mintStr = deposit.tokenMint.toBase58();
+    const rawAmount = Number(deposit.amount);
+
+    let template = heliusByMint.get(mintStr) ?? null;
+    if (!template) {
+      const asset = assetByMint.get(mintStr) ?? null;
+      if (asset) {
+        template = buildHoldingTemplateFromAsset(asset);
+      }
     }
+
+    if (!template) {
+      // Fall back to a placeholder — we still want the row visible so the
+      // user can see their shielded balance and unshield it. Decimals default
+      // to 0 so the raw on-chain amount is displayed verbatim; that is ugly
+      // but correct and only hit when every metadata source failed.
+      template = buildUnknownHoldingTemplate(mintStr, 0);
+    }
+
+    const securedBalance = rawAmount / Math.pow(10, template.decimals);
+    securedHoldings.push({
+      ...template,
+      balance: securedBalance,
+      valueUsd:
+        template.priceUsd !== null ? securedBalance * template.priceUsd : null,
+      isSecured: true,
+    });
   }
 
   const allHoldings = [...holdingsFromHelius, ...securedHoldings];

--- a/sdk/private-transactions/dist/index.js
+++ b/sdk/private-transactions/dist/index.js
@@ -4,39 +4,60 @@ var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+function __accessProp(key) {
+  return this[key];
+}
+var __toESMCache_node;
+var __toESMCache_esm;
 var __toESM = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
   for (let key of __getOwnPropNames(mod))
     if (!__hasOwnProp.call(to, key))
       __defProp(to, key, {
-        get: () => mod[key],
+        get: __accessProp.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
-var __moduleCache = /* @__PURE__ */ new WeakMap;
 var __toCommonJS = (from) => {
-  var entry = __moduleCache.get(from), desc;
+  var entry = (__moduleCache ??= new WeakMap).get(from), desc;
   if (entry)
     return entry;
   entry = __defProp({}, "__esModule", { value: true });
-  if (from && typeof from === "object" || typeof from === "function")
-    __getOwnPropNames(from).map((key) => !__hasOwnProp.call(entry, key) && __defProp(entry, key, {
-      get: () => from[key],
-      enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
-    }));
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (var key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(entry, key))
+        __defProp(entry, key, {
+          get: __accessProp.bind(from, key),
+          enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+        });
+  }
   __moduleCache.set(from, entry);
   return entry;
 };
+var __moduleCache;
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __returnValue = (v) => v;
+function __exportSetter(name, newValue) {
+  this[name] = __returnValue.bind(null, newValue);
+}
 var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, {
       get: all[name],
       enumerable: true,
       configurable: true,
-      set: (newValue) => all[name] = () => newValue
+      set: __exportSetter.bind(all, name)
     });
 };
 var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
@@ -49,8 +70,8 @@ var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require
 });
 
 // node:buffer
-var exports_buffer2 = {};
-__export(exports_buffer2, {
+var exports_buffer = {};
+__export(exports_buffer, {
   transcode: () => transcode,
   resolveObjectURL: () => resolveObjectURL,
   kStringMaxLength: () => kStringMaxLength,
@@ -69,7 +90,7 @@ __export(exports_buffer2, {
 function getLens(b64) {
   var len2 = b64.length;
   if (len2 % 4 > 0)
-    throw new Error("Invalid string. Length must be a multiple of 4");
+    throw Error("Invalid string. Length must be a multiple of 4");
   var validLen = b64.indexOf("=");
   if (validLen === -1)
     validLen = len2;
@@ -153,12 +174,12 @@ function write(buffer, value, offset, isLE, mLen, nBytes) {
 }
 function createBuffer(length) {
   if (length > kMaxLength)
-    throw new RangeError('The value "' + length + '" is invalid for option "size"');
+    throw RangeError('The value "' + length + '" is invalid for option "size"');
   let buf = new Uint8Array(length);
   return Object.setPrototypeOf(buf, Buffer2.prototype), buf;
 }
 function E(sym, getMessage, Base) {
-  return class NodeError extends Base {
+  return class extends Base {
     constructor() {
       super();
       Object.defineProperty(this, "message", { value: getMessage.apply(this, arguments), writable: true, configurable: true }), this.name = `${this.name} [${sym}]`, this.stack, delete this.name;
@@ -177,7 +198,7 @@ function E(sym, getMessage, Base) {
 function Buffer2(arg, encodingOrOffset, length) {
   if (typeof arg === "number") {
     if (typeof encodingOrOffset === "string")
-      throw new TypeError('The "string" argument must be of type string. Received type number');
+      throw TypeError('The "string" argument must be of type string. Received type number');
     return allocUnsafe(arg);
   }
   return from(arg, encodingOrOffset, length);
@@ -188,28 +209,28 @@ function from(value, encodingOrOffset, length) {
   if (ArrayBuffer.isView(value))
     return fromArrayView(value);
   if (value == null)
-    throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
+    throw TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
   if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer))
     return fromArrayBuffer(value, encodingOrOffset, length);
-  if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer)))
+  if (typeof SharedArrayBuffer < "u" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer)))
     return fromArrayBuffer(value, encodingOrOffset, length);
   if (typeof value === "number")
-    throw new TypeError('The "value" argument must not be of type number. Received type number');
+    throw TypeError('The "value" argument must not be of type number. Received type number');
   let valueOf = value.valueOf && value.valueOf();
   if (valueOf != null && valueOf !== value)
     return Buffer2.from(valueOf, encodingOrOffset, length);
   let b = fromObject(value);
   if (b)
     return b;
-  if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function")
+  if (typeof Symbol < "u" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function")
     return Buffer2.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
-  throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
+  throw TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
 }
 function assertSize(size) {
   if (typeof size !== "number")
-    throw new TypeError('"size" argument must be of type number');
+    throw TypeError('"size" argument must be of type number');
   else if (size < 0)
-    throw new RangeError('The value "' + size + '" is invalid for option "size"');
+    throw RangeError('The value "' + size + '" is invalid for option "size"');
 }
 function alloc(size, fill, encoding) {
   if (assertSize(size), size <= 0)
@@ -225,7 +246,7 @@ function fromString(string, encoding) {
   if (typeof encoding !== "string" || encoding === "")
     encoding = "utf8";
   if (!Buffer2.isEncoding(encoding))
-    throw new TypeError("Unknown encoding: " + encoding);
+    throw TypeError("Unknown encoding: " + encoding);
   let length = byteLength(string, encoding) | 0, buf = createBuffer(length), actual = buf.write(string, encoding);
   if (actual !== length)
     buf = buf.slice(0, actual);
@@ -246,9 +267,9 @@ function fromArrayView(arrayView) {
 }
 function fromArrayBuffer(array, byteOffset, length) {
   if (byteOffset < 0 || array.byteLength < byteOffset)
-    throw new RangeError('"offset" is outside of buffer bounds');
+    throw RangeError('"offset" is outside of buffer bounds');
   if (array.byteLength < byteOffset + (length || 0))
-    throw new RangeError('"length" is outside of buffer bounds');
+    throw RangeError('"length" is outside of buffer bounds');
   let buf;
   if (byteOffset === undefined && length === undefined)
     buf = new Uint8Array(array);
@@ -266,7 +287,7 @@ function fromObject(obj) {
     return obj.copy(buf, 0, 0, len2), buf;
   }
   if (obj.length !== undefined) {
-    if (typeof obj.length !== "number" || numberIsNaN(obj.length))
+    if (typeof obj.length !== "number" || Number.isNaN(obj.length))
       return createBuffer(0);
     return fromArrayLike(obj);
   }
@@ -275,7 +296,7 @@ function fromObject(obj) {
 }
 function checked(length) {
   if (length >= kMaxLength)
-    throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + kMaxLength.toString(16) + " bytes");
+    throw RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + kMaxLength.toString(16) + " bytes");
   return length | 0;
 }
 function byteLength(string, encoding) {
@@ -284,7 +305,7 @@ function byteLength(string, encoding) {
   if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer))
     return string.byteLength;
   if (typeof string !== "string")
-    throw new TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
+    throw TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
   let len2 = string.length, mustMatch = arguments.length > 2 && arguments[2] === true;
   if (!mustMatch && len2 === 0)
     return 0;
@@ -348,7 +369,7 @@ function slowToString(encoding, start, end) {
         return utf16leSlice(this, start, end);
       default:
         if (loweredCase)
-          throw new TypeError("Unknown encoding: " + encoding);
+          throw TypeError("Unknown encoding: " + encoding);
         encoding = (encoding + "").toLowerCase(), loweredCase = true;
     }
 }
@@ -393,7 +414,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
         return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
     return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
   }
-  throw new TypeError("val must be string, number or Buffer");
+  throw TypeError("val must be string, number or Buffer");
 }
 function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
   let indexSize = 1, arrLength = arr.length, valLength = val.length;
@@ -453,7 +474,7 @@ function hexWrite(buf, string, offset, length) {
   let i2;
   for (i2 = 0;i2 < length; ++i2) {
     let parsed = parseInt(string.substr(i2 * 2, 2), 16);
-    if (numberIsNaN(parsed))
+    if (Number.isNaN(parsed))
       return i2;
     buf[offset + i2] = parsed;
   }
@@ -558,17 +579,17 @@ function utf16leSlice(buf, start, end) {
 }
 function checkOffset(offset, ext, length) {
   if (offset % 1 !== 0 || offset < 0)
-    throw new RangeError("offset is not uint");
+    throw RangeError("offset is not uint");
   if (offset + ext > length)
-    throw new RangeError("Trying to access beyond buffer length");
+    throw RangeError("Trying to access beyond buffer length");
 }
 function checkInt(buf, value, offset, ext, max, min) {
   if (!Buffer2.isBuffer(buf))
-    throw new TypeError('"buffer" argument must be a Buffer instance');
+    throw TypeError('"buffer" argument must be a Buffer instance');
   if (value > max || value < min)
-    throw new RangeError('"value" argument is out of bounds');
+    throw RangeError('"value" argument is out of bounds');
   if (offset + ext > buf.length)
-    throw new RangeError("Index out of range");
+    throw RangeError("Index out of range");
 }
 function wrtBigUInt64LE(buf, value, offset, min, max) {
   checkIntBI(value, min, max, buf, offset, 7);
@@ -586,9 +607,9 @@ function wrtBigUInt64BE(buf, value, offset, min, max) {
 }
 function checkIEEE754(buf, value, offset, ext, max, min) {
   if (offset + ext > buf.length)
-    throw new RangeError("Index out of range");
+    throw RangeError("Index out of range");
   if (offset < 0)
-    throw new RangeError("Index out of range");
+    throw RangeError("Index out of range");
 }
 function writeFloat(buf, value, offset, littleEndian, noAssert) {
   if (value = +value, offset = offset >>> 0, !noAssert)
@@ -688,7 +709,7 @@ function utf8ToBytes(string, units) {
         break;
       bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
     } else
-      throw new Error("Invalid code point");
+      throw Error("Invalid code point");
   }
   return bytes;
 }
@@ -723,14 +744,14 @@ function isInstance(obj, type) {
   return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
 }
 function defineBigIntMethod(fn) {
-  return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
+  return typeof BigInt > "u" ? BufferBigIntNotDefined : fn;
 }
 function BufferBigIntNotDefined() {
-  throw new Error("BigInt not supported");
+  throw Error("BigInt not supported");
 }
 function notimpl(name) {
   return () => {
-    throw new Error(name + " is not implemented for node:buffer browser polyfill");
+    throw Error(name + " is not implemented for node:buffer browser polyfill");
   };
 }
 var lookup, revLookup, code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", i, len, customInspectSymbol, INSPECT_MAX_BYTES = 50, kMaxLength = 2147483647, kStringMaxLength = 536870888, btoa, atob, File, Blob, constants, ERR_BUFFER_OUT_OF_BOUNDS, ERR_INVALID_ARG_TYPE, ERR_OUT_OF_RANGE, MAX_ARGUMENTS_LENGTH = 4096, INVALID_BASE64_RE, hexSliceLookupTable, resolveObjectURL, isUtf8, isAscii = (str) => {
@@ -796,16 +817,16 @@ var init_buffer = __esm(() => {
   Buffer2.allocUnsafeSlow = function(size) {
     return allocUnsafe(size);
   };
-  Buffer2.isBuffer = function isBuffer(b) {
+  Buffer2.isBuffer = function(b) {
     return b != null && b._isBuffer === true && b !== Buffer2.prototype;
   };
-  Buffer2.compare = function compare(a, b) {
+  Buffer2.compare = function(a, b) {
     if (isInstance(a, Uint8Array))
       a = Buffer2.from(a, a.offset, a.byteLength);
     if (isInstance(b, Uint8Array))
       b = Buffer2.from(b, b.offset, b.byteLength);
     if (!Buffer2.isBuffer(a) || !Buffer2.isBuffer(b))
-      throw new TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
+      throw TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
     if (a === b)
       return 0;
     let x = a.length, y = b.length;
@@ -820,7 +841,7 @@ var init_buffer = __esm(() => {
       return 1;
     return 0;
   };
-  Buffer2.isEncoding = function isEncoding(encoding) {
+  Buffer2.isEncoding = function(encoding) {
     switch (String(encoding).toLowerCase()) {
       case "hex":
       case "utf8":
@@ -838,9 +859,9 @@ var init_buffer = __esm(() => {
         return false;
     }
   };
-  Buffer2.concat = function concat(list, length) {
+  Buffer2.concat = function(list, length) {
     if (!Array.isArray(list))
-      throw new TypeError('"list" argument must be an Array of Buffers');
+      throw TypeError('"list" argument must be an Array of Buffers');
     if (list.length === 0)
       return Buffer2.alloc(0);
     let i2;
@@ -860,7 +881,7 @@ var init_buffer = __esm(() => {
         } else
           Uint8Array.prototype.set.call(buffer, buf, pos);
       else if (!Buffer2.isBuffer(buf))
-        throw new TypeError('"list" argument must be an Array of Buffers');
+        throw TypeError('"list" argument must be an Array of Buffers');
       else
         buf.copy(buffer, pos);
       pos += buf.length;
@@ -869,31 +890,31 @@ var init_buffer = __esm(() => {
   };
   Buffer2.byteLength = byteLength;
   Buffer2.prototype._isBuffer = true;
-  Buffer2.prototype.swap16 = function swap16() {
+  Buffer2.prototype.swap16 = function() {
     let len2 = this.length;
     if (len2 % 2 !== 0)
-      throw new RangeError("Buffer size must be a multiple of 16-bits");
+      throw RangeError("Buffer size must be a multiple of 16-bits");
     for (let i2 = 0;i2 < len2; i2 += 2)
       swap(this, i2, i2 + 1);
     return this;
   };
-  Buffer2.prototype.swap32 = function swap32() {
+  Buffer2.prototype.swap32 = function() {
     let len2 = this.length;
     if (len2 % 4 !== 0)
-      throw new RangeError("Buffer size must be a multiple of 32-bits");
+      throw RangeError("Buffer size must be a multiple of 32-bits");
     for (let i2 = 0;i2 < len2; i2 += 4)
       swap(this, i2, i2 + 3), swap(this, i2 + 1, i2 + 2);
     return this;
   };
-  Buffer2.prototype.swap64 = function swap64() {
+  Buffer2.prototype.swap64 = function() {
     let len2 = this.length;
     if (len2 % 8 !== 0)
-      throw new RangeError("Buffer size must be a multiple of 64-bits");
+      throw RangeError("Buffer size must be a multiple of 64-bits");
     for (let i2 = 0;i2 < len2; i2 += 8)
       swap(this, i2, i2 + 7), swap(this, i2 + 1, i2 + 6), swap(this, i2 + 2, i2 + 5), swap(this, i2 + 3, i2 + 4);
     return this;
   };
-  Buffer2.prototype.toString = function toString() {
+  Buffer2.prototype.toString = function() {
     let length = this.length;
     if (length === 0)
       return "";
@@ -902,26 +923,26 @@ var init_buffer = __esm(() => {
     return slowToString.apply(this, arguments);
   };
   Buffer2.prototype.toLocaleString = Buffer2.prototype.toString;
-  Buffer2.prototype.equals = function equals(b) {
+  Buffer2.prototype.equals = function(b) {
     if (!Buffer2.isBuffer(b))
-      throw new TypeError("Argument must be a Buffer");
+      throw TypeError("Argument must be a Buffer");
     if (this === b)
       return true;
     return Buffer2.compare(this, b) === 0;
   };
-  Buffer2.prototype.inspect = function inspect() {
-    let str = "", max = exports_buffer.INSPECT_MAX_BYTES;
+  Buffer2.prototype.inspect = function() {
+    let str = "", max = INSPECT_MAX_BYTES;
     if (str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim(), this.length > max)
       str += " ... ";
     return "<Buffer " + str + ">";
   };
   if (customInspectSymbol)
     Buffer2.prototype[customInspectSymbol] = Buffer2.prototype.inspect;
-  Buffer2.prototype.compare = function compare2(target, start, end, thisStart, thisEnd) {
+  Buffer2.prototype.compare = function(target, start, end, thisStart, thisEnd) {
     if (isInstance(target, Uint8Array))
       target = Buffer2.from(target, target.offset, target.byteLength);
     if (!Buffer2.isBuffer(target))
-      throw new TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
+      throw TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
     if (start === undefined)
       start = 0;
     if (end === undefined)
@@ -931,7 +952,7 @@ var init_buffer = __esm(() => {
     if (thisEnd === undefined)
       thisEnd = this.length;
     if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length)
-      throw new RangeError("out of range index");
+      throw RangeError("out of range index");
     if (thisStart >= thisEnd && start >= end)
       return 0;
     if (thisStart >= thisEnd)
@@ -952,16 +973,16 @@ var init_buffer = __esm(() => {
       return 1;
     return 0;
   };
-  Buffer2.prototype.includes = function includes(val, byteOffset, encoding) {
+  Buffer2.prototype.includes = function(val, byteOffset, encoding) {
     return this.indexOf(val, byteOffset, encoding) !== -1;
   };
-  Buffer2.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+  Buffer2.prototype.indexOf = function(val, byteOffset, encoding) {
     return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
   };
-  Buffer2.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+  Buffer2.prototype.lastIndexOf = function(val, byteOffset, encoding) {
     return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
   };
-  Buffer2.prototype.write = function write2(string, offset, length, encoding) {
+  Buffer2.prototype.write = function(string, offset, length, encoding) {
     if (offset === undefined)
       encoding = "utf8", length = this.length, offset = 0;
     else if (length === undefined && typeof offset === "string")
@@ -973,12 +994,12 @@ var init_buffer = __esm(() => {
       } else
         encoding = length, length = undefined;
     else
-      throw new Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
+      throw Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
     let remaining = this.length - offset;
     if (length === undefined || length > remaining)
       length = remaining;
     if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length)
-      throw new RangeError("Attempt to write outside buffer bounds");
+      throw RangeError("Attempt to write outside buffer bounds");
     if (!encoding)
       encoding = "utf8";
     let loweredCase = false;
@@ -1002,14 +1023,14 @@ var init_buffer = __esm(() => {
           return ucs2Write(this, string, offset, length);
         default:
           if (loweredCase)
-            throw new TypeError("Unknown encoding: " + encoding);
+            throw TypeError("Unknown encoding: " + encoding);
           encoding = ("" + encoding).toLowerCase(), loweredCase = true;
       }
   };
-  Buffer2.prototype.toJSON = function toJSON() {
+  Buffer2.prototype.toJSON = function() {
     return { type: "Buffer", data: Array.prototype.slice.call(this._arr || this, 0) };
   };
-  Buffer2.prototype.slice = function slice(start, end) {
+  Buffer2.prototype.slice = function(start, end) {
     let len2 = this.length;
     if (start = ~~start, end = end === undefined ? len2 : ~~end, start < 0) {
       if (start += len2, start < 0)
@@ -1026,7 +1047,7 @@ var init_buffer = __esm(() => {
     let newBuf = this.subarray(start, end);
     return Object.setPrototypeOf(newBuf, Buffer2.prototype), newBuf;
   };
-  Buffer2.prototype.readUintLE = Buffer2.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+  Buffer2.prototype.readUintLE = Buffer2.prototype.readUIntLE = function(offset, byteLength2, noAssert) {
     if (offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert)
       checkOffset(offset, byteLength2, this.length);
     let val = this[offset], mul = 1, i2 = 0;
@@ -1034,7 +1055,7 @@ var init_buffer = __esm(() => {
       val += this[offset + i2] * mul;
     return val;
   };
-  Buffer2.prototype.readUintBE = Buffer2.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+  Buffer2.prototype.readUintBE = Buffer2.prototype.readUIntBE = function(offset, byteLength2, noAssert) {
     if (offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert)
       checkOffset(offset, byteLength2, this.length);
     let val = this[offset + --byteLength2], mul = 1;
@@ -1042,32 +1063,32 @@ var init_buffer = __esm(() => {
       val += this[offset + --byteLength2] * mul;
     return val;
   };
-  Buffer2.prototype.readUint8 = Buffer2.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+  Buffer2.prototype.readUint8 = Buffer2.prototype.readUInt8 = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 1, this.length);
     return this[offset];
   };
-  Buffer2.prototype.readUint16LE = Buffer2.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+  Buffer2.prototype.readUint16LE = Buffer2.prototype.readUInt16LE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 2, this.length);
     return this[offset] | this[offset + 1] << 8;
   };
-  Buffer2.prototype.readUint16BE = Buffer2.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+  Buffer2.prototype.readUint16BE = Buffer2.prototype.readUInt16BE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 2, this.length);
     return this[offset] << 8 | this[offset + 1];
   };
-  Buffer2.prototype.readUint32LE = Buffer2.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+  Buffer2.prototype.readUint32LE = Buffer2.prototype.readUInt32LE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
   };
-  Buffer2.prototype.readUint32BE = Buffer2.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+  Buffer2.prototype.readUint32BE = Buffer2.prototype.readUInt32BE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
   };
-  Buffer2.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+  Buffer2.prototype.readBigUInt64LE = defineBigIntMethod(function(offset) {
     offset = offset >>> 0, validateNumber(offset, "offset");
     let first = this[offset], last = this[offset + 7];
     if (first === undefined || last === undefined)
@@ -1075,7 +1096,7 @@ var init_buffer = __esm(() => {
     let lo = first + this[++offset] * 256 + this[++offset] * 65536 + this[++offset] * 16777216, hi = this[++offset] + this[++offset] * 256 + this[++offset] * 65536 + last * 16777216;
     return BigInt(lo) + (BigInt(hi) << BigInt(32));
   });
-  Buffer2.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+  Buffer2.prototype.readBigUInt64BE = defineBigIntMethod(function(offset) {
     offset = offset >>> 0, validateNumber(offset, "offset");
     let first = this[offset], last = this[offset + 7];
     if (first === undefined || last === undefined)
@@ -1083,7 +1104,7 @@ var init_buffer = __esm(() => {
     let hi = first * 16777216 + this[++offset] * 65536 + this[++offset] * 256 + this[++offset], lo = this[++offset] * 16777216 + this[++offset] * 65536 + this[++offset] * 256 + last;
     return (BigInt(hi) << BigInt(32)) + BigInt(lo);
   });
-  Buffer2.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+  Buffer2.prototype.readIntLE = function(offset, byteLength2, noAssert) {
     if (offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert)
       checkOffset(offset, byteLength2, this.length);
     let val = this[offset], mul = 1, i2 = 0;
@@ -1093,7 +1114,7 @@ var init_buffer = __esm(() => {
       val -= Math.pow(2, 8 * byteLength2);
     return val;
   };
-  Buffer2.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+  Buffer2.prototype.readIntBE = function(offset, byteLength2, noAssert) {
     if (offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert)
       checkOffset(offset, byteLength2, this.length);
     let i2 = byteLength2, mul = 1, val = this[offset + --i2];
@@ -1103,36 +1124,36 @@ var init_buffer = __esm(() => {
       val -= Math.pow(2, 8 * byteLength2);
     return val;
   };
-  Buffer2.prototype.readInt8 = function readInt8(offset, noAssert) {
+  Buffer2.prototype.readInt8 = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 1, this.length);
     if (!(this[offset] & 128))
       return this[offset];
     return (255 - this[offset] + 1) * -1;
   };
-  Buffer2.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+  Buffer2.prototype.readInt16LE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 2, this.length);
     let val = this[offset] | this[offset + 1] << 8;
     return val & 32768 ? val | 4294901760 : val;
   };
-  Buffer2.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+  Buffer2.prototype.readInt16BE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 2, this.length);
     let val = this[offset + 1] | this[offset] << 8;
     return val & 32768 ? val | 4294901760 : val;
   };
-  Buffer2.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+  Buffer2.prototype.readInt32LE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
   };
-  Buffer2.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+  Buffer2.prototype.readInt32BE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
   };
-  Buffer2.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+  Buffer2.prototype.readBigInt64LE = defineBigIntMethod(function(offset) {
     offset = offset >>> 0, validateNumber(offset, "offset");
     let first = this[offset], last = this[offset + 7];
     if (first === undefined || last === undefined)
@@ -1140,7 +1161,7 @@ var init_buffer = __esm(() => {
     let val = this[offset + 4] + this[offset + 5] * 256 + this[offset + 6] * 65536 + (last << 24);
     return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 256 + this[++offset] * 65536 + this[++offset] * 16777216);
   });
-  Buffer2.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+  Buffer2.prototype.readBigInt64BE = defineBigIntMethod(function(offset) {
     offset = offset >>> 0, validateNumber(offset, "offset");
     let first = this[offset], last = this[offset + 7];
     if (first === undefined || last === undefined)
@@ -1148,27 +1169,27 @@ var init_buffer = __esm(() => {
     let val = (first << 24) + this[++offset] * 65536 + this[++offset] * 256 + this[++offset];
     return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 16777216 + this[++offset] * 65536 + this[++offset] * 256 + last);
   });
-  Buffer2.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+  Buffer2.prototype.readFloatLE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return read(this, offset, true, 23, 4);
   };
-  Buffer2.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+  Buffer2.prototype.readFloatBE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 4, this.length);
     return read(this, offset, false, 23, 4);
   };
-  Buffer2.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+  Buffer2.prototype.readDoubleLE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 8, this.length);
     return read(this, offset, true, 52, 8);
   };
-  Buffer2.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+  Buffer2.prototype.readDoubleBE = function(offset, noAssert) {
     if (offset = offset >>> 0, !noAssert)
       checkOffset(offset, 8, this.length);
     return read(this, offset, false, 52, 8);
   };
-  Buffer2.prototype.writeUintLE = Buffer2.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+  Buffer2.prototype.writeUintLE = Buffer2.prototype.writeUIntLE = function(value, offset, byteLength2, noAssert) {
     if (value = +value, offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert) {
       let maxBytes = Math.pow(2, 8 * byteLength2) - 1;
       checkInt(this, value, offset, byteLength2, maxBytes, 0);
@@ -1179,7 +1200,7 @@ var init_buffer = __esm(() => {
       this[offset + i2] = value / mul & 255;
     return offset + byteLength2;
   };
-  Buffer2.prototype.writeUintBE = Buffer2.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+  Buffer2.prototype.writeUintBE = Buffer2.prototype.writeUIntBE = function(value, offset, byteLength2, noAssert) {
     if (value = +value, offset = offset >>> 0, byteLength2 = byteLength2 >>> 0, !noAssert) {
       let maxBytes = Math.pow(2, 8 * byteLength2) - 1;
       checkInt(this, value, offset, byteLength2, maxBytes, 0);
@@ -1190,38 +1211,38 @@ var init_buffer = __esm(() => {
       this[offset + i2] = value / mul & 255;
     return offset + byteLength2;
   };
-  Buffer2.prototype.writeUint8 = Buffer2.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+  Buffer2.prototype.writeUint8 = Buffer2.prototype.writeUInt8 = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 1, 255, 0);
     return this[offset] = value & 255, offset + 1;
   };
-  Buffer2.prototype.writeUint16LE = Buffer2.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+  Buffer2.prototype.writeUint16LE = Buffer2.prototype.writeUInt16LE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 2, 65535, 0);
     return this[offset] = value & 255, this[offset + 1] = value >>> 8, offset + 2;
   };
-  Buffer2.prototype.writeUint16BE = Buffer2.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+  Buffer2.prototype.writeUint16BE = Buffer2.prototype.writeUInt16BE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 2, 65535, 0);
     return this[offset] = value >>> 8, this[offset + 1] = value & 255, offset + 2;
   };
-  Buffer2.prototype.writeUint32LE = Buffer2.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+  Buffer2.prototype.writeUint32LE = Buffer2.prototype.writeUInt32LE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 4, 4294967295, 0);
     return this[offset + 3] = value >>> 24, this[offset + 2] = value >>> 16, this[offset + 1] = value >>> 8, this[offset] = value & 255, offset + 4;
   };
-  Buffer2.prototype.writeUint32BE = Buffer2.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+  Buffer2.prototype.writeUint32BE = Buffer2.prototype.writeUInt32BE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 4, 4294967295, 0);
     return this[offset] = value >>> 24, this[offset + 1] = value >>> 16, this[offset + 2] = value >>> 8, this[offset + 3] = value & 255, offset + 4;
   };
-  Buffer2.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+  Buffer2.prototype.writeBigUInt64LE = defineBigIntMethod(function(value, offset = 0) {
     return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
   });
-  Buffer2.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+  Buffer2.prototype.writeBigUInt64BE = defineBigIntMethod(function(value, offset = 0) {
     return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
   });
-  Buffer2.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+  Buffer2.prototype.writeIntLE = function(value, offset, byteLength2, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert) {
       let limit = Math.pow(2, 8 * byteLength2 - 1);
       checkInt(this, value, offset, byteLength2, limit - 1, -limit);
@@ -1235,7 +1256,7 @@ var init_buffer = __esm(() => {
     }
     return offset + byteLength2;
   };
-  Buffer2.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+  Buffer2.prototype.writeIntBE = function(value, offset, byteLength2, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert) {
       let limit = Math.pow(2, 8 * byteLength2 - 1);
       checkInt(this, value, offset, byteLength2, limit - 1, -limit);
@@ -1249,56 +1270,56 @@ var init_buffer = __esm(() => {
     }
     return offset + byteLength2;
   };
-  Buffer2.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+  Buffer2.prototype.writeInt8 = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 1, 127, -128);
     if (value < 0)
       value = 255 + value + 1;
     return this[offset] = value & 255, offset + 1;
   };
-  Buffer2.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+  Buffer2.prototype.writeInt16LE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 2, 32767, -32768);
     return this[offset] = value & 255, this[offset + 1] = value >>> 8, offset + 2;
   };
-  Buffer2.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+  Buffer2.prototype.writeInt16BE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 2, 32767, -32768);
     return this[offset] = value >>> 8, this[offset + 1] = value & 255, offset + 2;
   };
-  Buffer2.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+  Buffer2.prototype.writeInt32LE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 4, 2147483647, -2147483648);
     return this[offset] = value & 255, this[offset + 1] = value >>> 8, this[offset + 2] = value >>> 16, this[offset + 3] = value >>> 24, offset + 4;
   };
-  Buffer2.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+  Buffer2.prototype.writeInt32BE = function(value, offset, noAssert) {
     if (value = +value, offset = offset >>> 0, !noAssert)
       checkInt(this, value, offset, 4, 2147483647, -2147483648);
     if (value < 0)
       value = 4294967295 + value + 1;
     return this[offset] = value >>> 24, this[offset + 1] = value >>> 16, this[offset + 2] = value >>> 8, this[offset + 3] = value & 255, offset + 4;
   };
-  Buffer2.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+  Buffer2.prototype.writeBigInt64LE = defineBigIntMethod(function(value, offset = 0) {
     return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
   });
-  Buffer2.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+  Buffer2.prototype.writeBigInt64BE = defineBigIntMethod(function(value, offset = 0) {
     return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
   });
-  Buffer2.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+  Buffer2.prototype.writeFloatLE = function(value, offset, noAssert) {
     return writeFloat(this, value, offset, true, noAssert);
   };
-  Buffer2.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+  Buffer2.prototype.writeFloatBE = function(value, offset, noAssert) {
     return writeFloat(this, value, offset, false, noAssert);
   };
-  Buffer2.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+  Buffer2.prototype.writeDoubleLE = function(value, offset, noAssert) {
     return writeDouble(this, value, offset, true, noAssert);
   };
-  Buffer2.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+  Buffer2.prototype.writeDoubleBE = function(value, offset, noAssert) {
     return writeDouble(this, value, offset, false, noAssert);
   };
-  Buffer2.prototype.copy = function copy(target, targetStart, start, end) {
+  Buffer2.prototype.copy = function(target, targetStart, start, end) {
     if (!Buffer2.isBuffer(target))
-      throw new TypeError("argument should be a Buffer");
+      throw TypeError("argument should be a Buffer");
     if (!start)
       start = 0;
     if (!end && end !== 0)
@@ -1314,11 +1335,11 @@ var init_buffer = __esm(() => {
     if (target.length === 0 || this.length === 0)
       return 0;
     if (targetStart < 0)
-      throw new RangeError("targetStart out of bounds");
+      throw RangeError("targetStart out of bounds");
     if (start < 0 || start >= this.length)
-      throw new RangeError("Index out of range");
+      throw RangeError("Index out of range");
     if (end < 0)
-      throw new RangeError("sourceEnd out of bounds");
+      throw RangeError("sourceEnd out of bounds");
     if (end > this.length)
       end = this.length;
     if (target.length - targetStart < end - start)
@@ -1330,16 +1351,16 @@ var init_buffer = __esm(() => {
       Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
     return len2;
   };
-  Buffer2.prototype.fill = function fill(val, start, end, encoding) {
+  Buffer2.prototype.fill = function(val, start, end, encoding) {
     if (typeof val === "string") {
       if (typeof start === "string")
         encoding = start, start = 0, end = this.length;
       else if (typeof end === "string")
         encoding = end, end = this.length;
       if (encoding !== undefined && typeof encoding !== "string")
-        throw new TypeError("encoding must be a string");
+        throw TypeError("encoding must be a string");
       if (typeof encoding === "string" && !Buffer2.isEncoding(encoding))
-        throw new TypeError("Unknown encoding: " + encoding);
+        throw TypeError("Unknown encoding: " + encoding);
       if (val.length === 1) {
         let code2 = val.charCodeAt(0);
         if (encoding === "utf8" && code2 < 128 || encoding === "latin1")
@@ -1350,7 +1371,7 @@ var init_buffer = __esm(() => {
     else if (typeof val === "boolean")
       val = Number(val);
     if (start < 0 || this.length < start || this.length < end)
-      throw new RangeError("Out of range index");
+      throw RangeError("Out of range index");
     if (end <= start)
       return this;
     if (start = start >>> 0, end = end === undefined ? this.length : end >>> 0, !val)
@@ -1362,7 +1383,7 @@ var init_buffer = __esm(() => {
     else {
       let bytes = Buffer2.isBuffer(val) ? val : Buffer2.from(val, encoding), len2 = bytes.length;
       if (len2 === 0)
-        throw new TypeError('The value "' + val + '" is invalid for argument "value"');
+        throw TypeError('The value "' + val + '" is invalid for argument "value"');
       for (i2 = 0;i2 < end - start; ++i2)
         this[i2 + start] = bytes[i2 % len2];
     }
@@ -1370,7 +1391,7 @@ var init_buffer = __esm(() => {
   };
   INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
   hexSliceLookupTable = function() {
-    let table = new Array(256);
+    let table = Array(256);
     for (let i2 = 0;i2 < 16; ++i2) {
       let i16 = i2 * 16;
       for (let j = 0;j < 16; ++j)
@@ -1402,10 +1423,10 @@ __export(exports_util, {
   isFunction: () => isFunction,
   isError: () => isError,
   isDate: () => isDate,
-  isBuffer: () => isBuffer2,
+  isBuffer: () => isBuffer,
   isBoolean: () => isBoolean,
   isArray: () => isArray,
-  inspect: () => inspect2,
+  inspect: () => inspect,
   inherits: () => inherits,
   format: () => format,
   deprecate: () => deprecate,
@@ -1421,7 +1442,7 @@ function format(f, ...args) {
   if (!isString(f)) {
     var objects = [f];
     for (var i2 = 0;i2 < args.length; i2++)
-      objects.push(inspect2(args[i2]));
+      objects.push(inspect(args[i2]));
     return objects.join(" ");
   }
   var i2 = 0, len2 = args.length, str = String(f).replace(formatRegExp, function(x2) {
@@ -1448,17 +1469,17 @@ function format(f, ...args) {
     if (isNull(x) || !isObject(x))
       str += " " + x;
     else
-      str += " " + inspect2(x);
+      str += " " + inspect(x);
   return str;
 }
 function deprecate(fn, msg) {
-  if (typeof process === "undefined" || process?.noDeprecation === true)
+  if (typeof process > "u" || process?.noDeprecation === true)
     return fn;
   var warned = false;
   function deprecated(...args) {
     if (!warned) {
       if (process.throwDeprecation)
-        throw new Error(msg);
+        throw Error(msg);
       else if (process.traceDeprecation)
         console.trace(msg);
       else
@@ -1470,9 +1491,9 @@ function deprecate(fn, msg) {
   return deprecated;
 }
 function stylizeWithColor(str, styleType) {
-  var style = inspect2.styles[styleType];
+  var style = inspect.styles[styleType];
   if (style)
-    return "\x1B[" + inspect2.colors[style][0] + "m" + str + "\x1B[" + inspect2.colors[style][1] + "m";
+    return "\x1B[" + inspect.colors[style][0] + "m" + str + "\x1B[" + inspect.colors[style][1] + "m";
   else
     return str;
 }
@@ -1486,7 +1507,7 @@ function arrayToHash(array) {
   }), hash;
 }
 function formatValue(ctx, value, recurseTimes) {
-  if (ctx.customInspect && value && isFunction(value.inspect) && value.inspect !== inspect2 && !(value.constructor && value.constructor.prototype === value)) {
+  if (ctx.customInspect && value && isFunction(value.inspect) && value.inspect !== inspect && !(value.constructor && value.constructor.prototype === value)) {
     var ret = value.inspect(recurseTimes, ctx);
     if (!isString(ret))
       ret = formatValue(ctx, ret, recurseTimes);
@@ -1668,9 +1689,9 @@ function isFunction(arg) {
   return typeof arg === "function";
 }
 function isPrimitive(arg) {
-  return arg === null || typeof arg === "boolean" || typeof arg === "number" || typeof arg === "string" || typeof arg === "symbol" || typeof arg === "undefined";
+  return arg === null || typeof arg === "boolean" || typeof arg === "number" || typeof arg === "string" || typeof arg === "symbol" || typeof arg > "u";
 }
-function isBuffer2(arg) {
+function isBuffer(arg) {
   return arg instanceof Buffer;
 }
 function objectToString(o) {
@@ -1703,18 +1724,18 @@ function hasOwnProperty(obj, prop) {
 }
 function callbackifyOnRejected(reason, cb) {
   if (!reason) {
-    var newReason = new Error("Promise was rejected with a falsy value");
+    var newReason = Error("Promise was rejected with a falsy value");
     newReason.reason = reason, reason = newReason;
   }
   return cb(reason);
 }
 function callbackify(original) {
   if (typeof original !== "function")
-    throw new TypeError('The "original" argument must be of type Function');
+    throw TypeError('The "original" argument must be of type Function');
   function callbackified(...args) {
     var maybeCb = args.pop();
     if (typeof maybeCb !== "function")
-      throw new TypeError("The last argument must be of type Function");
+      throw TypeError("The last argument must be of type Function");
     var self2 = this, cb = function(...args2) {
       return maybeCb.apply(self2, ...args2);
     };
@@ -1726,10 +1747,10 @@ function callbackify(original) {
   }
   return Object.setPrototypeOf(callbackified, Object.getPrototypeOf(original)), Object.defineProperties(callbackified, Object.getOwnPropertyDescriptors(original)), callbackified;
 }
-var formatRegExp, debuglog, inspect2, types = () => {}, months, promisify, TextEncoder2, TextDecoder, util_default;
+var formatRegExp, debuglog, inspect, types = () => {}, months, promisify, TextEncoder2, TextDecoder, util_default;
 var init_util = __esm(() => {
   formatRegExp = /%[sdj%]/g;
-  debuglog = ((debugs = {}, debugEnvRegex = {}, debugEnv) => ((debugEnv = typeof process !== "undefined" && false) && (debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*").replace(/,/g, "$|^").toUpperCase()), debugEnvRegex = new RegExp("^" + debugEnv + "$", "i"), (set) => {
+  debuglog = ((debugs = {}, debugEnvRegex = {}, debugEnv) => ((debugEnv = typeof process < "u" && false) && (debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*").replace(/,/g, "$|^").toUpperCase()), debugEnvRegex = new RegExp("^" + debugEnv + "$", "i"), (set) => {
     if (set = set.toUpperCase(), !debugs[set])
       if (debugEnvRegex.test(set))
         debugs[set] = function(...args) {
@@ -1739,7 +1760,7 @@ var init_util = __esm(() => {
         debugs[set] = function() {};
     return debugs[set];
   }))();
-  inspect2 = ((i2) => (i2.colors = { bold: [1, 22], italic: [3, 23], underline: [4, 24], inverse: [7, 27], white: [37, 39], grey: [90, 39], black: [30, 39], blue: [34, 39], cyan: [36, 39], green: [32, 39], magenta: [35, 39], red: [31, 39], yellow: [33, 39] }, i2.styles = { special: "cyan", number: "yellow", boolean: "yellow", undefined: "grey", null: "bold", string: "green", date: "magenta", regexp: "red" }, i2.custom = Symbol.for("nodejs.util.inspect.custom"), i2))(function inspect22(obj, opts, ...rest) {
+  inspect = ((i2) => (i2.colors = { bold: [1, 22], italic: [3, 23], underline: [4, 24], inverse: [7, 27], white: [37, 39], grey: [90, 39], black: [30, 39], blue: [34, 39], cyan: [36, 39], green: [32, 39], magenta: [35, 39], red: [31, 39], yellow: [33, 39] }, i2.styles = { special: "cyan", number: "yellow", boolean: "yellow", undefined: "grey", null: "bold", string: "green", date: "magenta", regexp: "red" }, i2.custom = Symbol.for("nodejs.util.inspect.custom"), i2))(function(obj, opts, ...rest) {
     var ctx = { seen: [], stylize: stylizeNoColor };
     if (rest.length >= 1)
       ctx.depth = rest[0];
@@ -1760,13 +1781,13 @@ var init_util = __esm(() => {
     return formatValue(ctx, obj, ctx.depth);
   });
   months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-  promisify = ((x) => (x.custom = Symbol.for("nodejs.util.promisify.custom"), x))(function promisify2(original) {
+  promisify = ((x) => (x.custom = Symbol.for("nodejs.util.promisify.custom"), x))(function(original) {
     if (typeof original !== "function")
-      throw new TypeError('The "original" argument must be of type Function');
+      throw TypeError('The "original" argument must be of type Function');
     if (kCustomPromisifiedSymbol && original[kCustomPromisifiedSymbol]) {
       var fn = original[kCustomPromisifiedSymbol];
       if (typeof fn !== "function")
-        throw new TypeError('The "nodejs.util.promisify.custom" argument must be of type Function');
+        throw TypeError('The "nodejs.util.promisify.custom" argument must be of type Function');
       return Object.defineProperty(fn, kCustomPromisifiedSymbol, { value: fn, enumerable: false, writable: false, configurable: true }), fn;
     }
     function fn(...args) {
@@ -1810,7 +1831,7 @@ __export(exports_events, {
 });
 function emitError(emitter, args) {
   var { _events: events } = emitter;
-  if (args[0] ??= new Error("Unhandled error."), !events)
+  if (args[0] ??= Error("Unhandled error."), !events)
     throw args[0];
   var errorMonitor = events[kErrorMonitor];
   if (errorMonitor)
@@ -1840,7 +1861,7 @@ function emitUnhandledRejectionOrErr(emitter, err, type, args) {
 }
 function overflowWarning(emitter, type, handlers) {
   handlers.warned = true;
-  let warn = new Error(`Possible EventEmitter memory leak detected. ${handlers.length} ${String(type)} listeners added to [${emitter.constructor.name}]. Use emitter.setMaxListeners() to increase limit`);
+  let warn = Error(`Possible EventEmitter memory leak detected. ${handlers.length} ${String(type)} listeners added to [${emitter.constructor.name}]. Use emitter.setMaxListeners() to increase limit`);
   warn.name = "MaxListenersExceededWarning", warn.emitter = emitter, warn.type = type, warn.count = handlers.length, console.warn(warn);
 }
 function onceWrapper(type, listener, ...args) {
@@ -1901,11 +1922,11 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
     emitter.addEventListener(name, listener, flags);
 }
 function ERR_INVALID_ARG_TYPE2(name, type, value) {
-  let err = new TypeError(`The "${name}" argument must be of type ${type}. Received ${value}`);
+  let err = TypeError(`The "${name}" argument must be of type ${type}. Received ${value}`);
   return err.code = "ERR_INVALID_ARG_TYPE", err;
 }
 function ERR_OUT_OF_RANGE2(name, range, value) {
-  let err = new RangeError(`The "${name}" argument is out of range. It must be ${range}. Received ${value}`);
+  let err = RangeError(`The "${name}" argument is out of range. It must be ${range}. Received ${value}`);
   return err.code = "ERR_OUT_OF_RANGE", err;
 }
 function validateAbortSignal(signal, name) {
@@ -1920,7 +1941,7 @@ function validateNumber2(value, name, min, max) {
 }
 function checkListener(listener) {
   if (typeof listener !== "function")
-    throw new TypeError("The listener must be a function");
+    throw TypeError("The listener must be a function");
 }
 function validateBoolean(value, name) {
   if (typeof value !== "boolean")
@@ -1945,12 +1966,12 @@ function addAbortListener(signal, listener) {
     removeEventListener?.();
   } };
 }
-var SymbolFor, kCapture, kErrorMonitor, kMaxEventTargetListeners, kMaxEventTargetListenersWarned, kRejection, captureRejectionSymbol, ArrayPrototypeSlice, defaultMaxListeners = 10, EventEmitter = function EventEmitter2(opts) {
+var SymbolFor, kCapture, kErrorMonitor, kMaxEventTargetListeners, kMaxEventTargetListenersWarned, kRejection, captureRejectionSymbol, ArrayPrototypeSlice, defaultMaxListeners = 10, EventEmitter = function(opts) {
   if (this._events === undefined || this._events === this.__proto__._events)
     this._events = { __proto__: null }, this._eventsCount = 0;
   if (this._maxListeners ??= undefined, this[kCapture] = opts?.captureRejections ? Boolean(opts?.captureRejections) : EventEmitterPrototype[kCapture])
     this.emit = emitWithRejectionCapture;
-}, EventEmitterPrototype, emitWithoutRejectionCapture = function emit(type, ...args) {
+}, EventEmitterPrototype, emitWithoutRejectionCapture = function(type, ...args) {
   if (type === "error")
     return emitError(this, args);
   var { _events: events } = this;
@@ -1981,7 +2002,7 @@ var SymbolFor, kCapture, kErrorMonitor, kMaxEventTargetListeners, kMaxEventTarge
     }
   }
   return true;
-}, emitWithRejectionCapture = function emit2(type, ...args) {
+}, emitWithRejectionCapture = function(type, ...args) {
   if (type === "error")
     return emitError(this, args);
   var { _events: events } = this;
@@ -2028,15 +2049,15 @@ var init_events = __esm(() => {
   EventEmitterPrototype._events = undefined;
   EventEmitterPrototype._eventsCount = 0;
   EventEmitterPrototype._maxListeners = undefined;
-  EventEmitterPrototype.setMaxListeners = function setMaxListeners(n) {
+  EventEmitterPrototype.setMaxListeners = function(n) {
     return validateNumber2(n, "setMaxListeners", 0), this._maxListeners = n, this;
   };
   EventEmitterPrototype.constructor = EventEmitter;
-  EventEmitterPrototype.getMaxListeners = function getMaxListeners() {
+  EventEmitterPrototype.getMaxListeners = function() {
     return this?._maxListeners ?? defaultMaxListeners;
   };
   EventEmitterPrototype.emit = emitWithoutRejectionCapture;
-  EventEmitterPrototype.addListener = function addListener(type, fn) {
+  EventEmitterPrototype.addListener = function(type, fn) {
     checkListener(fn);
     var events = this._events;
     if (!events)
@@ -2055,7 +2076,7 @@ var init_events = __esm(() => {
     return this;
   };
   EventEmitterPrototype.on = EventEmitterPrototype.addListener;
-  EventEmitterPrototype.prependListener = function prependListener(type, fn) {
+  EventEmitterPrototype.prependListener = function(type, fn) {
     checkListener(fn);
     var events = this._events;
     if (!events)
@@ -2073,17 +2094,17 @@ var init_events = __esm(() => {
     }
     return this;
   };
-  EventEmitterPrototype.once = function once(type, fn) {
+  EventEmitterPrototype.once = function(type, fn) {
     checkListener(fn);
     let bound = onceWrapper.bind(this, type, fn);
     return bound.listener = fn, this.addListener(type, bound), this;
   };
-  EventEmitterPrototype.prependOnceListener = function prependOnceListener(type, fn) {
+  EventEmitterPrototype.prependOnceListener = function(type, fn) {
     checkListener(fn);
     let bound = onceWrapper.bind(this, type, fn);
     return bound.listener = fn, this.prependListener(type, bound), this;
   };
-  EventEmitterPrototype.removeListener = function removeListener(type, fn) {
+  EventEmitterPrototype.removeListener = function(type, fn) {
     checkListener(fn);
     var { _events: events } = this;
     if (!events)
@@ -2109,7 +2130,7 @@ var init_events = __esm(() => {
     return this;
   };
   EventEmitterPrototype.off = EventEmitterPrototype.removeListener;
-  EventEmitterPrototype.removeAllListeners = function removeAllListeners(type) {
+  EventEmitterPrototype.removeAllListeners = function(type) {
     var { _events: events } = this;
     if (type && events) {
       if (events[type])
@@ -2118,7 +2139,7 @@ var init_events = __esm(() => {
       this._events = { __proto__: null };
     return this;
   };
-  EventEmitterPrototype.listeners = function listeners(type) {
+  EventEmitterPrototype.listeners = function(type) {
     var { _events: events } = this;
     if (!events)
       return [];
@@ -2127,7 +2148,7 @@ var init_events = __esm(() => {
       return [];
     return handlers.map((x) => x.listener ?? x);
   };
-  EventEmitterPrototype.rawListeners = function rawListeners(type) {
+  EventEmitterPrototype.rawListeners = function(type) {
     var { _events } = this;
     if (!_events)
       return [];
@@ -2136,13 +2157,13 @@ var init_events = __esm(() => {
       return [];
     return handlers.slice();
   };
-  EventEmitterPrototype.listenerCount = function listenerCount(type) {
+  EventEmitterPrototype.listenerCount = function(type) {
     var { _events: events } = this;
     if (!events)
       return 0;
     return events[type]?.length ?? 0;
   };
-  EventEmitterPrototype.eventNames = function eventNames() {
+  EventEmitterPrototype.eventNames = function() {
     return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
   };
   EventEmitterPrototype[kCapture] = false;
@@ -2172,10 +2193,10 @@ var require_stream = __commonJS((exports, module) => {
   var __commonJS2 = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
   var require_primordials = __commonJS2((exports2, module2) => {
 
-    class AggregateError extends Error {
+    class AggregateError2 extends Error {
       constructor(errors) {
         if (!Array.isArray(errors))
-          throw new TypeError(`Expected input to be an Array, got ${typeof errors}`);
+          throw TypeError(`Expected input to be an Array, got ${typeof errors}`);
         let message = "";
         for (let i2 = 0;i2 < errors.length; i2++)
           message += `    ${errors[i2].stack}
@@ -2184,7 +2205,7 @@ var require_stream = __commonJS((exports, module) => {
         this.name = "AggregateError", this.errors = errors;
       }
     }
-    module2.exports = { AggregateError, ArrayIsArray(self2) {
+    module2.exports = { AggregateError: AggregateError2, ArrayIsArray(self2) {
       return Array.isArray(self2);
     }, ArrayPrototypeIncludes(self2, el) {
       return self2.includes(el);
@@ -2276,7 +2297,7 @@ var require_stream = __commonJS((exports, module) => {
     } };
   });
   var require_errors = __commonJS2((exports2, module2) => {
-    var { format: format2, inspect: inspect3 } = require_inspect(), { AggregateError: CustomAggregateError } = require_primordials(), AggregateError = globalThis.AggregateError || CustomAggregateError, kIsNodeError = Symbol("kIsNodeError"), kTypes = ["string", "function", "number", "object", "Function", "Object", "boolean", "bigint", "symbol"], classRegExp = /^([A-Z][a-z0-9]*)+$/, codes = {};
+    var { format: format2, inspect: inspect2 } = require_inspect(), { AggregateError: CustomAggregateError } = require_primordials(), AggregateError2 = globalThis.AggregateError || CustomAggregateError, kIsNodeError = Symbol("kIsNodeError"), kTypes = ["string", "function", "number", "object", "Function", "Object", "boolean", "bigint", "symbol"], classRegExp = /^([A-Z][a-z0-9]*)+$/, codes = {};
     function assert(value, message) {
       if (!value)
         throw new codes.ERR_INTERNAL_ASSERTION(message);
@@ -2319,7 +2340,7 @@ var require_stream = __commonJS((exports, module) => {
       if (innerError && outerError && innerError !== outerError) {
         if (Array.isArray(outerError.errors))
           return outerError.errors.push(innerError), outerError;
-        let err = new AggregateError([outerError, innerError], outerError.message);
+        let err = new AggregateError2([outerError, innerError], outerError.message);
         return err.code = outerError.code, err;
       }
       return innerError || outerError;
@@ -2413,11 +2434,11 @@ var require_stream = __commonJS((exports, module) => {
         if ((_actual$constructor = actual.constructor) !== null && _actual$constructor !== undefined && _actual$constructor.name)
           msg += `. Received an instance of ${actual.constructor.name}`;
         else {
-          let inspected = inspect3(actual, { depth: -1 });
+          let inspected = inspect2(actual, { depth: -1 });
           msg += `. Received ${inspected}`;
         }
       } else {
-        let inspected = inspect3(actual, { colors: false });
+        let inspected = inspect2(actual, { colors: false });
         if (inspected.length > 25)
           inspected = `${inspected.slice(0, 25)}...`;
         msg += `. Received type ${typeof actual} (${inspected})`;
@@ -2425,7 +2446,7 @@ var require_stream = __commonJS((exports, module) => {
       return msg;
     }, TypeError);
     E2("ERR_INVALID_ARG_VALUE", (name, value, reason = "is invalid") => {
-      let inspected = inspect3(value);
+      let inspected = inspect2(value);
       if (inspected.length > 128)
         inspected = inspected.slice(0, 128) + "...";
       return `The ${name.includes(".") ? "property" : "argument"} '${name}' ${reason}. Received ${inspected}`;
@@ -2466,7 +2487,7 @@ var require_stream = __commonJS((exports, module) => {
           received = addNumericalSeparator2(received);
         received += "n";
       } else
-        received = inspect3(input);
+        received = inspect2(input);
       return `The value of "${str}" is out of range. It must be ${range}. Received ${received}`;
     }, RangeError);
     E2("ERR_MULTIPLE_CALLBACK", "Callback called multiple times", Error);
@@ -2491,7 +2512,7 @@ var require_stream = __commonJS((exports, module) => {
     }
     function setCancelFlag(data) {
       if (data.passiveListener != null) {
-        if (typeof console !== "undefined" && typeof console.error === "function")
+        if (typeof console < "u" && typeof console.error === "function")
           console.error("Unable to preventDefault inside passive event listener invocation.", data.passiveListener);
         return;
       }
@@ -2567,7 +2588,7 @@ var require_stream = __commonJS((exports, module) => {
         setCancelFlag(pd(this));
     }, initEvent() {} };
     Object.defineProperty(Event.prototype, "constructor", { value: Event, configurable: true, writable: true });
-    if (typeof window !== "undefined" && typeof window.Event !== "undefined")
+    if (typeof window < "u" && typeof window.Event < "u")
       Object.setPrototypeOf(Event.prototype, window.Event.prototype), wrappers.set(window.Event.prototype, Event);
     function defineRedirectDescriptor(key) {
       return { get() {
@@ -2627,10 +2648,10 @@ var require_stream = __commonJS((exports, module) => {
       return x !== null && typeof x === "object";
     }
     function getListeners(eventTarget) {
-      let listeners2 = listenersMap.get(eventTarget);
-      if (listeners2 == null)
-        throw new TypeError("'this' is expected an EventTarget object, but got another value.");
-      return listeners2;
+      let listeners = listenersMap.get(eventTarget);
+      if (listeners == null)
+        throw TypeError("'this' is expected an EventTarget object, but got another value.");
+      return listeners;
     }
     function defineEventAttributeDescriptor(eventName) {
       return { get() {
@@ -2644,15 +2665,15 @@ var require_stream = __commonJS((exports, module) => {
       }, set(listener) {
         if (typeof listener !== "function" && !isObject2(listener))
           listener = null;
-        let listeners2 = getListeners(this), prev = null, node = listeners2.get(eventName);
+        let listeners = getListeners(this), prev = null, node = listeners.get(eventName);
         while (node != null) {
           if (node.listenerType === ATTRIBUTE)
             if (prev !== null)
               prev.next = node.next;
             else if (node.next !== null)
-              listeners2.set(eventName, node.next);
+              listeners.set(eventName, node.next);
             else
-              listeners2.delete(eventName);
+              listeners.delete(eventName);
           else
             prev = node;
           node = node.next;
@@ -2660,7 +2681,7 @@ var require_stream = __commonJS((exports, module) => {
         if (listener !== null) {
           let newNode = { listener, listenerType: ATTRIBUTE, passive: false, once: false, next: null };
           if (prev === null)
-            listeners2.set(eventName, newNode);
+            listeners.set(eventName, newNode);
           else
             prev.next = newNode;
         }
@@ -2669,13 +2690,13 @@ var require_stream = __commonJS((exports, module) => {
     function defineEventAttribute(eventTargetPrototype, eventName) {
       Object.defineProperty(eventTargetPrototype, `on${eventName}`, defineEventAttributeDescriptor(eventName));
     }
-    function defineCustomEventTarget(eventNames2) {
+    function defineCustomEventTarget(eventNames) {
       function CustomEventTarget() {
         EventTarget.call(this);
       }
       CustomEventTarget.prototype = Object.create(EventTarget.prototype, { constructor: { value: CustomEventTarget, configurable: true, writable: true } });
-      for (let i2 = 0;i2 < eventNames2.length; ++i2)
-        defineEventAttribute(CustomEventTarget.prototype, eventNames2[i2]);
+      for (let i2 = 0;i2 < eventNames.length; ++i2)
+        defineEventAttribute(CustomEventTarget.prototype, eventNames[i2]);
       return CustomEventTarget;
     }
     function EventTarget() {
@@ -2686,21 +2707,21 @@ var require_stream = __commonJS((exports, module) => {
       if (arguments.length === 1 && Array.isArray(arguments[0]))
         return defineCustomEventTarget(arguments[0]);
       if (arguments.length > 0) {
-        let types2 = new Array(arguments.length);
+        let types2 = Array(arguments.length);
         for (let i2 = 0;i2 < arguments.length; ++i2)
           types2[i2] = arguments[i2];
         return defineCustomEventTarget(types2);
       }
-      throw new TypeError("Cannot call a class as a function");
+      throw TypeError("Cannot call a class as a function");
     }
     EventTarget.prototype = { addEventListener(eventName, listener, options) {
       if (listener == null)
         return;
       if (typeof listener !== "function" && !isObject2(listener))
-        throw new TypeError("'listener' should be a function or an object.");
-      let listeners2 = getListeners(this), optionsIsObj = isObject2(options), listenerType = (optionsIsObj ? Boolean(options.capture) : Boolean(options)) ? CAPTURE : BUBBLE, newNode = { listener, listenerType, passive: optionsIsObj && Boolean(options.passive), once: optionsIsObj && Boolean(options.once), next: null }, node = listeners2.get(eventName);
+        throw TypeError("'listener' should be a function or an object.");
+      let listeners = getListeners(this), optionsIsObj = isObject2(options), listenerType = (optionsIsObj ? Boolean(options.capture) : Boolean(options)) ? CAPTURE : BUBBLE, newNode = { listener, listenerType, passive: optionsIsObj && Boolean(options.passive), once: optionsIsObj && Boolean(options.once), next: null }, node = listeners.get(eventName);
       if (node === undefined) {
-        listeners2.set(eventName, newNode);
+        listeners.set(eventName, newNode);
         return;
       }
       let prev = null;
@@ -2713,23 +2734,23 @@ var require_stream = __commonJS((exports, module) => {
     }, removeEventListener(eventName, listener, options) {
       if (listener == null)
         return;
-      let listeners2 = getListeners(this), listenerType = (isObject2(options) ? Boolean(options.capture) : Boolean(options)) ? CAPTURE : BUBBLE, prev = null, node = listeners2.get(eventName);
+      let listeners = getListeners(this), listenerType = (isObject2(options) ? Boolean(options.capture) : Boolean(options)) ? CAPTURE : BUBBLE, prev = null, node = listeners.get(eventName);
       while (node != null) {
         if (node.listener === listener && node.listenerType === listenerType) {
           if (prev !== null)
             prev.next = node.next;
           else if (node.next !== null)
-            listeners2.set(eventName, node.next);
+            listeners.set(eventName, node.next);
           else
-            listeners2.delete(eventName);
+            listeners.delete(eventName);
           return;
         }
         prev = node, node = node.next;
       }
     }, dispatchEvent(event) {
       if (event == null || typeof event.type !== "string")
-        throw new TypeError('"event.type" should be a string.');
-      let listeners2 = getListeners(this), eventName = event.type, node = listeners2.get(eventName);
+        throw TypeError('"event.type" should be a string.');
+      let listeners = getListeners(this), eventName = event.type, node = listeners.get(eventName);
       if (node == null)
         return true;
       let wrappedEvent = wrapEvent(this, event), prev = null;
@@ -2738,16 +2759,16 @@ var require_stream = __commonJS((exports, module) => {
           if (prev !== null)
             prev.next = node.next;
           else if (node.next !== null)
-            listeners2.set(eventName, node.next);
+            listeners.set(eventName, node.next);
           else
-            listeners2.delete(eventName);
+            listeners.delete(eventName);
         else
           prev = node;
         if (setPassiveListener(wrappedEvent, node.passive ? node.listener : null), typeof node.listener === "function")
           try {
             node.listener.call(this, wrappedEvent);
           } catch (err) {
-            if (typeof console !== "undefined" && typeof console.error === "function")
+            if (typeof console < "u" && typeof console.error === "function")
               console.error(err);
           }
         else if (node.listenerType !== ATTRIBUTE && typeof node.listener.handleEvent === "function")
@@ -2759,7 +2780,7 @@ var require_stream = __commonJS((exports, module) => {
       return setPassiveListener(wrappedEvent, null), setEventPhase(wrappedEvent, 0), setCurrentTarget(wrappedEvent, null), !wrappedEvent.defaultPrevented;
     } };
     Object.defineProperty(EventTarget.prototype, "constructor", { value: EventTarget, configurable: true, writable: true });
-    if (typeof window !== "undefined" && typeof window.EventTarget !== "undefined")
+    if (typeof window < "u" && typeof window.EventTarget < "u")
       Object.setPrototypeOf(EventTarget.prototype, window.EventTarget.prototype);
     exports2.defineEventAttribute = defineEventAttribute;
     exports2.EventTarget = EventTarget;
@@ -2775,12 +2796,12 @@ var require_stream = __commonJS((exports, module) => {
     class AbortSignal extends eventTargetShim.EventTarget {
       constructor() {
         super();
-        throw new TypeError("AbortSignal cannot be constructed directly");
+        throw TypeError("AbortSignal cannot be constructed directly");
       }
       get aborted() {
         let aborted = abortedFlags.get(this);
         if (typeof aborted !== "boolean")
-          throw new TypeError(`Expected 'this' to be an 'AbortSignal' object, but got ${this === null ? "null" : typeof this}`);
+          throw TypeError(`Expected 'this' to be an 'AbortSignal' object, but got ${this === null ? "null" : typeof this}`);
         return aborted;
       }
     }
@@ -2814,7 +2835,7 @@ var require_stream = __commonJS((exports, module) => {
     function getSignal(controller) {
       let signal = signals.get(controller);
       if (signal == null)
-        throw new TypeError(`Expected 'this' to be an 'AbortController' object, but got ${controller === null ? "null" : typeof controller}`);
+        throw TypeError(`Expected 'this' to be an 'AbortController' object, but got ${controller === null ? "null" : typeof controller}`);
       return signal;
     }
     Object.defineProperties(AbortController.prototype, { signal: { enumerable: true }, abort: { enumerable: true } });
@@ -2828,9 +2849,9 @@ var require_stream = __commonJS((exports, module) => {
     module2.exports.AbortSignal = AbortSignal;
   });
   var require_util = __commonJS2((exports2, module2) => {
-    var bufferModule = (init_buffer(), __toCommonJS(exports_buffer2)), { format: format2, inspect: inspect3 } = require_inspect(), { codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3 } } = require_errors(), { kResistStopPropagation, AggregateError, SymbolDispose } = require_primordials(), AbortSignal = globalThis.AbortSignal || require_abort_controller().AbortSignal, AbortController = globalThis.AbortController || require_abort_controller().AbortController, AsyncFunction = Object.getPrototypeOf(async function() {}).constructor, Blob2 = globalThis.Blob || bufferModule.Blob, isBlob = typeof Blob2 !== "undefined" ? function isBlob(b) {
+    var bufferModule = (init_buffer(), __toCommonJS(exports_buffer)), { format: format2, inspect: inspect2 } = require_inspect(), { codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3 } } = require_errors(), { kResistStopPropagation, AggregateError: AggregateError2, SymbolDispose } = require_primordials(), AbortSignal = globalThis.AbortSignal || require_abort_controller().AbortSignal, AbortController = globalThis.AbortController || require_abort_controller().AbortController, AsyncFunction = Object.getPrototypeOf(async function() {}).constructor, Blob2 = globalThis.Blob || bufferModule.Blob, isBlob = typeof Blob2 < "u" ? function(b) {
       return b instanceof Blob2;
-    } : function isBlob(b) {
+    } : function(b) {
       return false;
     }, validateAbortSignal2 = (signal, name) => {
       if (signal !== undefined && (signal === null || typeof signal !== "object" || !("aborted" in signal)))
@@ -2839,7 +2860,7 @@ var require_stream = __commonJS((exports, module) => {
       if (typeof value !== "function")
         throw new ERR_INVALID_ARG_TYPE3(name, "Function", value);
     };
-    module2.exports = { AggregateError, kEmptyObject: Object.freeze({}), once(callback) {
+    module2.exports = { AggregateError: AggregateError2, kEmptyObject: Object.freeze({}), once(callback) {
       let called = false;
       return function(...args) {
         if (called)
@@ -2861,13 +2882,13 @@ var require_stream = __commonJS((exports, module) => {
       });
     }, debuglog() {
       return function() {};
-    }, format: format2, inspect: inspect3, types: { isAsyncFunction(fn) {
+    }, format: format2, inspect: inspect2, types: { isAsyncFunction(fn) {
       return fn instanceof AsyncFunction;
     }, isArrayBufferView(arr) {
       return ArrayBuffer.isView(arr);
     } }, isBlob, deprecate(fn, message) {
       return fn;
-    }, addAbortListener: (init_events(), __toCommonJS(exports_events)).addAbortListener || function addAbortListener(signal, listener) {
+    }, addAbortListener: (init_events(), __toCommonJS(exports_events)).addAbortListener || function(signal, listener) {
       if (signal === undefined)
         throw new ERR_INVALID_ARG_TYPE3("signal", "AbortSignal", signal);
       validateAbortSignal2(signal, "signal"), validateFunction(listener, "listener");
@@ -2882,7 +2903,7 @@ var require_stream = __commonJS((exports, module) => {
         var _removeEventListener;
         (_removeEventListener = removeEventListener) === null || _removeEventListener === undefined || _removeEventListener();
       } };
-    }, AbortSignalAny: AbortSignal.any || function AbortSignalAny(signals) {
+    }, AbortSignalAny: AbortSignal.any || function(signals) {
       if (signals.length === 1)
         return signals[0];
       let ac = new AbortController, abort = () => ac.abort();
@@ -2904,7 +2925,7 @@ var require_stream = __commonJS((exports, module) => {
     }
     var octalReg = /^[0-7]+$/, modeDesc = "must be a 32-bit unsigned integer or an octal string";
     function parseFileMode(value, name, def) {
-      if (typeof value === "undefined")
+      if (typeof value > "u")
         value = def;
       if (typeof value === "string") {
         if (RegExpPrototypeExec(octalReg, value) === null)
@@ -3033,7 +3054,7 @@ var require_stream = __commonJS((exports, module) => {
     }
     var linkValueRegExp = /^(?:<[^>]*>)(?:\s*;\s*[^;"\s]+(?:=(")?[^;"\s]*\1)?)*$/;
     function validateLinkHeaderFormat(value, name) {
-      if (typeof value === "undefined" || !RegExpPrototypeExec(linkValueRegExp, value))
+      if (typeof value > "u" || !RegExpPrototypeExec(linkValueRegExp, value))
         throw new ERR_INVALID_ARG_VALUE(name, value, 'must be an array or string of format "</styles.css>; rel=preload; as=style"');
     }
     function validateLinkHeaderValue(hints) {
@@ -3230,7 +3251,7 @@ var require_stream = __commonJS((exports, module) => {
     module2.exports = { isDestroyed, kIsDestroyed, isDisturbed, kIsDisturbed, isErrored, kIsErrored, isReadable, kIsReadable, kIsClosedPromise, kControllerErrorFunction, kIsWritable, isClosed, isDuplexNodeStream, isFinished, isIterable, isReadableNodeStream, isReadableStream, isReadableEnded, isReadableFinished, isReadableErrored, isNodeStream, isWebStream, isWritable, isWritableNodeStream, isWritableStream, isWritableEnded, isWritableFinished, isWritableErrored, isServerRequest, isServerResponse, willEmitClose, isTransformStream };
   });
   var require_end_of_stream = __commonJS2((exports2, module2) => {
-    var process2 = require_process(), { AbortError: AbortError2, codes } = require_errors(), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_STREAM_PREMATURE_CLOSE } = codes, { kEmptyObject, once: once3 } = require_util(), { validateAbortSignal: validateAbortSignal2, validateFunction, validateObject, validateBoolean: validateBoolean2 } = require_validators(), { Promise: Promise2, PromisePrototypeThen, SymbolDispose } = require_primordials(), { isClosed, isReadable, isReadableNodeStream, isReadableStream, isReadableFinished, isReadableErrored, isWritable, isWritableNodeStream, isWritableStream, isWritableFinished, isWritableErrored, isNodeStream, willEmitClose: _willEmitClose, kIsClosedPromise } = require_utils(), addAbortListener2;
+    var process2 = require_process(), { AbortError: AbortError2, codes } = require_errors(), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_STREAM_PREMATURE_CLOSE } = codes, { kEmptyObject, once } = require_util(), { validateAbortSignal: validateAbortSignal2, validateFunction, validateObject, validateBoolean: validateBoolean2 } = require_validators(), { Promise: Promise2, PromisePrototypeThen, SymbolDispose } = require_primordials(), { isClosed, isReadable, isReadableNodeStream, isReadableStream, isReadableFinished, isReadableErrored, isWritable, isWritableNodeStream, isWritableStream, isWritableFinished, isWritableErrored, isNodeStream, willEmitClose: _willEmitClose, kIsClosedPromise } = require_utils(), addAbortListener2;
     function isRequest(stream) {
       return stream.setHeader && typeof stream.abort === "function";
     }
@@ -3243,7 +3264,7 @@ var require_stream = __commonJS((exports, module) => {
         options = kEmptyObject;
       else
         validateObject(options, "options");
-      if (validateFunction(callback, "callback"), validateAbortSignal2(options.signal, "options.signal"), callback = once3(callback), isReadableStream(stream) || isWritableStream(stream))
+      if (validateFunction(callback, "callback"), validateAbortSignal2(options.signal, "options.signal"), callback = once(callback), isReadableStream(stream) || isWritableStream(stream))
         return eosWeb(stream, options, callback);
       if (!isNodeStream(stream))
         throw new ERR_INVALID_ARG_TYPE3("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
@@ -3328,7 +3349,7 @@ var require_stream = __commonJS((exports, module) => {
         else {
           addAbortListener2 = addAbortListener2 || require_util().addAbortListener;
           let disposable = addAbortListener2(options.signal, abort), originalCallback = callback;
-          callback = once3((...args) => {
+          callback = once((...args) => {
             disposable[SymbolDispose](), originalCallback.apply(stream, args);
           });
         }
@@ -3345,7 +3366,7 @@ var require_stream = __commonJS((exports, module) => {
         else {
           addAbortListener2 = addAbortListener2 || require_util().addAbortListener;
           let disposable = addAbortListener2(options.signal, abort), originalCallback = callback;
-          callback = once3((...args) => {
+          callback = once((...args) => {
             disposable[SymbolDispose](), originalCallback.apply(stream, args);
           });
         }
@@ -3587,13 +3608,13 @@ var require_stream = __commonJS((exports, module) => {
         if (cleanup(), EE.listenerCount(this, "error") === 0)
           this.emit("error", er);
       }
-      prependListener2(source, "error", onerror), prependListener2(dest, "error", onerror);
+      prependListener(source, "error", onerror), prependListener(dest, "error", onerror);
       function cleanup() {
         source.removeListener("data", ondata), dest.removeListener("drain", ondrain), source.removeListener("end", onend), source.removeListener("close", onclose), source.removeListener("error", onerror), dest.removeListener("error", onerror), source.removeListener("end", cleanup), source.removeListener("close", cleanup), dest.removeListener("close", cleanup);
       }
       return source.on("end", cleanup), source.on("close", cleanup), dest.on("close", cleanup), dest.emit("pipe", source), dest;
     };
-    function prependListener2(emitter, event, fn) {
+    function prependListener(emitter, event, fn) {
       if (typeof emitter.prependListener === "function")
         return emitter.prependListener(event, fn);
       if (!emitter._events || !emitter._events[event])
@@ -3603,14 +3624,14 @@ var require_stream = __commonJS((exports, module) => {
       else
         emitter._events[event] = [fn, emitter._events[event]];
     }
-    module2.exports = { Stream, prependListener: prependListener2 };
+    module2.exports = { Stream, prependListener };
   });
   var require_add_abort_signal = __commonJS2((exports2, module2) => {
     var { SymbolDispose } = require_primordials(), { AbortError: AbortError2, codes } = require_errors(), { isNodeStream, isWebStream, kControllerErrorFunction } = require_utils(), eos = require_end_of_stream(), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3 } = codes, addAbortListener2, validateAbortSignal2 = (signal, name) => {
       if (typeof signal !== "object" || !("aborted" in signal))
         throw new ERR_INVALID_ARG_TYPE3(name, "AbortSignal", signal);
     };
-    module2.exports.addAbortSignal = function addAbortSignal(signal, stream) {
+    module2.exports.addAbortSignal = function(signal, stream) {
       if (validateAbortSignal2(signal, "signal"), !isNodeStream(stream) && !isWebStream(stream))
         throw new ERR_INVALID_ARG_TYPE3("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
       return module2.exports.addAbortSignalNoValidate(signal, stream);
@@ -3634,8 +3655,8 @@ var require_stream = __commonJS((exports, module) => {
     };
   });
   var require_buffer_list = __commonJS2((exports2, module2) => {
-    var { StringPrototypeSlice, SymbolIterator, TypedArrayPrototypeSet, Uint8Array: Uint8Array2 } = require_primordials(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer2)), { inspect: inspect3 } = require_util();
-    module2.exports = class BufferList {
+    var { StringPrototypeSlice, SymbolIterator, TypedArrayPrototypeSet, Uint8Array: Uint8Array2 } = require_primordials(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer)), { inspect: inspect2 } = require_util();
+    module2.exports = class {
       constructor() {
         this.head = null, this.tail = null, this.length = 0;
       }
@@ -3685,8 +3706,8 @@ var require_stream = __commonJS((exports, module) => {
       consume(n, hasStrings) {
         let data = this.head.data;
         if (n < data.length) {
-          let slice2 = data.slice(0, n);
-          return this.head.data = data.slice(n), slice2;
+          let slice = data.slice(0, n);
+          return this.head.data = data.slice(n), slice;
         }
         if (n === data.length)
           return this.shift();
@@ -3740,7 +3761,7 @@ var require_stream = __commonJS((exports, module) => {
         return this.length -= c, ret;
       }
       [Symbol.for("nodejs.util.inspect.custom")](_, options) {
-        return inspect3(this, { ...options, depth: 0, customInspect: false });
+        return inspect2(this, { ...options, depth: 0, customInspect: false });
       }
     };
   });
@@ -3773,7 +3794,7 @@ var require_stream = __commonJS((exports, module) => {
   });
   var require_safe_buffer = __commonJS2((exports2, module2) => {
     /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
-    var buffer = (init_buffer(), __toCommonJS(exports_buffer2)), Buffer3 = buffer.Buffer;
+    var buffer = (init_buffer(), __toCommonJS(exports_buffer)), Buffer3 = buffer.Buffer;
     function copyProps(src, dst) {
       for (var key in src)
         dst[key] = src[key];
@@ -3789,35 +3810,35 @@ var require_stream = __commonJS((exports, module) => {
     copyProps(Buffer3, SafeBuffer);
     SafeBuffer.from = function(arg, encodingOrOffset, length) {
       if (typeof arg === "number")
-        throw new TypeError("Argument must not be a number");
+        throw TypeError("Argument must not be a number");
       return Buffer3(arg, encodingOrOffset, length);
     };
-    SafeBuffer.alloc = function(size, fill2, encoding) {
+    SafeBuffer.alloc = function(size, fill, encoding) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       var buf = Buffer3(size);
-      if (fill2 !== undefined)
+      if (fill !== undefined)
         if (typeof encoding === "string")
-          buf.fill(fill2, encoding);
+          buf.fill(fill, encoding);
         else
-          buf.fill(fill2);
+          buf.fill(fill);
       else
         buf.fill(0);
       return buf;
     };
     SafeBuffer.allocUnsafe = function(size) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       return Buffer3(size);
     };
     SafeBuffer.allocUnsafeSlow = function(size) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       return buffer.SlowBuffer(size);
     };
   });
   var require_string_decoder = __commonJS2((exports2) => {
-    var Buffer3 = require_safe_buffer().Buffer, isEncoding2 = Buffer3.isEncoding || function(encoding) {
+    var Buffer3 = require_safe_buffer().Buffer, isEncoding = Buffer3.isEncoding || function(encoding) {
       switch (encoding = "" + encoding, encoding && encoding.toLowerCase()) {
         case "hex":
         case "utf8":
@@ -3864,8 +3885,8 @@ var require_stream = __commonJS((exports, module) => {
     }
     function normalizeEncoding(enc) {
       var nenc = _normalizeEncoding(enc);
-      if (typeof nenc !== "string" && (Buffer3.isEncoding === isEncoding2 || !isEncoding2(enc)))
-        throw new Error("Unknown encoding: " + enc);
+      if (typeof nenc !== "string" && (Buffer3.isEncoding === isEncoding || !isEncoding(enc)))
+        throw Error("Unknown encoding: " + enc);
       return nenc || enc;
     }
     exports2.StringDecoder = StringDecoder;
@@ -4027,7 +4048,7 @@ var require_stream = __commonJS((exports, module) => {
     }
   });
   var require_from = __commonJS2((exports2, module2) => {
-    var process2 = require_process(), { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require_primordials(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer2)), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_STREAM_NULL_VALUES } = require_errors().codes;
+    var process2 = require_process(), { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require_primordials(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer)), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_STREAM_NULL_VALUES } = require_errors().codes;
     function from2(Readable, iterable, opts) {
       let iterator;
       if (typeof iterable === "string" || iterable instanceof Buffer3)
@@ -4089,7 +4110,7 @@ var require_stream = __commonJS((exports, module) => {
     var process2 = require_process(), { ArrayPrototypeIndexOf, NumberIsInteger, NumberIsNaN, NumberParseInt, ObjectDefineProperties, ObjectKeys, ObjectSetPrototypeOf, Promise: Promise2, SafeSet, SymbolAsyncDispose, SymbolAsyncIterator, Symbol: Symbol2 } = require_primordials();
     module2.exports = Readable;
     Readable.ReadableState = ReadableState;
-    var { EventEmitter: EE } = (init_events(), __toCommonJS(exports_events)), { Stream, prependListener: prependListener2 } = require_legacy(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer2)), { addAbortSignal } = require_add_abort_signal(), eos = require_end_of_stream(), debug = require_util().debuglog("stream", (fn) => {
+    var { EventEmitter: EE } = (init_events(), __toCommonJS(exports_events)), { Stream, prependListener } = require_legacy(), { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer)), { addAbortSignal } = require_add_abort_signal(), eos = require_end_of_stream(), debug = require_util().debuglog("stream", (fn) => {
       debug = fn;
     }), BufferList = require_buffer_list(), destroyImpl = require_destroy(), { getHighWaterMark, getDefaultHighWaterMark } = require_state(), { aggregateTwoErrors, codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_METHOD_NOT_IMPLEMENTED, ERR_OUT_OF_RANGE: ERR_OUT_OF_RANGE3, ERR_STREAM_PUSH_AFTER_EOF, ERR_STREAM_UNSHIFT_AFTER_END_EVENT }, AbortError: AbortError2 } = require_errors(), { validateObject } = require_validators(), kPaused = Symbol2("kPaused"), { StringDecoder } = require_string_decoder(), from2 = require_from();
     ObjectSetPrototypeOf(Readable.prototype, Stream.prototype);
@@ -4410,7 +4431,7 @@ var require_stream = __commonJS((exports, module) => {
             dest.emit("error", er);
         }
       }
-      prependListener2(dest, "error", onerror);
+      prependListener(dest, "error", onerror);
       function onclose() {
         dest.removeListener("finish", onfinish), unpipe();
       }
@@ -4429,7 +4450,7 @@ var require_stream = __commonJS((exports, module) => {
       return dest;
     };
     function pipeOnDrain(src, dest) {
-      return function pipeOnDrainFunctionResult() {
+      return function() {
         let state = src._readableState;
         if (state.awaitDrainWriters === dest)
           debug("pipeOnDrain", 1), state.awaitDrainWriters = null;
@@ -4707,7 +4728,7 @@ var require_stream = __commonJS((exports, module) => {
     var process2 = require_process(), { ArrayPrototypeSlice: ArrayPrototypeSlice2, Error: Error2, FunctionPrototypeSymbolHasInstance, ObjectDefineProperty, ObjectDefineProperties, ObjectSetPrototypeOf, StringPrototypeToLowerCase, Symbol: Symbol2, SymbolHasInstance } = require_primordials();
     module2.exports = Writable;
     Writable.WritableState = WritableState;
-    var { EventEmitter: EE } = (init_events(), __toCommonJS(exports_events)), Stream = require_legacy().Stream, { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer2)), destroyImpl = require_destroy(), { addAbortSignal } = require_add_abort_signal(), { getHighWaterMark, getDefaultHighWaterMark } = require_state(), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_METHOD_NOT_IMPLEMENTED, ERR_MULTIPLE_CALLBACK, ERR_STREAM_CANNOT_PIPE, ERR_STREAM_DESTROYED, ERR_STREAM_ALREADY_FINISHED, ERR_STREAM_NULL_VALUES, ERR_STREAM_WRITE_AFTER_END, ERR_UNKNOWN_ENCODING } = require_errors().codes, { errorOrDestroy } = destroyImpl;
+    var { EventEmitter: EE } = (init_events(), __toCommonJS(exports_events)), Stream = require_legacy().Stream, { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer)), destroyImpl = require_destroy(), { addAbortSignal } = require_add_abort_signal(), { getHighWaterMark, getDefaultHighWaterMark } = require_state(), { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_METHOD_NOT_IMPLEMENTED, ERR_MULTIPLE_CALLBACK, ERR_STREAM_CANNOT_PIPE, ERR_STREAM_DESTROYED, ERR_STREAM_ALREADY_FINISHED, ERR_STREAM_NULL_VALUES, ERR_STREAM_WRITE_AFTER_END, ERR_UNKNOWN_ENCODING } = require_errors().codes, { errorOrDestroy } = destroyImpl;
     ObjectSetPrototypeOf(Writable.prototype, Stream.prototype);
     ObjectSetPrototypeOf(Writable, Stream);
     function nop() {}
@@ -4724,7 +4745,7 @@ var require_stream = __commonJS((exports, module) => {
     function resetBuffer(state) {
       state.buffered = [], state.bufferedIndex = 0, state.allBuffers = true, state.allNoop = true;
     }
-    WritableState.prototype.getBuffer = function getBuffer() {
+    WritableState.prototype.getBuffer = function() {
       return ArrayPrototypeSlice2(this.buffered, this.bufferedIndex);
     };
     ObjectDefineProperty(WritableState.prototype, "bufferedRequestCount", { __proto__: null, get() {
@@ -4811,7 +4832,7 @@ var require_stream = __commonJS((exports, module) => {
           clearBuffer(this, state);
       }
     };
-    Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
+    Writable.prototype.setDefaultEncoding = function(encoding) {
       if (typeof encoding === "string")
         encoding = StringPrototypeToLowerCase(encoding);
       if (!Buffer3.isEncoding(encoding))
@@ -5089,9 +5110,9 @@ var require_stream = __commonJS((exports, module) => {
     };
   });
   var require_duplexify = __commonJS2((exports2, module2) => {
-    var process2 = require_process(), bufferModule = (init_buffer(), __toCommonJS(exports_buffer2)), { isReadable, isWritable, isIterable, isNodeStream, isReadableNodeStream, isWritableNodeStream, isDuplexNodeStream, isReadableStream, isWritableStream } = require_utils(), eos = require_end_of_stream(), { AbortError: AbortError2, codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_INVALID_RETURN_VALUE } } = require_errors(), { destroyer } = require_destroy(), Duplex = require_duplex(), Readable = require_readable(), Writable = require_writable(), { createDeferredPromise } = require_util(), from2 = require_from(), Blob2 = globalThis.Blob || bufferModule.Blob, isBlob = typeof Blob2 !== "undefined" ? function isBlob(b) {
+    var process2 = require_process(), bufferModule = (init_buffer(), __toCommonJS(exports_buffer)), { isReadable, isWritable, isIterable, isNodeStream, isReadableNodeStream, isWritableNodeStream, isDuplexNodeStream, isReadableStream, isWritableStream } = require_utils(), eos = require_end_of_stream(), { AbortError: AbortError2, codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_INVALID_RETURN_VALUE } } = require_errors(), { destroyer } = require_destroy(), Duplex = require_duplex(), Readable = require_readable(), Writable = require_writable(), { createDeferredPromise } = require_util(), from2 = require_from(), Blob2 = globalThis.Blob || bufferModule.Blob, isBlob = typeof Blob2 < "u" ? function(b) {
       return b instanceof Blob2;
-    } : function isBlob(b) {
+    } : function(b) {
       return false;
     }, AbortController = globalThis.AbortController || require_abort_controller().AbortController, { FunctionPrototypeCall } = require_primordials();
 
@@ -5118,9 +5139,9 @@ var require_stream = __commonJS((exports, module) => {
       if (isWritableStream(body))
         return _duplexify({ writable: Writable.fromWeb(body) });
       if (typeof body === "function") {
-        let { value, write: write3, final, destroy } = fromAsyncGen(body);
+        let { value, write: write2, final, destroy } = fromAsyncGen(body);
         if (isIterable(value))
-          return from2(Duplexify, value, { objectMode: true, write: write3, final, destroy });
+          return from2(Duplexify, value, { objectMode: true, write: write2, final, destroy });
         let then2 = value === null || value === undefined ? undefined : value.then;
         if (typeof then2 === "function") {
           let d, promise = FunctionPrototypeCall(then2, value, (val) => {
@@ -5129,7 +5150,7 @@ var require_stream = __commonJS((exports, module) => {
           }, (err) => {
             destroyer(d, err);
           });
-          return d = new Duplexify({ objectMode: true, readable: false, write: write3, final(cb) {
+          return d = new Duplexify({ objectMode: true, readable: false, write: write2, final(cb) {
             final(async () => {
               try {
                 await promise, process2.nextTick(cb, null);
@@ -5389,7 +5410,7 @@ var require_stream = __commonJS((exports, module) => {
     };
   });
   var require_pipeline = __commonJS2((exports2, module2) => {
-    var process2 = require_process(), { ArrayIsArray, Promise: Promise2, SymbolAsyncIterator, SymbolDispose } = require_primordials(), eos = require_end_of_stream(), { once: once3 } = require_util(), destroyImpl = require_destroy(), Duplex = require_duplex(), { aggregateTwoErrors, codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_INVALID_RETURN_VALUE, ERR_MISSING_ARGS, ERR_STREAM_DESTROYED, ERR_STREAM_PREMATURE_CLOSE }, AbortError: AbortError2 } = require_errors(), { validateFunction, validateAbortSignal: validateAbortSignal2 } = require_validators(), { isIterable, isReadable, isReadableNodeStream, isNodeStream, isTransformStream, isWebStream, isReadableStream, isReadableFinished } = require_utils(), AbortController = globalThis.AbortController || require_abort_controller().AbortController, PassThrough, Readable, addAbortListener2;
+    var process2 = require_process(), { ArrayIsArray, Promise: Promise2, SymbolAsyncIterator, SymbolDispose } = require_primordials(), eos = require_end_of_stream(), { once } = require_util(), destroyImpl = require_destroy(), Duplex = require_duplex(), { aggregateTwoErrors, codes: { ERR_INVALID_ARG_TYPE: ERR_INVALID_ARG_TYPE3, ERR_INVALID_RETURN_VALUE, ERR_MISSING_ARGS, ERR_STREAM_DESTROYED, ERR_STREAM_PREMATURE_CLOSE }, AbortError: AbortError2 } = require_errors(), { validateFunction, validateAbortSignal: validateAbortSignal2 } = require_validators(), { isIterable, isReadable, isReadableNodeStream, isNodeStream, isTransformStream, isWebStream, isReadableStream, isReadableFinished } = require_utils(), AbortController = globalThis.AbortController || require_abort_controller().AbortController, PassThrough, Readable, addAbortListener2;
     function destroyer(stream, reading, writing) {
       let finished = false;
       stream.on("close", () => {
@@ -5474,7 +5495,7 @@ var require_stream = __commonJS((exports, module) => {
       }
     }
     function pipeline(...streams) {
-      return pipelineImpl(streams, once3(popCallback(streams)));
+      return pipelineImpl(streams, once(popCallback(streams)));
     }
     function pipelineImpl(streams, callback, opts) {
       if (streams.length === 1 && ArrayIsArray(streams[0]))
@@ -5630,7 +5651,7 @@ var require_stream = __commonJS((exports, module) => {
   });
   var require_compose = __commonJS2((exports2, module2) => {
     var { pipeline } = require_pipeline(), Duplex = require_duplex(), { destroyer } = require_destroy(), { isNodeStream, isReadable, isWritable, isWebStream, isTransformStream, isWritableStream, isReadableStream } = require_utils(), { AbortError: AbortError2, codes: { ERR_INVALID_ARG_VALUE, ERR_MISSING_ARGS } } = require_errors(), eos = require_end_of_stream();
-    module2.exports = function compose(...streams) {
+    module2.exports = function(...streams) {
       if (streams.length === 0)
         throw new ERR_MISSING_ARGS("streams");
       if (streams.length === 1)
@@ -5775,7 +5796,7 @@ var require_stream = __commonJS((exports, module) => {
       let highWaterMark = concurrency - 1;
       if ((options === null || options === undefined ? undefined : options.highWaterMark) != null)
         highWaterMark = MathFloor(options.highWaterMark);
-      return validateInteger(concurrency, "options.concurrency", 1), validateInteger(highWaterMark, "options.highWaterMark", 0), highWaterMark += concurrency, async function* map() {
+      return validateInteger(concurrency, "options.concurrency", 1), validateInteger(highWaterMark, "options.highWaterMark", 0), highWaterMark += concurrency, async function* () {
         let signal = require_util().AbortSignalAny([options === null || options === undefined ? undefined : options.signal].filter(Boolean2)), stream = this, queue = [], signalOpt = { signal }, next, resume, done = false, cnt = 0;
         function onCatch() {
           done = true, afterItemProcessed();
@@ -5845,7 +5866,7 @@ var require_stream = __commonJS((exports, module) => {
         validateObject(options, "options");
       if ((options === null || options === undefined ? undefined : options.signal) != null)
         validateAbortSignal2(options.signal, "options.signal");
-      return async function* asIndexedPairs() {
+      return async function* () {
         let index = 0;
         for await (let val of this) {
           var _options$signal;
@@ -5950,7 +5971,7 @@ var require_stream = __commonJS((exports, module) => {
     }
     function flatMap(fn, options) {
       let values = map.call(this, fn, options);
-      return async function* flatMap() {
+      return async function* () {
         for await (let val of values)
           yield* val;
       }.call(this);
@@ -5967,7 +5988,7 @@ var require_stream = __commonJS((exports, module) => {
         validateObject(options, "options");
       if ((options === null || options === undefined ? undefined : options.signal) != null)
         validateAbortSignal2(options.signal, "options.signal");
-      return number = toIntegerOrInfinity(number), async function* drop() {
+      return number = toIntegerOrInfinity(number), async function* () {
         var _options$signal5;
         if (options !== null && options !== undefined && (_options$signal5 = options.signal) !== null && _options$signal5 !== undefined && _options$signal5.aborted)
           throw new AbortError2;
@@ -5985,7 +6006,7 @@ var require_stream = __commonJS((exports, module) => {
         validateObject(options, "options");
       if ((options === null || options === undefined ? undefined : options.signal) != null)
         validateAbortSignal2(options.signal, "options.signal");
-      return number = toIntegerOrInfinity(number), async function* take() {
+      return number = toIntegerOrInfinity(number), async function* () {
         var _options$signal7;
         if (options !== null && options !== undefined && (_options$signal7 = options.signal) !== null && _options$signal7 !== undefined && _options$signal7.aborted)
           throw new AbortError2;
@@ -6024,7 +6045,7 @@ var require_stream = __commonJS((exports, module) => {
     module2.exports = { finished, pipeline };
   });
   var require_stream2 = __commonJS2((exports2, module2) => {
-    var { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer2)), { ObjectDefineProperty, ObjectKeys, ReflectApply } = require_primordials(), { promisify: { custom: customPromisify } } = require_util(), { streamReturningOperators, promiseReturningOperators } = require_operators(), { codes: { ERR_ILLEGAL_CONSTRUCTOR } } = require_errors(), compose = require_compose(), { setDefaultHighWaterMark, getDefaultHighWaterMark } = require_state(), { pipeline } = require_pipeline(), { destroyer } = require_destroy(), eos = require_end_of_stream(), promises = require_promises(), utils = require_utils(), Stream = module2.exports = require_legacy().Stream;
+    var { Buffer: Buffer3 } = (init_buffer(), __toCommonJS(exports_buffer)), { ObjectDefineProperty, ObjectKeys, ReflectApply } = require_primordials(), { promisify: { custom: customPromisify } } = require_util(), { streamReturningOperators, promiseReturningOperators } = require_operators(), { codes: { ERR_ILLEGAL_CONSTRUCTOR } } = require_errors(), compose = require_compose(), { setDefaultHighWaterMark, getDefaultHighWaterMark } = require_state(), { pipeline } = require_pipeline(), { destroyer } = require_destroy(), eos = require_end_of_stream(), promises = require_promises(), utils = require_utils(), Stream = module2.exports = require_legacy().Stream;
     Stream.isDestroyed = utils.isDestroyed;
     Stream.isDisturbed = utils.isDisturbed;
     Stream.isErrored = utils.isErrored;
@@ -6069,10 +6090,10 @@ var require_stream = __commonJS((exports, module) => {
       return promises.finished;
     } });
     Stream.Stream = Stream;
-    Stream._isUint8Array = function isUint8Array(value) {
+    Stream._isUint8Array = function(value) {
       return value instanceof Uint8Array;
     };
-    Stream._uint8ArrayToBuffer = function _uint8ArrayToBuffer(chunk) {
+    Stream._uint8ArrayToBuffer = function(chunk) {
       return Buffer3.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
     };
   });
@@ -6148,7 +6169,7 @@ var __create2, __getProtoOf2, __defProp2, __getOwnPropNames2, __hasOwnProp2, __t
     if (!__hasOwnProp2.call(to, key))
       __defProp2(to, key, { get: () => mod[key], enumerable: true });
   return to;
-}, __commonJS2 = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports), require_randombytes, require_create_hash, require_create_hmac, require_algorithms, require_precondition, require_default_encoding, require_safe_buffer, require_to_buffer, require_sync, require_async, require_pbkdf2, require_browserify_cipher, require_diffie_hellman, require_browserify_sign, require_package, require_bn, require_minimalistic_assert, require_utils, require_utils2, require_brorand, require_base, require_inherits_browser, require_inherits, require_short, require_mont, require_edwards, require_curve, require_utils3, require_common, require_common2, require_1, require_256, require_224, require_512, require_384, require_sha, require_ripemd, require_hmac, require_hash, require_secp256k1, require_curves, require_hmac_drbg, require_key, require_signature, require_ec, require_key2, require_signature2, require_eddsa, require_elliptic, require_bn2, require_browser, require_create_ecdh, require_bn3, require_api, require_reporter, require_buffer, require_node, require_base2, require_der, require_constants, require_der2, require_pem, require_decoders, require_der3, require_pem2, require_encoders, require_asn1, require_certificate, require_asn12, require_aesid, require_hash_base, require_md5, require_evp_bytestokey, require_browserify_aes, require_fixProc, require_parse_asn1, require_mgf, require_xor, require_bn4, require_withPublic, require_bn5, require_browserify_rsa, require_publicEncrypt, require_privateDecrypt, require_browser2, require_public_encrypt, require_browser3, require_randomfill, require_crypto_browserify, cryptoBrowserify, prng2, pseudoRandomBytes2, rng2, randomBytes2, Hash2, createHash2, Hmac2, createHmac2, getHashes2, pbkdf22, pbkdf2Sync2, Cipher2, createCipher2, Cipheriv2, createCipheriv2, Decipher2, createDecipher2, Decipheriv2, createDecipheriv2, getCiphers2, listCiphers2, DiffieHellmanGroup2, createDiffieHellmanGroup2, getDiffieHellman2, createDiffieHellman2, DiffieHellman2, createSign2, Sign2, createVerify2, Verify2, createECDH2, publicEncrypt2, privateEncrypt2, publicDecrypt2, privateDecrypt2, randomFill2, randomFillSync2, createCredentials2, constants2, DEFAULT_ENCODING = "buffer", getRandomValues = (array) => {
+}, __commonJS2 = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports), require_randombytes, require_create_hash, require_create_hmac, require_algorithms, require_precondition, require_default_encoding, require_safe_buffer, require_isarray, require_type, require_es_object_atoms, require_es_errors, require_eval, require_range, require_ref, require_syntax, require_uri, require_abs, require_floor, require_max, require_min, require_pow, require_round, require_isNaN, require_sign, require_gOPD, require_gopd, require_es_define_property, require_shams, require_has_symbols, require_Reflect_getPrototypeOf, require_Object_getPrototypeOf, require_implementation, require_function_bind, require_functionCall, require_functionApply, require_reflectApply, require_actualApply, require_call_bind_apply_helpers, require_get, require_get_proto, require_hasown, require_get_intrinsic, require_call_bound, require_is_callable, require_for_each, require_possible_typed_array_names, require_available_typed_arrays, require_define_data_property, require_has_property_descriptors, require_set_function_length, require_applyBind, require_call_bind, require_shams2, require_which_typed_array, require_is_typed_array, require_typed_array_buffer, require_to_buffer, require_to_buffer2, require_sync, require_async, require_pbkdf2, require_browserify_cipher, require_diffie_hellman, require_browserify_sign, require_package, require_bn, require_minimalistic_assert, require_utils, require_utils2, require_brorand, require_base, require_inherits_browser, require_inherits, require_short, require_mont, require_edwards, require_curve, require_utils3, require_common, require_common2, require_1, require_256, require_224, require_512, require_384, require_sha, require_ripemd, require_hmac, require_hash, require_secp256k1, require_curves, require_hmac_drbg, require_key, require_signature, require_ec, require_key2, require_signature2, require_eddsa, require_elliptic, require_bn2, require_browser, require_create_ecdh, require_bn3, require_api, require_reporter, require_buffer, require_node, require_base2, require_der, require_constants, require_der2, require_pem, require_decoders, require_der3, require_pem2, require_encoders, require_asn1, require_certificate, require_asn12, require_aesid, require_hash_base, require_md5, require_evp_bytestokey, require_browserify_aes, require_fixProc, require_parse_asn1, require_mgf, require_xor, require_bn4, require_withPublic, require_bn5, require_browserify_rsa, require_publicEncrypt, require_privateDecrypt, require_browser2, require_public_encrypt, require_browser3, require_randomfill, require_crypto_browserify, cryptoBrowserify, prng2, pseudoRandomBytes2, rng2, randomBytes2, Hash2, createHash2, Hmac2, createHmac2, getHashes2, pbkdf22, pbkdf2Sync2, Cipher2, createCipher2, Cipheriv2, createCipheriv2, Decipher2, createDecipher2, Decipheriv2, createDecipheriv2, getCiphers2, listCiphers2, DiffieHellmanGroup2, createDiffieHellmanGroup2, getDiffieHellman2, createDiffieHellman2, DiffieHellman2, createSign2, Sign2, createVerify2, Verify2, createECDH2, publicEncrypt2, privateEncrypt2, publicDecrypt2, privateDecrypt2, randomFill2, randomFillSync2, createCredentials2, constants2, DEFAULT_ENCODING = "buffer", getRandomValues = (array) => {
   return crypto.getRandomValues(array);
 }, randomUUID = () => {
   return crypto.randomUUID();
@@ -6170,16 +6191,16 @@ var init_crypto = __esm(() => {
     module.exports = { sha224WithRSAEncryption: { sign: "rsa", hash: "sha224", id: "302d300d06096086480165030402040500041c" }, "RSA-SHA224": { sign: "ecdsa/rsa", hash: "sha224", id: "302d300d06096086480165030402040500041c" }, sha256WithRSAEncryption: { sign: "rsa", hash: "sha256", id: "3031300d060960864801650304020105000420" }, "RSA-SHA256": { sign: "ecdsa/rsa", hash: "sha256", id: "3031300d060960864801650304020105000420" }, sha384WithRSAEncryption: { sign: "rsa", hash: "sha384", id: "3041300d060960864801650304020205000430" }, "RSA-SHA384": { sign: "ecdsa/rsa", hash: "sha384", id: "3041300d060960864801650304020205000430" }, sha512WithRSAEncryption: { sign: "rsa", hash: "sha512", id: "3051300d060960864801650304020305000440" }, "RSA-SHA512": { sign: "ecdsa/rsa", hash: "sha512", id: "3051300d060960864801650304020305000440" }, "RSA-SHA1": { sign: "rsa", hash: "sha1", id: "3021300906052b0e03021a05000414" }, "ecdsa-with-SHA1": { sign: "ecdsa", hash: "sha1", id: "" }, sha256: { sign: "ecdsa", hash: "sha256", id: "" }, sha224: { sign: "ecdsa", hash: "sha224", id: "" }, sha384: { sign: "ecdsa", hash: "sha384", id: "" }, sha512: { sign: "ecdsa", hash: "sha512", id: "" }, "DSA-SHA": { sign: "dsa", hash: "sha1", id: "" }, "DSA-SHA1": { sign: "dsa", hash: "sha1", id: "" }, DSA: { sign: "dsa", hash: "sha1", id: "" }, "DSA-WITH-SHA224": { sign: "dsa", hash: "sha224", id: "" }, "DSA-SHA224": { sign: "dsa", hash: "sha224", id: "" }, "DSA-WITH-SHA256": { sign: "dsa", hash: "sha256", id: "" }, "DSA-SHA256": { sign: "dsa", hash: "sha256", id: "" }, "DSA-WITH-SHA384": { sign: "dsa", hash: "sha384", id: "" }, "DSA-SHA384": { sign: "dsa", hash: "sha384", id: "" }, "DSA-WITH-SHA512": { sign: "dsa", hash: "sha512", id: "" }, "DSA-SHA512": { sign: "dsa", hash: "sha512", id: "" }, "DSA-RIPEMD160": { sign: "dsa", hash: "rmd160", id: "" }, ripemd160WithRSA: { sign: "rsa", hash: "rmd160", id: "3021300906052b2403020105000414" }, "RSA-RIPEMD160": { sign: "rsa", hash: "rmd160", id: "3021300906052b2403020105000414" }, md5WithRSAEncryption: { sign: "rsa", hash: "md5", id: "3020300c06082a864886f70d020505000410" }, "RSA-MD5": { sign: "rsa", hash: "md5", id: "3020300c06082a864886f70d020505000410" } };
   });
   require_precondition = __commonJS2((exports, module) => {
-    var MAX_ALLOC = Math.pow(2, 30) - 1;
+    var $isFinite = isFinite, MAX_ALLOC = Math.pow(2, 30) - 1;
     module.exports = function(iterations, keylen) {
       if (typeof iterations !== "number")
-        throw new TypeError("Iterations not a number");
-      if (iterations < 0)
-        throw new TypeError("Bad iterations");
+        throw TypeError("Iterations not a number");
+      if (iterations < 0 || !$isFinite(iterations))
+        throw TypeError("Bad iterations");
       if (typeof keylen !== "number")
-        throw new TypeError("Key length not a number");
+        throw TypeError("Key length not a number");
       if (keylen < 0 || keylen > MAX_ALLOC || keylen !== keylen)
-        throw new TypeError("Bad key length");
+        throw TypeError("Bad key length");
     };
   });
   require_default_encoding = __commonJS2((exports, module) => {
@@ -6195,7 +6216,7 @@ var init_crypto = __esm(() => {
   });
   require_safe_buffer = __commonJS2((exports, module) => {
     /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
-    var buffer = (init_buffer(), __toCommonJS(exports_buffer2)), Buffer22 = buffer.Buffer;
+    var buffer = (init_buffer(), __toCommonJS(exports_buffer)), Buffer22 = buffer.Buffer;
     function copyProps(src, dst) {
       for (var key in src)
         dst[key] = src[key];
@@ -6211,58 +6232,733 @@ var init_crypto = __esm(() => {
     copyProps(Buffer22, SafeBuffer);
     SafeBuffer.from = function(arg, encodingOrOffset, length) {
       if (typeof arg === "number")
-        throw new TypeError("Argument must not be a number");
+        throw TypeError("Argument must not be a number");
       return Buffer22(arg, encodingOrOffset, length);
     };
-    SafeBuffer.alloc = function(size, fill2, encoding) {
+    SafeBuffer.alloc = function(size, fill, encoding) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       var buf = Buffer22(size);
-      if (fill2 !== undefined)
+      if (fill !== undefined)
         if (typeof encoding === "string")
-          buf.fill(fill2, encoding);
+          buf.fill(fill, encoding);
         else
-          buf.fill(fill2);
+          buf.fill(fill);
       else
         buf.fill(0);
       return buf;
     };
     SafeBuffer.allocUnsafe = function(size) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       return Buffer22(size);
     };
     SafeBuffer.allocUnsafeSlow = function(size) {
       if (typeof size !== "number")
-        throw new TypeError("Argument must be a number");
+        throw TypeError("Argument must be a number");
       return buffer.SlowBuffer(size);
     };
   });
-  require_to_buffer = __commonJS2((exports, module) => {
-    var Buffer22 = require_safe_buffer().Buffer;
-    module.exports = function(thing, encoding, name) {
-      if (Buffer22.isBuffer(thing))
-        return thing;
-      else if (typeof thing === "string")
-        return Buffer22.from(thing, encoding);
-      else if (ArrayBuffer.isView(thing))
-        return Buffer22.from(thing.buffer);
+  require_isarray = __commonJS2((exports, module) => {
+    var toString = {}.toString;
+    module.exports = Array.isArray || function(arr) {
+      return toString.call(arr) == "[object Array]";
+    };
+  });
+  require_type = __commonJS2((exports, module) => {
+    module.exports = TypeError;
+  });
+  require_es_object_atoms = __commonJS2((exports, module) => {
+    module.exports = Object;
+  });
+  require_es_errors = __commonJS2((exports, module) => {
+    module.exports = Error;
+  });
+  require_eval = __commonJS2((exports, module) => {
+    module.exports = EvalError;
+  });
+  require_range = __commonJS2((exports, module) => {
+    module.exports = RangeError;
+  });
+  require_ref = __commonJS2((exports, module) => {
+    module.exports = ReferenceError;
+  });
+  require_syntax = __commonJS2((exports, module) => {
+    module.exports = SyntaxError;
+  });
+  require_uri = __commonJS2((exports, module) => {
+    module.exports = URIError;
+  });
+  require_abs = __commonJS2((exports, module) => {
+    module.exports = Math.abs;
+  });
+  require_floor = __commonJS2((exports, module) => {
+    module.exports = Math.floor;
+  });
+  require_max = __commonJS2((exports, module) => {
+    module.exports = Math.max;
+  });
+  require_min = __commonJS2((exports, module) => {
+    module.exports = Math.min;
+  });
+  require_pow = __commonJS2((exports, module) => {
+    module.exports = Math.pow;
+  });
+  require_round = __commonJS2((exports, module) => {
+    module.exports = Math.round;
+  });
+  require_isNaN = __commonJS2((exports, module) => {
+    module.exports = Number.isNaN || function(a) {
+      return a !== a;
+    };
+  });
+  require_sign = __commonJS2((exports, module) => {
+    var $isNaN = require_isNaN();
+    module.exports = function(number) {
+      if ($isNaN(number) || number === 0)
+        return number;
+      return number < 0 ? -1 : 1;
+    };
+  });
+  require_gOPD = __commonJS2((exports, module) => {
+    module.exports = Object.getOwnPropertyDescriptor;
+  });
+  require_gopd = __commonJS2((exports, module) => {
+    var $gOPD = require_gOPD();
+    if ($gOPD)
+      try {
+        $gOPD([], "length");
+      } catch (e) {
+        $gOPD = null;
+      }
+    module.exports = $gOPD;
+  });
+  require_es_define_property = __commonJS2((exports, module) => {
+    var $defineProperty = Object.defineProperty || false;
+    if ($defineProperty)
+      try {
+        $defineProperty({}, "a", { value: 1 });
+      } catch (e) {
+        $defineProperty = false;
+      }
+    module.exports = $defineProperty;
+  });
+  require_shams = __commonJS2((exports, module) => {
+    module.exports = function() {
+      if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function")
+        return false;
+      if (typeof Symbol.iterator === "symbol")
+        return true;
+      var obj = {}, sym = Symbol("test"), symObj = Object(sym);
+      if (typeof sym === "string")
+        return false;
+      if (Object.prototype.toString.call(sym) !== "[object Symbol]")
+        return false;
+      if (Object.prototype.toString.call(symObj) !== "[object Symbol]")
+        return false;
+      var symVal = 42;
+      obj[sym] = symVal;
+      for (var _ in obj)
+        return false;
+      if (typeof Object.keys === "function" && Object.keys(obj).length !== 0)
+        return false;
+      if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0)
+        return false;
+      var syms = Object.getOwnPropertySymbols(obj);
+      if (syms.length !== 1 || syms[0] !== sym)
+        return false;
+      if (!Object.prototype.propertyIsEnumerable.call(obj, sym))
+        return false;
+      if (typeof Object.getOwnPropertyDescriptor === "function") {
+        var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
+        if (descriptor.value !== symVal || descriptor.enumerable !== true)
+          return false;
+      }
+      return true;
+    };
+  });
+  require_has_symbols = __commonJS2((exports, module) => {
+    var origSymbol = typeof Symbol < "u" && Symbol, hasSymbolSham = require_shams();
+    module.exports = function() {
+      if (typeof origSymbol !== "function")
+        return false;
+      if (typeof Symbol !== "function")
+        return false;
+      if (typeof origSymbol("foo") !== "symbol")
+        return false;
+      if (typeof Symbol("bar") !== "symbol")
+        return false;
+      return hasSymbolSham();
+    };
+  });
+  require_Reflect_getPrototypeOf = __commonJS2((exports, module) => {
+    module.exports = typeof Reflect < "u" && Reflect.getPrototypeOf || null;
+  });
+  require_Object_getPrototypeOf = __commonJS2((exports, module) => {
+    var $Object = require_es_object_atoms();
+    module.exports = $Object.getPrototypeOf || null;
+  });
+  require_implementation = __commonJS2((exports, module) => {
+    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ", toStr = Object.prototype.toString, max = Math.max, funcType = "[object Function]", concatty = function(a, b) {
+      var arr = [];
+      for (var i2 = 0;i2 < a.length; i2 += 1)
+        arr[i2] = a[i2];
+      for (var j = 0;j < b.length; j += 1)
+        arr[j + a.length] = b[j];
+      return arr;
+    }, slicy = function(arrLike, offset) {
+      var arr = [];
+      for (var i2 = offset || 0, j = 0;i2 < arrLike.length; i2 += 1, j += 1)
+        arr[j] = arrLike[i2];
+      return arr;
+    }, joiny = function(arr, joiner) {
+      var str = "";
+      for (var i2 = 0;i2 < arr.length; i2 += 1)
+        if (str += arr[i2], i2 + 1 < arr.length)
+          str += joiner;
+      return str;
+    };
+    module.exports = function(that) {
+      var target = this;
+      if (typeof target !== "function" || toStr.apply(target) !== funcType)
+        throw TypeError(ERROR_MESSAGE + target);
+      var args = slicy(arguments, 1), bound, binder = function() {
+        if (this instanceof bound) {
+          var result = target.apply(this, concatty(args, arguments));
+          if (Object(result) === result)
+            return result;
+          return this;
+        }
+        return target.apply(that, concatty(args, arguments));
+      }, boundLength = max(0, target.length - args.length), boundArgs = [];
+      for (var i2 = 0;i2 < boundLength; i2++)
+        boundArgs[i2] = "$" + i2;
+      if (bound = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder), target.prototype) {
+        var Empty = function() {};
+        Empty.prototype = target.prototype, bound.prototype = new Empty, Empty.prototype = null;
+      }
+      return bound;
+    };
+  });
+  require_function_bind = __commonJS2((exports, module) => {
+    var implementation = require_implementation();
+    module.exports = Function.prototype.bind || implementation;
+  });
+  require_functionCall = __commonJS2((exports, module) => {
+    module.exports = Function.prototype.call;
+  });
+  require_functionApply = __commonJS2((exports, module) => {
+    module.exports = Function.prototype.apply;
+  });
+  require_reflectApply = __commonJS2((exports, module) => {
+    module.exports = typeof Reflect < "u" && Reflect && Reflect.apply;
+  });
+  require_actualApply = __commonJS2((exports, module) => {
+    var bind = require_function_bind(), $apply = require_functionApply(), $call = require_functionCall(), $reflectApply = require_reflectApply();
+    module.exports = $reflectApply || bind.call($call, $apply);
+  });
+  require_call_bind_apply_helpers = __commonJS2((exports, module) => {
+    var bind = require_function_bind(), $TypeError = require_type(), $call = require_functionCall(), $actualApply = require_actualApply();
+    module.exports = function(args) {
+      if (args.length < 1 || typeof args[0] !== "function")
+        throw new $TypeError("a function is required");
+      return $actualApply(bind, $call, args);
+    };
+  });
+  require_get = __commonJS2((exports, module) => {
+    var callBind = require_call_bind_apply_helpers(), gOPD = require_gopd(), hasProtoAccessor;
+    try {
+      hasProtoAccessor = [].__proto__ === Array.prototype;
+    } catch (e) {
+      if (!e || typeof e !== "object" || !("code" in e) || e.code !== "ERR_PROTO_ACCESS")
+        throw e;
+    }
+    var desc = !!hasProtoAccessor && gOPD && gOPD(Object.prototype, "__proto__"), $Object = Object, $getPrototypeOf = $Object.getPrototypeOf;
+    module.exports = desc && typeof desc.get === "function" ? callBind([desc.get]) : typeof $getPrototypeOf === "function" ? function(value) {
+      return $getPrototypeOf(value == null ? value : $Object(value));
+    } : false;
+  });
+  require_get_proto = __commonJS2((exports, module) => {
+    var reflectGetProto = require_Reflect_getPrototypeOf(), originalGetProto = require_Object_getPrototypeOf(), getDunderProto = require_get();
+    module.exports = reflectGetProto ? function(O) {
+      return reflectGetProto(O);
+    } : originalGetProto ? function(O) {
+      if (!O || typeof O !== "object" && typeof O !== "function")
+        throw TypeError("getProto: not an object");
+      return originalGetProto(O);
+    } : getDunderProto ? function(O) {
+      return getDunderProto(O);
+    } : null;
+  });
+  require_hasown = __commonJS2((exports, module) => {
+    var call = Function.prototype.call, $hasOwn = Object.prototype.hasOwnProperty, bind = require_function_bind();
+    module.exports = bind.call(call, $hasOwn);
+  });
+  require_get_intrinsic = __commonJS2((exports, module) => {
+    var undefined2, $Object = require_es_object_atoms(), $Error = require_es_errors(), $EvalError = require_eval(), $RangeError = require_range(), $ReferenceError = require_ref(), $SyntaxError = require_syntax(), $TypeError = require_type(), $URIError = require_uri(), abs = require_abs(), floor = require_floor(), max = require_max(), min = require_min(), pow = require_pow(), round = require_round(), sign = require_sign(), $Function = Function, getEvalledConstructor = function(expressionSyntax) {
+      try {
+        return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
+      } catch (e) {}
+    }, $gOPD = require_gopd(), $defineProperty = require_es_define_property(), throwTypeError = function() {
+      throw new $TypeError;
+    }, ThrowTypeError = $gOPD ? function() {
+      try {
+        return arguments.callee, throwTypeError;
+      } catch (calleeThrows) {
+        try {
+          return $gOPD(arguments, "callee").get;
+        } catch (gOPDthrows) {
+          return throwTypeError;
+        }
+      }
+    }() : throwTypeError, hasSymbols = require_has_symbols()(), getProto = require_get_proto(), $ObjectGPO = require_Object_getPrototypeOf(), $ReflectGPO = require_Reflect_getPrototypeOf(), $apply = require_functionApply(), $call = require_functionCall(), needsEval = {}, TypedArray = typeof Uint8Array > "u" || !getProto ? undefined2 : getProto(Uint8Array), INTRINSICS = { __proto__: null, "%AggregateError%": typeof AggregateError > "u" ? undefined2 : AggregateError, "%Array%": Array, "%ArrayBuffer%": typeof ArrayBuffer > "u" ? undefined2 : ArrayBuffer, "%ArrayIteratorPrototype%": hasSymbols && getProto ? getProto([][Symbol.iterator]()) : undefined2, "%AsyncFromSyncIteratorPrototype%": undefined2, "%AsyncFunction%": needsEval, "%AsyncGenerator%": needsEval, "%AsyncGeneratorFunction%": needsEval, "%AsyncIteratorPrototype%": needsEval, "%Atomics%": typeof Atomics > "u" ? undefined2 : Atomics, "%BigInt%": typeof BigInt > "u" ? undefined2 : BigInt, "%BigInt64Array%": typeof BigInt64Array > "u" ? undefined2 : BigInt64Array, "%BigUint64Array%": typeof BigUint64Array > "u" ? undefined2 : BigUint64Array, "%Boolean%": Boolean, "%DataView%": typeof DataView > "u" ? undefined2 : DataView, "%Date%": Date, "%decodeURI%": decodeURI, "%decodeURIComponent%": decodeURIComponent, "%encodeURI%": encodeURI, "%encodeURIComponent%": encodeURIComponent, "%Error%": $Error, "%eval%": eval, "%EvalError%": $EvalError, "%Float16Array%": typeof Float16Array > "u" ? undefined2 : Float16Array, "%Float32Array%": typeof Float32Array > "u" ? undefined2 : Float32Array, "%Float64Array%": typeof Float64Array > "u" ? undefined2 : Float64Array, "%FinalizationRegistry%": typeof FinalizationRegistry > "u" ? undefined2 : FinalizationRegistry, "%Function%": $Function, "%GeneratorFunction%": needsEval, "%Int8Array%": typeof Int8Array > "u" ? undefined2 : Int8Array, "%Int16Array%": typeof Int16Array > "u" ? undefined2 : Int16Array, "%Int32Array%": typeof Int32Array > "u" ? undefined2 : Int32Array, "%isFinite%": isFinite, "%isNaN%": isNaN, "%IteratorPrototype%": hasSymbols && getProto ? getProto(getProto([][Symbol.iterator]())) : undefined2, "%JSON%": typeof JSON === "object" ? JSON : undefined2, "%Map%": typeof Map > "u" ? undefined2 : Map, "%MapIteratorPrototype%": typeof Map > "u" || !hasSymbols || !getProto ? undefined2 : getProto(new Map()[Symbol.iterator]()), "%Math%": Math, "%Number%": Number, "%Object%": $Object, "%Object.getOwnPropertyDescriptor%": $gOPD, "%parseFloat%": parseFloat, "%parseInt%": parseInt, "%Promise%": typeof Promise > "u" ? undefined2 : Promise, "%Proxy%": typeof Proxy > "u" ? undefined2 : Proxy, "%RangeError%": $RangeError, "%ReferenceError%": $ReferenceError, "%Reflect%": typeof Reflect > "u" ? undefined2 : Reflect, "%RegExp%": RegExp, "%Set%": typeof Set > "u" ? undefined2 : Set, "%SetIteratorPrototype%": typeof Set > "u" || !hasSymbols || !getProto ? undefined2 : getProto(new Set()[Symbol.iterator]()), "%SharedArrayBuffer%": typeof SharedArrayBuffer > "u" ? undefined2 : SharedArrayBuffer, "%String%": String, "%StringIteratorPrototype%": hasSymbols && getProto ? getProto(""[Symbol.iterator]()) : undefined2, "%Symbol%": hasSymbols ? Symbol : undefined2, "%SyntaxError%": $SyntaxError, "%ThrowTypeError%": ThrowTypeError, "%TypedArray%": TypedArray, "%TypeError%": $TypeError, "%Uint8Array%": typeof Uint8Array > "u" ? undefined2 : Uint8Array, "%Uint8ClampedArray%": typeof Uint8ClampedArray > "u" ? undefined2 : Uint8ClampedArray, "%Uint16Array%": typeof Uint16Array > "u" ? undefined2 : Uint16Array, "%Uint32Array%": typeof Uint32Array > "u" ? undefined2 : Uint32Array, "%URIError%": $URIError, "%WeakMap%": typeof WeakMap > "u" ? undefined2 : WeakMap, "%WeakRef%": typeof WeakRef > "u" ? undefined2 : WeakRef, "%WeakSet%": typeof WeakSet > "u" ? undefined2 : WeakSet, "%Function.prototype.call%": $call, "%Function.prototype.apply%": $apply, "%Object.defineProperty%": $defineProperty, "%Object.getPrototypeOf%": $ObjectGPO, "%Math.abs%": abs, "%Math.floor%": floor, "%Math.max%": max, "%Math.min%": min, "%Math.pow%": pow, "%Math.round%": round, "%Math.sign%": sign, "%Reflect.getPrototypeOf%": $ReflectGPO };
+    if (getProto)
+      try {
+        null.error;
+      } catch (e) {
+        errorProto = getProto(getProto(e)), INTRINSICS["%Error.prototype%"] = errorProto;
+      }
+    var errorProto, doEval = function doEval2(name) {
+      var value;
+      if (name === "%AsyncFunction%")
+        value = getEvalledConstructor("async function () {}");
+      else if (name === "%GeneratorFunction%")
+        value = getEvalledConstructor("function* () {}");
+      else if (name === "%AsyncGeneratorFunction%")
+        value = getEvalledConstructor("async function* () {}");
+      else if (name === "%AsyncGenerator%") {
+        var fn = doEval2("%AsyncGeneratorFunction%");
+        if (fn)
+          value = fn.prototype;
+      } else if (name === "%AsyncIteratorPrototype%") {
+        var gen = doEval2("%AsyncGenerator%");
+        if (gen && getProto)
+          value = getProto(gen.prototype);
+      }
+      return INTRINSICS[name] = value, value;
+    }, LEGACY_ALIASES = { __proto__: null, "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"], "%ArrayPrototype%": ["Array", "prototype"], "%ArrayProto_entries%": ["Array", "prototype", "entries"], "%ArrayProto_forEach%": ["Array", "prototype", "forEach"], "%ArrayProto_keys%": ["Array", "prototype", "keys"], "%ArrayProto_values%": ["Array", "prototype", "values"], "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"], "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"], "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"], "%BooleanPrototype%": ["Boolean", "prototype"], "%DataViewPrototype%": ["DataView", "prototype"], "%DatePrototype%": ["Date", "prototype"], "%ErrorPrototype%": ["Error", "prototype"], "%EvalErrorPrototype%": ["EvalError", "prototype"], "%Float32ArrayPrototype%": ["Float32Array", "prototype"], "%Float64ArrayPrototype%": ["Float64Array", "prototype"], "%FunctionPrototype%": ["Function", "prototype"], "%Generator%": ["GeneratorFunction", "prototype"], "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"], "%Int8ArrayPrototype%": ["Int8Array", "prototype"], "%Int16ArrayPrototype%": ["Int16Array", "prototype"], "%Int32ArrayPrototype%": ["Int32Array", "prototype"], "%JSONParse%": ["JSON", "parse"], "%JSONStringify%": ["JSON", "stringify"], "%MapPrototype%": ["Map", "prototype"], "%NumberPrototype%": ["Number", "prototype"], "%ObjectPrototype%": ["Object", "prototype"], "%ObjProto_toString%": ["Object", "prototype", "toString"], "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"], "%PromisePrototype%": ["Promise", "prototype"], "%PromiseProto_then%": ["Promise", "prototype", "then"], "%Promise_all%": ["Promise", "all"], "%Promise_reject%": ["Promise", "reject"], "%Promise_resolve%": ["Promise", "resolve"], "%RangeErrorPrototype%": ["RangeError", "prototype"], "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"], "%RegExpPrototype%": ["RegExp", "prototype"], "%SetPrototype%": ["Set", "prototype"], "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"], "%StringPrototype%": ["String", "prototype"], "%SymbolPrototype%": ["Symbol", "prototype"], "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"], "%TypedArrayPrototype%": ["TypedArray", "prototype"], "%TypeErrorPrototype%": ["TypeError", "prototype"], "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"], "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"], "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"], "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"], "%URIErrorPrototype%": ["URIError", "prototype"], "%WeakMapPrototype%": ["WeakMap", "prototype"], "%WeakSetPrototype%": ["WeakSet", "prototype"] }, bind = require_function_bind(), hasOwn = require_hasown(), $concat = bind.call($call, Array.prototype.concat), $spliceApply = bind.call($apply, Array.prototype.splice), $replace = bind.call($call, String.prototype.replace), $strSlice = bind.call($call, String.prototype.slice), $exec = bind.call($call, RegExp.prototype.exec), rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g, reEscapeChar = /\\(\\)?/g, stringToPath = function(string) {
+      var first = $strSlice(string, 0, 1), last = $strSlice(string, -1);
+      if (first === "%" && last !== "%")
+        throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
+      else if (last === "%" && first !== "%")
+        throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
+      var result = [];
+      return $replace(string, rePropName, function(match, number, quote, subString) {
+        result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
+      }), result;
+    }, getBaseIntrinsic = function(name, allowMissing) {
+      var intrinsicName = name, alias;
+      if (hasOwn(LEGACY_ALIASES, intrinsicName))
+        alias = LEGACY_ALIASES[intrinsicName], intrinsicName = "%" + alias[0] + "%";
+      if (hasOwn(INTRINSICS, intrinsicName)) {
+        var value = INTRINSICS[intrinsicName];
+        if (value === needsEval)
+          value = doEval(intrinsicName);
+        if (typeof value > "u" && !allowMissing)
+          throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
+        return { alias, name: intrinsicName, value };
+      }
+      throw new $SyntaxError("intrinsic " + name + " does not exist!");
+    };
+    module.exports = function(name, allowMissing) {
+      if (typeof name !== "string" || name.length === 0)
+        throw new $TypeError("intrinsic name must be a non-empty string");
+      if (arguments.length > 1 && typeof allowMissing !== "boolean")
+        throw new $TypeError('"allowMissing" argument must be a boolean');
+      if ($exec(/^%?[^%]*%?$/, name) === null)
+        throw new $SyntaxError("`%` may not be present anywhere but at the beginning and end of the intrinsic name");
+      var parts = stringToPath(name), intrinsicBaseName = parts.length > 0 ? parts[0] : "", intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing), intrinsicRealName = intrinsic.name, value = intrinsic.value, skipFurtherCaching = false, alias = intrinsic.alias;
+      if (alias)
+        intrinsicBaseName = alias[0], $spliceApply(parts, $concat([0, 1], alias));
+      for (var i2 = 1, isOwn = true;i2 < parts.length; i2 += 1) {
+        var part = parts[i2], first = $strSlice(part, 0, 1), last = $strSlice(part, -1);
+        if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last)
+          throw new $SyntaxError("property names with quotes must have matching quotes");
+        if (part === "constructor" || !isOwn)
+          skipFurtherCaching = true;
+        if (intrinsicBaseName += "." + part, intrinsicRealName = "%" + intrinsicBaseName + "%", hasOwn(INTRINSICS, intrinsicRealName))
+          value = INTRINSICS[intrinsicRealName];
+        else if (value != null) {
+          if (!(part in value)) {
+            if (!allowMissing)
+              throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
+            return;
+          }
+          if ($gOPD && i2 + 1 >= parts.length) {
+            var desc = $gOPD(value, part);
+            if (isOwn = !!desc, isOwn && "get" in desc && !("originalValue" in desc.get))
+              value = desc.get;
+            else
+              value = value[part];
+          } else
+            isOwn = hasOwn(value, part), value = value[part];
+          if (isOwn && !skipFurtherCaching)
+            INTRINSICS[intrinsicRealName] = value;
+        }
+      }
+      return value;
+    };
+  });
+  require_call_bound = __commonJS2((exports, module) => {
+    var GetIntrinsic = require_get_intrinsic(), callBindBasic = require_call_bind_apply_helpers(), $indexOf = callBindBasic([GetIntrinsic("%String.prototype.indexOf%")]);
+    module.exports = function(name, allowMissing) {
+      var intrinsic = GetIntrinsic(name, !!allowMissing);
+      if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1)
+        return callBindBasic([intrinsic]);
+      return intrinsic;
+    };
+  });
+  require_is_callable = __commonJS2((exports, module) => {
+    var fnToStr = Function.prototype.toString, reflectApply = typeof Reflect === "object" && Reflect !== null && Reflect.apply, badArrayLike, isCallableMarker;
+    if (typeof reflectApply === "function" && typeof Object.defineProperty === "function")
+      try {
+        badArrayLike = Object.defineProperty({}, "length", { get: function() {
+          throw isCallableMarker;
+        } }), isCallableMarker = {}, reflectApply(function() {
+          throw 42;
+        }, null, badArrayLike);
+      } catch (_) {
+        if (_ !== isCallableMarker)
+          reflectApply = null;
+      }
+    else
+      reflectApply = null;
+    var constructorRegex = /^\s*class\b/, isES6ClassFn = function(value) {
+      try {
+        var fnStr = fnToStr.call(value);
+        return constructorRegex.test(fnStr);
+      } catch (e) {
+        return false;
+      }
+    }, tryFunctionObject = function(value) {
+      try {
+        if (isES6ClassFn(value))
+          return false;
+        return fnToStr.call(value), true;
+      } catch (e) {
+        return false;
+      }
+    }, toStr = Object.prototype.toString, objectClass = "[object Object]", fnClass = "[object Function]", genClass = "[object GeneratorFunction]", ddaClass = "[object HTMLAllCollection]", ddaClass2 = "[object HTML document.all class]", ddaClass3 = "[object HTMLCollection]", hasToStringTag = typeof Symbol === "function" && !!Symbol.toStringTag, isIE68 = !(0 in [,]), isDDA = function() {
+      return false;
+    };
+    if (typeof document === "object") {
+      if (all = document.all, toStr.call(all) === toStr.call(document.all))
+        isDDA = function(value) {
+          if ((isIE68 || !value) && (typeof value > "u" || typeof value === "object"))
+            try {
+              var str = toStr.call(value);
+              return (str === ddaClass || str === ddaClass2 || str === ddaClass3 || str === objectClass) && value("") == null;
+            } catch (e) {}
+          return false;
+        };
+    }
+    var all;
+    module.exports = reflectApply ? function(value) {
+      if (isDDA(value))
+        return true;
+      if (!value)
+        return false;
+      if (typeof value !== "function" && typeof value !== "object")
+        return false;
+      try {
+        reflectApply(value, null, badArrayLike);
+      } catch (e) {
+        if (e !== isCallableMarker)
+          return false;
+      }
+      return !isES6ClassFn(value) && tryFunctionObject(value);
+    } : function(value) {
+      if (isDDA(value))
+        return true;
+      if (!value)
+        return false;
+      if (typeof value !== "function" && typeof value !== "object")
+        return false;
+      if (hasToStringTag)
+        return tryFunctionObject(value);
+      if (isES6ClassFn(value))
+        return false;
+      var strClass = toStr.call(value);
+      if (strClass !== fnClass && strClass !== genClass && !/^\[object HTML/.test(strClass))
+        return false;
+      return tryFunctionObject(value);
+    };
+  });
+  require_for_each = __commonJS2((exports, module) => {
+    var isCallable = require_is_callable(), toStr = Object.prototype.toString, hasOwnProperty2 = Object.prototype.hasOwnProperty, forEachArray = function(array, iterator, receiver) {
+      for (var i2 = 0, len2 = array.length;i2 < len2; i2++)
+        if (hasOwnProperty2.call(array, i2))
+          if (receiver == null)
+            iterator(array[i2], i2, array);
+          else
+            iterator.call(receiver, array[i2], i2, array);
+    }, forEachString = function(string, iterator, receiver) {
+      for (var i2 = 0, len2 = string.length;i2 < len2; i2++)
+        if (receiver == null)
+          iterator(string.charAt(i2), i2, string);
+        else
+          iterator.call(receiver, string.charAt(i2), i2, string);
+    }, forEachObject = function(object, iterator, receiver) {
+      for (var k in object)
+        if (hasOwnProperty2.call(object, k))
+          if (receiver == null)
+            iterator(object[k], k, object);
+          else
+            iterator.call(receiver, object[k], k, object);
+    };
+    function isArray2(x) {
+      return toStr.call(x) === "[object Array]";
+    }
+    module.exports = function(list, iterator, thisArg) {
+      if (!isCallable(iterator))
+        throw TypeError("iterator must be a function");
+      var receiver;
+      if (arguments.length >= 3)
+        receiver = thisArg;
+      if (isArray2(list))
+        forEachArray(list, iterator, receiver);
+      else if (typeof list === "string")
+        forEachString(list, iterator, receiver);
       else
-        throw new TypeError(name + " must be a string, a Buffer, a typed array or a DataView");
+        forEachObject(list, iterator, receiver);
+    };
+  });
+  require_possible_typed_array_names = __commonJS2((exports, module) => {
+    module.exports = ["Float16Array", "Float32Array", "Float64Array", "Int8Array", "Int16Array", "Int32Array", "Uint8Array", "Uint8ClampedArray", "Uint16Array", "Uint32Array", "BigInt64Array", "BigUint64Array"];
+  });
+  require_available_typed_arrays = __commonJS2((exports, module) => {
+    var possibleNames = require_possible_typed_array_names(), g = typeof globalThis > "u" ? globalThis : globalThis;
+    module.exports = function() {
+      var out = [];
+      for (var i2 = 0;i2 < possibleNames.length; i2++)
+        if (typeof g[possibleNames[i2]] === "function")
+          out[out.length] = possibleNames[i2];
+      return out;
+    };
+  });
+  require_define_data_property = __commonJS2((exports, module) => {
+    var $defineProperty = require_es_define_property(), $SyntaxError = require_syntax(), $TypeError = require_type(), gopd = require_gopd();
+    module.exports = function(obj, property, value) {
+      if (!obj || typeof obj !== "object" && typeof obj !== "function")
+        throw new $TypeError("`obj` must be an object or a function`");
+      if (typeof property !== "string" && typeof property !== "symbol")
+        throw new $TypeError("`property` must be a string or a symbol`");
+      if (arguments.length > 3 && typeof arguments[3] !== "boolean" && arguments[3] !== null)
+        throw new $TypeError("`nonEnumerable`, if provided, must be a boolean or null");
+      if (arguments.length > 4 && typeof arguments[4] !== "boolean" && arguments[4] !== null)
+        throw new $TypeError("`nonWritable`, if provided, must be a boolean or null");
+      if (arguments.length > 5 && typeof arguments[5] !== "boolean" && arguments[5] !== null)
+        throw new $TypeError("`nonConfigurable`, if provided, must be a boolean or null");
+      if (arguments.length > 6 && typeof arguments[6] !== "boolean")
+        throw new $TypeError("`loose`, if provided, must be a boolean");
+      var nonEnumerable = arguments.length > 3 ? arguments[3] : null, nonWritable = arguments.length > 4 ? arguments[4] : null, nonConfigurable = arguments.length > 5 ? arguments[5] : null, loose = arguments.length > 6 ? arguments[6] : false, desc = !!gopd && gopd(obj, property);
+      if ($defineProperty)
+        $defineProperty(obj, property, { configurable: nonConfigurable === null && desc ? desc.configurable : !nonConfigurable, enumerable: nonEnumerable === null && desc ? desc.enumerable : !nonEnumerable, value, writable: nonWritable === null && desc ? desc.writable : !nonWritable });
+      else if (loose || !nonEnumerable && !nonWritable && !nonConfigurable)
+        obj[property] = value;
+      else
+        throw new $SyntaxError("This environment does not support defining a property as non-configurable, non-writable, or non-enumerable.");
+    };
+  });
+  require_has_property_descriptors = __commonJS2((exports, module) => {
+    var $defineProperty = require_es_define_property(), hasPropertyDescriptors = function() {
+      return !!$defineProperty;
+    };
+    hasPropertyDescriptors.hasArrayLengthDefineBug = function() {
+      if (!$defineProperty)
+        return null;
+      try {
+        return $defineProperty([], "length", { value: 1 }).length !== 1;
+      } catch (e) {
+        return true;
+      }
+    };
+    module.exports = hasPropertyDescriptors;
+  });
+  require_set_function_length = __commonJS2((exports, module) => {
+    var GetIntrinsic = require_get_intrinsic(), define = require_define_data_property(), hasDescriptors = require_has_property_descriptors()(), gOPD = require_gopd(), $TypeError = require_type(), $floor = GetIntrinsic("%Math.floor%");
+    module.exports = function(fn, length) {
+      if (typeof fn !== "function")
+        throw new $TypeError("`fn` is not a function");
+      if (typeof length !== "number" || length < 0 || length > 4294967295 || $floor(length) !== length)
+        throw new $TypeError("`length` must be a positive 32-bit integer");
+      var loose = arguments.length > 2 && !!arguments[2], functionLengthIsConfigurable = true, functionLengthIsWritable = true;
+      if ("length" in fn && gOPD) {
+        var desc = gOPD(fn, "length");
+        if (desc && !desc.configurable)
+          functionLengthIsConfigurable = false;
+        if (desc && !desc.writable)
+          functionLengthIsWritable = false;
+      }
+      if (functionLengthIsConfigurable || functionLengthIsWritable || !loose)
+        if (hasDescriptors)
+          define(fn, "length", length, true, true);
+        else
+          define(fn, "length", length);
+      return fn;
+    };
+  });
+  require_applyBind = __commonJS2((exports, module) => {
+    var bind = require_function_bind(), $apply = require_functionApply(), actualApply = require_actualApply();
+    module.exports = function() {
+      return actualApply(bind, $apply, arguments);
+    };
+  });
+  require_call_bind = __commonJS2((exports, module) => {
+    var setFunctionLength = require_set_function_length(), $defineProperty = require_es_define_property(), callBindBasic = require_call_bind_apply_helpers(), applyBind = require_applyBind();
+    module.exports = function(originalFunction) {
+      var func = callBindBasic(arguments), adjustedLength = originalFunction.length - (arguments.length - 1);
+      return setFunctionLength(func, 1 + (adjustedLength > 0 ? adjustedLength : 0), true);
+    };
+    if ($defineProperty)
+      $defineProperty(module.exports, "apply", { value: applyBind });
+    else
+      module.exports.apply = applyBind;
+  });
+  require_shams2 = __commonJS2((exports, module) => {
+    var hasSymbols = require_shams();
+    module.exports = function() {
+      return hasSymbols() && !!Symbol.toStringTag;
+    };
+  });
+  require_which_typed_array = __commonJS2((exports, module) => {
+    var forEach = require_for_each(), availableTypedArrays = require_available_typed_arrays(), callBind = require_call_bind(), callBound = require_call_bound(), gOPD = require_gopd(), getProto = require_get_proto(), $toString = callBound("Object.prototype.toString"), hasToStringTag = require_shams2()(), g = typeof globalThis > "u" ? globalThis : globalThis, typedArrays = availableTypedArrays(), $slice = callBound("String.prototype.slice"), $indexOf = callBound("Array.prototype.indexOf", true) || function(array, value) {
+      for (var i2 = 0;i2 < array.length; i2 += 1)
+        if (array[i2] === value)
+          return i2;
+      return -1;
+    }, cache = { __proto__: null };
+    if (hasToStringTag && gOPD && getProto)
+      forEach(typedArrays, function(typedArray) {
+        var arr = new g[typedArray];
+        if (Symbol.toStringTag in arr && getProto) {
+          var proto = getProto(arr), descriptor = gOPD(proto, Symbol.toStringTag);
+          if (!descriptor && proto) {
+            var superProto = getProto(proto);
+            descriptor = gOPD(superProto, Symbol.toStringTag);
+          }
+          cache["$" + typedArray] = callBind(descriptor.get);
+        }
+      });
+    else
+      forEach(typedArrays, function(typedArray) {
+        var arr = new g[typedArray], fn = arr.slice || arr.set;
+        if (fn)
+          cache["$" + typedArray] = callBind(fn);
+      });
+    var tryTypedArrays = function(value) {
+      var found = false;
+      return forEach(cache, function(getter, typedArray) {
+        if (!found)
+          try {
+            if ("$" + getter(value) === typedArray)
+              found = $slice(typedArray, 1);
+          } catch (e) {}
+      }), found;
+    }, trySlices = function(value) {
+      var found = false;
+      return forEach(cache, function(getter, name) {
+        if (!found)
+          try {
+            getter(value), found = $slice(name, 1);
+          } catch (e) {}
+      }), found;
+    };
+    module.exports = function(value) {
+      if (!value || typeof value !== "object")
+        return false;
+      if (!hasToStringTag) {
+        var tag = $slice($toString(value), 8, -1);
+        if ($indexOf(typedArrays, tag) > -1)
+          return tag;
+        if (tag !== "Object")
+          return false;
+        return trySlices(value);
+      }
+      if (!gOPD)
+        return null;
+      return tryTypedArrays(value);
+    };
+  });
+  require_is_typed_array = __commonJS2((exports, module) => {
+    var whichTypedArray = require_which_typed_array();
+    module.exports = function(value) {
+      return !!whichTypedArray(value);
+    };
+  });
+  require_typed_array_buffer = __commonJS2((exports, module) => {
+    var $TypeError = require_type(), callBound = require_call_bound(), $typedArrayBuffer = callBound("TypedArray.prototype.buffer", true), isTypedArray = require_is_typed_array();
+    module.exports = $typedArrayBuffer || function(x) {
+      if (!isTypedArray(x))
+        throw new $TypeError("Not a Typed Array");
+      return x.buffer;
+    };
+  });
+  require_to_buffer = __commonJS2((exports, module) => {
+    var Buffer22 = require_safe_buffer().Buffer, isArray2 = require_isarray(), typedArrayBuffer = require_typed_array_buffer(), isView = ArrayBuffer.isView || function(obj) {
+      try {
+        return typedArrayBuffer(obj), true;
+      } catch (e) {
+        return false;
+      }
+    }, useUint8Array = typeof Uint8Array < "u", useArrayBuffer = typeof ArrayBuffer < "u" && typeof Uint8Array < "u", useFromArrayBuffer = useArrayBuffer && (Buffer22.prototype instanceof Uint8Array || Buffer22.TYPED_ARRAY_SUPPORT);
+    module.exports = function(data, encoding) {
+      if (Buffer22.isBuffer(data)) {
+        if (data.constructor && !("isBuffer" in data))
+          return Buffer22.from(data);
+        return data;
+      }
+      if (typeof data === "string")
+        return Buffer22.from(data, encoding);
+      if (useArrayBuffer && isView(data)) {
+        if (data.byteLength === 0)
+          return Buffer22.alloc(0);
+        if (useFromArrayBuffer) {
+          var res = Buffer22.from(data.buffer, data.byteOffset, data.byteLength);
+          if (res.byteLength === data.byteLength)
+            return res;
+        }
+        var uint8 = data instanceof Uint8Array ? data : new Uint8Array(data.buffer, data.byteOffset, data.byteLength), result = Buffer22.from(uint8);
+        if (result.length === data.byteLength)
+          return result;
+      }
+      if (useUint8Array && data instanceof Uint8Array)
+        return Buffer22.from(data);
+      var isArr = isArray2(data);
+      if (isArr)
+        for (var i2 = 0;i2 < data.length; i2 += 1) {
+          var x = data[i2];
+          if (typeof x !== "number" || x < 0 || x > 255 || ~~x !== x)
+            throw RangeError("Array items must be numbers in the range 0-255.");
+        }
+      if (isArr || Buffer22.isBuffer(data) && data.constructor && typeof data.constructor.isBuffer === "function" && data.constructor.isBuffer(data))
+        return Buffer22.from(data);
+      throw TypeError('The "data" argument must be a string, an Array, a Buffer, a Uint8Array, or a DataView.');
+    };
+  });
+  require_to_buffer2 = __commonJS2((exports, module) => {
+    var Buffer22 = require_safe_buffer().Buffer, toBuffer = require_to_buffer(), useUint8Array = typeof Uint8Array < "u", useArrayBuffer = useUint8Array && typeof ArrayBuffer < "u", isView = useArrayBuffer && ArrayBuffer.isView;
+    module.exports = function(thing, encoding, name) {
+      if (typeof thing === "string" || Buffer22.isBuffer(thing) || useUint8Array && thing instanceof Uint8Array || isView && isView(thing))
+        return toBuffer(thing, encoding);
+      throw TypeError(name + " must be a string, a Buffer, a Uint8Array, or a DataView");
     };
   });
   require_sync = __commonJS2((exports, module) => {
-    var sizes = { md5: 16, sha1: 20, sha224: 28, sha256: 32, sha384: 48, sha512: 64, rmd160: 20, ripemd160: 20 }, createHmac = require_create_hmac(), Buffer22 = require_safe_buffer().Buffer, checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), toBuffer = require_to_buffer();
+    var sizes = { __proto__: null, md5: 16, sha1: 20, sha224: 28, sha256: 32, sha384: 48, sha512: 64, "sha512-256": 32, rmd160: 20, ripemd160: 20 }, mapping = { __proto__: null, "sha-1": "sha1", "sha-224": "sha224", "sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512", "ripemd-160": "ripemd160" }, createHmac = require_create_hmac(), Buffer22 = require_safe_buffer().Buffer, checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), toBuffer = require_to_buffer2();
     function pbkdf2(password, salt, iterations, keylen, digest) {
-      checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), digest = digest || "sha1";
+      checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt");
+      var lowerDigest = (digest || "sha1").toLowerCase(), mappedDigest = mapping[lowerDigest] || lowerDigest, size = sizes[mappedDigest];
+      if (typeof size !== "number" || !size)
+        throw TypeError("Digest algorithm not supported: " + digest);
       var DK = Buffer22.allocUnsafe(keylen), block1 = Buffer22.allocUnsafe(salt.length + 4);
       salt.copy(block1, 0, 0, salt.length);
-      var destPos = 0, hLen = sizes[digest], l = Math.ceil(keylen / hLen);
+      var destPos = 0, hLen = size, l = Math.ceil(keylen / hLen);
       for (var i2 = 1;i2 <= l; i2++) {
         block1.writeUInt32BE(i2, salt.length);
-        var T = createHmac(digest, password).update(block1).digest(), U = T;
+        var T = createHmac(mappedDigest, password).update(block1).digest(), U = T;
         for (var j = 1;j < iterations; j++) {
-          U = createHmac(digest, password).update(U).digest();
+          U = createHmac(mappedDigest, password).update(U).digest();
           for (var k = 0;k < hLen; k++)
             T[k] ^= U[k];
         }
@@ -6273,23 +6969,7 @@ var init_crypto = __esm(() => {
     module.exports = pbkdf2;
   });
   require_async = __commonJS2((exports, module) => {
-    var Buffer22 = require_safe_buffer().Buffer, checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), sync = require_sync(), toBuffer = require_to_buffer(), ZERO_BUF, subtle = globalThis.crypto && globalThis.crypto.subtle, toBrowser = { sha: "SHA-1", "sha-1": "SHA-1", sha1: "SHA-1", sha256: "SHA-256", "sha-256": "SHA-256", sha384: "SHA-384", "sha-384": "SHA-384", "sha-512": "SHA-512", sha512: "SHA-512" }, checks = [];
-    function checkNative(algo) {
-      if (globalThis.process && !globalThis.process.browser)
-        return Promise.resolve(false);
-      if (!subtle || !subtle.importKey || !subtle.deriveBits)
-        return Promise.resolve(false);
-      if (checks[algo] !== undefined)
-        return checks[algo];
-      ZERO_BUF = ZERO_BUF || Buffer22.alloc(8);
-      var prom = browserPbkdf2(ZERO_BUF, ZERO_BUF, 10, 128, algo).then(function() {
-        return true;
-      }).catch(function() {
-        return false;
-      });
-      return checks[algo] = prom, prom;
-    }
-    var nextTick;
+    var Buffer22 = require_safe_buffer().Buffer, checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), sync = require_sync(), toBuffer = require_to_buffer2(), ZERO_BUF, subtle = globalThis.crypto && globalThis.crypto.subtle, toBrowser = { sha: "SHA-1", "sha-1": "SHA-1", sha1: "SHA-1", sha256: "SHA-256", "sha-256": "SHA-256", sha384: "SHA-384", "sha-384": "SHA-384", "sha-512": "SHA-512", sha512: "SHA-512" }, checks = [], nextTick;
     function getNextTick() {
       if (nextTick)
         return nextTick;
@@ -6310,6 +6990,21 @@ var init_crypto = __esm(() => {
         return Buffer22.from(res);
       });
     }
+    function checkNative(algo) {
+      if (globalThis.process && !globalThis.process.browser)
+        return Promise.resolve(false);
+      if (!subtle || !subtle.importKey || !subtle.deriveBits)
+        return Promise.resolve(false);
+      if (checks[algo] !== undefined)
+        return checks[algo];
+      ZERO_BUF = ZERO_BUF || Buffer22.alloc(8);
+      var prom = browserPbkdf2(ZERO_BUF, ZERO_BUF, 10, 128, algo).then(function() {
+        return true;
+      }, function() {
+        return false;
+      });
+      return checks[algo] = prom, prom;
+    }
     function resolvePromise(promise, callback) {
       promise.then(function(out) {
         getNextTick()(function() {
@@ -6324,6 +7019,8 @@ var init_crypto = __esm(() => {
     module.exports = function(password, salt, iterations, keylen, digest, callback) {
       if (typeof digest === "function")
         callback = digest, digest = undefined;
+      if (checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), typeof callback !== "function")
+        throw Error("No callback provided to pbkdf2");
       digest = digest || "sha1";
       var algo = toBrowser[digest.toLowerCase()];
       if (!algo || typeof globalThis.Promise !== "function") {
@@ -6332,14 +7029,13 @@ var init_crypto = __esm(() => {
           try {
             out = sync(password, salt, iterations, keylen, digest);
           } catch (e) {
-            return callback(e);
+            callback(e);
+            return;
           }
           callback(null, out);
         });
         return;
       }
-      if (checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), typeof callback !== "function")
-        throw new Error("No callback provided to pbkdf2");
       resolvePromise(checkNative(algo).then(function(resp) {
         if (resp)
           return browserPbkdf2(password, salt, iterations, keylen, algo);
@@ -6348,18 +7044,18 @@ var init_crypto = __esm(() => {
     };
   });
   require_pbkdf2 = __commonJS2((exports) => {
-    var native = (init_crypto(), __toCommonJS(exports_crypto)), checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), toBuffer = require_to_buffer();
+    var nativeImpl = (init_crypto(), __toCommonJS(exports_crypto)), checkParameters = require_precondition(), defaultEncoding = require_default_encoding(), toBuffer = require_to_buffer2();
     function nativePBKDF2(password, salt, iterations, keylen, digest, callback) {
       if (checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), typeof digest === "function")
         callback = digest, digest = "sha1";
       if (typeof callback !== "function")
-        throw new Error("No callback provided to pbkdf2");
-      return native.pbkdf2(password, salt, iterations, keylen, digest, callback);
+        throw Error("No callback provided to pbkdf2");
+      return nativeImpl.pbkdf2(password, salt, iterations, keylen, digest, callback);
     }
     function nativePBKDF2Sync(password, salt, iterations, keylen, digest) {
-      return checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), digest = digest || "sha1", native.pbkdf2Sync(password, salt, iterations, keylen, digest);
+      return checkParameters(iterations, keylen), password = toBuffer(password, defaultEncoding, "Password"), salt = toBuffer(salt, defaultEncoding, "Salt"), digest = digest || "sha1", nativeImpl.pbkdf2Sync(password, salt, iterations, keylen, digest);
     }
-    if (!native.pbkdf2Sync || native.pbkdf2Sync.toString().indexOf("keylen, digest") === -1)
+    if (!nativeImpl.pbkdf2Sync || nativeImpl.pbkdf2Sync.toString().indexOf("keylen, digest") === -1)
       exports.pbkdf2Sync = require_sync(), exports.pbkdf2 = require_async();
     else
       exports.pbkdf2Sync = nativePBKDF2Sync, exports.pbkdf2 = nativePBKDF2;
@@ -6394,7 +7090,7 @@ var init_crypto = __esm(() => {
     (function(module2, exports2) {
       function assert(val, msg) {
         if (!val)
-          throw new Error(msg || "Assertion failed");
+          throw Error(msg || "Assertion failed");
       }
       function inherits2(ctor, superCtor) {
         ctor.super_ = superCtor;
@@ -6417,24 +7113,24 @@ var init_crypto = __esm(() => {
       BN.BN = BN, BN.wordSize = 26;
       var Buffer22;
       try {
-        if (typeof window !== "undefined" && typeof window.Buffer !== "undefined")
+        if (typeof window < "u" && typeof window.Buffer < "u")
           Buffer22 = window.Buffer;
         else
-          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
       } catch (e) {}
-      BN.isBN = function isBN(num) {
+      BN.isBN = function(num) {
         if (num instanceof BN)
           return true;
         return num !== null && typeof num === "object" && num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
-      }, BN.max = function max(left, right) {
+      }, BN.max = function(left, right) {
         if (left.cmp(right) > 0)
           return left;
         return right;
-      }, BN.min = function min(left, right) {
+      }, BN.min = function(left, right) {
         if (left.cmp(right) < 0)
           return left;
         return right;
-      }, BN.prototype._init = function init(number, base, endian) {
+      }, BN.prototype._init = function(number, base, endian) {
         if (typeof number === "number")
           return this._initNumber(number, base, endian);
         if (typeof number === "object")
@@ -6451,7 +7147,7 @@ var init_crypto = __esm(() => {
           else if (this._parseBase(number, base, start), endian === "le")
             this._initArray(this.toArray(), base, endian);
         }
-      }, BN.prototype._initNumber = function _initNumber(number, base, endian) {
+      }, BN.prototype._initNumber = function(number, base, endian) {
         if (number < 0)
           this.negative = 1, number = -number;
         if (number < 67108864)
@@ -6463,10 +7159,10 @@ var init_crypto = __esm(() => {
         if (endian !== "le")
           return;
         this._initArray(this.toArray(), base, endian);
-      }, BN.prototype._initArray = function _initArray(number, base, endian) {
+      }, BN.prototype._initArray = function(number, base, endian) {
         if (assert(typeof number.length === "number"), number.length <= 0)
           return this.words = [0], this.length = 1, this;
-        this.length = Math.ceil(number.length / 3), this.words = new Array(this.length);
+        this.length = Math.ceil(number.length / 3), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var j, w, off = 0;
@@ -6496,8 +7192,8 @@ var init_crypto = __esm(() => {
           r |= parseHex4Bits(string, index - 1) << 4;
         return r;
       }
-      BN.prototype._parseHex = function _parseHex(number, start, endian) {
-        this.length = Math.ceil((number.length - start) / 6), this.words = new Array(this.length);
+      BN.prototype._parseHex = function(number, start, endian) {
+        this.length = Math.ceil((number.length - start) / 6), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var off = 0, j = 0, w;
@@ -6530,7 +7226,7 @@ var init_crypto = __esm(() => {
         }
         return r;
       }
-      BN.prototype._parseBase = function _parseBase(number, base, start) {
+      BN.prototype._parseBase = function(number, base, start) {
         this.words = [0], this.length = 1;
         for (var limbLen = 0, limbPow = 1;limbPow <= 67108863; limbPow *= base)
           limbLen++;
@@ -6552,31 +7248,31 @@ var init_crypto = __esm(() => {
             this._iaddn(word);
         }
         this.strip();
-      }, BN.prototype.copy = function copy(dest) {
-        dest.words = new Array(this.length);
+      }, BN.prototype.copy = function(dest) {
+        dest.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           dest.words[i2] = this.words[i2];
         dest.length = this.length, dest.negative = this.negative, dest.red = this.red;
-      }, BN.prototype.clone = function clone() {
+      }, BN.prototype.clone = function() {
         var r = new BN(null);
         return this.copy(r), r;
-      }, BN.prototype._expand = function _expand(size) {
+      }, BN.prototype._expand = function(size) {
         while (this.length < size)
           this.words[this.length++] = 0;
         return this;
-      }, BN.prototype.strip = function strip() {
+      }, BN.prototype.strip = function() {
         while (this.length > 1 && this.words[this.length - 1] === 0)
           this.length--;
         return this._normSign();
-      }, BN.prototype._normSign = function _normSign() {
+      }, BN.prototype._normSign = function() {
         if (this.length === 1 && this.words[0] === 0)
           this.negative = 0;
         return this;
-      }, BN.prototype.inspect = function inspect() {
+      }, BN.prototype.inspect = function() {
         return (this.red ? "<BN-R: " : "<BN: ") + this.toString(16) + ">";
       };
       var zeros = ["", "0", "00", "000", "0000", "00000", "000000", "0000000", "00000000", "000000000", "0000000000", "00000000000", "000000000000", "0000000000000", "00000000000000", "000000000000000", "0000000000000000", "00000000000000000", "000000000000000000", "0000000000000000000", "00000000000000000000", "000000000000000000000", "0000000000000000000000", "00000000000000000000000", "000000000000000000000000", "0000000000000000000000000"], groupSizes = [0, 0, 25, 16, 12, 11, 10, 9, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], groupBases = [0, 0, 33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216, 43046721, 1e7, 19487171, 35831808, 62748517, 7529536, 11390625, 16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632, 6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149, 24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176];
-      if (BN.prototype.toString = function toString(base, padding) {
+      if (BN.prototype.toString = function(base, padding) {
         base = base || 10, padding = padding | 0 || 1;
         var out;
         if (base === 16 || base === "hex") {
@@ -6620,7 +7316,7 @@ var init_crypto = __esm(() => {
           return out;
         }
         assert(false, "Base should be between 2 and 36");
-      }, BN.prototype.toNumber = function toNumber() {
+      }, BN.prototype.toNumber = function() {
         var ret = this.words[0];
         if (this.length === 2)
           ret += this.words[1] * 67108864;
@@ -6629,13 +7325,13 @@ var init_crypto = __esm(() => {
         else if (this.length > 2)
           assert(false, "Number can only safely store up to 53 bits");
         return this.negative !== 0 ? -ret : ret;
-      }, BN.prototype.toJSON = function toJSON() {
+      }, BN.prototype.toJSON = function() {
         return this.toString(16);
-      }, BN.prototype.toBuffer = function toBuffer(endian, length) {
-        return assert(typeof Buffer22 !== "undefined"), this.toArrayLike(Buffer22, endian, length);
-      }, BN.prototype.toArray = function toArray(endian, length) {
+      }, BN.prototype.toBuffer = function(endian, length) {
+        return assert(typeof Buffer22 < "u"), this.toArrayLike(Buffer22, endian, length);
+      }, BN.prototype.toArray = function(endian, length) {
         return this.toArrayLike(Array, endian, length);
-      }, BN.prototype.toArrayLike = function toArrayLike(ArrayType, endian, length) {
+      }, BN.prototype.toArrayLike = function(ArrayType, endian, length) {
         var byteLength2 = this.byteLength(), reqLength = length || Math.max(1, byteLength2);
         assert(byteLength2 <= reqLength, "byte array longer than desired length"), assert(reqLength > 0, "Requested array length <= 0"), this.strip();
         var littleEndian = endian === "le", res = new ArrayType(reqLength), b, i2, q = this.clone();
@@ -6652,11 +7348,11 @@ var init_crypto = __esm(() => {
         }
         return res;
       }, Math.clz32)
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           return 32 - Math.clz32(w);
         };
       else
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           var t = w, r = 0;
           if (t >= 4096)
             r += 13, t >>>= 13;
@@ -6668,7 +7364,7 @@ var init_crypto = __esm(() => {
             r += 2, t >>>= 2;
           return r + t;
         };
-      BN.prototype._zeroBits = function _zeroBits(w) {
+      BN.prototype._zeroBits = function(w) {
         if (w === 0)
           return 26;
         var t = w, r = 0;
@@ -6683,19 +7379,19 @@ var init_crypto = __esm(() => {
         if ((t & 1) === 0)
           r++;
         return r;
-      }, BN.prototype.bitLength = function bitLength() {
+      }, BN.prototype.bitLength = function() {
         var w = this.words[this.length - 1], hi = this._countBits(w);
         return (this.length - 1) * 26 + hi;
       };
       function toBitArray(num) {
-        var w = new Array(num.bitLength());
+        var w = Array(num.bitLength());
         for (var bit = 0;bit < w.length; bit++) {
           var off = bit / 26 | 0, wbit = bit % 26;
           w[bit] = (num.words[off] & 1 << wbit) >>> wbit;
         }
         return w;
       }
-      BN.prototype.zeroBits = function zeroBits() {
+      BN.prototype.zeroBits = function() {
         if (this.isZero())
           return 0;
         var r = 0;
@@ -6705,41 +7401,41 @@ var init_crypto = __esm(() => {
             break;
         }
         return r;
-      }, BN.prototype.byteLength = function byteLength() {
+      }, BN.prototype.byteLength = function() {
         return Math.ceil(this.bitLength() / 8);
-      }, BN.prototype.toTwos = function toTwos(width) {
+      }, BN.prototype.toTwos = function(width) {
         if (this.negative !== 0)
           return this.abs().inotn(width).iaddn(1);
         return this.clone();
-      }, BN.prototype.fromTwos = function fromTwos(width) {
+      }, BN.prototype.fromTwos = function(width) {
         if (this.testn(width - 1))
           return this.notn(width).iaddn(1).ineg();
         return this.clone();
-      }, BN.prototype.isNeg = function isNeg() {
+      }, BN.prototype.isNeg = function() {
         return this.negative !== 0;
-      }, BN.prototype.neg = function neg() {
+      }, BN.prototype.neg = function() {
         return this.clone().ineg();
-      }, BN.prototype.ineg = function ineg() {
+      }, BN.prototype.ineg = function() {
         if (!this.isZero())
           this.negative ^= 1;
         return this;
-      }, BN.prototype.iuor = function iuor(num) {
+      }, BN.prototype.iuor = function(num) {
         while (this.length < num.length)
           this.words[this.length++] = 0;
         for (var i2 = 0;i2 < num.length; i2++)
           this.words[i2] = this.words[i2] | num.words[i2];
         return this.strip();
-      }, BN.prototype.ior = function ior(num) {
+      }, BN.prototype.ior = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuor(num);
-      }, BN.prototype.or = function or(num) {
+      }, BN.prototype.or = function(num) {
         if (this.length > num.length)
           return this.clone().ior(num);
         return num.clone().ior(this);
-      }, BN.prototype.uor = function uor(num) {
+      }, BN.prototype.uor = function(num) {
         if (this.length > num.length)
           return this.clone().iuor(num);
         return num.clone().iuor(this);
-      }, BN.prototype.iuand = function iuand(num) {
+      }, BN.prototype.iuand = function(num) {
         var b;
         if (this.length > num.length)
           b = num;
@@ -6748,17 +7444,17 @@ var init_crypto = __esm(() => {
         for (var i2 = 0;i2 < b.length; i2++)
           this.words[i2] = this.words[i2] & num.words[i2];
         return this.length = b.length, this.strip();
-      }, BN.prototype.iand = function iand(num) {
+      }, BN.prototype.iand = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuand(num);
-      }, BN.prototype.and = function and(num) {
+      }, BN.prototype.and = function(num) {
         if (this.length > num.length)
           return this.clone().iand(num);
         return num.clone().iand(this);
-      }, BN.prototype.uand = function uand(num) {
+      }, BN.prototype.uand = function(num) {
         if (this.length > num.length)
           return this.clone().iuand(num);
         return num.clone().iuand(this);
-      }, BN.prototype.iuxor = function iuxor(num) {
+      }, BN.prototype.iuxor = function(num) {
         var a, b;
         if (this.length > num.length)
           a = this, b = num;
@@ -6770,17 +7466,17 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this.length = a.length, this.strip();
-      }, BN.prototype.ixor = function ixor(num) {
+      }, BN.prototype.ixor = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuxor(num);
-      }, BN.prototype.xor = function xor(num) {
+      }, BN.prototype.xor = function(num) {
         if (this.length > num.length)
           return this.clone().ixor(num);
         return num.clone().ixor(this);
-      }, BN.prototype.uxor = function uxor(num) {
+      }, BN.prototype.uxor = function(num) {
         if (this.length > num.length)
           return this.clone().iuxor(num);
         return num.clone().iuxor(this);
-      }, BN.prototype.inotn = function inotn(width) {
+      }, BN.prototype.inotn = function(width) {
         assert(typeof width === "number" && width >= 0);
         var bytesNeeded = Math.ceil(width / 26) | 0, bitsLeft = width % 26;
         if (this._expand(bytesNeeded), bitsLeft > 0)
@@ -6790,9 +7486,9 @@ var init_crypto = __esm(() => {
         if (bitsLeft > 0)
           this.words[i2] = ~this.words[i2] & 67108863 >> 26 - bitsLeft;
         return this.strip();
-      }, BN.prototype.notn = function notn(width) {
+      }, BN.prototype.notn = function(width) {
         return this.clone().inotn(width);
-      }, BN.prototype.setn = function setn(bit, val) {
+      }, BN.prototype.setn = function(bit, val) {
         assert(typeof bit === "number" && bit >= 0);
         var off = bit / 26 | 0, wbit = bit % 26;
         if (this._expand(off + 1), val)
@@ -6800,7 +7496,7 @@ var init_crypto = __esm(() => {
         else
           this.words[off] = this.words[off] & ~(1 << wbit);
         return this.strip();
-      }, BN.prototype.iadd = function iadd(num) {
+      }, BN.prototype.iadd = function(num) {
         var r;
         if (this.negative !== 0 && num.negative === 0)
           return this.negative = 0, r = this.isub(num), this.negative ^= 1, this._normSign();
@@ -6822,7 +7518,7 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this;
-      }, BN.prototype.add = function add(num) {
+      }, BN.prototype.add = function(num) {
         var res;
         if (num.negative !== 0 && this.negative === 0)
           return num.negative = 0, res = this.sub(num), num.negative ^= 1, res;
@@ -6831,7 +7527,7 @@ var init_crypto = __esm(() => {
         if (this.length > num.length)
           return this.clone().iadd(num);
         return num.clone().iadd(this);
-      }, BN.prototype.isub = function isub(num) {
+      }, BN.prototype.isub = function(num) {
         if (num.negative !== 0) {
           num.negative = 0;
           var r = this.iadd(num);
@@ -6857,7 +7553,7 @@ var init_crypto = __esm(() => {
         if (this.length = Math.max(this.length, i2), a !== this)
           this.negative = 1;
         return this.strip();
-      }, BN.prototype.sub = function sub(num) {
+      }, BN.prototype.sub = function(num) {
         return this.clone().isub(num);
       };
       function smallMulTo(self2, num, out) {
@@ -6880,7 +7576,7 @@ var init_crypto = __esm(() => {
           out.length--;
         return out.strip();
       }
-      var comb10MulTo = function comb10MulTo(self2, num, out) {
+      var comb10MulTo = function(self2, num, out) {
         var a = self2.words, b = num.words, o = out.words, c = 0, lo, mid, hi, a0 = a[0] | 0, al0 = a0 & 8191, ah0 = a0 >>> 13, a1 = a[1] | 0, al1 = a1 & 8191, ah1 = a1 >>> 13, a2 = a[2] | 0, al2 = a2 & 8191, ah2 = a2 >>> 13, a3 = a[3] | 0, al3 = a3 & 8191, ah3 = a3 >>> 13, a4 = a[4] | 0, al4 = a4 & 8191, ah4 = a4 >>> 13, a5 = a[5] | 0, al5 = a5 & 8191, ah5 = a5 >>> 13, a6 = a[6] | 0, al6 = a6 & 8191, ah6 = a6 >>> 13, a7 = a[7] | 0, al7 = a7 & 8191, ah7 = a7 >>> 13, a8 = a[8] | 0, al8 = a8 & 8191, ah8 = a8 >>> 13, a9 = a[9] | 0, al9 = a9 & 8191, ah9 = a9 >>> 13, b0 = b[0] | 0, bl0 = b0 & 8191, bh0 = b0 >>> 13, b1 = b[1] | 0, bl1 = b1 & 8191, bh1 = b1 >>> 13, b2 = b[2] | 0, bl2 = b2 & 8191, bh2 = b2 >>> 13, b3 = b[3] | 0, bl3 = b3 & 8191, bh3 = b3 >>> 13, b4 = b[4] | 0, bl4 = b4 & 8191, bh4 = b4 >>> 13, b5 = b[5] | 0, bl5 = b5 & 8191, bh5 = b5 >>> 13, b6 = b[6] | 0, bl6 = b6 & 8191, bh6 = b6 >>> 13, b7 = b[7] | 0, bl7 = b7 & 8191, bh7 = b7 >>> 13, b8 = b[8] | 0, bl8 = b8 & 8191, bh8 = b8 >>> 13, b9 = b[9] | 0, bl9 = b9 & 8191, bh9 = b9 >>> 13;
         out.negative = self2.negative ^ num.negative, out.length = 19, lo = Math.imul(al0, bl0), mid = Math.imul(al0, bh0), mid = mid + Math.imul(ah0, bl0) | 0, hi = Math.imul(ah0, bh0);
         var w0 = (c + lo | 0) + ((mid & 8191) << 13) | 0;
@@ -6949,7 +7645,7 @@ var init_crypto = __esm(() => {
         var fftm = new FFTM;
         return fftm.mulp(self2, num, out);
       }
-      BN.prototype.mulTo = function mulTo(num, out) {
+      BN.prototype.mulTo = function(num, out) {
         var res, len2 = this.length + num.length;
         if (this.length === 10 && num.length === 10)
           res = comb10MulTo(this, num, out);
@@ -6964,22 +7660,22 @@ var init_crypto = __esm(() => {
       function FFTM(x, y) {
         this.x = x, this.y = y;
       }
-      FFTM.prototype.makeRBT = function makeRBT(N) {
-        var t = new Array(N), l = BN.prototype._countBits(N) - 1;
+      FFTM.prototype.makeRBT = function(N) {
+        var t = Array(N), l = BN.prototype._countBits(N) - 1;
         for (var i2 = 0;i2 < N; i2++)
           t[i2] = this.revBin(i2, l, N);
         return t;
-      }, FFTM.prototype.revBin = function revBin(x, l, N) {
+      }, FFTM.prototype.revBin = function(x, l, N) {
         if (x === 0 || x === N - 1)
           return x;
         var rb = 0;
         for (var i2 = 0;i2 < l; i2++)
           rb |= (x & 1) << l - i2 - 1, x >>= 1;
         return rb;
-      }, FFTM.prototype.permute = function permute(rbt, rws, iws, rtws, itws, N) {
+      }, FFTM.prototype.permute = function(rbt, rws, iws, rtws, itws, N) {
         for (var i2 = 0;i2 < N; i2++)
           rtws[i2] = rws[rbt[i2]], itws[i2] = iws[rbt[i2]];
-      }, FFTM.prototype.transform = function transform(rws, iws, rtws, itws, N, rbt) {
+      }, FFTM.prototype.transform = function(rws, iws, rtws, itws, N, rbt) {
         this.permute(rbt, rws, iws, rtws, itws, N);
         for (var s = 1;s < N; s <<= 1) {
           var l = s << 1, rtwdf = Math.cos(2 * Math.PI / l), itwdf = Math.sin(2 * Math.PI / l);
@@ -6992,19 +7688,19 @@ var init_crypto = __esm(() => {
             }
           }
         }
-      }, FFTM.prototype.guessLen13b = function guessLen13b(n, m) {
+      }, FFTM.prototype.guessLen13b = function(n, m) {
         var N = Math.max(m, n) | 1, odd = N & 1, i2 = 0;
         for (N = N / 2 | 0;N; N = N >>> 1)
           i2++;
         return 1 << i2 + 1 + odd;
-      }, FFTM.prototype.conjugate = function conjugate(rws, iws, N) {
+      }, FFTM.prototype.conjugate = function(rws, iws, N) {
         if (N <= 1)
           return;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var t = rws[i2];
           rws[i2] = rws[N - i2 - 1], rws[N - i2 - 1] = t, t = iws[i2], iws[i2] = -iws[N - i2 - 1], iws[N - i2 - 1] = -t;
         }
-      }, FFTM.prototype.normalize13b = function normalize13b(ws, N) {
+      }, FFTM.prototype.normalize13b = function(ws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var w = Math.round(ws[2 * i2 + 1] / N) * 8192 + Math.round(ws[2 * i2] / N) + carry;
@@ -7014,35 +7710,35 @@ var init_crypto = __esm(() => {
             carry = w / 67108864 | 0;
         }
         return ws;
-      }, FFTM.prototype.convert13b = function convert13b(ws, len2, rws, N) {
+      }, FFTM.prototype.convert13b = function(ws, len2, rws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < len2; i2++)
           carry = carry + (ws[i2] | 0), rws[2 * i2] = carry & 8191, carry = carry >>> 13, rws[2 * i2 + 1] = carry & 8191, carry = carry >>> 13;
         for (i2 = 2 * len2;i2 < N; ++i2)
           rws[i2] = 0;
         assert(carry === 0), assert((carry & -8192) === 0);
-      }, FFTM.prototype.stub = function stub(N) {
-        var ph = new Array(N);
+      }, FFTM.prototype.stub = function(N) {
+        var ph = Array(N);
         for (var i2 = 0;i2 < N; i2++)
           ph[i2] = 0;
         return ph;
-      }, FFTM.prototype.mulp = function mulp(x, y, out) {
-        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = new Array(N), rwst = new Array(N), iwst = new Array(N), nrws = new Array(N), nrwst = new Array(N), niwst = new Array(N), rmws = out.words;
+      }, FFTM.prototype.mulp = function(x, y, out) {
+        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = Array(N), rwst = Array(N), iwst = Array(N), nrws = Array(N), nrwst = Array(N), niwst = Array(N), rmws = out.words;
         rmws.length = N, this.convert13b(x.words, x.length, rws, N), this.convert13b(y.words, y.length, nrws, N), this.transform(rws, _, rwst, iwst, N, rbt), this.transform(nrws, _, nrwst, niwst, N, rbt);
         for (var i2 = 0;i2 < N; i2++) {
           var rx = rwst[i2] * nrwst[i2] - iwst[i2] * niwst[i2];
           iwst[i2] = rwst[i2] * niwst[i2] + iwst[i2] * nrwst[i2], rwst[i2] = rx;
         }
         return this.conjugate(rwst, iwst, N), this.transform(rwst, iwst, rmws, _, N, rbt), this.conjugate(rmws, _, N), this.normalize13b(rmws, N), out.negative = x.negative ^ y.negative, out.length = x.length + y.length, out.strip();
-      }, BN.prototype.mul = function mul(num) {
+      }, BN.prototype.mul = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), this.mulTo(num, out);
-      }, BN.prototype.mulf = function mulf(num) {
+        return out.words = Array(this.length + num.length), this.mulTo(num, out);
+      }, BN.prototype.mulf = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), jumboMulTo(this, num, out);
-      }, BN.prototype.imul = function imul(num) {
+        return out.words = Array(this.length + num.length), jumboMulTo(this, num, out);
+      }, BN.prototype.imul = function(num) {
         return this.clone().mulTo(num, this);
-      }, BN.prototype.imuln = function imuln(num) {
+      }, BN.prototype.imuln = function(num) {
         assert(typeof num === "number"), assert(num < 67108864);
         var carry = 0;
         for (var i2 = 0;i2 < this.length; i2++) {
@@ -7052,13 +7748,13 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this.length = num === 0 ? 1 : this.length, this;
-      }, BN.prototype.muln = function muln(num) {
+      }, BN.prototype.muln = function(num) {
         return this.clone().imuln(num);
-      }, BN.prototype.sqr = function sqr() {
+      }, BN.prototype.sqr = function() {
         return this.mul(this);
-      }, BN.prototype.isqr = function isqr() {
+      }, BN.prototype.isqr = function() {
         return this.imul(this.clone());
-      }, BN.prototype.pow = function pow(num) {
+      }, BN.prototype.pow = function(num) {
         var w = toBitArray(num);
         if (w.length === 0)
           return new BN(1);
@@ -7073,7 +7769,7 @@ var init_crypto = __esm(() => {
             res = res.mul(q);
           }
         return res;
-      }, BN.prototype.iushln = function iushln(bits) {
+      }, BN.prototype.iushln = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26, carryMask = 67108863 >>> 26 - r << 26 - r, i2;
         if (r !== 0) {
@@ -7093,9 +7789,9 @@ var init_crypto = __esm(() => {
           this.length += s;
         }
         return this.strip();
-      }, BN.prototype.ishln = function ishln(bits) {
+      }, BN.prototype.ishln = function(bits) {
         return assert(this.negative === 0), this.iushln(bits);
-      }, BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+      }, BN.prototype.iushrn = function(bits, hint, extended) {
         assert(typeof bits === "number" && bits >= 0);
         var h;
         if (hint)
@@ -7126,24 +7822,24 @@ var init_crypto = __esm(() => {
         if (this.length === 0)
           this.words[0] = 0, this.length = 1;
         return this.strip();
-      }, BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+      }, BN.prototype.ishrn = function(bits, hint, extended) {
         return assert(this.negative === 0), this.iushrn(bits, hint, extended);
-      }, BN.prototype.shln = function shln(bits) {
+      }, BN.prototype.shln = function(bits) {
         return this.clone().ishln(bits);
-      }, BN.prototype.ushln = function ushln(bits) {
+      }, BN.prototype.ushln = function(bits) {
         return this.clone().iushln(bits);
-      }, BN.prototype.shrn = function shrn(bits) {
+      }, BN.prototype.shrn = function(bits) {
         return this.clone().ishrn(bits);
-      }, BN.prototype.ushrn = function ushrn(bits) {
+      }, BN.prototype.ushrn = function(bits) {
         return this.clone().iushrn(bits);
-      }, BN.prototype.testn = function testn(bit) {
+      }, BN.prototype.testn = function(bit) {
         assert(typeof bit === "number" && bit >= 0);
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
           return false;
         var w = this.words[s];
         return !!(w & q);
-      }, BN.prototype.imaskn = function imaskn(bits) {
+      }, BN.prototype.imaskn = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26;
         if (assert(this.negative === 0, "imaskn works only with positive numbers"), this.length <= s)
@@ -7155,9 +7851,9 @@ var init_crypto = __esm(() => {
           this.words[this.length - 1] &= mask;
         }
         return this.strip();
-      }, BN.prototype.maskn = function maskn(bits) {
+      }, BN.prototype.maskn = function(bits) {
         return this.clone().imaskn(bits);
-      }, BN.prototype.iaddn = function iaddn(num) {
+      }, BN.prototype.iaddn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.isubn(-num);
         if (this.negative !== 0) {
@@ -7166,7 +7862,7 @@ var init_crypto = __esm(() => {
           return this.negative = 0, this.isubn(num), this.negative = 1, this;
         }
         return this._iaddn(num);
-      }, BN.prototype._iaddn = function _iaddn(num) {
+      }, BN.prototype._iaddn = function(num) {
         this.words[0] += num;
         for (var i2 = 0;i2 < this.length && this.words[i2] >= 67108864; i2++)
           if (this.words[i2] -= 67108864, i2 === this.length - 1)
@@ -7174,7 +7870,7 @@ var init_crypto = __esm(() => {
           else
             this.words[i2 + 1]++;
         return this.length = Math.max(this.length, i2 + 1), this;
-      }, BN.prototype.isubn = function isubn(num) {
+      }, BN.prototype.isubn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.iaddn(-num);
         if (this.negative !== 0)
@@ -7185,15 +7881,15 @@ var init_crypto = __esm(() => {
           for (var i2 = 0;i2 < this.length && this.words[i2] < 0; i2++)
             this.words[i2] += 67108864, this.words[i2 + 1] -= 1;
         return this.strip();
-      }, BN.prototype.addn = function addn(num) {
+      }, BN.prototype.addn = function(num) {
         return this.clone().iaddn(num);
-      }, BN.prototype.subn = function subn(num) {
+      }, BN.prototype.subn = function(num) {
         return this.clone().isubn(num);
-      }, BN.prototype.iabs = function iabs() {
+      }, BN.prototype.iabs = function() {
         return this.negative = 0, this;
-      }, BN.prototype.abs = function abs() {
+      }, BN.prototype.abs = function() {
         return this.clone().iabs();
-      }, BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+      }, BN.prototype._ishlnsubmul = function(num, mul, shift) {
         var len2 = num.length + shift, i2;
         this._expand(len2);
         var w, carry = 0;
@@ -7210,13 +7906,13 @@ var init_crypto = __esm(() => {
         for (i2 = 0;i2 < this.length; i2++)
           w = -(this.words[i2] | 0) + carry, carry = w >> 26, this.words[i2] = w & 67108863;
         return this.negative = 1, this.strip();
-      }, BN.prototype._wordDiv = function _wordDiv(num, mode) {
+      }, BN.prototype._wordDiv = function(num, mode) {
         var shift = this.length - num.length, a = this.clone(), b = num, bhi = b.words[b.length - 1] | 0, bhiBits = this._countBits(bhi);
         if (shift = 26 - bhiBits, shift !== 0)
           b = b.ushln(shift), a.iushln(shift), bhi = b.words[b.length - 1] | 0;
         var m = a.length - b.length, q;
         if (mode !== "mod") {
-          q = new BN(null), q.length = m + 1, q.words = new Array(q.length);
+          q = new BN(null), q.length = m + 1, q.words = Array(q.length);
           for (var i2 = 0;i2 < q.length; i2++)
             q.words[i2] = 0;
         }
@@ -7239,7 +7935,7 @@ var init_crypto = __esm(() => {
         if (a.strip(), mode !== "div" && shift !== 0)
           a.iushrn(shift);
         return { div: q || null, mod: a };
-      }, BN.prototype.divmod = function divmod(num, mode, positive) {
+      }, BN.prototype.divmod = function(num, mode, positive) {
         if (assert(!num.isZero()), this.isZero())
           return { div: new BN(0), mod: new BN(0) };
         var div, mod, res;
@@ -7274,13 +7970,13 @@ var init_crypto = __esm(() => {
           return { div: this.divn(num.words[0]), mod: new BN(this.modn(num.words[0])) };
         }
         return this._wordDiv(num, mode);
-      }, BN.prototype.div = function div(num) {
+      }, BN.prototype.div = function(num) {
         return this.divmod(num, "div", false).div;
-      }, BN.prototype.mod = function mod(num) {
+      }, BN.prototype.mod = function(num) {
         return this.divmod(num, "mod", false).mod;
-      }, BN.prototype.umod = function umod(num) {
+      }, BN.prototype.umod = function(num) {
         return this.divmod(num, "mod", true).mod;
-      }, BN.prototype.divRound = function divRound(num) {
+      }, BN.prototype.divRound = function(num) {
         var dm = this.divmod(num);
         if (dm.mod.isZero())
           return dm.div;
@@ -7288,13 +7984,13 @@ var init_crypto = __esm(() => {
         if (cmp < 0 || r2 === 1 && cmp === 0)
           return dm.div;
         return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
-      }, BN.prototype.modn = function modn(num) {
+      }, BN.prototype.modn = function(num) {
         assert(num <= 67108863);
         var p = 67108864 % num, acc = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--)
           acc = (p * acc + (this.words[i2] | 0)) % num;
         return acc;
-      }, BN.prototype.idivn = function idivn(num) {
+      }, BN.prototype.idivn = function(num) {
         assert(num <= 67108863);
         var carry = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--) {
@@ -7302,9 +7998,9 @@ var init_crypto = __esm(() => {
           this.words[i2] = w / num | 0, carry = w % num;
         }
         return this.strip();
-      }, BN.prototype.divn = function divn(num) {
+      }, BN.prototype.divn = function(num) {
         return this.clone().idivn(num);
-      }, BN.prototype.egcd = function egcd(p) {
+      }, BN.prototype.egcd = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var x = this, y = p.clone();
         if (x.negative !== 0)
@@ -7342,7 +8038,7 @@ var init_crypto = __esm(() => {
             y.isub(x), C.isub(A), D.isub(B);
         }
         return { a: C, b: D, gcd: y.iushln(g) };
-      }, BN.prototype._invmp = function _invmp(p) {
+      }, BN.prototype._invmp = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var a = this, b = p.clone();
         if (a.negative !== 0)
@@ -7384,7 +8080,7 @@ var init_crypto = __esm(() => {
         if (res.cmpn(0) < 0)
           res.iadd(p);
         return res;
-      }, BN.prototype.gcd = function gcd(num) {
+      }, BN.prototype.gcd = function(num) {
         if (this.isZero())
           return num.abs();
         if (num.isZero())
@@ -7407,15 +8103,15 @@ var init_crypto = __esm(() => {
           a.isub(b);
         } while (true);
         return b.iushln(shift);
-      }, BN.prototype.invm = function invm(num) {
+      }, BN.prototype.invm = function(num) {
         return this.egcd(num).a.umod(num);
-      }, BN.prototype.isEven = function isEven() {
+      }, BN.prototype.isEven = function() {
         return (this.words[0] & 1) === 0;
-      }, BN.prototype.isOdd = function isOdd() {
+      }, BN.prototype.isOdd = function() {
         return (this.words[0] & 1) === 1;
-      }, BN.prototype.andln = function andln(num) {
+      }, BN.prototype.andln = function(num) {
         return this.words[0] & num;
-      }, BN.prototype.bincn = function bincn(bit) {
+      }, BN.prototype.bincn = function(bit) {
         assert(typeof bit === "number");
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
@@ -7428,9 +8124,9 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this;
-      }, BN.prototype.isZero = function isZero() {
+      }, BN.prototype.isZero = function() {
         return this.length === 1 && this.words[0] === 0;
-      }, BN.prototype.cmpn = function cmpn(num) {
+      }, BN.prototype.cmpn = function(num) {
         var negative = num < 0;
         if (this.negative !== 0 && !negative)
           return -1;
@@ -7450,7 +8146,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.cmp = function cmp(num) {
+      }, BN.prototype.cmp = function(num) {
         if (this.negative !== 0 && num.negative === 0)
           return -1;
         if (this.negative === 0 && num.negative !== 0)
@@ -7459,7 +8155,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.ucmp = function ucmp(num) {
+      }, BN.prototype.ucmp = function(num) {
         if (this.length > num.length)
           return 1;
         if (this.length < num.length)
@@ -7476,71 +8172,71 @@ var init_crypto = __esm(() => {
           break;
         }
         return res;
-      }, BN.prototype.gtn = function gtn(num) {
+      }, BN.prototype.gtn = function(num) {
         return this.cmpn(num) === 1;
-      }, BN.prototype.gt = function gt(num) {
+      }, BN.prototype.gt = function(num) {
         return this.cmp(num) === 1;
-      }, BN.prototype.gten = function gten(num) {
+      }, BN.prototype.gten = function(num) {
         return this.cmpn(num) >= 0;
-      }, BN.prototype.gte = function gte(num) {
+      }, BN.prototype.gte = function(num) {
         return this.cmp(num) >= 0;
-      }, BN.prototype.ltn = function ltn(num) {
+      }, BN.prototype.ltn = function(num) {
         return this.cmpn(num) === -1;
-      }, BN.prototype.lt = function lt(num) {
+      }, BN.prototype.lt = function(num) {
         return this.cmp(num) === -1;
-      }, BN.prototype.lten = function lten(num) {
+      }, BN.prototype.lten = function(num) {
         return this.cmpn(num) <= 0;
-      }, BN.prototype.lte = function lte(num) {
+      }, BN.prototype.lte = function(num) {
         return this.cmp(num) <= 0;
-      }, BN.prototype.eqn = function eqn(num) {
+      }, BN.prototype.eqn = function(num) {
         return this.cmpn(num) === 0;
-      }, BN.prototype.eq = function eq(num) {
+      }, BN.prototype.eq = function(num) {
         return this.cmp(num) === 0;
-      }, BN.red = function red(num) {
+      }, BN.red = function(num) {
         return new Red(num);
-      }, BN.prototype.toRed = function toRed(ctx) {
+      }, BN.prototype.toRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), assert(this.negative === 0, "red works only with positives"), ctx.convertTo(this)._forceRed(ctx);
-      }, BN.prototype.fromRed = function fromRed() {
+      }, BN.prototype.fromRed = function() {
         return assert(this.red, "fromRed works only with numbers in reduction context"), this.red.convertFrom(this);
-      }, BN.prototype._forceRed = function _forceRed(ctx) {
+      }, BN.prototype._forceRed = function(ctx) {
         return this.red = ctx, this;
-      }, BN.prototype.forceRed = function forceRed(ctx) {
+      }, BN.prototype.forceRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), this._forceRed(ctx);
-      }, BN.prototype.redAdd = function redAdd(num) {
+      }, BN.prototype.redAdd = function(num) {
         return assert(this.red, "redAdd works only with red numbers"), this.red.add(this, num);
-      }, BN.prototype.redIAdd = function redIAdd(num) {
+      }, BN.prototype.redIAdd = function(num) {
         return assert(this.red, "redIAdd works only with red numbers"), this.red.iadd(this, num);
-      }, BN.prototype.redSub = function redSub(num) {
+      }, BN.prototype.redSub = function(num) {
         return assert(this.red, "redSub works only with red numbers"), this.red.sub(this, num);
-      }, BN.prototype.redISub = function redISub(num) {
+      }, BN.prototype.redISub = function(num) {
         return assert(this.red, "redISub works only with red numbers"), this.red.isub(this, num);
-      }, BN.prototype.redShl = function redShl(num) {
+      }, BN.prototype.redShl = function(num) {
         return assert(this.red, "redShl works only with red numbers"), this.red.shl(this, num);
-      }, BN.prototype.redMul = function redMul(num) {
+      }, BN.prototype.redMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.mul(this, num);
-      }, BN.prototype.redIMul = function redIMul(num) {
+      }, BN.prototype.redIMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.imul(this, num);
-      }, BN.prototype.redSqr = function redSqr() {
+      }, BN.prototype.redSqr = function() {
         return assert(this.red, "redSqr works only with red numbers"), this.red._verify1(this), this.red.sqr(this);
-      }, BN.prototype.redISqr = function redISqr() {
+      }, BN.prototype.redISqr = function() {
         return assert(this.red, "redISqr works only with red numbers"), this.red._verify1(this), this.red.isqr(this);
-      }, BN.prototype.redSqrt = function redSqrt() {
+      }, BN.prototype.redSqrt = function() {
         return assert(this.red, "redSqrt works only with red numbers"), this.red._verify1(this), this.red.sqrt(this);
-      }, BN.prototype.redInvm = function redInvm() {
+      }, BN.prototype.redInvm = function() {
         return assert(this.red, "redInvm works only with red numbers"), this.red._verify1(this), this.red.invm(this);
-      }, BN.prototype.redNeg = function redNeg() {
+      }, BN.prototype.redNeg = function() {
         return assert(this.red, "redNeg works only with red numbers"), this.red._verify1(this), this.red.neg(this);
-      }, BN.prototype.redPow = function redPow(num) {
+      }, BN.prototype.redPow = function(num) {
         return assert(this.red && !num.red, "redPow(normalNum)"), this.red._verify1(this), this.red.pow(this, num);
       };
       var primes = { k256: null, p224: null, p192: null, p25519: null };
       function MPrime(name, p) {
         this.name = name, this.p = new BN(p, 16), this.n = this.p.bitLength(), this.k = new BN(1).iushln(this.n).isub(this.p), this.tmp = this._tmp();
       }
-      MPrime.prototype._tmp = function _tmp() {
+      MPrime.prototype._tmp = function() {
         var tmp = new BN(null);
-        return tmp.words = new Array(Math.ceil(this.n / 13)), tmp;
-      }, MPrime.prototype.ireduce = function ireduce(num) {
+        return tmp.words = Array(Math.ceil(this.n / 13)), tmp;
+      }, MPrime.prototype.ireduce = function(num) {
         var r = num, rlen;
         do
           this.split(r, this.tmp), r = this.imulK(r), r = r.iadd(this.tmp), rlen = r.bitLength();
@@ -7555,15 +8251,15 @@ var init_crypto = __esm(() => {
         else
           r._strip();
         return r;
-      }, MPrime.prototype.split = function split(input, out) {
+      }, MPrime.prototype.split = function(input, out) {
         input.iushrn(this.n, 0, out);
-      }, MPrime.prototype.imulK = function imulK(num) {
+      }, MPrime.prototype.imulK = function(num) {
         return num.imul(this.k);
       };
       function K256() {
         MPrime.call(this, "k256", "ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f");
       }
-      inherits2(K256, MPrime), K256.prototype.split = function split(input, output) {
+      inherits2(K256, MPrime), K256.prototype.split = function(input, output) {
         var mask = 4194303, outLen = Math.min(input.length, 9);
         for (var i2 = 0;i2 < outLen; i2++)
           output.words[i2] = input.words[i2];
@@ -7581,7 +8277,7 @@ var init_crypto = __esm(() => {
           input.length -= 10;
         else
           input.length -= 9;
-      }, K256.prototype.imulK = function imulK(num) {
+      }, K256.prototype.imulK = function(num) {
         num.words[num.length] = 0, num.words[num.length + 1] = 0, num.length += 2;
         var lo = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
@@ -7605,7 +8301,7 @@ var init_crypto = __esm(() => {
       function P25519() {
         MPrime.call(this, "25519", "7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed");
       }
-      inherits2(P25519, MPrime), P25519.prototype.imulK = function imulK(num) {
+      inherits2(P25519, MPrime), P25519.prototype.imulK = function(num) {
         var carry = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
           var hi = (num.words[i2] | 0) * 19 + carry, lo = hi & 67108863;
@@ -7614,7 +8310,7 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           num.words[num.length++] = carry;
         return num;
-      }, BN._prime = function prime(name) {
+      }, BN._prime = function(name) {
         if (primes[name])
           return primes[name];
         var prime;
@@ -7627,7 +8323,7 @@ var init_crypto = __esm(() => {
         else if (name === "p25519")
           prime = new P25519;
         else
-          throw new Error("Unknown prime " + name);
+          throw Error("Unknown prime " + name);
         return primes[name] = prime, prime;
       };
       function Red(m) {
@@ -7637,53 +8333,53 @@ var init_crypto = __esm(() => {
         } else
           assert(m.gtn(1), "modulus must be greater than 1"), this.m = m, this.prime = null;
       }
-      Red.prototype._verify1 = function _verify1(a) {
+      Red.prototype._verify1 = function(a) {
         assert(a.negative === 0, "red works only with positives"), assert(a.red, "red works only with red numbers");
-      }, Red.prototype._verify2 = function _verify2(a, b) {
+      }, Red.prototype._verify2 = function(a, b) {
         assert((a.negative | b.negative) === 0, "red works only with positives"), assert(a.red && a.red === b.red, "red works only with red numbers");
-      }, Red.prototype.imod = function imod(a) {
+      }, Red.prototype.imod = function(a) {
         if (this.prime)
           return this.prime.ireduce(a)._forceRed(this);
         return a.umod(this.m)._forceRed(this);
-      }, Red.prototype.neg = function neg(a) {
+      }, Red.prototype.neg = function(a) {
         if (a.isZero())
           return a.clone();
         return this.m.sub(a)._forceRed(this);
-      }, Red.prototype.add = function add(a, b) {
+      }, Red.prototype.add = function(a, b) {
         this._verify2(a, b);
         var res = a.add(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res._forceRed(this);
-      }, Red.prototype.iadd = function iadd(a, b) {
+      }, Red.prototype.iadd = function(a, b) {
         this._verify2(a, b);
         var res = a.iadd(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res;
-      }, Red.prototype.sub = function sub(a, b) {
+      }, Red.prototype.sub = function(a, b) {
         this._verify2(a, b);
         var res = a.sub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res._forceRed(this);
-      }, Red.prototype.isub = function isub(a, b) {
+      }, Red.prototype.isub = function(a, b) {
         this._verify2(a, b);
         var res = a.isub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res;
-      }, Red.prototype.shl = function shl(a, num) {
+      }, Red.prototype.shl = function(a, num) {
         return this._verify1(a), this.imod(a.ushln(num));
-      }, Red.prototype.imul = function imul(a, b) {
+      }, Red.prototype.imul = function(a, b) {
         return this._verify2(a, b), this.imod(a.imul(b));
-      }, Red.prototype.mul = function mul(a, b) {
+      }, Red.prototype.mul = function(a, b) {
         return this._verify2(a, b), this.imod(a.mul(b));
-      }, Red.prototype.isqr = function isqr(a) {
+      }, Red.prototype.isqr = function(a) {
         return this.imul(a, a.clone());
-      }, Red.prototype.sqr = function sqr(a) {
+      }, Red.prototype.sqr = function(a) {
         return this.mul(a, a);
-      }, Red.prototype.sqrt = function sqrt(a) {
+      }, Red.prototype.sqrt = function(a) {
         if (a.isZero())
           return a.clone();
         var mod3 = this.m.andln(3);
@@ -7709,18 +8405,18 @@ var init_crypto = __esm(() => {
           r = r.redMul(b), c = b.redSqr(), t = t.redMul(c), m = i2;
         }
         return r;
-      }, Red.prototype.invm = function invm(a) {
+      }, Red.prototype.invm = function(a) {
         var inv = a._invmp(this.m);
         if (inv.negative !== 0)
           return inv.negative = 0, this.imod(inv).redNeg();
         else
           return this.imod(inv);
-      }, Red.prototype.pow = function pow(a, num) {
+      }, Red.prototype.pow = function(a, num) {
         if (num.isZero())
           return new BN(1).toRed(this);
         if (num.cmpn(1) === 0)
           return a.clone();
-        var windowSize = 4, wnd = new Array(1 << windowSize);
+        var windowSize = 4, wnd = Array(1 << windowSize);
         wnd[0] = new BN(1).toRed(this), wnd[1] = a;
         for (var i2 = 2;i2 < wnd.length; i2++)
           wnd[i2] = this.mul(wnd[i2 - 1], a);
@@ -7744,13 +8440,13 @@ var init_crypto = __esm(() => {
           start = 26;
         }
         return res;
-      }, Red.prototype.convertTo = function convertTo(num) {
+      }, Red.prototype.convertTo = function(num) {
         var r = num.umod(this.m);
         return r === num ? r.clone() : r;
-      }, Red.prototype.convertFrom = function convertFrom(num) {
+      }, Red.prototype.convertFrom = function(num) {
         var res = num.clone();
         return res.red = null, res;
-      }, BN.mont = function mont(num) {
+      }, BN.mont = function(num) {
         return new Mont(num);
       };
       function Mont(m) {
@@ -7758,12 +8454,12 @@ var init_crypto = __esm(() => {
           this.shift += 26 - this.shift % 26;
         this.r = new BN(1).iushln(this.shift), this.r2 = this.imod(this.r.sqr()), this.rinv = this.r._invmp(this.m), this.minv = this.rinv.mul(this.r).isubn(1).div(this.m), this.minv = this.minv.umod(this.r), this.minv = this.r.sub(this.minv);
       }
-      inherits2(Mont, Red), Mont.prototype.convertTo = function convertTo(num) {
+      inherits2(Mont, Red), Mont.prototype.convertTo = function(num) {
         return this.imod(num.ushln(this.shift));
-      }, Mont.prototype.convertFrom = function convertFrom(num) {
+      }, Mont.prototype.convertFrom = function(num) {
         var r = this.imod(num.mul(this.rinv));
         return r.red = null, r;
-      }, Mont.prototype.imul = function imul(a, b) {
+      }, Mont.prototype.imul = function(a, b) {
         if (a.isZero() || b.isZero())
           return a.words[0] = 0, a.length = 1, a;
         var t = a.imul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -7772,7 +8468,7 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.mul = function mul(a, b) {
+      }, Mont.prototype.mul = function(a, b) {
         if (a.isZero() || b.isZero())
           return new BN(0)._forceRed(this);
         var t = a.mul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -7781,21 +8477,21 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.invm = function invm(a) {
+      }, Mont.prototype.invm = function(a) {
         var res = this.imod(a._invmp(this.m).mul(this.r2));
         return res._forceRed(this);
       };
-    })(typeof module === "undefined" || module, exports);
+    })(typeof module > "u" || module, exports);
   });
   require_minimalistic_assert = __commonJS2((exports, module) => {
     module.exports = assert;
     function assert(val, msg) {
       if (!val)
-        throw new Error(msg || "Assertion failed");
+        throw Error(msg || "Assertion failed");
     }
-    assert.equal = function assertEqual(l, r, msg) {
+    assert.equal = function(l, r, msg) {
       if (l != r)
-        throw new Error(msg || "Assertion failed: " + l + " != " + r);
+        throw Error(msg || "Assertion failed: " + l + " != " + r);
     };
   });
   require_utils = __commonJS2((exports) => {
@@ -7841,7 +8537,7 @@ var init_crypto = __esm(() => {
       return res;
     }
     utils.toHex = toHex;
-    utils.encode = function encode(arr, enc) {
+    utils.encode = function(arr, enc) {
       if (enc === "hex")
         return toHex(arr);
       else
@@ -7856,7 +8552,7 @@ var init_crypto = __esm(() => {
     utils.toHex = minUtils.toHex;
     utils.encode = minUtils.encode;
     function getNAF(num, w, bits) {
-      var naf = new Array(Math.max(num.bitLength(), bits) + 1), i2;
+      var naf = Array(Math.max(num.bitLength(), bits) + 1), i2;
       for (i2 = 0;i2 < naf.length; i2 += 1)
         naf[i2] = 0;
       var ws = 1 << w + 1, k = num.clone();
@@ -7911,7 +8607,7 @@ var init_crypto = __esm(() => {
     utils.getJSF = getJSF;
     function cachedProperty(obj, name, computer) {
       var key = "_" + name;
-      obj.prototype[name] = function cachedProperty() {
+      obj.prototype[name] = function() {
         return this[key] !== undefined ? this[key] : this[key] = computer.call(this);
       };
     }
@@ -7927,7 +8623,7 @@ var init_crypto = __esm(() => {
   });
   require_brorand = __commonJS2((exports, module) => {
     var r;
-    module.exports = function rand(len2) {
+    module.exports = function(len2) {
       if (!r)
         r = new Rand(null);
       return r.generate(len2);
@@ -7936,10 +8632,10 @@ var init_crypto = __esm(() => {
       this.rand = rand;
     }
     module.exports.Rand = Rand;
-    Rand.prototype.generate = function generate(len2) {
+    Rand.prototype.generate = function(len2) {
       return this._rand(len2);
     };
-    Rand.prototype._rand = function _rand(n) {
+    Rand.prototype._rand = function(n) {
       if (this.rand.getBytes)
         return this.rand.getBytes(n);
       var res = new Uint8Array(n);
@@ -7949,24 +8645,24 @@ var init_crypto = __esm(() => {
     };
     if (typeof self === "object") {
       if (self.crypto && self.crypto.getRandomValues)
-        Rand.prototype._rand = function _rand(n) {
+        Rand.prototype._rand = function(n) {
           var arr = new Uint8Array(n);
           return self.crypto.getRandomValues(arr), arr;
         };
       else if (self.msCrypto && self.msCrypto.getRandomValues)
-        Rand.prototype._rand = function _rand(n) {
+        Rand.prototype._rand = function(n) {
           var arr = new Uint8Array(n);
           return self.msCrypto.getRandomValues(arr), arr;
         };
       else if (typeof window === "object")
         Rand.prototype._rand = function() {
-          throw new Error("Not implemented yet");
+          throw Error("Not implemented yet");
         };
     } else
       try {
         if (crypto2 = (init_crypto(), __toCommonJS(exports_crypto)), typeof crypto2.randomBytes !== "function")
-          throw new Error("Not supported");
-        Rand.prototype._rand = function _rand(n) {
+          throw Error("Not supported");
+        Rand.prototype._rand = function(n) {
           return crypto2.randomBytes(n);
         };
       } catch (e) {}
@@ -7975,7 +8671,7 @@ var init_crypto = __esm(() => {
   require_base = __commonJS2((exports, module) => {
     var BN = require_bn(), utils = require_utils2(), getNAF = utils.getNAF, getJSF = utils.getJSF, assert = utils.assert;
     function BaseCurve(type, conf) {
-      this.type = type, this.p = new BN(conf.p, 16), this.red = conf.prime ? BN.red(conf.prime) : BN.mont(this.p), this.zero = new BN(0).toRed(this.red), this.one = new BN(1).toRed(this.red), this.two = new BN(2).toRed(this.red), this.n = conf.n && new BN(conf.n, 16), this.g = conf.g && this.pointFromJSON(conf.g, conf.gRed), this._wnafT1 = new Array(4), this._wnafT2 = new Array(4), this._wnafT3 = new Array(4), this._wnafT4 = new Array(4), this._bitLength = this.n ? this.n.bitLength() : 0;
+      this.type = type, this.p = new BN(conf.p, 16), this.red = conf.prime ? BN.red(conf.prime) : BN.mont(this.p), this.zero = new BN(0).toRed(this.red), this.one = new BN(1).toRed(this.red), this.two = new BN(2).toRed(this.red), this.n = conf.n && new BN(conf.n, 16), this.g = conf.g && this.pointFromJSON(conf.g, conf.gRed), this._wnafT1 = [, , , ,], this._wnafT2 = [, , , ,], this._wnafT3 = [, , , ,], this._wnafT4 = [, , , ,], this._bitLength = this.n ? this.n.bitLength() : 0;
       var adjustCount = this.n && this.p.div(this.n);
       if (!adjustCount || adjustCount.cmpn(100) > 0)
         this.redN = null;
@@ -7983,13 +8679,13 @@ var init_crypto = __esm(() => {
         this._maxwellTrick = true, this.redN = this.n.toRed(this.red);
     }
     module.exports = BaseCurve;
-    BaseCurve.prototype.point = function point() {
-      throw new Error("Not implemented");
+    BaseCurve.prototype.point = function() {
+      throw Error("Not implemented");
     };
-    BaseCurve.prototype.validate = function validate() {
-      throw new Error("Not implemented");
+    BaseCurve.prototype.validate = function() {
+      throw Error("Not implemented");
     };
-    BaseCurve.prototype._fixedNafMul = function _fixedNafMul(p, k) {
+    BaseCurve.prototype._fixedNafMul = function(p, k) {
       assert(p.precomputed);
       var doubles = p._getDoubles(), naf = getNAF(k, 1, this._bitLength), I = (1 << doubles.step + 1) - (doubles.step % 2 === 0 ? 2 : 1);
       I /= 3;
@@ -8011,7 +8707,7 @@ var init_crypto = __esm(() => {
       }
       return a.toP();
     };
-    BaseCurve.prototype._wnafMul = function _wnafMul(p, k) {
+    BaseCurve.prototype._wnafMul = function(p, k) {
       var w = 4, nafPoints = p._getNAFPoints(w);
       w = nafPoints.wnd;
       var wnd = nafPoints.points, naf = getNAF(k, w, this._bitLength), acc = this.jpoint(null, null, null);
@@ -8035,7 +8731,7 @@ var init_crypto = __esm(() => {
       }
       return p.type === "affine" ? acc.toP() : acc;
     };
-    BaseCurve.prototype._wnafMulAdd = function _wnafMulAdd(defW, points, coeffs, len2, jacobianResult) {
+    BaseCurve.prototype._wnafMulAdd = function(defW, points, coeffs, len2, jacobianResult) {
       var wndWidth = this._wnafT1, wnd = this._wnafT2, naf = this._wnafT3, max = 0, i2, j, p;
       for (i2 = 0;i2 < len2; i2++) {
         p = points[i2];
@@ -8056,7 +8752,7 @@ var init_crypto = __esm(() => {
         else
           comb[1] = points[a].toJ().mixedAdd(points[b]), comb[2] = points[a].toJ().mixedAdd(points[b].neg());
         var index = [-3, -1, -5, -7, 0, 7, 5, 1, 3], jsf = getJSF(coeffs[a], coeffs[b]);
-        max = Math.max(jsf[0].length, max), naf[a] = new Array(max), naf[b] = new Array(max);
+        max = Math.max(jsf[0].length, max), naf[a] = Array(max), naf[b] = Array(max);
         for (j = 0;j < max; j++) {
           var ja = jsf[0][j] | 0, jb = jsf[1][j] | 0;
           naf[a][j] = index[(ja + 1) * 3 + (jb + 1)], naf[b][j] = 0, wnd[a] = comb;
@@ -8103,13 +8799,13 @@ var init_crypto = __esm(() => {
       this.curve = curve, this.type = type, this.precomputed = null;
     }
     BaseCurve.BasePoint = BasePoint;
-    BasePoint.prototype.eq = function eq() {
-      throw new Error("Not implemented");
+    BasePoint.prototype.eq = function() {
+      throw Error("Not implemented");
     };
-    BasePoint.prototype.validate = function validate() {
+    BasePoint.prototype.validate = function() {
       return this.curve.validate(this);
     };
-    BaseCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+    BaseCurve.prototype.decodePoint = function(bytes, enc) {
       bytes = utils.toArray(bytes, enc);
       var len2 = this.p.byteLength();
       if ((bytes[0] === 4 || bytes[0] === 6 || bytes[0] === 7) && bytes.length - 1 === 2 * len2) {
@@ -8121,27 +8817,27 @@ var init_crypto = __esm(() => {
         return res;
       } else if ((bytes[0] === 2 || bytes[0] === 3) && bytes.length - 1 === len2)
         return this.pointFromX(bytes.slice(1, 1 + len2), bytes[0] === 3);
-      throw new Error("Unknown point format");
+      throw Error("Unknown point format");
     };
-    BasePoint.prototype.encodeCompressed = function encodeCompressed(enc) {
+    BasePoint.prototype.encodeCompressed = function(enc) {
       return this.encode(enc, true);
     };
-    BasePoint.prototype._encode = function _encode(compact) {
+    BasePoint.prototype._encode = function(compact) {
       var len2 = this.curve.p.byteLength(), x = this.getX().toArray("be", len2);
       if (compact)
         return [this.getY().isEven() ? 2 : 3].concat(x);
       return [4].concat(x, this.getY().toArray("be", len2));
     };
-    BasePoint.prototype.encode = function encode(enc, compact) {
+    BasePoint.prototype.encode = function(enc, compact) {
       return utils.encode(this._encode(compact), enc);
     };
-    BasePoint.prototype.precompute = function precompute(power) {
+    BasePoint.prototype.precompute = function(power) {
       if (this.precomputed)
         return this;
       var precomputed = { doubles: null, naf: null, beta: null };
       return precomputed.naf = this._getNAFPoints(8), precomputed.doubles = this._getDoubles(4, power), precomputed.beta = this._getBeta(), this.precomputed = precomputed, this;
     };
-    BasePoint.prototype._hasDoubles = function _hasDoubles(k) {
+    BasePoint.prototype._hasDoubles = function(k) {
       if (!this.precomputed)
         return false;
       var doubles = this.precomputed.doubles;
@@ -8149,7 +8845,7 @@ var init_crypto = __esm(() => {
         return false;
       return doubles.points.length >= Math.ceil((k.bitLength() + 1) / doubles.step);
     };
-    BasePoint.prototype._getDoubles = function _getDoubles(step, power) {
+    BasePoint.prototype._getDoubles = function(step, power) {
       if (this.precomputed && this.precomputed.doubles)
         return this.precomputed.doubles;
       var doubles = [this], acc = this;
@@ -8160,7 +8856,7 @@ var init_crypto = __esm(() => {
       }
       return { step, points: doubles };
     };
-    BasePoint.prototype._getNAFPoints = function _getNAFPoints(wnd) {
+    BasePoint.prototype._getNAFPoints = function(wnd) {
       if (this.precomputed && this.precomputed.naf)
         return this.precomputed.naf;
       var res = [this], max = (1 << wnd) - 1, dbl = max === 1 ? null : this.dbl();
@@ -8168,10 +8864,10 @@ var init_crypto = __esm(() => {
         res[i2] = res[i2 - 1].add(dbl);
       return { wnd, points: res };
     };
-    BasePoint.prototype._getBeta = function _getBeta() {
+    BasePoint.prototype._getBeta = function() {
       return null;
     };
-    BasePoint.prototype.dblp = function dblp(k) {
+    BasePoint.prototype.dblp = function(k) {
       var r = this;
       for (var i2 = 0;i2 < k; i2++)
         r = r.dbl();
@@ -8180,12 +8876,12 @@ var init_crypto = __esm(() => {
   });
   require_inherits_browser = __commonJS2((exports, module) => {
     if (typeof Object.create === "function")
-      module.exports = function inherits(ctor, superCtor) {
+      module.exports = function(ctor, superCtor) {
         if (superCtor)
           ctor.super_ = superCtor, ctor.prototype = Object.create(superCtor.prototype, { constructor: { value: ctor, enumerable: false, writable: true, configurable: true } });
       };
     else
-      module.exports = function inherits(ctor, superCtor) {
+      module.exports = function(ctor, superCtor) {
         if (superCtor) {
           ctor.super_ = superCtor;
           var TempCtor = function() {};
@@ -8206,11 +8902,11 @@ var init_crypto = __esm(() => {
   require_short = __commonJS2((exports, module) => {
     var utils = require_utils2(), BN = require_bn(), inherits2 = require_inherits(), Base = require_base(), assert = utils.assert;
     function ShortCurve(conf) {
-      Base.call(this, "short", conf), this.a = new BN(conf.a, 16).toRed(this.red), this.b = new BN(conf.b, 16).toRed(this.red), this.tinv = this.two.redInvm(), this.zeroA = this.a.fromRed().cmpn(0) === 0, this.threeA = this.a.fromRed().sub(this.p).cmpn(-3) === 0, this.endo = this._getEndomorphism(conf), this._endoWnafT1 = new Array(4), this._endoWnafT2 = new Array(4);
+      Base.call(this, "short", conf), this.a = new BN(conf.a, 16).toRed(this.red), this.b = new BN(conf.b, 16).toRed(this.red), this.tinv = this.two.redInvm(), this.zeroA = this.a.fromRed().cmpn(0) === 0, this.threeA = this.a.fromRed().sub(this.p).cmpn(-3) === 0, this.endo = this._getEndomorphism(conf), this._endoWnafT1 = [, , , ,], this._endoWnafT2 = [, , , ,];
     }
     inherits2(ShortCurve, Base);
     module.exports = ShortCurve;
-    ShortCurve.prototype._getEndomorphism = function _getEndomorphism(conf) {
+    ShortCurve.prototype._getEndomorphism = function(conf) {
       if (!this.zeroA || !this.g || !this.n || this.p.modn(3) !== 1)
         return;
       var beta, lambda;
@@ -8238,11 +8934,11 @@ var init_crypto = __esm(() => {
         basis = this._getEndoBasis(lambda);
       return { beta, lambda, basis };
     };
-    ShortCurve.prototype._getEndoRoots = function _getEndoRoots(num) {
+    ShortCurve.prototype._getEndoRoots = function(num) {
       var red = num === this.p ? this.red : BN.mont(num), tinv = new BN(2).toRed(red).redInvm(), ntinv = tinv.redNeg(), s = new BN(3).toRed(red).redNeg().redSqrt().redMul(tinv), l1 = ntinv.redAdd(s).fromRed(), l2 = ntinv.redSub(s).fromRed();
       return [l1, l2];
     };
-    ShortCurve.prototype._getEndoBasis = function _getEndoBasis(lambda) {
+    ShortCurve.prototype._getEndoBasis = function(lambda) {
       var aprxSqrt = this.n.ushrn(Math.floor(this.n.bitLength() / 2)), u = lambda, v = this.n.clone(), x1 = new BN(1), y1 = new BN(0), x2 = new BN(0), y2 = new BN(1), a0, b0, a1, b1, a2, b2, prevR, i2 = 0, r, x;
       while (u.cmpn(0) !== 0) {
         var q = v.div(u);
@@ -8264,28 +8960,28 @@ var init_crypto = __esm(() => {
         a2 = a2.neg(), b2 = b2.neg();
       return [{ a: a1, b: b1 }, { a: a2, b: b2 }];
     };
-    ShortCurve.prototype._endoSplit = function _endoSplit(k) {
+    ShortCurve.prototype._endoSplit = function(k) {
       var basis = this.endo.basis, v1 = basis[0], v2 = basis[1], c1 = v2.b.mul(k).divRound(this.n), c2 = v1.b.neg().mul(k).divRound(this.n), p1 = c1.mul(v1.a), p2 = c2.mul(v2.a), q1 = c1.mul(v1.b), q2 = c2.mul(v2.b), k1 = k.sub(p1).sub(p2), k2 = q1.add(q2).neg();
       return { k1, k2 };
     };
-    ShortCurve.prototype.pointFromX = function pointFromX(x, odd) {
+    ShortCurve.prototype.pointFromX = function(x, odd) {
       if (x = new BN(x, 16), !x.red)
         x = x.toRed(this.red);
       var y2 = x.redSqr().redMul(x).redIAdd(x.redMul(this.a)).redIAdd(this.b), y = y2.redSqrt();
       if (y.redSqr().redSub(y2).cmp(this.zero) !== 0)
-        throw new Error("invalid point");
+        throw Error("invalid point");
       var isOdd = y.fromRed().isOdd();
       if (odd && !isOdd || !odd && isOdd)
         y = y.redNeg();
       return this.point(x, y);
     };
-    ShortCurve.prototype.validate = function validate(point) {
+    ShortCurve.prototype.validate = function(point) {
       if (point.inf)
         return true;
       var { x, y } = point, ax = this.a.redMul(x), rhs = x.redSqr().redMul(x).redIAdd(ax).redIAdd(this.b);
       return y.redSqr().redISub(rhs).cmpn(0) === 0;
     };
-    ShortCurve.prototype._endoWnafMulAdd = function _endoWnafMulAdd(points, coeffs, jacobianResult) {
+    ShortCurve.prototype._endoWnafMulAdd = function(points, coeffs, jacobianResult) {
       var npoints = this._endoWnafT1, ncoeffs = this._endoWnafT2;
       for (var i2 = 0;i2 < points.length; i2++) {
         var split = this._endoSplit(coeffs[i2]), p = points[i2], beta = p._getBeta();
@@ -8314,13 +9010,13 @@ var init_crypto = __esm(() => {
       }
     }
     inherits2(Point, Base.BasePoint);
-    ShortCurve.prototype.point = function point(x, y, isRed) {
+    ShortCurve.prototype.point = function(x, y, isRed) {
       return new Point(this, x, y, isRed);
     };
-    ShortCurve.prototype.pointFromJSON = function pointFromJSON(obj, red) {
+    ShortCurve.prototype.pointFromJSON = function(obj, red) {
       return Point.fromJSON(this, obj, red);
     };
-    Point.prototype._getBeta = function _getBeta() {
+    Point.prototype._getBeta = function() {
       if (!this.curve.endo)
         return;
       var pre = this.precomputed;
@@ -8335,12 +9031,12 @@ var init_crypto = __esm(() => {
       }
       return beta;
     };
-    Point.prototype.toJSON = function toJSON() {
+    Point.prototype.toJSON = function() {
       if (!this.precomputed)
         return [this.x, this.y];
       return [this.x, this.y, this.precomputed && { doubles: this.precomputed.doubles && { step: this.precomputed.doubles.step, points: this.precomputed.doubles.points.slice(1) }, naf: this.precomputed.naf && { wnd: this.precomputed.naf.wnd, points: this.precomputed.naf.points.slice(1) } }];
     };
-    Point.fromJSON = function fromJSON(curve, obj, red) {
+    Point.fromJSON = function(curve, obj, red) {
       if (typeof obj === "string")
         obj = JSON.parse(obj);
       var res = curve.point(obj[0], obj[1], red);
@@ -8352,15 +9048,15 @@ var init_crypto = __esm(() => {
       var pre = obj[2];
       return res.precomputed = { beta: null, doubles: pre.doubles && { step: pre.doubles.step, points: [res].concat(pre.doubles.points.map(obj2point)) }, naf: pre.naf && { wnd: pre.naf.wnd, points: [res].concat(pre.naf.points.map(obj2point)) } }, res;
     };
-    Point.prototype.inspect = function inspect() {
+    Point.prototype.inspect = function() {
       if (this.isInfinity())
         return "<EC Point Infinity>";
       return "<EC Point x: " + this.x.fromRed().toString(16, 2) + " y: " + this.y.fromRed().toString(16, 2) + ">";
     };
-    Point.prototype.isInfinity = function isInfinity() {
+    Point.prototype.isInfinity = function() {
       return this.inf;
     };
-    Point.prototype.add = function add(p) {
+    Point.prototype.add = function(p) {
       if (this.inf)
         return p;
       if (p.inf)
@@ -8377,7 +9073,7 @@ var init_crypto = __esm(() => {
       var nx = c.redSqr().redISub(this.x).redISub(p.x), ny = c.redMul(this.x.redSub(nx)).redISub(this.y);
       return this.curve.point(nx, ny);
     };
-    Point.prototype.dbl = function dbl() {
+    Point.prototype.dbl = function() {
       if (this.inf)
         return this;
       var ys1 = this.y.redAdd(this.y);
@@ -8386,13 +9082,13 @@ var init_crypto = __esm(() => {
       var a = this.curve.a, x2 = this.x.redSqr(), dyinv = ys1.redInvm(), c = x2.redAdd(x2).redIAdd(x2).redIAdd(a).redMul(dyinv), nx = c.redSqr().redISub(this.x.redAdd(this.x)), ny = c.redMul(this.x.redSub(nx)).redISub(this.y);
       return this.curve.point(nx, ny);
     };
-    Point.prototype.getX = function getX() {
+    Point.prototype.getX = function() {
       return this.x.fromRed();
     };
-    Point.prototype.getY = function getY() {
+    Point.prototype.getY = function() {
       return this.y.fromRed();
     };
-    Point.prototype.mul = function mul(k) {
+    Point.prototype.mul = function(k) {
       if (k = new BN(k, 16), this.isInfinity())
         return this;
       else if (this._hasDoubles(k))
@@ -8402,24 +9098,24 @@ var init_crypto = __esm(() => {
       else
         return this.curve._wnafMul(this, k);
     };
-    Point.prototype.mulAdd = function mulAdd(k1, p2, k2) {
+    Point.prototype.mulAdd = function(k1, p2, k2) {
       var points = [this, p2], coeffs = [k1, k2];
       if (this.curve.endo)
         return this.curve._endoWnafMulAdd(points, coeffs);
       else
         return this.curve._wnafMulAdd(1, points, coeffs, 2);
     };
-    Point.prototype.jmulAdd = function jmulAdd(k1, p2, k2) {
+    Point.prototype.jmulAdd = function(k1, p2, k2) {
       var points = [this, p2], coeffs = [k1, k2];
       if (this.curve.endo)
         return this.curve._endoWnafMulAdd(points, coeffs, true);
       else
         return this.curve._wnafMulAdd(1, points, coeffs, 2, true);
     };
-    Point.prototype.eq = function eq(p) {
+    Point.prototype.eq = function(p) {
       return this === p || this.inf === p.inf && (this.inf || this.x.cmp(p.x) === 0 && this.y.cmp(p.y) === 0);
     };
-    Point.prototype.neg = function neg(_precompute) {
+    Point.prototype.neg = function(_precompute) {
       if (this.inf)
         return this;
       var res = this.curve.point(this.x, this.y.redNeg());
@@ -8431,7 +9127,7 @@ var init_crypto = __esm(() => {
       }
       return res;
     };
-    Point.prototype.toJ = function toJ() {
+    Point.prototype.toJ = function() {
       if (this.inf)
         return this.curve.jpoint(null, null, null);
       var res = this.curve.jpoint(this.x, this.y, this.curve.one);
@@ -8451,19 +9147,19 @@ var init_crypto = __esm(() => {
       this.zOne = this.z === this.curve.one;
     }
     inherits2(JPoint, Base.BasePoint);
-    ShortCurve.prototype.jpoint = function jpoint(x, y, z) {
+    ShortCurve.prototype.jpoint = function(x, y, z) {
       return new JPoint(this, x, y, z);
     };
-    JPoint.prototype.toP = function toP() {
+    JPoint.prototype.toP = function() {
       if (this.isInfinity())
         return this.curve.point(null, null);
       var zinv = this.z.redInvm(), zinv2 = zinv.redSqr(), ax = this.x.redMul(zinv2), ay = this.y.redMul(zinv2).redMul(zinv);
       return this.curve.point(ax, ay);
     };
-    JPoint.prototype.neg = function neg() {
+    JPoint.prototype.neg = function() {
       return this.curve.jpoint(this.x, this.y.redNeg(), this.z);
     };
-    JPoint.prototype.add = function add(p) {
+    JPoint.prototype.add = function(p) {
       if (this.isInfinity())
         return p;
       if (p.isInfinity())
@@ -8477,7 +9173,7 @@ var init_crypto = __esm(() => {
       var h2 = h.redSqr(), h3 = h2.redMul(h), v = u1.redMul(h2), nx = r.redSqr().redIAdd(h3).redISub(v).redISub(v), ny = r.redMul(v.redISub(nx)).redISub(s1.redMul(h3)), nz = this.z.redMul(p.z).redMul(h);
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype.mixedAdd = function mixedAdd(p) {
+    JPoint.prototype.mixedAdd = function(p) {
       if (this.isInfinity())
         return p.toJ();
       if (p.isInfinity())
@@ -8491,7 +9187,7 @@ var init_crypto = __esm(() => {
       var h2 = h.redSqr(), h3 = h2.redMul(h), v = u1.redMul(h2), nx = r.redSqr().redIAdd(h3).redISub(v).redISub(v), ny = r.redMul(v.redISub(nx)).redISub(s1.redMul(h3)), nz = this.z.redMul(h);
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype.dblp = function dblp(pow) {
+    JPoint.prototype.dblp = function(pow) {
       if (pow === 0)
         return this;
       if (this.isInfinity())
@@ -8516,7 +9212,7 @@ var init_crypto = __esm(() => {
       }
       return this.curve.jpoint(jx, jyd.redMul(tinv), jz);
     };
-    JPoint.prototype.dbl = function dbl() {
+    JPoint.prototype.dbl = function() {
       if (this.isInfinity())
         return this;
       if (this.curve.zeroA)
@@ -8526,7 +9222,7 @@ var init_crypto = __esm(() => {
       else
         return this._dbl();
     };
-    JPoint.prototype._zeroDbl = function _zeroDbl() {
+    JPoint.prototype._zeroDbl = function() {
       var nx, ny, nz;
       if (this.zOne) {
         var xx = this.x.redSqr(), yy = this.y.redSqr(), yyyy = yy.redSqr(), s = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
@@ -8541,7 +9237,7 @@ var init_crypto = __esm(() => {
       }
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype._threeDbl = function _threeDbl() {
+    JPoint.prototype._threeDbl = function() {
       var nx, ny, nz;
       if (this.zOne) {
         var xx = this.x.redSqr(), yy = this.y.redSqr(), yyyy = yy.redSqr(), s = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
@@ -8562,7 +9258,7 @@ var init_crypto = __esm(() => {
       }
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype._dbl = function _dbl() {
+    JPoint.prototype._dbl = function() {
       var a = this.curve.a, jx = this.x, jy = this.y, jz = this.z, jz4 = jz.redSqr().redSqr(), jx2 = jx.redSqr(), jy2 = jy.redSqr(), c = jx2.redAdd(jx2).redIAdd(jx2).redIAdd(a.redMul(jz4)), jxd4 = jx.redAdd(jx);
       jxd4 = jxd4.redIAdd(jxd4);
       var t1 = jxd4.redMul(jy2), nx = c.redSqr().redISub(t1.redAdd(t1)), t2 = t1.redISub(nx), jyd8 = jy2.redSqr();
@@ -8570,7 +9266,7 @@ var init_crypto = __esm(() => {
       var ny = c.redMul(t2).redISub(jyd8), nz = jy.redAdd(jy).redMul(jz);
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype.trpl = function trpl() {
+    JPoint.prototype.trpl = function() {
       if (!this.curve.zeroA)
         return this.dbl().add(this);
       var xx = this.x.redSqr(), yy = this.y.redSqr(), zz = this.z.redSqr(), yyyy = yy.redSqr(), m = xx.redAdd(xx).redIAdd(xx), mm = m.redSqr(), e = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
@@ -8586,10 +9282,10 @@ var init_crypto = __esm(() => {
       var nz = this.z.redAdd(e).redSqr().redISub(zz).redISub(ee);
       return this.curve.jpoint(nx, ny, nz);
     };
-    JPoint.prototype.mul = function mul(k, kbase) {
+    JPoint.prototype.mul = function(k, kbase) {
       return k = new BN(k, kbase), this.curve._wnafMul(this, k);
     };
-    JPoint.prototype.eq = function eq(p) {
+    JPoint.prototype.eq = function(p) {
       if (p.type === "affine")
         return this.eq(p.toJ());
       if (this === p)
@@ -8600,7 +9296,7 @@ var init_crypto = __esm(() => {
       var z3 = z2.redMul(this.z), pz3 = pz2.redMul(p.z);
       return this.y.redMul(pz3).redISub(p.y.redMul(z3)).cmpn(0) === 0;
     };
-    JPoint.prototype.eqXToP = function eqXToP(x) {
+    JPoint.prototype.eqXToP = function(x) {
       var zs = this.z.redSqr(), rx = x.toRed(this.curve.red).redMul(zs);
       if (this.x.cmp(rx) === 0)
         return true;
@@ -8612,12 +9308,12 @@ var init_crypto = __esm(() => {
           return true;
       }
     };
-    JPoint.prototype.inspect = function inspect() {
+    JPoint.prototype.inspect = function() {
       if (this.isInfinity())
         return "<EC JPoint Infinity>";
       return "<EC JPoint x: " + this.x.toString(16, 2) + " y: " + this.y.toString(16, 2) + " z: " + this.z.toString(16, 2) + ">";
     };
-    JPoint.prototype.isInfinity = function isInfinity() {
+    JPoint.prototype.isInfinity = function() {
       return this.z.cmpn(0) === 0;
     };
   });
@@ -8628,7 +9324,7 @@ var init_crypto = __esm(() => {
     }
     inherits2(MontCurve, Base);
     module.exports = MontCurve;
-    MontCurve.prototype.validate = function validate(point) {
+    MontCurve.prototype.validate = function(point) {
       var x = point.normalize().x, x2 = x.redSqr(), rhs = x2.redMul(x).redAdd(x2.redMul(this.a)).redAdd(x), y = rhs.redSqrt();
       return y.redSqr().cmp(rhs) === 0;
     };
@@ -8643,42 +9339,42 @@ var init_crypto = __esm(() => {
       }
     }
     inherits2(Point, Base.BasePoint);
-    MontCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+    MontCurve.prototype.decodePoint = function(bytes, enc) {
       return this.point(utils.toArray(bytes, enc), 1);
     };
-    MontCurve.prototype.point = function point(x, z) {
+    MontCurve.prototype.point = function(x, z) {
       return new Point(this, x, z);
     };
-    MontCurve.prototype.pointFromJSON = function pointFromJSON(obj) {
+    MontCurve.prototype.pointFromJSON = function(obj) {
       return Point.fromJSON(this, obj);
     };
-    Point.prototype.precompute = function precompute() {};
-    Point.prototype._encode = function _encode() {
+    Point.prototype.precompute = function() {};
+    Point.prototype._encode = function() {
       return this.getX().toArray("be", this.curve.p.byteLength());
     };
-    Point.fromJSON = function fromJSON(curve, obj) {
+    Point.fromJSON = function(curve, obj) {
       return new Point(curve, obj[0], obj[1] || curve.one);
     };
-    Point.prototype.inspect = function inspect() {
+    Point.prototype.inspect = function() {
       if (this.isInfinity())
         return "<EC Point Infinity>";
       return "<EC Point x: " + this.x.fromRed().toString(16, 2) + " z: " + this.z.fromRed().toString(16, 2) + ">";
     };
-    Point.prototype.isInfinity = function isInfinity() {
+    Point.prototype.isInfinity = function() {
       return this.z.cmpn(0) === 0;
     };
-    Point.prototype.dbl = function dbl() {
+    Point.prototype.dbl = function() {
       var a = this.x.redAdd(this.z), aa = a.redSqr(), b = this.x.redSub(this.z), bb = b.redSqr(), c = aa.redSub(bb), nx = aa.redMul(bb), nz = c.redMul(bb.redAdd(this.curve.a24.redMul(c)));
       return this.curve.point(nx, nz);
     };
-    Point.prototype.add = function add() {
-      throw new Error("Not supported on Montgomery curve");
+    Point.prototype.add = function() {
+      throw Error("Not supported on Montgomery curve");
     };
-    Point.prototype.diffAdd = function diffAdd(p, diff) {
+    Point.prototype.diffAdd = function(p, diff) {
       var a = this.x.redAdd(this.z), b = this.x.redSub(this.z), c = p.x.redAdd(p.z), d = p.x.redSub(p.z), da = d.redMul(a), cb = c.redMul(b), nx = diff.z.redMul(da.redAdd(cb).redSqr()), nz = diff.x.redMul(da.redISub(cb).redSqr());
       return this.curve.point(nx, nz);
     };
-    Point.prototype.mul = function mul(k) {
+    Point.prototype.mul = function(k) {
       var t = k.clone(), a = this, b = this.curve.point(null, null), c = this;
       for (var bits = [];t.cmpn(0) !== 0; t.iushrn(1))
         bits.push(t.andln(1));
@@ -8689,19 +9385,19 @@ var init_crypto = __esm(() => {
           b = a.diffAdd(b, c), a = a.dbl();
       return b;
     };
-    Point.prototype.mulAdd = function mulAdd() {
-      throw new Error("Not supported on Montgomery curve");
+    Point.prototype.mulAdd = function() {
+      throw Error("Not supported on Montgomery curve");
     };
-    Point.prototype.jumlAdd = function jumlAdd() {
-      throw new Error("Not supported on Montgomery curve");
+    Point.prototype.jumlAdd = function() {
+      throw Error("Not supported on Montgomery curve");
     };
-    Point.prototype.eq = function eq(other) {
+    Point.prototype.eq = function(other) {
       return this.getX().cmp(other.getX()) === 0;
     };
-    Point.prototype.normalize = function normalize() {
+    Point.prototype.normalize = function() {
       return this.x = this.x.redMul(this.z.redInvm()), this.z = this.curve.one, this;
     };
-    Point.prototype.getX = function getX() {
+    Point.prototype.getX = function() {
       return this.normalize(), this.x.fromRed();
     };
   });
@@ -8712,49 +9408,49 @@ var init_crypto = __esm(() => {
     }
     inherits2(EdwardsCurve, Base);
     module.exports = EdwardsCurve;
-    EdwardsCurve.prototype._mulA = function _mulA(num) {
+    EdwardsCurve.prototype._mulA = function(num) {
       if (this.mOneA)
         return num.redNeg();
       else
         return this.a.redMul(num);
     };
-    EdwardsCurve.prototype._mulC = function _mulC(num) {
+    EdwardsCurve.prototype._mulC = function(num) {
       if (this.oneC)
         return num;
       else
         return this.c.redMul(num);
     };
-    EdwardsCurve.prototype.jpoint = function jpoint(x, y, z, t) {
+    EdwardsCurve.prototype.jpoint = function(x, y, z, t) {
       return this.point(x, y, z, t);
     };
-    EdwardsCurve.prototype.pointFromX = function pointFromX(x, odd) {
+    EdwardsCurve.prototype.pointFromX = function(x, odd) {
       if (x = new BN(x, 16), !x.red)
         x = x.toRed(this.red);
       var x2 = x.redSqr(), rhs = this.c2.redSub(this.a.redMul(x2)), lhs = this.one.redSub(this.c2.redMul(this.d).redMul(x2)), y2 = rhs.redMul(lhs.redInvm()), y = y2.redSqrt();
       if (y.redSqr().redSub(y2).cmp(this.zero) !== 0)
-        throw new Error("invalid point");
+        throw Error("invalid point");
       var isOdd = y.fromRed().isOdd();
       if (odd && !isOdd || !odd && isOdd)
         y = y.redNeg();
       return this.point(x, y);
     };
-    EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
+    EdwardsCurve.prototype.pointFromY = function(y, odd) {
       if (y = new BN(y, 16), !y.red)
         y = y.toRed(this.red);
       var y2 = y.redSqr(), lhs = y2.redSub(this.c2), rhs = y2.redMul(this.d).redMul(this.c2).redSub(this.a), x2 = lhs.redMul(rhs.redInvm());
       if (x2.cmp(this.zero) === 0)
         if (odd)
-          throw new Error("invalid point");
+          throw Error("invalid point");
         else
           return this.point(this.zero, y);
       var x = x2.redSqrt();
       if (x.redSqr().redSub(x2).cmp(this.zero) !== 0)
-        throw new Error("invalid point");
+        throw Error("invalid point");
       if (x.fromRed().isOdd() !== odd)
         x = x.redNeg();
       return this.point(x, y);
     };
-    EdwardsCurve.prototype.validate = function validate(point) {
+    EdwardsCurve.prototype.validate = function(point) {
       if (point.isInfinity())
         return true;
       point.normalize();
@@ -8780,30 +9476,30 @@ var init_crypto = __esm(() => {
       }
     }
     inherits2(Point, Base.BasePoint);
-    EdwardsCurve.prototype.pointFromJSON = function pointFromJSON(obj) {
+    EdwardsCurve.prototype.pointFromJSON = function(obj) {
       return Point.fromJSON(this, obj);
     };
-    EdwardsCurve.prototype.point = function point(x, y, z, t) {
+    EdwardsCurve.prototype.point = function(x, y, z, t) {
       return new Point(this, x, y, z, t);
     };
-    Point.fromJSON = function fromJSON(curve, obj) {
+    Point.fromJSON = function(curve, obj) {
       return new Point(curve, obj[0], obj[1], obj[2]);
     };
-    Point.prototype.inspect = function inspect() {
+    Point.prototype.inspect = function() {
       if (this.isInfinity())
         return "<EC Point Infinity>";
       return "<EC Point x: " + this.x.fromRed().toString(16, 2) + " y: " + this.y.fromRed().toString(16, 2) + " z: " + this.z.fromRed().toString(16, 2) + ">";
     };
-    Point.prototype.isInfinity = function isInfinity() {
+    Point.prototype.isInfinity = function() {
       return this.x.cmpn(0) === 0 && (this.y.cmp(this.z) === 0 || this.zOne && this.y.cmp(this.curve.c) === 0);
     };
-    Point.prototype._extDbl = function _extDbl() {
+    Point.prototype._extDbl = function() {
       var a = this.x.redSqr(), b = this.y.redSqr(), c = this.z.redSqr();
       c = c.redIAdd(c);
       var d = this.curve._mulA(a), e = this.x.redAdd(this.y).redSqr().redISub(a).redISub(b), g = d.redAdd(b), f = g.redSub(c), h = d.redSub(b), nx = e.redMul(f), ny = g.redMul(h), nt = e.redMul(h), nz = f.redMul(g);
       return this.curve.point(nx, ny, nz, nt);
     };
-    Point.prototype._projDbl = function _projDbl() {
+    Point.prototype._projDbl = function() {
       var b = this.x.redAdd(this.y).redSqr(), c = this.x.redSqr(), d = this.y.redSqr(), nx, ny, nz, e, h, j;
       if (this.curve.twisted) {
         e = this.curve._mulA(c);
@@ -8816,7 +9512,7 @@ var init_crypto = __esm(() => {
         e = c.redAdd(d), h = this.curve._mulC(this.z).redSqr(), j = e.redSub(h).redSub(h), nx = this.curve._mulC(b.redISub(e)).redMul(j), ny = this.curve._mulC(e).redMul(c.redISub(d)), nz = e.redMul(j);
       return this.curve.point(nx, ny, nz);
     };
-    Point.prototype.dbl = function dbl() {
+    Point.prototype.dbl = function() {
       if (this.isInfinity())
         return this;
       if (this.curve.extended)
@@ -8824,11 +9520,11 @@ var init_crypto = __esm(() => {
       else
         return this._projDbl();
     };
-    Point.prototype._extAdd = function _extAdd(p) {
+    Point.prototype._extAdd = function(p) {
       var a = this.y.redSub(this.x).redMul(p.y.redSub(p.x)), b = this.y.redAdd(this.x).redMul(p.y.redAdd(p.x)), c = this.t.redMul(this.curve.dd).redMul(p.t), d = this.z.redMul(p.z.redAdd(p.z)), e = b.redSub(a), f = d.redSub(c), g = d.redAdd(c), h = b.redAdd(a), nx = e.redMul(f), ny = g.redMul(h), nt = e.redMul(h), nz = f.redMul(g);
       return this.curve.point(nx, ny, nz, nt);
     };
-    Point.prototype._projAdd = function _projAdd(p) {
+    Point.prototype._projAdd = function(p) {
       var a = this.z.redMul(p.z), b = a.redSqr(), c = this.x.redMul(p.x), d = this.y.redMul(p.y), e = this.curve.d.redMul(c).redMul(d), f = b.redSub(e), g = b.redAdd(e), tmp = this.x.redAdd(this.y).redMul(p.x.redAdd(p.y)).redISub(c).redISub(d), nx = a.redMul(f).redMul(tmp), ny, nz;
       if (this.curve.twisted)
         ny = a.redMul(g).redMul(d.redSub(this.curve._mulA(c))), nz = f.redMul(g);
@@ -8836,7 +9532,7 @@ var init_crypto = __esm(() => {
         ny = a.redMul(g).redMul(d.redSub(c)), nz = this.curve._mulC(f).redMul(g);
       return this.curve.point(nx, ny, nz);
     };
-    Point.prototype.add = function add(p) {
+    Point.prototype.add = function(p) {
       if (this.isInfinity())
         return p;
       if (p.isInfinity())
@@ -8846,19 +9542,19 @@ var init_crypto = __esm(() => {
       else
         return this._projAdd(p);
     };
-    Point.prototype.mul = function mul(k) {
+    Point.prototype.mul = function(k) {
       if (this._hasDoubles(k))
         return this.curve._fixedNafMul(this, k);
       else
         return this.curve._wnafMul(this, k);
     };
-    Point.prototype.mulAdd = function mulAdd(k1, p, k2) {
+    Point.prototype.mulAdd = function(k1, p, k2) {
       return this.curve._wnafMulAdd(1, [this, p], [k1, k2], 2, false);
     };
-    Point.prototype.jmulAdd = function jmulAdd(k1, p, k2) {
+    Point.prototype.jmulAdd = function(k1, p, k2) {
       return this.curve._wnafMulAdd(1, [this, p], [k1, k2], 2, true);
     };
-    Point.prototype.normalize = function normalize() {
+    Point.prototype.normalize = function() {
       if (this.zOne)
         return this;
       var zi = this.z.redInvm();
@@ -8866,19 +9562,19 @@ var init_crypto = __esm(() => {
         this.t = this.t.redMul(zi);
       return this.z = this.curve.one, this.zOne = true, this;
     };
-    Point.prototype.neg = function neg() {
+    Point.prototype.neg = function() {
       return this.curve.point(this.x.redNeg(), this.y, this.z, this.t && this.t.redNeg());
     };
-    Point.prototype.getX = function getX() {
+    Point.prototype.getX = function() {
       return this.normalize(), this.x.fromRed();
     };
-    Point.prototype.getY = function getY() {
+    Point.prototype.getY = function() {
       return this.normalize(), this.y.fromRed();
     };
-    Point.prototype.eq = function eq(other) {
+    Point.prototype.eq = function(other) {
       return this === other || this.getX().cmp(other.getX()) === 0 && this.getY().cmp(other.getY()) === 0;
     };
-    Point.prototype.eqXToP = function eqXToP(x) {
+    Point.prototype.eqXToP = function(x) {
       var rx = x.toRed(this.curve.red).redMul(this.z);
       if (this.x.cmp(rx) === 0)
         return true;
@@ -8994,7 +9690,7 @@ var init_crypto = __esm(() => {
     function join32(msg, start, end, endian) {
       var len2 = end - start;
       assert(len2 % 4 === 0);
-      var res = new Array(len2 / 4);
+      var res = Array(len2 / 4);
       for (var i2 = 0, k = start;i2 < res.length; i2++, k += 4) {
         var w;
         if (endian === "big")
@@ -9007,7 +9703,7 @@ var init_crypto = __esm(() => {
     }
     exports.join32 = join32;
     function split32(msg, endian) {
-      var res = new Array(msg.length * 4);
+      var res = Array(msg.length * 4);
       for (var i2 = 0, k = 0;i2 < msg.length; i2++, k += 4) {
         var m = msg[i2];
         if (endian === "big")
@@ -9107,7 +9803,7 @@ var init_crypto = __esm(() => {
       this.pending = null, this.pendingTotal = 0, this.blockSize = this.constructor.blockSize, this.outSize = this.constructor.outSize, this.hmacStrength = this.constructor.hmacStrength, this.padLength = this.constructor.padLength / 8, this.endian = "big", this._delta8 = this.blockSize / 8, this._delta32 = this.blockSize / 32;
     }
     exports.BlockHash = BlockHash;
-    BlockHash.prototype.update = function update(msg, enc) {
+    BlockHash.prototype.update = function(msg, enc) {
       if (msg = utils.toArray(msg, enc), !this.pending)
         this.pending = msg;
       else
@@ -9123,11 +9819,11 @@ var init_crypto = __esm(() => {
       }
       return this;
     };
-    BlockHash.prototype.digest = function digest(enc) {
+    BlockHash.prototype.digest = function(enc) {
       return this.update(this._pad()), assert(this.pending === null), this._digest(enc);
     };
-    BlockHash.prototype._pad = function pad() {
-      var len2 = this.pendingTotal, bytes = this._delta8, k = bytes - (len2 + this.padLength) % bytes, res = new Array(k + this.padLength);
+    BlockHash.prototype._pad = function() {
+      var len2 = this.pendingTotal, bytes = this._delta8, k = bytes - (len2 + this.padLength) % bytes, res = Array(k + this.padLength);
       res[0] = 128;
       for (var i2 = 1;i2 < k; i2++)
         res[i2] = 0;
@@ -9188,7 +9884,7 @@ var init_crypto = __esm(() => {
     function SHA1() {
       if (!(this instanceof SHA1))
         return new SHA1;
-      BlockHash.call(this), this.h = [1732584193, 4023233417, 2562383102, 271733878, 3285377520], this.W = new Array(80);
+      BlockHash.call(this), this.h = [1732584193, 4023233417, 2562383102, 271733878, 3285377520], this.W = Array(80);
     }
     utils.inherits(SHA1, BlockHash);
     module.exports = SHA1;
@@ -9196,7 +9892,7 @@ var init_crypto = __esm(() => {
     SHA1.outSize = 160;
     SHA1.hmacStrength = 80;
     SHA1.padLength = 64;
-    SHA1.prototype._update = function _update(msg, start) {
+    SHA1.prototype._update = function(msg, start) {
       var W = this.W;
       for (var i2 = 0;i2 < 16; i2++)
         W[i2] = msg[start + i2];
@@ -9209,7 +9905,7 @@ var init_crypto = __esm(() => {
       }
       this.h[0] = sum32(this.h[0], a), this.h[1] = sum32(this.h[1], b), this.h[2] = sum32(this.h[2], c), this.h[3] = sum32(this.h[3], d), this.h[4] = sum32(this.h[4], e);
     };
-    SHA1.prototype._digest = function digest(enc) {
+    SHA1.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h, "big");
       else
@@ -9221,7 +9917,7 @@ var init_crypto = __esm(() => {
     function SHA256() {
       if (!(this instanceof SHA256))
         return new SHA256;
-      BlockHash.call(this), this.h = [1779033703, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225], this.k = sha256_K, this.W = new Array(64);
+      BlockHash.call(this), this.h = [1779033703, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635, 1541459225], this.k = sha256_K, this.W = Array(64);
     }
     utils.inherits(SHA256, BlockHash);
     module.exports = SHA256;
@@ -9229,7 +9925,7 @@ var init_crypto = __esm(() => {
     SHA256.outSize = 256;
     SHA256.hmacStrength = 192;
     SHA256.padLength = 64;
-    SHA256.prototype._update = function _update(msg, start) {
+    SHA256.prototype._update = function(msg, start) {
       var W = this.W;
       for (var i2 = 0;i2 < 16; i2++)
         W[i2] = msg[start + i2];
@@ -9243,7 +9939,7 @@ var init_crypto = __esm(() => {
       }
       this.h[0] = sum32(this.h[0], a), this.h[1] = sum32(this.h[1], b), this.h[2] = sum32(this.h[2], c), this.h[3] = sum32(this.h[3], d), this.h[4] = sum32(this.h[4], e), this.h[5] = sum32(this.h[5], f), this.h[6] = sum32(this.h[6], g), this.h[7] = sum32(this.h[7], h);
     };
-    SHA256.prototype._digest = function digest(enc) {
+    SHA256.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h, "big");
       else
@@ -9263,7 +9959,7 @@ var init_crypto = __esm(() => {
     SHA224.outSize = 224;
     SHA224.hmacStrength = 192;
     SHA224.padLength = 64;
-    SHA224.prototype._digest = function digest(enc) {
+    SHA224.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h.slice(0, 7), "big");
       else
@@ -9275,7 +9971,7 @@ var init_crypto = __esm(() => {
     function SHA512() {
       if (!(this instanceof SHA512))
         return new SHA512;
-      BlockHash.call(this), this.h = [1779033703, 4089235720, 3144134277, 2227873595, 1013904242, 4271175723, 2773480762, 1595750129, 1359893119, 2917565137, 2600822924, 725511199, 528734635, 4215389547, 1541459225, 327033209], this.k = sha512_K, this.W = new Array(160);
+      BlockHash.call(this), this.h = [1779033703, 4089235720, 3144134277, 2227873595, 1013904242, 4271175723, 2773480762, 1595750129, 1359893119, 2917565137, 2600822924, 725511199, 528734635, 4215389547, 1541459225, 327033209], this.k = sha512_K, this.W = Array(160);
     }
     utils.inherits(SHA512, BlockHash);
     module.exports = SHA512;
@@ -9283,7 +9979,7 @@ var init_crypto = __esm(() => {
     SHA512.outSize = 512;
     SHA512.hmacStrength = 192;
     SHA512.padLength = 128;
-    SHA512.prototype._prepareBlock = function _prepareBlock(msg, start) {
+    SHA512.prototype._prepareBlock = function(msg, start) {
       var W = this.W;
       for (var i2 = 0;i2 < 32; i2++)
         W[i2] = msg[start + i2];
@@ -9292,7 +9988,7 @@ var init_crypto = __esm(() => {
         W[i2] = sum64_4_hi(c0_hi, c0_lo, c1_hi, c1_lo, c2_hi, c2_lo, c3_hi, c3_lo), W[i2 + 1] = sum64_4_lo(c0_hi, c0_lo, c1_hi, c1_lo, c2_hi, c2_lo, c3_hi, c3_lo);
       }
     };
-    SHA512.prototype._update = function _update(msg, start) {
+    SHA512.prototype._update = function(msg, start) {
       this._prepareBlock(msg, start);
       var W = this.W, ah = this.h[0], al = this.h[1], bh = this.h[2], bl = this.h[3], ch = this.h[4], cl = this.h[5], dh = this.h[6], dl = this.h[7], eh = this.h[8], el = this.h[9], fh = this.h[10], fl = this.h[11], gh = this.h[12], gl = this.h[13], hh = this.h[14], hl = this.h[15];
       assert(this.k.length === W.length);
@@ -9304,7 +10000,7 @@ var init_crypto = __esm(() => {
       }
       sum64(this.h, 0, ah, al), sum64(this.h, 2, bh, bl), sum64(this.h, 4, ch, cl), sum64(this.h, 6, dh, dl), sum64(this.h, 8, eh, el), sum64(this.h, 10, fh, fl), sum64(this.h, 12, gh, gl), sum64(this.h, 14, hh, hl);
     };
-    SHA512.prototype._digest = function digest(enc) {
+    SHA512.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h, "big");
       else
@@ -9396,7 +10092,7 @@ var init_crypto = __esm(() => {
     SHA384.outSize = 384;
     SHA384.hmacStrength = 192;
     SHA384.padLength = 128;
-    SHA384.prototype._digest = function digest(enc) {
+    SHA384.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h.slice(0, 12), "big");
       else
@@ -9423,7 +10119,7 @@ var init_crypto = __esm(() => {
     RIPEMD160.outSize = 160;
     RIPEMD160.hmacStrength = 192;
     RIPEMD160.padLength = 64;
-    RIPEMD160.prototype._update = function update(msg, start) {
+    RIPEMD160.prototype._update = function(msg, start) {
       var A = this.h[0], B = this.h[1], C = this.h[2], D = this.h[3], E2 = this.h[4], Ah = A, Bh = B, Ch = C, Dh = D, Eh = E2;
       for (var j = 0;j < 80; j++) {
         var T = sum32(rotl32(sum32_4(A, f(j, B, C, D), msg[r[j] + start], K(j)), s[j]), E2);
@@ -9431,7 +10127,7 @@ var init_crypto = __esm(() => {
       }
       T = sum32_3(this.h[1], C, Dh), this.h[1] = sum32_3(this.h[2], D, Eh), this.h[2] = sum32_3(this.h[3], E2, Ah), this.h[3] = sum32_3(this.h[4], A, Bh), this.h[4] = sum32_3(this.h[0], B, Ch), this.h[0] = T;
     };
-    RIPEMD160.prototype._digest = function digest(enc) {
+    RIPEMD160.prototype._digest = function(enc) {
       if (enc === "hex")
         return utils.toHex32(this.h, "little");
       else
@@ -9483,7 +10179,7 @@ var init_crypto = __esm(() => {
       this.Hash = hash, this.blockSize = hash.blockSize / 8, this.outSize = hash.outSize / 8, this.inner = null, this.outer = null, this._init(utils.toArray(key, enc));
     }
     module.exports = Hmac;
-    Hmac.prototype._init = function init(key) {
+    Hmac.prototype._init = function(key) {
       if (key.length > this.blockSize)
         key = new this.Hash().update(key).digest();
       assert(key.length <= this.blockSize);
@@ -9496,10 +10192,10 @@ var init_crypto = __esm(() => {
         key[i2] ^= 106;
       this.outer = new this.Hash().update(key);
     };
-    Hmac.prototype.update = function update(msg, enc) {
+    Hmac.prototype.update = function(msg, enc) {
       return this.inner.update(msg, enc), this;
     };
-    Hmac.prototype.digest = function digest(enc) {
+    Hmac.prototype.digest = function(enc) {
       return this.outer.update(this.inner.digest()), this.outer.digest(enc);
     };
   });
@@ -9563,17 +10259,17 @@ var init_crypto = __esm(() => {
       assert(entropy.length >= this.minEntropy / 8, "Not enough entropy. Minimum is: " + this.minEntropy + " bits"), this._init(entropy, nonce, pers);
     }
     module.exports = HmacDRBG;
-    HmacDRBG.prototype._init = function init(entropy, nonce, pers) {
+    HmacDRBG.prototype._init = function(entropy, nonce, pers) {
       var seed = entropy.concat(nonce).concat(pers);
-      this.K = new Array(this.outLen / 8), this.V = new Array(this.outLen / 8);
+      this.K = Array(this.outLen / 8), this.V = Array(this.outLen / 8);
       for (var i2 = 0;i2 < this.V.length; i2++)
         this.K[i2] = 0, this.V[i2] = 1;
       this._update(seed), this._reseed = 1, this.reseedInterval = 281474976710656;
     };
-    HmacDRBG.prototype._hmac = function hmac() {
+    HmacDRBG.prototype._hmac = function() {
       return new hash.hmac(this.hash, this.K);
     };
-    HmacDRBG.prototype._update = function update(seed) {
+    HmacDRBG.prototype._update = function(seed) {
       var kmac = this._hmac().update(this.V).update([0]);
       if (seed)
         kmac = kmac.update(seed);
@@ -9581,14 +10277,14 @@ var init_crypto = __esm(() => {
         return;
       this.K = this._hmac().update(this.V).update([1]).update(seed).digest(), this.V = this._hmac().update(this.V).digest();
     };
-    HmacDRBG.prototype.reseed = function reseed(entropy, entropyEnc, add, addEnc) {
+    HmacDRBG.prototype.reseed = function(entropy, entropyEnc, add, addEnc) {
       if (typeof entropyEnc !== "string")
         addEnc = add, add = entropyEnc, entropyEnc = null;
       entropy = utils.toArray(entropy, entropyEnc), add = utils.toArray(add, addEnc), assert(entropy.length >= this.minEntropy / 8, "Not enough entropy. Minimum is: " + this.minEntropy + " bits"), this._update(entropy.concat(add || [])), this._reseed = 1;
     };
-    HmacDRBG.prototype.generate = function generate(len2, enc, add, addEnc) {
+    HmacDRBG.prototype.generate = function(len2, enc, add, addEnc) {
       if (this._reseed > this.reseedInterval)
-        throw new Error("Reseed is required");
+        throw Error("Reseed is required");
       if (typeof enc !== "string")
         addEnc = add, add = enc, enc = null;
       if (add)
@@ -9609,17 +10305,17 @@ var init_crypto = __esm(() => {
         this._importPublic(options.pub, options.pubEnc);
     }
     module.exports = KeyPair;
-    KeyPair.fromPublic = function fromPublic(ec, pub, enc) {
+    KeyPair.fromPublic = function(ec, pub, enc) {
       if (pub instanceof KeyPair)
         return pub;
       return new KeyPair(ec, { pub, pubEnc: enc });
     };
-    KeyPair.fromPrivate = function fromPrivate(ec, priv, enc) {
+    KeyPair.fromPrivate = function(ec, priv, enc) {
       if (priv instanceof KeyPair)
         return priv;
       return new KeyPair(ec, { priv, privEnc: enc });
     };
-    KeyPair.prototype.validate = function validate() {
+    KeyPair.prototype.validate = function() {
       var pub = this.getPublic();
       if (pub.isInfinity())
         return { result: false, reason: "Invalid public key" };
@@ -9629,7 +10325,7 @@ var init_crypto = __esm(() => {
         return { result: false, reason: "Public key * N != O" };
       return { result: true, reason: null };
     };
-    KeyPair.prototype.getPublic = function getPublic(compact, enc) {
+    KeyPair.prototype.getPublic = function(compact, enc) {
       if (typeof compact === "string")
         enc = compact, compact = null;
       if (!this.pub)
@@ -9638,16 +10334,16 @@ var init_crypto = __esm(() => {
         return this.pub;
       return this.pub.encode(enc, compact);
     };
-    KeyPair.prototype.getPrivate = function getPrivate(enc) {
+    KeyPair.prototype.getPrivate = function(enc) {
       if (enc === "hex")
         return this.priv.toString(16, 2);
       else
         return this.priv;
     };
-    KeyPair.prototype._importPrivate = function _importPrivate(key, enc) {
+    KeyPair.prototype._importPrivate = function(key, enc) {
       this.priv = new BN(key, enc || 16), this.priv = this.priv.umod(this.ec.curve.n);
     };
-    KeyPair.prototype._importPublic = function _importPublic(key, enc) {
+    KeyPair.prototype._importPublic = function(key, enc) {
       if (key.x || key.y) {
         if (this.ec.curve.type === "mont")
           assert(key.x, "Need x coordinate");
@@ -9658,18 +10354,18 @@ var init_crypto = __esm(() => {
       }
       this.pub = this.ec.curve.decodePoint(key, enc);
     };
-    KeyPair.prototype.derive = function derive(pub) {
+    KeyPair.prototype.derive = function(pub) {
       if (!pub.validate())
         assert(pub.validate(), "public point not validated");
       return pub.mul(this.priv).getX();
     };
-    KeyPair.prototype.sign = function sign(msg, enc, options) {
+    KeyPair.prototype.sign = function(msg, enc, options) {
       return this.ec.sign(msg, this, enc, options);
     };
-    KeyPair.prototype.verify = function verify(msg, signature, options) {
+    KeyPair.prototype.verify = function(msg, signature, options) {
       return this.ec.verify(msg, signature, this, undefined, options);
     };
-    KeyPair.prototype.inspect = function inspect() {
+    KeyPair.prototype.inspect = function() {
       return "<Key priv: " + (this.priv && this.priv.toString(16, 2)) + " pub: " + (this.pub && this.pub.inspect()) + " >";
     };
   });
@@ -9713,7 +10409,7 @@ var init_crypto = __esm(() => {
         return buf;
       return buf.slice(i2);
     }
-    Signature.prototype._importDER = function _importDER(data, enc) {
+    Signature.prototype._importDER = function(data, enc) {
       data = utils.toArray(data, enc);
       var p = new Position;
       if (data[p.place++] !== 48)
@@ -9764,7 +10460,7 @@ var init_crypto = __esm(() => {
         arr.push(len2 >>> (octets << 3) & 255);
       arr.push(len2);
     }
-    Signature.prototype.toDER = function toDER(enc) {
+    Signature.prototype.toDER = function(enc) {
       var r = this.r.toArray(), s = this.s.toArray();
       if (r[0] & 128)
         r = [0].concat(r);
@@ -9791,16 +10487,16 @@ var init_crypto = __esm(() => {
       this.curve = options.curve.curve, this.n = this.curve.n, this.nh = this.n.ushrn(1), this.g = this.curve.g, this.g = options.curve.g, this.g.precompute(options.curve.n.bitLength() + 1), this.hash = options.hash || options.curve.hash;
     }
     module.exports = EC;
-    EC.prototype.keyPair = function keyPair(options) {
+    EC.prototype.keyPair = function(options) {
       return new KeyPair(this, options);
     };
-    EC.prototype.keyFromPrivate = function keyFromPrivate(priv, enc) {
+    EC.prototype.keyFromPrivate = function(priv, enc) {
       return KeyPair.fromPrivate(this, priv, enc);
     };
-    EC.prototype.keyFromPublic = function keyFromPublic(pub, enc) {
+    EC.prototype.keyFromPublic = function(pub, enc) {
       return KeyPair.fromPublic(this, pub, enc);
     };
-    EC.prototype.genKeyPair = function genKeyPair(options) {
+    EC.prototype.genKeyPair = function(options) {
       if (!options)
         options = {};
       var drbg = new HmacDRBG({ hash: this.hash, pers: options.pers, persEnc: options.persEnc || "utf8", entropy: options.entropy || rand(this.hash.hmacStrength), entropyEnc: options.entropy && options.entropyEnc || "utf8", nonce: this.n.toArray() }), bytes = this.n.byteLength(), ns2 = this.n.sub(new BN(2));
@@ -9811,7 +10507,7 @@ var init_crypto = __esm(() => {
         return priv.iaddn(1), this.keyFromPrivate(priv);
       }
     };
-    EC.prototype._truncateToN = function _truncateToN(msg, truncOnly, bitLength) {
+    EC.prototype._truncateToN = function(msg, truncOnly, bitLength) {
       var byteLength2;
       if (BN.isBN(msg) || typeof msg === "number")
         msg = new BN(msg, 16), byteLength2 = msg.byteLength();
@@ -9831,7 +10527,7 @@ var init_crypto = __esm(() => {
       else
         return msg;
     };
-    EC.prototype.sign = function sign(msg, key, enc, options) {
+    EC.prototype.sign = function(msg, key, enc, options) {
       if (typeof enc === "object")
         options = enc, enc = null;
       if (!options)
@@ -9864,7 +10560,7 @@ var init_crypto = __esm(() => {
         return new Signature({ r, s, recoveryParam });
       }
     };
-    EC.prototype.verify = function verify(msg, signature, key, enc, options) {
+    EC.prototype.verify = function(msg, signature, key, enc, options) {
       if (!options)
         options = {};
       msg = this._truncateToN(msg, false, options.msgBitLength), key = this.keyFromPublic(key, enc), signature = new Signature(signature, "hex");
@@ -9887,7 +10583,7 @@ var init_crypto = __esm(() => {
       assert((3 & j) === j, "The recovery param is more than two bits"), signature = new Signature(signature, enc);
       var n = this.n, e = new BN(msg), r = signature.r, s = signature.s, isYOdd = j & 1, isSecondKey = j >> 1;
       if (r.cmp(this.curve.p.umod(this.curve.n)) >= 0 && isSecondKey)
-        throw new Error("Unable to find sencond key candinate");
+        throw Error("Unable to find sencond key candinate");
       if (isSecondKey)
         r = this.curve.pointFromX(r.add(this.curve.n), isYOdd);
       else
@@ -9908,7 +10604,7 @@ var init_crypto = __esm(() => {
         if (Qprime.eq(Q))
           return i2;
       }
-      throw new Error("Unable to find valid recovery factor");
+      throw Error("Unable to find valid recovery factor");
     };
   });
   require_key2 = __commonJS2((exports, module) => {
@@ -9919,50 +10615,50 @@ var init_crypto = __esm(() => {
       else
         this._pubBytes = parseBytes(params.pub);
     }
-    KeyPair.fromPublic = function fromPublic(eddsa, pub) {
+    KeyPair.fromPublic = function(eddsa, pub) {
       if (pub instanceof KeyPair)
         return pub;
       return new KeyPair(eddsa, { pub });
     };
-    KeyPair.fromSecret = function fromSecret(eddsa, secret) {
+    KeyPair.fromSecret = function(eddsa, secret) {
       if (secret instanceof KeyPair)
         return secret;
       return new KeyPair(eddsa, { secret });
     };
-    KeyPair.prototype.secret = function secret() {
+    KeyPair.prototype.secret = function() {
       return this._secret;
     };
-    cachedProperty(KeyPair, "pubBytes", function pubBytes() {
+    cachedProperty(KeyPair, "pubBytes", function() {
       return this.eddsa.encodePoint(this.pub());
     });
-    cachedProperty(KeyPair, "pub", function pub() {
+    cachedProperty(KeyPair, "pub", function() {
       if (this._pubBytes)
         return this.eddsa.decodePoint(this._pubBytes);
       return this.eddsa.g.mul(this.priv());
     });
-    cachedProperty(KeyPair, "privBytes", function privBytes() {
+    cachedProperty(KeyPair, "privBytes", function() {
       var eddsa = this.eddsa, hash = this.hash(), lastIx = eddsa.encodingLength - 1, a = hash.slice(0, eddsa.encodingLength);
       return a[0] &= 248, a[lastIx] &= 127, a[lastIx] |= 64, a;
     });
-    cachedProperty(KeyPair, "priv", function priv() {
+    cachedProperty(KeyPair, "priv", function() {
       return this.eddsa.decodeInt(this.privBytes());
     });
-    cachedProperty(KeyPair, "hash", function hash() {
+    cachedProperty(KeyPair, "hash", function() {
       return this.eddsa.hash().update(this.secret()).digest();
     });
-    cachedProperty(KeyPair, "messagePrefix", function messagePrefix() {
+    cachedProperty(KeyPair, "messagePrefix", function() {
       return this.hash().slice(this.eddsa.encodingLength);
     });
-    KeyPair.prototype.sign = function sign(message) {
+    KeyPair.prototype.sign = function(message) {
       return assert(this._secret, "KeyPair can only verify"), this.eddsa.sign(message, this);
     };
-    KeyPair.prototype.verify = function verify(message, sig) {
+    KeyPair.prototype.verify = function(message, sig) {
       return this.eddsa.verify(message, sig, this);
     };
-    KeyPair.prototype.getSecret = function getSecret(enc) {
+    KeyPair.prototype.getSecret = function(enc) {
       return assert(this._secret, "KeyPair is public only"), utils.encode(this.secret(), enc);
     };
-    KeyPair.prototype.getPublic = function getPublic(enc) {
+    KeyPair.prototype.getPublic = function(enc) {
       return utils.encode(this.pubBytes(), enc);
     };
     module.exports = KeyPair;
@@ -9980,22 +10676,22 @@ var init_crypto = __esm(() => {
         this._S = sig.S;
       this._Rencoded = Array.isArray(sig.R) ? sig.R : sig.Rencoded, this._Sencoded = Array.isArray(sig.S) ? sig.S : sig.Sencoded;
     }
-    cachedProperty(Signature, "S", function S() {
+    cachedProperty(Signature, "S", function() {
       return this.eddsa.decodeInt(this.Sencoded());
     });
-    cachedProperty(Signature, "R", function R() {
+    cachedProperty(Signature, "R", function() {
       return this.eddsa.decodePoint(this.Rencoded());
     });
-    cachedProperty(Signature, "Rencoded", function Rencoded() {
+    cachedProperty(Signature, "Rencoded", function() {
       return this.eddsa.encodePoint(this.R());
     });
-    cachedProperty(Signature, "Sencoded", function Sencoded() {
+    cachedProperty(Signature, "Sencoded", function() {
       return this.eddsa.encodeInt(this.S());
     });
-    Signature.prototype.toBytes = function toBytes() {
+    Signature.prototype.toBytes = function() {
       return this.Rencoded().concat(this.Sencoded());
     };
-    Signature.prototype.toHex = function toHex() {
+    Signature.prototype.toHex = function() {
       return utils.encode(this.toBytes(), "hex").toUpperCase();
     };
     module.exports = Signature;
@@ -10008,50 +10704,50 @@ var init_crypto = __esm(() => {
       curve = curves[curve].curve, this.curve = curve, this.g = curve.g, this.g.precompute(curve.n.bitLength() + 1), this.pointClass = curve.point().constructor, this.encodingLength = Math.ceil(curve.n.bitLength() / 8), this.hash = hash.sha512;
     }
     module.exports = EDDSA;
-    EDDSA.prototype.sign = function sign(message, secret) {
+    EDDSA.prototype.sign = function(message, secret) {
       message = parseBytes(message);
       var key = this.keyFromSecret(secret), r = this.hashInt(key.messagePrefix(), message), R = this.g.mul(r), Rencoded = this.encodePoint(R), s_ = this.hashInt(Rencoded, key.pubBytes(), message).mul(key.priv()), S = r.add(s_).umod(this.curve.n);
       return this.makeSignature({ R, S, Rencoded });
     };
-    EDDSA.prototype.verify = function verify(message, sig, pub) {
+    EDDSA.prototype.verify = function(message, sig, pub) {
       if (message = parseBytes(message), sig = this.makeSignature(sig), sig.S().gte(sig.eddsa.curve.n) || sig.S().isNeg())
         return false;
       var key = this.keyFromPublic(pub), h = this.hashInt(sig.Rencoded(), key.pubBytes(), message), SG = this.g.mul(sig.S()), RplusAh = sig.R().add(key.pub().mul(h));
       return RplusAh.eq(SG);
     };
-    EDDSA.prototype.hashInt = function hashInt() {
+    EDDSA.prototype.hashInt = function() {
       var hash2 = this.hash();
       for (var i2 = 0;i2 < arguments.length; i2++)
         hash2.update(arguments[i2]);
       return utils.intFromLE(hash2.digest()).umod(this.curve.n);
     };
-    EDDSA.prototype.keyFromPublic = function keyFromPublic(pub) {
+    EDDSA.prototype.keyFromPublic = function(pub) {
       return KeyPair.fromPublic(this, pub);
     };
-    EDDSA.prototype.keyFromSecret = function keyFromSecret(secret) {
+    EDDSA.prototype.keyFromSecret = function(secret) {
       return KeyPair.fromSecret(this, secret);
     };
-    EDDSA.prototype.makeSignature = function makeSignature(sig) {
+    EDDSA.prototype.makeSignature = function(sig) {
       if (sig instanceof Signature)
         return sig;
       return new Signature(this, sig);
     };
-    EDDSA.prototype.encodePoint = function encodePoint(point) {
+    EDDSA.prototype.encodePoint = function(point) {
       var enc = point.getY().toArray("le", this.encodingLength);
       return enc[this.encodingLength - 1] |= point.getX().isOdd() ? 128 : 0, enc;
     };
-    EDDSA.prototype.decodePoint = function decodePoint(bytes) {
+    EDDSA.prototype.decodePoint = function(bytes) {
       bytes = utils.parseBytes(bytes);
       var lastIx = bytes.length - 1, normed = bytes.slice(0, lastIx).concat(bytes[lastIx] & -129), xIsOdd = (bytes[lastIx] & 128) !== 0, y = utils.intFromLE(normed);
       return this.curve.pointFromY(y, xIsOdd);
     };
-    EDDSA.prototype.encodeInt = function encodeInt(num) {
+    EDDSA.prototype.encodeInt = function(num) {
       return num.toArray("le", this.encodingLength);
     };
-    EDDSA.prototype.decodeInt = function decodeInt(bytes) {
+    EDDSA.prototype.decodeInt = function(bytes) {
       return utils.intFromLE(bytes);
     };
-    EDDSA.prototype.isPoint = function isPoint(val) {
+    EDDSA.prototype.isPoint = function(val) {
       return val instanceof this.pointClass;
     };
   });
@@ -10069,7 +10765,7 @@ var init_crypto = __esm(() => {
     (function(module2, exports2) {
       function assert(val, msg) {
         if (!val)
-          throw new Error(msg || "Assertion failed");
+          throw Error(msg || "Assertion failed");
       }
       function inherits2(ctor, superCtor) {
         ctor.super_ = superCtor;
@@ -10092,24 +10788,24 @@ var init_crypto = __esm(() => {
       BN.BN = BN, BN.wordSize = 26;
       var Buffer22;
       try {
-        if (typeof window !== "undefined" && typeof window.Buffer !== "undefined")
+        if (typeof window < "u" && typeof window.Buffer < "u")
           Buffer22 = window.Buffer;
         else
-          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
       } catch (e) {}
-      BN.isBN = function isBN(num) {
+      BN.isBN = function(num) {
         if (num instanceof BN)
           return true;
         return num !== null && typeof num === "object" && num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
-      }, BN.max = function max(left, right) {
+      }, BN.max = function(left, right) {
         if (left.cmp(right) > 0)
           return left;
         return right;
-      }, BN.min = function min(left, right) {
+      }, BN.min = function(left, right) {
         if (left.cmp(right) < 0)
           return left;
         return right;
-      }, BN.prototype._init = function init(number, base, endian) {
+      }, BN.prototype._init = function(number, base, endian) {
         if (typeof number === "number")
           return this._initNumber(number, base, endian);
         if (typeof number === "object")
@@ -10126,7 +10822,7 @@ var init_crypto = __esm(() => {
           else if (this._parseBase(number, base, start), endian === "le")
             this._initArray(this.toArray(), base, endian);
         }
-      }, BN.prototype._initNumber = function _initNumber(number, base, endian) {
+      }, BN.prototype._initNumber = function(number, base, endian) {
         if (number < 0)
           this.negative = 1, number = -number;
         if (number < 67108864)
@@ -10138,10 +10834,10 @@ var init_crypto = __esm(() => {
         if (endian !== "le")
           return;
         this._initArray(this.toArray(), base, endian);
-      }, BN.prototype._initArray = function _initArray(number, base, endian) {
+      }, BN.prototype._initArray = function(number, base, endian) {
         if (assert(typeof number.length === "number"), number.length <= 0)
           return this.words = [0], this.length = 1, this;
-        this.length = Math.ceil(number.length / 3), this.words = new Array(this.length);
+        this.length = Math.ceil(number.length / 3), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var j, w, off = 0;
@@ -10171,8 +10867,8 @@ var init_crypto = __esm(() => {
           r |= parseHex4Bits(string, index - 1) << 4;
         return r;
       }
-      BN.prototype._parseHex = function _parseHex(number, start, endian) {
-        this.length = Math.ceil((number.length - start) / 6), this.words = new Array(this.length);
+      BN.prototype._parseHex = function(number, start, endian) {
+        this.length = Math.ceil((number.length - start) / 6), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var off = 0, j = 0, w;
@@ -10205,7 +10901,7 @@ var init_crypto = __esm(() => {
         }
         return r;
       }
-      BN.prototype._parseBase = function _parseBase(number, base, start) {
+      BN.prototype._parseBase = function(number, base, start) {
         this.words = [0], this.length = 1;
         for (var limbLen = 0, limbPow = 1;limbPow <= 67108863; limbPow *= base)
           limbLen++;
@@ -10227,31 +10923,31 @@ var init_crypto = __esm(() => {
             this._iaddn(word);
         }
         this.strip();
-      }, BN.prototype.copy = function copy(dest) {
-        dest.words = new Array(this.length);
+      }, BN.prototype.copy = function(dest) {
+        dest.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           dest.words[i2] = this.words[i2];
         dest.length = this.length, dest.negative = this.negative, dest.red = this.red;
-      }, BN.prototype.clone = function clone() {
+      }, BN.prototype.clone = function() {
         var r = new BN(null);
         return this.copy(r), r;
-      }, BN.prototype._expand = function _expand(size) {
+      }, BN.prototype._expand = function(size) {
         while (this.length < size)
           this.words[this.length++] = 0;
         return this;
-      }, BN.prototype.strip = function strip() {
+      }, BN.prototype.strip = function() {
         while (this.length > 1 && this.words[this.length - 1] === 0)
           this.length--;
         return this._normSign();
-      }, BN.prototype._normSign = function _normSign() {
+      }, BN.prototype._normSign = function() {
         if (this.length === 1 && this.words[0] === 0)
           this.negative = 0;
         return this;
-      }, BN.prototype.inspect = function inspect() {
+      }, BN.prototype.inspect = function() {
         return (this.red ? "<BN-R: " : "<BN: ") + this.toString(16) + ">";
       };
       var zeros = ["", "0", "00", "000", "0000", "00000", "000000", "0000000", "00000000", "000000000", "0000000000", "00000000000", "000000000000", "0000000000000", "00000000000000", "000000000000000", "0000000000000000", "00000000000000000", "000000000000000000", "0000000000000000000", "00000000000000000000", "000000000000000000000", "0000000000000000000000", "00000000000000000000000", "000000000000000000000000", "0000000000000000000000000"], groupSizes = [0, 0, 25, 16, 12, 11, 10, 9, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], groupBases = [0, 0, 33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216, 43046721, 1e7, 19487171, 35831808, 62748517, 7529536, 11390625, 16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632, 6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149, 24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176];
-      if (BN.prototype.toString = function toString(base, padding) {
+      if (BN.prototype.toString = function(base, padding) {
         base = base || 10, padding = padding | 0 || 1;
         var out;
         if (base === 16 || base === "hex") {
@@ -10295,7 +10991,7 @@ var init_crypto = __esm(() => {
           return out;
         }
         assert(false, "Base should be between 2 and 36");
-      }, BN.prototype.toNumber = function toNumber() {
+      }, BN.prototype.toNumber = function() {
         var ret = this.words[0];
         if (this.length === 2)
           ret += this.words[1] * 67108864;
@@ -10304,13 +11000,13 @@ var init_crypto = __esm(() => {
         else if (this.length > 2)
           assert(false, "Number can only safely store up to 53 bits");
         return this.negative !== 0 ? -ret : ret;
-      }, BN.prototype.toJSON = function toJSON() {
+      }, BN.prototype.toJSON = function() {
         return this.toString(16);
-      }, BN.prototype.toBuffer = function toBuffer(endian, length) {
-        return assert(typeof Buffer22 !== "undefined"), this.toArrayLike(Buffer22, endian, length);
-      }, BN.prototype.toArray = function toArray(endian, length) {
+      }, BN.prototype.toBuffer = function(endian, length) {
+        return assert(typeof Buffer22 < "u"), this.toArrayLike(Buffer22, endian, length);
+      }, BN.prototype.toArray = function(endian, length) {
         return this.toArrayLike(Array, endian, length);
-      }, BN.prototype.toArrayLike = function toArrayLike(ArrayType, endian, length) {
+      }, BN.prototype.toArrayLike = function(ArrayType, endian, length) {
         var byteLength2 = this.byteLength(), reqLength = length || Math.max(1, byteLength2);
         assert(byteLength2 <= reqLength, "byte array longer than desired length"), assert(reqLength > 0, "Requested array length <= 0"), this.strip();
         var littleEndian = endian === "le", res = new ArrayType(reqLength), b, i2, q = this.clone();
@@ -10327,11 +11023,11 @@ var init_crypto = __esm(() => {
         }
         return res;
       }, Math.clz32)
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           return 32 - Math.clz32(w);
         };
       else
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           var t = w, r = 0;
           if (t >= 4096)
             r += 13, t >>>= 13;
@@ -10343,7 +11039,7 @@ var init_crypto = __esm(() => {
             r += 2, t >>>= 2;
           return r + t;
         };
-      BN.prototype._zeroBits = function _zeroBits(w) {
+      BN.prototype._zeroBits = function(w) {
         if (w === 0)
           return 26;
         var t = w, r = 0;
@@ -10358,19 +11054,19 @@ var init_crypto = __esm(() => {
         if ((t & 1) === 0)
           r++;
         return r;
-      }, BN.prototype.bitLength = function bitLength() {
+      }, BN.prototype.bitLength = function() {
         var w = this.words[this.length - 1], hi = this._countBits(w);
         return (this.length - 1) * 26 + hi;
       };
       function toBitArray(num) {
-        var w = new Array(num.bitLength());
+        var w = Array(num.bitLength());
         for (var bit = 0;bit < w.length; bit++) {
           var off = bit / 26 | 0, wbit = bit % 26;
           w[bit] = (num.words[off] & 1 << wbit) >>> wbit;
         }
         return w;
       }
-      BN.prototype.zeroBits = function zeroBits() {
+      BN.prototype.zeroBits = function() {
         if (this.isZero())
           return 0;
         var r = 0;
@@ -10380,41 +11076,41 @@ var init_crypto = __esm(() => {
             break;
         }
         return r;
-      }, BN.prototype.byteLength = function byteLength() {
+      }, BN.prototype.byteLength = function() {
         return Math.ceil(this.bitLength() / 8);
-      }, BN.prototype.toTwos = function toTwos(width) {
+      }, BN.prototype.toTwos = function(width) {
         if (this.negative !== 0)
           return this.abs().inotn(width).iaddn(1);
         return this.clone();
-      }, BN.prototype.fromTwos = function fromTwos(width) {
+      }, BN.prototype.fromTwos = function(width) {
         if (this.testn(width - 1))
           return this.notn(width).iaddn(1).ineg();
         return this.clone();
-      }, BN.prototype.isNeg = function isNeg() {
+      }, BN.prototype.isNeg = function() {
         return this.negative !== 0;
-      }, BN.prototype.neg = function neg() {
+      }, BN.prototype.neg = function() {
         return this.clone().ineg();
-      }, BN.prototype.ineg = function ineg() {
+      }, BN.prototype.ineg = function() {
         if (!this.isZero())
           this.negative ^= 1;
         return this;
-      }, BN.prototype.iuor = function iuor(num) {
+      }, BN.prototype.iuor = function(num) {
         while (this.length < num.length)
           this.words[this.length++] = 0;
         for (var i2 = 0;i2 < num.length; i2++)
           this.words[i2] = this.words[i2] | num.words[i2];
         return this.strip();
-      }, BN.prototype.ior = function ior(num) {
+      }, BN.prototype.ior = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuor(num);
-      }, BN.prototype.or = function or(num) {
+      }, BN.prototype.or = function(num) {
         if (this.length > num.length)
           return this.clone().ior(num);
         return num.clone().ior(this);
-      }, BN.prototype.uor = function uor(num) {
+      }, BN.prototype.uor = function(num) {
         if (this.length > num.length)
           return this.clone().iuor(num);
         return num.clone().iuor(this);
-      }, BN.prototype.iuand = function iuand(num) {
+      }, BN.prototype.iuand = function(num) {
         var b;
         if (this.length > num.length)
           b = num;
@@ -10423,17 +11119,17 @@ var init_crypto = __esm(() => {
         for (var i2 = 0;i2 < b.length; i2++)
           this.words[i2] = this.words[i2] & num.words[i2];
         return this.length = b.length, this.strip();
-      }, BN.prototype.iand = function iand(num) {
+      }, BN.prototype.iand = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuand(num);
-      }, BN.prototype.and = function and(num) {
+      }, BN.prototype.and = function(num) {
         if (this.length > num.length)
           return this.clone().iand(num);
         return num.clone().iand(this);
-      }, BN.prototype.uand = function uand(num) {
+      }, BN.prototype.uand = function(num) {
         if (this.length > num.length)
           return this.clone().iuand(num);
         return num.clone().iuand(this);
-      }, BN.prototype.iuxor = function iuxor(num) {
+      }, BN.prototype.iuxor = function(num) {
         var a, b;
         if (this.length > num.length)
           a = this, b = num;
@@ -10445,17 +11141,17 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this.length = a.length, this.strip();
-      }, BN.prototype.ixor = function ixor(num) {
+      }, BN.prototype.ixor = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuxor(num);
-      }, BN.prototype.xor = function xor(num) {
+      }, BN.prototype.xor = function(num) {
         if (this.length > num.length)
           return this.clone().ixor(num);
         return num.clone().ixor(this);
-      }, BN.prototype.uxor = function uxor(num) {
+      }, BN.prototype.uxor = function(num) {
         if (this.length > num.length)
           return this.clone().iuxor(num);
         return num.clone().iuxor(this);
-      }, BN.prototype.inotn = function inotn(width) {
+      }, BN.prototype.inotn = function(width) {
         assert(typeof width === "number" && width >= 0);
         var bytesNeeded = Math.ceil(width / 26) | 0, bitsLeft = width % 26;
         if (this._expand(bytesNeeded), bitsLeft > 0)
@@ -10465,9 +11161,9 @@ var init_crypto = __esm(() => {
         if (bitsLeft > 0)
           this.words[i2] = ~this.words[i2] & 67108863 >> 26 - bitsLeft;
         return this.strip();
-      }, BN.prototype.notn = function notn(width) {
+      }, BN.prototype.notn = function(width) {
         return this.clone().inotn(width);
-      }, BN.prototype.setn = function setn(bit, val) {
+      }, BN.prototype.setn = function(bit, val) {
         assert(typeof bit === "number" && bit >= 0);
         var off = bit / 26 | 0, wbit = bit % 26;
         if (this._expand(off + 1), val)
@@ -10475,7 +11171,7 @@ var init_crypto = __esm(() => {
         else
           this.words[off] = this.words[off] & ~(1 << wbit);
         return this.strip();
-      }, BN.prototype.iadd = function iadd(num) {
+      }, BN.prototype.iadd = function(num) {
         var r;
         if (this.negative !== 0 && num.negative === 0)
           return this.negative = 0, r = this.isub(num), this.negative ^= 1, this._normSign();
@@ -10497,7 +11193,7 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this;
-      }, BN.prototype.add = function add(num) {
+      }, BN.prototype.add = function(num) {
         var res;
         if (num.negative !== 0 && this.negative === 0)
           return num.negative = 0, res = this.sub(num), num.negative ^= 1, res;
@@ -10506,7 +11202,7 @@ var init_crypto = __esm(() => {
         if (this.length > num.length)
           return this.clone().iadd(num);
         return num.clone().iadd(this);
-      }, BN.prototype.isub = function isub(num) {
+      }, BN.prototype.isub = function(num) {
         if (num.negative !== 0) {
           num.negative = 0;
           var r = this.iadd(num);
@@ -10532,7 +11228,7 @@ var init_crypto = __esm(() => {
         if (this.length = Math.max(this.length, i2), a !== this)
           this.negative = 1;
         return this.strip();
-      }, BN.prototype.sub = function sub(num) {
+      }, BN.prototype.sub = function(num) {
         return this.clone().isub(num);
       };
       function smallMulTo(self2, num, out) {
@@ -10555,7 +11251,7 @@ var init_crypto = __esm(() => {
           out.length--;
         return out.strip();
       }
-      var comb10MulTo = function comb10MulTo(self2, num, out) {
+      var comb10MulTo = function(self2, num, out) {
         var a = self2.words, b = num.words, o = out.words, c = 0, lo, mid, hi, a0 = a[0] | 0, al0 = a0 & 8191, ah0 = a0 >>> 13, a1 = a[1] | 0, al1 = a1 & 8191, ah1 = a1 >>> 13, a2 = a[2] | 0, al2 = a2 & 8191, ah2 = a2 >>> 13, a3 = a[3] | 0, al3 = a3 & 8191, ah3 = a3 >>> 13, a4 = a[4] | 0, al4 = a4 & 8191, ah4 = a4 >>> 13, a5 = a[5] | 0, al5 = a5 & 8191, ah5 = a5 >>> 13, a6 = a[6] | 0, al6 = a6 & 8191, ah6 = a6 >>> 13, a7 = a[7] | 0, al7 = a7 & 8191, ah7 = a7 >>> 13, a8 = a[8] | 0, al8 = a8 & 8191, ah8 = a8 >>> 13, a9 = a[9] | 0, al9 = a9 & 8191, ah9 = a9 >>> 13, b0 = b[0] | 0, bl0 = b0 & 8191, bh0 = b0 >>> 13, b1 = b[1] | 0, bl1 = b1 & 8191, bh1 = b1 >>> 13, b2 = b[2] | 0, bl2 = b2 & 8191, bh2 = b2 >>> 13, b3 = b[3] | 0, bl3 = b3 & 8191, bh3 = b3 >>> 13, b4 = b[4] | 0, bl4 = b4 & 8191, bh4 = b4 >>> 13, b5 = b[5] | 0, bl5 = b5 & 8191, bh5 = b5 >>> 13, b6 = b[6] | 0, bl6 = b6 & 8191, bh6 = b6 >>> 13, b7 = b[7] | 0, bl7 = b7 & 8191, bh7 = b7 >>> 13, b8 = b[8] | 0, bl8 = b8 & 8191, bh8 = b8 >>> 13, b9 = b[9] | 0, bl9 = b9 & 8191, bh9 = b9 >>> 13;
         out.negative = self2.negative ^ num.negative, out.length = 19, lo = Math.imul(al0, bl0), mid = Math.imul(al0, bh0), mid = mid + Math.imul(ah0, bl0) | 0, hi = Math.imul(ah0, bh0);
         var w0 = (c + lo | 0) + ((mid & 8191) << 13) | 0;
@@ -10624,7 +11320,7 @@ var init_crypto = __esm(() => {
         var fftm = new FFTM;
         return fftm.mulp(self2, num, out);
       }
-      BN.prototype.mulTo = function mulTo(num, out) {
+      BN.prototype.mulTo = function(num, out) {
         var res, len2 = this.length + num.length;
         if (this.length === 10 && num.length === 10)
           res = comb10MulTo(this, num, out);
@@ -10639,22 +11335,22 @@ var init_crypto = __esm(() => {
       function FFTM(x, y) {
         this.x = x, this.y = y;
       }
-      FFTM.prototype.makeRBT = function makeRBT(N) {
-        var t = new Array(N), l = BN.prototype._countBits(N) - 1;
+      FFTM.prototype.makeRBT = function(N) {
+        var t = Array(N), l = BN.prototype._countBits(N) - 1;
         for (var i2 = 0;i2 < N; i2++)
           t[i2] = this.revBin(i2, l, N);
         return t;
-      }, FFTM.prototype.revBin = function revBin(x, l, N) {
+      }, FFTM.prototype.revBin = function(x, l, N) {
         if (x === 0 || x === N - 1)
           return x;
         var rb = 0;
         for (var i2 = 0;i2 < l; i2++)
           rb |= (x & 1) << l - i2 - 1, x >>= 1;
         return rb;
-      }, FFTM.prototype.permute = function permute(rbt, rws, iws, rtws, itws, N) {
+      }, FFTM.prototype.permute = function(rbt, rws, iws, rtws, itws, N) {
         for (var i2 = 0;i2 < N; i2++)
           rtws[i2] = rws[rbt[i2]], itws[i2] = iws[rbt[i2]];
-      }, FFTM.prototype.transform = function transform(rws, iws, rtws, itws, N, rbt) {
+      }, FFTM.prototype.transform = function(rws, iws, rtws, itws, N, rbt) {
         this.permute(rbt, rws, iws, rtws, itws, N);
         for (var s = 1;s < N; s <<= 1) {
           var l = s << 1, rtwdf = Math.cos(2 * Math.PI / l), itwdf = Math.sin(2 * Math.PI / l);
@@ -10667,19 +11363,19 @@ var init_crypto = __esm(() => {
             }
           }
         }
-      }, FFTM.prototype.guessLen13b = function guessLen13b(n, m) {
+      }, FFTM.prototype.guessLen13b = function(n, m) {
         var N = Math.max(m, n) | 1, odd = N & 1, i2 = 0;
         for (N = N / 2 | 0;N; N = N >>> 1)
           i2++;
         return 1 << i2 + 1 + odd;
-      }, FFTM.prototype.conjugate = function conjugate(rws, iws, N) {
+      }, FFTM.prototype.conjugate = function(rws, iws, N) {
         if (N <= 1)
           return;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var t = rws[i2];
           rws[i2] = rws[N - i2 - 1], rws[N - i2 - 1] = t, t = iws[i2], iws[i2] = -iws[N - i2 - 1], iws[N - i2 - 1] = -t;
         }
-      }, FFTM.prototype.normalize13b = function normalize13b(ws, N) {
+      }, FFTM.prototype.normalize13b = function(ws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var w = Math.round(ws[2 * i2 + 1] / N) * 8192 + Math.round(ws[2 * i2] / N) + carry;
@@ -10689,35 +11385,35 @@ var init_crypto = __esm(() => {
             carry = w / 67108864 | 0;
         }
         return ws;
-      }, FFTM.prototype.convert13b = function convert13b(ws, len2, rws, N) {
+      }, FFTM.prototype.convert13b = function(ws, len2, rws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < len2; i2++)
           carry = carry + (ws[i2] | 0), rws[2 * i2] = carry & 8191, carry = carry >>> 13, rws[2 * i2 + 1] = carry & 8191, carry = carry >>> 13;
         for (i2 = 2 * len2;i2 < N; ++i2)
           rws[i2] = 0;
         assert(carry === 0), assert((carry & -8192) === 0);
-      }, FFTM.prototype.stub = function stub(N) {
-        var ph = new Array(N);
+      }, FFTM.prototype.stub = function(N) {
+        var ph = Array(N);
         for (var i2 = 0;i2 < N; i2++)
           ph[i2] = 0;
         return ph;
-      }, FFTM.prototype.mulp = function mulp(x, y, out) {
-        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = new Array(N), rwst = new Array(N), iwst = new Array(N), nrws = new Array(N), nrwst = new Array(N), niwst = new Array(N), rmws = out.words;
+      }, FFTM.prototype.mulp = function(x, y, out) {
+        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = Array(N), rwst = Array(N), iwst = Array(N), nrws = Array(N), nrwst = Array(N), niwst = Array(N), rmws = out.words;
         rmws.length = N, this.convert13b(x.words, x.length, rws, N), this.convert13b(y.words, y.length, nrws, N), this.transform(rws, _, rwst, iwst, N, rbt), this.transform(nrws, _, nrwst, niwst, N, rbt);
         for (var i2 = 0;i2 < N; i2++) {
           var rx = rwst[i2] * nrwst[i2] - iwst[i2] * niwst[i2];
           iwst[i2] = rwst[i2] * niwst[i2] + iwst[i2] * nrwst[i2], rwst[i2] = rx;
         }
         return this.conjugate(rwst, iwst, N), this.transform(rwst, iwst, rmws, _, N, rbt), this.conjugate(rmws, _, N), this.normalize13b(rmws, N), out.negative = x.negative ^ y.negative, out.length = x.length + y.length, out.strip();
-      }, BN.prototype.mul = function mul(num) {
+      }, BN.prototype.mul = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), this.mulTo(num, out);
-      }, BN.prototype.mulf = function mulf(num) {
+        return out.words = Array(this.length + num.length), this.mulTo(num, out);
+      }, BN.prototype.mulf = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), jumboMulTo(this, num, out);
-      }, BN.prototype.imul = function imul(num) {
+        return out.words = Array(this.length + num.length), jumboMulTo(this, num, out);
+      }, BN.prototype.imul = function(num) {
         return this.clone().mulTo(num, this);
-      }, BN.prototype.imuln = function imuln(num) {
+      }, BN.prototype.imuln = function(num) {
         assert(typeof num === "number"), assert(num < 67108864);
         var carry = 0;
         for (var i2 = 0;i2 < this.length; i2++) {
@@ -10727,13 +11423,13 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this.length = num === 0 ? 1 : this.length, this;
-      }, BN.prototype.muln = function muln(num) {
+      }, BN.prototype.muln = function(num) {
         return this.clone().imuln(num);
-      }, BN.prototype.sqr = function sqr() {
+      }, BN.prototype.sqr = function() {
         return this.mul(this);
-      }, BN.prototype.isqr = function isqr() {
+      }, BN.prototype.isqr = function() {
         return this.imul(this.clone());
-      }, BN.prototype.pow = function pow(num) {
+      }, BN.prototype.pow = function(num) {
         var w = toBitArray(num);
         if (w.length === 0)
           return new BN(1);
@@ -10748,7 +11444,7 @@ var init_crypto = __esm(() => {
             res = res.mul(q);
           }
         return res;
-      }, BN.prototype.iushln = function iushln(bits) {
+      }, BN.prototype.iushln = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26, carryMask = 67108863 >>> 26 - r << 26 - r, i2;
         if (r !== 0) {
@@ -10768,9 +11464,9 @@ var init_crypto = __esm(() => {
           this.length += s;
         }
         return this.strip();
-      }, BN.prototype.ishln = function ishln(bits) {
+      }, BN.prototype.ishln = function(bits) {
         return assert(this.negative === 0), this.iushln(bits);
-      }, BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+      }, BN.prototype.iushrn = function(bits, hint, extended) {
         assert(typeof bits === "number" && bits >= 0);
         var h;
         if (hint)
@@ -10801,24 +11497,24 @@ var init_crypto = __esm(() => {
         if (this.length === 0)
           this.words[0] = 0, this.length = 1;
         return this.strip();
-      }, BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+      }, BN.prototype.ishrn = function(bits, hint, extended) {
         return assert(this.negative === 0), this.iushrn(bits, hint, extended);
-      }, BN.prototype.shln = function shln(bits) {
+      }, BN.prototype.shln = function(bits) {
         return this.clone().ishln(bits);
-      }, BN.prototype.ushln = function ushln(bits) {
+      }, BN.prototype.ushln = function(bits) {
         return this.clone().iushln(bits);
-      }, BN.prototype.shrn = function shrn(bits) {
+      }, BN.prototype.shrn = function(bits) {
         return this.clone().ishrn(bits);
-      }, BN.prototype.ushrn = function ushrn(bits) {
+      }, BN.prototype.ushrn = function(bits) {
         return this.clone().iushrn(bits);
-      }, BN.prototype.testn = function testn(bit) {
+      }, BN.prototype.testn = function(bit) {
         assert(typeof bit === "number" && bit >= 0);
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
           return false;
         var w = this.words[s];
         return !!(w & q);
-      }, BN.prototype.imaskn = function imaskn(bits) {
+      }, BN.prototype.imaskn = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26;
         if (assert(this.negative === 0, "imaskn works only with positive numbers"), this.length <= s)
@@ -10830,9 +11526,9 @@ var init_crypto = __esm(() => {
           this.words[this.length - 1] &= mask;
         }
         return this.strip();
-      }, BN.prototype.maskn = function maskn(bits) {
+      }, BN.prototype.maskn = function(bits) {
         return this.clone().imaskn(bits);
-      }, BN.prototype.iaddn = function iaddn(num) {
+      }, BN.prototype.iaddn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.isubn(-num);
         if (this.negative !== 0) {
@@ -10841,7 +11537,7 @@ var init_crypto = __esm(() => {
           return this.negative = 0, this.isubn(num), this.negative = 1, this;
         }
         return this._iaddn(num);
-      }, BN.prototype._iaddn = function _iaddn(num) {
+      }, BN.prototype._iaddn = function(num) {
         this.words[0] += num;
         for (var i2 = 0;i2 < this.length && this.words[i2] >= 67108864; i2++)
           if (this.words[i2] -= 67108864, i2 === this.length - 1)
@@ -10849,7 +11545,7 @@ var init_crypto = __esm(() => {
           else
             this.words[i2 + 1]++;
         return this.length = Math.max(this.length, i2 + 1), this;
-      }, BN.prototype.isubn = function isubn(num) {
+      }, BN.prototype.isubn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.iaddn(-num);
         if (this.negative !== 0)
@@ -10860,15 +11556,15 @@ var init_crypto = __esm(() => {
           for (var i2 = 0;i2 < this.length && this.words[i2] < 0; i2++)
             this.words[i2] += 67108864, this.words[i2 + 1] -= 1;
         return this.strip();
-      }, BN.prototype.addn = function addn(num) {
+      }, BN.prototype.addn = function(num) {
         return this.clone().iaddn(num);
-      }, BN.prototype.subn = function subn(num) {
+      }, BN.prototype.subn = function(num) {
         return this.clone().isubn(num);
-      }, BN.prototype.iabs = function iabs() {
+      }, BN.prototype.iabs = function() {
         return this.negative = 0, this;
-      }, BN.prototype.abs = function abs() {
+      }, BN.prototype.abs = function() {
         return this.clone().iabs();
-      }, BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+      }, BN.prototype._ishlnsubmul = function(num, mul, shift) {
         var len2 = num.length + shift, i2;
         this._expand(len2);
         var w, carry = 0;
@@ -10885,13 +11581,13 @@ var init_crypto = __esm(() => {
         for (i2 = 0;i2 < this.length; i2++)
           w = -(this.words[i2] | 0) + carry, carry = w >> 26, this.words[i2] = w & 67108863;
         return this.negative = 1, this.strip();
-      }, BN.prototype._wordDiv = function _wordDiv(num, mode) {
+      }, BN.prototype._wordDiv = function(num, mode) {
         var shift = this.length - num.length, a = this.clone(), b = num, bhi = b.words[b.length - 1] | 0, bhiBits = this._countBits(bhi);
         if (shift = 26 - bhiBits, shift !== 0)
           b = b.ushln(shift), a.iushln(shift), bhi = b.words[b.length - 1] | 0;
         var m = a.length - b.length, q;
         if (mode !== "mod") {
-          q = new BN(null), q.length = m + 1, q.words = new Array(q.length);
+          q = new BN(null), q.length = m + 1, q.words = Array(q.length);
           for (var i2 = 0;i2 < q.length; i2++)
             q.words[i2] = 0;
         }
@@ -10914,7 +11610,7 @@ var init_crypto = __esm(() => {
         if (a.strip(), mode !== "div" && shift !== 0)
           a.iushrn(shift);
         return { div: q || null, mod: a };
-      }, BN.prototype.divmod = function divmod(num, mode, positive) {
+      }, BN.prototype.divmod = function(num, mode, positive) {
         if (assert(!num.isZero()), this.isZero())
           return { div: new BN(0), mod: new BN(0) };
         var div, mod, res;
@@ -10949,13 +11645,13 @@ var init_crypto = __esm(() => {
           return { div: this.divn(num.words[0]), mod: new BN(this.modn(num.words[0])) };
         }
         return this._wordDiv(num, mode);
-      }, BN.prototype.div = function div(num) {
+      }, BN.prototype.div = function(num) {
         return this.divmod(num, "div", false).div;
-      }, BN.prototype.mod = function mod(num) {
+      }, BN.prototype.mod = function(num) {
         return this.divmod(num, "mod", false).mod;
-      }, BN.prototype.umod = function umod(num) {
+      }, BN.prototype.umod = function(num) {
         return this.divmod(num, "mod", true).mod;
-      }, BN.prototype.divRound = function divRound(num) {
+      }, BN.prototype.divRound = function(num) {
         var dm = this.divmod(num);
         if (dm.mod.isZero())
           return dm.div;
@@ -10963,13 +11659,13 @@ var init_crypto = __esm(() => {
         if (cmp < 0 || r2 === 1 && cmp === 0)
           return dm.div;
         return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
-      }, BN.prototype.modn = function modn(num) {
+      }, BN.prototype.modn = function(num) {
         assert(num <= 67108863);
         var p = 67108864 % num, acc = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--)
           acc = (p * acc + (this.words[i2] | 0)) % num;
         return acc;
-      }, BN.prototype.idivn = function idivn(num) {
+      }, BN.prototype.idivn = function(num) {
         assert(num <= 67108863);
         var carry = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--) {
@@ -10977,9 +11673,9 @@ var init_crypto = __esm(() => {
           this.words[i2] = w / num | 0, carry = w % num;
         }
         return this.strip();
-      }, BN.prototype.divn = function divn(num) {
+      }, BN.prototype.divn = function(num) {
         return this.clone().idivn(num);
-      }, BN.prototype.egcd = function egcd(p) {
+      }, BN.prototype.egcd = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var x = this, y = p.clone();
         if (x.negative !== 0)
@@ -11017,7 +11713,7 @@ var init_crypto = __esm(() => {
             y.isub(x), C.isub(A), D.isub(B);
         }
         return { a: C, b: D, gcd: y.iushln(g) };
-      }, BN.prototype._invmp = function _invmp(p) {
+      }, BN.prototype._invmp = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var a = this, b = p.clone();
         if (a.negative !== 0)
@@ -11059,7 +11755,7 @@ var init_crypto = __esm(() => {
         if (res.cmpn(0) < 0)
           res.iadd(p);
         return res;
-      }, BN.prototype.gcd = function gcd(num) {
+      }, BN.prototype.gcd = function(num) {
         if (this.isZero())
           return num.abs();
         if (num.isZero())
@@ -11082,15 +11778,15 @@ var init_crypto = __esm(() => {
           a.isub(b);
         } while (true);
         return b.iushln(shift);
-      }, BN.prototype.invm = function invm(num) {
+      }, BN.prototype.invm = function(num) {
         return this.egcd(num).a.umod(num);
-      }, BN.prototype.isEven = function isEven() {
+      }, BN.prototype.isEven = function() {
         return (this.words[0] & 1) === 0;
-      }, BN.prototype.isOdd = function isOdd() {
+      }, BN.prototype.isOdd = function() {
         return (this.words[0] & 1) === 1;
-      }, BN.prototype.andln = function andln(num) {
+      }, BN.prototype.andln = function(num) {
         return this.words[0] & num;
-      }, BN.prototype.bincn = function bincn(bit) {
+      }, BN.prototype.bincn = function(bit) {
         assert(typeof bit === "number");
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
@@ -11103,9 +11799,9 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this;
-      }, BN.prototype.isZero = function isZero() {
+      }, BN.prototype.isZero = function() {
         return this.length === 1 && this.words[0] === 0;
-      }, BN.prototype.cmpn = function cmpn(num) {
+      }, BN.prototype.cmpn = function(num) {
         var negative = num < 0;
         if (this.negative !== 0 && !negative)
           return -1;
@@ -11125,7 +11821,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.cmp = function cmp(num) {
+      }, BN.prototype.cmp = function(num) {
         if (this.negative !== 0 && num.negative === 0)
           return -1;
         if (this.negative === 0 && num.negative !== 0)
@@ -11134,7 +11830,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.ucmp = function ucmp(num) {
+      }, BN.prototype.ucmp = function(num) {
         if (this.length > num.length)
           return 1;
         if (this.length < num.length)
@@ -11151,71 +11847,71 @@ var init_crypto = __esm(() => {
           break;
         }
         return res;
-      }, BN.prototype.gtn = function gtn(num) {
+      }, BN.prototype.gtn = function(num) {
         return this.cmpn(num) === 1;
-      }, BN.prototype.gt = function gt(num) {
+      }, BN.prototype.gt = function(num) {
         return this.cmp(num) === 1;
-      }, BN.prototype.gten = function gten(num) {
+      }, BN.prototype.gten = function(num) {
         return this.cmpn(num) >= 0;
-      }, BN.prototype.gte = function gte(num) {
+      }, BN.prototype.gte = function(num) {
         return this.cmp(num) >= 0;
-      }, BN.prototype.ltn = function ltn(num) {
+      }, BN.prototype.ltn = function(num) {
         return this.cmpn(num) === -1;
-      }, BN.prototype.lt = function lt(num) {
+      }, BN.prototype.lt = function(num) {
         return this.cmp(num) === -1;
-      }, BN.prototype.lten = function lten(num) {
+      }, BN.prototype.lten = function(num) {
         return this.cmpn(num) <= 0;
-      }, BN.prototype.lte = function lte(num) {
+      }, BN.prototype.lte = function(num) {
         return this.cmp(num) <= 0;
-      }, BN.prototype.eqn = function eqn(num) {
+      }, BN.prototype.eqn = function(num) {
         return this.cmpn(num) === 0;
-      }, BN.prototype.eq = function eq(num) {
+      }, BN.prototype.eq = function(num) {
         return this.cmp(num) === 0;
-      }, BN.red = function red(num) {
+      }, BN.red = function(num) {
         return new Red(num);
-      }, BN.prototype.toRed = function toRed(ctx) {
+      }, BN.prototype.toRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), assert(this.negative === 0, "red works only with positives"), ctx.convertTo(this)._forceRed(ctx);
-      }, BN.prototype.fromRed = function fromRed() {
+      }, BN.prototype.fromRed = function() {
         return assert(this.red, "fromRed works only with numbers in reduction context"), this.red.convertFrom(this);
-      }, BN.prototype._forceRed = function _forceRed(ctx) {
+      }, BN.prototype._forceRed = function(ctx) {
         return this.red = ctx, this;
-      }, BN.prototype.forceRed = function forceRed(ctx) {
+      }, BN.prototype.forceRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), this._forceRed(ctx);
-      }, BN.prototype.redAdd = function redAdd(num) {
+      }, BN.prototype.redAdd = function(num) {
         return assert(this.red, "redAdd works only with red numbers"), this.red.add(this, num);
-      }, BN.prototype.redIAdd = function redIAdd(num) {
+      }, BN.prototype.redIAdd = function(num) {
         return assert(this.red, "redIAdd works only with red numbers"), this.red.iadd(this, num);
-      }, BN.prototype.redSub = function redSub(num) {
+      }, BN.prototype.redSub = function(num) {
         return assert(this.red, "redSub works only with red numbers"), this.red.sub(this, num);
-      }, BN.prototype.redISub = function redISub(num) {
+      }, BN.prototype.redISub = function(num) {
         return assert(this.red, "redISub works only with red numbers"), this.red.isub(this, num);
-      }, BN.prototype.redShl = function redShl(num) {
+      }, BN.prototype.redShl = function(num) {
         return assert(this.red, "redShl works only with red numbers"), this.red.shl(this, num);
-      }, BN.prototype.redMul = function redMul(num) {
+      }, BN.prototype.redMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.mul(this, num);
-      }, BN.prototype.redIMul = function redIMul(num) {
+      }, BN.prototype.redIMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.imul(this, num);
-      }, BN.prototype.redSqr = function redSqr() {
+      }, BN.prototype.redSqr = function() {
         return assert(this.red, "redSqr works only with red numbers"), this.red._verify1(this), this.red.sqr(this);
-      }, BN.prototype.redISqr = function redISqr() {
+      }, BN.prototype.redISqr = function() {
         return assert(this.red, "redISqr works only with red numbers"), this.red._verify1(this), this.red.isqr(this);
-      }, BN.prototype.redSqrt = function redSqrt() {
+      }, BN.prototype.redSqrt = function() {
         return assert(this.red, "redSqrt works only with red numbers"), this.red._verify1(this), this.red.sqrt(this);
-      }, BN.prototype.redInvm = function redInvm() {
+      }, BN.prototype.redInvm = function() {
         return assert(this.red, "redInvm works only with red numbers"), this.red._verify1(this), this.red.invm(this);
-      }, BN.prototype.redNeg = function redNeg() {
+      }, BN.prototype.redNeg = function() {
         return assert(this.red, "redNeg works only with red numbers"), this.red._verify1(this), this.red.neg(this);
-      }, BN.prototype.redPow = function redPow(num) {
+      }, BN.prototype.redPow = function(num) {
         return assert(this.red && !num.red, "redPow(normalNum)"), this.red._verify1(this), this.red.pow(this, num);
       };
       var primes = { k256: null, p224: null, p192: null, p25519: null };
       function MPrime(name, p) {
         this.name = name, this.p = new BN(p, 16), this.n = this.p.bitLength(), this.k = new BN(1).iushln(this.n).isub(this.p), this.tmp = this._tmp();
       }
-      MPrime.prototype._tmp = function _tmp() {
+      MPrime.prototype._tmp = function() {
         var tmp = new BN(null);
-        return tmp.words = new Array(Math.ceil(this.n / 13)), tmp;
-      }, MPrime.prototype.ireduce = function ireduce(num) {
+        return tmp.words = Array(Math.ceil(this.n / 13)), tmp;
+      }, MPrime.prototype.ireduce = function(num) {
         var r = num, rlen;
         do
           this.split(r, this.tmp), r = this.imulK(r), r = r.iadd(this.tmp), rlen = r.bitLength();
@@ -11230,15 +11926,15 @@ var init_crypto = __esm(() => {
         else
           r._strip();
         return r;
-      }, MPrime.prototype.split = function split(input, out) {
+      }, MPrime.prototype.split = function(input, out) {
         input.iushrn(this.n, 0, out);
-      }, MPrime.prototype.imulK = function imulK(num) {
+      }, MPrime.prototype.imulK = function(num) {
         return num.imul(this.k);
       };
       function K256() {
         MPrime.call(this, "k256", "ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f");
       }
-      inherits2(K256, MPrime), K256.prototype.split = function split(input, output) {
+      inherits2(K256, MPrime), K256.prototype.split = function(input, output) {
         var mask = 4194303, outLen = Math.min(input.length, 9);
         for (var i2 = 0;i2 < outLen; i2++)
           output.words[i2] = input.words[i2];
@@ -11256,7 +11952,7 @@ var init_crypto = __esm(() => {
           input.length -= 10;
         else
           input.length -= 9;
-      }, K256.prototype.imulK = function imulK(num) {
+      }, K256.prototype.imulK = function(num) {
         num.words[num.length] = 0, num.words[num.length + 1] = 0, num.length += 2;
         var lo = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
@@ -11280,7 +11976,7 @@ var init_crypto = __esm(() => {
       function P25519() {
         MPrime.call(this, "25519", "7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed");
       }
-      inherits2(P25519, MPrime), P25519.prototype.imulK = function imulK(num) {
+      inherits2(P25519, MPrime), P25519.prototype.imulK = function(num) {
         var carry = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
           var hi = (num.words[i2] | 0) * 19 + carry, lo = hi & 67108863;
@@ -11289,7 +11985,7 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           num.words[num.length++] = carry;
         return num;
-      }, BN._prime = function prime(name) {
+      }, BN._prime = function(name) {
         if (primes[name])
           return primes[name];
         var prime;
@@ -11302,7 +11998,7 @@ var init_crypto = __esm(() => {
         else if (name === "p25519")
           prime = new P25519;
         else
-          throw new Error("Unknown prime " + name);
+          throw Error("Unknown prime " + name);
         return primes[name] = prime, prime;
       };
       function Red(m) {
@@ -11312,53 +12008,53 @@ var init_crypto = __esm(() => {
         } else
           assert(m.gtn(1), "modulus must be greater than 1"), this.m = m, this.prime = null;
       }
-      Red.prototype._verify1 = function _verify1(a) {
+      Red.prototype._verify1 = function(a) {
         assert(a.negative === 0, "red works only with positives"), assert(a.red, "red works only with red numbers");
-      }, Red.prototype._verify2 = function _verify2(a, b) {
+      }, Red.prototype._verify2 = function(a, b) {
         assert((a.negative | b.negative) === 0, "red works only with positives"), assert(a.red && a.red === b.red, "red works only with red numbers");
-      }, Red.prototype.imod = function imod(a) {
+      }, Red.prototype.imod = function(a) {
         if (this.prime)
           return this.prime.ireduce(a)._forceRed(this);
         return a.umod(this.m)._forceRed(this);
-      }, Red.prototype.neg = function neg(a) {
+      }, Red.prototype.neg = function(a) {
         if (a.isZero())
           return a.clone();
         return this.m.sub(a)._forceRed(this);
-      }, Red.prototype.add = function add(a, b) {
+      }, Red.prototype.add = function(a, b) {
         this._verify2(a, b);
         var res = a.add(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res._forceRed(this);
-      }, Red.prototype.iadd = function iadd(a, b) {
+      }, Red.prototype.iadd = function(a, b) {
         this._verify2(a, b);
         var res = a.iadd(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res;
-      }, Red.prototype.sub = function sub(a, b) {
+      }, Red.prototype.sub = function(a, b) {
         this._verify2(a, b);
         var res = a.sub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res._forceRed(this);
-      }, Red.prototype.isub = function isub(a, b) {
+      }, Red.prototype.isub = function(a, b) {
         this._verify2(a, b);
         var res = a.isub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res;
-      }, Red.prototype.shl = function shl(a, num) {
+      }, Red.prototype.shl = function(a, num) {
         return this._verify1(a), this.imod(a.ushln(num));
-      }, Red.prototype.imul = function imul(a, b) {
+      }, Red.prototype.imul = function(a, b) {
         return this._verify2(a, b), this.imod(a.imul(b));
-      }, Red.prototype.mul = function mul(a, b) {
+      }, Red.prototype.mul = function(a, b) {
         return this._verify2(a, b), this.imod(a.mul(b));
-      }, Red.prototype.isqr = function isqr(a) {
+      }, Red.prototype.isqr = function(a) {
         return this.imul(a, a.clone());
-      }, Red.prototype.sqr = function sqr(a) {
+      }, Red.prototype.sqr = function(a) {
         return this.mul(a, a);
-      }, Red.prototype.sqrt = function sqrt(a) {
+      }, Red.prototype.sqrt = function(a) {
         if (a.isZero())
           return a.clone();
         var mod3 = this.m.andln(3);
@@ -11384,18 +12080,18 @@ var init_crypto = __esm(() => {
           r = r.redMul(b), c = b.redSqr(), t = t.redMul(c), m = i2;
         }
         return r;
-      }, Red.prototype.invm = function invm(a) {
+      }, Red.prototype.invm = function(a) {
         var inv = a._invmp(this.m);
         if (inv.negative !== 0)
           return inv.negative = 0, this.imod(inv).redNeg();
         else
           return this.imod(inv);
-      }, Red.prototype.pow = function pow(a, num) {
+      }, Red.prototype.pow = function(a, num) {
         if (num.isZero())
           return new BN(1).toRed(this);
         if (num.cmpn(1) === 0)
           return a.clone();
-        var windowSize = 4, wnd = new Array(1 << windowSize);
+        var windowSize = 4, wnd = Array(1 << windowSize);
         wnd[0] = new BN(1).toRed(this), wnd[1] = a;
         for (var i2 = 2;i2 < wnd.length; i2++)
           wnd[i2] = this.mul(wnd[i2 - 1], a);
@@ -11419,13 +12115,13 @@ var init_crypto = __esm(() => {
           start = 26;
         }
         return res;
-      }, Red.prototype.convertTo = function convertTo(num) {
+      }, Red.prototype.convertTo = function(num) {
         var r = num.umod(this.m);
         return r === num ? r.clone() : r;
-      }, Red.prototype.convertFrom = function convertFrom(num) {
+      }, Red.prototype.convertFrom = function(num) {
         var res = num.clone();
         return res.red = null, res;
-      }, BN.mont = function mont(num) {
+      }, BN.mont = function(num) {
         return new Mont(num);
       };
       function Mont(m) {
@@ -11433,12 +12129,12 @@ var init_crypto = __esm(() => {
           this.shift += 26 - this.shift % 26;
         this.r = new BN(1).iushln(this.shift), this.r2 = this.imod(this.r.sqr()), this.rinv = this.r._invmp(this.m), this.minv = this.rinv.mul(this.r).isubn(1).div(this.m), this.minv = this.minv.umod(this.r), this.minv = this.r.sub(this.minv);
       }
-      inherits2(Mont, Red), Mont.prototype.convertTo = function convertTo(num) {
+      inherits2(Mont, Red), Mont.prototype.convertTo = function(num) {
         return this.imod(num.ushln(this.shift));
-      }, Mont.prototype.convertFrom = function convertFrom(num) {
+      }, Mont.prototype.convertFrom = function(num) {
         var r = this.imod(num.mul(this.rinv));
         return r.red = null, r;
-      }, Mont.prototype.imul = function imul(a, b) {
+      }, Mont.prototype.imul = function(a, b) {
         if (a.isZero() || b.isZero())
           return a.words[0] = 0, a.length = 1, a;
         var t = a.imul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -11447,7 +12143,7 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.mul = function mul(a, b) {
+      }, Mont.prototype.mul = function(a, b) {
         if (a.isZero() || b.isZero())
           return new BN(0)._forceRed(this);
         var t = a.mul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -11456,15 +12152,15 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.invm = function invm(a) {
+      }, Mont.prototype.invm = function(a) {
         var res = this.imod(a._invmp(this.m).mul(this.r2));
         return res._forceRed(this);
       };
-    })(typeof module === "undefined" || module, exports);
+    })(typeof module > "u" || module, exports);
   });
   require_browser = __commonJS2((exports, module) => {
     var elliptic = require_elliptic(), BN = require_bn2();
-    module.exports = function createECDH(curve) {
+    module.exports = function(curve) {
       return new ECDH(curve);
     };
     var aliases = { secp256k1: { name: "secp256k1", byteLength: 32 }, secp224r1: { name: "p224", byteLength: 28 }, prime256v1: { name: "p256", byteLength: 32 }, prime192v1: { name: "p192", byteLength: 24 }, ed25519: { name: "ed25519", byteLength: 32 }, secp384r1: { name: "p384", byteLength: 48 }, secp521r1: { name: "p521", byteLength: 66 } };
@@ -11532,7 +12228,7 @@ var init_crypto = __esm(() => {
     (function(module2, exports2) {
       function assert(val, msg) {
         if (!val)
-          throw new Error(msg || "Assertion failed");
+          throw Error(msg || "Assertion failed");
       }
       function inherits2(ctor, superCtor) {
         ctor.super_ = superCtor;
@@ -11555,24 +12251,24 @@ var init_crypto = __esm(() => {
       BN.BN = BN, BN.wordSize = 26;
       var Buffer22;
       try {
-        if (typeof window !== "undefined" && typeof window.Buffer !== "undefined")
+        if (typeof window < "u" && typeof window.Buffer < "u")
           Buffer22 = window.Buffer;
         else
-          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
       } catch (e) {}
-      BN.isBN = function isBN(num) {
+      BN.isBN = function(num) {
         if (num instanceof BN)
           return true;
         return num !== null && typeof num === "object" && num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
-      }, BN.max = function max(left, right) {
+      }, BN.max = function(left, right) {
         if (left.cmp(right) > 0)
           return left;
         return right;
-      }, BN.min = function min(left, right) {
+      }, BN.min = function(left, right) {
         if (left.cmp(right) < 0)
           return left;
         return right;
-      }, BN.prototype._init = function init(number, base, endian) {
+      }, BN.prototype._init = function(number, base, endian) {
         if (typeof number === "number")
           return this._initNumber(number, base, endian);
         if (typeof number === "object")
@@ -11589,7 +12285,7 @@ var init_crypto = __esm(() => {
           else if (this._parseBase(number, base, start), endian === "le")
             this._initArray(this.toArray(), base, endian);
         }
-      }, BN.prototype._initNumber = function _initNumber(number, base, endian) {
+      }, BN.prototype._initNumber = function(number, base, endian) {
         if (number < 0)
           this.negative = 1, number = -number;
         if (number < 67108864)
@@ -11601,10 +12297,10 @@ var init_crypto = __esm(() => {
         if (endian !== "le")
           return;
         this._initArray(this.toArray(), base, endian);
-      }, BN.prototype._initArray = function _initArray(number, base, endian) {
+      }, BN.prototype._initArray = function(number, base, endian) {
         if (assert(typeof number.length === "number"), number.length <= 0)
           return this.words = [0], this.length = 1, this;
-        this.length = Math.ceil(number.length / 3), this.words = new Array(this.length);
+        this.length = Math.ceil(number.length / 3), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var j, w, off = 0;
@@ -11634,8 +12330,8 @@ var init_crypto = __esm(() => {
           r |= parseHex4Bits(string, index - 1) << 4;
         return r;
       }
-      BN.prototype._parseHex = function _parseHex(number, start, endian) {
-        this.length = Math.ceil((number.length - start) / 6), this.words = new Array(this.length);
+      BN.prototype._parseHex = function(number, start, endian) {
+        this.length = Math.ceil((number.length - start) / 6), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var off = 0, j = 0, w;
@@ -11668,7 +12364,7 @@ var init_crypto = __esm(() => {
         }
         return r;
       }
-      BN.prototype._parseBase = function _parseBase(number, base, start) {
+      BN.prototype._parseBase = function(number, base, start) {
         this.words = [0], this.length = 1;
         for (var limbLen = 0, limbPow = 1;limbPow <= 67108863; limbPow *= base)
           limbLen++;
@@ -11690,31 +12386,31 @@ var init_crypto = __esm(() => {
             this._iaddn(word);
         }
         this.strip();
-      }, BN.prototype.copy = function copy(dest) {
-        dest.words = new Array(this.length);
+      }, BN.prototype.copy = function(dest) {
+        dest.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           dest.words[i2] = this.words[i2];
         dest.length = this.length, dest.negative = this.negative, dest.red = this.red;
-      }, BN.prototype.clone = function clone() {
+      }, BN.prototype.clone = function() {
         var r = new BN(null);
         return this.copy(r), r;
-      }, BN.prototype._expand = function _expand(size) {
+      }, BN.prototype._expand = function(size) {
         while (this.length < size)
           this.words[this.length++] = 0;
         return this;
-      }, BN.prototype.strip = function strip() {
+      }, BN.prototype.strip = function() {
         while (this.length > 1 && this.words[this.length - 1] === 0)
           this.length--;
         return this._normSign();
-      }, BN.prototype._normSign = function _normSign() {
+      }, BN.prototype._normSign = function() {
         if (this.length === 1 && this.words[0] === 0)
           this.negative = 0;
         return this;
-      }, BN.prototype.inspect = function inspect() {
+      }, BN.prototype.inspect = function() {
         return (this.red ? "<BN-R: " : "<BN: ") + this.toString(16) + ">";
       };
       var zeros = ["", "0", "00", "000", "0000", "00000", "000000", "0000000", "00000000", "000000000", "0000000000", "00000000000", "000000000000", "0000000000000", "00000000000000", "000000000000000", "0000000000000000", "00000000000000000", "000000000000000000", "0000000000000000000", "00000000000000000000", "000000000000000000000", "0000000000000000000000", "00000000000000000000000", "000000000000000000000000", "0000000000000000000000000"], groupSizes = [0, 0, 25, 16, 12, 11, 10, 9, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], groupBases = [0, 0, 33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216, 43046721, 1e7, 19487171, 35831808, 62748517, 7529536, 11390625, 16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632, 6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149, 24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176];
-      if (BN.prototype.toString = function toString(base, padding) {
+      if (BN.prototype.toString = function(base, padding) {
         base = base || 10, padding = padding | 0 || 1;
         var out;
         if (base === 16 || base === "hex") {
@@ -11758,7 +12454,7 @@ var init_crypto = __esm(() => {
           return out;
         }
         assert(false, "Base should be between 2 and 36");
-      }, BN.prototype.toNumber = function toNumber() {
+      }, BN.prototype.toNumber = function() {
         var ret = this.words[0];
         if (this.length === 2)
           ret += this.words[1] * 67108864;
@@ -11767,13 +12463,13 @@ var init_crypto = __esm(() => {
         else if (this.length > 2)
           assert(false, "Number can only safely store up to 53 bits");
         return this.negative !== 0 ? -ret : ret;
-      }, BN.prototype.toJSON = function toJSON() {
+      }, BN.prototype.toJSON = function() {
         return this.toString(16);
-      }, BN.prototype.toBuffer = function toBuffer(endian, length) {
-        return assert(typeof Buffer22 !== "undefined"), this.toArrayLike(Buffer22, endian, length);
-      }, BN.prototype.toArray = function toArray(endian, length) {
+      }, BN.prototype.toBuffer = function(endian, length) {
+        return assert(typeof Buffer22 < "u"), this.toArrayLike(Buffer22, endian, length);
+      }, BN.prototype.toArray = function(endian, length) {
         return this.toArrayLike(Array, endian, length);
-      }, BN.prototype.toArrayLike = function toArrayLike(ArrayType, endian, length) {
+      }, BN.prototype.toArrayLike = function(ArrayType, endian, length) {
         var byteLength2 = this.byteLength(), reqLength = length || Math.max(1, byteLength2);
         assert(byteLength2 <= reqLength, "byte array longer than desired length"), assert(reqLength > 0, "Requested array length <= 0"), this.strip();
         var littleEndian = endian === "le", res = new ArrayType(reqLength), b, i2, q = this.clone();
@@ -11790,11 +12486,11 @@ var init_crypto = __esm(() => {
         }
         return res;
       }, Math.clz32)
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           return 32 - Math.clz32(w);
         };
       else
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           var t = w, r = 0;
           if (t >= 4096)
             r += 13, t >>>= 13;
@@ -11806,7 +12502,7 @@ var init_crypto = __esm(() => {
             r += 2, t >>>= 2;
           return r + t;
         };
-      BN.prototype._zeroBits = function _zeroBits(w) {
+      BN.prototype._zeroBits = function(w) {
         if (w === 0)
           return 26;
         var t = w, r = 0;
@@ -11821,19 +12517,19 @@ var init_crypto = __esm(() => {
         if ((t & 1) === 0)
           r++;
         return r;
-      }, BN.prototype.bitLength = function bitLength() {
+      }, BN.prototype.bitLength = function() {
         var w = this.words[this.length - 1], hi = this._countBits(w);
         return (this.length - 1) * 26 + hi;
       };
       function toBitArray(num) {
-        var w = new Array(num.bitLength());
+        var w = Array(num.bitLength());
         for (var bit = 0;bit < w.length; bit++) {
           var off = bit / 26 | 0, wbit = bit % 26;
           w[bit] = (num.words[off] & 1 << wbit) >>> wbit;
         }
         return w;
       }
-      BN.prototype.zeroBits = function zeroBits() {
+      BN.prototype.zeroBits = function() {
         if (this.isZero())
           return 0;
         var r = 0;
@@ -11843,41 +12539,41 @@ var init_crypto = __esm(() => {
             break;
         }
         return r;
-      }, BN.prototype.byteLength = function byteLength() {
+      }, BN.prototype.byteLength = function() {
         return Math.ceil(this.bitLength() / 8);
-      }, BN.prototype.toTwos = function toTwos(width) {
+      }, BN.prototype.toTwos = function(width) {
         if (this.negative !== 0)
           return this.abs().inotn(width).iaddn(1);
         return this.clone();
-      }, BN.prototype.fromTwos = function fromTwos(width) {
+      }, BN.prototype.fromTwos = function(width) {
         if (this.testn(width - 1))
           return this.notn(width).iaddn(1).ineg();
         return this.clone();
-      }, BN.prototype.isNeg = function isNeg() {
+      }, BN.prototype.isNeg = function() {
         return this.negative !== 0;
-      }, BN.prototype.neg = function neg() {
+      }, BN.prototype.neg = function() {
         return this.clone().ineg();
-      }, BN.prototype.ineg = function ineg() {
+      }, BN.prototype.ineg = function() {
         if (!this.isZero())
           this.negative ^= 1;
         return this;
-      }, BN.prototype.iuor = function iuor(num) {
+      }, BN.prototype.iuor = function(num) {
         while (this.length < num.length)
           this.words[this.length++] = 0;
         for (var i2 = 0;i2 < num.length; i2++)
           this.words[i2] = this.words[i2] | num.words[i2];
         return this.strip();
-      }, BN.prototype.ior = function ior(num) {
+      }, BN.prototype.ior = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuor(num);
-      }, BN.prototype.or = function or(num) {
+      }, BN.prototype.or = function(num) {
         if (this.length > num.length)
           return this.clone().ior(num);
         return num.clone().ior(this);
-      }, BN.prototype.uor = function uor(num) {
+      }, BN.prototype.uor = function(num) {
         if (this.length > num.length)
           return this.clone().iuor(num);
         return num.clone().iuor(this);
-      }, BN.prototype.iuand = function iuand(num) {
+      }, BN.prototype.iuand = function(num) {
         var b;
         if (this.length > num.length)
           b = num;
@@ -11886,17 +12582,17 @@ var init_crypto = __esm(() => {
         for (var i2 = 0;i2 < b.length; i2++)
           this.words[i2] = this.words[i2] & num.words[i2];
         return this.length = b.length, this.strip();
-      }, BN.prototype.iand = function iand(num) {
+      }, BN.prototype.iand = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuand(num);
-      }, BN.prototype.and = function and(num) {
+      }, BN.prototype.and = function(num) {
         if (this.length > num.length)
           return this.clone().iand(num);
         return num.clone().iand(this);
-      }, BN.prototype.uand = function uand(num) {
+      }, BN.prototype.uand = function(num) {
         if (this.length > num.length)
           return this.clone().iuand(num);
         return num.clone().iuand(this);
-      }, BN.prototype.iuxor = function iuxor(num) {
+      }, BN.prototype.iuxor = function(num) {
         var a, b;
         if (this.length > num.length)
           a = this, b = num;
@@ -11908,17 +12604,17 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this.length = a.length, this.strip();
-      }, BN.prototype.ixor = function ixor(num) {
+      }, BN.prototype.ixor = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuxor(num);
-      }, BN.prototype.xor = function xor(num) {
+      }, BN.prototype.xor = function(num) {
         if (this.length > num.length)
           return this.clone().ixor(num);
         return num.clone().ixor(this);
-      }, BN.prototype.uxor = function uxor(num) {
+      }, BN.prototype.uxor = function(num) {
         if (this.length > num.length)
           return this.clone().iuxor(num);
         return num.clone().iuxor(this);
-      }, BN.prototype.inotn = function inotn(width) {
+      }, BN.prototype.inotn = function(width) {
         assert(typeof width === "number" && width >= 0);
         var bytesNeeded = Math.ceil(width / 26) | 0, bitsLeft = width % 26;
         if (this._expand(bytesNeeded), bitsLeft > 0)
@@ -11928,9 +12624,9 @@ var init_crypto = __esm(() => {
         if (bitsLeft > 0)
           this.words[i2] = ~this.words[i2] & 67108863 >> 26 - bitsLeft;
         return this.strip();
-      }, BN.prototype.notn = function notn(width) {
+      }, BN.prototype.notn = function(width) {
         return this.clone().inotn(width);
-      }, BN.prototype.setn = function setn(bit, val) {
+      }, BN.prototype.setn = function(bit, val) {
         assert(typeof bit === "number" && bit >= 0);
         var off = bit / 26 | 0, wbit = bit % 26;
         if (this._expand(off + 1), val)
@@ -11938,7 +12634,7 @@ var init_crypto = __esm(() => {
         else
           this.words[off] = this.words[off] & ~(1 << wbit);
         return this.strip();
-      }, BN.prototype.iadd = function iadd(num) {
+      }, BN.prototype.iadd = function(num) {
         var r;
         if (this.negative !== 0 && num.negative === 0)
           return this.negative = 0, r = this.isub(num), this.negative ^= 1, this._normSign();
@@ -11960,7 +12656,7 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this;
-      }, BN.prototype.add = function add(num) {
+      }, BN.prototype.add = function(num) {
         var res;
         if (num.negative !== 0 && this.negative === 0)
           return num.negative = 0, res = this.sub(num), num.negative ^= 1, res;
@@ -11969,7 +12665,7 @@ var init_crypto = __esm(() => {
         if (this.length > num.length)
           return this.clone().iadd(num);
         return num.clone().iadd(this);
-      }, BN.prototype.isub = function isub(num) {
+      }, BN.prototype.isub = function(num) {
         if (num.negative !== 0) {
           num.negative = 0;
           var r = this.iadd(num);
@@ -11995,7 +12691,7 @@ var init_crypto = __esm(() => {
         if (this.length = Math.max(this.length, i2), a !== this)
           this.negative = 1;
         return this.strip();
-      }, BN.prototype.sub = function sub(num) {
+      }, BN.prototype.sub = function(num) {
         return this.clone().isub(num);
       };
       function smallMulTo(self2, num, out) {
@@ -12018,7 +12714,7 @@ var init_crypto = __esm(() => {
           out.length--;
         return out.strip();
       }
-      var comb10MulTo = function comb10MulTo(self2, num, out) {
+      var comb10MulTo = function(self2, num, out) {
         var a = self2.words, b = num.words, o = out.words, c = 0, lo, mid, hi, a0 = a[0] | 0, al0 = a0 & 8191, ah0 = a0 >>> 13, a1 = a[1] | 0, al1 = a1 & 8191, ah1 = a1 >>> 13, a2 = a[2] | 0, al2 = a2 & 8191, ah2 = a2 >>> 13, a3 = a[3] | 0, al3 = a3 & 8191, ah3 = a3 >>> 13, a4 = a[4] | 0, al4 = a4 & 8191, ah4 = a4 >>> 13, a5 = a[5] | 0, al5 = a5 & 8191, ah5 = a5 >>> 13, a6 = a[6] | 0, al6 = a6 & 8191, ah6 = a6 >>> 13, a7 = a[7] | 0, al7 = a7 & 8191, ah7 = a7 >>> 13, a8 = a[8] | 0, al8 = a8 & 8191, ah8 = a8 >>> 13, a9 = a[9] | 0, al9 = a9 & 8191, ah9 = a9 >>> 13, b0 = b[0] | 0, bl0 = b0 & 8191, bh0 = b0 >>> 13, b1 = b[1] | 0, bl1 = b1 & 8191, bh1 = b1 >>> 13, b2 = b[2] | 0, bl2 = b2 & 8191, bh2 = b2 >>> 13, b3 = b[3] | 0, bl3 = b3 & 8191, bh3 = b3 >>> 13, b4 = b[4] | 0, bl4 = b4 & 8191, bh4 = b4 >>> 13, b5 = b[5] | 0, bl5 = b5 & 8191, bh5 = b5 >>> 13, b6 = b[6] | 0, bl6 = b6 & 8191, bh6 = b6 >>> 13, b7 = b[7] | 0, bl7 = b7 & 8191, bh7 = b7 >>> 13, b8 = b[8] | 0, bl8 = b8 & 8191, bh8 = b8 >>> 13, b9 = b[9] | 0, bl9 = b9 & 8191, bh9 = b9 >>> 13;
         out.negative = self2.negative ^ num.negative, out.length = 19, lo = Math.imul(al0, bl0), mid = Math.imul(al0, bh0), mid = mid + Math.imul(ah0, bl0) | 0, hi = Math.imul(ah0, bh0);
         var w0 = (c + lo | 0) + ((mid & 8191) << 13) | 0;
@@ -12087,7 +12783,7 @@ var init_crypto = __esm(() => {
         var fftm = new FFTM;
         return fftm.mulp(self2, num, out);
       }
-      BN.prototype.mulTo = function mulTo(num, out) {
+      BN.prototype.mulTo = function(num, out) {
         var res, len2 = this.length + num.length;
         if (this.length === 10 && num.length === 10)
           res = comb10MulTo(this, num, out);
@@ -12102,22 +12798,22 @@ var init_crypto = __esm(() => {
       function FFTM(x, y) {
         this.x = x, this.y = y;
       }
-      FFTM.prototype.makeRBT = function makeRBT(N) {
-        var t = new Array(N), l = BN.prototype._countBits(N) - 1;
+      FFTM.prototype.makeRBT = function(N) {
+        var t = Array(N), l = BN.prototype._countBits(N) - 1;
         for (var i2 = 0;i2 < N; i2++)
           t[i2] = this.revBin(i2, l, N);
         return t;
-      }, FFTM.prototype.revBin = function revBin(x, l, N) {
+      }, FFTM.prototype.revBin = function(x, l, N) {
         if (x === 0 || x === N - 1)
           return x;
         var rb = 0;
         for (var i2 = 0;i2 < l; i2++)
           rb |= (x & 1) << l - i2 - 1, x >>= 1;
         return rb;
-      }, FFTM.prototype.permute = function permute(rbt, rws, iws, rtws, itws, N) {
+      }, FFTM.prototype.permute = function(rbt, rws, iws, rtws, itws, N) {
         for (var i2 = 0;i2 < N; i2++)
           rtws[i2] = rws[rbt[i2]], itws[i2] = iws[rbt[i2]];
-      }, FFTM.prototype.transform = function transform(rws, iws, rtws, itws, N, rbt) {
+      }, FFTM.prototype.transform = function(rws, iws, rtws, itws, N, rbt) {
         this.permute(rbt, rws, iws, rtws, itws, N);
         for (var s = 1;s < N; s <<= 1) {
           var l = s << 1, rtwdf = Math.cos(2 * Math.PI / l), itwdf = Math.sin(2 * Math.PI / l);
@@ -12130,19 +12826,19 @@ var init_crypto = __esm(() => {
             }
           }
         }
-      }, FFTM.prototype.guessLen13b = function guessLen13b(n, m) {
+      }, FFTM.prototype.guessLen13b = function(n, m) {
         var N = Math.max(m, n) | 1, odd = N & 1, i2 = 0;
         for (N = N / 2 | 0;N; N = N >>> 1)
           i2++;
         return 1 << i2 + 1 + odd;
-      }, FFTM.prototype.conjugate = function conjugate(rws, iws, N) {
+      }, FFTM.prototype.conjugate = function(rws, iws, N) {
         if (N <= 1)
           return;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var t = rws[i2];
           rws[i2] = rws[N - i2 - 1], rws[N - i2 - 1] = t, t = iws[i2], iws[i2] = -iws[N - i2 - 1], iws[N - i2 - 1] = -t;
         }
-      }, FFTM.prototype.normalize13b = function normalize13b(ws, N) {
+      }, FFTM.prototype.normalize13b = function(ws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var w = Math.round(ws[2 * i2 + 1] / N) * 8192 + Math.round(ws[2 * i2] / N) + carry;
@@ -12152,35 +12848,35 @@ var init_crypto = __esm(() => {
             carry = w / 67108864 | 0;
         }
         return ws;
-      }, FFTM.prototype.convert13b = function convert13b(ws, len2, rws, N) {
+      }, FFTM.prototype.convert13b = function(ws, len2, rws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < len2; i2++)
           carry = carry + (ws[i2] | 0), rws[2 * i2] = carry & 8191, carry = carry >>> 13, rws[2 * i2 + 1] = carry & 8191, carry = carry >>> 13;
         for (i2 = 2 * len2;i2 < N; ++i2)
           rws[i2] = 0;
         assert(carry === 0), assert((carry & -8192) === 0);
-      }, FFTM.prototype.stub = function stub(N) {
-        var ph = new Array(N);
+      }, FFTM.prototype.stub = function(N) {
+        var ph = Array(N);
         for (var i2 = 0;i2 < N; i2++)
           ph[i2] = 0;
         return ph;
-      }, FFTM.prototype.mulp = function mulp(x, y, out) {
-        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = new Array(N), rwst = new Array(N), iwst = new Array(N), nrws = new Array(N), nrwst = new Array(N), niwst = new Array(N), rmws = out.words;
+      }, FFTM.prototype.mulp = function(x, y, out) {
+        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = Array(N), rwst = Array(N), iwst = Array(N), nrws = Array(N), nrwst = Array(N), niwst = Array(N), rmws = out.words;
         rmws.length = N, this.convert13b(x.words, x.length, rws, N), this.convert13b(y.words, y.length, nrws, N), this.transform(rws, _, rwst, iwst, N, rbt), this.transform(nrws, _, nrwst, niwst, N, rbt);
         for (var i2 = 0;i2 < N; i2++) {
           var rx = rwst[i2] * nrwst[i2] - iwst[i2] * niwst[i2];
           iwst[i2] = rwst[i2] * niwst[i2] + iwst[i2] * nrwst[i2], rwst[i2] = rx;
         }
         return this.conjugate(rwst, iwst, N), this.transform(rwst, iwst, rmws, _, N, rbt), this.conjugate(rmws, _, N), this.normalize13b(rmws, N), out.negative = x.negative ^ y.negative, out.length = x.length + y.length, out.strip();
-      }, BN.prototype.mul = function mul(num) {
+      }, BN.prototype.mul = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), this.mulTo(num, out);
-      }, BN.prototype.mulf = function mulf(num) {
+        return out.words = Array(this.length + num.length), this.mulTo(num, out);
+      }, BN.prototype.mulf = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), jumboMulTo(this, num, out);
-      }, BN.prototype.imul = function imul(num) {
+        return out.words = Array(this.length + num.length), jumboMulTo(this, num, out);
+      }, BN.prototype.imul = function(num) {
         return this.clone().mulTo(num, this);
-      }, BN.prototype.imuln = function imuln(num) {
+      }, BN.prototype.imuln = function(num) {
         assert(typeof num === "number"), assert(num < 67108864);
         var carry = 0;
         for (var i2 = 0;i2 < this.length; i2++) {
@@ -12190,13 +12886,13 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this.length = num === 0 ? 1 : this.length, this;
-      }, BN.prototype.muln = function muln(num) {
+      }, BN.prototype.muln = function(num) {
         return this.clone().imuln(num);
-      }, BN.prototype.sqr = function sqr() {
+      }, BN.prototype.sqr = function() {
         return this.mul(this);
-      }, BN.prototype.isqr = function isqr() {
+      }, BN.prototype.isqr = function() {
         return this.imul(this.clone());
-      }, BN.prototype.pow = function pow(num) {
+      }, BN.prototype.pow = function(num) {
         var w = toBitArray(num);
         if (w.length === 0)
           return new BN(1);
@@ -12211,7 +12907,7 @@ var init_crypto = __esm(() => {
             res = res.mul(q);
           }
         return res;
-      }, BN.prototype.iushln = function iushln(bits) {
+      }, BN.prototype.iushln = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26, carryMask = 67108863 >>> 26 - r << 26 - r, i2;
         if (r !== 0) {
@@ -12231,9 +12927,9 @@ var init_crypto = __esm(() => {
           this.length += s;
         }
         return this.strip();
-      }, BN.prototype.ishln = function ishln(bits) {
+      }, BN.prototype.ishln = function(bits) {
         return assert(this.negative === 0), this.iushln(bits);
-      }, BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+      }, BN.prototype.iushrn = function(bits, hint, extended) {
         assert(typeof bits === "number" && bits >= 0);
         var h;
         if (hint)
@@ -12264,24 +12960,24 @@ var init_crypto = __esm(() => {
         if (this.length === 0)
           this.words[0] = 0, this.length = 1;
         return this.strip();
-      }, BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+      }, BN.prototype.ishrn = function(bits, hint, extended) {
         return assert(this.negative === 0), this.iushrn(bits, hint, extended);
-      }, BN.prototype.shln = function shln(bits) {
+      }, BN.prototype.shln = function(bits) {
         return this.clone().ishln(bits);
-      }, BN.prototype.ushln = function ushln(bits) {
+      }, BN.prototype.ushln = function(bits) {
         return this.clone().iushln(bits);
-      }, BN.prototype.shrn = function shrn(bits) {
+      }, BN.prototype.shrn = function(bits) {
         return this.clone().ishrn(bits);
-      }, BN.prototype.ushrn = function ushrn(bits) {
+      }, BN.prototype.ushrn = function(bits) {
         return this.clone().iushrn(bits);
-      }, BN.prototype.testn = function testn(bit) {
+      }, BN.prototype.testn = function(bit) {
         assert(typeof bit === "number" && bit >= 0);
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
           return false;
         var w = this.words[s];
         return !!(w & q);
-      }, BN.prototype.imaskn = function imaskn(bits) {
+      }, BN.prototype.imaskn = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26;
         if (assert(this.negative === 0, "imaskn works only with positive numbers"), this.length <= s)
@@ -12293,9 +12989,9 @@ var init_crypto = __esm(() => {
           this.words[this.length - 1] &= mask;
         }
         return this.strip();
-      }, BN.prototype.maskn = function maskn(bits) {
+      }, BN.prototype.maskn = function(bits) {
         return this.clone().imaskn(bits);
-      }, BN.prototype.iaddn = function iaddn(num) {
+      }, BN.prototype.iaddn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.isubn(-num);
         if (this.negative !== 0) {
@@ -12304,7 +13000,7 @@ var init_crypto = __esm(() => {
           return this.negative = 0, this.isubn(num), this.negative = 1, this;
         }
         return this._iaddn(num);
-      }, BN.prototype._iaddn = function _iaddn(num) {
+      }, BN.prototype._iaddn = function(num) {
         this.words[0] += num;
         for (var i2 = 0;i2 < this.length && this.words[i2] >= 67108864; i2++)
           if (this.words[i2] -= 67108864, i2 === this.length - 1)
@@ -12312,7 +13008,7 @@ var init_crypto = __esm(() => {
           else
             this.words[i2 + 1]++;
         return this.length = Math.max(this.length, i2 + 1), this;
-      }, BN.prototype.isubn = function isubn(num) {
+      }, BN.prototype.isubn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.iaddn(-num);
         if (this.negative !== 0)
@@ -12323,15 +13019,15 @@ var init_crypto = __esm(() => {
           for (var i2 = 0;i2 < this.length && this.words[i2] < 0; i2++)
             this.words[i2] += 67108864, this.words[i2 + 1] -= 1;
         return this.strip();
-      }, BN.prototype.addn = function addn(num) {
+      }, BN.prototype.addn = function(num) {
         return this.clone().iaddn(num);
-      }, BN.prototype.subn = function subn(num) {
+      }, BN.prototype.subn = function(num) {
         return this.clone().isubn(num);
-      }, BN.prototype.iabs = function iabs() {
+      }, BN.prototype.iabs = function() {
         return this.negative = 0, this;
-      }, BN.prototype.abs = function abs() {
+      }, BN.prototype.abs = function() {
         return this.clone().iabs();
-      }, BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+      }, BN.prototype._ishlnsubmul = function(num, mul, shift) {
         var len2 = num.length + shift, i2;
         this._expand(len2);
         var w, carry = 0;
@@ -12348,13 +13044,13 @@ var init_crypto = __esm(() => {
         for (i2 = 0;i2 < this.length; i2++)
           w = -(this.words[i2] | 0) + carry, carry = w >> 26, this.words[i2] = w & 67108863;
         return this.negative = 1, this.strip();
-      }, BN.prototype._wordDiv = function _wordDiv(num, mode) {
+      }, BN.prototype._wordDiv = function(num, mode) {
         var shift = this.length - num.length, a = this.clone(), b = num, bhi = b.words[b.length - 1] | 0, bhiBits = this._countBits(bhi);
         if (shift = 26 - bhiBits, shift !== 0)
           b = b.ushln(shift), a.iushln(shift), bhi = b.words[b.length - 1] | 0;
         var m = a.length - b.length, q;
         if (mode !== "mod") {
-          q = new BN(null), q.length = m + 1, q.words = new Array(q.length);
+          q = new BN(null), q.length = m + 1, q.words = Array(q.length);
           for (var i2 = 0;i2 < q.length; i2++)
             q.words[i2] = 0;
         }
@@ -12377,7 +13073,7 @@ var init_crypto = __esm(() => {
         if (a.strip(), mode !== "div" && shift !== 0)
           a.iushrn(shift);
         return { div: q || null, mod: a };
-      }, BN.prototype.divmod = function divmod(num, mode, positive) {
+      }, BN.prototype.divmod = function(num, mode, positive) {
         if (assert(!num.isZero()), this.isZero())
           return { div: new BN(0), mod: new BN(0) };
         var div, mod, res;
@@ -12412,13 +13108,13 @@ var init_crypto = __esm(() => {
           return { div: this.divn(num.words[0]), mod: new BN(this.modn(num.words[0])) };
         }
         return this._wordDiv(num, mode);
-      }, BN.prototype.div = function div(num) {
+      }, BN.prototype.div = function(num) {
         return this.divmod(num, "div", false).div;
-      }, BN.prototype.mod = function mod(num) {
+      }, BN.prototype.mod = function(num) {
         return this.divmod(num, "mod", false).mod;
-      }, BN.prototype.umod = function umod(num) {
+      }, BN.prototype.umod = function(num) {
         return this.divmod(num, "mod", true).mod;
-      }, BN.prototype.divRound = function divRound(num) {
+      }, BN.prototype.divRound = function(num) {
         var dm = this.divmod(num);
         if (dm.mod.isZero())
           return dm.div;
@@ -12426,13 +13122,13 @@ var init_crypto = __esm(() => {
         if (cmp < 0 || r2 === 1 && cmp === 0)
           return dm.div;
         return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
-      }, BN.prototype.modn = function modn(num) {
+      }, BN.prototype.modn = function(num) {
         assert(num <= 67108863);
         var p = 67108864 % num, acc = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--)
           acc = (p * acc + (this.words[i2] | 0)) % num;
         return acc;
-      }, BN.prototype.idivn = function idivn(num) {
+      }, BN.prototype.idivn = function(num) {
         assert(num <= 67108863);
         var carry = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--) {
@@ -12440,9 +13136,9 @@ var init_crypto = __esm(() => {
           this.words[i2] = w / num | 0, carry = w % num;
         }
         return this.strip();
-      }, BN.prototype.divn = function divn(num) {
+      }, BN.prototype.divn = function(num) {
         return this.clone().idivn(num);
-      }, BN.prototype.egcd = function egcd(p) {
+      }, BN.prototype.egcd = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var x = this, y = p.clone();
         if (x.negative !== 0)
@@ -12480,7 +13176,7 @@ var init_crypto = __esm(() => {
             y.isub(x), C.isub(A), D.isub(B);
         }
         return { a: C, b: D, gcd: y.iushln(g) };
-      }, BN.prototype._invmp = function _invmp(p) {
+      }, BN.prototype._invmp = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var a = this, b = p.clone();
         if (a.negative !== 0)
@@ -12522,7 +13218,7 @@ var init_crypto = __esm(() => {
         if (res.cmpn(0) < 0)
           res.iadd(p);
         return res;
-      }, BN.prototype.gcd = function gcd(num) {
+      }, BN.prototype.gcd = function(num) {
         if (this.isZero())
           return num.abs();
         if (num.isZero())
@@ -12545,15 +13241,15 @@ var init_crypto = __esm(() => {
           a.isub(b);
         } while (true);
         return b.iushln(shift);
-      }, BN.prototype.invm = function invm(num) {
+      }, BN.prototype.invm = function(num) {
         return this.egcd(num).a.umod(num);
-      }, BN.prototype.isEven = function isEven() {
+      }, BN.prototype.isEven = function() {
         return (this.words[0] & 1) === 0;
-      }, BN.prototype.isOdd = function isOdd() {
+      }, BN.prototype.isOdd = function() {
         return (this.words[0] & 1) === 1;
-      }, BN.prototype.andln = function andln(num) {
+      }, BN.prototype.andln = function(num) {
         return this.words[0] & num;
-      }, BN.prototype.bincn = function bincn(bit) {
+      }, BN.prototype.bincn = function(bit) {
         assert(typeof bit === "number");
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
@@ -12566,9 +13262,9 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this;
-      }, BN.prototype.isZero = function isZero() {
+      }, BN.prototype.isZero = function() {
         return this.length === 1 && this.words[0] === 0;
-      }, BN.prototype.cmpn = function cmpn(num) {
+      }, BN.prototype.cmpn = function(num) {
         var negative = num < 0;
         if (this.negative !== 0 && !negative)
           return -1;
@@ -12588,7 +13284,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.cmp = function cmp(num) {
+      }, BN.prototype.cmp = function(num) {
         if (this.negative !== 0 && num.negative === 0)
           return -1;
         if (this.negative === 0 && num.negative !== 0)
@@ -12597,7 +13293,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.ucmp = function ucmp(num) {
+      }, BN.prototype.ucmp = function(num) {
         if (this.length > num.length)
           return 1;
         if (this.length < num.length)
@@ -12614,71 +13310,71 @@ var init_crypto = __esm(() => {
           break;
         }
         return res;
-      }, BN.prototype.gtn = function gtn(num) {
+      }, BN.prototype.gtn = function(num) {
         return this.cmpn(num) === 1;
-      }, BN.prototype.gt = function gt(num) {
+      }, BN.prototype.gt = function(num) {
         return this.cmp(num) === 1;
-      }, BN.prototype.gten = function gten(num) {
+      }, BN.prototype.gten = function(num) {
         return this.cmpn(num) >= 0;
-      }, BN.prototype.gte = function gte(num) {
+      }, BN.prototype.gte = function(num) {
         return this.cmp(num) >= 0;
-      }, BN.prototype.ltn = function ltn(num) {
+      }, BN.prototype.ltn = function(num) {
         return this.cmpn(num) === -1;
-      }, BN.prototype.lt = function lt(num) {
+      }, BN.prototype.lt = function(num) {
         return this.cmp(num) === -1;
-      }, BN.prototype.lten = function lten(num) {
+      }, BN.prototype.lten = function(num) {
         return this.cmpn(num) <= 0;
-      }, BN.prototype.lte = function lte(num) {
+      }, BN.prototype.lte = function(num) {
         return this.cmp(num) <= 0;
-      }, BN.prototype.eqn = function eqn(num) {
+      }, BN.prototype.eqn = function(num) {
         return this.cmpn(num) === 0;
-      }, BN.prototype.eq = function eq(num) {
+      }, BN.prototype.eq = function(num) {
         return this.cmp(num) === 0;
-      }, BN.red = function red(num) {
+      }, BN.red = function(num) {
         return new Red(num);
-      }, BN.prototype.toRed = function toRed(ctx) {
+      }, BN.prototype.toRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), assert(this.negative === 0, "red works only with positives"), ctx.convertTo(this)._forceRed(ctx);
-      }, BN.prototype.fromRed = function fromRed() {
+      }, BN.prototype.fromRed = function() {
         return assert(this.red, "fromRed works only with numbers in reduction context"), this.red.convertFrom(this);
-      }, BN.prototype._forceRed = function _forceRed(ctx) {
+      }, BN.prototype._forceRed = function(ctx) {
         return this.red = ctx, this;
-      }, BN.prototype.forceRed = function forceRed(ctx) {
+      }, BN.prototype.forceRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), this._forceRed(ctx);
-      }, BN.prototype.redAdd = function redAdd(num) {
+      }, BN.prototype.redAdd = function(num) {
         return assert(this.red, "redAdd works only with red numbers"), this.red.add(this, num);
-      }, BN.prototype.redIAdd = function redIAdd(num) {
+      }, BN.prototype.redIAdd = function(num) {
         return assert(this.red, "redIAdd works only with red numbers"), this.red.iadd(this, num);
-      }, BN.prototype.redSub = function redSub(num) {
+      }, BN.prototype.redSub = function(num) {
         return assert(this.red, "redSub works only with red numbers"), this.red.sub(this, num);
-      }, BN.prototype.redISub = function redISub(num) {
+      }, BN.prototype.redISub = function(num) {
         return assert(this.red, "redISub works only with red numbers"), this.red.isub(this, num);
-      }, BN.prototype.redShl = function redShl(num) {
+      }, BN.prototype.redShl = function(num) {
         return assert(this.red, "redShl works only with red numbers"), this.red.shl(this, num);
-      }, BN.prototype.redMul = function redMul(num) {
+      }, BN.prototype.redMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.mul(this, num);
-      }, BN.prototype.redIMul = function redIMul(num) {
+      }, BN.prototype.redIMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.imul(this, num);
-      }, BN.prototype.redSqr = function redSqr() {
+      }, BN.prototype.redSqr = function() {
         return assert(this.red, "redSqr works only with red numbers"), this.red._verify1(this), this.red.sqr(this);
-      }, BN.prototype.redISqr = function redISqr() {
+      }, BN.prototype.redISqr = function() {
         return assert(this.red, "redISqr works only with red numbers"), this.red._verify1(this), this.red.isqr(this);
-      }, BN.prototype.redSqrt = function redSqrt() {
+      }, BN.prototype.redSqrt = function() {
         return assert(this.red, "redSqrt works only with red numbers"), this.red._verify1(this), this.red.sqrt(this);
-      }, BN.prototype.redInvm = function redInvm() {
+      }, BN.prototype.redInvm = function() {
         return assert(this.red, "redInvm works only with red numbers"), this.red._verify1(this), this.red.invm(this);
-      }, BN.prototype.redNeg = function redNeg() {
+      }, BN.prototype.redNeg = function() {
         return assert(this.red, "redNeg works only with red numbers"), this.red._verify1(this), this.red.neg(this);
-      }, BN.prototype.redPow = function redPow(num) {
+      }, BN.prototype.redPow = function(num) {
         return assert(this.red && !num.red, "redPow(normalNum)"), this.red._verify1(this), this.red.pow(this, num);
       };
       var primes = { k256: null, p224: null, p192: null, p25519: null };
       function MPrime(name, p) {
         this.name = name, this.p = new BN(p, 16), this.n = this.p.bitLength(), this.k = new BN(1).iushln(this.n).isub(this.p), this.tmp = this._tmp();
       }
-      MPrime.prototype._tmp = function _tmp() {
+      MPrime.prototype._tmp = function() {
         var tmp = new BN(null);
-        return tmp.words = new Array(Math.ceil(this.n / 13)), tmp;
-      }, MPrime.prototype.ireduce = function ireduce(num) {
+        return tmp.words = Array(Math.ceil(this.n / 13)), tmp;
+      }, MPrime.prototype.ireduce = function(num) {
         var r = num, rlen;
         do
           this.split(r, this.tmp), r = this.imulK(r), r = r.iadd(this.tmp), rlen = r.bitLength();
@@ -12693,15 +13389,15 @@ var init_crypto = __esm(() => {
         else
           r._strip();
         return r;
-      }, MPrime.prototype.split = function split(input, out) {
+      }, MPrime.prototype.split = function(input, out) {
         input.iushrn(this.n, 0, out);
-      }, MPrime.prototype.imulK = function imulK(num) {
+      }, MPrime.prototype.imulK = function(num) {
         return num.imul(this.k);
       };
       function K256() {
         MPrime.call(this, "k256", "ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f");
       }
-      inherits2(K256, MPrime), K256.prototype.split = function split(input, output) {
+      inherits2(K256, MPrime), K256.prototype.split = function(input, output) {
         var mask = 4194303, outLen = Math.min(input.length, 9);
         for (var i2 = 0;i2 < outLen; i2++)
           output.words[i2] = input.words[i2];
@@ -12719,7 +13415,7 @@ var init_crypto = __esm(() => {
           input.length -= 10;
         else
           input.length -= 9;
-      }, K256.prototype.imulK = function imulK(num) {
+      }, K256.prototype.imulK = function(num) {
         num.words[num.length] = 0, num.words[num.length + 1] = 0, num.length += 2;
         var lo = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
@@ -12743,7 +13439,7 @@ var init_crypto = __esm(() => {
       function P25519() {
         MPrime.call(this, "25519", "7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed");
       }
-      inherits2(P25519, MPrime), P25519.prototype.imulK = function imulK(num) {
+      inherits2(P25519, MPrime), P25519.prototype.imulK = function(num) {
         var carry = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
           var hi = (num.words[i2] | 0) * 19 + carry, lo = hi & 67108863;
@@ -12752,7 +13448,7 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           num.words[num.length++] = carry;
         return num;
-      }, BN._prime = function prime(name) {
+      }, BN._prime = function(name) {
         if (primes[name])
           return primes[name];
         var prime;
@@ -12765,7 +13461,7 @@ var init_crypto = __esm(() => {
         else if (name === "p25519")
           prime = new P25519;
         else
-          throw new Error("Unknown prime " + name);
+          throw Error("Unknown prime " + name);
         return primes[name] = prime, prime;
       };
       function Red(m) {
@@ -12775,53 +13471,53 @@ var init_crypto = __esm(() => {
         } else
           assert(m.gtn(1), "modulus must be greater than 1"), this.m = m, this.prime = null;
       }
-      Red.prototype._verify1 = function _verify1(a) {
+      Red.prototype._verify1 = function(a) {
         assert(a.negative === 0, "red works only with positives"), assert(a.red, "red works only with red numbers");
-      }, Red.prototype._verify2 = function _verify2(a, b) {
+      }, Red.prototype._verify2 = function(a, b) {
         assert((a.negative | b.negative) === 0, "red works only with positives"), assert(a.red && a.red === b.red, "red works only with red numbers");
-      }, Red.prototype.imod = function imod(a) {
+      }, Red.prototype.imod = function(a) {
         if (this.prime)
           return this.prime.ireduce(a)._forceRed(this);
         return a.umod(this.m)._forceRed(this);
-      }, Red.prototype.neg = function neg(a) {
+      }, Red.prototype.neg = function(a) {
         if (a.isZero())
           return a.clone();
         return this.m.sub(a)._forceRed(this);
-      }, Red.prototype.add = function add(a, b) {
+      }, Red.prototype.add = function(a, b) {
         this._verify2(a, b);
         var res = a.add(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res._forceRed(this);
-      }, Red.prototype.iadd = function iadd(a, b) {
+      }, Red.prototype.iadd = function(a, b) {
         this._verify2(a, b);
         var res = a.iadd(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res;
-      }, Red.prototype.sub = function sub(a, b) {
+      }, Red.prototype.sub = function(a, b) {
         this._verify2(a, b);
         var res = a.sub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res._forceRed(this);
-      }, Red.prototype.isub = function isub(a, b) {
+      }, Red.prototype.isub = function(a, b) {
         this._verify2(a, b);
         var res = a.isub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res;
-      }, Red.prototype.shl = function shl(a, num) {
+      }, Red.prototype.shl = function(a, num) {
         return this._verify1(a), this.imod(a.ushln(num));
-      }, Red.prototype.imul = function imul(a, b) {
+      }, Red.prototype.imul = function(a, b) {
         return this._verify2(a, b), this.imod(a.imul(b));
-      }, Red.prototype.mul = function mul(a, b) {
+      }, Red.prototype.mul = function(a, b) {
         return this._verify2(a, b), this.imod(a.mul(b));
-      }, Red.prototype.isqr = function isqr(a) {
+      }, Red.prototype.isqr = function(a) {
         return this.imul(a, a.clone());
-      }, Red.prototype.sqr = function sqr(a) {
+      }, Red.prototype.sqr = function(a) {
         return this.mul(a, a);
-      }, Red.prototype.sqrt = function sqrt(a) {
+      }, Red.prototype.sqrt = function(a) {
         if (a.isZero())
           return a.clone();
         var mod3 = this.m.andln(3);
@@ -12847,18 +13543,18 @@ var init_crypto = __esm(() => {
           r = r.redMul(b), c = b.redSqr(), t = t.redMul(c), m = i2;
         }
         return r;
-      }, Red.prototype.invm = function invm(a) {
+      }, Red.prototype.invm = function(a) {
         var inv = a._invmp(this.m);
         if (inv.negative !== 0)
           return inv.negative = 0, this.imod(inv).redNeg();
         else
           return this.imod(inv);
-      }, Red.prototype.pow = function pow(a, num) {
+      }, Red.prototype.pow = function(a, num) {
         if (num.isZero())
           return new BN(1).toRed(this);
         if (num.cmpn(1) === 0)
           return a.clone();
-        var windowSize = 4, wnd = new Array(1 << windowSize);
+        var windowSize = 4, wnd = Array(1 << windowSize);
         wnd[0] = new BN(1).toRed(this), wnd[1] = a;
         for (var i2 = 2;i2 < wnd.length; i2++)
           wnd[i2] = this.mul(wnd[i2 - 1], a);
@@ -12882,13 +13578,13 @@ var init_crypto = __esm(() => {
           start = 26;
         }
         return res;
-      }, Red.prototype.convertTo = function convertTo(num) {
+      }, Red.prototype.convertTo = function(num) {
         var r = num.umod(this.m);
         return r === num ? r.clone() : r;
-      }, Red.prototype.convertFrom = function convertFrom(num) {
+      }, Red.prototype.convertFrom = function(num) {
         var res = num.clone();
         return res.red = null, res;
-      }, BN.mont = function mont(num) {
+      }, BN.mont = function(num) {
         return new Mont(num);
       };
       function Mont(m) {
@@ -12896,12 +13592,12 @@ var init_crypto = __esm(() => {
           this.shift += 26 - this.shift % 26;
         this.r = new BN(1).iushln(this.shift), this.r2 = this.imod(this.r.sqr()), this.rinv = this.r._invmp(this.m), this.minv = this.rinv.mul(this.r).isubn(1).div(this.m), this.minv = this.minv.umod(this.r), this.minv = this.r.sub(this.minv);
       }
-      inherits2(Mont, Red), Mont.prototype.convertTo = function convertTo(num) {
+      inherits2(Mont, Red), Mont.prototype.convertTo = function(num) {
         return this.imod(num.ushln(this.shift));
-      }, Mont.prototype.convertFrom = function convertFrom(num) {
+      }, Mont.prototype.convertFrom = function(num) {
         var r = this.imod(num.mul(this.rinv));
         return r.red = null, r;
-      }, Mont.prototype.imul = function imul(a, b) {
+      }, Mont.prototype.imul = function(a, b) {
         if (a.isZero() || b.isZero())
           return a.words[0] = 0, a.length = 1, a;
         var t = a.imul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -12910,7 +13606,7 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.mul = function mul(a, b) {
+      }, Mont.prototype.mul = function(a, b) {
         if (a.isZero() || b.isZero())
           return new BN(0)._forceRed(this);
         var t = a.mul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -12919,21 +13615,21 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.invm = function invm(a) {
+      }, Mont.prototype.invm = function(a) {
         var res = this.imod(a._invmp(this.m).mul(this.r2));
         return res._forceRed(this);
       };
-    })(typeof module === "undefined" || module, exports);
+    })(typeof module > "u" || module, exports);
   });
   require_api = __commonJS2((exports) => {
     var asn1 = require_asn1(), inherits2 = require_inherits(), api = exports;
-    api.define = function define(name, body) {
+    api.define = function(name, body) {
       return new Entity(name, body);
     };
     function Entity(name, body) {
       this.name = name, this.body = body, this.decoders = {}, this.encoders = {};
     }
-    Entity.prototype._createNamed = function createNamed(base) {
+    Entity.prototype._createNamed = function(base) {
       var named;
       try {
         named = (()=>{throw new Error("Cannot require module "+"vm");})().runInThisContext("(function " + this.name + `(entity) {
@@ -12944,24 +13640,24 @@ var init_crypto = __esm(() => {
           this._initNamed(entity);
         };
       }
-      return inherits2(named, base), named.prototype._initNamed = function initnamed(entity) {
+      return inherits2(named, base), named.prototype._initNamed = function(entity) {
         base.call(this, entity);
       }, new named(this);
     };
-    Entity.prototype._getDecoder = function _getDecoder(enc) {
+    Entity.prototype._getDecoder = function(enc) {
       if (enc = enc || "der", !this.decoders.hasOwnProperty(enc))
         this.decoders[enc] = this._createNamed(asn1.decoders[enc]);
       return this.decoders[enc];
     };
-    Entity.prototype.decode = function decode(data, enc, options) {
+    Entity.prototype.decode = function(data, enc, options) {
       return this._getDecoder(enc).decode(data, options);
     };
-    Entity.prototype._getEncoder = function _getEncoder(enc) {
+    Entity.prototype._getEncoder = function(enc) {
       if (enc = enc || "der", !this.encoders.hasOwnProperty(enc))
         this.encoders[enc] = this._createNamed(asn1.encoders[enc]);
       return this.encoders[enc];
     };
-    Entity.prototype.encode = function encode(data, enc, reporter) {
+    Entity.prototype.encode = function(data, enc, reporter) {
       return this._getEncoder(enc).encode(data, reporter);
     };
   });
@@ -12971,41 +13667,41 @@ var init_crypto = __esm(() => {
       this._reporterState = { obj: null, path: [], options: options || {}, errors: [] };
     }
     exports.Reporter = Reporter;
-    Reporter.prototype.isError = function isError(obj) {
+    Reporter.prototype.isError = function(obj) {
       return obj instanceof ReporterError;
     };
-    Reporter.prototype.save = function save() {
+    Reporter.prototype.save = function() {
       var state = this._reporterState;
       return { obj: state.obj, pathLen: state.path.length };
     };
-    Reporter.prototype.restore = function restore(data) {
+    Reporter.prototype.restore = function(data) {
       var state = this._reporterState;
       state.obj = data.obj, state.path = state.path.slice(0, data.pathLen);
     };
-    Reporter.prototype.enterKey = function enterKey(key) {
+    Reporter.prototype.enterKey = function(key) {
       return this._reporterState.path.push(key);
     };
-    Reporter.prototype.exitKey = function exitKey(index) {
+    Reporter.prototype.exitKey = function(index) {
       var state = this._reporterState;
       state.path = state.path.slice(0, index - 1);
     };
-    Reporter.prototype.leaveKey = function leaveKey(index, key, value) {
+    Reporter.prototype.leaveKey = function(index, key, value) {
       var state = this._reporterState;
       if (this.exitKey(index), state.obj !== null)
         state.obj[key] = value;
     };
-    Reporter.prototype.path = function path() {
+    Reporter.prototype.path = function() {
       return this._reporterState.path.join("/");
     };
-    Reporter.prototype.enterObject = function enterObject() {
+    Reporter.prototype.enterObject = function() {
       var state = this._reporterState, prev = state.obj;
       return state.obj = {}, prev;
     };
-    Reporter.prototype.leaveObject = function leaveObject(prev) {
+    Reporter.prototype.leaveObject = function(prev) {
       var state = this._reporterState, now = state.obj;
       return state.obj = prev, now;
     };
-    Reporter.prototype.error = function error(msg) {
+    Reporter.prototype.error = function(msg) {
       var err, state = this._reporterState, inherited = msg instanceof ReporterError;
       if (inherited)
         err = msg;
@@ -13019,7 +13715,7 @@ var init_crypto = __esm(() => {
         state.errors.push(err);
       return err;
     };
-    Reporter.prototype.wrapResult = function wrapResult(result) {
+    Reporter.prototype.wrapResult = function(result) {
       var state = this._reporterState;
       if (!state.options.partial)
         return result;
@@ -13029,12 +13725,12 @@ var init_crypto = __esm(() => {
       this.path = path, this.rethrow(msg);
     }
     inherits2(ReporterError, Error);
-    ReporterError.prototype.rethrow = function rethrow(msg) {
+    ReporterError.prototype.rethrow = function(msg) {
       if (this.message = msg + " at: " + (this.path || "(shallow)"), Error.captureStackTrace)
         Error.captureStackTrace(this, ReporterError);
       if (!this.stack)
         try {
-          throw new Error(this.message);
+          throw Error(this.message);
         } catch (e) {
           this.stack = e.stack;
         }
@@ -13042,7 +13738,7 @@ var init_crypto = __esm(() => {
     };
   });
   require_buffer = __commonJS2((exports) => {
-    var inherits2 = require_inherits(), Reporter = require_base2().Reporter, Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+    var inherits2 = require_inherits(), Reporter = require_base2().Reporter, Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
     function DecoderBuffer(base, options) {
       if (Reporter.call(this, options), !Buffer22.isBuffer(base)) {
         this.error("Input not Buffer");
@@ -13052,29 +13748,29 @@ var init_crypto = __esm(() => {
     }
     inherits2(DecoderBuffer, Reporter);
     exports.DecoderBuffer = DecoderBuffer;
-    DecoderBuffer.prototype.save = function save() {
+    DecoderBuffer.prototype.save = function() {
       return { offset: this.offset, reporter: Reporter.prototype.save.call(this) };
     };
-    DecoderBuffer.prototype.restore = function restore(save) {
+    DecoderBuffer.prototype.restore = function(save) {
       var res = new DecoderBuffer(this.base);
       return res.offset = save.offset, res.length = this.offset, this.offset = save.offset, Reporter.prototype.restore.call(this, save.reporter), res;
     };
-    DecoderBuffer.prototype.isEmpty = function isEmpty() {
+    DecoderBuffer.prototype.isEmpty = function() {
       return this.offset === this.length;
     };
-    DecoderBuffer.prototype.readUInt8 = function readUInt8(fail) {
+    DecoderBuffer.prototype.readUInt8 = function(fail) {
       if (this.offset + 1 <= this.length)
         return this.base.readUInt8(this.offset++, true);
       else
         return this.error(fail || "DecoderBuffer overrun");
     };
-    DecoderBuffer.prototype.skip = function skip(bytes, fail) {
+    DecoderBuffer.prototype.skip = function(bytes, fail) {
       if (!(this.offset + bytes <= this.length))
         return this.error(fail || "DecoderBuffer overrun");
       var res = new DecoderBuffer(this.base);
       return res._reporterState = this._reporterState, res.offset = this.offset, res.length = this.offset + bytes, this.offset += bytes, res;
     };
-    DecoderBuffer.prototype.raw = function raw(save) {
+    DecoderBuffer.prototype.raw = function(save) {
       return this.base.slice(save ? save.offset : this.offset, this.length);
     };
     function EncoderBuffer(value, reporter) {
@@ -13096,7 +13792,7 @@ var init_crypto = __esm(() => {
         return reporter.error("Unsupported type: " + typeof value);
     }
     exports.EncoderBuffer = EncoderBuffer;
-    EncoderBuffer.prototype.join = function join(out, offset) {
+    EncoderBuffer.prototype.join = function(out, offset) {
       if (!out)
         out = new Buffer22(this.length);
       if (!offset)
@@ -13128,7 +13824,7 @@ var init_crypto = __esm(() => {
     }
     module.exports = Node;
     var stateProps = ["enc", "parent", "children", "tag", "args", "reverseArgs", "choice", "optional", "any", "obj", "use", "alteredUse", "key", "default", "explicit", "implicit", "contains"];
-    Node.prototype.clone = function clone() {
+    Node.prototype.clone = function() {
       var state = this._baseState, cstate = {};
       stateProps.forEach(function(prop) {
         cstate[prop] = state[prop];
@@ -13136,22 +13832,22 @@ var init_crypto = __esm(() => {
       var res = new this.constructor(cstate.parent);
       return res._baseState = cstate, res;
     };
-    Node.prototype._wrap = function wrap() {
+    Node.prototype._wrap = function() {
       var state = this._baseState;
       methods.forEach(function(method) {
-        this[method] = function _wrappedMethod() {
+        this[method] = function() {
           var clone = new this.constructor(this);
           return state.children.push(clone), clone[method].apply(clone, arguments);
         };
       }, this);
     };
-    Node.prototype._init = function init(body) {
+    Node.prototype._init = function(body) {
       var state = this._baseState;
       assert(state.parent === null), body.call(this), state.children = state.children.filter(function(child) {
         return child._baseState.parent === this;
       }, this), assert.equal(state.children.length, 1, "Root node can have only one child");
     };
-    Node.prototype._useArgs = function useArgs(args) {
+    Node.prototype._useArgs = function(args) {
       var state = this._baseState, children = args.filter(function(arg) {
         return arg instanceof this.constructor;
       }, this);
@@ -13175,63 +13871,63 @@ var init_crypto = __esm(() => {
         });
     };
     overrided.forEach(function(method) {
-      Node.prototype[method] = function _overrided() {
+      Node.prototype[method] = function() {
         var state = this._baseState;
-        throw new Error(method + " not implemented for encoding: " + state.enc);
+        throw Error(method + " not implemented for encoding: " + state.enc);
       };
     });
     tags.forEach(function(tag) {
-      Node.prototype[tag] = function _tagMethod() {
+      Node.prototype[tag] = function() {
         var state = this._baseState, args = Array.prototype.slice.call(arguments);
         return assert(state.tag === null), state.tag = tag, this._useArgs(args), this;
       };
     });
-    Node.prototype.use = function use(item) {
+    Node.prototype.use = function(item) {
       assert(item);
       var state = this._baseState;
       return assert(state.use === null), state.use = item, this;
     };
-    Node.prototype.optional = function optional() {
+    Node.prototype.optional = function() {
       var state = this._baseState;
       return state.optional = true, this;
     };
-    Node.prototype.def = function def(val) {
+    Node.prototype.def = function(val) {
       var state = this._baseState;
       return assert(state.default === null), state.default = val, state.optional = true, this;
     };
-    Node.prototype.explicit = function explicit(num) {
+    Node.prototype.explicit = function(num) {
       var state = this._baseState;
       return assert(state.explicit === null && state.implicit === null), state.explicit = num, this;
     };
-    Node.prototype.implicit = function implicit(num) {
+    Node.prototype.implicit = function(num) {
       var state = this._baseState;
       return assert(state.explicit === null && state.implicit === null), state.implicit = num, this;
     };
-    Node.prototype.obj = function obj() {
+    Node.prototype.obj = function() {
       var state = this._baseState, args = Array.prototype.slice.call(arguments);
       if (state.obj = true, args.length !== 0)
         this._useArgs(args);
       return this;
     };
-    Node.prototype.key = function key(newKey) {
+    Node.prototype.key = function(newKey) {
       var state = this._baseState;
       return assert(state.key === null), state.key = newKey, this;
     };
-    Node.prototype.any = function any() {
+    Node.prototype.any = function() {
       var state = this._baseState;
       return state.any = true, this;
     };
-    Node.prototype.choice = function choice(obj) {
+    Node.prototype.choice = function(obj) {
       var state = this._baseState;
       return assert(state.choice === null), state.choice = obj, this._useArgs(Object.keys(obj).map(function(key) {
         return obj[key];
       })), this;
     };
-    Node.prototype.contains = function contains(item) {
+    Node.prototype.contains = function(item) {
       var state = this._baseState;
       return assert(state.use === null), state.contains = item, this;
     };
-    Node.prototype._decode = function decode(input, options) {
+    Node.prototype._decode = function(input, options) {
       var state = this._baseState;
       if (state.parent === null)
         return input.wrapResult(state.children[0]._decode(input, options));
@@ -13296,7 +13992,7 @@ var init_crypto = __esm(() => {
         if (input.isError(result))
           return result;
         if (!state.any && state.choice === null && state.children !== null)
-          state.children.forEach(function decodeChildren(child) {
+          state.children.forEach(function(child) {
             child._decode(input, options);
           });
         if (state.contains && (state.tag === "octstr" || state.tag === "bitstr")) {
@@ -13312,7 +14008,7 @@ var init_crypto = __esm(() => {
         input.exitKey(prevKey);
       return result;
     };
-    Node.prototype._decodeGeneric = function decodeGeneric(tag, input, options) {
+    Node.prototype._decodeGeneric = function(tag, input, options) {
       var state = this._baseState;
       if (tag === "seq" || tag === "set")
         return null;
@@ -13339,13 +14035,13 @@ var init_crypto = __esm(() => {
       else
         return input.error("unknown tag: " + tag);
     };
-    Node.prototype._getUse = function _getUse(entity, obj) {
+    Node.prototype._getUse = function(entity, obj) {
       var state = this._baseState;
       if (state.useDecoder = this._use(entity, obj), assert(state.useDecoder._baseState.parent === null), state.useDecoder = state.useDecoder._baseState.children[0], state.implicit !== state.useDecoder._baseState.implicit)
         state.useDecoder = state.useDecoder.clone(), state.useDecoder._baseState.implicit = state.implicit;
       return state.useDecoder;
     };
-    Node.prototype._decodeChoice = function decodeChoice(input, options) {
+    Node.prototype._decodeChoice = function(input, options) {
       var state = this._baseState, result = null, match = false;
       if (Object.keys(state.choice).some(function(key) {
         var save = input.save(), node = state.choice[key];
@@ -13362,10 +14058,10 @@ var init_crypto = __esm(() => {
         return input.error("Choice not matched");
       return result;
     };
-    Node.prototype._createEncoderBuffer = function createEncoderBuffer(data) {
+    Node.prototype._createEncoderBuffer = function(data) {
       return new EncoderBuffer(data, this.reporter);
     };
-    Node.prototype._encode = function encode(data, reporter, parent) {
+    Node.prototype._encode = function(data, reporter, parent) {
       var state = this._baseState;
       if (state.default !== null && state.default === data)
         return;
@@ -13376,7 +14072,7 @@ var init_crypto = __esm(() => {
         return;
       return result;
     };
-    Node.prototype._encodeValue = function encode(data, reporter, parent) {
+    Node.prototype._encodeValue = function(data, reporter, parent) {
       var state = this._baseState;
       if (state.parent === null)
         return state.children[0]._encode(data, reporter || new Reporter);
@@ -13434,13 +14130,13 @@ var init_crypto = __esm(() => {
         result = this._encodeComposite(state.explicit, false, "context", result);
       return result;
     };
-    Node.prototype._encodeChoice = function encodeChoice(data, reporter) {
+    Node.prototype._encodeChoice = function(data, reporter) {
       var state = this._baseState, node = state.choice[data.type];
       if (!node)
         assert(false, data.type + " not found in " + JSON.stringify(Object.keys(state.choice)));
       return node._encode(data.value, reporter);
     };
-    Node.prototype._encodePrimitive = function encodePrimitive(tag, data) {
+    Node.prototype._encodePrimitive = function(tag, data) {
       var state = this._baseState;
       if (/str$/.test(tag))
         return this._encodeStr(data, tag);
@@ -13459,12 +14155,12 @@ var init_crypto = __esm(() => {
       else if (tag === "objDesc")
         return this._encodeStr(data, tag);
       else
-        throw new Error("Unsupported tag: " + tag);
+        throw Error("Unsupported tag: " + tag);
     };
-    Node.prototype._isNumstr = function isNumstr(str) {
+    Node.prototype._isNumstr = function(str) {
       return /^[0-9 ]*$/.test(str);
     };
-    Node.prototype._isPrintstr = function isPrintstr(str) {
+    Node.prototype._isPrintstr = function(str) {
       return /^[A-Za-z0-9 '\(\)\+,\-\.\/:=\?]*$/.test(str);
     };
   });
@@ -13484,7 +14180,7 @@ var init_crypto = __esm(() => {
   });
   require_constants = __commonJS2((exports) => {
     var constants2 = exports;
-    constants2._reverse = function reverse(map) {
+    constants2._reverse = function(map) {
       var res = {};
       return Object.keys(map).forEach(function(key) {
         if ((key | 0) == key)
@@ -13501,7 +14197,7 @@ var init_crypto = __esm(() => {
       this.enc = "der", this.name = entity.name, this.entity = entity, this.tree = new DERNode, this.tree._init(entity.body);
     }
     module.exports = DERDecoder;
-    DERDecoder.prototype.decode = function decode(data, options) {
+    DERDecoder.prototype.decode = function(data, options) {
       if (!(data instanceof base.DecoderBuffer))
         data = new base.DecoderBuffer(data, options);
       return this.tree._decode(data, options);
@@ -13510,7 +14206,7 @@ var init_crypto = __esm(() => {
       base.Node.call(this, "der", parent);
     }
     inherits2(DERNode, base.Node);
-    DERNode.prototype._peekTag = function peekTag(buffer, tag, any) {
+    DERNode.prototype._peekTag = function(buffer, tag, any) {
       if (buffer.isEmpty())
         return false;
       var state = buffer.save(), decodedTag = derDecodeTag(buffer, 'Failed to peek tag: "' + tag + '"');
@@ -13518,7 +14214,7 @@ var init_crypto = __esm(() => {
         return decodedTag;
       return buffer.restore(state), decodedTag.tag === tag || decodedTag.tagStr === tag || decodedTag.tagStr + "of" === tag || any;
     };
-    DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
+    DERNode.prototype._decodeTag = function(buffer, tag, any) {
       var decodedTag = derDecodeTag(buffer, 'Failed to decode tag of "' + tag + '"');
       if (buffer.isError(decodedTag))
         return decodedTag;
@@ -13534,7 +14230,7 @@ var init_crypto = __esm(() => {
         return res;
       return len2 = buffer.offset - state.offset, buffer.restore(state), buffer.skip(len2, 'Failed to match body of: "' + tag + '"');
     };
-    DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
+    DERNode.prototype._skipUntilEnd = function(buffer, fail) {
       while (true) {
         var tag = derDecodeTag(buffer, fail);
         if (buffer.isError(tag))
@@ -13553,7 +14249,7 @@ var init_crypto = __esm(() => {
           break;
       }
     };
-    DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder, options) {
+    DERNode.prototype._decodeList = function(buffer, tag, decoder, options) {
       var result = [];
       while (!buffer.isEmpty()) {
         var possibleEnd = this._peekTag(buffer, "end");
@@ -13566,7 +14262,7 @@ var init_crypto = __esm(() => {
       }
       return result;
     };
-    DERNode.prototype._decodeStr = function decodeStr(buffer, tag) {
+    DERNode.prototype._decodeStr = function(buffer, tag) {
       if (tag === "bitstr") {
         var unused = buffer.readUInt8();
         if (buffer.isError(unused))
@@ -13599,7 +14295,7 @@ var init_crypto = __esm(() => {
       else
         return buffer.error("Decoding of string type: " + tag + " unsupported");
     };
-    DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) {
+    DERNode.prototype._decodeObjid = function(buffer, values, relative) {
       var result, identifiers = [], ident = 0;
       while (!buffer.isEmpty()) {
         var subident = buffer.readUInt8();
@@ -13622,7 +14318,7 @@ var init_crypto = __esm(() => {
       }
       return result;
     };
-    DERNode.prototype._decodeTime = function decodeTime(buffer, tag) {
+    DERNode.prototype._decodeTime = function(buffer, tag) {
       var str = buffer.raw().toString();
       if (tag === "gentime")
         var year = str.slice(0, 4) | 0, mon = str.slice(4, 6) | 0, day = str.slice(6, 8) | 0, hour = str.slice(8, 10) | 0, min = str.slice(10, 12) | 0, sec = str.slice(12, 14) | 0;
@@ -13636,23 +14332,23 @@ var init_crypto = __esm(() => {
         return buffer.error("Decoding " + tag + " time is not supported yet");
       return Date.UTC(year, mon - 1, day, hour, min, sec, 0);
     };
-    DERNode.prototype._decodeNull = function decodeNull(buffer) {
+    DERNode.prototype._decodeNull = function(buffer) {
       return null;
     };
-    DERNode.prototype._decodeBool = function decodeBool(buffer) {
+    DERNode.prototype._decodeBool = function(buffer) {
       var res = buffer.readUInt8();
       if (buffer.isError(res))
         return res;
       else
         return res !== 0;
     };
-    DERNode.prototype._decodeInt = function decodeInt(buffer, values) {
+    DERNode.prototype._decodeInt = function(buffer, values) {
       var raw = buffer.raw(), res = new bignum(raw);
       if (values)
         res = values[res.toString(10)] || res;
       return res;
     };
-    DERNode.prototype._use = function use(entity, obj) {
+    DERNode.prototype._use = function(entity, obj) {
       if (typeof entity === "function")
         entity = entity(obj);
       return entity._getDecoder("der").tree;
@@ -13698,13 +14394,13 @@ var init_crypto = __esm(() => {
     }
   });
   require_pem = __commonJS2((exports, module) => {
-    var inherits2 = require_inherits(), Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer, DERDecoder = require_der2();
+    var inherits2 = require_inherits(), Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer, DERDecoder = require_der2();
     function PEMDecoder(entity) {
       DERDecoder.call(this, entity), this.enc = "pem";
     }
     inherits2(PEMDecoder, DERDecoder);
     module.exports = PEMDecoder;
-    PEMDecoder.prototype.decode = function decode(data, options) {
+    PEMDecoder.prototype.decode = function(data, options) {
       var lines = data.toString().split(/[\r\n]+/g), label = options.label.toUpperCase(), re = /^-----(BEGIN|END) ([^-]+)-----$/, start = -1, end = -1;
       for (var i2 = 0;i2 < lines.length; i2++) {
         var match = lines[i2].match(re);
@@ -13724,7 +14420,7 @@ var init_crypto = __esm(() => {
         }
       }
       if (start === -1 || end === -1)
-        throw new Error("PEM section not found for: " + label);
+        throw Error("PEM section not found for: " + label);
       var base64 = lines.slice(start + 1, end).join("");
       base64.replace(/[^a-z0-9\+\/=]+/gi, "");
       var input = new Buffer22(base64, "base64");
@@ -13737,19 +14433,19 @@ var init_crypto = __esm(() => {
     decoders.pem = require_pem();
   });
   require_der3 = __commonJS2((exports, module) => {
-    var inherits2 = require_inherits(), Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer, asn1 = require_asn1(), base = asn1.base, der = asn1.constants.der;
+    var inherits2 = require_inherits(), Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer, asn1 = require_asn1(), base = asn1.base, der = asn1.constants.der;
     function DEREncoder(entity) {
       this.enc = "der", this.name = entity.name, this.entity = entity, this.tree = new DERNode, this.tree._init(entity.body);
     }
     module.exports = DEREncoder;
-    DEREncoder.prototype.encode = function encode(data, reporter) {
+    DEREncoder.prototype.encode = function(data, reporter) {
       return this.tree._encode(data, reporter).join();
     };
     function DERNode(parent) {
       base.Node.call(this, "der", parent);
     }
     inherits2(DERNode, base.Node);
-    DERNode.prototype._encodeComposite = function encodeComposite(tag, primitive, cls, content) {
+    DERNode.prototype._encodeComposite = function(tag, primitive, cls, content) {
       var encodedTag = encodeTag(tag, primitive, cls, this.reporter);
       if (content.length < 128) {
         var header = new Buffer22(2);
@@ -13764,7 +14460,7 @@ var init_crypto = __esm(() => {
         header[i2] = j & 255;
       return this._createEncoderBuffer([header, content]);
     };
-    DERNode.prototype._encodeStr = function encodeStr(str, tag) {
+    DERNode.prototype._encodeStr = function(str, tag) {
       if (tag === "bitstr")
         return this._createEncoderBuffer([str.unused | 0, str.data]);
       else if (tag === "bmpstr") {
@@ -13787,7 +14483,7 @@ var init_crypto = __esm(() => {
       else
         return this.reporter.error("Encoding of string type: " + tag + " unsupported");
     };
-    DERNode.prototype._encodeObjid = function encodeObjid(id, values, relative) {
+    DERNode.prototype._encodeObjid = function(id, values, relative) {
       if (typeof id === "string") {
         if (!values)
           return this.reporter.error("string objid given, but no values map found");
@@ -13829,7 +14525,7 @@ var init_crypto = __esm(() => {
       else
         return num;
     }
-    DERNode.prototype._encodeTime = function encodeTime(time, tag) {
+    DERNode.prototype._encodeTime = function(time, tag) {
       var str, date = new Date(time);
       if (tag === "gentime")
         str = [two(date.getFullYear()), two(date.getUTCMonth() + 1), two(date.getUTCDate()), two(date.getUTCHours()), two(date.getUTCMinutes()), two(date.getUTCSeconds()), "Z"].join("");
@@ -13839,10 +14535,10 @@ var init_crypto = __esm(() => {
         this.reporter.error("Encoding " + tag + " time is not supported yet");
       return this._encodeStr(str, "octstr");
     };
-    DERNode.prototype._encodeNull = function encodeNull() {
+    DERNode.prototype._encodeNull = function() {
       return this._createEncoderBuffer("");
     };
-    DERNode.prototype._encodeInt = function encodeInt(num, values) {
+    DERNode.prototype._encodeInt = function(num, values) {
       if (typeof num === "string") {
         if (!values)
           return this.reporter.error("String int or enum given, but no values map");
@@ -13872,22 +14568,22 @@ var init_crypto = __esm(() => {
       var size = 1;
       for (var i2 = num;i2 >= 256; i2 >>= 8)
         size++;
-      var out = new Array(size);
+      var out = Array(size);
       for (var i2 = out.length - 1;i2 >= 0; i2--)
         out[i2] = num & 255, num >>= 8;
       if (out[0] & 128)
         out.unshift(0);
       return this._createEncoderBuffer(new Buffer22(out));
     };
-    DERNode.prototype._encodeBool = function encodeBool(value) {
+    DERNode.prototype._encodeBool = function(value) {
       return this._createEncoderBuffer(value ? 255 : 0);
     };
-    DERNode.prototype._use = function use(entity, obj) {
+    DERNode.prototype._use = function(entity, obj) {
       if (typeof entity === "function")
         entity = entity(obj);
       return entity._getEncoder("der").tree;
     };
-    DERNode.prototype._skipDefault = function skipDefault(dataBuffer, reporter, parent) {
+    DERNode.prototype._skipDefault = function(dataBuffer, reporter, parent) {
       var state = this._baseState, i2;
       if (state.default === null)
         return false;
@@ -13927,7 +14623,7 @@ var init_crypto = __esm(() => {
     }
     inherits2(PEMEncoder, DEREncoder);
     module.exports = PEMEncoder;
-    PEMEncoder.prototype.encode = function encode(data, options) {
+    PEMEncoder.prototype.encode = function(data, options) {
       var buf = DEREncoder.prototype.encode.call(this, data), p = buf.toString("base64"), out = ["-----BEGIN " + options.label + "-----"];
       for (var i2 = 0;i2 < p.length; i2 += 64)
         out.push(p.slice(i2, i2 + 64));
@@ -14044,7 +14740,7 @@ var init_crypto = __esm(() => {
       }
       callback(error);
     };
-    var useUint8Array = typeof Uint8Array !== "undefined", useArrayBuffer = typeof ArrayBuffer !== "undefined" && typeof Uint8Array !== "undefined" && ArrayBuffer.isView && (Buffer22.prototype instanceof Uint8Array || Buffer22.TYPED_ARRAY_SUPPORT);
+    var useUint8Array = typeof Uint8Array < "u", useArrayBuffer = typeof ArrayBuffer < "u" && typeof Uint8Array < "u" && ArrayBuffer.isView && (Buffer22.prototype instanceof Uint8Array || Buffer22.TYPED_ARRAY_SUPPORT);
     function toBuffer(data, encoding) {
       if (data instanceof Buffer22)
         return data;
@@ -14061,11 +14757,11 @@ var init_crypto = __esm(() => {
         return Buffer22.from(data);
       if (Buffer22.isBuffer(data) && data.constructor && typeof data.constructor.isBuffer === "function" && data.constructor.isBuffer(data))
         return Buffer22.from(data);
-      throw new TypeError('The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView.');
+      throw TypeError('The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView.');
     }
     HashBase.prototype.update = function(data, encoding) {
       if (this._finalized)
-        throw new Error("Digest already called");
+        throw Error("Digest already called");
       data = toBuffer(data, encoding);
       var block = this._block, offset = 0;
       while (this._blockOffset + data.length - offset >= this._blockSize) {
@@ -14081,11 +14777,11 @@ var init_crypto = __esm(() => {
       return this;
     };
     HashBase.prototype._update = function() {
-      throw new Error("_update is not implemented");
+      throw Error("_update is not implemented");
     };
     HashBase.prototype.digest = function(encoding) {
       if (this._finalized)
-        throw new Error("Digest already called");
+        throw Error("Digest already called");
       this._finalized = true;
       var digest = this._digest();
       if (encoding !== undefined)
@@ -14096,12 +14792,12 @@ var init_crypto = __esm(() => {
       return digest;
     };
     HashBase.prototype._digest = function() {
-      throw new Error("_digest is not implemented");
+      throw Error("_digest is not implemented");
     };
     module.exports = HashBase;
   });
   require_md5 = __commonJS2((exports, module) => {
-    var inherits2 = require_inherits(), HashBase = require_hash_base(), Buffer22 = require_safe_buffer().Buffer, ARRAY16 = new Array(16);
+    var inherits2 = require_inherits(), HashBase = require_hash_base(), Buffer22 = require_safe_buffer().Buffer, ARRAY16 = Array(16);
     function MD5() {
       HashBase.call(this, 64), this._a = 1732584193, this._b = 4023233417, this._c = 2562383102, this._d = 271733878;
     }
@@ -14146,7 +14842,7 @@ var init_crypto = __esm(() => {
         if (!Buffer22.isBuffer(salt))
           salt = Buffer22.from(salt, "binary");
         if (salt.length !== 8)
-          throw new RangeError("salt should be Buffer with 8 byte length");
+          throw RangeError("salt should be Buffer with 8 byte length");
       }
       var keyLen = keyBits / 8, key = Buffer22.alloc(keyLen), iv = Buffer22.alloc(ivLen || 0), tmp = Buffer22.alloc(0);
       while (keyLen > 0 || ivLen > 0) {
@@ -14192,9 +14888,9 @@ var init_crypto = __esm(() => {
     };
   });
   require_parse_asn1 = __commonJS2((exports, module) => {
-    var asn1 = require_asn12(), aesid = require_aesid(), fixProc = require_fixProc(), ciphers = require_browserify_aes(), compat = require_pbkdf2(), Buffer22 = require_safe_buffer().Buffer;
+    var asn1 = require_asn12(), aesid = require_aesid(), fixProc = require_fixProc(), ciphers = require_browserify_aes(), pbkdf2Sync = require_pbkdf2().pbkdf2Sync, Buffer22 = require_safe_buffer().Buffer;
     function decrypt(data, password) {
-      var salt = data.algorithm.decrypt.kde.kdeparams.salt, iters = parseInt(data.algorithm.decrypt.kde.kdeparams.iters.toString(), 10), algo = aesid[data.algorithm.decrypt.cipher.algo.join(".")], iv = data.algorithm.decrypt.cipher.iv, cipherText = data.subjectPrivateKey, keylen = parseInt(algo.split("-")[1], 10) / 8, key = compat.pbkdf2Sync(password, salt, iters, keylen, "sha1"), cipher = ciphers.createDecipheriv(algo, key, iv), out = [];
+      var salt = data.algorithm.decrypt.kde.kdeparams.salt, iters = parseInt(data.algorithm.decrypt.kde.kdeparams.iters.toString(), 10), algo = aesid[data.algorithm.decrypt.cipher.algo.join(".")], iv = data.algorithm.decrypt.cipher.iv, cipherText = data.subjectPrivateKey, keylen = parseInt(algo.split("-")[1], 10) / 8, key = pbkdf2Sync(password, salt, iters, keylen, "sha1"), cipher = ciphers.createDecipheriv(algo, key, iv), out = [];
       return out.push(cipher.update(cipherText)), out.push(cipher.final()), Buffer22.concat(out);
     }
     function parseKeys(buffer) {
@@ -14218,7 +14914,7 @@ var init_crypto = __esm(() => {
             case "1.2.840.10040.4.1":
               return ndata.algorithm.params.pub_key = asn1.DSAparam.decode(ndata.subjectPublicKey.data, "der"), { type: "dsa", data: ndata.algorithm.params };
             default:
-              throw new Error("unknown key id " + subtype);
+              throw Error("unknown key id " + subtype);
           }
         case "ENCRYPTED PRIVATE KEY":
           data = asn1.EncryptedPrivateKey.decode(data, "der"), data = decrypt(data, password);
@@ -14231,7 +14927,7 @@ var init_crypto = __esm(() => {
             case "1.2.840.10040.4.1":
               return ndata.algorithm.params.priv_key = asn1.DSAparam.decode(ndata.subjectPrivateKey, "der"), { type: "dsa", params: ndata.algorithm.params };
             default:
-              throw new Error("unknown key id " + subtype);
+              throw Error("unknown key id " + subtype);
           }
         case "RSA PUBLIC KEY":
           return asn1.RSAPublicKey.decode(data, "der");
@@ -14242,7 +14938,7 @@ var init_crypto = __esm(() => {
         case "EC PRIVATE KEY":
           return data = asn1.ECPrivateKey.decode(data, "der"), { curve: data.parameters.value, privateKey: data.privateKey };
         default:
-          throw new Error("unknown key type " + type);
+          throw Error("unknown key type " + type);
       }
     }
     parseKeys.signature = asn1.signature;
@@ -14262,7 +14958,7 @@ var init_crypto = __esm(() => {
     }
   });
   require_xor = __commonJS2((exports, module) => {
-    module.exports = function xor(a, b) {
+    module.exports = function(a, b) {
       var len2 = a.length, i2 = -1;
       while (++i2 < len2)
         a[i2] ^= b[i2];
@@ -14273,7 +14969,7 @@ var init_crypto = __esm(() => {
     (function(module2, exports2) {
       function assert(val, msg) {
         if (!val)
-          throw new Error(msg || "Assertion failed");
+          throw Error(msg || "Assertion failed");
       }
       function inherits2(ctor, superCtor) {
         ctor.super_ = superCtor;
@@ -14296,24 +14992,24 @@ var init_crypto = __esm(() => {
       BN.BN = BN, BN.wordSize = 26;
       var Buffer22;
       try {
-        if (typeof window !== "undefined" && typeof window.Buffer !== "undefined")
+        if (typeof window < "u" && typeof window.Buffer < "u")
           Buffer22 = window.Buffer;
         else
-          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
       } catch (e) {}
-      BN.isBN = function isBN(num) {
+      BN.isBN = function(num) {
         if (num instanceof BN)
           return true;
         return num !== null && typeof num === "object" && num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
-      }, BN.max = function max(left, right) {
+      }, BN.max = function(left, right) {
         if (left.cmp(right) > 0)
           return left;
         return right;
-      }, BN.min = function min(left, right) {
+      }, BN.min = function(left, right) {
         if (left.cmp(right) < 0)
           return left;
         return right;
-      }, BN.prototype._init = function init(number, base, endian) {
+      }, BN.prototype._init = function(number, base, endian) {
         if (typeof number === "number")
           return this._initNumber(number, base, endian);
         if (typeof number === "object")
@@ -14330,7 +15026,7 @@ var init_crypto = __esm(() => {
           else if (this._parseBase(number, base, start), endian === "le")
             this._initArray(this.toArray(), base, endian);
         }
-      }, BN.prototype._initNumber = function _initNumber(number, base, endian) {
+      }, BN.prototype._initNumber = function(number, base, endian) {
         if (number < 0)
           this.negative = 1, number = -number;
         if (number < 67108864)
@@ -14342,10 +15038,10 @@ var init_crypto = __esm(() => {
         if (endian !== "le")
           return;
         this._initArray(this.toArray(), base, endian);
-      }, BN.prototype._initArray = function _initArray(number, base, endian) {
+      }, BN.prototype._initArray = function(number, base, endian) {
         if (assert(typeof number.length === "number"), number.length <= 0)
           return this.words = [0], this.length = 1, this;
-        this.length = Math.ceil(number.length / 3), this.words = new Array(this.length);
+        this.length = Math.ceil(number.length / 3), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var j, w, off = 0;
@@ -14375,8 +15071,8 @@ var init_crypto = __esm(() => {
           r |= parseHex4Bits(string, index - 1) << 4;
         return r;
       }
-      BN.prototype._parseHex = function _parseHex(number, start, endian) {
-        this.length = Math.ceil((number.length - start) / 6), this.words = new Array(this.length);
+      BN.prototype._parseHex = function(number, start, endian) {
+        this.length = Math.ceil((number.length - start) / 6), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var off = 0, j = 0, w;
@@ -14409,7 +15105,7 @@ var init_crypto = __esm(() => {
         }
         return r;
       }
-      BN.prototype._parseBase = function _parseBase(number, base, start) {
+      BN.prototype._parseBase = function(number, base, start) {
         this.words = [0], this.length = 1;
         for (var limbLen = 0, limbPow = 1;limbPow <= 67108863; limbPow *= base)
           limbLen++;
@@ -14431,31 +15127,31 @@ var init_crypto = __esm(() => {
             this._iaddn(word);
         }
         this.strip();
-      }, BN.prototype.copy = function copy(dest) {
-        dest.words = new Array(this.length);
+      }, BN.prototype.copy = function(dest) {
+        dest.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           dest.words[i2] = this.words[i2];
         dest.length = this.length, dest.negative = this.negative, dest.red = this.red;
-      }, BN.prototype.clone = function clone() {
+      }, BN.prototype.clone = function() {
         var r = new BN(null);
         return this.copy(r), r;
-      }, BN.prototype._expand = function _expand(size) {
+      }, BN.prototype._expand = function(size) {
         while (this.length < size)
           this.words[this.length++] = 0;
         return this;
-      }, BN.prototype.strip = function strip() {
+      }, BN.prototype.strip = function() {
         while (this.length > 1 && this.words[this.length - 1] === 0)
           this.length--;
         return this._normSign();
-      }, BN.prototype._normSign = function _normSign() {
+      }, BN.prototype._normSign = function() {
         if (this.length === 1 && this.words[0] === 0)
           this.negative = 0;
         return this;
-      }, BN.prototype.inspect = function inspect() {
+      }, BN.prototype.inspect = function() {
         return (this.red ? "<BN-R: " : "<BN: ") + this.toString(16) + ">";
       };
       var zeros = ["", "0", "00", "000", "0000", "00000", "000000", "0000000", "00000000", "000000000", "0000000000", "00000000000", "000000000000", "0000000000000", "00000000000000", "000000000000000", "0000000000000000", "00000000000000000", "000000000000000000", "0000000000000000000", "00000000000000000000", "000000000000000000000", "0000000000000000000000", "00000000000000000000000", "000000000000000000000000", "0000000000000000000000000"], groupSizes = [0, 0, 25, 16, 12, 11, 10, 9, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], groupBases = [0, 0, 33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216, 43046721, 1e7, 19487171, 35831808, 62748517, 7529536, 11390625, 16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632, 6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149, 24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176];
-      if (BN.prototype.toString = function toString(base, padding) {
+      if (BN.prototype.toString = function(base, padding) {
         base = base || 10, padding = padding | 0 || 1;
         var out;
         if (base === 16 || base === "hex") {
@@ -14499,7 +15195,7 @@ var init_crypto = __esm(() => {
           return out;
         }
         assert(false, "Base should be between 2 and 36");
-      }, BN.prototype.toNumber = function toNumber() {
+      }, BN.prototype.toNumber = function() {
         var ret = this.words[0];
         if (this.length === 2)
           ret += this.words[1] * 67108864;
@@ -14508,13 +15204,13 @@ var init_crypto = __esm(() => {
         else if (this.length > 2)
           assert(false, "Number can only safely store up to 53 bits");
         return this.negative !== 0 ? -ret : ret;
-      }, BN.prototype.toJSON = function toJSON() {
+      }, BN.prototype.toJSON = function() {
         return this.toString(16);
-      }, BN.prototype.toBuffer = function toBuffer(endian, length) {
-        return assert(typeof Buffer22 !== "undefined"), this.toArrayLike(Buffer22, endian, length);
-      }, BN.prototype.toArray = function toArray(endian, length) {
+      }, BN.prototype.toBuffer = function(endian, length) {
+        return assert(typeof Buffer22 < "u"), this.toArrayLike(Buffer22, endian, length);
+      }, BN.prototype.toArray = function(endian, length) {
         return this.toArrayLike(Array, endian, length);
-      }, BN.prototype.toArrayLike = function toArrayLike(ArrayType, endian, length) {
+      }, BN.prototype.toArrayLike = function(ArrayType, endian, length) {
         var byteLength2 = this.byteLength(), reqLength = length || Math.max(1, byteLength2);
         assert(byteLength2 <= reqLength, "byte array longer than desired length"), assert(reqLength > 0, "Requested array length <= 0"), this.strip();
         var littleEndian = endian === "le", res = new ArrayType(reqLength), b, i2, q = this.clone();
@@ -14531,11 +15227,11 @@ var init_crypto = __esm(() => {
         }
         return res;
       }, Math.clz32)
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           return 32 - Math.clz32(w);
         };
       else
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           var t = w, r = 0;
           if (t >= 4096)
             r += 13, t >>>= 13;
@@ -14547,7 +15243,7 @@ var init_crypto = __esm(() => {
             r += 2, t >>>= 2;
           return r + t;
         };
-      BN.prototype._zeroBits = function _zeroBits(w) {
+      BN.prototype._zeroBits = function(w) {
         if (w === 0)
           return 26;
         var t = w, r = 0;
@@ -14562,19 +15258,19 @@ var init_crypto = __esm(() => {
         if ((t & 1) === 0)
           r++;
         return r;
-      }, BN.prototype.bitLength = function bitLength() {
+      }, BN.prototype.bitLength = function() {
         var w = this.words[this.length - 1], hi = this._countBits(w);
         return (this.length - 1) * 26 + hi;
       };
       function toBitArray(num) {
-        var w = new Array(num.bitLength());
+        var w = Array(num.bitLength());
         for (var bit = 0;bit < w.length; bit++) {
           var off = bit / 26 | 0, wbit = bit % 26;
           w[bit] = (num.words[off] & 1 << wbit) >>> wbit;
         }
         return w;
       }
-      BN.prototype.zeroBits = function zeroBits() {
+      BN.prototype.zeroBits = function() {
         if (this.isZero())
           return 0;
         var r = 0;
@@ -14584,41 +15280,41 @@ var init_crypto = __esm(() => {
             break;
         }
         return r;
-      }, BN.prototype.byteLength = function byteLength() {
+      }, BN.prototype.byteLength = function() {
         return Math.ceil(this.bitLength() / 8);
-      }, BN.prototype.toTwos = function toTwos(width) {
+      }, BN.prototype.toTwos = function(width) {
         if (this.negative !== 0)
           return this.abs().inotn(width).iaddn(1);
         return this.clone();
-      }, BN.prototype.fromTwos = function fromTwos(width) {
+      }, BN.prototype.fromTwos = function(width) {
         if (this.testn(width - 1))
           return this.notn(width).iaddn(1).ineg();
         return this.clone();
-      }, BN.prototype.isNeg = function isNeg() {
+      }, BN.prototype.isNeg = function() {
         return this.negative !== 0;
-      }, BN.prototype.neg = function neg() {
+      }, BN.prototype.neg = function() {
         return this.clone().ineg();
-      }, BN.prototype.ineg = function ineg() {
+      }, BN.prototype.ineg = function() {
         if (!this.isZero())
           this.negative ^= 1;
         return this;
-      }, BN.prototype.iuor = function iuor(num) {
+      }, BN.prototype.iuor = function(num) {
         while (this.length < num.length)
           this.words[this.length++] = 0;
         for (var i2 = 0;i2 < num.length; i2++)
           this.words[i2] = this.words[i2] | num.words[i2];
         return this.strip();
-      }, BN.prototype.ior = function ior(num) {
+      }, BN.prototype.ior = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuor(num);
-      }, BN.prototype.or = function or(num) {
+      }, BN.prototype.or = function(num) {
         if (this.length > num.length)
           return this.clone().ior(num);
         return num.clone().ior(this);
-      }, BN.prototype.uor = function uor(num) {
+      }, BN.prototype.uor = function(num) {
         if (this.length > num.length)
           return this.clone().iuor(num);
         return num.clone().iuor(this);
-      }, BN.prototype.iuand = function iuand(num) {
+      }, BN.prototype.iuand = function(num) {
         var b;
         if (this.length > num.length)
           b = num;
@@ -14627,17 +15323,17 @@ var init_crypto = __esm(() => {
         for (var i2 = 0;i2 < b.length; i2++)
           this.words[i2] = this.words[i2] & num.words[i2];
         return this.length = b.length, this.strip();
-      }, BN.prototype.iand = function iand(num) {
+      }, BN.prototype.iand = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuand(num);
-      }, BN.prototype.and = function and(num) {
+      }, BN.prototype.and = function(num) {
         if (this.length > num.length)
           return this.clone().iand(num);
         return num.clone().iand(this);
-      }, BN.prototype.uand = function uand(num) {
+      }, BN.prototype.uand = function(num) {
         if (this.length > num.length)
           return this.clone().iuand(num);
         return num.clone().iuand(this);
-      }, BN.prototype.iuxor = function iuxor(num) {
+      }, BN.prototype.iuxor = function(num) {
         var a, b;
         if (this.length > num.length)
           a = this, b = num;
@@ -14649,17 +15345,17 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this.length = a.length, this.strip();
-      }, BN.prototype.ixor = function ixor(num) {
+      }, BN.prototype.ixor = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuxor(num);
-      }, BN.prototype.xor = function xor(num) {
+      }, BN.prototype.xor = function(num) {
         if (this.length > num.length)
           return this.clone().ixor(num);
         return num.clone().ixor(this);
-      }, BN.prototype.uxor = function uxor(num) {
+      }, BN.prototype.uxor = function(num) {
         if (this.length > num.length)
           return this.clone().iuxor(num);
         return num.clone().iuxor(this);
-      }, BN.prototype.inotn = function inotn(width) {
+      }, BN.prototype.inotn = function(width) {
         assert(typeof width === "number" && width >= 0);
         var bytesNeeded = Math.ceil(width / 26) | 0, bitsLeft = width % 26;
         if (this._expand(bytesNeeded), bitsLeft > 0)
@@ -14669,9 +15365,9 @@ var init_crypto = __esm(() => {
         if (bitsLeft > 0)
           this.words[i2] = ~this.words[i2] & 67108863 >> 26 - bitsLeft;
         return this.strip();
-      }, BN.prototype.notn = function notn(width) {
+      }, BN.prototype.notn = function(width) {
         return this.clone().inotn(width);
-      }, BN.prototype.setn = function setn(bit, val) {
+      }, BN.prototype.setn = function(bit, val) {
         assert(typeof bit === "number" && bit >= 0);
         var off = bit / 26 | 0, wbit = bit % 26;
         if (this._expand(off + 1), val)
@@ -14679,7 +15375,7 @@ var init_crypto = __esm(() => {
         else
           this.words[off] = this.words[off] & ~(1 << wbit);
         return this.strip();
-      }, BN.prototype.iadd = function iadd(num) {
+      }, BN.prototype.iadd = function(num) {
         var r;
         if (this.negative !== 0 && num.negative === 0)
           return this.negative = 0, r = this.isub(num), this.negative ^= 1, this._normSign();
@@ -14701,7 +15397,7 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this;
-      }, BN.prototype.add = function add(num) {
+      }, BN.prototype.add = function(num) {
         var res;
         if (num.negative !== 0 && this.negative === 0)
           return num.negative = 0, res = this.sub(num), num.negative ^= 1, res;
@@ -14710,7 +15406,7 @@ var init_crypto = __esm(() => {
         if (this.length > num.length)
           return this.clone().iadd(num);
         return num.clone().iadd(this);
-      }, BN.prototype.isub = function isub(num) {
+      }, BN.prototype.isub = function(num) {
         if (num.negative !== 0) {
           num.negative = 0;
           var r = this.iadd(num);
@@ -14736,7 +15432,7 @@ var init_crypto = __esm(() => {
         if (this.length = Math.max(this.length, i2), a !== this)
           this.negative = 1;
         return this.strip();
-      }, BN.prototype.sub = function sub(num) {
+      }, BN.prototype.sub = function(num) {
         return this.clone().isub(num);
       };
       function smallMulTo(self2, num, out) {
@@ -14759,7 +15455,7 @@ var init_crypto = __esm(() => {
           out.length--;
         return out.strip();
       }
-      var comb10MulTo = function comb10MulTo(self2, num, out) {
+      var comb10MulTo = function(self2, num, out) {
         var a = self2.words, b = num.words, o = out.words, c = 0, lo, mid, hi, a0 = a[0] | 0, al0 = a0 & 8191, ah0 = a0 >>> 13, a1 = a[1] | 0, al1 = a1 & 8191, ah1 = a1 >>> 13, a2 = a[2] | 0, al2 = a2 & 8191, ah2 = a2 >>> 13, a3 = a[3] | 0, al3 = a3 & 8191, ah3 = a3 >>> 13, a4 = a[4] | 0, al4 = a4 & 8191, ah4 = a4 >>> 13, a5 = a[5] | 0, al5 = a5 & 8191, ah5 = a5 >>> 13, a6 = a[6] | 0, al6 = a6 & 8191, ah6 = a6 >>> 13, a7 = a[7] | 0, al7 = a7 & 8191, ah7 = a7 >>> 13, a8 = a[8] | 0, al8 = a8 & 8191, ah8 = a8 >>> 13, a9 = a[9] | 0, al9 = a9 & 8191, ah9 = a9 >>> 13, b0 = b[0] | 0, bl0 = b0 & 8191, bh0 = b0 >>> 13, b1 = b[1] | 0, bl1 = b1 & 8191, bh1 = b1 >>> 13, b2 = b[2] | 0, bl2 = b2 & 8191, bh2 = b2 >>> 13, b3 = b[3] | 0, bl3 = b3 & 8191, bh3 = b3 >>> 13, b4 = b[4] | 0, bl4 = b4 & 8191, bh4 = b4 >>> 13, b5 = b[5] | 0, bl5 = b5 & 8191, bh5 = b5 >>> 13, b6 = b[6] | 0, bl6 = b6 & 8191, bh6 = b6 >>> 13, b7 = b[7] | 0, bl7 = b7 & 8191, bh7 = b7 >>> 13, b8 = b[8] | 0, bl8 = b8 & 8191, bh8 = b8 >>> 13, b9 = b[9] | 0, bl9 = b9 & 8191, bh9 = b9 >>> 13;
         out.negative = self2.negative ^ num.negative, out.length = 19, lo = Math.imul(al0, bl0), mid = Math.imul(al0, bh0), mid = mid + Math.imul(ah0, bl0) | 0, hi = Math.imul(ah0, bh0);
         var w0 = (c + lo | 0) + ((mid & 8191) << 13) | 0;
@@ -14828,7 +15524,7 @@ var init_crypto = __esm(() => {
         var fftm = new FFTM;
         return fftm.mulp(self2, num, out);
       }
-      BN.prototype.mulTo = function mulTo(num, out) {
+      BN.prototype.mulTo = function(num, out) {
         var res, len2 = this.length + num.length;
         if (this.length === 10 && num.length === 10)
           res = comb10MulTo(this, num, out);
@@ -14843,22 +15539,22 @@ var init_crypto = __esm(() => {
       function FFTM(x, y) {
         this.x = x, this.y = y;
       }
-      FFTM.prototype.makeRBT = function makeRBT(N) {
-        var t = new Array(N), l = BN.prototype._countBits(N) - 1;
+      FFTM.prototype.makeRBT = function(N) {
+        var t = Array(N), l = BN.prototype._countBits(N) - 1;
         for (var i2 = 0;i2 < N; i2++)
           t[i2] = this.revBin(i2, l, N);
         return t;
-      }, FFTM.prototype.revBin = function revBin(x, l, N) {
+      }, FFTM.prototype.revBin = function(x, l, N) {
         if (x === 0 || x === N - 1)
           return x;
         var rb = 0;
         for (var i2 = 0;i2 < l; i2++)
           rb |= (x & 1) << l - i2 - 1, x >>= 1;
         return rb;
-      }, FFTM.prototype.permute = function permute(rbt, rws, iws, rtws, itws, N) {
+      }, FFTM.prototype.permute = function(rbt, rws, iws, rtws, itws, N) {
         for (var i2 = 0;i2 < N; i2++)
           rtws[i2] = rws[rbt[i2]], itws[i2] = iws[rbt[i2]];
-      }, FFTM.prototype.transform = function transform(rws, iws, rtws, itws, N, rbt) {
+      }, FFTM.prototype.transform = function(rws, iws, rtws, itws, N, rbt) {
         this.permute(rbt, rws, iws, rtws, itws, N);
         for (var s = 1;s < N; s <<= 1) {
           var l = s << 1, rtwdf = Math.cos(2 * Math.PI / l), itwdf = Math.sin(2 * Math.PI / l);
@@ -14871,19 +15567,19 @@ var init_crypto = __esm(() => {
             }
           }
         }
-      }, FFTM.prototype.guessLen13b = function guessLen13b(n, m) {
+      }, FFTM.prototype.guessLen13b = function(n, m) {
         var N = Math.max(m, n) | 1, odd = N & 1, i2 = 0;
         for (N = N / 2 | 0;N; N = N >>> 1)
           i2++;
         return 1 << i2 + 1 + odd;
-      }, FFTM.prototype.conjugate = function conjugate(rws, iws, N) {
+      }, FFTM.prototype.conjugate = function(rws, iws, N) {
         if (N <= 1)
           return;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var t = rws[i2];
           rws[i2] = rws[N - i2 - 1], rws[N - i2 - 1] = t, t = iws[i2], iws[i2] = -iws[N - i2 - 1], iws[N - i2 - 1] = -t;
         }
-      }, FFTM.prototype.normalize13b = function normalize13b(ws, N) {
+      }, FFTM.prototype.normalize13b = function(ws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var w = Math.round(ws[2 * i2 + 1] / N) * 8192 + Math.round(ws[2 * i2] / N) + carry;
@@ -14893,35 +15589,35 @@ var init_crypto = __esm(() => {
             carry = w / 67108864 | 0;
         }
         return ws;
-      }, FFTM.prototype.convert13b = function convert13b(ws, len2, rws, N) {
+      }, FFTM.prototype.convert13b = function(ws, len2, rws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < len2; i2++)
           carry = carry + (ws[i2] | 0), rws[2 * i2] = carry & 8191, carry = carry >>> 13, rws[2 * i2 + 1] = carry & 8191, carry = carry >>> 13;
         for (i2 = 2 * len2;i2 < N; ++i2)
           rws[i2] = 0;
         assert(carry === 0), assert((carry & -8192) === 0);
-      }, FFTM.prototype.stub = function stub(N) {
-        var ph = new Array(N);
+      }, FFTM.prototype.stub = function(N) {
+        var ph = Array(N);
         for (var i2 = 0;i2 < N; i2++)
           ph[i2] = 0;
         return ph;
-      }, FFTM.prototype.mulp = function mulp(x, y, out) {
-        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = new Array(N), rwst = new Array(N), iwst = new Array(N), nrws = new Array(N), nrwst = new Array(N), niwst = new Array(N), rmws = out.words;
+      }, FFTM.prototype.mulp = function(x, y, out) {
+        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = Array(N), rwst = Array(N), iwst = Array(N), nrws = Array(N), nrwst = Array(N), niwst = Array(N), rmws = out.words;
         rmws.length = N, this.convert13b(x.words, x.length, rws, N), this.convert13b(y.words, y.length, nrws, N), this.transform(rws, _, rwst, iwst, N, rbt), this.transform(nrws, _, nrwst, niwst, N, rbt);
         for (var i2 = 0;i2 < N; i2++) {
           var rx = rwst[i2] * nrwst[i2] - iwst[i2] * niwst[i2];
           iwst[i2] = rwst[i2] * niwst[i2] + iwst[i2] * nrwst[i2], rwst[i2] = rx;
         }
         return this.conjugate(rwst, iwst, N), this.transform(rwst, iwst, rmws, _, N, rbt), this.conjugate(rmws, _, N), this.normalize13b(rmws, N), out.negative = x.negative ^ y.negative, out.length = x.length + y.length, out.strip();
-      }, BN.prototype.mul = function mul(num) {
+      }, BN.prototype.mul = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), this.mulTo(num, out);
-      }, BN.prototype.mulf = function mulf(num) {
+        return out.words = Array(this.length + num.length), this.mulTo(num, out);
+      }, BN.prototype.mulf = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), jumboMulTo(this, num, out);
-      }, BN.prototype.imul = function imul(num) {
+        return out.words = Array(this.length + num.length), jumboMulTo(this, num, out);
+      }, BN.prototype.imul = function(num) {
         return this.clone().mulTo(num, this);
-      }, BN.prototype.imuln = function imuln(num) {
+      }, BN.prototype.imuln = function(num) {
         assert(typeof num === "number"), assert(num < 67108864);
         var carry = 0;
         for (var i2 = 0;i2 < this.length; i2++) {
@@ -14931,13 +15627,13 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this.length = num === 0 ? 1 : this.length, this;
-      }, BN.prototype.muln = function muln(num) {
+      }, BN.prototype.muln = function(num) {
         return this.clone().imuln(num);
-      }, BN.prototype.sqr = function sqr() {
+      }, BN.prototype.sqr = function() {
         return this.mul(this);
-      }, BN.prototype.isqr = function isqr() {
+      }, BN.prototype.isqr = function() {
         return this.imul(this.clone());
-      }, BN.prototype.pow = function pow(num) {
+      }, BN.prototype.pow = function(num) {
         var w = toBitArray(num);
         if (w.length === 0)
           return new BN(1);
@@ -14952,7 +15648,7 @@ var init_crypto = __esm(() => {
             res = res.mul(q);
           }
         return res;
-      }, BN.prototype.iushln = function iushln(bits) {
+      }, BN.prototype.iushln = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26, carryMask = 67108863 >>> 26 - r << 26 - r, i2;
         if (r !== 0) {
@@ -14972,9 +15668,9 @@ var init_crypto = __esm(() => {
           this.length += s;
         }
         return this.strip();
-      }, BN.prototype.ishln = function ishln(bits) {
+      }, BN.prototype.ishln = function(bits) {
         return assert(this.negative === 0), this.iushln(bits);
-      }, BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+      }, BN.prototype.iushrn = function(bits, hint, extended) {
         assert(typeof bits === "number" && bits >= 0);
         var h;
         if (hint)
@@ -15005,24 +15701,24 @@ var init_crypto = __esm(() => {
         if (this.length === 0)
           this.words[0] = 0, this.length = 1;
         return this.strip();
-      }, BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+      }, BN.prototype.ishrn = function(bits, hint, extended) {
         return assert(this.negative === 0), this.iushrn(bits, hint, extended);
-      }, BN.prototype.shln = function shln(bits) {
+      }, BN.prototype.shln = function(bits) {
         return this.clone().ishln(bits);
-      }, BN.prototype.ushln = function ushln(bits) {
+      }, BN.prototype.ushln = function(bits) {
         return this.clone().iushln(bits);
-      }, BN.prototype.shrn = function shrn(bits) {
+      }, BN.prototype.shrn = function(bits) {
         return this.clone().ishrn(bits);
-      }, BN.prototype.ushrn = function ushrn(bits) {
+      }, BN.prototype.ushrn = function(bits) {
         return this.clone().iushrn(bits);
-      }, BN.prototype.testn = function testn(bit) {
+      }, BN.prototype.testn = function(bit) {
         assert(typeof bit === "number" && bit >= 0);
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
           return false;
         var w = this.words[s];
         return !!(w & q);
-      }, BN.prototype.imaskn = function imaskn(bits) {
+      }, BN.prototype.imaskn = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26;
         if (assert(this.negative === 0, "imaskn works only with positive numbers"), this.length <= s)
@@ -15034,9 +15730,9 @@ var init_crypto = __esm(() => {
           this.words[this.length - 1] &= mask;
         }
         return this.strip();
-      }, BN.prototype.maskn = function maskn(bits) {
+      }, BN.prototype.maskn = function(bits) {
         return this.clone().imaskn(bits);
-      }, BN.prototype.iaddn = function iaddn(num) {
+      }, BN.prototype.iaddn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.isubn(-num);
         if (this.negative !== 0) {
@@ -15045,7 +15741,7 @@ var init_crypto = __esm(() => {
           return this.negative = 0, this.isubn(num), this.negative = 1, this;
         }
         return this._iaddn(num);
-      }, BN.prototype._iaddn = function _iaddn(num) {
+      }, BN.prototype._iaddn = function(num) {
         this.words[0] += num;
         for (var i2 = 0;i2 < this.length && this.words[i2] >= 67108864; i2++)
           if (this.words[i2] -= 67108864, i2 === this.length - 1)
@@ -15053,7 +15749,7 @@ var init_crypto = __esm(() => {
           else
             this.words[i2 + 1]++;
         return this.length = Math.max(this.length, i2 + 1), this;
-      }, BN.prototype.isubn = function isubn(num) {
+      }, BN.prototype.isubn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.iaddn(-num);
         if (this.negative !== 0)
@@ -15064,15 +15760,15 @@ var init_crypto = __esm(() => {
           for (var i2 = 0;i2 < this.length && this.words[i2] < 0; i2++)
             this.words[i2] += 67108864, this.words[i2 + 1] -= 1;
         return this.strip();
-      }, BN.prototype.addn = function addn(num) {
+      }, BN.prototype.addn = function(num) {
         return this.clone().iaddn(num);
-      }, BN.prototype.subn = function subn(num) {
+      }, BN.prototype.subn = function(num) {
         return this.clone().isubn(num);
-      }, BN.prototype.iabs = function iabs() {
+      }, BN.prototype.iabs = function() {
         return this.negative = 0, this;
-      }, BN.prototype.abs = function abs() {
+      }, BN.prototype.abs = function() {
         return this.clone().iabs();
-      }, BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+      }, BN.prototype._ishlnsubmul = function(num, mul, shift) {
         var len2 = num.length + shift, i2;
         this._expand(len2);
         var w, carry = 0;
@@ -15089,13 +15785,13 @@ var init_crypto = __esm(() => {
         for (i2 = 0;i2 < this.length; i2++)
           w = -(this.words[i2] | 0) + carry, carry = w >> 26, this.words[i2] = w & 67108863;
         return this.negative = 1, this.strip();
-      }, BN.prototype._wordDiv = function _wordDiv(num, mode) {
+      }, BN.prototype._wordDiv = function(num, mode) {
         var shift = this.length - num.length, a = this.clone(), b = num, bhi = b.words[b.length - 1] | 0, bhiBits = this._countBits(bhi);
         if (shift = 26 - bhiBits, shift !== 0)
           b = b.ushln(shift), a.iushln(shift), bhi = b.words[b.length - 1] | 0;
         var m = a.length - b.length, q;
         if (mode !== "mod") {
-          q = new BN(null), q.length = m + 1, q.words = new Array(q.length);
+          q = new BN(null), q.length = m + 1, q.words = Array(q.length);
           for (var i2 = 0;i2 < q.length; i2++)
             q.words[i2] = 0;
         }
@@ -15118,7 +15814,7 @@ var init_crypto = __esm(() => {
         if (a.strip(), mode !== "div" && shift !== 0)
           a.iushrn(shift);
         return { div: q || null, mod: a };
-      }, BN.prototype.divmod = function divmod(num, mode, positive) {
+      }, BN.prototype.divmod = function(num, mode, positive) {
         if (assert(!num.isZero()), this.isZero())
           return { div: new BN(0), mod: new BN(0) };
         var div, mod, res;
@@ -15153,13 +15849,13 @@ var init_crypto = __esm(() => {
           return { div: this.divn(num.words[0]), mod: new BN(this.modn(num.words[0])) };
         }
         return this._wordDiv(num, mode);
-      }, BN.prototype.div = function div(num) {
+      }, BN.prototype.div = function(num) {
         return this.divmod(num, "div", false).div;
-      }, BN.prototype.mod = function mod(num) {
+      }, BN.prototype.mod = function(num) {
         return this.divmod(num, "mod", false).mod;
-      }, BN.prototype.umod = function umod(num) {
+      }, BN.prototype.umod = function(num) {
         return this.divmod(num, "mod", true).mod;
-      }, BN.prototype.divRound = function divRound(num) {
+      }, BN.prototype.divRound = function(num) {
         var dm = this.divmod(num);
         if (dm.mod.isZero())
           return dm.div;
@@ -15167,13 +15863,13 @@ var init_crypto = __esm(() => {
         if (cmp < 0 || r2 === 1 && cmp === 0)
           return dm.div;
         return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
-      }, BN.prototype.modn = function modn(num) {
+      }, BN.prototype.modn = function(num) {
         assert(num <= 67108863);
         var p = 67108864 % num, acc = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--)
           acc = (p * acc + (this.words[i2] | 0)) % num;
         return acc;
-      }, BN.prototype.idivn = function idivn(num) {
+      }, BN.prototype.idivn = function(num) {
         assert(num <= 67108863);
         var carry = 0;
         for (var i2 = this.length - 1;i2 >= 0; i2--) {
@@ -15181,9 +15877,9 @@ var init_crypto = __esm(() => {
           this.words[i2] = w / num | 0, carry = w % num;
         }
         return this.strip();
-      }, BN.prototype.divn = function divn(num) {
+      }, BN.prototype.divn = function(num) {
         return this.clone().idivn(num);
-      }, BN.prototype.egcd = function egcd(p) {
+      }, BN.prototype.egcd = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var x = this, y = p.clone();
         if (x.negative !== 0)
@@ -15221,7 +15917,7 @@ var init_crypto = __esm(() => {
             y.isub(x), C.isub(A), D.isub(B);
         }
         return { a: C, b: D, gcd: y.iushln(g) };
-      }, BN.prototype._invmp = function _invmp(p) {
+      }, BN.prototype._invmp = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var a = this, b = p.clone();
         if (a.negative !== 0)
@@ -15263,7 +15959,7 @@ var init_crypto = __esm(() => {
         if (res.cmpn(0) < 0)
           res.iadd(p);
         return res;
-      }, BN.prototype.gcd = function gcd(num) {
+      }, BN.prototype.gcd = function(num) {
         if (this.isZero())
           return num.abs();
         if (num.isZero())
@@ -15286,15 +15982,15 @@ var init_crypto = __esm(() => {
           a.isub(b);
         } while (true);
         return b.iushln(shift);
-      }, BN.prototype.invm = function invm(num) {
+      }, BN.prototype.invm = function(num) {
         return this.egcd(num).a.umod(num);
-      }, BN.prototype.isEven = function isEven() {
+      }, BN.prototype.isEven = function() {
         return (this.words[0] & 1) === 0;
-      }, BN.prototype.isOdd = function isOdd() {
+      }, BN.prototype.isOdd = function() {
         return (this.words[0] & 1) === 1;
-      }, BN.prototype.andln = function andln(num) {
+      }, BN.prototype.andln = function(num) {
         return this.words[0] & num;
-      }, BN.prototype.bincn = function bincn(bit) {
+      }, BN.prototype.bincn = function(bit) {
         assert(typeof bit === "number");
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
@@ -15307,9 +16003,9 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this;
-      }, BN.prototype.isZero = function isZero() {
+      }, BN.prototype.isZero = function() {
         return this.length === 1 && this.words[0] === 0;
-      }, BN.prototype.cmpn = function cmpn(num) {
+      }, BN.prototype.cmpn = function(num) {
         var negative = num < 0;
         if (this.negative !== 0 && !negative)
           return -1;
@@ -15329,7 +16025,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.cmp = function cmp(num) {
+      }, BN.prototype.cmp = function(num) {
         if (this.negative !== 0 && num.negative === 0)
           return -1;
         if (this.negative === 0 && num.negative !== 0)
@@ -15338,7 +16034,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.ucmp = function ucmp(num) {
+      }, BN.prototype.ucmp = function(num) {
         if (this.length > num.length)
           return 1;
         if (this.length < num.length)
@@ -15355,71 +16051,71 @@ var init_crypto = __esm(() => {
           break;
         }
         return res;
-      }, BN.prototype.gtn = function gtn(num) {
+      }, BN.prototype.gtn = function(num) {
         return this.cmpn(num) === 1;
-      }, BN.prototype.gt = function gt(num) {
+      }, BN.prototype.gt = function(num) {
         return this.cmp(num) === 1;
-      }, BN.prototype.gten = function gten(num) {
+      }, BN.prototype.gten = function(num) {
         return this.cmpn(num) >= 0;
-      }, BN.prototype.gte = function gte(num) {
+      }, BN.prototype.gte = function(num) {
         return this.cmp(num) >= 0;
-      }, BN.prototype.ltn = function ltn(num) {
+      }, BN.prototype.ltn = function(num) {
         return this.cmpn(num) === -1;
-      }, BN.prototype.lt = function lt(num) {
+      }, BN.prototype.lt = function(num) {
         return this.cmp(num) === -1;
-      }, BN.prototype.lten = function lten(num) {
+      }, BN.prototype.lten = function(num) {
         return this.cmpn(num) <= 0;
-      }, BN.prototype.lte = function lte(num) {
+      }, BN.prototype.lte = function(num) {
         return this.cmp(num) <= 0;
-      }, BN.prototype.eqn = function eqn(num) {
+      }, BN.prototype.eqn = function(num) {
         return this.cmpn(num) === 0;
-      }, BN.prototype.eq = function eq(num) {
+      }, BN.prototype.eq = function(num) {
         return this.cmp(num) === 0;
-      }, BN.red = function red(num) {
+      }, BN.red = function(num) {
         return new Red(num);
-      }, BN.prototype.toRed = function toRed(ctx) {
+      }, BN.prototype.toRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), assert(this.negative === 0, "red works only with positives"), ctx.convertTo(this)._forceRed(ctx);
-      }, BN.prototype.fromRed = function fromRed() {
+      }, BN.prototype.fromRed = function() {
         return assert(this.red, "fromRed works only with numbers in reduction context"), this.red.convertFrom(this);
-      }, BN.prototype._forceRed = function _forceRed(ctx) {
+      }, BN.prototype._forceRed = function(ctx) {
         return this.red = ctx, this;
-      }, BN.prototype.forceRed = function forceRed(ctx) {
+      }, BN.prototype.forceRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), this._forceRed(ctx);
-      }, BN.prototype.redAdd = function redAdd(num) {
+      }, BN.prototype.redAdd = function(num) {
         return assert(this.red, "redAdd works only with red numbers"), this.red.add(this, num);
-      }, BN.prototype.redIAdd = function redIAdd(num) {
+      }, BN.prototype.redIAdd = function(num) {
         return assert(this.red, "redIAdd works only with red numbers"), this.red.iadd(this, num);
-      }, BN.prototype.redSub = function redSub(num) {
+      }, BN.prototype.redSub = function(num) {
         return assert(this.red, "redSub works only with red numbers"), this.red.sub(this, num);
-      }, BN.prototype.redISub = function redISub(num) {
+      }, BN.prototype.redISub = function(num) {
         return assert(this.red, "redISub works only with red numbers"), this.red.isub(this, num);
-      }, BN.prototype.redShl = function redShl(num) {
+      }, BN.prototype.redShl = function(num) {
         return assert(this.red, "redShl works only with red numbers"), this.red.shl(this, num);
-      }, BN.prototype.redMul = function redMul(num) {
+      }, BN.prototype.redMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.mul(this, num);
-      }, BN.prototype.redIMul = function redIMul(num) {
+      }, BN.prototype.redIMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.imul(this, num);
-      }, BN.prototype.redSqr = function redSqr() {
+      }, BN.prototype.redSqr = function() {
         return assert(this.red, "redSqr works only with red numbers"), this.red._verify1(this), this.red.sqr(this);
-      }, BN.prototype.redISqr = function redISqr() {
+      }, BN.prototype.redISqr = function() {
         return assert(this.red, "redISqr works only with red numbers"), this.red._verify1(this), this.red.isqr(this);
-      }, BN.prototype.redSqrt = function redSqrt() {
+      }, BN.prototype.redSqrt = function() {
         return assert(this.red, "redSqrt works only with red numbers"), this.red._verify1(this), this.red.sqrt(this);
-      }, BN.prototype.redInvm = function redInvm() {
+      }, BN.prototype.redInvm = function() {
         return assert(this.red, "redInvm works only with red numbers"), this.red._verify1(this), this.red.invm(this);
-      }, BN.prototype.redNeg = function redNeg() {
+      }, BN.prototype.redNeg = function() {
         return assert(this.red, "redNeg works only with red numbers"), this.red._verify1(this), this.red.neg(this);
-      }, BN.prototype.redPow = function redPow(num) {
+      }, BN.prototype.redPow = function(num) {
         return assert(this.red && !num.red, "redPow(normalNum)"), this.red._verify1(this), this.red.pow(this, num);
       };
       var primes = { k256: null, p224: null, p192: null, p25519: null };
       function MPrime(name, p) {
         this.name = name, this.p = new BN(p, 16), this.n = this.p.bitLength(), this.k = new BN(1).iushln(this.n).isub(this.p), this.tmp = this._tmp();
       }
-      MPrime.prototype._tmp = function _tmp() {
+      MPrime.prototype._tmp = function() {
         var tmp = new BN(null);
-        return tmp.words = new Array(Math.ceil(this.n / 13)), tmp;
-      }, MPrime.prototype.ireduce = function ireduce(num) {
+        return tmp.words = Array(Math.ceil(this.n / 13)), tmp;
+      }, MPrime.prototype.ireduce = function(num) {
         var r = num, rlen;
         do
           this.split(r, this.tmp), r = this.imulK(r), r = r.iadd(this.tmp), rlen = r.bitLength();
@@ -15434,15 +16130,15 @@ var init_crypto = __esm(() => {
         else
           r._strip();
         return r;
-      }, MPrime.prototype.split = function split(input, out) {
+      }, MPrime.prototype.split = function(input, out) {
         input.iushrn(this.n, 0, out);
-      }, MPrime.prototype.imulK = function imulK(num) {
+      }, MPrime.prototype.imulK = function(num) {
         return num.imul(this.k);
       };
       function K256() {
         MPrime.call(this, "k256", "ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f");
       }
-      inherits2(K256, MPrime), K256.prototype.split = function split(input, output) {
+      inherits2(K256, MPrime), K256.prototype.split = function(input, output) {
         var mask = 4194303, outLen = Math.min(input.length, 9);
         for (var i2 = 0;i2 < outLen; i2++)
           output.words[i2] = input.words[i2];
@@ -15460,7 +16156,7 @@ var init_crypto = __esm(() => {
           input.length -= 10;
         else
           input.length -= 9;
-      }, K256.prototype.imulK = function imulK(num) {
+      }, K256.prototype.imulK = function(num) {
         num.words[num.length] = 0, num.words[num.length + 1] = 0, num.length += 2;
         var lo = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
@@ -15484,7 +16180,7 @@ var init_crypto = __esm(() => {
       function P25519() {
         MPrime.call(this, "25519", "7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed");
       }
-      inherits2(P25519, MPrime), P25519.prototype.imulK = function imulK(num) {
+      inherits2(P25519, MPrime), P25519.prototype.imulK = function(num) {
         var carry = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
           var hi = (num.words[i2] | 0) * 19 + carry, lo = hi & 67108863;
@@ -15493,7 +16189,7 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           num.words[num.length++] = carry;
         return num;
-      }, BN._prime = function prime(name) {
+      }, BN._prime = function(name) {
         if (primes[name])
           return primes[name];
         var prime;
@@ -15506,7 +16202,7 @@ var init_crypto = __esm(() => {
         else if (name === "p25519")
           prime = new P25519;
         else
-          throw new Error("Unknown prime " + name);
+          throw Error("Unknown prime " + name);
         return primes[name] = prime, prime;
       };
       function Red(m) {
@@ -15516,53 +16212,53 @@ var init_crypto = __esm(() => {
         } else
           assert(m.gtn(1), "modulus must be greater than 1"), this.m = m, this.prime = null;
       }
-      Red.prototype._verify1 = function _verify1(a) {
+      Red.prototype._verify1 = function(a) {
         assert(a.negative === 0, "red works only with positives"), assert(a.red, "red works only with red numbers");
-      }, Red.prototype._verify2 = function _verify2(a, b) {
+      }, Red.prototype._verify2 = function(a, b) {
         assert((a.negative | b.negative) === 0, "red works only with positives"), assert(a.red && a.red === b.red, "red works only with red numbers");
-      }, Red.prototype.imod = function imod(a) {
+      }, Red.prototype.imod = function(a) {
         if (this.prime)
           return this.prime.ireduce(a)._forceRed(this);
         return a.umod(this.m)._forceRed(this);
-      }, Red.prototype.neg = function neg(a) {
+      }, Red.prototype.neg = function(a) {
         if (a.isZero())
           return a.clone();
         return this.m.sub(a)._forceRed(this);
-      }, Red.prototype.add = function add(a, b) {
+      }, Red.prototype.add = function(a, b) {
         this._verify2(a, b);
         var res = a.add(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res._forceRed(this);
-      }, Red.prototype.iadd = function iadd(a, b) {
+      }, Red.prototype.iadd = function(a, b) {
         this._verify2(a, b);
         var res = a.iadd(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res;
-      }, Red.prototype.sub = function sub(a, b) {
+      }, Red.prototype.sub = function(a, b) {
         this._verify2(a, b);
         var res = a.sub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res._forceRed(this);
-      }, Red.prototype.isub = function isub(a, b) {
+      }, Red.prototype.isub = function(a, b) {
         this._verify2(a, b);
         var res = a.isub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res;
-      }, Red.prototype.shl = function shl(a, num) {
+      }, Red.prototype.shl = function(a, num) {
         return this._verify1(a), this.imod(a.ushln(num));
-      }, Red.prototype.imul = function imul(a, b) {
+      }, Red.prototype.imul = function(a, b) {
         return this._verify2(a, b), this.imod(a.imul(b));
-      }, Red.prototype.mul = function mul(a, b) {
+      }, Red.prototype.mul = function(a, b) {
         return this._verify2(a, b), this.imod(a.mul(b));
-      }, Red.prototype.isqr = function isqr(a) {
+      }, Red.prototype.isqr = function(a) {
         return this.imul(a, a.clone());
-      }, Red.prototype.sqr = function sqr(a) {
+      }, Red.prototype.sqr = function(a) {
         return this.mul(a, a);
-      }, Red.prototype.sqrt = function sqrt(a) {
+      }, Red.prototype.sqrt = function(a) {
         if (a.isZero())
           return a.clone();
         var mod3 = this.m.andln(3);
@@ -15588,18 +16284,18 @@ var init_crypto = __esm(() => {
           r = r.redMul(b), c = b.redSqr(), t = t.redMul(c), m = i2;
         }
         return r;
-      }, Red.prototype.invm = function invm(a) {
+      }, Red.prototype.invm = function(a) {
         var inv = a._invmp(this.m);
         if (inv.negative !== 0)
           return inv.negative = 0, this.imod(inv).redNeg();
         else
           return this.imod(inv);
-      }, Red.prototype.pow = function pow(a, num) {
+      }, Red.prototype.pow = function(a, num) {
         if (num.isZero())
           return new BN(1).toRed(this);
         if (num.cmpn(1) === 0)
           return a.clone();
-        var windowSize = 4, wnd = new Array(1 << windowSize);
+        var windowSize = 4, wnd = Array(1 << windowSize);
         wnd[0] = new BN(1).toRed(this), wnd[1] = a;
         for (var i2 = 2;i2 < wnd.length; i2++)
           wnd[i2] = this.mul(wnd[i2 - 1], a);
@@ -15623,13 +16319,13 @@ var init_crypto = __esm(() => {
           start = 26;
         }
         return res;
-      }, Red.prototype.convertTo = function convertTo(num) {
+      }, Red.prototype.convertTo = function(num) {
         var r = num.umod(this.m);
         return r === num ? r.clone() : r;
-      }, Red.prototype.convertFrom = function convertFrom(num) {
+      }, Red.prototype.convertFrom = function(num) {
         var res = num.clone();
         return res.red = null, res;
-      }, BN.mont = function mont(num) {
+      }, BN.mont = function(num) {
         return new Mont(num);
       };
       function Mont(m) {
@@ -15637,12 +16333,12 @@ var init_crypto = __esm(() => {
           this.shift += 26 - this.shift % 26;
         this.r = new BN(1).iushln(this.shift), this.r2 = this.imod(this.r.sqr()), this.rinv = this.r._invmp(this.m), this.minv = this.rinv.mul(this.r).isubn(1).div(this.m), this.minv = this.minv.umod(this.r), this.minv = this.r.sub(this.minv);
       }
-      inherits2(Mont, Red), Mont.prototype.convertTo = function convertTo(num) {
+      inherits2(Mont, Red), Mont.prototype.convertTo = function(num) {
         return this.imod(num.ushln(this.shift));
-      }, Mont.prototype.convertFrom = function convertFrom(num) {
+      }, Mont.prototype.convertFrom = function(num) {
         var r = this.imod(num.mul(this.rinv));
         return r.red = null, r;
-      }, Mont.prototype.imul = function imul(a, b) {
+      }, Mont.prototype.imul = function(a, b) {
         if (a.isZero() || b.isZero())
           return a.words[0] = 0, a.length = 1, a;
         var t = a.imul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -15651,7 +16347,7 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.mul = function mul(a, b) {
+      }, Mont.prototype.mul = function(a, b) {
         if (a.isZero() || b.isZero())
           return new BN(0)._forceRed(this);
         var t = a.mul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -15660,11 +16356,11 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.invm = function invm(a) {
+      }, Mont.prototype.invm = function(a) {
         var res = this.imod(a._invmp(this.m).mul(this.r2));
         return res._forceRed(this);
       };
-    })(typeof module === "undefined" || module, exports);
+    })(typeof module > "u" || module, exports);
   });
   require_withPublic = __commonJS2((exports, module) => {
     var BN = require_bn4(), Buffer22 = require_safe_buffer().Buffer;
@@ -15677,7 +16373,7 @@ var init_crypto = __esm(() => {
     (function(module2, exports2) {
       function assert(val, msg) {
         if (!val)
-          throw new Error(msg || "Assertion failed");
+          throw Error(msg || "Assertion failed");
       }
       function inherits2(ctor, superCtor) {
         ctor.super_ = superCtor;
@@ -15700,24 +16396,24 @@ var init_crypto = __esm(() => {
       BN.BN = BN, BN.wordSize = 26;
       var Buffer22;
       try {
-        if (typeof window !== "undefined" && typeof window.Buffer !== "undefined")
+        if (typeof window < "u" && typeof window.Buffer < "u")
           Buffer22 = window.Buffer;
         else
-          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer2)).Buffer;
+          Buffer22 = (init_buffer(), __toCommonJS(exports_buffer)).Buffer;
       } catch (e) {}
-      BN.isBN = function isBN(num) {
+      BN.isBN = function(num) {
         if (num instanceof BN)
           return true;
         return num !== null && typeof num === "object" && num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
-      }, BN.max = function max(left, right) {
+      }, BN.max = function(left, right) {
         if (left.cmp(right) > 0)
           return left;
         return right;
-      }, BN.min = function min(left, right) {
+      }, BN.min = function(left, right) {
         if (left.cmp(right) < 0)
           return left;
         return right;
-      }, BN.prototype._init = function init(number, base, endian) {
+      }, BN.prototype._init = function(number, base, endian) {
         if (typeof number === "number")
           return this._initNumber(number, base, endian);
         if (typeof number === "object")
@@ -15734,7 +16430,7 @@ var init_crypto = __esm(() => {
           else if (this._parseBase(number, base, start), endian === "le")
             this._initArray(this.toArray(), base, endian);
         }
-      }, BN.prototype._initNumber = function _initNumber(number, base, endian) {
+      }, BN.prototype._initNumber = function(number, base, endian) {
         if (number < 0)
           this.negative = 1, number = -number;
         if (number < 67108864)
@@ -15746,10 +16442,10 @@ var init_crypto = __esm(() => {
         if (endian !== "le")
           return;
         this._initArray(this.toArray(), base, endian);
-      }, BN.prototype._initArray = function _initArray(number, base, endian) {
+      }, BN.prototype._initArray = function(number, base, endian) {
         if (assert(typeof number.length === "number"), number.length <= 0)
           return this.words = [0], this.length = 1, this;
-        this.length = Math.ceil(number.length / 3), this.words = new Array(this.length);
+        this.length = Math.ceil(number.length / 3), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var j, w, off = 0;
@@ -15781,8 +16477,8 @@ var init_crypto = __esm(() => {
           r |= parseHex4Bits(string, index - 1) << 4;
         return r;
       }
-      BN.prototype._parseHex = function _parseHex(number, start, endian) {
-        this.length = Math.ceil((number.length - start) / 6), this.words = new Array(this.length);
+      BN.prototype._parseHex = function(number, start, endian) {
+        this.length = Math.ceil((number.length - start) / 6), this.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           this.words[i2] = 0;
         var off = 0, j = 0, w;
@@ -15816,7 +16512,7 @@ var init_crypto = __esm(() => {
         }
         return r;
       }
-      BN.prototype._parseBase = function _parseBase(number, base, start) {
+      BN.prototype._parseBase = function(number, base, start) {
         this.words = [0], this.length = 1;
         for (var limbLen = 0, limbPow = 1;limbPow <= 67108863; limbPow *= base)
           limbLen++;
@@ -15838,8 +16534,8 @@ var init_crypto = __esm(() => {
             this._iaddn(word);
         }
         this._strip();
-      }, BN.prototype.copy = function copy(dest) {
-        dest.words = new Array(this.length);
+      }, BN.prototype.copy = function(dest) {
+        dest.words = Array(this.length);
         for (var i2 = 0;i2 < this.length; i2++)
           dest.words[i2] = this.words[i2];
         dest.length = this.length, dest.negative = this.negative, dest.red = this.red;
@@ -15847,36 +16543,36 @@ var init_crypto = __esm(() => {
       function move(dest, src) {
         dest.words = src.words, dest.length = src.length, dest.negative = src.negative, dest.red = src.red;
       }
-      if (BN.prototype._move = function _move(dest) {
+      if (BN.prototype._move = function(dest) {
         move(dest, this);
-      }, BN.prototype.clone = function clone() {
+      }, BN.prototype.clone = function() {
         var r = new BN(null);
         return this.copy(r), r;
-      }, BN.prototype._expand = function _expand(size) {
+      }, BN.prototype._expand = function(size) {
         while (this.length < size)
           this.words[this.length++] = 0;
         return this;
-      }, BN.prototype._strip = function strip() {
+      }, BN.prototype._strip = function() {
         while (this.length > 1 && this.words[this.length - 1] === 0)
           this.length--;
         return this._normSign();
-      }, BN.prototype._normSign = function _normSign() {
+      }, BN.prototype._normSign = function() {
         if (this.length === 1 && this.words[0] === 0)
           this.negative = 0;
         return this;
-      }, typeof Symbol !== "undefined" && typeof Symbol.for === "function")
+      }, typeof Symbol < "u" && typeof Symbol.for === "function")
         try {
-          BN.prototype[Symbol.for("nodejs.util.inspect.custom")] = inspect3;
+          BN.prototype[Symbol.for("nodejs.util.inspect.custom")] = inspect2;
         } catch (e) {
-          BN.prototype.inspect = inspect3;
+          BN.prototype.inspect = inspect2;
         }
       else
-        BN.prototype.inspect = inspect3;
-      function inspect3() {
+        BN.prototype.inspect = inspect2;
+      function inspect2() {
         return (this.red ? "<BN-R: " : "<BN: ") + this.toString(16) + ">";
       }
       var zeros = ["", "0", "00", "000", "0000", "00000", "000000", "0000000", "00000000", "000000000", "0000000000", "00000000000", "000000000000", "0000000000000", "00000000000000", "000000000000000", "0000000000000000", "00000000000000000", "000000000000000000", "0000000000000000000", "00000000000000000000", "000000000000000000000", "0000000000000000000000", "00000000000000000000000", "000000000000000000000000", "0000000000000000000000000"], groupSizes = [0, 0, 25, 16, 12, 11, 10, 9, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], groupBases = [0, 0, 33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216, 43046721, 1e7, 19487171, 35831808, 62748517, 7529536, 11390625, 16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632, 6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149, 24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176];
-      if (BN.prototype.toString = function toString(base, padding) {
+      if (BN.prototype.toString = function(base, padding) {
         base = base || 10, padding = padding | 0 || 1;
         var out;
         if (base === 16 || base === "hex") {
@@ -15920,7 +16616,7 @@ var init_crypto = __esm(() => {
           return out;
         }
         assert(false, "Base should be between 2 and 36");
-      }, BN.prototype.toNumber = function toNumber() {
+      }, BN.prototype.toNumber = function() {
         var ret = this.words[0];
         if (this.length === 2)
           ret += this.words[1] * 67108864;
@@ -15929,27 +16625,27 @@ var init_crypto = __esm(() => {
         else if (this.length > 2)
           assert(false, "Number can only safely store up to 53 bits");
         return this.negative !== 0 ? -ret : ret;
-      }, BN.prototype.toJSON = function toJSON() {
+      }, BN.prototype.toJSON = function() {
         return this.toString(16, 2);
       }, Buffer22)
-        BN.prototype.toBuffer = function toBuffer(endian, length) {
+        BN.prototype.toBuffer = function(endian, length) {
           return this.toArrayLike(Buffer22, endian, length);
         };
-      BN.prototype.toArray = function toArray(endian, length) {
+      BN.prototype.toArray = function(endian, length) {
         return this.toArrayLike(Array, endian, length);
       };
-      var allocate = function allocate(ArrayType, size) {
+      var allocate = function(ArrayType, size) {
         if (ArrayType.allocUnsafe)
           return ArrayType.allocUnsafe(size);
         return new ArrayType(size);
       };
-      if (BN.prototype.toArrayLike = function toArrayLike(ArrayType, endian, length) {
+      if (BN.prototype.toArrayLike = function(ArrayType, endian, length) {
         this._strip();
         var byteLength2 = this.byteLength(), reqLength = length || Math.max(1, byteLength2);
         assert(byteLength2 <= reqLength, "byte array longer than desired length"), assert(reqLength > 0, "Requested array length <= 0");
         var res = allocate(ArrayType, reqLength), postfix = endian === "le" ? "LE" : "BE";
         return this["_toArrayLike" + postfix](res, byteLength2), res;
-      }, BN.prototype._toArrayLikeLE = function _toArrayLikeLE(res, byteLength2) {
+      }, BN.prototype._toArrayLikeLE = function(res, byteLength2) {
         var position = 0, carry = 0;
         for (var i2 = 0, shift = 0;i2 < this.length; i2++) {
           var word = this.words[i2] << shift | carry;
@@ -15969,7 +16665,7 @@ var init_crypto = __esm(() => {
           while (position < res.length)
             res[position++] = 0;
         }
-      }, BN.prototype._toArrayLikeBE = function _toArrayLikeBE(res, byteLength2) {
+      }, BN.prototype._toArrayLikeBE = function(res, byteLength2) {
         var position = res.length - 1, carry = 0;
         for (var i2 = 0, shift = 0;i2 < this.length; i2++) {
           var word = this.words[i2] << shift | carry;
@@ -15990,11 +16686,11 @@ var init_crypto = __esm(() => {
             res[position--] = 0;
         }
       }, Math.clz32)
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           return 32 - Math.clz32(w);
         };
       else
-        BN.prototype._countBits = function _countBits(w) {
+        BN.prototype._countBits = function(w) {
           var t = w, r = 0;
           if (t >= 4096)
             r += 13, t >>>= 13;
@@ -16006,7 +16702,7 @@ var init_crypto = __esm(() => {
             r += 2, t >>>= 2;
           return r + t;
         };
-      BN.prototype._zeroBits = function _zeroBits(w) {
+      BN.prototype._zeroBits = function(w) {
         if (w === 0)
           return 26;
         var t = w, r = 0;
@@ -16021,19 +16717,19 @@ var init_crypto = __esm(() => {
         if ((t & 1) === 0)
           r++;
         return r;
-      }, BN.prototype.bitLength = function bitLength() {
+      }, BN.prototype.bitLength = function() {
         var w = this.words[this.length - 1], hi = this._countBits(w);
         return (this.length - 1) * 26 + hi;
       };
       function toBitArray(num) {
-        var w = new Array(num.bitLength());
+        var w = Array(num.bitLength());
         for (var bit = 0;bit < w.length; bit++) {
           var off = bit / 26 | 0, wbit = bit % 26;
           w[bit] = num.words[off] >>> wbit & 1;
         }
         return w;
       }
-      BN.prototype.zeroBits = function zeroBits() {
+      BN.prototype.zeroBits = function() {
         if (this.isZero())
           return 0;
         var r = 0;
@@ -16043,41 +16739,41 @@ var init_crypto = __esm(() => {
             break;
         }
         return r;
-      }, BN.prototype.byteLength = function byteLength() {
+      }, BN.prototype.byteLength = function() {
         return Math.ceil(this.bitLength() / 8);
-      }, BN.prototype.toTwos = function toTwos(width) {
+      }, BN.prototype.toTwos = function(width) {
         if (this.negative !== 0)
           return this.abs().inotn(width).iaddn(1);
         return this.clone();
-      }, BN.prototype.fromTwos = function fromTwos(width) {
+      }, BN.prototype.fromTwos = function(width) {
         if (this.testn(width - 1))
           return this.notn(width).iaddn(1).ineg();
         return this.clone();
-      }, BN.prototype.isNeg = function isNeg() {
+      }, BN.prototype.isNeg = function() {
         return this.negative !== 0;
-      }, BN.prototype.neg = function neg() {
+      }, BN.prototype.neg = function() {
         return this.clone().ineg();
-      }, BN.prototype.ineg = function ineg() {
+      }, BN.prototype.ineg = function() {
         if (!this.isZero())
           this.negative ^= 1;
         return this;
-      }, BN.prototype.iuor = function iuor(num) {
+      }, BN.prototype.iuor = function(num) {
         while (this.length < num.length)
           this.words[this.length++] = 0;
         for (var i2 = 0;i2 < num.length; i2++)
           this.words[i2] = this.words[i2] | num.words[i2];
         return this._strip();
-      }, BN.prototype.ior = function ior(num) {
+      }, BN.prototype.ior = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuor(num);
-      }, BN.prototype.or = function or(num) {
+      }, BN.prototype.or = function(num) {
         if (this.length > num.length)
           return this.clone().ior(num);
         return num.clone().ior(this);
-      }, BN.prototype.uor = function uor(num) {
+      }, BN.prototype.uor = function(num) {
         if (this.length > num.length)
           return this.clone().iuor(num);
         return num.clone().iuor(this);
-      }, BN.prototype.iuand = function iuand(num) {
+      }, BN.prototype.iuand = function(num) {
         var b;
         if (this.length > num.length)
           b = num;
@@ -16086,17 +16782,17 @@ var init_crypto = __esm(() => {
         for (var i2 = 0;i2 < b.length; i2++)
           this.words[i2] = this.words[i2] & num.words[i2];
         return this.length = b.length, this._strip();
-      }, BN.prototype.iand = function iand(num) {
+      }, BN.prototype.iand = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuand(num);
-      }, BN.prototype.and = function and(num) {
+      }, BN.prototype.and = function(num) {
         if (this.length > num.length)
           return this.clone().iand(num);
         return num.clone().iand(this);
-      }, BN.prototype.uand = function uand(num) {
+      }, BN.prototype.uand = function(num) {
         if (this.length > num.length)
           return this.clone().iuand(num);
         return num.clone().iuand(this);
-      }, BN.prototype.iuxor = function iuxor(num) {
+      }, BN.prototype.iuxor = function(num) {
         var a, b;
         if (this.length > num.length)
           a = this, b = num;
@@ -16108,17 +16804,17 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this.length = a.length, this._strip();
-      }, BN.prototype.ixor = function ixor(num) {
+      }, BN.prototype.ixor = function(num) {
         return assert((this.negative | num.negative) === 0), this.iuxor(num);
-      }, BN.prototype.xor = function xor(num) {
+      }, BN.prototype.xor = function(num) {
         if (this.length > num.length)
           return this.clone().ixor(num);
         return num.clone().ixor(this);
-      }, BN.prototype.uxor = function uxor(num) {
+      }, BN.prototype.uxor = function(num) {
         if (this.length > num.length)
           return this.clone().iuxor(num);
         return num.clone().iuxor(this);
-      }, BN.prototype.inotn = function inotn(width) {
+      }, BN.prototype.inotn = function(width) {
         assert(typeof width === "number" && width >= 0);
         var bytesNeeded = Math.ceil(width / 26) | 0, bitsLeft = width % 26;
         if (this._expand(bytesNeeded), bitsLeft > 0)
@@ -16128,9 +16824,9 @@ var init_crypto = __esm(() => {
         if (bitsLeft > 0)
           this.words[i2] = ~this.words[i2] & 67108863 >> 26 - bitsLeft;
         return this._strip();
-      }, BN.prototype.notn = function notn(width) {
+      }, BN.prototype.notn = function(width) {
         return this.clone().inotn(width);
-      }, BN.prototype.setn = function setn(bit, val) {
+      }, BN.prototype.setn = function(bit, val) {
         assert(typeof bit === "number" && bit >= 0);
         var off = bit / 26 | 0, wbit = bit % 26;
         if (this._expand(off + 1), val)
@@ -16138,7 +16834,7 @@ var init_crypto = __esm(() => {
         else
           this.words[off] = this.words[off] & ~(1 << wbit);
         return this._strip();
-      }, BN.prototype.iadd = function iadd(num) {
+      }, BN.prototype.iadd = function(num) {
         var r;
         if (this.negative !== 0 && num.negative === 0)
           return this.negative = 0, r = this.isub(num), this.negative ^= 1, this._normSign();
@@ -16160,7 +16856,7 @@ var init_crypto = __esm(() => {
           for (;i2 < a.length; i2++)
             this.words[i2] = a.words[i2];
         return this;
-      }, BN.prototype.add = function add(num) {
+      }, BN.prototype.add = function(num) {
         var res;
         if (num.negative !== 0 && this.negative === 0)
           return num.negative = 0, res = this.sub(num), num.negative ^= 1, res;
@@ -16169,7 +16865,7 @@ var init_crypto = __esm(() => {
         if (this.length > num.length)
           return this.clone().iadd(num);
         return num.clone().iadd(this);
-      }, BN.prototype.isub = function isub(num) {
+      }, BN.prototype.isub = function(num) {
         if (num.negative !== 0) {
           num.negative = 0;
           var r = this.iadd(num);
@@ -16195,7 +16891,7 @@ var init_crypto = __esm(() => {
         if (this.length = Math.max(this.length, i2), a !== this)
           this.negative = 1;
         return this._strip();
-      }, BN.prototype.sub = function sub(num) {
+      }, BN.prototype.sub = function(num) {
         return this.clone().isub(num);
       };
       function smallMulTo(self2, num, out) {
@@ -16218,7 +16914,7 @@ var init_crypto = __esm(() => {
           out.length--;
         return out._strip();
       }
-      var comb10MulTo = function comb10MulTo(self2, num, out) {
+      var comb10MulTo = function(self2, num, out) {
         var a = self2.words, b = num.words, o = out.words, c = 0, lo, mid, hi, a0 = a[0] | 0, al0 = a0 & 8191, ah0 = a0 >>> 13, a1 = a[1] | 0, al1 = a1 & 8191, ah1 = a1 >>> 13, a2 = a[2] | 0, al2 = a2 & 8191, ah2 = a2 >>> 13, a3 = a[3] | 0, al3 = a3 & 8191, ah3 = a3 >>> 13, a4 = a[4] | 0, al4 = a4 & 8191, ah4 = a4 >>> 13, a5 = a[5] | 0, al5 = a5 & 8191, ah5 = a5 >>> 13, a6 = a[6] | 0, al6 = a6 & 8191, ah6 = a6 >>> 13, a7 = a[7] | 0, al7 = a7 & 8191, ah7 = a7 >>> 13, a8 = a[8] | 0, al8 = a8 & 8191, ah8 = a8 >>> 13, a9 = a[9] | 0, al9 = a9 & 8191, ah9 = a9 >>> 13, b0 = b[0] | 0, bl0 = b0 & 8191, bh0 = b0 >>> 13, b1 = b[1] | 0, bl1 = b1 & 8191, bh1 = b1 >>> 13, b2 = b[2] | 0, bl2 = b2 & 8191, bh2 = b2 >>> 13, b3 = b[3] | 0, bl3 = b3 & 8191, bh3 = b3 >>> 13, b4 = b[4] | 0, bl4 = b4 & 8191, bh4 = b4 >>> 13, b5 = b[5] | 0, bl5 = b5 & 8191, bh5 = b5 >>> 13, b6 = b[6] | 0, bl6 = b6 & 8191, bh6 = b6 >>> 13, b7 = b[7] | 0, bl7 = b7 & 8191, bh7 = b7 >>> 13, b8 = b[8] | 0, bl8 = b8 & 8191, bh8 = b8 >>> 13, b9 = b[9] | 0, bl9 = b9 & 8191, bh9 = b9 >>> 13;
         out.negative = self2.negative ^ num.negative, out.length = 19, lo = Math.imul(al0, bl0), mid = Math.imul(al0, bh0), mid = mid + Math.imul(ah0, bl0) | 0, hi = Math.imul(ah0, bh0);
         var w0 = (c + lo | 0) + ((mid & 8191) << 13) | 0;
@@ -16286,7 +16982,7 @@ var init_crypto = __esm(() => {
       function jumboMulTo(self2, num, out) {
         return bigMulTo(self2, num, out);
       }
-      BN.prototype.mulTo = function mulTo(num, out) {
+      BN.prototype.mulTo = function(num, out) {
         var res, len2 = this.length + num.length;
         if (this.length === 10 && num.length === 10)
           res = comb10MulTo(this, num, out);
@@ -16301,22 +16997,22 @@ var init_crypto = __esm(() => {
       function FFTM(x, y) {
         this.x = x, this.y = y;
       }
-      FFTM.prototype.makeRBT = function makeRBT(N) {
-        var t = new Array(N), l = BN.prototype._countBits(N) - 1;
+      FFTM.prototype.makeRBT = function(N) {
+        var t = Array(N), l = BN.prototype._countBits(N) - 1;
         for (var i2 = 0;i2 < N; i2++)
           t[i2] = this.revBin(i2, l, N);
         return t;
-      }, FFTM.prototype.revBin = function revBin(x, l, N) {
+      }, FFTM.prototype.revBin = function(x, l, N) {
         if (x === 0 || x === N - 1)
           return x;
         var rb = 0;
         for (var i2 = 0;i2 < l; i2++)
           rb |= (x & 1) << l - i2 - 1, x >>= 1;
         return rb;
-      }, FFTM.prototype.permute = function permute(rbt, rws, iws, rtws, itws, N) {
+      }, FFTM.prototype.permute = function(rbt, rws, iws, rtws, itws, N) {
         for (var i2 = 0;i2 < N; i2++)
           rtws[i2] = rws[rbt[i2]], itws[i2] = iws[rbt[i2]];
-      }, FFTM.prototype.transform = function transform(rws, iws, rtws, itws, N, rbt) {
+      }, FFTM.prototype.transform = function(rws, iws, rtws, itws, N, rbt) {
         this.permute(rbt, rws, iws, rtws, itws, N);
         for (var s = 1;s < N; s <<= 1) {
           var l = s << 1, rtwdf = Math.cos(2 * Math.PI / l), itwdf = Math.sin(2 * Math.PI / l);
@@ -16329,19 +17025,19 @@ var init_crypto = __esm(() => {
             }
           }
         }
-      }, FFTM.prototype.guessLen13b = function guessLen13b(n, m) {
+      }, FFTM.prototype.guessLen13b = function(n, m) {
         var N = Math.max(m, n) | 1, odd = N & 1, i2 = 0;
         for (N = N / 2 | 0;N; N = N >>> 1)
           i2++;
         return 1 << i2 + 1 + odd;
-      }, FFTM.prototype.conjugate = function conjugate(rws, iws, N) {
+      }, FFTM.prototype.conjugate = function(rws, iws, N) {
         if (N <= 1)
           return;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var t = rws[i2];
           rws[i2] = rws[N - i2 - 1], rws[N - i2 - 1] = t, t = iws[i2], iws[i2] = -iws[N - i2 - 1], iws[N - i2 - 1] = -t;
         }
-      }, FFTM.prototype.normalize13b = function normalize13b(ws, N) {
+      }, FFTM.prototype.normalize13b = function(ws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < N / 2; i2++) {
           var w = Math.round(ws[2 * i2 + 1] / N) * 8192 + Math.round(ws[2 * i2] / N) + carry;
@@ -16351,35 +17047,35 @@ var init_crypto = __esm(() => {
             carry = w / 67108864 | 0;
         }
         return ws;
-      }, FFTM.prototype.convert13b = function convert13b(ws, len2, rws, N) {
+      }, FFTM.prototype.convert13b = function(ws, len2, rws, N) {
         var carry = 0;
         for (var i2 = 0;i2 < len2; i2++)
           carry = carry + (ws[i2] | 0), rws[2 * i2] = carry & 8191, carry = carry >>> 13, rws[2 * i2 + 1] = carry & 8191, carry = carry >>> 13;
         for (i2 = 2 * len2;i2 < N; ++i2)
           rws[i2] = 0;
         assert(carry === 0), assert((carry & -8192) === 0);
-      }, FFTM.prototype.stub = function stub(N) {
-        var ph = new Array(N);
+      }, FFTM.prototype.stub = function(N) {
+        var ph = Array(N);
         for (var i2 = 0;i2 < N; i2++)
           ph[i2] = 0;
         return ph;
-      }, FFTM.prototype.mulp = function mulp(x, y, out) {
-        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = new Array(N), rwst = new Array(N), iwst = new Array(N), nrws = new Array(N), nrwst = new Array(N), niwst = new Array(N), rmws = out.words;
+      }, FFTM.prototype.mulp = function(x, y, out) {
+        var N = 2 * this.guessLen13b(x.length, y.length), rbt = this.makeRBT(N), _ = this.stub(N), rws = Array(N), rwst = Array(N), iwst = Array(N), nrws = Array(N), nrwst = Array(N), niwst = Array(N), rmws = out.words;
         rmws.length = N, this.convert13b(x.words, x.length, rws, N), this.convert13b(y.words, y.length, nrws, N), this.transform(rws, _, rwst, iwst, N, rbt), this.transform(nrws, _, nrwst, niwst, N, rbt);
         for (var i2 = 0;i2 < N; i2++) {
           var rx = rwst[i2] * nrwst[i2] - iwst[i2] * niwst[i2];
           iwst[i2] = rwst[i2] * niwst[i2] + iwst[i2] * nrwst[i2], rwst[i2] = rx;
         }
         return this.conjugate(rwst, iwst, N), this.transform(rwst, iwst, rmws, _, N, rbt), this.conjugate(rmws, _, N), this.normalize13b(rmws, N), out.negative = x.negative ^ y.negative, out.length = x.length + y.length, out._strip();
-      }, BN.prototype.mul = function mul(num) {
+      }, BN.prototype.mul = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), this.mulTo(num, out);
-      }, BN.prototype.mulf = function mulf(num) {
+        return out.words = Array(this.length + num.length), this.mulTo(num, out);
+      }, BN.prototype.mulf = function(num) {
         var out = new BN(null);
-        return out.words = new Array(this.length + num.length), jumboMulTo(this, num, out);
-      }, BN.prototype.imul = function imul(num) {
+        return out.words = Array(this.length + num.length), jumboMulTo(this, num, out);
+      }, BN.prototype.imul = function(num) {
         return this.clone().mulTo(num, this);
-      }, BN.prototype.imuln = function imuln(num) {
+      }, BN.prototype.imuln = function(num) {
         var isNegNum = num < 0;
         if (isNegNum)
           num = -num;
@@ -16392,13 +17088,13 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this.length = num === 0 ? 1 : this.length, isNegNum ? this.ineg() : this;
-      }, BN.prototype.muln = function muln(num) {
+      }, BN.prototype.muln = function(num) {
         return this.clone().imuln(num);
-      }, BN.prototype.sqr = function sqr() {
+      }, BN.prototype.sqr = function() {
         return this.mul(this);
-      }, BN.prototype.isqr = function isqr() {
+      }, BN.prototype.isqr = function() {
         return this.imul(this.clone());
-      }, BN.prototype.pow = function pow(num) {
+      }, BN.prototype.pow = function(num) {
         var w = toBitArray(num);
         if (w.length === 0)
           return new BN(1);
@@ -16413,7 +17109,7 @@ var init_crypto = __esm(() => {
             res = res.mul(q);
           }
         return res;
-      }, BN.prototype.iushln = function iushln(bits) {
+      }, BN.prototype.iushln = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26, carryMask = 67108863 >>> 26 - r << 26 - r, i2;
         if (r !== 0) {
@@ -16433,9 +17129,9 @@ var init_crypto = __esm(() => {
           this.length += s;
         }
         return this._strip();
-      }, BN.prototype.ishln = function ishln(bits) {
+      }, BN.prototype.ishln = function(bits) {
         return assert(this.negative === 0), this.iushln(bits);
-      }, BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+      }, BN.prototype.iushrn = function(bits, hint, extended) {
         assert(typeof bits === "number" && bits >= 0);
         var h;
         if (hint)
@@ -16466,24 +17162,24 @@ var init_crypto = __esm(() => {
         if (this.length === 0)
           this.words[0] = 0, this.length = 1;
         return this._strip();
-      }, BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+      }, BN.prototype.ishrn = function(bits, hint, extended) {
         return assert(this.negative === 0), this.iushrn(bits, hint, extended);
-      }, BN.prototype.shln = function shln(bits) {
+      }, BN.prototype.shln = function(bits) {
         return this.clone().ishln(bits);
-      }, BN.prototype.ushln = function ushln(bits) {
+      }, BN.prototype.ushln = function(bits) {
         return this.clone().iushln(bits);
-      }, BN.prototype.shrn = function shrn(bits) {
+      }, BN.prototype.shrn = function(bits) {
         return this.clone().ishrn(bits);
-      }, BN.prototype.ushrn = function ushrn(bits) {
+      }, BN.prototype.ushrn = function(bits) {
         return this.clone().iushrn(bits);
-      }, BN.prototype.testn = function testn(bit) {
+      }, BN.prototype.testn = function(bit) {
         assert(typeof bit === "number" && bit >= 0);
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
           return false;
         var w = this.words[s];
         return !!(w & q);
-      }, BN.prototype.imaskn = function imaskn(bits) {
+      }, BN.prototype.imaskn = function(bits) {
         assert(typeof bits === "number" && bits >= 0);
         var r = bits % 26, s = (bits - r) / 26;
         if (assert(this.negative === 0, "imaskn works only with positive numbers"), this.length <= s)
@@ -16495,9 +17191,9 @@ var init_crypto = __esm(() => {
           this.words[this.length - 1] &= mask;
         }
         return this._strip();
-      }, BN.prototype.maskn = function maskn(bits) {
+      }, BN.prototype.maskn = function(bits) {
         return this.clone().imaskn(bits);
-      }, BN.prototype.iaddn = function iaddn(num) {
+      }, BN.prototype.iaddn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.isubn(-num);
         if (this.negative !== 0) {
@@ -16506,7 +17202,7 @@ var init_crypto = __esm(() => {
           return this.negative = 0, this.isubn(num), this.negative = 1, this;
         }
         return this._iaddn(num);
-      }, BN.prototype._iaddn = function _iaddn(num) {
+      }, BN.prototype._iaddn = function(num) {
         this.words[0] += num;
         for (var i2 = 0;i2 < this.length && this.words[i2] >= 67108864; i2++)
           if (this.words[i2] -= 67108864, i2 === this.length - 1)
@@ -16514,7 +17210,7 @@ var init_crypto = __esm(() => {
           else
             this.words[i2 + 1]++;
         return this.length = Math.max(this.length, i2 + 1), this;
-      }, BN.prototype.isubn = function isubn(num) {
+      }, BN.prototype.isubn = function(num) {
         if (assert(typeof num === "number"), assert(num < 67108864), num < 0)
           return this.iaddn(-num);
         if (this.negative !== 0)
@@ -16525,15 +17221,15 @@ var init_crypto = __esm(() => {
           for (var i2 = 0;i2 < this.length && this.words[i2] < 0; i2++)
             this.words[i2] += 67108864, this.words[i2 + 1] -= 1;
         return this._strip();
-      }, BN.prototype.addn = function addn(num) {
+      }, BN.prototype.addn = function(num) {
         return this.clone().iaddn(num);
-      }, BN.prototype.subn = function subn(num) {
+      }, BN.prototype.subn = function(num) {
         return this.clone().isubn(num);
-      }, BN.prototype.iabs = function iabs() {
+      }, BN.prototype.iabs = function() {
         return this.negative = 0, this;
-      }, BN.prototype.abs = function abs() {
+      }, BN.prototype.abs = function() {
         return this.clone().iabs();
-      }, BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+      }, BN.prototype._ishlnsubmul = function(num, mul, shift) {
         var len2 = num.length + shift, i2;
         this._expand(len2);
         var w, carry = 0;
@@ -16550,13 +17246,13 @@ var init_crypto = __esm(() => {
         for (i2 = 0;i2 < this.length; i2++)
           w = -(this.words[i2] | 0) + carry, carry = w >> 26, this.words[i2] = w & 67108863;
         return this.negative = 1, this._strip();
-      }, BN.prototype._wordDiv = function _wordDiv(num, mode) {
+      }, BN.prototype._wordDiv = function(num, mode) {
         var shift = this.length - num.length, a = this.clone(), b = num, bhi = b.words[b.length - 1] | 0, bhiBits = this._countBits(bhi);
         if (shift = 26 - bhiBits, shift !== 0)
           b = b.ushln(shift), a.iushln(shift), bhi = b.words[b.length - 1] | 0;
         var m = a.length - b.length, q;
         if (mode !== "mod") {
-          q = new BN(null), q.length = m + 1, q.words = new Array(q.length);
+          q = new BN(null), q.length = m + 1, q.words = Array(q.length);
           for (var i2 = 0;i2 < q.length; i2++)
             q.words[i2] = 0;
         }
@@ -16579,7 +17275,7 @@ var init_crypto = __esm(() => {
         if (a._strip(), mode !== "div" && shift !== 0)
           a.iushrn(shift);
         return { div: q || null, mod: a };
-      }, BN.prototype.divmod = function divmod(num, mode, positive) {
+      }, BN.prototype.divmod = function(num, mode, positive) {
         if (assert(!num.isZero()), this.isZero())
           return { div: new BN(0), mod: new BN(0) };
         var div, mod, res;
@@ -16614,13 +17310,13 @@ var init_crypto = __esm(() => {
           return { div: this.divn(num.words[0]), mod: new BN(this.modrn(num.words[0])) };
         }
         return this._wordDiv(num, mode);
-      }, BN.prototype.div = function div(num) {
+      }, BN.prototype.div = function(num) {
         return this.divmod(num, "div", false).div;
-      }, BN.prototype.mod = function mod(num) {
+      }, BN.prototype.mod = function(num) {
         return this.divmod(num, "mod", false).mod;
-      }, BN.prototype.umod = function umod(num) {
+      }, BN.prototype.umod = function(num) {
         return this.divmod(num, "mod", true).mod;
-      }, BN.prototype.divRound = function divRound(num) {
+      }, BN.prototype.divRound = function(num) {
         var dm = this.divmod(num);
         if (dm.mod.isZero())
           return dm.div;
@@ -16628,7 +17324,7 @@ var init_crypto = __esm(() => {
         if (cmp < 0 || r2 === 1 && cmp === 0)
           return dm.div;
         return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
-      }, BN.prototype.modrn = function modrn(num) {
+      }, BN.prototype.modrn = function(num) {
         var isNegNum = num < 0;
         if (isNegNum)
           num = -num;
@@ -16637,9 +17333,9 @@ var init_crypto = __esm(() => {
         for (var i2 = this.length - 1;i2 >= 0; i2--)
           acc = (p * acc + (this.words[i2] | 0)) % num;
         return isNegNum ? -acc : acc;
-      }, BN.prototype.modn = function modn(num) {
+      }, BN.prototype.modn = function(num) {
         return this.modrn(num);
-      }, BN.prototype.idivn = function idivn(num) {
+      }, BN.prototype.idivn = function(num) {
         var isNegNum = num < 0;
         if (isNegNum)
           num = -num;
@@ -16650,9 +17346,9 @@ var init_crypto = __esm(() => {
           this.words[i2] = w / num | 0, carry = w % num;
         }
         return this._strip(), isNegNum ? this.ineg() : this;
-      }, BN.prototype.divn = function divn(num) {
+      }, BN.prototype.divn = function(num) {
         return this.clone().idivn(num);
-      }, BN.prototype.egcd = function egcd(p) {
+      }, BN.prototype.egcd = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var x = this, y = p.clone();
         if (x.negative !== 0)
@@ -16690,7 +17386,7 @@ var init_crypto = __esm(() => {
             y.isub(x), C.isub(A), D.isub(B);
         }
         return { a: C, b: D, gcd: y.iushln(g) };
-      }, BN.prototype._invmp = function _invmp(p) {
+      }, BN.prototype._invmp = function(p) {
         assert(p.negative === 0), assert(!p.isZero());
         var a = this, b = p.clone();
         if (a.negative !== 0)
@@ -16732,7 +17428,7 @@ var init_crypto = __esm(() => {
         if (res.cmpn(0) < 0)
           res.iadd(p);
         return res;
-      }, BN.prototype.gcd = function gcd(num) {
+      }, BN.prototype.gcd = function(num) {
         if (this.isZero())
           return num.abs();
         if (num.isZero())
@@ -16755,15 +17451,15 @@ var init_crypto = __esm(() => {
           a.isub(b);
         } while (true);
         return b.iushln(shift);
-      }, BN.prototype.invm = function invm(num) {
+      }, BN.prototype.invm = function(num) {
         return this.egcd(num).a.umod(num);
-      }, BN.prototype.isEven = function isEven() {
+      }, BN.prototype.isEven = function() {
         return (this.words[0] & 1) === 0;
-      }, BN.prototype.isOdd = function isOdd() {
+      }, BN.prototype.isOdd = function() {
         return (this.words[0] & 1) === 1;
-      }, BN.prototype.andln = function andln(num) {
+      }, BN.prototype.andln = function(num) {
         return this.words[0] & num;
-      }, BN.prototype.bincn = function bincn(bit) {
+      }, BN.prototype.bincn = function(bit) {
         assert(typeof bit === "number");
         var r = bit % 26, s = (bit - r) / 26, q = 1 << r;
         if (this.length <= s)
@@ -16776,9 +17472,9 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           this.words[i2] = carry, this.length++;
         return this;
-      }, BN.prototype.isZero = function isZero() {
+      }, BN.prototype.isZero = function() {
         return this.length === 1 && this.words[0] === 0;
-      }, BN.prototype.cmpn = function cmpn(num) {
+      }, BN.prototype.cmpn = function(num) {
         var negative = num < 0;
         if (this.negative !== 0 && !negative)
           return -1;
@@ -16798,7 +17494,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.cmp = function cmp(num) {
+      }, BN.prototype.cmp = function(num) {
         if (this.negative !== 0 && num.negative === 0)
           return -1;
         if (this.negative === 0 && num.negative !== 0)
@@ -16807,7 +17503,7 @@ var init_crypto = __esm(() => {
         if (this.negative !== 0)
           return -res | 0;
         return res;
-      }, BN.prototype.ucmp = function ucmp(num) {
+      }, BN.prototype.ucmp = function(num) {
         if (this.length > num.length)
           return 1;
         if (this.length < num.length)
@@ -16824,71 +17520,71 @@ var init_crypto = __esm(() => {
           break;
         }
         return res;
-      }, BN.prototype.gtn = function gtn(num) {
+      }, BN.prototype.gtn = function(num) {
         return this.cmpn(num) === 1;
-      }, BN.prototype.gt = function gt(num) {
+      }, BN.prototype.gt = function(num) {
         return this.cmp(num) === 1;
-      }, BN.prototype.gten = function gten(num) {
+      }, BN.prototype.gten = function(num) {
         return this.cmpn(num) >= 0;
-      }, BN.prototype.gte = function gte(num) {
+      }, BN.prototype.gte = function(num) {
         return this.cmp(num) >= 0;
-      }, BN.prototype.ltn = function ltn(num) {
+      }, BN.prototype.ltn = function(num) {
         return this.cmpn(num) === -1;
-      }, BN.prototype.lt = function lt(num) {
+      }, BN.prototype.lt = function(num) {
         return this.cmp(num) === -1;
-      }, BN.prototype.lten = function lten(num) {
+      }, BN.prototype.lten = function(num) {
         return this.cmpn(num) <= 0;
-      }, BN.prototype.lte = function lte(num) {
+      }, BN.prototype.lte = function(num) {
         return this.cmp(num) <= 0;
-      }, BN.prototype.eqn = function eqn(num) {
+      }, BN.prototype.eqn = function(num) {
         return this.cmpn(num) === 0;
-      }, BN.prototype.eq = function eq(num) {
+      }, BN.prototype.eq = function(num) {
         return this.cmp(num) === 0;
-      }, BN.red = function red(num) {
+      }, BN.red = function(num) {
         return new Red(num);
-      }, BN.prototype.toRed = function toRed(ctx) {
+      }, BN.prototype.toRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), assert(this.negative === 0, "red works only with positives"), ctx.convertTo(this)._forceRed(ctx);
-      }, BN.prototype.fromRed = function fromRed() {
+      }, BN.prototype.fromRed = function() {
         return assert(this.red, "fromRed works only with numbers in reduction context"), this.red.convertFrom(this);
-      }, BN.prototype._forceRed = function _forceRed(ctx) {
+      }, BN.prototype._forceRed = function(ctx) {
         return this.red = ctx, this;
-      }, BN.prototype.forceRed = function forceRed(ctx) {
+      }, BN.prototype.forceRed = function(ctx) {
         return assert(!this.red, "Already a number in reduction context"), this._forceRed(ctx);
-      }, BN.prototype.redAdd = function redAdd(num) {
+      }, BN.prototype.redAdd = function(num) {
         return assert(this.red, "redAdd works only with red numbers"), this.red.add(this, num);
-      }, BN.prototype.redIAdd = function redIAdd(num) {
+      }, BN.prototype.redIAdd = function(num) {
         return assert(this.red, "redIAdd works only with red numbers"), this.red.iadd(this, num);
-      }, BN.prototype.redSub = function redSub(num) {
+      }, BN.prototype.redSub = function(num) {
         return assert(this.red, "redSub works only with red numbers"), this.red.sub(this, num);
-      }, BN.prototype.redISub = function redISub(num) {
+      }, BN.prototype.redISub = function(num) {
         return assert(this.red, "redISub works only with red numbers"), this.red.isub(this, num);
-      }, BN.prototype.redShl = function redShl(num) {
+      }, BN.prototype.redShl = function(num) {
         return assert(this.red, "redShl works only with red numbers"), this.red.shl(this, num);
-      }, BN.prototype.redMul = function redMul(num) {
+      }, BN.prototype.redMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.mul(this, num);
-      }, BN.prototype.redIMul = function redIMul(num) {
+      }, BN.prototype.redIMul = function(num) {
         return assert(this.red, "redMul works only with red numbers"), this.red._verify2(this, num), this.red.imul(this, num);
-      }, BN.prototype.redSqr = function redSqr() {
+      }, BN.prototype.redSqr = function() {
         return assert(this.red, "redSqr works only with red numbers"), this.red._verify1(this), this.red.sqr(this);
-      }, BN.prototype.redISqr = function redISqr() {
+      }, BN.prototype.redISqr = function() {
         return assert(this.red, "redISqr works only with red numbers"), this.red._verify1(this), this.red.isqr(this);
-      }, BN.prototype.redSqrt = function redSqrt() {
+      }, BN.prototype.redSqrt = function() {
         return assert(this.red, "redSqrt works only with red numbers"), this.red._verify1(this), this.red.sqrt(this);
-      }, BN.prototype.redInvm = function redInvm() {
+      }, BN.prototype.redInvm = function() {
         return assert(this.red, "redInvm works only with red numbers"), this.red._verify1(this), this.red.invm(this);
-      }, BN.prototype.redNeg = function redNeg() {
+      }, BN.prototype.redNeg = function() {
         return assert(this.red, "redNeg works only with red numbers"), this.red._verify1(this), this.red.neg(this);
-      }, BN.prototype.redPow = function redPow(num) {
+      }, BN.prototype.redPow = function(num) {
         return assert(this.red && !num.red, "redPow(normalNum)"), this.red._verify1(this), this.red.pow(this, num);
       };
       var primes = { k256: null, p224: null, p192: null, p25519: null };
       function MPrime(name, p) {
         this.name = name, this.p = new BN(p, 16), this.n = this.p.bitLength(), this.k = new BN(1).iushln(this.n).isub(this.p), this.tmp = this._tmp();
       }
-      MPrime.prototype._tmp = function _tmp() {
+      MPrime.prototype._tmp = function() {
         var tmp = new BN(null);
-        return tmp.words = new Array(Math.ceil(this.n / 13)), tmp;
-      }, MPrime.prototype.ireduce = function ireduce(num) {
+        return tmp.words = Array(Math.ceil(this.n / 13)), tmp;
+      }, MPrime.prototype.ireduce = function(num) {
         var r = num, rlen;
         do
           this.split(r, this.tmp), r = this.imulK(r), r = r.iadd(this.tmp), rlen = r.bitLength();
@@ -16903,15 +17599,15 @@ var init_crypto = __esm(() => {
         else
           r._strip();
         return r;
-      }, MPrime.prototype.split = function split(input, out) {
+      }, MPrime.prototype.split = function(input, out) {
         input.iushrn(this.n, 0, out);
-      }, MPrime.prototype.imulK = function imulK(num) {
+      }, MPrime.prototype.imulK = function(num) {
         return num.imul(this.k);
       };
       function K256() {
         MPrime.call(this, "k256", "ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f");
       }
-      inherits2(K256, MPrime), K256.prototype.split = function split(input, output) {
+      inherits2(K256, MPrime), K256.prototype.split = function(input, output) {
         var mask = 4194303, outLen = Math.min(input.length, 9);
         for (var i2 = 0;i2 < outLen; i2++)
           output.words[i2] = input.words[i2];
@@ -16929,7 +17625,7 @@ var init_crypto = __esm(() => {
           input.length -= 10;
         else
           input.length -= 9;
-      }, K256.prototype.imulK = function imulK(num) {
+      }, K256.prototype.imulK = function(num) {
         num.words[num.length] = 0, num.words[num.length + 1] = 0, num.length += 2;
         var lo = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
@@ -16953,7 +17649,7 @@ var init_crypto = __esm(() => {
       function P25519() {
         MPrime.call(this, "25519", "7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed");
       }
-      inherits2(P25519, MPrime), P25519.prototype.imulK = function imulK(num) {
+      inherits2(P25519, MPrime), P25519.prototype.imulK = function(num) {
         var carry = 0;
         for (var i2 = 0;i2 < num.length; i2++) {
           var hi = (num.words[i2] | 0) * 19 + carry, lo = hi & 67108863;
@@ -16962,7 +17658,7 @@ var init_crypto = __esm(() => {
         if (carry !== 0)
           num.words[num.length++] = carry;
         return num;
-      }, BN._prime = function prime(name) {
+      }, BN._prime = function(name) {
         if (primes[name])
           return primes[name];
         var prime;
@@ -16975,7 +17671,7 @@ var init_crypto = __esm(() => {
         else if (name === "p25519")
           prime = new P25519;
         else
-          throw new Error("Unknown prime " + name);
+          throw Error("Unknown prime " + name);
         return primes[name] = prime, prime;
       };
       function Red(m) {
@@ -16985,53 +17681,53 @@ var init_crypto = __esm(() => {
         } else
           assert(m.gtn(1), "modulus must be greater than 1"), this.m = m, this.prime = null;
       }
-      Red.prototype._verify1 = function _verify1(a) {
+      Red.prototype._verify1 = function(a) {
         assert(a.negative === 0, "red works only with positives"), assert(a.red, "red works only with red numbers");
-      }, Red.prototype._verify2 = function _verify2(a, b) {
+      }, Red.prototype._verify2 = function(a, b) {
         assert((a.negative | b.negative) === 0, "red works only with positives"), assert(a.red && a.red === b.red, "red works only with red numbers");
-      }, Red.prototype.imod = function imod(a) {
+      }, Red.prototype.imod = function(a) {
         if (this.prime)
           return this.prime.ireduce(a)._forceRed(this);
         return move(a, a.umod(this.m)._forceRed(this)), a;
-      }, Red.prototype.neg = function neg(a) {
+      }, Red.prototype.neg = function(a) {
         if (a.isZero())
           return a.clone();
         return this.m.sub(a)._forceRed(this);
-      }, Red.prototype.add = function add(a, b) {
+      }, Red.prototype.add = function(a, b) {
         this._verify2(a, b);
         var res = a.add(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res._forceRed(this);
-      }, Red.prototype.iadd = function iadd(a, b) {
+      }, Red.prototype.iadd = function(a, b) {
         this._verify2(a, b);
         var res = a.iadd(b);
         if (res.cmp(this.m) >= 0)
           res.isub(this.m);
         return res;
-      }, Red.prototype.sub = function sub(a, b) {
+      }, Red.prototype.sub = function(a, b) {
         this._verify2(a, b);
         var res = a.sub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res._forceRed(this);
-      }, Red.prototype.isub = function isub(a, b) {
+      }, Red.prototype.isub = function(a, b) {
         this._verify2(a, b);
         var res = a.isub(b);
         if (res.cmpn(0) < 0)
           res.iadd(this.m);
         return res;
-      }, Red.prototype.shl = function shl(a, num) {
+      }, Red.prototype.shl = function(a, num) {
         return this._verify1(a), this.imod(a.ushln(num));
-      }, Red.prototype.imul = function imul(a, b) {
+      }, Red.prototype.imul = function(a, b) {
         return this._verify2(a, b), this.imod(a.imul(b));
-      }, Red.prototype.mul = function mul(a, b) {
+      }, Red.prototype.mul = function(a, b) {
         return this._verify2(a, b), this.imod(a.mul(b));
-      }, Red.prototype.isqr = function isqr(a) {
+      }, Red.prototype.isqr = function(a) {
         return this.imul(a, a.clone());
-      }, Red.prototype.sqr = function sqr(a) {
+      }, Red.prototype.sqr = function(a) {
         return this.mul(a, a);
-      }, Red.prototype.sqrt = function sqrt(a) {
+      }, Red.prototype.sqrt = function(a) {
         if (a.isZero())
           return a.clone();
         var mod3 = this.m.andln(3);
@@ -17057,18 +17753,18 @@ var init_crypto = __esm(() => {
           r = r.redMul(b), c = b.redSqr(), t = t.redMul(c), m = i2;
         }
         return r;
-      }, Red.prototype.invm = function invm(a) {
+      }, Red.prototype.invm = function(a) {
         var inv = a._invmp(this.m);
         if (inv.negative !== 0)
           return inv.negative = 0, this.imod(inv).redNeg();
         else
           return this.imod(inv);
-      }, Red.prototype.pow = function pow(a, num) {
+      }, Red.prototype.pow = function(a, num) {
         if (num.isZero())
           return new BN(1).toRed(this);
         if (num.cmpn(1) === 0)
           return a.clone();
-        var windowSize = 4, wnd = new Array(1 << windowSize);
+        var windowSize = 4, wnd = Array(1 << windowSize);
         wnd[0] = new BN(1).toRed(this), wnd[1] = a;
         for (var i2 = 2;i2 < wnd.length; i2++)
           wnd[i2] = this.mul(wnd[i2 - 1], a);
@@ -17092,13 +17788,13 @@ var init_crypto = __esm(() => {
           start = 26;
         }
         return res;
-      }, Red.prototype.convertTo = function convertTo(num) {
+      }, Red.prototype.convertTo = function(num) {
         var r = num.umod(this.m);
         return r === num ? r.clone() : r;
-      }, Red.prototype.convertFrom = function convertFrom(num) {
+      }, Red.prototype.convertFrom = function(num) {
         var res = num.clone();
         return res.red = null, res;
-      }, BN.mont = function mont(num) {
+      }, BN.mont = function(num) {
         return new Mont(num);
       };
       function Mont(m) {
@@ -17106,12 +17802,12 @@ var init_crypto = __esm(() => {
           this.shift += 26 - this.shift % 26;
         this.r = new BN(1).iushln(this.shift), this.r2 = this.imod(this.r.sqr()), this.rinv = this.r._invmp(this.m), this.minv = this.rinv.mul(this.r).isubn(1).div(this.m), this.minv = this.minv.umod(this.r), this.minv = this.r.sub(this.minv);
       }
-      inherits2(Mont, Red), Mont.prototype.convertTo = function convertTo(num) {
+      inherits2(Mont, Red), Mont.prototype.convertTo = function(num) {
         return this.imod(num.ushln(this.shift));
-      }, Mont.prototype.convertFrom = function convertFrom(num) {
+      }, Mont.prototype.convertFrom = function(num) {
         var r = this.imod(num.mul(this.rinv));
         return r.red = null, r;
-      }, Mont.prototype.imul = function imul(a, b) {
+      }, Mont.prototype.imul = function(a, b) {
         if (a.isZero() || b.isZero())
           return a.words[0] = 0, a.length = 1, a;
         var t = a.imul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -17120,7 +17816,7 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.mul = function mul(a, b) {
+      }, Mont.prototype.mul = function(a, b) {
         if (a.isZero() || b.isZero())
           return new BN(0)._forceRed(this);
         var t = a.mul(b), c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m), u = t.isub(c).iushrn(this.shift), res = u;
@@ -17129,11 +17825,11 @@ var init_crypto = __esm(() => {
         else if (u.cmpn(0) < 0)
           res = u.iadd(this.m);
         return res._forceRed(this);
-      }, Mont.prototype.invm = function invm(a) {
+      }, Mont.prototype.invm = function(a) {
         var res = this.imod(a._invmp(this.m).mul(this.r2));
         return res._forceRed(this);
       };
-    })(typeof module === "undefined" || module, exports);
+    })(typeof module > "u" || module, exports);
   });
   require_browserify_rsa = __commonJS2((exports, module) => {
     var BN = require_bn5(), randomBytes = require_randombytes(), Buffer22 = require_safe_buffer().Buffer;
@@ -17157,7 +17853,7 @@ var init_crypto = __esm(() => {
   });
   require_publicEncrypt = __commonJS2((exports, module) => {
     var parseKeys = require_parse_asn1(), randomBytes = require_randombytes(), createHash = require_create_hash(), mgf = require_mgf(), xor = require_xor(), BN = require_bn4(), withPublic = require_withPublic(), crt = require_browserify_rsa(), Buffer22 = require_safe_buffer().Buffer;
-    module.exports = function publicEncrypt(publicKey, msg, reverse) {
+    module.exports = function(publicKey, msg, reverse) {
       var padding;
       if (publicKey.padding)
         padding = publicKey.padding;
@@ -17172,9 +17868,9 @@ var init_crypto = __esm(() => {
         paddedMsg = pkcs1(key, msg, reverse);
       else if (padding === 3) {
         if (paddedMsg = new BN(msg), paddedMsg.cmp(key.modulus) >= 0)
-          throw new Error("data too long for modulus");
+          throw Error("data too long for modulus");
       } else
-        throw new Error("unknown padding");
+        throw Error("unknown padding");
       if (reverse)
         return crt(paddedMsg, key);
       else
@@ -17183,14 +17879,14 @@ var init_crypto = __esm(() => {
     function oaep(key, msg) {
       var k = key.modulus.byteLength(), mLen = msg.length, iHash = createHash("sha1").update(Buffer22.alloc(0)).digest(), hLen = iHash.length, hLen2 = 2 * hLen;
       if (mLen > k - hLen2 - 2)
-        throw new Error("message too long");
+        throw Error("message too long");
       var ps = Buffer22.alloc(k - mLen - hLen2 - 2), dblen = k - hLen - 1, seed = randomBytes(hLen), maskedDb = xor(Buffer22.concat([iHash, ps, Buffer22.alloc(1, 1), msg], dblen), mgf(seed, dblen)), maskedSeed = xor(seed, mgf(maskedDb, hLen));
       return new BN(Buffer22.concat([Buffer22.alloc(1), maskedSeed, maskedDb], k));
     }
     function pkcs1(key, msg, reverse) {
       var mLen = msg.length, k = key.modulus.byteLength();
       if (mLen > k - 11)
-        throw new Error("message too long");
+        throw Error("message too long");
       var ps;
       if (reverse)
         ps = Buffer22.alloc(k - mLen - 3, 255);
@@ -17211,7 +17907,7 @@ var init_crypto = __esm(() => {
   });
   require_privateDecrypt = __commonJS2((exports, module) => {
     var parseKeys = require_parse_asn1(), mgf = require_mgf(), xor = require_xor(), BN = require_bn4(), crt = require_browserify_rsa(), createHash = require_create_hash(), withPublic = require_withPublic(), Buffer22 = require_safe_buffer().Buffer;
-    module.exports = function privateDecrypt(privateKey, enc, reverse) {
+    module.exports = function(privateKey, enc, reverse) {
       var padding;
       if (privateKey.padding)
         padding = privateKey.padding;
@@ -17221,7 +17917,7 @@ var init_crypto = __esm(() => {
         padding = 4;
       var key = parseKeys(privateKey), k = key.modulus.byteLength();
       if (enc.length > k || new BN(enc).cmp(key.modulus) >= 0)
-        throw new Error("decryption error");
+        throw Error("decryption error");
       var msg;
       if (reverse)
         msg = withPublic(new BN(enc), key);
@@ -17235,20 +17931,20 @@ var init_crypto = __esm(() => {
       else if (padding === 3)
         return msg;
       else
-        throw new Error("unknown padding");
+        throw Error("unknown padding");
     };
     function oaep(key, msg) {
       var k = key.modulus.byteLength(), iHash = createHash("sha1").update(Buffer22.alloc(0)).digest(), hLen = iHash.length;
       if (msg[0] !== 0)
-        throw new Error("decryption error");
+        throw Error("decryption error");
       var maskedSeed = msg.slice(1, hLen + 1), maskedDb = msg.slice(hLen + 1), seed = xor(maskedSeed, mgf(maskedDb, hLen)), db = xor(maskedDb, mgf(seed, k - hLen - 1));
-      if (compare3(iHash, db.slice(0, hLen)))
-        throw new Error("decryption error");
+      if (compare(iHash, db.slice(0, hLen)))
+        throw Error("decryption error");
       var i2 = hLen;
       while (db[i2] === 0)
         i2++;
       if (db[i2++] !== 1)
-        throw new Error("decryption error");
+        throw Error("decryption error");
       return db.slice(i2);
     }
     function pkcs1(key, msg, reverse) {
@@ -17264,10 +17960,10 @@ var init_crypto = __esm(() => {
       if (ps.length < 8)
         status++;
       if (status)
-        throw new Error("decryption error");
+        throw Error("decryption error");
       return msg.slice(i2);
     }
-    function compare3(a, b) {
+    function compare(a, b) {
       a = Buffer22.from(a), b = Buffer22.from(b);
       var dif = 0, len2 = a.length;
       if (a.length !== b.length)
@@ -17281,10 +17977,10 @@ var init_crypto = __esm(() => {
   require_browser2 = __commonJS2((exports) => {
     exports.publicEncrypt = require_publicEncrypt();
     exports.privateDecrypt = require_privateDecrypt();
-    exports.privateEncrypt = function privateEncrypt(key, buf) {
+    exports.privateEncrypt = function(key, buf) {
       return exports.publicEncrypt(key, buf, true);
     };
-    exports.publicDecrypt = function publicDecrypt(key, buf) {
+    exports.publicDecrypt = function(key, buf) {
       return exports.privateDecrypt(key, buf, true);
     };
   });
@@ -17307,30 +18003,30 @@ var init_crypto = __esm(() => {
     var safeBuffer = require_safe_buffer(), randombytes = require_randombytes(), Buffer22 = safeBuffer.Buffer, kBufferMaxLength = safeBuffer.kMaxLength, crypto2 = globalThis.crypto || globalThis.msCrypto, kMaxUint32 = Math.pow(2, 32) - 1;
     function assertOffset(offset, length) {
       if (typeof offset !== "number" || offset !== offset)
-        throw new TypeError("offset must be a number");
+        throw TypeError("offset must be a number");
       if (offset > kMaxUint32 || offset < 0)
-        throw new TypeError("offset must be a uint32");
+        throw TypeError("offset must be a uint32");
       if (offset > kBufferMaxLength || offset > length)
-        throw new RangeError("offset out of range");
+        throw RangeError("offset out of range");
     }
     function assertSize2(size, offset, length) {
       if (typeof size !== "number" || size !== size)
-        throw new TypeError("size must be a number");
+        throw TypeError("size must be a number");
       if (size > kMaxUint32 || size < 0)
-        throw new TypeError("size must be a uint32");
+        throw TypeError("size must be a uint32");
       if (size + offset > length || size > kBufferMaxLength)
-        throw new RangeError("buffer too small");
+        throw RangeError("buffer too small");
     }
     crypto2 && crypto2.getRandomValues, exports.randomFill = randomFill, exports.randomFillSync = randomFillSync;
     function randomFill(buf, offset, size, cb) {
       if (!Buffer22.isBuffer(buf) && !(buf instanceof globalThis.Uint8Array))
-        throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+        throw TypeError('"buf" argument must be a Buffer or Uint8Array');
       if (typeof offset === "function")
         cb = offset, offset = 0, size = buf.length;
       else if (typeof size === "function")
         cb = size, size = buf.length - offset;
       else if (typeof cb !== "function")
-        throw new TypeError('"cb" argument must be a function');
+        throw TypeError('"cb" argument must be a function');
       return assertOffset(offset, buf.length), assertSize2(size, offset, buf.length), actualFill(buf, offset, size, cb);
     }
     function actualFill(buf, offset, size, cb) {
@@ -17348,10 +18044,10 @@ var init_crypto = __esm(() => {
       return bytes.copy(buf, offset), buf;
     }
     function randomFillSync(buf, offset, size) {
-      if (typeof offset === "undefined")
+      if (typeof offset > "u")
         offset = 0;
       if (!Buffer22.isBuffer(buf) && !(buf instanceof globalThis.Uint8Array))
-        throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+        throw TypeError('"buf" argument must be a Buffer or Uint8Array');
       if (assertOffset(offset, buf.length), size === undefined)
         size = buf.length - offset;
       return assertSize2(size, offset, buf.length), actualFill(buf, offset, size);
@@ -17407,7 +18103,7 @@ var init_crypto = __esm(() => {
     exports.randomFill = rf.randomFill;
     exports.randomFillSync = rf.randomFillSync;
     exports.createCredentials = function() {
-      throw new Error(`sorry, createCredentials is not implemented yet
+      throw Error(`sorry, createCredentials is not implemented yet
 we accept pull requests
 https://github.com/browserify/crypto-browserify`);
     };
@@ -22368,6 +23064,45 @@ class LoyalPrivateTransactionsClient {
     } catch {
       return null;
     }
+  }
+  async getAllDepositsByUser(user) {
+    const userFilter = [
+      {
+        memcmp: {
+          offset: 8,
+          bytes: user.toBase58()
+        }
+      }
+    ];
+    const [baseResults, ephemeralResults] = await Promise.allSettled([
+      this.baseProgram.account.deposit.all(userFilter),
+      this.ephemeralProgram.account.deposit.all(userFilter)
+    ]);
+    const byPda = new Map;
+    const ingest = (results, preferOverwrite) => {
+      for (const { publicKey, account } of results) {
+        const key = publicKey.toBase58();
+        if (!preferOverwrite && byPda.has(key))
+          continue;
+        byPda.set(key, {
+          user: account.user,
+          tokenMint: account.tokenMint,
+          amount: BigInt(account.amount.toString()),
+          address: publicKey
+        });
+      }
+    };
+    if (baseResults.status === "fulfilled") {
+      ingest(baseResults.value, false);
+    } else {
+      console.warn("[getAllDepositsByUser] base program enumeration failed", baseResults.reason);
+    }
+    if (ephemeralResults.status === "fulfilled") {
+      ingest(ephemeralResults.value, true);
+    } else {
+      console.warn("[getAllDepositsByUser] ephemeral program enumeration failed", ephemeralResults.reason);
+    }
+    return Array.from(byPda.values());
   }
   async getBaseUsernameDeposit(username, tokenMint) {
     const [depositPda] = await findUsernameDepositPda(username, tokenMint);

--- a/sdk/private-transactions/dist/src/LoyalPrivateTransactionsClient.d.ts
+++ b/sdk/private-transactions/dist/src/LoyalPrivateTransactionsClient.d.ts
@@ -94,6 +94,19 @@ export declare class LoyalPrivateTransactionsClient {
     getBaseDeposit(user: PublicKey, tokenMint: PublicKey): Promise<DepositData | null>;
     getEphemeralDeposit(user: PublicKey, tokenMint: PublicKey): Promise<DepositData | null>;
     /**
+     * Enumerate every Deposit account owned by a user across both the base
+     * program and the ephemeral program. Used by the wallet UI to discover
+     * shielded holdings even when the user no longer has a matching base-chain
+     * token balance.
+     *
+     * Delegated deposits only exist on the ephemeral chain (on base the PDA is
+     * owned by the delegation program and Anchor cannot deserialize it as a
+     * `Deposit`). Undelegated deposits only exist on base. We query both and
+     * merge by PDA address, preferring the ephemeral amount when both return
+     * an entry because ephemeral reflects the live balance.
+     */
+    getAllDepositsByUser(user: PublicKey): Promise<DepositData[]>;
+    /**
      * Get username deposit data
      */
     getBaseUsernameDeposit(username: string, tokenMint: PublicKey): Promise<UsernameDepositData | null>;

--- a/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
+++ b/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
@@ -1171,6 +1171,80 @@ export class LoyalPrivateTransactionsClient {
   }
 
   /**
+   * Enumerate every Deposit account owned by a user across both the base
+   * program and the ephemeral program. Used by the wallet UI to discover
+   * shielded holdings even when the user no longer has a matching base-chain
+   * token balance.
+   *
+   * Delegated deposits only exist on the ephemeral chain (on base the PDA is
+   * owned by the delegation program and Anchor cannot deserialize it as a
+   * `Deposit`). Undelegated deposits only exist on base. We query both and
+   * merge by PDA address, preferring the ephemeral amount when both return
+   * an entry because ephemeral reflects the live balance.
+   */
+  async getAllDepositsByUser(user: PublicKey): Promise<DepositData[]> {
+    // Deposit layout after the 8-byte discriminator:
+    //   user: pubkey (32 bytes) @ offset 8
+    //   token_mint: pubkey (32 bytes) @ offset 40
+    //   amount: u64 (8 bytes) @ offset 72
+    const userFilter = [
+      {
+        memcmp: {
+          offset: 8,
+          bytes: user.toBase58(),
+        },
+      },
+    ];
+
+    const [baseResults, ephemeralResults] = await Promise.allSettled([
+      this.baseProgram.account.deposit.all(userFilter),
+      this.ephemeralProgram.account.deposit.all(userFilter),
+    ]);
+
+    const byPda = new Map<string, DepositData>();
+
+    const ingest = (
+      results: Array<{
+        publicKey: PublicKey;
+        account: { user: PublicKey; tokenMint: PublicKey; amount: BN };
+      }>,
+      preferOverwrite: boolean
+    ) => {
+      for (const { publicKey, account } of results) {
+        const key = publicKey.toBase58();
+        if (!preferOverwrite && byPda.has(key)) continue;
+        byPda.set(key, {
+          user: account.user,
+          tokenMint: account.tokenMint,
+          amount: BigInt(account.amount.toString()),
+          address: publicKey,
+        });
+      }
+    };
+
+    if (baseResults.status === "fulfilled") {
+      ingest(baseResults.value, /* preferOverwrite */ false);
+    } else {
+      console.warn(
+        "[getAllDepositsByUser] base program enumeration failed",
+        baseResults.reason
+      );
+    }
+
+    // Ephemeral state wins over base state for live balances.
+    if (ephemeralResults.status === "fulfilled") {
+      ingest(ephemeralResults.value, /* preferOverwrite */ true);
+    } else {
+      console.warn(
+        "[getAllDepositsByUser] ephemeral program enumeration failed",
+        ephemeralResults.reason
+      );
+    }
+
+    return Array.from(byPda.values());
+  }
+
+  /**
    * Get username deposit data
    */
   async getBaseUsernameDeposit(


### PR DESCRIPTION
Shielded holdings were discovered only via mints present in the Helius base-chain response, so shielding the full balance of a token hid the shielded row (ASK-841). Enumerate deposits directly from the Loyal program on both base and ephemeral chains via a new `getAllDepositsByUser` SDK method, and resolve metadata for shielded-only mints with a Helius `getAsset` fallback.