### PR TITLE
ci(mirrors): skip publish lifecycle scripts

### DIFF
--- a/scripts/release-packages.ts
+++ b/scripts/release-packages.ts
@@ -215,7 +215,7 @@ function main(): void {
     }
 
     const tempPackageDir = copyPackageForPublish(info, versionsByName);
-    const publishArgs = ["publish", "--access", "public"];
+    const publishArgs = ["publish", "--access", "public", "--ignore-scripts"];
     if (process.env.GITHUB_ACTIONS === "true") {
       publishArgs.push("--provenance");
     }


### PR DESCRIPTION
Updates the package release script to publish prebuilt temp package copies with npm lifecycle scripts disabled. CI already runs `bun run build:packages` and the script checks required dist output, so rerunning package builds during `npm publish` breaks packages whose dev-only build dependencies are not copied into the temp publish directory.

After this merges, rerun the failed Release Packages workflow; already-published package versions are skipped and remaining packages should publish.