### PR TITLE
fix(extension): preserve unlocked session across worker restarts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -282,7 +282,7 @@
     },
     "packages/auth-core": {
       "name": "@loyal-labs/auth-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/grid-core": "workspace:*",
         "@sqds/grid": "^3.1.2",
@@ -295,7 +295,7 @@
     },
     "packages/db-adapter-neon": {
       "name": "@loyal-labs/db-adapter-neon",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/db-core": "workspace:*",
       },
@@ -309,7 +309,7 @@
     },
     "packages/db-core": {
       "name": "@loyal-labs/db-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "drizzle-orm": "^0.45.1",
@@ -321,7 +321,7 @@
     },
     "packages/flags": {
       "name": "@loyal-labs/flags",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5",
@@ -329,7 +329,7 @@
     },
     "packages/grid-core": {
       "name": "@loyal-labs/grid-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sqds/grid": "^3.1.2",
         "zod": "^4.0.17",
@@ -341,7 +341,7 @@
     },
     "packages/llm-core": {
       "name": "@loyal-labs/llm-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5",
@@ -349,7 +349,7 @@
     },
     "packages/llm-server": {
       "name": "@loyal-labs/llm-server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ax-llm/ax": "^14.0.32",
         "@loyal-labs/llm-core": "workspace:*",
@@ -360,7 +360,7 @@
     },
     "packages/shared": {
       "name": "@loyal-labs/shared",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "mixpanel": "^0.20.0",
         "mixpanel-browser": "^2.74.0",
@@ -372,7 +372,7 @@
     },
     "packages/smart-account-vaults": {
       "name": "@loyal-labs/smart-account-vaults",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/loyal-smart-accounts": "workspace:*",
         "@loyal-labs/loyal-smart-accounts-core": "workspace:*",
@@ -392,7 +392,7 @@
     },
     "packages/solana-instruction-decoder": {
       "name": "@loyal-labs/solana-instruction-decoder",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@solana/spl-token": "^0.4.13",
         "@solana/web3.js": "^1.98.0",
@@ -405,7 +405,7 @@
     },
     "packages/solana-rpc": {
       "name": "@loyal-labs/solana-rpc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@solana/web3.js": "^1.98.0",
       },
@@ -416,7 +416,7 @@
     },
     "packages/solana-wallet": {
       "name": "@loyal-labs/solana-wallet",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/shared": "workspace:*",
         "@loyal-labs/solana-rpc": "workspace:*",
@@ -430,7 +430,7 @@
     },
     "packages/wallet-core": {
       "name": "@loyal-labs/wallet-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/private-transactions": "workspace:*",
         "@loyal-labs/solana-rpc": "workspace:*",
@@ -475,7 +475,7 @@
     },
     "sdk/loyal-smart-accounts": {
       "name": "@loyal-labs/loyal-smart-accounts",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/loyal-smart-accounts-core": "workspace:*",
       },
@@ -490,7 +490,7 @@
     },
     "sdk/loyal-smart-accounts-core": {
       "name": "@loyal-labs/loyal-smart-accounts-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@loyal-labs/solana-rpc": "workspace:*",
         "@metaplex-foundation/beet": "0.7.1",
@@ -515,7 +515,7 @@
     },
     "sdk/private-transactions": {
       "name": "@loyal-labs/private-transactions",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "devDependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@solana/web3.js": "^1.95.0",

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -22,9 +22,10 @@ import {
   viewMode,
 } from "~/src/lib/storage";
 
-// In-memory session keypair — never persisted to storage.
-// Lost when service worker restarts; wallet falls back to locked state.
+// In-memory session keypair cache. Chrome MV3 can suspend the background
+// service worker between requests, so mirror it to browser.storage.session.
 let sessionSecretKey: string | null = null;
+const SESSION_SECRET_KEY_STORAGE_KEY = "walletSessionSecretKey";
 
 // Track the connect tab so we can route signing requests to it
 let connectTabId: number | null = null;
@@ -49,6 +50,45 @@ const pendingDappRequests = new Map<string, PendingDappRequest>();
 
 const LOCK_ALARM = "auto-lock-check";
 
+async function storeSessionSecretKey(secretKey: string): Promise<void> {
+  sessionSecretKey = secretKey;
+  try {
+    await browser.storage.session.set({
+      [SESSION_SECRET_KEY_STORAGE_KEY]: secretKey,
+    });
+  } catch {
+    // Firefox MV2 has no storage.session; the background page keeps memory.
+  }
+}
+
+async function clearSessionSecretKey(): Promise<void> {
+  sessionSecretKey = null;
+  try {
+    await browser.storage.session.remove(SESSION_SECRET_KEY_STORAGE_KEY);
+  } catch {
+    // Firefox MV2 has no storage.session; clearing memory is enough there.
+  }
+}
+
+async function readSessionSecretKey(): Promise<string | null> {
+  if (sessionSecretKey) return sessionSecretKey;
+
+  try {
+    const stored = await browser.storage.session.get<{
+      walletSessionSecretKey?: unknown;
+    }>(SESSION_SECRET_KEY_STORAGE_KEY);
+    const secretKey = stored.walletSessionSecretKey;
+    if (typeof secretKey === "string") {
+      sessionSecretKey = secretKey;
+      return secretKey;
+    }
+  } catch {
+    // Firefox MV2 has no storage.session; fall back to the memory cache.
+  }
+
+  return null;
+}
+
 async function checkAutoLock() {
   const [unlocked, timeout, lastActive] = await Promise.all([
     isWalletUnlocked.getValue(),
@@ -59,8 +99,19 @@ async function checkAutoLock() {
   const elapsed = Date.now() - lastActive;
   if (elapsed >= timeout * 60_000) {
     await isWalletUnlocked.setValue(false);
-    sessionSecretKey = null;
+    await clearSessionSecretKey();
   }
+}
+
+async function readActiveSessionSecretKey(): Promise<string | null> {
+  await checkAutoLock();
+
+  if (!(await isWalletUnlocked.getValue())) {
+    await clearSessionSecretKey();
+    return null;
+  }
+
+  return readSessionSecretKey();
 }
 
 const hasSidePanel = typeof browser.sidePanel !== "undefined";
@@ -206,7 +257,7 @@ export default defineBackground(() => {
   browser.idle.onStateChanged.addListener((state) => {
     if (state === "locked") {
       void isWalletUnlocked.setValue(false);
-      sessionSecretKey = null;
+      void clearSessionSecretKey();
     } else if (state === "idle") {
       void checkAutoLock();
     }
@@ -219,25 +270,31 @@ export default defineBackground(() => {
       return;
     }
 
-    // --- Session keypair: kept in memory only, never persisted ---
+    // --- Session keypair: kept only for the current unlocked browser session ---
     if (message.type === "STORE_SESSION_KEYPAIR") {
       if (!isTrustedExtensionPageSender(sender)) return;
       if (typeof message.secretKey !== "string") return;
-      sessionSecretKey = message.secretKey;
-      return;
+      void storeSessionSecretKey(message.secretKey).then(() => {
+        sendResponse({ ok: true });
+      });
+      return true;
     }
     if (message.type === "GET_SESSION_KEYPAIR") {
       if (!isTrustedExtensionPageSender(sender)) {
         sendResponse({ secretKey: null, error: "Unauthorized sender." });
         return;
       }
-      sendResponse({ secretKey: sessionSecretKey });
-      return;
+      void readActiveSessionSecretKey().then((secretKey) => {
+        sendResponse({ secretKey });
+      });
+      return true;
     }
     if (message.type === "CLEAR_SESSION_KEYPAIR") {
       if (!isTrustedExtensionPageSender(sender)) return;
-      sessionSecretKey = null;
-      return;
+      void clearSessionSecretKey().then(() => {
+        sendResponse({ ok: true });
+      });
+      return true;
     }
   });
 
@@ -657,13 +714,14 @@ export default defineBackground(() => {
                 publicKey,
               } satisfies DappConnectResponse);
             } else {
-              // User approved — sign with in-memory session keypair
-              if (!sessionSecretKey) throw new Error("Wallet is locked.");
+              // User approved — sign with the current unlocked session keypair
+              const secretKey = await readActiveSessionSecretKey();
+              if (!secretKey) throw new Error("Wallet is locked.");
 
               const { Keypair, Transaction, VersionedTransaction } =
                 await import("@solana/web3.js");
               const keypair = Keypair.fromSecretKey(
-                new Uint8Array(JSON.parse(sessionSecretKey))
+                new Uint8Array(JSON.parse(secretKey))
               );
 
               if (pending.kind === "signTransaction" && pending.transaction) {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@loyal-labs/extension",
   "description": "Loyal wallet browser extension",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/extension/src/components/wallet/wallet-provider.tsx
+++ b/extension/src/components/wallet/wallet-provider.tsx
@@ -142,7 +142,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       setNetworkState(net);
       setBalanceHidden(hidden);
 
-      // Auto-unlock from in-memory session keypair held by background
+      // Auto-unlock from the current unlocked browser session keypair
       if (sessionResponse?.secretKey) {
         try {
           const keypair = Keypair.fromSecretKey(
@@ -229,7 +229,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       setState("unlocked");
       void isWalletUnlockedStorage.setValue(true);
       void lastActivityAtStorage.setValue(Date.now());
-      // Send keypair to background — held in memory only, never persisted to storage
+      // Send keypair to background for the current unlocked browser session.
       void browser.runtime.sendMessage({
         type: "STORE_SESSION_KEYPAIR",
         secretKey: JSON.stringify(Array.from(keypair.secretKey)),


### PR DESCRIPTION
Preserves the extension unlock session across MV3 background worker restarts by mirroring the active session key into browser session storage and clearing it on auto-lock or manual lock.