### PR TITLE
docs(transparency): add Q1 2026 transparency report

### DIFF
--- a/user-docs/docs.json
+++ b/user-docs/docs.json
@@ -88,7 +88,7 @@
           },
           {
             "group": "Reports",
-            "pages": ["transparency/q4-2025"]
+            "pages": ["transparency/q1-2026", "transparency/q4-2025"]
           }
         ]
       }

--- a/user-docs/transparency/q1-2026.mdx
+++ b/user-docs/transparency/q1-2026.mdx
@@ -1,0 +1,119 @@
+---
+title: "Q1 2026 Transparency Report"
+description: "Loyal Public Transparency Report covering January 1 – March 31, 2026"
+---
+
+<Info>
+**Period:** Jan 1, 2026 → Mar 31, 2026  
+**Currency:** USDC  
+**Accounting view:** Cash basis (expenses recognized when paid)
+</Info>
+
+## What Happened This Quarter
+
+During the Jan 1–Mar 31 reporting period, Loyal achieved several key milestones:
+
+- **Shipped:** Private transfers over Telegram username — send tokens to anyone by their Telegram handle, no wallet address needed. Available as a web app and a Telegram mini app. The first product where the privacy layer is invisible to the end user: the counterparty just sees an `@username`, the protocol does the rest.
+- **Team buildout:** Hired a senior Solana engineer and a UI/UX designer. Both joined during the quarter and are already shipping.
+- **External recognition:** Loyal was accepted into the Blockworks Research transparency filing, joining a curated set of projects that publish standardized financial and governance disclosures.
+- **Governance:** No new MetaDAO proposals passed during the quarter. The structured buyback program approved in Q4 continued executing per its 30-day schedule.
+
+## Organizational Status
+
+| Item | Status |
+|------|--------|
+| **Scope** | Consolidated reporting for Loyal (no separate "company ops" vs "DAO ops" separation at this stage) |
+| **Incorporation** | Completed. Certificate of formation issued. Loyal is now a registered Marshall Islands entity |
+| **Legal provider** | MiDAO |
+
+## Expense Details
+
+**Total operating expenses paid (Jan 1–Mar 31): 162,779.52 USDC**
+
+<Note>
+This operating expense summary excludes governance-directed capital actions (e.g., buybacks and liquidity changes), which are disclosed separately and are inherently dynamic.
+</Note>
+
+### Monthly Breakdown
+
+| Category | Jan | Feb | Mar | Total |
+|----------|-----|-----|-----|-------|
+| Salaries | 43,626.00 | 27,532.00 | 68,829.00 | 139,987.00 |
+| Marketing | 2,843.31 | 4,005.34 | 7,179.70 | 14,028.35 |
+| Administrative | 148.66 | 5,378.11 | 1,160.19 | 6,686.96 |
+| Software | 436.47 | 295.11 | 866.63 | 1,598.21 |
+| Legal | 0.00 | 479.00 | 0.00 | 479.00 |
+| Travel | 0.00 | 0.00 | 0.00 | 0.00 |
+| **Total** | **47,054.44** | **37,689.56** | **78,035.52** | **162,779.52** |
+
+## Statement of Operations
+
+### Spending Analysis
+
+- **Salaries (86.00%)** moved up from 66.76% in Q4. Two reasons: market conditions were rough this quarter and we pulled marketing spend down a notch, and we hired a full-time designer — work that previously showed up in Marketing as one-off contractor or agency spend now flows through Salaries. Absolute headcount cost is up, output quality and velocity are meaningfully higher, and total spend on design is lower than it would have been through contractors.
+- **Marketing (8.62%)** is down from 16.21% in Q4. Community growth programs (Sector 0 and Cohort Zero payouts, outreach partners) make up the majority of what remains. Subscription and platform spend (X Premium, LinkedIn Business, Discord boosts) continued at roughly the Q4 cadence.
+- **Legal (0.29%)** dropped to near zero. Q4 was structuring-heavy as we worked through MiDAO and incorporation. Q1 had only a small contract review fee. Q2 will see Delaware corp & tax and Qe.tax fees land.
+- **Administrative + Software (5.09% combined)** stayed lean. The Solana Seeker purchase (1 unit, $543) sits in Administrative.
+- **Travel (0.00%)** had no spend this quarter. Q4 had Solana Breakpoint and the Dubai hacker house.
+- **Bundled salary payments:** several Feb and Mar lines covered two months of pay in a single check ("feb + jan", "part 2"), which is why March looks heavier than January and February on a cash basis. The quarterly total is unaffected.
+- **Totals reconcile:** the sum of monthly totals equals the sum of category totals (162,779.52 USDC).
+
+### Income Statement
+
+| Line Item | Amount (USDC) | % of Operating Expenses |
+|-----------|---------------|------------------------|
+| **Revenue** | 0.00 | — |
+| **Total revenue** | 0.00 | — |
+| **Operating expenses** | | |
+| Salaries (including R&D) | 139,987.00 | 86.00% |
+| Marketing | 14,028.35 | 8.62% |
+| Administrative | 6,686.96 | 4.11% |
+| Software | 1,598.21 | 0.98% |
+| Legal | 479.00 | 0.29% |
+| Travel | 0.00 | 0.00% |
+| **Total operating expenses** | **162,779.52** | 100.00% |
+| **Operating income (loss)** | (162,779.52) | — |
+| Other income (expenses) | 0.00 | — |
+| **Net income (loss)** | **(162,779.52)** | — |
+
+## Balance Sheet
+
+<Warning>
+**Snapshot date:** Apr 1, 2026 (outside the Jan 1–Mar 31 reporting window)
+</Warning>
+
+### Published Addresses
+
+<Accordion title="View on-chain addresses">
+| Wallet | Address |
+|--------|---------|
+| Squads treasury | `AQyyTwCKemeeMu8ZPZFxrXMbVwAYTSbBhi1w4PBrhvYE` |
+| Meteora LP | `BGg7WsK98rhqtTp2uSKMa2yETqgwShFAjyf1RmYqCF7n` |
+| Operating | `92yGiPxBVG3E6voo1XyaKXaBR4Uvd7cntMsj3pL1fAYa` |
+| LOYAL mint / CA | `LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta` |
+| Futarchy AMM LP | `GxpJkPEsPmuRCCTNnfZaDKg4X3gf4ZPgmqgFqtibaPtK` |
+</Accordion>
+
+### USDC Assets
+
+| Asset | Amount (USDC) |
+|-------|---------------|
+| USDC — Squads treasury | 139,972.69 |
+| USDC — operating wallet | 49,666.00 |
+| USDC — in Futarchy AMM LP | 392,210.00 |
+| **Total USDC assets** | **581,848.69** |
+
+### Token Balances
+
+| Asset | Amount (LOYAL) |
+|-------|----------------|
+| LOYAL — held in treasury | 5,833,214 |
+| LOYAL — in Futarchy AMM LP | 5,833,214 |
+| LOYAL — in Meteora LP position | 2,055,257 |
+| **Total LOYAL units** | **13,721,685** |
+
+## Governance Actions
+
+No new MetaDAO proposals were submitted or passed during Q1 2026. The two governance actions approved in Q4 2025 — the structured LOYAL buyback program and the liquidity adjustment — continued executing per their original specifications. Both can be verified against the published addresses above and the proposal records on [metadao.fi](https://www.metadao.fi/projects/loyal).
+
+Loyal's treasury is governed through MetaDAO proposals and executed transparently on-chain. Operational reporting follows a cash basis. All figures are denominated in USDC. Questions: [main@askloyal.com](mailto:main@askloyal.com).

--- a/user-docs/transparency/q1-2026.mdx
+++ b/user-docs/transparency/q1-2026.mdx
@@ -78,10 +78,6 @@ This operating expense summary excludes governance-directed capital actions (e.g
 
 ## Balance Sheet
 
-<Warning>
-**Snapshot date:** Apr 1, 2026 (outside the Jan 1–Mar 31 reporting window)
-</Warning>
-
 ### Published Addresses
 
 <Accordion title="View on-chain addresses">


### PR DESCRIPTION
Adds the Q1 2026 Transparency Report (Jan 1 – Mar 31, 2026) under `user-docs/transparency/q1-2026.mdx`, mirroring the Q4 2025 report structure, and registers it in the Mintlify nav so the newest quarter surfaces first.