### PR TITLE
fix(frontend): stop double-counting shielded balance in portfolio rows

### DIFF
--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -329,8 +329,8 @@ function mapPositionToTokenRow(position: PortfolioPosition): TokenRow {
     id: position.asset.mint,
     symbol: position.asset.symbol,
     price: formatUsd(position.priceUsd),
-    amount: formatTokenBalance(position.totalBalance),
-    value: formatUsd(position.totalValueUsd),
+    amount: formatTokenBalance(position.publicBalance),
+    value: formatUsd(position.publicValueUsd),
     icon: resolveTokenIcon(position),
   };
 }
@@ -638,7 +638,7 @@ export function useWalletDesktopData(): WalletDesktopData {
   const allTokenRows = useMemo(() => {
     const rows: TokenRow[] = [];
     for (const position of positions) {
-      if (position.totalBalance > 0) {
+      if (position.publicBalance > 0) {
         rows.push(mapPositionToTokenRow(position));
       }
       // Add secured row right after the public one
@@ -661,19 +661,27 @@ export function useWalletDesktopData(): WalletDesktopData {
         rows.splice(Math.min(2, rows.length), 0, loylRow);
       }
     } else {
-      // Not in rows — create placeholder with Jupiter price
       const loylPosition = positions.find((p) => p.asset.mint === LOYL_MINT);
-      const loylRow: TokenRow = loylPosition
-        ? mapPositionToTokenRow(loylPosition)
-        : {
-            id: LOYL_MINT,
-            symbol: "LOYAL",
-            price: formatUsd(loylPriceUsd),
-            amount: "0",
-            value: "$0.00",
-            icon: LOYL_ICON_URL,
-          };
-      rows.splice(Math.min(2, rows.length), 0, loylRow);
+      // If LOYAL is held only as shielded, the secured row already
+      // represents it — don't add an empty public placeholder row.
+      const loylHasOnlyShielded =
+        loylPosition !== undefined &&
+        loylPosition.publicBalance === 0 &&
+        loylPosition.securedBalance > 0;
+      if (!loylHasOnlyShielded) {
+        // Not in rows — create placeholder with Jupiter price
+        const loylRow: TokenRow = loylPosition
+          ? mapPositionToTokenRow(loylPosition)
+          : {
+              id: LOYL_MINT,
+              symbol: "LOYAL",
+              price: formatUsd(loylPriceUsd),
+              amount: "0",
+              value: "$0.00",
+              icon: LOYL_ICON_URL,
+            };
+        rows.splice(Math.min(2, rows.length), 0, loylRow);
+      }
     }
 
     return rows;


### PR DESCRIPTION
Portfolio shows the shielded portion on both the public row (via \`totalBalance\`) and the secured row, inflating the apparent balance and misleading users about how much is actually liquid.

Mirrors the same fix already landed in \`packages/wallet-core\` via #291 — \`/frontend\` carries its own copy of \`mapPositionToTokenRow\` at \`frontend/src/hooks/use-wallet-desktop-data.ts\` that wasn't covered by that PR.