### PR TITLE
fix(rpc): rotate Helius endpoints

### DIFF
--- a/admin/src/app/(admin)/transfers/transfers-data.ts
+++ b/admin/src/app/(admin)/transfers/transfers-data.ts
@@ -302,7 +302,7 @@ export async function getGaslessClaimsData(): Promise<GaslessClaimsData> {
 }
 
 const SOLANA_MAINNET_RPC_URL =
-  "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com";
+  "https://fredra-z7l52f-fast-mainnet.helius-rpc.com";
 
 async function loadFaucetBalance(): Promise<number | null> {
   const publicKey = process.env.DEPLOYMENT_PUBLIC_KEY;

--- a/app/.env.example
+++ b/app/.env.example
@@ -30,6 +30,7 @@ AX_SUMMARY_ENABLE_TELEMETRY=
 JUPITER_API_KEY=
 IRYS_SOLANA_KEY=
 DEPLOYMENT_PK=
+PRIVATE_MAINNET_RPC_URL=https://fredra-z7l52f-fast-mainnet.helius-rpc.com
 # Optional but recommended for encrypted content (base64-encoded 32-byte key)
 MESSAGE_ENCRYPTION_KEY=
 

--- a/extension/src/components/wallet/wallet-provider.tsx
+++ b/extension/src/components/wallet/wallet-provider.tsx
@@ -33,8 +33,8 @@ import {
 type Network = "mainnet" | "devnet";
 
 const RPC_ENDPOINTS: Record<Network, string> = {
-  mainnet: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-  devnet: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
+  mainnet: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+  devnet: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
 };
 
 function getRpcUrl(network: Network): string {

--- a/frontend/src/lib/core/config/__tests__/public.test.ts
+++ b/frontend/src/lib/core/config/__tests__/public.test.ts
@@ -80,7 +80,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("devnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://aurora-o23cd4-fast-devnet.helius-rpc.com"
+      "https://karlotta-a6micy-fast-devnet.helius-rpc.com"
     );
   });
 
@@ -91,7 +91,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("mainnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com"
+      "https://fredra-z7l52f-fast-mainnet.helius-rpc.com"
     );
   });
 
@@ -102,7 +102,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("devnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://aurora-o23cd4-fast-devnet.helius-rpc.com"
+      "https://karlotta-a6micy-fast-devnet.helius-rpc.com"
     );
   });
 

--- a/packages/solana-rpc/src/__tests__/solana-rpc.test.ts
+++ b/packages/solana-rpc/src/__tests__/solana-rpc.test.ts
@@ -32,15 +32,15 @@ describe("resolveSolanaEnv", () => {
 describe("getSolanaEndpoints", () => {
   test("returns the mainnet helius endpoints", () => {
     expect(getSolanaEndpoints("mainnet")).toEqual({
-      rpcEndpoint: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-      websocketEndpoint: "wss://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
+      rpcEndpoint: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+      websocketEndpoint: "wss://fredra-z7l52f-fast-mainnet.helius-rpc.com",
     });
   });
 
-  test("returns the current devnet split endpoints", () => {
+  test("returns the devnet helius endpoints", () => {
     expect(getSolanaEndpoints("devnet")).toEqual({
-      rpcEndpoint: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
-      websocketEndpoint: "wss://api.devnet.solana.com",
+      rpcEndpoint: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
+      websocketEndpoint: "wss://karlotta-a6micy-fast-devnet.helius-rpc.com",
     });
   });
 

--- a/packages/solana-rpc/src/solana-rpc.ts
+++ b/packages/solana-rpc/src/solana-rpc.ts
@@ -19,13 +19,12 @@ export type PerEndpoints = {
 
 const DEFAULT_SOLANA_ENV: SolanaEnv = "devnet";
 const MAINNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
-  rpcEndpoint: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-  websocketEndpoint: "wss://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
+  rpcEndpoint: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+  websocketEndpoint: "wss://fredra-z7l52f-fast-mainnet.helius-rpc.com",
 };
 const DEVNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
-  rpcEndpoint: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
-  // Keep the public Solana websocket endpoint until Helius devnet WSS is reliable.
-  websocketEndpoint: "wss://api.devnet.solana.com",
+  rpcEndpoint: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
+  websocketEndpoint: "wss://karlotta-a6micy-fast-devnet.helius-rpc.com",
 };
 const TESTNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
   rpcEndpoint: "https://api.testnet.solana.com",

--- a/sdk/private-transactions/tests/private-transactions-shield.test.ts
+++ b/sdk/private-transactions/tests/private-transactions-shield.test.ts
@@ -136,9 +136,9 @@ const PER_WS_ENDPOINT = "wss://tee.magicblock.app";
 // const PER_WS_ENDPOINT = "wss://devnet-as.magicblock.app";
 
 export const SECURE_DEVNET_RPC_URL =
-  "https://aurora-o23cd4-fast-devnet.helius-rpc.com";
+  "https://karlotta-a6micy-fast-devnet.helius-rpc.com";
 export const SECURE_DEVNET_RPC_WS =
-  "wss://aurora-o23cd4-fast-devnet.helius-rpc.com";
+  "wss://karlotta-a6micy-fast-devnet.helius-rpc.com";
 
 const solanaConnection = new Connection(SECURE_DEVNET_RPC_URL, {
   wsEndpoint: SECURE_DEVNET_RPC_WS,


### PR DESCRIPTION
Rotates hardcoded Helius RPC endpoints across shared RPC defaults, extension wallet provider, admin faucet balance reads, and private-transactions devnet tests. Also documents the app private mainnet RPC env value in app/.env.example.

Validation:
- bun test packages/solana-rpc/src/__tests__/solana-rpc.test.ts
- bun test frontend/src/lib/core/config/__tests__/public.test.ts