### PR TITLE
fix(sdk/private-transactions): include delegated deposits in base-only enumeration

### DIFF
--- a/sdk/private-transactions/dist/index.js
+++ b/sdk/private-transactions/dist/index.js
@@ -1891,6 +1891,11 @@ import { AnchorProvider, Program } from "@coral-xyz/anchor";
 import {
   PublicKey as PublicKey2
 } from "@solana/web3.js";
+var DEPOSIT_ACCOUNT_SIZE = 80;
+var DEPOSIT_USER_OFFSET = 8;
+var DEPOSIT_MINT_OFFSET = 40;
+var DEPOSIT_AMOUNT_OFFSET = 72;
+
 class ReadOnlyWallet {
   publicKey;
   constructor(publicKey) {
@@ -1910,23 +1915,58 @@ function createReadOnlyDepositProgram(connection) {
   });
   return new Program(telegram_private_transfer_default, provider);
 }
+function readDepositAmount(data) {
+  let value = BigInt(0);
+  for (let i = 0;i < 8; i++) {
+    value += BigInt(data[DEPOSIT_AMOUNT_OFFSET + i] ?? 0) << BigInt(i * 8);
+  }
+  return value;
+}
+async function readDelegatedDepositsOnBase(baseConnection, user) {
+  const accounts = await baseConnection.getProgramAccounts(DELEGATION_PROGRAM_ID, {
+    filters: [
+      { dataSize: DEPOSIT_ACCOUNT_SIZE },
+      {
+        memcmp: {
+          offset: DEPOSIT_USER_OFFSET,
+          bytes: user.toBase58()
+        }
+      }
+    ]
+  });
+  const result = [];
+  for (const { pubkey, account } of accounts) {
+    const data = account.data;
+    if (data.length < DEPOSIT_ACCOUNT_SIZE)
+      continue;
+    const tokenMint = new PublicKey2(data.subarray(DEPOSIT_MINT_OFFSET, DEPOSIT_MINT_OFFSET + 32));
+    result.push({
+      user,
+      tokenMint,
+      amount: readDepositAmount(data),
+      address: pubkey
+    });
+  }
+  return result;
+}
 async function enumerateDepositsByUser(args) {
   const userFilter = [
     {
       memcmp: {
-        offset: 8,
+        offset: DEPOSIT_USER_OFFSET,
         bytes: args.user.toBase58()
       }
     }
   ];
   const baseProgram = createReadOnlyDepositProgram(args.baseConnection);
   const ephemeralProgram = args.ephemeralConnection ? createReadOnlyDepositProgram(args.ephemeralConnection) : null;
-  const [baseResults, ephemeralResults] = await Promise.allSettled([
+  const [baseUndelegatedResult, baseDelegatedResult, ephemeralResult] = await Promise.allSettled([
     baseProgram.account.deposit.all(userFilter),
+    readDelegatedDepositsOnBase(args.baseConnection, args.user),
     ephemeralProgram ? ephemeralProgram.account.deposit.all(userFilter) : Promise.resolve([])
   ]);
   const byPda = new Map;
-  const ingest = (results, preferOverwrite) => {
+  const ingestAnchor = (results, preferOverwrite) => {
     for (const { publicKey, account } of results) {
       const key = publicKey.toBase58();
       if (!preferOverwrite && byPda.has(key))
@@ -1939,15 +1979,28 @@ async function enumerateDepositsByUser(args) {
       });
     }
   };
-  if (baseResults.status === "fulfilled") {
-    ingest(baseResults.value, false);
+  const ingestRaw = (results, preferOverwrite) => {
+    for (const data of results) {
+      const key = data.address.toBase58();
+      if (!preferOverwrite && byPda.has(key))
+        continue;
+      byPda.set(key, data);
+    }
+  };
+  if (baseUndelegatedResult.status === "fulfilled") {
+    ingestAnchor(baseUndelegatedResult.value, false);
   } else {
-    console.warn("[enumerateDepositsByUser] base program enumeration failed", baseResults.reason);
+    console.warn("[enumerateDepositsByUser] base undelegated enumeration failed", baseUndelegatedResult.reason);
   }
-  if (ephemeralResults.status === "fulfilled") {
-    ingest(ephemeralResults.value, true);
-  } else if (ephemeralProgram) {
-    console.warn("[enumerateDepositsByUser] ephemeral program enumeration failed", ephemeralResults.reason);
+  if (baseDelegatedResult.status === "fulfilled") {
+    ingestRaw(baseDelegatedResult.value, true);
+  } else {
+    console.warn("[enumerateDepositsByUser] base delegated enumeration failed", baseDelegatedResult.reason);
+  }
+  if (ephemeralResult.status === "fulfilled" && ephemeralProgram) {
+    ingestAnchor(ephemeralResult.value, true);
+  } else if (ephemeralProgram && ephemeralResult.status === "rejected") {
+    console.warn("[enumerateDepositsByUser] ephemeral enumeration failed", ephemeralResult.reason);
   }
   return Array.from(byPda.values());
 }
@@ -2326,7 +2379,7 @@ var U64_SIZE = 8;
 var U8_SIZE = 1;
 var BOOL_SIZE = 1;
 var VEC_PREFIX_SIZE = 4;
-var DEPOSIT_ACCOUNT_SIZE = DISCRIMINATOR_SIZE + PUBLIC_KEY_SIZE + PUBLIC_KEY_SIZE + U64_SIZE;
+var DEPOSIT_ACCOUNT_SIZE2 = DISCRIMINATOR_SIZE + PUBLIC_KEY_SIZE + PUBLIC_KEY_SIZE + U64_SIZE;
 var VAULT_ACCOUNT_SIZE = DISCRIMINATOR_SIZE + U8_SIZE;
 var PERMISSION_ACCOUNT_SIZE = 567;
 var DELEGATION_RECORD_ACCOUNT_SIZE = DISCRIMINATOR_SIZE + PUBLIC_KEY_SIZE + PUBLIC_KEY_SIZE + U64_SIZE * 3;
@@ -2359,7 +2412,7 @@ async function estimateDepositRentLamports(params) {
     accounts: [
       {
         address: params.depositPda,
-        space: DEPOSIT_ACCOUNT_SIZE,
+        space: DEPOSIT_ACCOUNT_SIZE2,
         forceCreate: params.forceCreate
       }
     ]
@@ -2672,6 +2725,13 @@ function wrapSolToWsolIx({
     }),
     createSyncNativeInstruction(wsolAta)
   ];
+}
+function createWsolAta({
+  user,
+  payer
+}) {
+  const wsolAta = getAssociatedTokenAddressSync2(NATIVE_MINT, user);
+  return createAssociatedTokenAccountIdempotentInstruction(payer, wsolAta, user, NATIVE_MINT);
 }
 function closeWsolAta({
   user,
@@ -3463,11 +3523,9 @@ async function buildUnshieldTokensInstructionPlan(params) {
   const instructions = [];
   const checks = [];
   if (isNativeSol) {
-    instructions.push(...labelTransactionInstructions("ensureWsolAta", wrapSolToWsolIx({
-      user,
-      payer,
-      lamports: 0n
-    })));
+    instructions.push(...labelTransactionInstructions("ensureWsolAta", [
+      createWsolAta({ user, payer })
+    ]));
   }
   const modifyBalanceIxs = await modifyBalanceIx(baseProgram, {
     tokenMint,

--- a/sdk/private-transactions/src/enumerate-deposits.ts
+++ b/sdk/private-transactions/src/enumerate-deposits.ts
@@ -6,9 +6,22 @@ import {
   type VersionedTransaction,
 } from "@solana/web3.js";
 
+import { DELEGATION_PROGRAM_ID } from "./constants";
 import idl from "./idl/telegram_private_transfer.json";
 import type { TelegramPrivateTransfer } from "./idl/telegram_private_transfer.ts";
 import type { DepositData } from "./types";
+
+/**
+ * Deposit account layout (after Anchor's 8-byte discriminator):
+ *   user:       Pubkey (32) @ offset 8
+ *   tokenMint:  Pubkey (32) @ offset 40
+ *   amount:     u64    (8)  @ offset 72
+ * Total size: 80 bytes.
+ */
+const DEPOSIT_ACCOUNT_SIZE = 80;
+const DEPOSIT_USER_OFFSET = 8;
+const DEPOSIT_MINT_OFFSET = 40;
+const DEPOSIT_AMOUNT_OFFSET = 72;
 
 class ReadOnlyWallet {
   readonly publicKey: PublicKey;
@@ -44,19 +57,75 @@ function createReadOnlyDepositProgram(
   return new Program(idl as TelegramPrivateTransfer, provider);
 }
 
+function readDepositAmount(data: Uint8Array): bigint {
+  let value = BigInt(0);
+  for (let i = 0; i < 8; i++) {
+    value += BigInt(data[DEPOSIT_AMOUNT_OFFSET + i] ?? 0) << BigInt(i * 8);
+  }
+  return value;
+}
+
+/**
+ * When a deposit is delegated to an ephemeral validator, the account remains
+ * on the base chain but its owner becomes `DELEGATION_PROGRAM_ID`. Anchor's
+ * program-scoped `account.deposit.all()` won't return these. We read them via
+ * a raw `getProgramAccounts` against the delegation program, filtered by the
+ * Deposit account size + user pubkey at offset 8, then parse the bytes.
+ *
+ * The data layout is preserved across delegation, so reading mint and amount
+ * from the same offsets as the undelegated case is safe.
+ */
+async function readDelegatedDepositsOnBase(
+  baseConnection: Connection,
+  user: PublicKey
+): Promise<DepositData[]> {
+  const accounts = await baseConnection.getProgramAccounts(
+    DELEGATION_PROGRAM_ID,
+    {
+      filters: [
+        { dataSize: DEPOSIT_ACCOUNT_SIZE },
+        {
+          memcmp: {
+            offset: DEPOSIT_USER_OFFSET,
+            bytes: user.toBase58(),
+          },
+        },
+      ],
+    }
+  );
+
+  const result: DepositData[] = [];
+  for (const { pubkey, account } of accounts) {
+    const data = account.data as Uint8Array;
+    if (data.length < DEPOSIT_ACCOUNT_SIZE) continue;
+    const tokenMint = new PublicKey(
+      data.subarray(DEPOSIT_MINT_OFFSET, DEPOSIT_MINT_OFFSET + 32)
+    );
+    result.push({
+      user,
+      tokenMint,
+      amount: readDepositAmount(data),
+      address: pubkey,
+    });
+  }
+  return result;
+}
+
 /**
  * Enumerate every Deposit account belonging to `user` across the base program
  * and (optionally) the ephemeral program. Read-only — no signer required.
  *
- * Delegated deposits only exist on the ephemeral chain (on base the PDA is
- * owned by the delegation program and Anchor cannot deserialize it as a
- * `Deposit`). Undelegated deposits only exist on base. We query both and
- * merge by PDA address, preferring the ephemeral entry when both return
- * one because ephemeral reflects the live balance for delegated deposits.
+ * Three sources are merged:
+ *   1. Base, owned by the deposit program — undelegated deposits (Anchor).
+ *   2. Base, owned by the delegation program — delegated deposits whose data
+ *      bytes are still readable on base. Required when no authenticated
+ *      ephemeral connection is available (e.g. browser wallet UI).
+ *   3. Ephemeral, owned by the deposit program — delegated deposits with the
+ *      live balance (Anchor). Wins over (2) for the same PDA when present.
  *
- * Used by wallet UIs to discover shielded holdings even when the user has
- * no matching base-chain token balance — e.g. after fully shielding an SPL
- * mint, where Helius `getAssetsByOwner` no longer surfaces it.
+ * Used by wallet UIs to discover shielded holdings even when the user has no
+ * matching base-chain token balance — e.g. after fully shielding an SPL mint,
+ * where Helius `getAssetsByOwner` no longer surfaces it.
  */
 export async function enumerateDepositsByUser(args: {
   user: PublicKey;
@@ -66,7 +135,7 @@ export async function enumerateDepositsByUser(args: {
   const userFilter = [
     {
       memcmp: {
-        offset: 8,
+        offset: DEPOSIT_USER_OFFSET,
         bytes: args.user.toBase58(),
       },
     },
@@ -77,18 +146,20 @@ export async function enumerateDepositsByUser(args: {
     ? createReadOnlyDepositProgram(args.ephemeralConnection)
     : null;
 
-  const [baseResults, ephemeralResults] = await Promise.allSettled([
-    baseProgram.account.deposit.all(userFilter),
-    ephemeralProgram
-      ? ephemeralProgram.account.deposit.all(userFilter)
-      : Promise.resolve(
-          [] as Awaited<ReturnType<typeof baseProgram.account.deposit.all>>
-        ),
-  ]);
+  const [baseUndelegatedResult, baseDelegatedResult, ephemeralResult] =
+    await Promise.allSettled([
+      baseProgram.account.deposit.all(userFilter),
+      readDelegatedDepositsOnBase(args.baseConnection, args.user),
+      ephemeralProgram
+        ? ephemeralProgram.account.deposit.all(userFilter)
+        : Promise.resolve(
+            [] as Awaited<ReturnType<typeof baseProgram.account.deposit.all>>
+          ),
+    ]);
 
   const byPda = new Map<string, DepositData>();
 
-  const ingest = (
+  const ingestAnchor = (
     results: Array<{
       publicKey: PublicKey;
       account: { user: PublicKey; tokenMint: PublicKey; amount: BN };
@@ -107,21 +178,41 @@ export async function enumerateDepositsByUser(args: {
     }
   };
 
-  if (baseResults.status === "fulfilled") {
-    ingest(baseResults.value, /* preferOverwrite */ false);
+  const ingestRaw = (results: DepositData[], preferOverwrite: boolean) => {
+    for (const data of results) {
+      const key = data.address.toBase58();
+      if (!preferOverwrite && byPda.has(key)) continue;
+      byPda.set(key, data);
+    }
+  };
+
+  if (baseUndelegatedResult.status === "fulfilled") {
+    ingestAnchor(baseUndelegatedResult.value, /* preferOverwrite */ false);
   } else {
     console.warn(
-      "[enumerateDepositsByUser] base program enumeration failed",
-      baseResults.reason
+      "[enumerateDepositsByUser] base undelegated enumeration failed",
+      baseUndelegatedResult.reason
     );
   }
 
-  if (ephemeralResults.status === "fulfilled") {
-    ingest(ephemeralResults.value, /* preferOverwrite */ true);
-  } else if (ephemeralProgram) {
+  // Base-delegated reads have stale amounts vs. ephemeral, but they are
+  // recoverable without auth — pick them up before ephemeral so ephemeral
+  // (when present) overwrites with the live value.
+  if (baseDelegatedResult.status === "fulfilled") {
+    ingestRaw(baseDelegatedResult.value, /* preferOverwrite */ true);
+  } else {
     console.warn(
-      "[enumerateDepositsByUser] ephemeral program enumeration failed",
-      ephemeralResults.reason
+      "[enumerateDepositsByUser] base delegated enumeration failed",
+      baseDelegatedResult.reason
+    );
+  }
+
+  if (ephemeralResult.status === "fulfilled" && ephemeralProgram) {
+    ingestAnchor(ephemeralResult.value, /* preferOverwrite */ true);
+  } else if (ephemeralProgram && ephemeralResult.status === "rejected") {
+    console.warn(
+      "[enumerateDepositsByUser] ephemeral enumeration failed",
+      ephemeralResult.reason
     );
   }
 


### PR DESCRIPTION
## Summary
- Follow-up to #309. \`enumerateDepositsByUser\` used Anchor's program-scoped \`account.deposit.all\` against base, which only returns accounts owned by the deposit program. Delegated deposits live on base but are owned by the delegation program, so they were invisible whenever no authenticated ephemeral connection was available — e.g. the desktop wallet UI, which has no TEE auth and got empty results on mainnet (shielded USDC \$4k+ vanished from the portfolio).
- Add a third source: raw \`getProgramAccounts(DELEGATION_PROGRAM_ID)\` filtered by Deposit \`dataSize\` (80) + user pubkey at offset 8. Data layout is preserved across delegation, so mint and amount parse from the same offsets. Source order: base-undelegated < base-delegated (raw) < ephemeral-delegated (Anchor, live), so authenticated callers still get live ephemeral values.

## Test plan
- [ ] \`cd sdk/private-transactions && bun run build\` succeeds and bundles the delegation read path.
- [ ] In a desktop wallet client (no TEE auth), confirm shielded balances surface in the portfolio without ephemeral access.
- [ ] In an app client (with TEE auth), confirm ephemeral values still take priority over base-delegated reads.