### PR TITLE
fix(admin): show wallet test key field

### DIFF
--- a/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
+++ b/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
@@ -174,18 +174,17 @@ export function ManualPushPanel({
               </label>
             </div>
 
-            {audience === "wallet" ? (
-              <label className="block">
-                <span className="mb-1 block text-xs font-medium">
-                  Wallet public key
-                </span>
-                <Input
-                  name="walletPublicKey"
-                  placeholder="Solana wallet address"
-                  required
-                />
-              </label>
-            ) : null}
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium">
+                Wallet public key
+              </span>
+              <Input
+                name="walletPublicKey"
+                placeholder="Required for Wallet test"
+                disabled={audience !== "wallet"}
+                required={audience === "wallet"}
+              />
+            </label>
 
             <label className="block">
               <span className="mb-1 block text-xs font-medium">Body</span>


### PR DESCRIPTION
Makes the wallet public key input permanently visible on the manual push form, while enabling and requiring it only for Wallet test sends.