### PR TITLE
fix(shared): raise SOL dust threshold to 100k lamports

### DIFF
--- a/packages/shared/src/__tests__/dust-filter.test.ts
+++ b/packages/shared/src/__tests__/dust-filter.test.ts
@@ -12,7 +12,17 @@ describe("isDustSolTransfer", () => {
       isDustSolTransfer({
         isUserSigned: false,
         hasTokenChange: false,
-        lamports: 9_999,
+        lamports: 99_999,
+      }),
+    ).toBe(true);
+  });
+
+  test("suppresses real-world evasion amounts (e.g. 10,044 lamports)", () => {
+    expect(
+      isDustSolTransfer({
+        isUserSigned: false,
+        hasTokenChange: false,
+        lamports: 10_044,
       }),
     ).toBe(true);
   });

--- a/packages/shared/src/dust-filter.ts
+++ b/packages/shared/src/dust-filter.ts
@@ -13,8 +13,15 @@
 // which is outside the bun workspace — can consume it without pulling in
 // solana-wallet's workspace-only transitive deps.
 
-/** SOL transfers below this many lamports are treated as dust (~0.00001 SOL). */
-export const SOL_DUST_THRESHOLD_LAMPORTS = 10_000;
+/**
+ * SOL transfers below this many lamports are treated as dust (~0.0001 SOL).
+ *
+ * Raised from 10_000 → 100_000 after observing address-poisoning spam
+ * sending amounts like 10,044 lamports (a deliberately above-10k value
+ * to evade a 10k-lamport filter). 100k leaves room for legitimate
+ * micro-transfers while catching the bulk of SOL-dust spam patterns.
+ */
+export const SOL_DUST_THRESHOLD_LAMPORTS = 100_000;
 
 /**
  * SPL token transfers whose *normalized* amount (raw / 10^decimals) is below


### PR DESCRIPTION
## Summary
Observed an address-poisoning tx sending **10,044 lamports** TO a user wallet — deliberately above the previous \`SOL_DUST_THRESHOLD_LAMPORTS = 10_000\` cutoff to evade the dust filter. Bumping to **100_000 lamports** (~0.0001 SOL) catches that class of spam while still leaving legit micro-transfers visible.

Example: https://solscan.io/tx/DEiN4bbu7p69acxrxZbEMAnXmFALGYb4KvcqaKheRTkFRn1wEkkb9NBX2763LuLgNZ8nJLVvvHHHqwzr11uEdAm

## Changes
- \`packages/shared/src/dust-filter.ts\`: threshold 10_000 → 100_000 with comment on rationale
- \`packages/shared/src/__tests__/dust-filter.test.ts\`: update existing below-threshold test + add regression test pinned to the observed evasion value (10_044)

## Test plan
- [x] \`bun test packages/shared/src/__tests__/dust-filter.test.ts\` — 11 pass
- [ ] After mobile rebuild, the tx above disappears from the activity feed on next load
- [ ] Legit transfers ≥ 0.0001 SOL still render