### PR TITLE
ci(mobile): build preview android apk on main

### DIFF
--- a/mobile/.eas/workflows/build-preview-android-apk.yml
+++ b/mobile/.eas/workflows/build-preview-android-apk.yml
@@ -1,0 +1,20 @@
+name: Build Preview Android APK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - mobile/**
+
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
+jobs:
+  build_android_preview:
+    name: Build Android preview APK
+    type: build
+    params:
+      platform: android
+      profile: preview


### PR DESCRIPTION
Adds an EAS workflow under the mobile Expo project to build the Android preview APK on pushes to main when files under mobile/** change. The workflow uses the existing preview EAS build profile, matching npx eas-cli@latest build --profile preview --platform android.