### PR TITLE
fix(sdk): remove duplicate diagnostics import

### DIFF
--- a/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
+++ b/sdk/private-transactions/src/LoyalPrivateTransactionsClient.ts
@@ -101,7 +101,6 @@ import {
   estimatePlannedTransactionFees,
   type FeeEstimateTransactionPlan,
 } from "./fee-estimate";
-import { sendAndConfirmWithDiagnostics } from "./transaction-debug";
 
 const KAMINO_API_BASE_URL = "https://api.kamino.finance";
 const KAMINO_MAINNET_ENV = "mainnet-beta";


### PR DESCRIPTION
Removes the duplicate sendAndConfirmWithDiagnostics import that broke the private transactions type build on Vercel.

Validated with `cd sdk/private-transactions && bun run build`.

This unblocks the package prebuild step for the frontend/app Vercel deployments.
