### PR TITLE
ci(mirrors): sync only changed mirrors

### DIFF
--- a/.github/workflows/sync-mirror-repos.yml
+++ b/.github/workflows/sync-mirror-repos.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -33,6 +34,10 @@ jobs:
             echo "MIRROR_SYNC_TOKEN is required to push generated mirrors."
             exit 1
           fi
-          bun run scripts/mirror-repos/sync.ts --skip-if-packages-unpublished
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            bun run scripts/mirror-repos/sync.ts --skip-if-packages-unpublished
+          else
+            bun run scripts/mirror-repos/sync.ts --skip-if-packages-unpublished --changed-only
+          fi
         env:
           MIRROR_SYNC_TOKEN: ${{ secrets.MIRROR_SYNC_TOKEN }}

--- a/scripts/mirror-repos/selection.test.ts
+++ b/scripts/mirror-repos/selection.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { selectMirrorsForChangedPaths } from "./selection";
+
+function reposFor(paths: string[]): string[] {
+  return selectMirrorsForChangedPaths(paths).map((mirror) => mirror.repo);
+}
+
+describe("selectMirrorsForChangedPaths", () => {
+  test("selects only the directly changed app mirror when root lockfile also changes", () => {
+    expect(
+      reposFor([
+        "bun.lock",
+        "extension/package.json",
+        "extension/src/components/wallet/wallet-provider.tsx",
+      ])
+    ).toEqual(["loyal-labs/loyal-extension"]);
+  });
+
+  test("fans package changes out to generated app mirrors and the packages mirror", () => {
+    expect(reposFor(["packages/shared/src/index.ts"])).toEqual([
+      "loyal-labs/loyal-webapp",
+      "loyal-labs/loyal-telegram-app",
+      "loyal-labs/loyal-mobile",
+      "loyal-labs/loyal-extension",
+      "loyal-labs/loyal-packages",
+    ]);
+  });
+
+  test("fans sdk changes out to generated app mirrors and the sdk mirror", () => {
+    expect(reposFor(["sdk/private-transactions/index.ts"])).toEqual([
+      "loyal-labs/loyal-webapp",
+      "loyal-labs/loyal-telegram-app",
+      "loyal-labs/loyal-mobile",
+      "loyal-labs/loyal-extension",
+      "loyal-labs/loyal-sdk",
+    ]);
+  });
+
+  test("selects every mirror when the mirror generator changes", () => {
+    expect(reposFor(["scripts/mirror-repos/file-rewrites.ts"])).toEqual([
+      "loyal-labs/loyal-webapp",
+      "loyal-labs/loyal-telegram-app",
+      "loyal-labs/loyal-mobile",
+      "loyal-labs/loyal-extension",
+      "loyal-labs/loyal-sdk",
+      "loyal-labs/loyal-packages",
+      "loyal-labs/loyal-cli",
+      "loyal-labs/loyal-contracts",
+    ]);
+  });
+
+  test("skips unrelated repository areas", () => {
+    expect(reposFor(["admin/src/app/page.tsx", "docs/notes.md"])).toEqual([]);
+  });
+});

--- a/scripts/mirror-repos/selection.ts
+++ b/scripts/mirror-repos/selection.ts
@@ -1,0 +1,92 @@
+import { mirrors } from "./config";
+import type { MirrorConfig } from "./config";
+
+const generatedAppMirrorKinds = new Set([
+  "next-app",
+  "telegram-app",
+  "expo-app",
+  "wxt-extension",
+]);
+
+const generatorPaths = [
+  ".github/workflows/sync-mirror-repos.yml",
+  "scripts/mirror-repos",
+];
+
+const ignoredRootFiles = new Set([
+  "bun.lock",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+]);
+
+function hasPathPrefix(filePath: string, prefix: string): boolean {
+  return filePath === prefix || filePath.startsWith(`${prefix}/`);
+}
+
+function addGeneratedAppMirrors(selected: Set<MirrorConfig>): void {
+  for (const mirror of mirrors) {
+    if (generatedAppMirrorKinds.has(mirror.kind)) {
+      selected.add(mirror);
+    }
+  }
+}
+
+function addMirrorByRepo(
+  selected: Set<MirrorConfig>,
+  repo: MirrorConfig["repo"]
+): void {
+  const mirror = mirrors.find((candidate) => candidate.repo === repo);
+  if (!mirror) {
+    throw new Error(`Unknown mirror repo ${repo}`);
+  }
+  selected.add(mirror);
+}
+
+export function selectMirrorsForChangedPaths(
+  changedPaths: string[]
+): MirrorConfig[] {
+  const selected = new Set<MirrorConfig>();
+
+  for (const filePath of changedPaths) {
+    if (ignoredRootFiles.has(filePath)) {
+      continue;
+    }
+
+    if (generatorPaths.some((prefix) => hasPathPrefix(filePath, prefix))) {
+      return [...mirrors];
+    }
+
+    if (hasPathPrefix(filePath, "packages")) {
+      addGeneratedAppMirrors(selected);
+      addMirrorByRepo(selected, "loyal-labs/loyal-packages");
+      continue;
+    }
+
+    if (hasPathPrefix(filePath, "sdk")) {
+      addGeneratedAppMirrors(selected);
+      addMirrorByRepo(selected, "loyal-labs/loyal-sdk");
+      continue;
+    }
+
+    if (
+      hasPathPrefix(filePath, "tests") ||
+      hasPathPrefix(filePath, "target/idl") ||
+      hasPathPrefix(filePath, "target/types") ||
+      filePath === "Anchor.toml" ||
+      filePath === "package.json" ||
+      filePath === "tsconfig.json"
+    ) {
+      addMirrorByRepo(selected, "loyal-labs/loyal-contracts");
+      continue;
+    }
+
+    for (const mirror of mirrors) {
+      if (hasPathPrefix(filePath, mirror.source)) {
+        selected.add(mirror);
+      }
+    }
+  }
+
+  return mirrors.filter((mirror) => selected.has(mirror));
+}

--- a/scripts/mirror-repos/sync.ts
+++ b/scripts/mirror-repos/sync.ts
@@ -11,7 +11,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { blockedMirrorRepos, mirrors, type MirrorConfig } from "./config";
+import { blockedMirrorRepos, mirrors } from "./config";
+import type { MirrorConfig } from "./config";
 import { applyMirrorRewrites, isGeneratedAppMirror } from "./file-rewrites";
 import {
   assertGitDirectory,
@@ -29,12 +30,14 @@ import {
   readJsonFile,
   writeJsonFile,
 } from "./package-rewrites";
+import { selectMirrorsForChangedPaths } from "./selection";
 
 type SyncOptions = {
   dryRun: boolean;
   createRepos: boolean;
   skipRepoCheck: boolean;
   skipIfPackagesUnpublished: boolean;
+  changedOnly: boolean;
 };
 
 const appMirrorForbiddenPattern =
@@ -47,6 +50,7 @@ function parseOptions(): SyncOptions {
     createRepos: args.has("--create-repos"),
     skipRepoCheck: args.has("--skip-repo-check"),
     skipIfPackagesUnpublished: args.has("--skip-if-packages-unpublished"),
+    changedOnly: args.has("--changed-only"),
   };
 }
 
@@ -335,6 +339,18 @@ function findUnpublishedInternalPackages(
     .map(([packageName, version]) => `${packageName}@${version}`);
 }
 
+function getChangedPathsSinceFirstParent(): string[] {
+  const revisionLine = runGit(["rev-list", "--parents", "-n", "1", "HEAD"]);
+  const [, firstParent] = revisionLine.split(/\s+/);
+
+  if (!firstParent) {
+    return [];
+  }
+
+  const output = runGit(["diff", "--name-only", firstParent, "HEAD"]);
+  return output ? output.split("\n").filter(Boolean) : [];
+}
+
 function copyGeneratedToClone(generatedRoot: string, cloneRoot: string): void {
   assertGitDirectory(cloneRoot);
   removeDirectoryContentsExceptGit(cloneRoot);
@@ -387,6 +403,24 @@ function main(): void {
     ? path.resolve(".context/mirror-dry-run")
     : path.join(tmpdir(), `loyal-mirror-output-${Date.now()}`);
   const token = process.env.MIRROR_SYNC_TOKEN;
+  const mirrorsToSync = options.changedOnly
+    ? selectMirrorsForChangedPaths(getChangedPathsSinceFirstParent())
+    : [...mirrors];
+
+  if (options.changedOnly) {
+    console.log(
+      mirrorsToSync.length > 0
+        ? `Selected mirrors: ${mirrorsToSync
+            .map((mirror) => mirror.repo)
+            .join(", ")}`
+        : "No mirror source paths changed; skipping mirror sync."
+    );
+  }
+
+  if (mirrorsToSync.length === 0) {
+    return;
+  }
+
   const internalPackageVersions = getInternalPackageVersions();
 
   if (!options.dryRun && options.skipIfPackagesUnpublished) {
@@ -411,7 +445,7 @@ function main(): void {
   rmSync(outputRoot, { recursive: true, force: true });
   mkdirSync(outputRoot, { recursive: true });
 
-  for (const mirror of mirrors) {
+  for (const mirror of mirrorsToSync) {
     verifyRepoConfig(mirror, options, token);
 
     const generatedRoot = path.join(outputRoot, repoName(mirror.repo));


### PR DESCRIPTION
Makes automatic mirror sync path-aware so workflow_run updates only mirrors affected by the triggering commit, while manual dispatch still performs a full resync. Adds an explicit dependency map for direct mirror sources, packages/sdk fan-out, contracts inputs, and mirror-generator changes. Validated with targeted selector tests, changed-only dry run, Prettier check, and commitlint.