### PR TITLE
fix(mobile): update unshield and notification flows

### DIFF
--- a/app/src/app/api/cron/summaries/route.test.ts
+++ b/app/src/app/api/cron/summaries/route.test.ts
@@ -3,6 +3,45 @@ import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "
 import type { SendSummaryResult } from "@/lib/telegram/bot-api/types";
 
 mock.module("server-only", () => ({}));
+mock.module("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...init?.headers,
+        },
+      }),
+  },
+}));
+mock.module("@loyal-labs/db-core/schema", () => ({
+  communities: {
+    isActive: "communities.isActive",
+  },
+  pushTokens: "pushTokens",
+}));
+mock.module("@loyal-labs/llm-core", () => ({
+  LlmRetryExhaustedError: class LlmRetryExhaustedError extends Error {
+    failureReasons: string[] = [];
+  },
+}));
+mock.module("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => ({ op: "eq", args }),
+}));
+mock.module("@/lib/core/config/server", () => ({
+  serverEnv: {
+    get cronSecret() {
+      if (!process.env.CRON_SECRET) {
+        throw new Error("CRON_SECRET is not set");
+      }
+      return process.env.CRON_SECRET;
+    },
+  },
+}));
+mock.module("@/lib/telegram/utils", () => ({
+  SUMMARY_INTERVAL_MS: 24 * 60 * 60 * 1000,
+}));
 
 const TEST_ENV_KEYS = ["CRON_SECRET"] as const;
 
@@ -26,6 +65,9 @@ function createDeliveredSummaryResult(
   };
 }
 
+const pushTokenRows: { token: string }[] = [];
+const sendExpoPushNotificationsCalls: unknown[][] = [];
+
 mock.module("@/lib/core/database", () => ({
   getDatabase: () => ({
     query: {
@@ -33,12 +75,32 @@ mock.module("@/lib/core/database", () => ({
         findMany: async () => [],
       },
     },
+    select: () => ({
+      from: async () => pushTokenRows,
+    }),
   }),
+}));
+
+mock.module("@/lib/push-notifications/send", () => ({
+  sendExpoPushNotifications: async (...args: unknown[]) => {
+    sendExpoPushNotificationsCalls.push(args);
+  },
 }));
 
 mock.module("@/lib/telegram/bot-api/bot", () => ({
   getBot: async () => ({
     api: {},
+  }),
+}));
+
+mock.module("@/lib/telegram/bot-api/summaries", () => ({
+  generateOrGetSummaryForRun: async () => ({
+    status: "not_enough_messages",
+    messageCount: 0,
+  }),
+  sendSummaryById: async () => ({
+    sent: false as const,
+    reason: "notifications_disabled" as const,
   }),
 }));
 
@@ -56,10 +118,14 @@ describe("cron summaries route", () => {
 
   beforeEach(() => {
     clearTestEnv();
+    pushTokenRows.length = 0;
+    sendExpoPushNotificationsCalls.length = 0;
   });
 
   afterEach(() => {
     clearTestEnv();
+    pushTokenRows.length = 0;
+    sendExpoPushNotificationsCalls.length = 0;
   });
 
   test("returns 500 when CRON_SECRET is missing", async () => {
@@ -106,6 +172,20 @@ describe("cron summaries route", () => {
     expect(payload.ok).toBe(true);
     expect(payload.run).toBeDefined();
     expect(payload.stats).toBeDefined();
+  });
+
+  test("does not send mobile push notifications for daily summaries", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+    pushTokenRows.push({ token: "ExponentPushToken[test]" });
+    const request = new Request("http://localhost/api/cron/summaries", {
+      method: "POST",
+      headers: { authorization: "Bearer expected-secret" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(sendExpoPushNotificationsCalls).toEqual([]);
   });
 
   test("builds a stable UTC daily run context", () => {

--- a/app/src/app/api/cron/summaries/route.ts
+++ b/app/src/app/api/cron/summaries/route.ts
@@ -1,10 +1,9 @@
-import { communities, pushTokens } from "@loyal-labs/db-core/schema";
+import { communities } from "@loyal-labs/db-core/schema";
 import { LlmRetryExhaustedError } from "@loyal-labs/llm-core";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 import { getDatabase } from "@/lib/core/database";
-import { sendExpoPushNotifications } from "@/lib/push-notifications/send";
 import { getBot } from "@/lib/telegram/bot-api/bot";
 import {
   generateOrGetSummaryForRun,
@@ -127,23 +126,6 @@ export async function POST(request: Request): Promise<NextResponse> {
         run,
       }),
   });
-
-  // Send push notifications to mobile app users
-  try {
-    const tokens = await db.select().from(pushTokens);
-    if (tokens.length > 0) {
-      const messages = tokens.map((t) => ({
-        to: t.token,
-        title: "New Chat Highlights",
-        body: "Your daily summaries are ready",
-        data: { screen: "summaries" },
-        sound: "default" as const,
-      }));
-      await sendExpoPushNotifications(messages);
-    }
-  } catch (error) {
-    console.error("[cron/summaries] Failed to send push notifications:", error);
-  }
 
   const hasErrors = result.stats.errors > 0;
   return NextResponse.json(

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import "@/global.css";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
 import { DatadogInit } from "@/components/DatadogInit";
+import { OtaUpdateBanner } from "@/components/OtaUpdateBanner";
 import { PushTokenRegistrar } from "@/components/PushTokenRegistrar";
 import { SplashAnimation } from "@/components/SplashAnimation";
 import { WalletAuthGate } from "@/components/wallet/WalletAuthGate";
@@ -108,6 +109,7 @@ export default function RootLayout() {
               {/* Summaries detail screen commented out — kept for potential reinstatement */}
               {/* <Stack.Screen name="summaries/[groupChatId]" /> */}
             </Stack>
+            <OtaUpdateBanner />
           </SignApprovalProvider>
         </WalletProvider>
         {showSplash && <SplashAnimation onFinish={handleSplashFinish} />}

--- a/mobile/src/components/OtaUpdateBanner.tsx
+++ b/mobile/src/components/OtaUpdateBanner.tsx
@@ -1,0 +1,216 @@
+import * as Updates from "expo-updates";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  AppState,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type AppStateStatus,
+} from "react-native";
+
+const CHECK_COOLDOWN_MS = 10 * 60 * 1000;
+
+export function OtaUpdateBanner() {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isCheckingRef = useRef(false);
+  const isApplyingRef = useRef(false);
+  const isVisibleRef = useRef(false);
+  const lastCheckedAtRef = useRef(0);
+
+  useEffect(() => {
+    isApplyingRef.current = isApplying;
+  }, [isApplying]);
+
+  useEffect(() => {
+    isVisibleRef.current = isVisible;
+  }, [isVisible]);
+
+  const checkForUpdate = useCallback(
+    async ({ bypassCooldown = false }: { bypassCooldown?: boolean } = {}) => {
+      if (
+        __DEV__ ||
+        !Updates.isEnabled ||
+        isApplyingRef.current ||
+        isVisibleRef.current
+      ) {
+        return;
+      }
+
+      const now = Date.now();
+      if (
+        !bypassCooldown &&
+        now - lastCheckedAtRef.current < CHECK_COOLDOWN_MS
+      ) {
+        return;
+      }
+      if (isCheckingRef.current) return;
+
+      isCheckingRef.current = true;
+      lastCheckedAtRef.current = now;
+      try {
+        const result = await Updates.checkForUpdateAsync();
+        if (!result.isAvailable) return;
+
+        setError(null);
+        setIsVisible(true);
+      } catch (err) {
+        console.warn("[ota-update] update check failed", err);
+      } finally {
+        isCheckingRef.current = false;
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void checkForUpdate({ bypassCooldown: true });
+
+    let previousState: AppStateStatus = AppState.currentState;
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      const becameActive = previousState !== "active" && nextState === "active";
+      previousState = nextState;
+      if (becameActive) {
+        void checkForUpdate();
+      }
+    });
+
+    return () => subscription.remove();
+  }, [checkForUpdate]);
+
+  const handleDismiss = useCallback(() => {
+    setIsVisible(false);
+    setError(null);
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    if (isApplying) return;
+
+    setIsApplying(true);
+    setError(null);
+    try {
+      const result = await Updates.fetchUpdateAsync();
+      if (!result.isNew && !result.isRollBackToEmbedded) {
+        setIsVisible(false);
+        setIsApplying(false);
+        return;
+      }
+
+      await Updates.reloadAsync();
+    } catch (err) {
+      console.warn("[ota-update] update apply failed", err);
+      setError("Could not update. Try again later.");
+      setIsApplying(false);
+    }
+  }, [isApplying]);
+
+  if (!isVisible) return null;
+
+  return (
+    <View pointerEvents="box-none" style={styles.overlay}>
+      <View style={styles.banner}>
+        <View style={styles.copy}>
+          <Text style={styles.title}>Update available</Text>
+          <Text style={styles.subtitle}>
+            Restart Loyal to use the latest version.
+          </Text>
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+        </View>
+
+        <View style={styles.actions}>
+          <Pressable
+            accessibilityRole="button"
+            disabled={isApplying}
+            onPress={handleDismiss}
+            style={[styles.button, styles.secondaryButton]}
+          >
+            <Text style={styles.secondaryText}>Later</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            disabled={isApplying}
+            onPress={handleApply}
+            style={[styles.button, styles.primaryButton]}
+          >
+            {isApplying ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text style={styles.primaryText}>Restart</Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    bottom: 24,
+    left: 16,
+    position: "absolute",
+    right: 16,
+    zIndex: 1000,
+  },
+  banner: {
+    backgroundColor: "#111113",
+    borderCurve: "continuous",
+    borderRadius: 22,
+    boxShadow: "0 12px 28px rgba(0, 0, 0, 0.22)",
+    gap: 14,
+    padding: 16,
+  },
+  copy: {
+    gap: 3,
+  },
+  title: {
+    color: "#fff",
+    fontFamily: "Geist_600SemiBold",
+    fontSize: 15,
+    lineHeight: 20,
+  },
+  subtitle: {
+    color: "rgba(255,255,255,0.72)",
+    fontFamily: "Geist_400Regular",
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  error: {
+    color: "#ffb4b4",
+    fontFamily: "Geist_400Regular",
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 4,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  button: {
+    alignItems: "center",
+    borderCurve: "continuous",
+    borderRadius: 14,
+    flex: 1,
+    height: 42,
+    justifyContent: "center",
+  },
+  secondaryButton: {
+    backgroundColor: "rgba(255,255,255,0.1)",
+  },
+  primaryButton: {
+    backgroundColor: "#f9363c",
+  },
+  secondaryText: {
+    color: "rgba(255,255,255,0.82)",
+    fontFamily: "Geist_600SemiBold",
+    fontSize: 14,
+  },
+  primaryText: {
+    color: "#fff",
+    fontFamily: "Geist_600SemiBold",
+    fontSize: 14,
+  },
+});

--- a/mobile/src/components/wallet/ShieldSheet.tsx
+++ b/mobile/src/components/wallet/ShieldSheet.tsx
@@ -208,6 +208,7 @@ export function ShieldSheet({
         amount: amountNum,
         tokenMint: selectedAsset.mint,
         tokenDecimals: selectedAsset.decimals,
+        isMax: isMaxSelected,
       })
         .then((estimate) => {
           if (feeRequestId.current !== requestId) return;
@@ -230,6 +231,7 @@ export function ShieldSheet({
     amountNum,
     direction,
     estimateFee,
+    isMaxSelected,
   ]);
 
   useEffect(() => {

--- a/mobile/src/hooks/wallet/useShield.ts
+++ b/mobile/src/hooks/wallet/useShield.ts
@@ -1,13 +1,11 @@
 import {
-  DELEGATION_PROGRAM_ID,
-  findDepositPda,
-  getErValidatorForSolanaEnv,
   LoyalPrivateTransactionsClient,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
+  type LoyalPrivateTransactionsClient as LoyalPrivateTransactionsClientType,
+  type ShieldFlowExecutionResult,
   shieldTokens,
 } from "@loyal-labs/private-transactions";
-import type { LoyalPrivateTransactionsClient as LoyalPrivateTransactionsClientType } from "@loyal-labs/private-transactions";
 import { PublicKey } from "@solana/web3.js";
 import { useCallback, useMemo, useRef, useState } from "react";
 
@@ -18,7 +16,6 @@ import {
 } from "@/lib/solana/deposits/kamino-usdc-position";
 import { mmkv } from "@/lib/storage";
 import {
-  getConnection,
   getEndpoints,
   getPerEndpoints,
   getSolanaEnv,
@@ -33,10 +30,6 @@ import {
   type ConfirmLabels,
 } from "@/lib/wallet/sign-approval";
 import { useWallet } from "@/lib/wallet/wallet-provider";
-// Lazy-loaded alongside the SDK to avoid top-level Buffer usage
-async function getWsolAdapter() {
-  return await import("@/lib/solana/wsol-adapter");
-}
 
 type PerAuthToken = {
   token: string;
@@ -109,8 +102,24 @@ function encodeBase58(bytes: Uint8Array): string {
   return encoded || "1";
 }
 
-async function getSplToken() {
-  return await import("@solana/spl-token");
+function getLastSignature(
+  result: ShieldFlowExecutionResult,
+): string | undefined {
+  return result.signatures.at(-1)?.signature;
+}
+
+async function getDepositAmount(params: {
+  client: LoyalPrivateTransactionsClientType;
+  tokenMint: PublicKey;
+  user: PublicKey;
+}): Promise<bigint> {
+  const { client, tokenMint, user } = params;
+  const [ephemeralDeposit, baseDeposit] = await Promise.all([
+    client.getEphemeralDeposit(user, tokenMint).catch(() => null),
+    client.getBaseDeposit(user, tokenMint).catch(() => null),
+  ]);
+
+  return ephemeralDeposit?.amount ?? baseDeposit?.amount ?? BigInt(0);
 }
 
 const TOKEN_MINTS: Record<string, string> = {
@@ -151,6 +160,7 @@ export type EstimateShieldFeeParams = {
   amount: number;
   tokenMint?: string;
   tokenDecimals?: number;
+  isMax?: boolean;
 };
 
 export function useShield(): {
@@ -179,8 +189,6 @@ export function useShield(): {
   const labelsRef = useRef<ConfirmLabels | undefined>(undefined);
 
   const solanaEnv = getSolanaEnv();
-  const connection = getConnection();
-
   // Stable wrapped signer: labels resolve per-op via `labelsRef`, so the
   // SDK client (built against this signer) can be cached across shield /
   // unshield calls without baking in stale titles.
@@ -488,9 +496,6 @@ export function useShield(): {
 
       try {
         const client = await getClient();
-        const { getAssociatedTokenAddressSync, NATIVE_MINT, TOKEN_PROGRAM_ID } =
-          await getSplToken();
-        const { closeWsolAta } = await getWsolAdapter();
 
         const resolvedMint =
           params.tokenMint || TOKEN_MINTS[params.tokenSymbol.toUpperCase()];
@@ -501,27 +506,6 @@ export function useShield(): {
         const decimals = getShieldTokenDecimals(params);
         const rawAmount = Math.floor(params.amount * 10 ** decimals);
         const user = signer.publicKey;
-        const isNativeSol = tokenMint.equals(NATIVE_MINT);
-
-        const userTokenAccount = getAssociatedTokenAddressSync(
-          tokenMint,
-          user,
-          false,
-          TOKEN_PROGRAM_ID,
-        );
-
-        // Undelegate if currently delegated
-        const [depositPda] = findDepositPda(user, tokenMint);
-        const depositInfo = await connection.getAccountInfo(depositPda);
-        if (depositInfo?.owner.equals(DELEGATION_PROGRAM_ID)) {
-          await client.undelegateDeposit({
-            tokenMint,
-            user,
-            payer: user,
-            magicProgram: MAGIC_PROGRAM_ID,
-            magicContext: MAGIC_CONTEXT_ID,
-          });
-        }
 
         // For tracked Kamino USDC the deposit stores collateral shares,
         // so a user-specified USDC liquidity amount must be quoted into
@@ -532,8 +516,11 @@ export function useShield(): {
           trackedKaminoMint === tokenMint.toBase58();
         const wantsMax = params.isMax === true;
 
-        const depositBeforeModify = await client.getBaseDeposit(user, tokenMint);
-        const currentDepositRaw = depositBeforeModify?.amount ?? BigInt(0);
+        const currentDepositRaw = await getDepositAmount({
+          client,
+          tokenMint,
+          user,
+        });
 
         let kaminoQuotedShares: bigint | null = null;
         if (!wantsMax && isTrackedKaminoToken) {
@@ -552,18 +539,25 @@ export function useShield(): {
           kaminoQuotedShares,
         });
 
-        // Move tokens out of deposit vault (decrease balance)
-        const { deposit: depositAfterModify } = await client.modifyBalance({
+        const plan = await client.buildUnshieldTokensTransactionPlan({
           tokenMint,
           amount: modifyAmount,
-          increase: false,
           user,
           payer: user,
+          magicProgram: MAGIC_PROGRAM_ID,
+          magicContext: MAGIC_CONTEXT_ID,
         });
+        const executionResult =
+          await client.executeUnshieldTokensTransactionPlan({ plan });
 
         if (isTrackedKaminoToken) {
+          const depositAfterModify = await getDepositAmount({
+            client,
+            tokenMint,
+            user,
+          });
           const burnedCollateralSharesAmountRaw =
-            currentDepositRaw - depositAfterModify.amount;
+            currentDepositRaw - depositAfterModify;
           if (burnedCollateralSharesAmountRaw > BigInt(0)) {
             try {
               await recordKaminoUsdcUnshield({
@@ -580,48 +574,9 @@ export function useShield(): {
           }
         }
 
-        // Unwrap wSOL if native SOL. Best-effort: the deposit already
-        // drained via modifyBalance above, so a failure here must not be
-        // surfaced as "Unshield Failed" (ASK-1134). If it fails, the user
-        // may have residual WSOL in their ATA that they can unwrap later.
-        if (isNativeSol) {
-          // Cleanup: skip the preview sheet. Users already approved the
-          // unshield intent; closing the wrapped-SOL account is a
-          // housekeeping step that should feel like part of the same op.
-          try {
-            await closeWsolAta({
-              connection,
-              signer,
-              wsolAta: userTokenAccount,
-            });
-          } catch (err) {
-            console.warn(
-              "[useShield] closeWsolAta failed after unshield — WSOL may remain in the user's ATA",
-              err,
-            );
-          }
-        }
-
-        // Re-delegate deposit. Best-effort: may already be delegated or
-        // the deposit may be empty after a full unshield.
-        try {
-          const validator = getErValidatorForSolanaEnv(solanaEnv);
-          await client.delegateDeposit({
-            tokenMint,
-            user,
-            payer: user,
-            validator,
-          });
-        } catch (err) {
-          console.warn(
-            "[useShield] re-delegateDeposit failed (often benign: already delegated or empty deposit)",
-            err,
-          );
-        }
-
         setLoading(false);
         labelsRef.current = undefined;
-        return { success: true };
+        return { success: true, signature: getLastSignature(executionResult) };
       } catch (err) {
         console.error("[useShield] executeUnshield failed", err);
         let errorMessage = "Unshield failed";
@@ -636,7 +591,7 @@ export function useShield(): {
         return { success: false, error: errorMessage };
       }
     },
-    [signer, confirmingSigner, connection, getClient, solanaEnv],
+    [signer, confirmingSigner, getClient, solanaEnv],
   );
 
   const estimateFee = useCallback(
@@ -650,8 +605,10 @@ export function useShield(): {
       if (!resolvedMint) return null;
 
       const decimals = getShieldTokenDecimals(params);
-      const rawAmount = BigInt(Math.floor(params.amount * 10 ** decimals));
-      if (rawAmount <= BigInt(0)) return null;
+      const requestedRawAmount = BigInt(
+        Math.floor(params.amount * 10 ** decimals),
+      );
+      if (requestedRawAmount <= BigInt(0)) return null;
 
       try {
         // Use the estimate-only client to avoid triggering PER auth.
@@ -661,18 +618,33 @@ export function useShield(): {
         const client = await getEstimateClient();
         const user = signer.publicKey;
         const tokenMint = new PublicKey(resolvedMint);
+        let planAmount = requestedRawAmount;
+
+        if (params.direction === "unshield" && params.isMax) {
+          const currentDepositRaw = await getDepositAmount({
+            client,
+            tokenMint,
+            user,
+          });
+          planAmount =
+            currentDepositRaw > BigInt(0)
+              ? currentDepositRaw
+              : requestedRawAmount;
+        }
 
         const plan =
           params.direction === "shield"
             ? await client.buildShieldTokensTransactionPlan({
                 user,
                 tokenMint,
-                amount: rawAmount,
+                amount: requestedRawAmount,
               })
             : await client.buildUnshieldTokensTransactionPlan({
                 user,
                 tokenMint,
-                amount: rawAmount,
+                amount: planAmount,
+                magicProgram: MAGIC_PROGRAM_ID,
+                magicContext: MAGIC_CONTEXT_ID,
               });
 
         const estimate =

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -126,7 +126,6 @@ export type RemoteLibraryArticle = {
   title: string;
   coverImageUrl: string;
   contentMarkdown: string;
-  readTime: string;
   excerpt: string | null;
   isFeatured: boolean;
   displayOrder: number;


### PR DESCRIPTION
Updates mobile unshield handling to use the SDK close/delegate plan, adds an in-app OTA update prompt, and removes library read-time from the mobile client. Also stops the summaries cron from sending the removed daily-summary mobile push while preserving the cron's summary generation and Telegram delivery.