### PR TITLE
fix(sdk/private-transactions): route all client mutations through diagnostics path

### DIFF
--- a/sdk/private-transactions/dist/index.js
+++ b/sdk/private-transactions/dist/index.js
@@ -3973,20 +3973,49 @@ class LoyalPrivateTransactionsClient {
     const { ix, ensure } = await initializeDepositIx(this.baseProgram, params);
     await processEnsureChecks(this.baseProgram.provider.connection, this.ephemeralProgram.provider.connection, ensure);
     const tx = new Transaction7().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
+    return await sendAndConfirmWithDiagnostics({
+      label: "initializeDeposit",
+      provider: this.baseProgram.provider,
+      tx,
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user: params.user,
+        tokenMint: params.tokenMint
+      }
+    });
   }
   async initializeUsernameDeposit(params) {
     const { ix, ensure } = await initializeUsernameDepositIx(this.baseProgram, params);
     await processEnsureChecks(this.baseProgram.provider.connection, this.ephemeralProgram.provider.connection, ensure);
     const tx = new Transaction7().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
+    return await sendAndConfirmWithDiagnostics({
+      label: "initializeUsernameDeposit",
+      provider: this.baseProgram.provider,
+      tx,
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        username: params.username,
+        tokenMint: params.tokenMint
+      }
+    });
   }
   async modifyBalance(params) {
     const { user, tokenMint } = params;
     const { ix, ensure } = await modifyBalanceIx(this.baseProgram, params);
     await processEnsureChecks(this.baseProgram.provider.connection, this.ephemeralProgram.provider.connection, ensure);
     const tx = new Transaction7().add(ix);
-    const signature = await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
+    const signature = await sendAndConfirmWithDiagnostics({
+      label: "modifyBalance",
+      provider: this.baseProgram.provider,
+      tx,
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user,
+        tokenMint,
+        amount: params.amount,
+        increase: params.increase
+      }
+    });
     const deposit = await this.getBaseDeposit(user, tokenMint);
     if (!deposit) {
       throw new Error("Failed to fetch deposit after modification");
@@ -4060,7 +4089,16 @@ class LoyalPrivateTransactionsClient {
     const { ix, ensure } = await createPermissionIx(this.baseProgram, params);
     await processEnsureChecks(this.baseProgram.provider.connection, this.ephemeralProgram.provider.connection, ensure);
     const tx = new Transaction7().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
+    return await sendAndConfirmWithDiagnostics({
+      label: "createPermission",
+      provider: this.baseProgram.provider,
+      tx,
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user: params.user,
+        tokenMint: params.tokenMint
+      }
+    });
   }
   async createUsernamePermission(params) {
     const { username, tokenMint, session, authority, payer, rpcOptions } = params;
@@ -4098,7 +4136,17 @@ class LoyalPrivateTransactionsClient {
     let signature;
     try {
       const tx = new Transaction7().add(ix);
-      signature = await this.baseProgram.provider.sendAndConfirm(tx, [], params.rpcOptions);
+      signature = await sendAndConfirmWithDiagnostics({
+        label: "delegateDeposit",
+        provider: this.baseProgram.provider,
+        tx,
+        rpcOptions: params.rpcOptions,
+        extraContext: {
+          user,
+          tokenMint,
+          depositPda
+        }
+      });
     } catch (e) {
       await delegationWatcher.cancel();
       throw e;

--- a/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
+++ b/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
@@ -92,6 +92,7 @@ import { modifyBalanceIx } from "./instructions/modifyBalance";
 import { createPermissionIx } from "./instructions/createPermission";
 import { delegateDepositIx } from "./instructions/delegateDeposit";
 import { undelegateDeposit } from "./actions/undelegateDeposit";
+import { sendAndConfirmWithDiagnostics } from "./transaction-debug";
 import {
   estimatePlannedTransactionFees,
   type FeeEstimateTransactionPlan,
@@ -672,11 +673,16 @@ export class LoyalPrivateTransactionsClient {
     );
 
     const tx = new Transaction().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm!(
+    return await sendAndConfirmWithDiagnostics({
+      label: "initializeDeposit",
+      provider: this.baseProgram.provider,
       tx,
-      [],
-      params.rpcOptions
-    );
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user: params.user,
+        tokenMint: params.tokenMint,
+      },
+    });
   }
 
   async initializeUsernameDeposit(
@@ -694,11 +700,16 @@ export class LoyalPrivateTransactionsClient {
     );
 
     const tx = new Transaction().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm!(
+    return await sendAndConfirmWithDiagnostics({
+      label: "initializeUsernameDeposit",
+      provider: this.baseProgram.provider,
       tx,
-      [],
-      params.rpcOptions
-    );
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        username: params.username,
+        tokenMint: params.tokenMint,
+      },
+    });
   }
 
   /**
@@ -717,11 +728,18 @@ export class LoyalPrivateTransactionsClient {
     );
 
     const tx = new Transaction().add(ix);
-    const signature = await this.baseProgram.provider.sendAndConfirm!(
+    const signature = await sendAndConfirmWithDiagnostics({
+      label: "modifyBalance",
+      provider: this.baseProgram.provider,
       tx,
-      [],
-      params.rpcOptions
-    );
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user,
+        tokenMint,
+        amount: params.amount,
+        increase: params.increase,
+      },
+    });
 
     // TODO: add wait
     const deposit = await this.getBaseDeposit(user, tokenMint);
@@ -863,11 +881,16 @@ export class LoyalPrivateTransactionsClient {
     );
 
     const tx = new Transaction().add(ix);
-    return await this.baseProgram.provider.sendAndConfirm!(
+    return await sendAndConfirmWithDiagnostics({
+      label: "createPermission",
+      provider: this.baseProgram.provider,
       tx,
-      [],
-      params.rpcOptions
-    );
+      rpcOptions: params.rpcOptions,
+      extraContext: {
+        user: params.user,
+        tokenMint: params.tokenMint,
+      },
+    });
   }
 
   /**
@@ -944,11 +967,17 @@ export class LoyalPrivateTransactionsClient {
     let signature: string;
     try {
       const tx = new Transaction().add(ix);
-      signature = await this.baseProgram.provider.sendAndConfirm!(
+      signature = await sendAndConfirmWithDiagnostics({
+        label: "delegateDeposit",
+        provider: this.baseProgram.provider,
         tx,
-        [],
-        params.rpcOptions
-      );
+        rpcOptions: params.rpcOptions,
+        extraContext: {
+          user,
+          tokenMint,
+          depositPda,
+        },
+      });
     } catch (e) {
       await delegationWatcher.cancel();
       throw e;


### PR DESCRIPTION
## Summary

Follow-up to #297. Extends the same Anchor confirmation-race fix to every remaining client-level mutation.

**Root cause:** Five `LoyalPrivateTransactionsClient` methods still called raw `provider.sendAndConfirm!(...)`, which uses Anchor's `confirmTransaction` internally. When Seeker biometric takes 5-30s, the blockhash expires before the poll returns and Anchor throws `TransactionExpiredBlockheightExceeded` — even though the tx already landed on chain.

Shield was immune because `shieldTokens` bundles everything into one tx that goes through `sendAndConfirmWithDiagnostics`. **Unshield** splits into four separate client calls (undelegate → modifyBalance → closeWsolAta → delegateDeposit), and only `undelegate` was ported in #297. When `modifyBalance` threw the race, the outer try/catch skipped `closeWsolAta` — leaving wSOL stranded in the user's ATA (not counted toward their native SOL balance) and the UI showing "Unshield failed" despite the on-chain success.

## Changes

- `initializeDeposit` → `sendAndConfirmWithDiagnostics`
- `initializeUsernameDeposit` → `sendAndConfirmWithDiagnostics`
- `modifyBalance` → `sendAndConfirmWithDiagnostics` ← **primary fix for unshield**
- `createPermission` → `sendAndConfirmWithDiagnostics`
- `delegateDeposit` → `sendAndConfirmWithDiagnostics`
- Rebuilt `dist/index.js`

The existing `.rpc(rpcOptions)` call sites on ephemeral-program username/transfer methods are left alone — they run on the ephemeral layer with fast finality and have not been observed to race.

## Test plan

- [ ] Unshield SOL on Seeker: balance moves correctly and UI reports success even if biometric takes 10+ seconds.
- [ ] Unshield USDC on Seeker: same.
- [ ] Re-delegate (`delegateDeposit` post-unshield) does not surface "Unshield failed" if the signer takes long.
- [ ] Cold-path first-time shield (`initializeDeposit` standalone path in username send flow) succeeds under slow biometric.