### PR TITLE
fix(frontend): swallow non-rendered SVG error in sparkline animation

### DIFF
--- a/frontend/src/components/wallet-sidebar/sparkline.tsx
+++ b/frontend/src/components/wallet-sidebar/sparkline.tsx
@@ -63,7 +63,18 @@ function SparklineInner({
     if (!line) return;
 
     if (!revealed) {
-      const length = line.getTotalLength();
+      // getTotalLength throws InvalidStateError on non-rendered elements
+      // (e.g. inside a collapsed parent) in stricter engines like Android
+      // WebView. If unavailable, skip the draw-on animation and reveal
+      // immediately rather than crashing the whole tree.
+      let length = 0;
+      try {
+        length = line.getTotalLength();
+      } catch {
+        setRevealed(true);
+        return;
+      }
+
       line.style.strokeDasharray = `${length}`;
       line.style.strokeDashoffset = `${length}`;
       line.style.transition = "none";


### PR DESCRIPTION
The wallet sidebar Sparkline calls \`getTotalLength()\` on a polyline inside a useLayoutEffect to power its draw-on animation. When the SVG happens to be inside a non-rendered container at that moment (Android WebView is much stricter than desktop Chrome here), the call throws \`InvalidStateError\` and bubbles up as a Next.js application-exception page, observed when opening askloyal.com inside the mobile in-app browser after wallet connect.

Fix: try/catch the measurement and reveal the line without the draw-on animation if it fails, instead of crashing the whole tree.