### PR TITLE
fix(frontend): point extension links at GitHub release zip

### DIFF
--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -364,7 +364,7 @@ export default function LandingPage() {
       >
         {!isChatMode && (
           <div
-            aria-label="Loyal is still in beta"
+            aria-label="Please use this browser extension while a new version is being submitted to the store"
             style={{
               position: "absolute",
               top: 24,
@@ -382,10 +382,10 @@ export default function LandingPage() {
               color: "#111",
               fontSize: "clamp(13px, 2.8vw, 14px)",
               fontWeight: 600,
-              lineHeight: 1,
+              lineHeight: 1.3,
               padding: "9px 13px",
-              pointerEvents: "none",
-              whiteSpace: "nowrap",
+              maxWidth: "min(92vw, 520px)",
+              textAlign: "center",
             }}
           >
             <span
@@ -395,9 +395,26 @@ export default function LandingPage() {
                 height: 7,
                 borderRadius: 999,
                 background: "#f9363c",
+                flexShrink: 0,
               }}
             />
-            Loyal is still in beta!
+            <span>
+              Please use{" "}
+              <TrackedExternalLink
+                href="https://github.com/loyal-labs/loyal-app/releases/download/ext-v0.5.5/loyal-ext-universal-v0.5.5.zip"
+                source="app-page-beta-banner"
+                linkText="this"
+                style={{
+                  color: "#111",
+                  textDecoration: "underline",
+                  fontWeight: 700,
+                }}
+              >
+                this
+              </TrackedExternalLink>{" "}
+              browser extension while a new version is being submitted to the
+              store
+            </span>
           </div>
         )}
 

--- a/frontend/src/components/landing-get-started.tsx
+++ b/frontend/src/components/landing-get-started.tsx
@@ -8,8 +8,10 @@ import { useEffect, useRef, useState } from "react";
 type Segment = "Extension" | "Mobile" | "Web";
 
 const appUrl = "https://app.askloyal.com";
+// Temporarily points at the GitHub release zip while v0.5.5 is being
+// re-submitted to the Chrome Web Store.
 const chromeWebStoreUrl =
-  "https://chromewebstore.google.com/detail/loyal-%E2%80%94-private-solana-wa/cdienfadefhlaknmedckgifkjdbioack?hl=en&authuser=1";
+  "https://github.com/loyal-labs/loyal-app/releases/download/ext-v0.5.5/loyal-ext-universal-v0.5.5.zip";
 const telegramMiniAppUrl =
   "https://t.me/askloyal_tgbot/app?startapp=askloyalcom";
 const seekerDappStoreUrl = "solanadappstore://details?id=com.loyal.app";


### PR DESCRIPTION
## Summary
Temporary critical hotfix while extension v0.5.5 is being re-submitted to the Chrome Web Store:

- Landing page **Get started → Extension** cards (Chrome / Brave / Edge) now link to the GitHub release zip (`loyal-ext-universal-v0.5.5.zip`) instead of the Chrome Web Store listing. Firefox card stays disabled.
- `/app` beta banner copy changed from "Loyal is still in beta!" to "Please use **this** browser extension while a new version is being submitted to the store" — with **this** linking to the same release zip. Banner is now wrappable on small screens and the link is clickable (previously had `pointer-events: none`).

## Revert plan
Restore `chromeWebStoreUrl` to the Chrome Web Store URL and revert the banner JSX once the new extension build is approved on the store.