### PR TITLE
fix(sdk/private-transactions): make delegation watcher best-effort

### DIFF
--- a/sdk/private-transactions/dist/index.js
+++ b/sdk/private-transactions/dist/index.js
@@ -2897,11 +2897,15 @@ async function undelegateDeposit(baseProgram, perProgram, params) {
         depositPda
       }
     });
-    await delegationWatcher.wait();
-    await new Promise((resolve) => setTimeout(resolve, 3000));
   } catch (e) {
     await delegationWatcher.cancel();
     throw e;
+  }
+  try {
+    await delegationWatcher.wait();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  } catch (err) {
+    console.warn(`[undelegateDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`, err);
   }
   return signature;
 }
@@ -3218,11 +3222,15 @@ class LoyalPrivateTransactionsClient {
     try {
       const tx = new Transaction4().add(ix);
       signature = await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
-      await delegationWatcher.wait();
-      await new Promise((resolve) => setTimeout(resolve, 3000));
     } catch (e) {
       await delegationWatcher.cancel();
       throw e;
+    }
+    try {
+      await delegationWatcher.wait();
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+    } catch (err) {
+      console.warn(`[delegateDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`, err);
     }
     return signature;
   }
@@ -3257,12 +3265,16 @@ class LoyalPrivateTransactionsClient {
     try {
       console.log("delegateUsernameDeposit Accounts:", prettyStringify2(accounts));
       signature = await this.baseProgram.methods.delegateUsernameDeposit(usernameHash, tokenMint).accountsPartial(accounts).rpc(rpcOptions);
-      console.log("delegateUsernameDeposit: waiting for depositPda owner to be DELEGATION_PROGRAM_ID on base connection...");
-      await delegationWatcher.wait();
-      await new Promise((resolve) => setTimeout(resolve, 3000));
     } catch (e) {
       await delegationWatcher.cancel();
       throw e;
+    }
+    try {
+      console.log("delegateUsernameDeposit: waiting for depositPda owner to be DELEGATION_PROGRAM_ID on base connection...");
+      await delegationWatcher.wait();
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+    } catch (err) {
+      console.warn(`[delegateUsernameDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`, err);
     }
     return signature;
   }
@@ -3781,11 +3793,15 @@ async function shieldTokens(params) {
         permissionAccountInfo
       }
     });
-    await delegationWatcher.wait();
-    await new Promise((resolve) => setTimeout(resolve, 3000));
   } catch (e) {
     await delegationWatcher.cancel();
     throw e;
+  }
+  try {
+    await delegationWatcher.wait();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  } catch (err) {
+    console.warn(`[shieldTokens] delegation watcher did not observe owner change (signature=${signature}); continuing`, err);
   }
   return signature;
 }

--- a/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
+++ b/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
@@ -721,7 +721,7 @@ export class LoyalPrivateTransactionsClient {
       DELEGATION_PROGRAM_ID
     );
 
-    let signature;
+    let signature: string;
     try {
       const tx = new Transaction().add(ix);
       signature = await this.baseProgram.provider.sendAndConfirm!(
@@ -729,11 +729,22 @@ export class LoyalPrivateTransactionsClient {
         [],
         params.rpcOptions
       );
-      await delegationWatcher.wait();
-      await new Promise((resolve) => setTimeout(resolve, 3_000));
     } catch (e) {
       await delegationWatcher.cancel();
       throw e;
+    }
+
+    // Delegation already landed; observing the owner change on the base
+    // connection is best-effort from here. Don't surface a watcher
+    // timeout as a delegate failure (ASK-1134).
+    try {
+      await delegationWatcher.wait();
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+    } catch (err) {
+      console.warn(
+        `[delegateDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`,
+        err,
+      );
     }
 
     return signature;
@@ -788,7 +799,7 @@ export class LoyalPrivateTransactionsClient {
       DELEGATION_PROGRAM_ID
     );
 
-    let signature;
+    let signature: string;
     try {
       console.log(
         "delegateUsernameDeposit Accounts:",
@@ -798,14 +809,24 @@ export class LoyalPrivateTransactionsClient {
         .delegateUsernameDeposit(usernameHash, tokenMint)
         .accountsPartial(accounts)
         .rpc(rpcOptions);
+    } catch (e) {
+      await delegationWatcher.cancel();
+      throw e;
+    }
+
+    // Best-effort watcher: delegation already landed, a wait timeout
+    // must not surface as a delegate failure (ASK-1134).
+    try {
       console.log(
         "delegateUsernameDeposit: waiting for depositPda owner to be DELEGATION_PROGRAM_ID on base connection..."
       );
       await delegationWatcher.wait();
       await new Promise((resolve) => setTimeout(resolve, 3_000));
-    } catch (e) {
-      await delegationWatcher.cancel();
-      throw e;
+    } catch (err) {
+      console.warn(
+        `[delegateUsernameDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`,
+        err,
+      );
     }
 
     return signature;

--- a/sdk/private-transactions/src/actions/shieldTokens.ts
+++ b/sdk/private-transactions/src/actions/shieldTokens.ts
@@ -149,7 +149,7 @@ export async function shieldTokens(params: {
   );
 
   const tx = new Transaction().add(...instructions);
-  let signature;
+  let signature: string;
   try {
     signature = await sendAndConfirmWithDiagnostics({
       label: "shieldTokens",
@@ -169,11 +169,24 @@ export async function shieldTokens(params: {
         permissionAccountInfo,
       },
     });
-    await delegationWatcher.wait();
-    await new Promise((resolve) => setTimeout(resolve, 3_000));
   } catch (e) {
     await delegationWatcher.cancel();
     throw e;
+  }
+
+  // Shield already landed on-chain. Waiting for the deposit PDA to get
+  // re-owned by the delegation program is best-effort from here on —
+  // if it times out or errors, we still return the signature. A hard
+  // throw here surfaced as "Shield failed" in the UI even though the
+  // tx succeeded (ASK-1134).
+  try {
+    await delegationWatcher.wait();
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  } catch (err) {
+    console.warn(
+      `[shieldTokens] delegation watcher did not observe owner change (signature=${signature}); continuing`,
+      err,
+    );
   }
 
   return signature;

--- a/sdk/private-transactions/src/actions/undelegateDeposit.ts
+++ b/sdk/private-transactions/src/actions/undelegateDeposit.ts
@@ -36,7 +36,7 @@ export async function undelegateDeposit(
   );
 
   const tx = new Transaction().add(ix);
-  let signature;
+  let signature: string;
   try {
     signature = await sendAndConfirmWithDiagnostics({
       label: "undelegateDeposit",
@@ -49,11 +49,22 @@ export async function undelegateDeposit(
         depositPda,
       },
     });
-    await delegationWatcher.wait();
-    await new Promise((resolve) => setTimeout(resolve, 3_000));
   } catch (e) {
     await delegationWatcher.cancel();
     throw e;
+  }
+
+  // Undelegate already landed on-chain. Ownership-change observation is
+  // best-effort from here: a wait timeout must not surface as an
+  // unshield failure to the caller (ASK-1134).
+  try {
+    await delegationWatcher.wait();
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  } catch (err) {
+    console.warn(
+      `[undelegateDeposit] delegation watcher did not observe owner change (signature=${signature}); continuing`,
+      err,
+    );
   }
 
   return signature;


### PR DESCRIPTION
## Summary

- After `sendAndConfirm` lands the tx, a 15s delegation-owner watcher timeout was being thrown as a hard error — mobile surfaced "Shield failed" despite the on-chain balance move (ASK-1134).
- Split `shieldTokens`, `undelegateDeposit`, `delegateDeposit`, `delegateUsernameDeposit` into two try blocks: send failures still throw; post-send watcher timeouts log a warning and return the signature.
- Rebuilt `dist/index.js`.

## Test plan

- [ ] Shield USDC on mobile → success toast, no "Shield failed" banner even if delegation owner change takes >15s
- [ ] Unshield SOL on mobile → success toast
- [ ] Existing send/send-confirm diagnostics still surface genuine tx errors