### PR TITLE
feat(push): shielded-transfer notifications via 1-min cron

### DIFF
--- a/app/src/app/api/cron/push-shielded-transfers/route.ts
+++ b/app/src/app/api/cron/push-shielded-transfers/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { runPushShieldedTransfersCron } from "@/features/push-shielded-transfers";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  return POST(request);
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const authErrorResponse = validateCronAuthHeader(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
+  }
+
+  try {
+    const stats = await runPushShieldedTransfersCron();
+    return NextResponse.json({ ok: true, stats });
+  } catch (error) {
+    console.error("[cron/push-shielded-transfers] Run failed", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        ok: false,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/src/features/push-shielded-transfers/index.ts
+++ b/app/src/features/push-shielded-transfers/index.ts
@@ -1,0 +1,2 @@
+export * from "./server/sync";
+export * from "./types";

--- a/app/src/features/push-shielded-transfers/server/connection.ts
+++ b/app/src/features/push-shielded-transfers/server/connection.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { Connection } from "@solana/web3.js";
+
+import { serverEnv } from "@/lib/core/config/server";
+
+// Dedicated cached connection for the shielded-transfers cron. Shares
+// the RPC endpoint with the other push crons so we don't explode the
+// connection count per Vercel function instance.
+let cachedConnection: Connection | null = null;
+
+export function getPushShieldedTransfersConnection(): Connection {
+  if (cachedConnection) return cachedConnection;
+  cachedConnection = new Connection(serverEnv.privateMainnetRpcUrl, {
+    commitment: "confirmed",
+  });
+  return cachedConnection;
+}

--- a/app/src/features/push-shielded-transfers/server/constants.ts
+++ b/app/src/features/push-shielded-transfers/server/constants.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+export const PUSH_SHIELDED_TRANSFERS_SYNC_KEY =
+  "push-shielded-transfers-mainnet";
+
+// Head-scan budget per run. 3 pages × 100 sigs = 300 program signatures
+// per tick, well above observed throughput. Keeps the cron bounded so a
+// single run can't monopolize RPC.
+export const MAX_HEAD_PAGES_PER_RUN = 3;
+export const HISTORY_PAGE_LIMIT = 100;
+
+// Batch size for getParsedTransactions — matches the analytics feature.
+export const PARSED_TX_BATCH_SIZE = 10;
+
+// Anchor account discriminator for the Deposit struct. Lifted from the
+// telegram_private_transfer IDL ("accounts" → "Deposit" → "discriminator").
+// Used to sanity-check we're deserializing a Deposit account before
+// reading the user pubkey off the front.
+export const DEPOSIT_DISCRIMINATOR = Uint8Array.from([
+  148, 146, 121, 66, 207, 173, 21, 227,
+]);

--- a/app/src/features/push-shielded-transfers/server/deposit-account.ts
+++ b/app/src/features/push-shielded-transfers/server/deposit-account.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { type Connection, PublicKey } from "@solana/web3.js";
+
+import { DEPOSIT_DISCRIMINATOR } from "./constants";
+
+// Anchor Deposit layout: 8B discriminator + 32B user + 32B token_mint + 8B amount.
+// We only need the user pubkey, sitting right after the discriminator.
+const DEPOSIT_USER_OFFSET = 8;
+const PUBKEY_BYTES = 32;
+const MIN_DEPOSIT_ACCOUNT_SIZE = 8 + 32 + 32 + 8;
+
+function decodeDepositUser(data: Buffer): string | null {
+  if (data.length < MIN_DEPOSIT_ACCOUNT_SIZE) return null;
+  for (let i = 0; i < DEPOSIT_DISCRIMINATOR.length; i += 1) {
+    if (data[i] !== DEPOSIT_DISCRIMINATOR[i]) return null;
+  }
+  const userBytes = data.subarray(
+    DEPOSIT_USER_OFFSET,
+    DEPOSIT_USER_OFFSET + PUBKEY_BYTES,
+  );
+  return new PublicKey(userBytes).toBase58();
+}
+
+// Chunk size matches the getMultipleAccountsInfo RPC cap on most
+// providers; Helius accepts 100 safely.
+const GET_ACCOUNTS_BATCH_SIZE = 100;
+
+export async function resolveDepositUsers(
+  connection: Connection,
+  depositAddresses: string[],
+): Promise<Map<string, string>> {
+  const userByDepositAddress = new Map<string, string>();
+  if (depositAddresses.length === 0) return userByDepositAddress;
+
+  const uniqueAddresses = Array.from(new Set(depositAddresses));
+  for (let i = 0; i < uniqueAddresses.length; i += GET_ACCOUNTS_BATCH_SIZE) {
+    const batch = uniqueAddresses.slice(i, i + GET_ACCOUNTS_BATCH_SIZE);
+    const publicKeys = batch.map((address) => new PublicKey(address));
+    const accountInfos = await connection.getMultipleAccountsInfo(publicKeys);
+    for (let j = 0; j < batch.length; j += 1) {
+      const address = batch[j];
+      const info = accountInfos[j];
+      if (!address || !info) continue;
+      const user = decodeDepositUser(info.data as Buffer);
+      if (user) userByDepositAddress.set(address, user);
+    }
+  }
+
+  return userByDepositAddress;
+}

--- a/app/src/features/push-shielded-transfers/server/format.ts
+++ b/app/src/features/push-shielded-transfers/server/format.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import {
+  formatAmount,
+  truncateAddress,
+} from "@/features/push-incoming-transfers/server/format";
+import type { WalletPushPayload } from "@/lib/push-notifications/send-to-wallet";
+
+import type { TransferDepositEvent } from "../types";
+
+type MintMetadata = {
+  symbol: string;
+  decimals: number;
+};
+
+// Conservative default for unknown mints — same as the incoming-transfer
+// formatter. Raw whole-token amounts are safer than guessing decimals.
+const UNKNOWN_DECIMALS = 0;
+
+export function formatShieldedTransferPush(
+  event: TransferDepositEvent,
+  metadata: MintMetadata | null,
+): WalletPushPayload {
+  const symbol = metadata?.symbol ?? truncateAddress(event.tokenMint);
+  const decimals = metadata?.decimals ?? UNKNOWN_DECIMALS;
+  const amount = formatAmount(event.amountRaw, decimals);
+
+  return {
+    body: `From ${truncateAddress(event.senderAddress)} privately`,
+    data: {
+      kind: "shielded-transfer",
+      mint: event.tokenMint,
+      screen: "activity",
+      sender: event.senderAddress,
+      signature: event.signature,
+    },
+    title: `+${amount} ${symbol}`,
+  };
+}

--- a/app/src/features/push-shielded-transfers/server/sync.ts
+++ b/app/src/features/push-shielded-transfers/server/sync.ts
@@ -1,0 +1,286 @@
+import "server-only";
+
+import {
+  privateTransferAnalyticsSyncState,
+  privateTransferTokenCatalog,
+} from "@loyal-labs/db-core/schema";
+import type { ParsedTransactionWithMeta } from "@solana/web3.js";
+import { eq, inArray } from "drizzle-orm";
+
+import {
+  PARSED_TX_BATCH_SIZE as ANALYTICS_BATCH_SIZE,
+  PRIVATE_TRANSFER_PROGRAM_ID,
+} from "@/features/private-transfer-analytics/server/constants";
+import {
+  buildTokenCatalogUpserts,
+  upsertTokenCatalog,
+} from "@/features/private-transfer-analytics/server/token-catalog";
+import { getDatabase } from "@/lib/core/database";
+import { sendPushToWallet } from "@/lib/push-notifications/send-to-wallet";
+
+import type {
+  PushShieldedTransfersStats,
+  TransferDepositEvent,
+} from "../types";
+import { getPushShieldedTransfersConnection } from "./connection";
+import {
+  HISTORY_PAGE_LIMIT,
+  MAX_HEAD_PAGES_PER_RUN,
+  PARSED_TX_BATCH_SIZE,
+  PUSH_SHIELDED_TRANSFERS_SYNC_KEY,
+} from "./constants";
+import { resolveDepositUsers } from "./deposit-account";
+import { formatShieldedTransferPush } from "./format";
+import { parseTransferDepositInstructions } from "./transfer-parser";
+
+type MintMetadata = { symbol: string; decimals: number };
+type SyncStateRow = typeof privateTransferAnalyticsSyncState.$inferSelect;
+
+// Prefer the feature-local batch size but fall back to the analytics
+// constant if that import path ever gets trimmed — keeps us loudly
+// co-ordered with the sibling cron.
+const TX_BATCH_SIZE = PARSED_TX_BATCH_SIZE ?? ANALYTICS_BATCH_SIZE;
+
+async function getOrCreateSyncState(): Promise<SyncStateRow> {
+  const db = getDatabase();
+  const existing = await db.query.privateTransferAnalyticsSyncState.findFirst({
+    where: eq(
+      privateTransferAnalyticsSyncState.syncKey,
+      PUSH_SHIELDED_TRANSFERS_SYNC_KEY,
+    ),
+  });
+  if (existing) return existing;
+
+  await db
+    .insert(privateTransferAnalyticsSyncState)
+    .values({ syncKey: PUSH_SHIELDED_TRANSFERS_SYNC_KEY })
+    .onConflictDoNothing();
+
+  const created = await db.query.privateTransferAnalyticsSyncState.findFirst({
+    where: eq(
+      privateTransferAnalyticsSyncState.syncKey,
+      PUSH_SHIELDED_TRANSFERS_SYNC_KEY,
+    ),
+  });
+  if (!created) {
+    throw new Error(
+      "Failed to initialize push_shielded_transfers sync state",
+    );
+  }
+  return created;
+}
+
+async function updateSyncState(
+  values: Partial<typeof privateTransferAnalyticsSyncState.$inferInsert>,
+): Promise<void> {
+  const db = getDatabase();
+  await db
+    .update(privateTransferAnalyticsSyncState)
+    .set({ ...values, updatedAt: new Date() })
+    .where(
+      eq(
+        privateTransferAnalyticsSyncState.syncKey,
+        PUSH_SHIELDED_TRANSFERS_SYNC_KEY,
+      ),
+    );
+}
+
+async function fetchHeadSignatures(
+  state: SyncStateRow,
+  stats: PushShieldedTransfersStats,
+): Promise<{ signatures: string[]; newestSignature: string | null }> {
+  const connection = getPushShieldedTransfersConnection();
+  const knownHead = state.latestSeenSignature ?? null;
+
+  const collected: string[] = [];
+  let before: string | undefined;
+  let firstPageHead: string | null = null;
+
+  for (let page = 0; page < MAX_HEAD_PAGES_PER_RUN; page += 1) {
+    const batch = await connection.getSignaturesForAddress(
+      PRIVATE_TRANSFER_PROGRAM_ID,
+      {
+        before,
+        limit: HISTORY_PAGE_LIMIT,
+        until: knownHead ?? undefined,
+      },
+    );
+    if (batch.length === 0) break;
+
+    stats.pagesProcessed += 1;
+    stats.signaturesFetched += batch.length;
+    if (page === 0) firstPageHead = batch[0]?.signature ?? null;
+
+    for (const entry of batch) collected.push(entry.signature);
+
+    if (batch.length < HISTORY_PAGE_LIMIT) break;
+    before = batch[batch.length - 1]?.signature;
+  }
+
+  const newestSignature = firstPageHead ?? knownHead;
+  return { newestSignature, signatures: collected };
+}
+
+async function fetchParsedTransactionsBatched(
+  signatures: string[],
+): Promise<(ParsedTransactionWithMeta | null)[]> {
+  const connection = getPushShieldedTransfersConnection();
+  const parsed: (ParsedTransactionWithMeta | null)[] = [];
+  for (let i = 0; i < signatures.length; i += TX_BATCH_SIZE) {
+    const slice = signatures.slice(i, i + TX_BATCH_SIZE);
+    parsed.push(
+      ...(await connection.getParsedTransactions(slice, {
+        maxSupportedTransactionVersion: 0,
+      })),
+    );
+  }
+  return parsed;
+}
+
+async function resolveMintMetadata(
+  mints: Iterable<string>,
+): Promise<Map<string, MintMetadata>> {
+  const uniqueMints = Array.from(new Set(Array.from(mints).filter(Boolean)));
+  if (uniqueMints.length === 0) return new Map();
+
+  const db = getDatabase();
+  const existing = await db
+    .select({
+      decimals: privateTransferTokenCatalog.decimals,
+      symbol: privateTransferTokenCatalog.symbol,
+      tokenMint: privateTransferTokenCatalog.tokenMint,
+    })
+    .from(privateTransferTokenCatalog)
+    .where(inArray(privateTransferTokenCatalog.tokenMint, uniqueMints));
+
+  const resolved = new Map<string, MintMetadata>();
+  for (const row of existing) {
+    resolved.set(row.tokenMint, {
+      decimals: row.decimals ?? 0,
+      symbol: row.symbol ?? row.tokenMint,
+    });
+  }
+
+  const missing = uniqueMints.filter((mint) => !resolved.has(mint));
+  if (missing.length > 0) {
+    const entries = await buildTokenCatalogUpserts(missing);
+    await upsertTokenCatalog(entries);
+    for (const entry of entries) {
+      resolved.set(entry.tokenMint, {
+        decimals: entry.decimals ?? 0,
+        symbol: entry.symbol,
+      });
+    }
+  }
+
+  return resolved;
+}
+
+export async function runPushShieldedTransfersCron(): Promise<PushShieldedTransfersStats> {
+  const stats: PushShieldedTransfersStats = {
+    errors: 0,
+    eventsDetected: 0,
+    firstRunPinned: false,
+    notificationsSent: 0,
+    pagesProcessed: 0,
+    recipientsResolved: 0,
+    signaturesFetched: 0,
+  };
+
+  const state = await getOrCreateSyncState();
+  await updateSyncState({ lastError: null, lastRunStartedAt: new Date() });
+
+  try {
+    const { signatures, newestSignature } = await fetchHeadSignatures(
+      state,
+      stats,
+    );
+
+    // First run (no cursor yet): don't dispatch pushes for historical
+    // transfers — just pin the cursor at current head and wait for the
+    // next tick. Mirrors the first-run policy in push-incoming-transfers.
+    if (!state.latestSeenSignature) {
+      stats.firstRunPinned = true;
+      await updateSyncState({
+        lastRunFinishedAt: new Date(),
+        latestSeenSignature: newestSignature,
+      });
+      return stats;
+    }
+
+    if (signatures.length === 0) {
+      await updateSyncState({
+        lastRunFinishedAt: new Date(),
+        latestSeenSignature: newestSignature,
+      });
+      return stats;
+    }
+
+    const parsedTransactions =
+      await fetchParsedTransactionsBatched(signatures);
+
+    const events: TransferDepositEvent[] = [];
+    for (let i = 0; i < parsedTransactions.length; i += 1) {
+      const tx = parsedTransactions[i];
+      const sig = signatures[i];
+      if (!tx || !sig) continue;
+      events.push(...parseTransferDepositInstructions(tx, sig));
+    }
+    stats.eventsDetected = events.length;
+
+    if (events.length === 0) {
+      await updateSyncState({
+        lastRunFinishedAt: new Date(),
+        latestSeenSignature: newestSignature,
+      });
+      return stats;
+    }
+
+    const connection = getPushShieldedTransfersConnection();
+    const depositUserByAddress = await resolveDepositUsers(
+      connection,
+      events.map((event) => event.destinationDepositAddress),
+    );
+
+    const metadataByMint = await resolveMintMetadata(
+      events.map((event) => event.tokenMint),
+    );
+
+    for (const event of events) {
+      const recipientWallet = depositUserByAddress.get(
+        event.destinationDepositAddress,
+      );
+      if (!recipientWallet) continue;
+      stats.recipientsResolved += 1;
+
+      const payload = formatShieldedTransferPush(
+        event,
+        metadataByMint.get(event.tokenMint) ?? null,
+      );
+      try {
+        const result = await sendPushToWallet(recipientWallet, payload);
+        stats.notificationsSent += result.sentTo;
+      } catch (error) {
+        stats.errors += 1;
+        console.error(
+          `[push-shielded-transfers] dispatch failed for ${recipientWallet}`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    await updateSyncState({
+      lastRunFinishedAt: new Date(),
+      latestSeenSignature: newestSignature,
+    });
+
+    return stats;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateSyncState({
+      lastError: message,
+      lastRunFinishedAt: new Date(),
+    });
+    throw error;
+  }
+}

--- a/app/src/features/push-shielded-transfers/server/transfer-parser.ts
+++ b/app/src/features/push-shielded-transfers/server/transfer-parser.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+import type {
+  ParsedTransactionWithMeta,
+  PartiallyDecodedInstruction,
+} from "@solana/web3.js";
+
+import { PRIVATE_TRANSFER_PROGRAM_ID } from "@/features/private-transfer-analytics/server/constants";
+import { decodeTelegramPrivateTransferInstruction } from "@/lib/solana/solana-helpers";
+
+import type { TransferDepositEvent } from "../types";
+
+type ParsedTransferDepositArgs = {
+  amount?: { toString(): string };
+};
+
+// transfer_deposit accounts layout (with optional session_token at slot 3):
+//   [0] user (sender)
+//   [1] payer
+//   [2] session_token   <- optional
+//   [..] source_deposit
+//   [..] destination_deposit
+//   [..] token_mint
+//   [..] system_program
+//
+// Rather than guess whether session_token is present, we pin the trailing
+// four slots from the end — the ordering is stable regardless of the
+// optional account.
+const ACCOUNTS_MIN_LENGTH = 6; // no session token
+const SOURCE_DEPOSIT_OFFSET_FROM_END = 4;
+const DESTINATION_DEPOSIT_OFFSET_FROM_END = 3;
+const TOKEN_MINT_OFFSET_FROM_END = 2;
+
+function isPartiallyDecodedInstruction(
+  instruction: unknown,
+): instruction is PartiallyDecodedInstruction {
+  return (
+    instruction !== null &&
+    typeof instruction === "object" &&
+    "programId" in instruction &&
+    "accounts" in instruction &&
+    "data" in instruction
+  );
+}
+
+export function parseTransferDepositInstructions(
+  tx: ParsedTransactionWithMeta,
+  signature: string,
+): TransferDepositEvent[] {
+  if (tx.meta?.err) return [];
+  if (!tx.blockTime) return [];
+
+  const occurredAt = new Date(tx.blockTime * 1000);
+  const slot = BigInt(tx.slot);
+  const events: TransferDepositEvent[] = [];
+
+  tx.transaction.message.instructions.forEach((instruction, instructionIndex) => {
+    if (!isPartiallyDecodedInstruction(instruction)) return;
+    if (
+      instruction.programId.toBase58() !==
+      PRIVATE_TRANSFER_PROGRAM_ID.toBase58()
+    ) {
+      return;
+    }
+
+    const decoded = decodeTelegramPrivateTransferInstruction(instruction.data);
+    if (!decoded || decoded.name !== "transfer_deposit") return;
+
+    const args = (decoded.data as { args?: ParsedTransferDepositArgs } | null)
+      ?.args;
+    if (!args?.amount) return;
+
+    const accounts = instruction.accounts.map((account) => account.toString());
+    if (accounts.length < ACCOUNTS_MIN_LENGTH) return;
+
+    const senderAddress = accounts[0];
+    const sourceDepositAddress =
+      accounts[accounts.length - SOURCE_DEPOSIT_OFFSET_FROM_END];
+    const destinationDepositAddress =
+      accounts[accounts.length - DESTINATION_DEPOSIT_OFFSET_FROM_END];
+    const tokenMint = accounts[accounts.length - TOKEN_MINT_OFFSET_FROM_END];
+
+    if (
+      !senderAddress ||
+      !sourceDepositAddress ||
+      !destinationDepositAddress ||
+      !tokenMint
+    ) {
+      return;
+    }
+
+    events.push({
+      amountRaw: BigInt(args.amount.toString()),
+      destinationDepositAddress,
+      instructionIndex,
+      occurredAt,
+      senderAddress,
+      signature,
+      slot,
+      sourceDepositAddress,
+      tokenMint,
+    });
+  });
+
+  return events;
+}

--- a/app/src/features/push-shielded-transfers/types.ts
+++ b/app/src/features/push-shielded-transfers/types.ts
@@ -1,0 +1,21 @@
+export type TransferDepositEvent = {
+  signature: string;
+  instructionIndex: number;
+  slot: bigint;
+  occurredAt: Date;
+  senderAddress: string;
+  sourceDepositAddress: string;
+  destinationDepositAddress: string;
+  tokenMint: string;
+  amountRaw: bigint;
+};
+
+export type PushShieldedTransfersStats = {
+  pagesProcessed: number;
+  signaturesFetched: number;
+  eventsDetected: number;
+  recipientsResolved: number;
+  notificationsSent: number;
+  errors: number;
+  firstRunPinned: boolean;
+};

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -18,6 +18,10 @@
     {
       "path": "/api/cron/push-incoming-transfers",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/push-shielded-transfers",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `/api/cron/push-shielded-transfers` (1-min schedule) that detects on-chain `transfer_deposit` instructions — A→B private transfers between wallets — and dispatches a push to the recipient.
- Resolves the recipient wallet by reading the `destination_deposit` PDA's user field on-chain (8-byte Anchor Deposit discriminator + 32-byte user).
- Reuses the token catalog (`buildTokenCatalogUpserts`/`upsertTokenCatalog`) from `private-transfer-analytics` and the amount/address formatters from `push-incoming-transfers`.
- First-run policy matches the sibling cron: pin the cursor at current head without notifying on historical transfers.
- Cursor lives in `private_transfer_analytics_sync_state` under a new sync_key (`push-shielded-transfers-mainnet`) so it does not race with the 15-min analytics cursor.

Claim-deposit notifications ("@X claimed your Y") are deferred to a follow-up — they require credit-matching over `transfer_to_username_deposit` history to identify the original funder.

## Test plan
- [ ] Vercel build succeeds and new cron appears in the project's cron list.
- [ ] Manual hit: `curl -H "Authorization: Bearer $CRON_SECRET" https://.../api/cron/push-shielded-transfers` returns `{ ok: true, firstRunPinned: true }` on first invocation.
- [ ] Second invocation with no new program activity returns `ok: true, eventsDetected: 0`.
- [ ] Send a private transfer (A→B, both on mainnet). Within ~1 min the destination wallet's registered device receives `+{amount} {symbol} / From {sender} privately`.
- [ ] Unknown-mint fallback: event with a mint not in the catalog shows the truncated mint as symbol and raw amount.