### PR TITLE
feat(library): add admin-managed library with markdown articles

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,3 +1,7 @@
 DATABASE_URL=postgresql://...
 ADMIN_USER=admin
 ADMIN_PASSWORD=changeme
+
+# Library image upload (proxies to /app's R2 endpoint)
+LIBRARY_UPLOAD_TOKEN=shared-hex-secret
+APP_API_BASE_URL=https://solana-telegram-transactions.vercel.app

--- a/admin/src/app/(admin)/library/actions.ts
+++ b/admin/src/app/(admin)/library/actions.ts
@@ -1,0 +1,265 @@
+"use server";
+
+import { libraryArticles, librarySections } from "@loyal-labs/db-core/schema";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import { serverEnv } from "@/lib/core/config/server";
+import { getDatabase } from "@/lib/core/database";
+
+type ActionResult = { error?: string; success?: boolean };
+
+function parseInt0(value: FormDataEntryValue | null): number {
+  if (typeof value !== "string") return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function readString(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readOptionalString(value: FormDataEntryValue | null): string | null {
+  const trimmed = readString(value);
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// ---------- Sections ----------
+
+export async function addLibrarySection(
+  formData: FormData
+): Promise<ActionResult> {
+  const title = readString(formData.get("title"));
+  if (!title) return { error: "Title is required" };
+
+  const db = getDatabase();
+  await db.insert(librarySections).values({
+    title,
+    displayOrder: parseInt0(formData.get("displayOrder")),
+    isActive: formData.get("isActive") === "on",
+  });
+
+  revalidatePath("/library");
+  return { success: true };
+}
+
+export async function updateLibrarySection(
+  id: string,
+  formData: FormData
+): Promise<ActionResult> {
+  const title = readString(formData.get("title"));
+  if (!title) return { error: "Title is required" };
+
+  const db = getDatabase();
+  await db
+    .update(librarySections)
+    .set({
+      title,
+      displayOrder: parseInt0(formData.get("displayOrder")),
+      isActive: formData.get("isActive") === "on",
+      updatedAt: new Date(),
+    })
+    .where(eq(librarySections.id, id));
+
+  revalidatePath("/library");
+  return { success: true };
+}
+
+export async function deleteLibrarySection(id: string): Promise<ActionResult> {
+  const db = getDatabase();
+  try {
+    await db.delete(librarySections).where(eq(librarySections.id, id));
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message.toLowerCase().includes("foreign")) {
+      return {
+        error: "Section has articles. Delete or move them first.",
+      };
+    }
+    return { error: "Failed to delete section" };
+  }
+  revalidatePath("/library");
+  return { success: true };
+}
+
+// ---------- Articles ----------
+
+function readArticleFields(formData: FormData): {
+  sectionId: string;
+  title: string;
+  coverImageUrl: string;
+  contentMarkdown: string;
+  readTime: string;
+  excerpt: string | null;
+  isFeatured: boolean;
+  isActive: boolean;
+  displayOrder: number;
+} {
+  return {
+    sectionId: readString(formData.get("sectionId")),
+    title: readString(formData.get("title")),
+    coverImageUrl: readString(formData.get("coverImageUrl")),
+    contentMarkdown: readString(formData.get("contentMarkdown")),
+    readTime: readString(formData.get("readTime")),
+    excerpt: readOptionalString(formData.get("excerpt")),
+    isFeatured: formData.get("isFeatured") === "on",
+    isActive: formData.get("isActive") === "on",
+    displayOrder: parseInt0(formData.get("displayOrder")),
+  };
+}
+
+function validateArticle(
+  fields: ReturnType<typeof readArticleFields>
+): string | null {
+  if (!fields.sectionId) return "Section is required";
+  if (!fields.title) return "Title is required";
+  if (!fields.coverImageUrl) return "Cover image is required";
+  if (!fields.contentMarkdown) return "Content is required";
+  if (!fields.readTime) return "Read time is required";
+  return null;
+}
+
+export async function addLibraryArticle(
+  formData: FormData
+): Promise<ActionResult> {
+  const fields = readArticleFields(formData);
+  const invalid = validateArticle(fields);
+  if (invalid) return { error: invalid };
+
+  const db = getDatabase();
+  await db.insert(libraryArticles).values({
+    sectionId: fields.sectionId,
+    title: fields.title,
+    coverImageUrl: fields.coverImageUrl,
+    contentMarkdown: fields.contentMarkdown,
+    readTime: fields.readTime,
+    excerpt: fields.excerpt,
+    isFeatured: fields.isFeatured,
+    isActive: fields.isActive,
+    displayOrder: fields.displayOrder,
+    publishedAt: fields.isActive ? new Date() : null,
+  });
+
+  revalidatePath("/library");
+  return { success: true };
+}
+
+export async function updateLibraryArticle(
+  id: string,
+  formData: FormData
+): Promise<ActionResult> {
+  const fields = readArticleFields(formData);
+  const invalid = validateArticle(fields);
+  if (invalid) return { error: invalid };
+
+  const db = getDatabase();
+  const [existing] = await db
+    .select({
+      isActive: libraryArticles.isActive,
+      publishedAt: libraryArticles.publishedAt,
+    })
+    .from(libraryArticles)
+    .where(eq(libraryArticles.id, id))
+    .limit(1);
+
+  const publishedAt = (() => {
+    if (!existing) return fields.isActive ? new Date() : null;
+    if (fields.isActive && !existing.publishedAt) return new Date();
+    return existing.publishedAt;
+  })();
+
+  await db
+    .update(libraryArticles)
+    .set({
+      sectionId: fields.sectionId,
+      title: fields.title,
+      coverImageUrl: fields.coverImageUrl,
+      contentMarkdown: fields.contentMarkdown,
+      readTime: fields.readTime,
+      excerpt: fields.excerpt,
+      isFeatured: fields.isFeatured,
+      isActive: fields.isActive,
+      displayOrder: fields.displayOrder,
+      publishedAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(libraryArticles.id, id));
+
+  revalidatePath("/library");
+  return { success: true };
+}
+
+export async function deleteLibraryArticle(id: string): Promise<ActionResult> {
+  const db = getDatabase();
+  await db.delete(libraryArticles).where(eq(libraryArticles.id, id));
+  revalidatePath("/library");
+  return { success: true };
+}
+
+export async function toggleLibraryArticleActive(
+  id: string,
+  isActive: boolean
+): Promise<ActionResult> {
+  const db = getDatabase();
+  const [existing] = await db
+    .select({ publishedAt: libraryArticles.publishedAt })
+    .from(libraryArticles)
+    .where(eq(libraryArticles.id, id))
+    .limit(1);
+
+  await db
+    .update(libraryArticles)
+    .set({
+      isActive,
+      publishedAt:
+        isActive && !existing?.publishedAt ? new Date() : existing?.publishedAt ?? null,
+      updatedAt: new Date(),
+    })
+    .where(eq(libraryArticles.id, id));
+
+  revalidatePath("/library");
+  return { success: true };
+}
+
+// ---------- Image upload (proxy to /app) ----------
+
+export async function uploadLibraryCover(
+  formData: FormData
+): Promise<{ url?: string; error?: string }> {
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return { error: "No file provided" };
+  }
+
+  const endpoint = `${serverEnv.appApiBaseUrl.replace(/\/$/, "")}/api/admin/library/upload`;
+  const proxyBody = new FormData();
+  proxyBody.set("file", file);
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${serverEnv.libraryUploadToken}`,
+      },
+      body: proxyBody,
+    });
+  } catch {
+    return { error: "Upload request failed" };
+  }
+
+  if (!response.ok) {
+    let message = `Upload failed (${response.status})`;
+    try {
+      const data = (await response.json()) as { error?: string };
+      if (data.error) message = data.error;
+    } catch {
+      // ignore parse error
+    }
+    return { error: message };
+  }
+
+  const data = (await response.json()) as { url?: string };
+  if (!data.url) return { error: "Upload returned no URL" };
+
+  return { url: data.url };
+}

--- a/admin/src/app/(admin)/library/library-list.tsx
+++ b/admin/src/app/(admin)/library/library-list.tsx
@@ -1,0 +1,704 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import {
+  addLibraryArticle,
+  addLibrarySection,
+  deleteLibraryArticle,
+  deleteLibrarySection,
+  toggleLibraryArticleActive,
+  updateLibraryArticle,
+  updateLibrarySection,
+  uploadLibraryCover,
+} from "./actions";
+
+type SectionRow = {
+  id: string;
+  title: string;
+  displayOrder: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ArticleRow = {
+  id: string;
+  sectionId: string;
+  title: string;
+  coverImageUrl: string;
+  contentMarkdown: string;
+  readTime: string;
+  excerpt: string | null;
+  isFeatured: boolean;
+  isActive: boolean;
+  displayOrder: number;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ActionResult = { error?: string; success?: boolean };
+
+// ============================================================================
+// Sections
+// ============================================================================
+
+function SectionForm({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: SectionRow;
+  onSubmit: (fd: FormData) => Promise<ActionResult>;
+  onCancel: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const result = await onSubmit(fd);
+      if (result.error) setError(result.error);
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      {error && (
+        <div className="mb-3 rounded bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+      <div className="grid grid-cols-3 gap-3">
+        <label className="col-span-2 block">
+          <span className="mb-1 block text-xs font-medium">
+            Title <span className="text-destructive">*</span>
+          </span>
+          <Input
+            name="title"
+            required
+            placeholder="App Updates"
+            defaultValue={initial?.title ?? ""}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium">Display Order</span>
+          <Input
+            name="displayOrder"
+            type="number"
+            defaultValue={String(initial?.displayOrder ?? 0)}
+          />
+        </label>
+        <label className="col-span-3 flex items-center gap-2">
+          <Switch name="isActive" defaultChecked={initial?.isActive ?? true} />
+          <span className="text-xs font-medium">Active</span>
+        </label>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <Button type="submit" size="sm" disabled={pending}>
+          {pending ? "Saving..." : initial ? "Save" : "Add section"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          disabled={pending}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function SectionsPanel({ sections }: { sections: SectionRow[] }) {
+  const router = useRouter();
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleAdd(fd: FormData) {
+    return addLibrarySection(fd).then((result) => {
+      if (result.success) {
+        setIsAdding(false);
+        router.refresh();
+      }
+      return result;
+    });
+  }
+
+  function handleUpdate(id: string) {
+    return (fd: FormData) =>
+      updateLibrarySection(id, fd).then((result) => {
+        if (result.success) {
+          setEditingId(null);
+          router.refresh();
+        }
+        return result;
+      });
+  }
+
+  function handleDelete(id: string) {
+    setDeleteError(null);
+    startTransition(async () => {
+      const result = await deleteLibrarySection(id);
+      if (result.error) {
+        setDeleteError(result.error);
+      } else {
+        setDeletingId(null);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Sections</h2>
+        {!isAdding && (
+          <Button
+            size="sm"
+            onClick={() => {
+              setIsAdding(true);
+              setEditingId(null);
+            }}
+          >
+            Add section
+          </Button>
+        )}
+      </div>
+
+      {isAdding && (
+        <SectionForm onSubmit={handleAdd} onCancel={() => setIsAdding(false)} />
+      )}
+
+      {editingId && (
+        <SectionForm
+          initial={sections.find((s) => s.id === editingId)}
+          onSubmit={handleUpdate(editingId)}
+          onCancel={() => setEditingId(null)}
+        />
+      )}
+
+      {deleteError && (
+        <div className="rounded bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {deleteError}
+        </div>
+      )}
+
+      {sections.length > 0 ? (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[60px]">Order</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead className="w-[80px]">Active</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sections.map((section) => (
+                <TableRow key={section.id}>
+                  <TableCell className="text-muted-foreground">
+                    {section.displayOrder}
+                  </TableCell>
+                  <TableCell className="font-medium">{section.title}</TableCell>
+                  <TableCell>{section.isActive ? "Yes" : "No"}</TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => {
+                          setEditingId(section.id);
+                          setIsAdding(false);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      {deletingId === section.id ? (
+                        <>
+                          <Button
+                            variant="destructive"
+                            size="xs"
+                            onClick={() => handleDelete(section.id)}
+                          >
+                            Confirm
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="xs"
+                            onClick={() => {
+                              setDeletingId(null);
+                              setDeleteError(null);
+                            }}
+                          >
+                            No
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setDeletingId(section.id)}
+                        >
+                          Delete
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : !isAdding ? (
+        <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+          No sections configured
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+// ============================================================================
+// Articles
+// ============================================================================
+
+function ArticleForm({
+  sections,
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  sections: SectionRow[];
+  initial?: ArticleRow;
+  onSubmit: (fd: FormData) => Promise<ActionResult>;
+  onCancel: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [uploading, setUploading] = useState(false);
+  const [coverUrl, setCoverUrl] = useState(initial?.coverImageUrl ?? "");
+  const [sectionId, setSectionId] = useState(
+    initial?.sectionId ?? sections[0]?.id ?? ""
+  );
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.currentTarget.files?.[0];
+    if (!file) return;
+    setError(null);
+    setUploading(true);
+
+    const fd = new FormData();
+    fd.set("file", file);
+    const result = await uploadLibraryCover(fd);
+    setUploading(false);
+
+    if (result.error) {
+      setError(result.error);
+      if (fileRef.current) fileRef.current.value = "";
+      return;
+    }
+    if (result.url) {
+      setCoverUrl(result.url);
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!coverUrl) {
+      setError("Cover image is required");
+      return;
+    }
+    const fd = new FormData(e.currentTarget);
+    fd.set("coverImageUrl", coverUrl);
+    fd.set("sectionId", sectionId);
+    startTransition(async () => {
+      const result = await onSubmit(fd);
+      if (result.error) setError(result.error);
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      {error && (
+        <div className="mb-3 rounded bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium">
+            Section <span className="text-destructive">*</span>
+          </span>
+          <Select
+            value={sectionId}
+            onValueChange={setSectionId}
+            disabled={sections.length === 0}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue
+                placeholder={
+                  sections.length === 0
+                    ? "Create a section first"
+                    : "Select section"
+                }
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {sections.map((section) => (
+                <SelectItem key={section.id} value={section.id}>
+                  {section.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium">
+            Title (admin label) <span className="text-destructive">*</span>
+          </span>
+          <Input
+            name="title"
+            required
+            placeholder="Shielded transfers release"
+            defaultValue={initial?.title ?? ""}
+          />
+        </label>
+        <div className="col-span-2">
+          <span className="mb-1 block text-xs font-medium">
+            Cover image <span className="text-destructive">*</span>
+          </span>
+          <div className="flex items-center gap-3">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              onChange={handleFile}
+              disabled={uploading || pending}
+              className="block text-sm file:mr-3 file:rounded file:border-0 file:bg-secondary file:px-3 file:py-1.5 file:text-xs file:font-medium"
+            />
+            {uploading && (
+              <span className="text-xs text-muted-foreground">Uploading...</span>
+            )}
+          </div>
+          {coverUrl && (
+            <div className="mt-2 flex items-start gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={coverUrl}
+                alt="Cover preview"
+                className="h-24 w-24 rounded-lg object-cover"
+              />
+              <div className="break-all text-xs text-muted-foreground">
+                {coverUrl}
+              </div>
+            </div>
+          )}
+        </div>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium">
+            Read time <span className="text-destructive">*</span>
+          </span>
+          <Input
+            name="readTime"
+            required
+            placeholder="4 min read"
+            defaultValue={initial?.readTime ?? ""}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium">Display Order</span>
+          <Input
+            name="displayOrder"
+            type="number"
+            defaultValue={String(initial?.displayOrder ?? 0)}
+          />
+        </label>
+        <label className="col-span-2 block">
+          <span className="mb-1 block text-xs font-medium">Excerpt</span>
+          <Input
+            name="excerpt"
+            placeholder="Short share preview text (optional)"
+            defaultValue={initial?.excerpt ?? ""}
+          />
+        </label>
+        <label className="col-span-2 block">
+          <span className="mb-1 block text-xs font-medium">
+            Content (Markdown) <span className="text-destructive">*</span>
+          </span>
+          <textarea
+            name="contentMarkdown"
+            required
+            rows={14}
+            placeholder={"# Heading\n\nWrite the body in markdown."}
+            defaultValue={initial?.contentMarkdown ?? ""}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm shadow-xs"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch
+            name="isFeatured"
+            defaultChecked={initial?.isFeatured ?? false}
+          />
+          <span className="text-xs font-medium">Featured</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch name="isActive" defaultChecked={initial?.isActive ?? true} />
+          <span className="text-xs font-medium">Active</span>
+        </label>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <Button type="submit" size="sm" disabled={pending || uploading}>
+          {pending ? "Saving..." : initial ? "Save" : "Add article"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          disabled={pending || uploading}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function ArticlesPanel({
+  sections,
+  articles,
+}: {
+  sections: SectionRow[];
+  articles: ArticleRow[];
+}) {
+  const router = useRouter();
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const sectionTitleById = new Map(sections.map((s) => [s.id, s.title]));
+
+  function handleAdd(fd: FormData) {
+    return addLibraryArticle(fd).then((result) => {
+      if (result.success) {
+        setIsAdding(false);
+        router.refresh();
+      }
+      return result;
+    });
+  }
+
+  function handleUpdate(id: string) {
+    return (fd: FormData) =>
+      updateLibraryArticle(id, fd).then((result) => {
+        if (result.success) {
+          setEditingId(null);
+          router.refresh();
+        }
+        return result;
+      });
+  }
+
+  function handleDelete(id: string) {
+    startTransition(async () => {
+      await deleteLibraryArticle(id);
+      setDeletingId(null);
+      router.refresh();
+    });
+  }
+
+  function handleToggle(id: string, next: boolean) {
+    startTransition(async () => {
+      await toggleLibraryArticleActive(id, next);
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Articles</h2>
+        {!isAdding && (
+          <Button
+            size="sm"
+            disabled={sections.length === 0}
+            onClick={() => {
+              setIsAdding(true);
+              setEditingId(null);
+            }}
+          >
+            Add article
+          </Button>
+        )}
+      </div>
+
+      {isAdding && (
+        <ArticleForm
+          sections={sections}
+          onSubmit={handleAdd}
+          onCancel={() => setIsAdding(false)}
+        />
+      )}
+
+      {editingId && (
+        <ArticleForm
+          sections={sections}
+          initial={articles.find((a) => a.id === editingId)}
+          onSubmit={handleUpdate(editingId)}
+          onCancel={() => setEditingId(null)}
+        />
+      )}
+
+      {articles.length > 0 ? (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[80px]">Cover</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Section</TableHead>
+                <TableHead className="w-[80px]">Featured</TableHead>
+                <TableHead className="w-[80px]">Active</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {articles.map((article) => (
+                <TableRow key={article.id}>
+                  <TableCell>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={article.coverImageUrl}
+                      alt=""
+                      className="h-12 w-12 rounded object-cover"
+                    />
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    {article.title}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {sectionTitleById.get(article.sectionId) ?? "—"}
+                  </TableCell>
+                  <TableCell>{article.isFeatured ? "Yes" : "—"}</TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={article.isActive}
+                      onCheckedChange={(next) =>
+                        handleToggle(article.id, next)
+                      }
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => {
+                          setEditingId(article.id);
+                          setIsAdding(false);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      {deletingId === article.id ? (
+                        <>
+                          <Button
+                            variant="destructive"
+                            size="xs"
+                            onClick={() => handleDelete(article.id)}
+                          >
+                            Confirm
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="xs"
+                            onClick={() => setDeletingId(null)}
+                          >
+                            No
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setDeletingId(article.id)}
+                        >
+                          Delete
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : !isAdding ? (
+        <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+          {sections.length === 0
+            ? "Create a section before adding articles"
+            : "No articles yet"}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+// ============================================================================
+// Root
+// ============================================================================
+
+export function LibraryList({
+  sections,
+  articles,
+}: {
+  sections: SectionRow[];
+  articles: ArticleRow[];
+}) {
+  return (
+    <div className="space-y-8">
+      <SectionsPanel sections={sections} />
+      <ArticlesPanel sections={sections} articles={articles} />
+    </div>
+  );
+}

--- a/admin/src/app/(admin)/library/page.tsx
+++ b/admin/src/app/(admin)/library/page.tsx
@@ -1,0 +1,45 @@
+import { libraryArticles, librarySections } from "@loyal-labs/db-core/schema";
+import { asc } from "drizzle-orm";
+
+import { PageContainer } from "@/components/layout/page-container";
+import { SectionHeader } from "@/components/layout/section-header";
+import { getDatabase } from "@/lib/core/database";
+
+import { LibraryList } from "./library-list";
+
+export const dynamic = "force-dynamic";
+
+export default async function LibraryPage() {
+  const db = getDatabase();
+
+  const [sectionRows, articleRows] = await Promise.all([
+    db
+      .select()
+      .from(librarySections)
+      .orderBy(asc(librarySections.displayOrder), asc(librarySections.title)),
+    db
+      .select()
+      .from(libraryArticles)
+      .orderBy(asc(libraryArticles.displayOrder), asc(libraryArticles.title)),
+  ]);
+
+  const sections = sectionRows.map((row) => ({
+    ...row,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }));
+
+  const articles = articleRows.map((row) => ({
+    ...row,
+    publishedAt: row.publishedAt ? row.publishedAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }));
+
+  return (
+    <PageContainer>
+      <SectionHeader title="Library" breadcrumbs={[{ label: "Library" }]} />
+      <LibraryList sections={sections} articles={articles} />
+    </PageContainer>
+  );
+}

--- a/admin/src/components/app-sidebar.tsx
+++ b/admin/src/components/app-sidebar.tsx
@@ -30,6 +30,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/flags", label: "Flags" },
   { href: "/transfers", label: "Transfers" },
   { href: "/dapps", label: "dApps" },
+  { href: "/library", label: "Library" },
   { href: "/admins", label: "Admins" },
 ];
 

--- a/admin/src/lib/core/config/server.ts
+++ b/admin/src/lib/core/config/server.ts
@@ -6,4 +6,10 @@ export const serverEnv = {
   get databaseUrl(): string {
     return getRequiredEnv("DATABASE_URL");
   },
+  get libraryUploadToken(): string {
+    return getRequiredEnv("LIBRARY_UPLOAD_TOKEN");
+  },
+  get appApiBaseUrl(): string {
+    return getRequiredEnv("APP_API_BASE_URL");
+  },
 } as const;

--- a/app/src/app/api/admin/library/upload/route.ts
+++ b/app/src/app/api/admin/library/upload/route.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import { getCloudflareCdnUrlClientFromEnv } from "@/lib/core/cdn-url";
+import { serverEnv } from "@/lib/core/config/server";
+import { getCloudflareR2UploadClientFromEnv } from "@/lib/core/r2-upload";
+
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+const ALLOWED_CONTENT_TYPES: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+};
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function unauthorized(): NextResponse {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function badRequest(message: string): NextResponse {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function authorize(request: Request): boolean {
+  const header = request.headers.get("authorization");
+  if (!header || !header.startsWith("Bearer ")) {
+    return false;
+  }
+  const presented = header.slice("Bearer ".length).trim();
+  if (!presented) return false;
+
+  const expected = serverEnv.libraryUploadToken;
+  if (presented.length !== expected.length) return false;
+
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i += 1) {
+    mismatch |= presented.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  if (!authorize(request)) {
+    return unauthorized();
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return badRequest("Expected multipart/form-data body");
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return badRequest("`file` field is required");
+  }
+
+  const extension = ALLOWED_CONTENT_TYPES[file.type];
+  if (!extension) {
+    return badRequest(
+      "Unsupported content type; allowed: image/png, image/jpeg, image/webp"
+    );
+  }
+
+  if (file.size <= 0) {
+    return badRequest("Uploaded file is empty");
+  }
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "File exceeds 5MB limit" },
+      { status: 413 }
+    );
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const key = `library/${randomUUID()}.${extension}`;
+
+  const r2 = getCloudflareR2UploadClientFromEnv();
+  await r2.uploadImage({
+    key,
+    body: buffer,
+    contentType: file.type,
+  });
+
+  // R2 client and CDN client both apply CLOUDFLARE_R2_UPLOAD_PREFIX.
+  // Pass the original (unprefixed) key to the CDN resolver to avoid a double prefix.
+  const cdn = getCloudflareCdnUrlClientFromEnv();
+  const url = cdn.resolveUrl({ key });
+
+  return NextResponse.json({ url });
+}

--- a/app/src/app/api/mobile/library/route.ts
+++ b/app/src/app/api/mobile/library/route.ts
@@ -1,0 +1,126 @@
+import { libraryArticles, librarySections } from "@loyal-labs/db-core/schema";
+import { asc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { getDatabase } from "@/lib/core/database";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Cache-Control": "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+};
+
+export type MobileLibraryArticle = {
+  id: string;
+  sectionId: string;
+  title: string;
+  coverImageUrl: string;
+  contentMarkdown: string;
+  readTime: string;
+  excerpt: string | null;
+  isFeatured: boolean;
+  displayOrder: number;
+  publishedAt: string | null;
+};
+
+export type MobileLibrarySection = {
+  id: string;
+  title: string;
+  displayOrder: number;
+  articles: MobileLibraryArticle[];
+};
+
+export type MobileLibraryResponse = {
+  featured: MobileLibraryArticle[];
+  sections: MobileLibrarySection[];
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const db = getDatabase();
+
+    const [sectionRows, articleRows] = await Promise.all([
+      db
+        .select({
+          id: librarySections.id,
+          title: librarySections.title,
+          displayOrder: librarySections.displayOrder,
+        })
+        .from(librarySections)
+        .where(eq(librarySections.isActive, true))
+        .orderBy(asc(librarySections.displayOrder), asc(librarySections.title)),
+      db
+        .select({
+          id: libraryArticles.id,
+          sectionId: libraryArticles.sectionId,
+          title: libraryArticles.title,
+          coverImageUrl: libraryArticles.coverImageUrl,
+          contentMarkdown: libraryArticles.contentMarkdown,
+          readTime: libraryArticles.readTime,
+          excerpt: libraryArticles.excerpt,
+          isFeatured: libraryArticles.isFeatured,
+          displayOrder: libraryArticles.displayOrder,
+          publishedAt: libraryArticles.publishedAt,
+        })
+        .from(libraryArticles)
+        .where(eq(libraryArticles.isActive, true))
+        .orderBy(
+          asc(libraryArticles.displayOrder),
+          asc(libraryArticles.title)
+        ),
+    ]);
+
+    const activeSectionIds = new Set(sectionRows.map((row) => row.id));
+    const articlesByActiveSection = new Map<string, MobileLibraryArticle[]>();
+    const featured: MobileLibraryArticle[] = [];
+
+    for (const row of articleRows) {
+      const article: MobileLibraryArticle = {
+        id: row.id,
+        sectionId: row.sectionId,
+        title: row.title,
+        coverImageUrl: row.coverImageUrl,
+        contentMarkdown: row.contentMarkdown,
+        readTime: row.readTime,
+        excerpt: row.excerpt,
+        isFeatured: row.isFeatured,
+        displayOrder: row.displayOrder,
+        publishedAt: row.publishedAt ? row.publishedAt.toISOString() : null,
+      };
+
+      if (row.isFeatured) {
+        featured.push(article);
+      }
+
+      if (!activeSectionIds.has(row.sectionId)) continue;
+
+      const list = articlesByActiveSection.get(row.sectionId);
+      if (list) {
+        list.push(article);
+      } else {
+        articlesByActiveSection.set(row.sectionId, [article]);
+      }
+    }
+
+    const sections: MobileLibrarySection[] = sectionRows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      displayOrder: row.displayOrder,
+      articles: articlesByActiveSection.get(row.id) ?? [],
+    }));
+
+    const body: MobileLibraryResponse = { featured, sections };
+    return NextResponse.json(body, { headers: corsHeaders });
+  } catch (error) {
+    console.error("[api/mobile/library] Failed to fetch library", error);
+    return NextResponse.json(
+      { error: "Failed to fetch library" },
+      { headers: corsHeaders, status: 500 }
+    );
+  }
+}

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -130,6 +130,9 @@ export const serverEnv = {
   get telegramSetupSecret(): string {
     return getRequiredEnv("TELEGRAM_SETUP_SECRET");
   },
+  get libraryUploadToken(): string {
+    return getRequiredEnv("LIBRARY_UPLOAD_TOKEN");
+  },
   get mixpanelToken(): string | undefined {
     return getOptionalEnv("NEXT_PUBLIC_MIXPANEL_TOKEN");
   },

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -1058,6 +1058,76 @@ export const trustedDapps = pgTable(
   ]
 );
 
+/**
+ * Library sections shown on the mobile Library tab.
+ * Managed via the admin dashboard. Each section groups a horizontal row
+ * of image-only article cards on the Library screen.
+ */
+export const librarySections = pgTable(
+  "library_sections",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    title: text("title").notNull(),
+    displayOrder: integer("display_order").default(0).notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("library_sections_active_order_idx").on(
+      table.isActive,
+      table.displayOrder
+    ),
+  ]
+);
+
+/**
+ * Library articles shown on the mobile Library tab.
+ * Cards render only the cover image (no title overlay). The detail screen
+ * renders the cover plus `contentMarkdown`. Articles with `isFeatured=true`
+ * also appear in the Featured carousel above the section list.
+ */
+export const libraryArticles = pgTable(
+  "library_articles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sectionId: uuid("section_id")
+      .notNull()
+      .references(() => librarySections.id, { onDelete: "restrict" }),
+    title: text("title").notNull(),
+    coverImageUrl: text("cover_image_url").notNull(),
+    contentMarkdown: text("content_markdown").notNull(),
+    readTime: text("read_time").notNull(),
+    excerpt: text("excerpt"),
+    isFeatured: boolean("is_featured").default(false).notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    displayOrder: integer("display_order").default(0).notNull(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("library_articles_section_order_idx").on(
+      table.sectionId,
+      table.isActive,
+      table.displayOrder
+    ),
+    index("library_articles_featured_idx").on(
+      table.isFeatured,
+      table.isActive,
+      table.displayOrder
+    ),
+  ]
+);
+
 // ============================================================================
 // RELATIONS (for type-safe queries with Drizzle)
 // ============================================================================
@@ -1177,6 +1247,17 @@ export const appChatMessagesRelations = relations(appChatMessages, ({ one }) => 
   chat: one(appChats, {
     fields: [appChatMessages.chatId],
     references: [appChats.id],
+  }),
+}));
+
+export const librarySectionsRelations = relations(librarySections, ({ many }) => ({
+  articles: many(libraryArticles),
+}));
+
+export const libraryArticlesRelations = relations(libraryArticles, ({ one }) => ({
+  section: one(librarySections, {
+    fields: [libraryArticles.sectionId],
+    references: [librarySections.id],
   }),
 }));
 
@@ -1322,3 +1403,9 @@ export type InsertGaslessClaimTransaction =
 
 export type TrustedDapp = typeof trustedDapps.$inferSelect;
 export type InsertTrustedDapp = typeof trustedDapps.$inferInsert;
+
+export type LibrarySection = typeof librarySections.$inferSelect;
+export type InsertLibrarySection = typeof librarySections.$inferInsert;
+
+export type LibraryArticle = typeof libraryArticles.$inferSelect;
+export type InsertLibraryArticle = typeof libraryArticles.$inferInsert;


### PR DESCRIPTION
## Summary
- Adds `library_sections` + `library_articles` tables and admin CRUD (sections panel + articles table with file-picker cover upload, markdown textarea, featured/active toggles).
- `/app` gets two routes: `POST /api/admin/library/upload` (bearer-auth proxy to R2) and `GET /api/mobile/library` (public, cached, returns sections + featured list).

## Notes
- No migration file is included — tables were applied to prod out-of-band on 2026-04-21 from the mobile branch. Each branch keeps its own migration chain; when main, mobile, and ask-735 reconcile, the missing migration will be regenerated into main's lineage at that time.
- Admin → /app upload uses shared secret `LIBRARY_UPLOAD_TOKEN` and `APP_API_BASE_URL` (both already set in Vercel admin + app projects).

## Test plan
- [ ] Set `LIBRARY_UPLOAD_TOKEN` and `APP_API_BASE_URL` in the admin Vercel project (already set in /app).
- [ ] In admin, create a Section → upload a cover → create an Article bound to it → toggle Featured + Active → save.
- [ ] `curl $APP_BASE/api/mobile/library` returns `{ featured, sections }` with the test article.
- [ ] Deleting a Section with articles attached returns the "Section has articles" error (FK RESTRICT).