### PR TITLE
docs: add custom robots.txt allowing AI crawlers

### DIFF
--- a/user-docs/robots.txt
+++ b/user-docs/robots.txt
@@ -1,0 +1,68 @@
+# Loyal Documentation — robots.txt
+# Source of truth: user-docs/robots.txt (served by Mintlify at /robots.txt).
+# We explicitly allow AI crawlers so that docs.askloyal.com remains
+# discoverable by AI search and assistant products.
+
+User-agent: *
+Allow: /
+
+# --- AI search & assistant crawlers (explicit allow) ---
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: Diffbot
+Allow: /
+
+Sitemap: https://docs.askloyal.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `user-docs/robots.txt` that explicitly allows AI search and assistant crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended, etc.) so `docs.askloyal.com` is discoverable by AI products.
- Mintlify serves this file at `/robots.txt`, overriding its default.

## Context
The live `docs.askloyal.com/robots.txt` currently disallows all major AI bots via a Cloudflare-managed `# BEGIN Cloudflare Managed content` block. The Cloudflare "Block AI Bots" toggle must also be disabled at the edge for this file to actually take effect — this PR is the origin-side belt-and-suspenders piece.

## Test plan
- [ ] Disable Cloudflare's managed AI bot block for the `askloyal.com` zone and purge cache for `/robots.txt`.
- [ ] After Mintlify redeploys, `curl -s https://docs.askloyal.com/robots.txt` returns the contents of `user-docs/robots.txt` (no `# BEGIN Cloudflare Managed content` block).
- [ ] Spot-check that `GPTBot`, `ClaudeBot`, `PerplexityBot`, and `Google-Extended` appear with `Allow: /`.