### PR TITLE
feat(frontend): add use spending limit button

### DIFF
--- a/frontend/src/components/wallet-sidebar/agent-page-view.tsx
+++ b/frontend/src/components/wallet-sidebar/agent-page-view.tsx
@@ -1418,7 +1418,8 @@ export function AgentPageView({
                         <div
                           style={{
                             display: "flex",
-                            alignItems: "baseline",
+                            alignItems: "center",
+                            gap: "10px",
                             overflow: "hidden",
                             borderRadius: "6px",
                           }}
@@ -1480,6 +1481,27 @@ export function AgentPageView({
                               limitAmounts?.total
                             )}
                           </span>
+                          <button
+                            disabled
+                            style={{
+                              background: "#000",
+                              border: "none",
+                              borderRadius: "9999px",
+                              color: "#fff",
+                              cursor: "default",
+                              flexShrink: 0,
+                              fontFamily: font,
+                              fontSize: "13px",
+                              fontWeight: 500,
+                              lineHeight: "16px",
+                              opacity: 1,
+                              padding: "7px 12px",
+                              whiteSpace: "nowrap",
+                            }}
+                            type="button"
+                          >
+                            Use spending limit
+                          </button>
                         </div>
                         <span
                           style={{

--- a/frontend/src/components/wallet-sidebar/spending-limit-section.tsx
+++ b/frontend/src/components/wallet-sidebar/spending-limit-section.tsx
@@ -386,7 +386,8 @@ export function SpendingLimitSection({
               <div
                 style={{
                   display: "flex",
-                  alignItems: "baseline",
+                  alignItems: "center",
+                  gap: "10px",
                   overflow: "hidden",
                   borderRadius: "6px",
                 }}
@@ -440,6 +441,27 @@ export function SpendingLimitSection({
                     limitAmounts?.total
                   )}
                 </span>
+                <button
+                  disabled
+                  style={{
+                    background: "#000",
+                    border: "none",
+                    borderRadius: "9999px",
+                    color: "#fff",
+                    cursor: "default",
+                    flexShrink: 0,
+                    fontFamily: font,
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    lineHeight: "16px",
+                    opacity: 1,
+                    padding: "7px 12px",
+                    whiteSpace: "nowrap",
+                  }}
+                  type="button"
+                >
+                  Use spending limit
+                </button>
               </div>
               <span
                 style={{


### PR DESCRIPTION
Adds a disabled black "Use spending limit" button next to the displayed spending-limit amount in the frontend wallet UI.