### PR TITLE
feat(admin): add manual push notifications

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -5,7 +5,11 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname, ".."),
   },
-  transpilePackages: ["@loyal-labs/db-core", "@loyal-labs/db-adapter-neon"],
+  transpilePackages: [
+    "@loyal-labs/db-core",
+    "@loyal-labs/db-adapter-neon",
+    "@loyal-labs/shared",
+  ],
   productionBrowserSourceMaps: true,
 };
 

--- a/admin/src/app/(admin)/push-notifications/actions.ts
+++ b/admin/src/app/(admin)/push-notifications/actions.ts
@@ -1,0 +1,307 @@
+"use server";
+
+import {
+  pushNotificationSends,
+  pushNotificationTickets,
+  pushTokens,
+  type ManualPushAudience,
+} from "@loyal-labs/db-core/schema";
+import {
+  getExpoPushReceipts,
+  sendExpoPushMessages,
+} from "@loyal-labs/shared/expo-push";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import { getDatabase } from "@/lib/core/database";
+
+type ActionResult = { success: true; message: string } | { error: string };
+
+type TokenRow = { token: string };
+
+type ReceiptTicketRow = {
+  id: string;
+  token: string;
+  ticketId: string | null;
+};
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function parsePlatform(
+  value: FormDataEntryValue | null
+): "all" | "ios" | "android" | "wallet" {
+  return value === "ios" || value === "android" || value === "wallet"
+    ? value
+    : "all";
+}
+
+function parseJsonData(
+  value: FormDataEntryValue | null
+): Record<string, unknown> | null {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  const parsed = JSON.parse(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Data must be a JSON object");
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+export async function sendManualPushNotification(
+  formData: FormData
+): Promise<ActionResult> {
+  const title = String(formData.get("title") ?? "").trim();
+  const body = String(formData.get("body") ?? "").trim();
+  const createdBy = String(formData.get("createdBy") ?? "").trim() || null;
+  const confirmation = String(formData.get("confirmation") ?? "").trim();
+  const platform = parsePlatform(formData.get("platform"));
+  const walletPublicKey = String(formData.get("walletPublicKey") ?? "").trim();
+
+  if (!title || !body) {
+    return { error: "Title and body are required" };
+  }
+
+  if (confirmation !== "SEND") {
+    return { error: "Type SEND to confirm the broadcast" };
+  }
+
+  if (platform === "wallet" && !walletPublicKey) {
+    return { error: "Wallet public key is required for wallet test sends" };
+  }
+
+  let data: Record<string, unknown> | null = null;
+  try {
+    data = parseJsonData(formData.get("data"));
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "Invalid JSON data",
+    };
+  }
+
+  const db = getDatabase();
+  const tokenRows = (await db
+    .select({ token: pushTokens.token })
+    .from(pushTokens)
+    .where(
+      platform === "wallet"
+        ? eq(pushTokens.walletPublicKey, walletPublicKey)
+        : platform === "all"
+        ? isNotNull(pushTokens.walletPublicKey)
+        : and(
+            isNotNull(pushTokens.walletPublicKey),
+            eq(pushTokens.platform, platform)
+          )
+    )) as TokenRow[];
+
+  const tokens = Array.from(new Set(tokenRows.map((row) => row.token)));
+  const audience: ManualPushAudience =
+    platform === "wallet" ? "wallet" : platform === "all" ? "all" : "platform";
+  const [sendRow] = await db
+    .insert(pushNotificationSends)
+    .values({
+      source: "admin",
+      audience,
+      platform: platform === "ios" || platform === "android" ? platform : null,
+      title,
+      body,
+      data,
+      createdBy,
+      status: "sending",
+      requestedCount: tokens.length,
+    })
+    .returning({ id: pushNotificationSends.id });
+
+  if (!sendRow) {
+    return { error: "Failed to create push send record" };
+  }
+
+  if (tokens.length === 0) {
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "sent",
+        sentAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(pushNotificationSends.id, sendRow.id));
+    revalidatePath("/push-notifications");
+    return {
+      success: true,
+      message: "No registered mobile push tokens matched",
+    };
+  }
+
+  try {
+    const result = await sendExpoPushMessages(
+      tokens.map((token) => ({
+        to: token,
+        title,
+        body,
+        data: data ?? undefined,
+        sound: "default",
+      }))
+    );
+
+    for (const ticketChunk of chunk(result.tickets, 1000)) {
+      await db.insert(pushNotificationTickets).values(
+        ticketChunk.map(({ token, ticket }) => ({
+          sendId: sendRow.id,
+          token,
+          ticketId: ticket.id ?? null,
+          ticketStatus: ticket.status,
+          ticketMessage: ticket.message ?? null,
+          ticketError: ticket.details?.error ?? null,
+        }))
+      );
+    }
+
+    const staleTokens = Array.from(new Set(result.deviceNotRegisteredTokens));
+    for (const staleTokenChunk of chunk(staleTokens, 1000)) {
+      await db
+        .delete(pushTokens)
+        .where(inArray(pushTokens.token, staleTokenChunk));
+    }
+
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "sent",
+        ticketCount: result.tickets.length,
+        deviceNotRegisteredCount: staleTokens.length,
+        sentAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(pushNotificationSends.id, sendRow.id));
+
+    revalidatePath("/push-notifications");
+    return {
+      success: true,
+      message: `Sent ${result.tickets.length} push tickets. Pruned ${staleTokens.length} dead tokens.`,
+    };
+  } catch (error) {
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        updatedAt: new Date(),
+      })
+      .where(eq(pushNotificationSends.id, sendRow.id));
+    revalidatePath("/push-notifications");
+    return { error: "Expo push send failed" };
+  }
+}
+
+export async function checkPushReceipts(sendId: string): Promise<ActionResult> {
+  const db = getDatabase();
+  const ticketRows = (await db
+    .select({
+      id: pushNotificationTickets.id,
+      token: pushNotificationTickets.token,
+      ticketId: pushNotificationTickets.ticketId,
+    })
+    .from(pushNotificationTickets)
+    .where(
+      and(
+        eq(pushNotificationTickets.sendId, sendId),
+        isNotNull(pushNotificationTickets.ticketId)
+      )
+    )) as ReceiptTicketRow[];
+
+  const ticketRowsWithReceiptIds = ticketRows.flatMap((row) =>
+    typeof row.ticketId === "string" && row.ticketId.length > 0
+      ? [{ ...row, ticketId: row.ticketId }]
+      : []
+  );
+
+  if (ticketRowsWithReceiptIds.length === 0) {
+    return { error: "No receipt IDs are available for this send" };
+  }
+
+  try {
+    const receiptResult = await getExpoPushReceipts(
+      ticketRowsWithReceiptIds.map((row) => row.ticketId)
+    );
+    const staleReceiptIds = new Set(
+      receiptResult.deviceNotRegisteredReceiptIds
+    );
+    const staleTokens = new Set<string>();
+    let receiptOkCount = 0;
+    let receiptErrorCount = 0;
+
+    for (const row of ticketRowsWithReceiptIds) {
+      const receipt = receiptResult.receipts[row.ticketId];
+      if (!receipt) continue;
+
+      if (receipt.status === "ok") {
+        receiptOkCount += 1;
+      } else {
+        receiptErrorCount += 1;
+      }
+
+      if (staleReceiptIds.has(row.ticketId)) {
+        staleTokens.add(row.token);
+      }
+
+      await db
+        .update(pushNotificationTickets)
+        .set({
+          receiptStatus: receipt.status,
+          receiptMessage: receipt.message ?? null,
+          receiptError: receipt.details?.error ?? null,
+          updatedAt: new Date(),
+        })
+        .where(eq(pushNotificationTickets.id, row.id));
+    }
+
+    const staleTokenList = Array.from(staleTokens);
+    for (const staleTokenChunk of chunk(staleTokenList, 1000)) {
+      await db
+        .delete(pushTokens)
+        .where(inArray(pushTokens.token, staleTokenChunk));
+    }
+
+    const [sendRow] = await db
+      .select({
+        deviceNotRegisteredCount:
+          pushNotificationSends.deviceNotRegisteredCount,
+      })
+      .from(pushNotificationSends)
+      .where(eq(pushNotificationSends.id, sendId));
+
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "receipt_checked",
+        receiptOkCount,
+        receiptErrorCount,
+        deviceNotRegisteredCount:
+          (sendRow?.deviceNotRegisteredCount ?? 0) + staleTokenList.length,
+        receiptsCheckedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(pushNotificationSends.id, sendId));
+
+    revalidatePath("/push-notifications");
+    return {
+      success: true,
+      message: `Checked ${
+        receiptOkCount + receiptErrorCount
+      } receipts. Pruned ${staleTokenList.length} dead tokens.`,
+    };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error ? error.message : "Failed to check receipts",
+    };
+  }
+}

--- a/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
+++ b/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { SendIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+import { checkPushReceipts, sendManualPushNotification } from "./actions";
+
+type PushCounts = {
+  all: number;
+  ios: number;
+  android: number;
+};
+
+type RecentSend = {
+  id: string;
+  source: string;
+  audience: string;
+  platform: string | null;
+  title: string;
+  status: string;
+  requestedCount: number;
+  ticketCount: number;
+  receiptOkCount: number;
+  receiptErrorCount: number;
+  deviceNotRegisteredCount: number;
+  sentAt: string | null;
+  receiptsCheckedAt: string | null;
+  createdAt: string;
+  createdBy: string | null;
+};
+
+type ActionState = {
+  kind: "success" | "error";
+  message: string;
+} | null;
+
+function formatDate(value: string | null): string {
+  if (!value) return "-";
+  return new Date(value).toLocaleString();
+}
+
+function statusVariant(status: string): "default" | "outline" | "destructive" {
+  if (status === "failed") return "destructive";
+  if (status === "receipt_checked") return "outline";
+  return "default";
+}
+
+export function ManualPushPanel({
+  counts,
+  recentSends,
+}: {
+  counts: PushCounts;
+  recentSends: RecentSend[];
+}) {
+  const router = useRouter();
+  const [state, setState] = useState<ActionState>(null);
+  const [audience, setAudience] = useState("all");
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    startTransition(async () => {
+      const result = await sendManualPushNotification(formData);
+      if ("error" in result) {
+        setState({ kind: "error", message: result.error });
+        return;
+      }
+
+      event.currentTarget.reset();
+      setState({ kind: "success", message: result.message });
+      router.refresh();
+    });
+  }
+
+  function handleCheckReceipts(sendId: string) {
+    startTransition(async () => {
+      const result = await checkPushReceipts(sendId);
+      if ("error" in result) {
+        setState({ kind: "error", message: result.error });
+        return;
+      }
+
+      setState({ kind: "success", message: result.message });
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs font-medium uppercase text-muted-foreground">
+            All mobile tokens
+          </div>
+          <div className="mt-2 text-2xl font-semibold">{counts.all}</div>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs font-medium uppercase text-muted-foreground">
+            iOS
+          </div>
+          <div className="mt-2 text-2xl font-semibold">{counts.ios}</div>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="text-xs font-medium uppercase text-muted-foreground">
+            Android
+          </div>
+          <div className="mt-2 text-2xl font-semibold">{counts.android}</div>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Compose broadcast</CardTitle>
+          <CardDescription>
+            Sends to registered mobile wallet push tokens.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {state ? (
+            <div
+              className={cn(
+                "mb-4 rounded-md border px-3 py-2 text-sm",
+                state.kind === "error"
+                  ? "border-destructive/30 bg-destructive/10 text-destructive"
+                  : "border-border bg-muted text-foreground"
+              )}
+            >
+              {state.message}
+            </div>
+          ) : null}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-[1fr_12rem]">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">Title</span>
+                <Input name="title" maxLength={120} required />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">Audience</span>
+                <select
+                  name="platform"
+                  value={audience}
+                  onChange={(event) => setAudience(event.target.value)}
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                >
+                  <option value="all">All mobile</option>
+                  <option value="ios">iOS only</option>
+                  <option value="android">Android only</option>
+                  <option value="wallet">Wallet test</option>
+                </select>
+              </label>
+            </div>
+
+            {audience === "wallet" ? (
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">
+                  Wallet public key
+                </span>
+                <Input
+                  name="walletPublicKey"
+                  placeholder="Solana wallet address"
+                  required
+                />
+              </label>
+            ) : null}
+
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium">Body</span>
+              <textarea
+                name="body"
+                rows={4}
+                maxLength={900}
+                required
+                className="min-h-28 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium">Data JSON</span>
+              <textarea
+                name="data"
+                rows={3}
+                placeholder='{"screen":"wallet"}'
+                className="min-h-20 w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </label>
+
+            <div className="grid gap-3 md:grid-cols-[1fr_12rem]">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">Operator</span>
+                <Input name="createdBy" placeholder="name or handle" />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">
+                  Confirmation
+                </span>
+                <Input name="confirmation" placeholder="SEND" required />
+              </label>
+            </div>
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={pending}>
+                <SendIcon className="size-4" />
+                {pending ? "Sending..." : "Send push"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent sends</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-hidden rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Audience</TableHead>
+                  <TableHead className="text-right">Tickets</TableHead>
+                  <TableHead className="text-right">Receipts</TableHead>
+                  <TableHead className="text-right">Pruned</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {recentSends.length > 0 ? (
+                  recentSends.map((send) => (
+                    <TableRow key={send.id}>
+                      <TableCell className="text-muted-foreground">
+                        {formatDate(send.createdAt)}
+                      </TableCell>
+                      <TableCell>
+                        <div className="max-w-56 truncate font-medium">
+                          {send.title}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {send.createdBy ?? send.source}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={statusVariant(send.status)}>
+                          {send.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {send.platform ? send.platform : send.audience}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {send.ticketCount}/{send.requestedCount}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {send.receiptOkCount}/{send.receiptErrorCount}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {send.deviceNotRegisteredCount}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="xs"
+                          disabled={pending || send.ticketCount === 0}
+                          onClick={() => handleCheckReceipts(send.id)}
+                        >
+                          Check receipts
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={8}
+                      className="py-8 text-center text-muted-foreground"
+                    >
+                      No sends yet
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/admin/src/app/(admin)/push-notifications/page.tsx
+++ b/admin/src/app/(admin)/push-notifications/page.tsx
@@ -1,0 +1,95 @@
+import { pushNotificationSends, pushTokens } from "@loyal-labs/db-core/schema";
+import { and, count, desc, eq, isNotNull } from "drizzle-orm";
+
+import { PageContainer } from "@/components/layout/page-container";
+import { SectionHeader } from "@/components/layout/section-header";
+import { getDatabase } from "@/lib/core/database";
+
+import { ManualPushPanel } from "./manual-push-panel";
+
+export const dynamic = "force-dynamic";
+
+type RecentSendRow = {
+  id: string;
+  source: string;
+  audience: string;
+  platform: string | null;
+  title: string;
+  status: string;
+  requestedCount: number;
+  ticketCount: number;
+  receiptOkCount: number;
+  receiptErrorCount: number;
+  deviceNotRegisteredCount: number;
+  sentAt: Date | null;
+  receiptsCheckedAt: Date | null;
+  createdAt: Date;
+  createdBy: string | null;
+};
+
+async function getPushTokenCount(platform?: "ios" | "android") {
+  const db = getDatabase();
+  const [row] = await db
+    .select({ count: count() })
+    .from(pushTokens)
+    .where(
+      platform
+        ? and(
+            isNotNull(pushTokens.walletPublicKey),
+            eq(pushTokens.platform, platform)
+          )
+        : isNotNull(pushTokens.walletPublicKey)
+    );
+
+  return row?.count ?? 0;
+}
+
+export default async function PushNotificationsPage() {
+  const db = getDatabase();
+  const [all, ios, android, recentSends] = await Promise.all([
+    getPushTokenCount(),
+    getPushTokenCount("ios"),
+    getPushTokenCount("android"),
+    db
+      .select({
+        id: pushNotificationSends.id,
+        source: pushNotificationSends.source,
+        audience: pushNotificationSends.audience,
+        platform: pushNotificationSends.platform,
+        title: pushNotificationSends.title,
+        status: pushNotificationSends.status,
+        requestedCount: pushNotificationSends.requestedCount,
+        ticketCount: pushNotificationSends.ticketCount,
+        receiptOkCount: pushNotificationSends.receiptOkCount,
+        receiptErrorCount: pushNotificationSends.receiptErrorCount,
+        deviceNotRegisteredCount:
+          pushNotificationSends.deviceNotRegisteredCount,
+        sentAt: pushNotificationSends.sentAt,
+        receiptsCheckedAt: pushNotificationSends.receiptsCheckedAt,
+        createdAt: pushNotificationSends.createdAt,
+        createdBy: pushNotificationSends.createdBy,
+      })
+      .from(pushNotificationSends)
+      .orderBy(desc(pushNotificationSends.createdAt))
+      .limit(20) as Promise<RecentSendRow[]>,
+  ]);
+
+  return (
+    <PageContainer>
+      <SectionHeader
+        title="Push notifications"
+        breadcrumbs={[{ label: "Push notifications" }]}
+        subtitle="Manual mobile broadcasts and Expo delivery cleanup."
+      />
+      <ManualPushPanel
+        counts={{ all, ios, android }}
+        recentSends={recentSends.map((send) => ({
+          ...send,
+          sentAt: send.sentAt?.toISOString() ?? null,
+          receiptsCheckedAt: send.receiptsCheckedAt?.toISOString() ?? null,
+          createdAt: send.createdAt.toISOString(),
+        }))}
+      />
+    </PageContainer>
+  );
+}

--- a/admin/src/components/app-sidebar.tsx
+++ b/admin/src/components/app-sidebar.tsx
@@ -30,6 +30,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/flags", label: "Flags" },
   { href: "/transfers", label: "Transfers" },
   { href: "/smart-accounts", label: "Smart accounts" },
+  { href: "/push-notifications", label: "Push notifications" },
   { href: "/dapps", label: "dApps" },
   { href: "/library", label: "Library" },
   { href: "/admins", label: "Admins" },

--- a/app/drizzle/0022_manual_push_notifications.sql
+++ b/app/drizzle/0022_manual_push_notifications.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS "push_notification_sends" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source" text NOT NULL,
+	"audience" text NOT NULL,
+	"platform" text,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"data" jsonb,
+	"created_by" text,
+	"status" text NOT NULL,
+	"requested_count" integer DEFAULT 0 NOT NULL,
+	"ticket_count" integer DEFAULT 0 NOT NULL,
+	"receipt_ok_count" integer DEFAULT 0 NOT NULL,
+	"receipt_error_count" integer DEFAULT 0 NOT NULL,
+	"device_not_registered_count" integer DEFAULT 0 NOT NULL,
+	"error_message" text,
+	"sent_at" timestamp with time zone,
+	"receipts_checked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "push_notification_sends_audience_check" CHECK ("push_notification_sends"."audience" IN ('all', 'platform', 'wallet')),
+	CONSTRAINT "push_notification_sends_status_check" CHECK ("push_notification_sends"."status" IN ('sending', 'sent', 'receipt_checked', 'failed'))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "push_notification_tickets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"send_id" uuid NOT NULL,
+	"token" text NOT NULL,
+	"ticket_id" text,
+	"ticket_status" text NOT NULL,
+	"ticket_message" text,
+	"ticket_error" text,
+	"receipt_status" text,
+	"receipt_message" text,
+	"receipt_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "push_notification_tickets_send_id_push_notification_sends_id_fk" FOREIGN KEY ("send_id") REFERENCES "public"."push_notification_sends"("id") ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "push_notification_sends_created_at_idx" ON "push_notification_sends" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "push_notification_sends_status_idx" ON "push_notification_sends" USING btree ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "push_notification_tickets_send_id_idx" ON "push_notification_tickets" USING btree ("send_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "push_notification_tickets_ticket_id_idx" ON "push_notification_tickets" USING btree ("ticket_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "push_notification_tickets_token_idx" ON "push_notification_tickets" USING btree ("token");

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1777879564863,
       "tag": "0021_old_hitman",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1779094226000,
+      "tag": "0022_manual_push_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/push-tokens/debug-send/route.ts
+++ b/app/src/app/api/push-tokens/debug-send/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     console.error("PUSH_DEBUG_SECRET environment variable is not set");
     return NextResponse.json(
       { error: "Server misconfigured" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 
@@ -55,7 +55,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!walletPublicKey || !title || !message) {
     return NextResponse.json(
       { error: "walletPublicKey, title, and body are required" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
@@ -73,7 +73,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (rows.length === 0) {
     return NextResponse.json(
       { error: "No push tokens registered for this wallet", sentTo: 0 },
-      { status: 404 },
+      { status: 404 }
     );
   }
 
@@ -85,6 +85,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       sound: "default",
       data,
     })),
+    { source: "debug" }
   );
 
   return NextResponse.json({ success: true, sentTo: rows.length });

--- a/app/src/lib/push-notifications/send-to-wallet.ts
+++ b/app/src/lib/push-notifications/send-to-wallet.ts
@@ -20,7 +20,7 @@ export type WalletPushPayload = {
  */
 export async function sendPushToWallet(
   walletPublicKey: string,
-  payload: WalletPushPayload,
+  payload: WalletPushPayload
 ): Promise<{ sentTo: number }> {
   const db = getDatabase();
   const rows = await db
@@ -40,6 +40,7 @@ export async function sendPushToWallet(
       sound: "default",
       data: payload.data,
     })),
+    { source: "wallet" }
   );
 
   return { sentTo: rows.length };

--- a/app/src/lib/push-notifications/send.ts
+++ b/app/src/lib/push-notifications/send.ts
@@ -1,10 +1,32 @@
-type ExpoPushMessage = {
-  to: string;
-  title: string;
-  body: string;
-  data?: Record<string, unknown>;
-  sound?: "default" | null;
+import {
+  pushNotificationSends,
+  pushNotificationTickets,
+  pushTokens,
+} from "@loyal-labs/db-core/schema";
+import {
+  type ExpoPushMessage,
+  sendExpoPushMessages,
+} from "@loyal-labs/shared/expo-push";
+import { eq, inArray } from "drizzle-orm";
+
+import { getDatabase } from "@/lib/core/database";
+
+export type { ExpoPushMessage };
+
+export type ExpoPushDispatchResult = {
+  sendId: string | null;
+  requested: number;
+  ticketCount: number;
+  prunedTokenCount: number;
 };
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
 
 /**
  * Send push notifications via Expo Push API.
@@ -12,35 +34,92 @@ type ExpoPushMessage = {
  */
 export async function sendExpoPushNotifications(
   messages: ExpoPushMessage[],
-): Promise<void> {
-  if (messages.length === 0) return;
-
-  // Expo Push API accepts batches of up to 100
-  const chunks: ExpoPushMessage[][] = [];
-  for (let i = 0; i < messages.length; i += 100) {
-    chunks.push(messages.slice(i, i + 100));
+  options: { source?: string } = {}
+): Promise<ExpoPushDispatchResult> {
+  if (messages.length === 0) {
+    return {
+      sendId: null,
+      requested: 0,
+      ticketCount: 0,
+      prunedTokenCount: 0,
+    };
   }
 
-  for (const chunk of chunks) {
-    try {
-      const response = await fetch("https://exp.host/--/api/v2/push/send", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify(chunk),
-      });
+  const db = getDatabase();
+  const [sendRow] = await db
+    .insert(pushNotificationSends)
+    .values({
+      source: options.source ?? "system",
+      audience: "all",
+      title: messages[0]?.title ?? "Notification",
+      body: messages[0]?.body ?? "",
+      data: null,
+      status: "sending",
+      requestedCount: messages.length,
+    })
+    .returning({ id: pushNotificationSends.id });
 
-      if (!response.ok) {
-        console.error(
-          "[push] Expo Push API error:",
-          response.status,
-          await response.text(),
-        );
-      }
-    } catch (error) {
-      console.error("[push] Failed to send push notifications:", error);
+  if (!sendRow) {
+    throw new Error("Failed to create push notification send record");
+  }
+
+  try {
+    const result = await sendExpoPushMessages(messages);
+    const now = new Date();
+
+    for (const ticketChunk of chunk(result.tickets, 1000)) {
+      await db.insert(pushNotificationTickets).values(
+        ticketChunk.map(({ token, ticket }) => ({
+          sendId: sendRow.id,
+          token,
+          ticketId: ticket.id ?? null,
+          ticketStatus: ticket.status,
+          ticketMessage: ticket.message ?? null,
+          ticketError: ticket.details?.error ?? null,
+        }))
+      );
     }
+
+    const staleTokens = Array.from(new Set(result.deviceNotRegisteredTokens));
+    for (const staleTokenChunk of chunk(staleTokens, 1000)) {
+      await db
+        .delete(pushTokens)
+        .where(inArray(pushTokens.token, staleTokenChunk));
+    }
+
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "sent",
+        ticketCount: result.tickets.length,
+        deviceNotRegisteredCount: staleTokens.length,
+        sentAt: now,
+        updatedAt: now,
+      })
+      .where(eq(pushNotificationSends.id, sendRow.id));
+
+    return {
+      sendId: sendRow.id,
+      requested: result.requested,
+      ticketCount: result.tickets.length,
+      prunedTokenCount: staleTokens.length,
+    };
+  } catch (error) {
+    const now = new Date();
+    console.error("[push] Failed to send push notifications:", error);
+    await db
+      .update(pushNotificationSends)
+      .set({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        updatedAt: now,
+      })
+      .where(eq(pushNotificationSends.id, sendRow.id));
+    return {
+      sendId: sendRow.id,
+      requested: messages.length,
+      ticketCount: 0,
+      prunedTokenCount: 0,
+    };
   }
 }

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -180,6 +180,14 @@ export type FlagAudience = "all" | "public" | "team";
  */
 export type FlagTargetEnvironment = "development" | "preview" | "production";
 
+export type ManualPushAudience = "all" | "platform" | "wallet";
+
+export type PushNotificationSendStatus =
+  | "sending"
+  | "sent"
+  | "receipt_checked"
+  | "failed";
+
 // ============================================================================
 // TABLES
 // ============================================================================
@@ -605,6 +613,80 @@ export const pushTokens = pgTable(
     uniqueIndex("push_tokens_token_unique").on(table.token),
     index("push_tokens_telegram_user_id_idx").on(table.telegramUserId),
     index("push_tokens_wallet_public_key_idx").on(table.walletPublicKey),
+  ]
+);
+
+export const pushNotificationSends = pgTable(
+  "push_notification_sends",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    source: text("source").notNull(),
+    audience: text("audience").$type<ManualPushAudience>().notNull(),
+    platform: text("platform"),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    data: jsonb("data").$type<Record<string, unknown> | null>(),
+    createdBy: text("created_by"),
+    status: text("status").$type<PushNotificationSendStatus>().notNull(),
+    requestedCount: integer("requested_count").default(0).notNull(),
+    ticketCount: integer("ticket_count").default(0).notNull(),
+    receiptOkCount: integer("receipt_ok_count").default(0).notNull(),
+    receiptErrorCount: integer("receipt_error_count").default(0).notNull(),
+    deviceNotRegisteredCount: integer("device_not_registered_count")
+      .default(0)
+      .notNull(),
+    errorMessage: text("error_message"),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    receiptsCheckedAt: timestamp("receipts_checked_at", {
+      withTimezone: true,
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("push_notification_sends_created_at_idx").on(table.createdAt),
+    index("push_notification_sends_status_idx").on(table.status),
+    check(
+      "push_notification_sends_audience_check",
+      sql`${table.audience} IN ('all', 'platform', 'wallet')`
+    ),
+    check(
+      "push_notification_sends_status_check",
+      sql`${table.status} IN ('sending', 'sent', 'receipt_checked', 'failed')`
+    ),
+  ]
+);
+
+export const pushNotificationTickets = pgTable(
+  "push_notification_tickets",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sendId: uuid("send_id")
+      .notNull()
+      .references(() => pushNotificationSends.id, { onDelete: "cascade" }),
+    token: text("token").notNull(),
+    ticketId: text("ticket_id"),
+    ticketStatus: text("ticket_status").notNull(),
+    ticketMessage: text("ticket_message"),
+    ticketError: text("ticket_error"),
+    receiptStatus: text("receipt_status"),
+    receiptMessage: text("receipt_message"),
+    receiptError: text("receipt_error"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("push_notification_tickets_send_id_idx").on(table.sendId),
+    index("push_notification_tickets_ticket_id_idx").on(table.ticketId),
+    index("push_notification_tickets_token_idx").on(table.token),
   ]
 );
 
@@ -1613,6 +1695,15 @@ export type InsertBotMessage = typeof botMessages.$inferInsert;
 
 export type PushToken = typeof pushTokens.$inferSelect;
 export type InsertPushToken = typeof pushTokens.$inferInsert;
+
+export type PushNotificationSend = typeof pushNotificationSends.$inferSelect;
+export type InsertPushNotificationSend =
+  typeof pushNotificationSends.$inferInsert;
+
+export type PushNotificationTicket =
+  typeof pushNotificationTickets.$inferSelect;
+export type InsertPushNotificationTicket =
+  typeof pushNotificationTickets.$inferInsert;
 
 export type WalletPushSyncState = typeof walletPushSyncState.$inferSelect;
 export type InsertWalletPushSyncState = typeof walletPushSyncState.$inferInsert;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,11 @@
       "import": "./dist/analytics-server.js",
       "default": "./dist/analytics-server.js",
       "types": "./dist/analytics-server.d.ts"
+    },
+    "./expo-push": {
+      "import": "./dist/expo-push.js",
+      "default": "./dist/expo-push.js",
+      "types": "./dist/expo-push.d.ts"
     }
   },
   "files": [

--- a/packages/shared/src/__tests__/expo-push.test.ts
+++ b/packages/shared/src/__tests__/expo-push.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { getExpoPushReceipts, sendExpoPushMessages } from "../expo-push";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("expo push transport", () => {
+  test("sends messages, reads receipts, and returns dead tokens", async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    const fetchFn = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ url, body });
+
+      if (url.endsWith("/push/send")) {
+        return jsonResponse({
+          data: [
+            { status: "ok", id: "receipt-ok" },
+            {
+              status: "error",
+              message: "Device is not registered",
+              details: { error: "DeviceNotRegistered" },
+            },
+          ],
+        });
+      }
+
+      return jsonResponse({
+        data: {
+          "receipt-ok": {
+            status: "error",
+            message: "Device is not registered",
+            details: { error: "DeviceNotRegistered" },
+          },
+        },
+      });
+    };
+
+    const sendResult = await sendExpoPushMessages(
+      [
+        { to: "ExponentPushToken[live]", title: "Title", body: "Body" },
+        { to: "ExponentPushToken[dead-ticket]", title: "Title", body: "Body" },
+      ],
+      { fetchFn }
+    );
+    const receiptResult = await getExpoPushReceipts(sendResult.receiptIds, {
+      fetchFn,
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://exp.host/--/api/v2/push/send",
+        body: [
+          { to: "ExponentPushToken[live]", title: "Title", body: "Body" },
+          {
+            to: "ExponentPushToken[dead-ticket]",
+            title: "Title",
+            body: "Body",
+          },
+        ],
+      },
+      {
+        url: "https://exp.host/--/api/v2/push/getReceipts",
+        body: { ids: ["receipt-ok"] },
+      },
+    ]);
+    expect(sendResult.receiptIds).toEqual(["receipt-ok"]);
+    expect(sendResult.deviceNotRegisteredTokens).toEqual([
+      "ExponentPushToken[dead-ticket]",
+    ]);
+    expect(receiptResult.deviceNotRegisteredReceiptIds).toEqual(["receipt-ok"]);
+  });
+});

--- a/packages/shared/src/expo-push.ts
+++ b/packages/shared/src/expo-push.ts
@@ -1,0 +1,174 @@
+const EXPO_PUSH_SEND_URL = "https://exp.host/--/api/v2/push/send";
+const EXPO_PUSH_RECEIPTS_URL = "https://exp.host/--/api/v2/push/getReceipts";
+const DEVICE_NOT_REGISTERED = "DeviceNotRegistered";
+
+export type ExpoPushMessage = {
+  to: string;
+  title?: string;
+  body?: string;
+  data?: Record<string, unknown>;
+  sound?: "default" | null;
+};
+
+export type ExpoPushTicket = {
+  status: "ok" | "error";
+  id?: string;
+  message?: string;
+  details?: { error?: string; [key: string]: unknown };
+};
+
+export type ExpoPushReceipt = {
+  status: "ok" | "error";
+  message?: string;
+  details?: { error?: string; [key: string]: unknown };
+};
+
+export type ExpoPushSentTicket = {
+  token: string;
+  ticket: ExpoPushTicket;
+};
+
+export type ExpoPushSendResult = {
+  requested: number;
+  tickets: ExpoPushSentTicket[];
+  receiptIds: string[];
+  deviceNotRegisteredTokens: string[];
+};
+
+export type ExpoPushReceiptResult = {
+  receipts: Record<string, ExpoPushReceipt>;
+  deviceNotRegisteredReceiptIds: string[];
+};
+
+type FetchLike = typeof fetch;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function isExpoPushTicket(value: unknown): value is ExpoPushTicket {
+  if (!value || typeof value !== "object") return false;
+  const status = (value as { status?: unknown }).status;
+  return status === "ok" || status === "error";
+}
+
+function isExpoPushReceipt(value: unknown): value is ExpoPushReceipt {
+  if (!value || typeof value !== "object") return false;
+  const status = (value as { status?: unknown }).status;
+  return status === "ok" || status === "error";
+}
+
+function hasDeviceNotRegisteredError(
+  item: ExpoPushTicket | ExpoPushReceipt
+): boolean {
+  return item.details?.error === DEVICE_NOT_REGISTERED;
+}
+
+export async function sendExpoPushMessages(
+  messages: ExpoPushMessage[],
+  options: { fetchFn?: FetchLike } = {}
+): Promise<ExpoPushSendResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const tickets: ExpoPushSentTicket[] = [];
+  const receiptIds: string[] = [];
+  const deviceNotRegisteredTokens: string[] = [];
+
+  for (const messageChunk of chunk(messages, 100)) {
+    const response = await fetchFn(EXPO_PUSH_SEND_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(messageChunk),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Expo Push API failed with ${response.status}: ${await response.text()}`
+      );
+    }
+
+    const payload = (await response.json()) as { data?: unknown };
+    const payloadTickets = Array.isArray(payload.data) ? payload.data : [];
+
+    for (const [index, rawTicket] of payloadTickets.entries()) {
+      if (!isExpoPushTicket(rawTicket)) continue;
+
+      const token = messageChunk[index]?.to;
+      if (!token) continue;
+
+      tickets.push({ token, ticket: rawTicket });
+
+      if (rawTicket.status === "ok" && rawTicket.id) {
+        receiptIds.push(rawTicket.id);
+      }
+
+      if (
+        rawTicket.status === "error" &&
+        hasDeviceNotRegisteredError(rawTicket)
+      ) {
+        deviceNotRegisteredTokens.push(token);
+      }
+    }
+  }
+
+  return {
+    requested: messages.length,
+    tickets,
+    receiptIds,
+    deviceNotRegisteredTokens,
+  };
+}
+
+export async function getExpoPushReceipts(
+  receiptIds: string[],
+  options: { fetchFn?: FetchLike } = {}
+): Promise<ExpoPushReceiptResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const receipts: Record<string, ExpoPushReceipt> = {};
+  const deviceNotRegisteredReceiptIds: string[] = [];
+
+  for (const idChunk of chunk(receiptIds, 1000)) {
+    if (idChunk.length === 0) continue;
+
+    const response = await fetchFn(EXPO_PUSH_RECEIPTS_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ ids: idChunk }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Expo Push receipts API failed with ${
+          response.status
+        }: ${await response.text()}`
+      );
+    }
+
+    const payload = (await response.json()) as { data?: unknown };
+    const payloadReceipts =
+      payload.data && typeof payload.data === "object" ? payload.data : {};
+
+    for (const [receiptId, rawReceipt] of Object.entries(payloadReceipts)) {
+      if (!isExpoPushReceipt(rawReceipt)) continue;
+
+      receipts[receiptId] = rawReceipt;
+      if (
+        rawReceipt.status === "error" &&
+        hasDeviceNotRegisteredError(rawReceipt)
+      ) {
+        deviceNotRegisteredReceiptIds.push(receiptId);
+      }
+    }
+  }
+
+  return { receipts, deviceNotRegisteredReceiptIds };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,8 +10,13 @@ export {
   TOKEN_DUST_NORMALIZED_THRESHOLD,
 } from "./dust-filter";
 export type { SolDustInput, TokenDustInput } from "./dust-filter";
+export { getExpoPushReceipts, sendExpoPushMessages } from "./expo-push";
 export type {
-  ChatSummary,
-  SummariesApiResponse,
-  Topic,
-} from "./summaries";
+  ExpoPushMessage,
+  ExpoPushReceipt,
+  ExpoPushReceiptResult,
+  ExpoPushSendResult,
+  ExpoPushSentTicket,
+  ExpoPushTicket,
+} from "./expo-push";
+export type { ChatSummary, SummariesApiResponse, Topic } from "./summaries";


### PR DESCRIPTION
Adds an admin manual push-notification console for mobile broadcasts and wallet-targeted test sends. Push delivery now records Expo tickets/receipts and prunes DeviceNotRegistered tokens.