### PR TITLE
fix(frontend): update extension store link

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
     },
     "extension": {
       "name": "@loyal-labs/extension",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-react": "^0.15.39",

--- a/frontend/src/components/landing-get-started.tsx
+++ b/frontend/src/components/landing-get-started.tsx
@@ -8,10 +8,8 @@ import { useEffect, useRef, useState } from "react";
 type Segment = "Extension" | "Mobile" | "Web";
 
 const appUrl = "https://app.askloyal.com";
-// Temporarily points at the GitHub release zip while v0.5.5 is being
-// re-submitted to the Chrome Web Store.
 const chromeWebStoreUrl =
-  "https://github.com/loyal-labs/loyal-app/releases/download/ext-v0.5.5/loyal-ext-universal-v0.5.5.zip";
+  "https://chromewebstore.google.com/detail/loyal-%E2%80%94-private-solana-wa/cdienfadefhlaknmedckgifkjdbioack?authuser=1&hl=en";
 const telegramMiniAppUrl =
   "https://t.me/askloyal_tgbot/app?startapp=askloyalcom";
 const seekerDappStoreUrl = "solanadappstore://details?id=com.loyal.app";


### PR DESCRIPTION
Updates the landing Get Started extension cards to use the Chrome Web Store listing. Also includes the current extension lockfile version bump already present in the workspace.