### PR TITLE
fix(admin): harden manual push page

### DIFF
--- a/admin/src/app/(admin)/push-notifications/actions.ts
+++ b/admin/src/app/(admin)/push-notifications/actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@loyal-labs/shared/expo-push";
 import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 import { getDatabase } from "@/lib/core/database";
 
@@ -54,6 +55,18 @@ function parseJsonData(
   }
 
   return parsed as Record<string, unknown>;
+}
+
+function redirectWithActionResult(result: ActionResult): never {
+  const searchParams = new URLSearchParams();
+  if ("error" in result) {
+    searchParams.set("result", "error");
+    searchParams.set("message", result.error);
+  } else {
+    searchParams.set("result", "success");
+    searchParams.set("message", result.message);
+  }
+  redirect(`/push-notifications?${searchParams.toString()}`);
 }
 
 export async function sendManualPushNotification(
@@ -150,6 +163,15 @@ export async function sendManualPushNotification(
         sound: "default",
       }))
     );
+    const receiptIdCount = result.receiptIds.length;
+    const ticketErrors = result.tickets.filter(
+      ({ ticket }) => ticket.status === "error"
+    );
+    const firstTicketError = ticketErrors[0]?.ticket.details?.error
+      ? `${ticketErrors[0].ticket.details.error}: ${
+          ticketErrors[0].ticket.message ?? "Expo rejected the ticket"
+        }`
+      : ticketErrors[0]?.ticket.message ?? null;
 
     for (const ticketChunk of chunk(result.tickets, 1000)) {
       await db.insert(pushNotificationTickets).values(
@@ -174,18 +196,27 @@ export async function sendManualPushNotification(
     await db
       .update(pushNotificationSends)
       .set({
-        status: "sent",
+        status: receiptIdCount === 0 ? "failed" : "sent",
         ticketCount: result.tickets.length,
         deviceNotRegisteredCount: staleTokens.length,
+        errorMessage: receiptIdCount === 0 ? firstTicketError : null,
         sentAt: new Date(),
         updatedAt: new Date(),
       })
       .where(eq(pushNotificationSends.id, sendRow.id));
 
     revalidatePath("/push-notifications");
+    if (receiptIdCount === 0) {
+      return {
+        error: `Expo rejected all push tickets: ${
+          firstTicketError ?? "no receipt IDs were returned"
+        }`,
+      };
+    }
+
     return {
       success: true,
-      message: `Sent ${result.tickets.length} push tickets. Pruned ${staleTokens.length} dead tokens.`,
+      message: `Accepted ${receiptIdCount}/${tokens.length} push tickets. Pruned ${staleTokens.length} dead tokens.`,
     };
   } catch (error) {
     await db
@@ -304,4 +335,13 @@ export async function checkPushReceipts(sendId: string): Promise<ActionResult> {
         error instanceof Error ? error.message : "Failed to check receipts",
     };
   }
+}
+
+export async function submitManualPushNotification(formData: FormData) {
+  redirectWithActionResult(await sendManualPushNotification(formData));
+}
+
+export async function submitPushReceiptCheck(formData: FormData) {
+  const sendId = String(formData.get("sendId") ?? "");
+  redirectWithActionResult(await checkPushReceipts(sendId));
 }

--- a/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
+++ b/admin/src/app/(admin)/push-notifications/manual-push-panel.tsx
@@ -1,8 +1,4 @@
-"use client";
-
 import { SendIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -24,7 +20,10 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
-import { checkPushReceipts, sendManualPushNotification } from "./actions";
+import {
+  submitManualPushNotification,
+  submitPushReceiptCheck,
+} from "./actions";
 
 type PushCounts = {
   all: number;
@@ -48,9 +47,11 @@ type RecentSend = {
   receiptsCheckedAt: string | null;
   createdAt: string;
   createdBy: string | null;
+  receiptIdCount: number;
+  lastTicketError: string | null;
 };
 
-type ActionState = {
+type ActionMessage = {
   kind: "success" | "error";
   message: string;
 } | null;
@@ -69,45 +70,12 @@ function statusVariant(status: string): "default" | "outline" | "destructive" {
 export function ManualPushPanel({
   counts,
   recentSends,
+  actionMessage,
 }: {
   counts: PushCounts;
   recentSends: RecentSend[];
+  actionMessage: ActionMessage;
 }) {
-  const router = useRouter();
-  const [state, setState] = useState<ActionState>(null);
-  const [audience, setAudience] = useState("all");
-  const [pending, startTransition] = useTransition();
-
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    startTransition(async () => {
-      const result = await sendManualPushNotification(formData);
-      if ("error" in result) {
-        setState({ kind: "error", message: result.error });
-        return;
-      }
-
-      event.currentTarget.reset();
-      setState({ kind: "success", message: result.message });
-      router.refresh();
-    });
-  }
-
-  function handleCheckReceipts(sendId: string) {
-    startTransition(async () => {
-      const result = await checkPushReceipts(sendId);
-      if ("error" in result) {
-        setState({ kind: "error", message: result.error });
-        return;
-      }
-
-      setState({ kind: "success", message: result.message });
-      router.refresh();
-    });
-  }
-
   return (
     <div className="space-y-5">
       <div className="grid gap-3 md:grid-cols-3">
@@ -139,20 +107,20 @@ export function ManualPushPanel({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {state ? (
+          {actionMessage ? (
             <div
               className={cn(
                 "mb-4 rounded-md border px-3 py-2 text-sm",
-                state.kind === "error"
+                actionMessage.kind === "error"
                   ? "border-destructive/30 bg-destructive/10 text-destructive"
                   : "border-border bg-muted text-foreground"
               )}
             >
-              {state.message}
+              {actionMessage.message}
             </div>
           ) : null}
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form action={submitManualPushNotification} className="space-y-4">
             <div className="grid gap-3 md:grid-cols-[1fr_12rem]">
               <label className="block">
                 <span className="mb-1 block text-xs font-medium">Title</span>
@@ -162,8 +130,7 @@ export function ManualPushPanel({
                 <span className="mb-1 block text-xs font-medium">Audience</span>
                 <select
                   name="platform"
-                  value={audience}
-                  onChange={(event) => setAudience(event.target.value)}
+                  defaultValue="all"
                   className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 >
                   <option value="all">All mobile</option>
@@ -180,9 +147,7 @@ export function ManualPushPanel({
               </span>
               <Input
                 name="walletPublicKey"
-                placeholder="Required for Wallet test"
-                disabled={audience !== "wallet"}
-                required={audience === "wallet"}
+                placeholder="Solana wallet address for Wallet test"
               />
             </label>
 
@@ -221,9 +186,9 @@ export function ManualPushPanel({
             </div>
 
             <div className="flex justify-end">
-              <Button type="submit" disabled={pending}>
+              <Button type="submit">
                 <SendIcon className="size-4" />
-                {pending ? "Sending..." : "Send push"}
+                Send push
               </Button>
             </div>
           </form>
@@ -263,6 +228,11 @@ export function ManualPushPanel({
                         <div className="text-xs text-muted-foreground">
                           {send.createdBy ?? send.source}
                         </div>
+                        {send.lastTicketError ? (
+                          <div className="mt-1 max-w-80 text-xs text-destructive">
+                            {send.lastTicketError}
+                          </div>
+                        ) : null}
                       </TableCell>
                       <TableCell>
                         <Badge variant={statusVariant(send.status)}>
@@ -274,6 +244,11 @@ export function ManualPushPanel({
                       </TableCell>
                       <TableCell className="text-right">
                         {send.ticketCount}/{send.requestedCount}
+                        {send.ticketCount > 0 ? (
+                          <div className="text-xs text-muted-foreground">
+                            {send.receiptIdCount} receipt IDs
+                          </div>
+                        ) : null}
                       </TableCell>
                       <TableCell className="text-right">
                         {send.receiptOkCount}/{send.receiptErrorCount}
@@ -282,15 +257,23 @@ export function ManualPushPanel({
                         {send.deviceNotRegisteredCount}
                       </TableCell>
                       <TableCell className="text-right">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="xs"
-                          disabled={pending || send.ticketCount === 0}
-                          onClick={() => handleCheckReceipts(send.id)}
-                        >
-                          Check receipts
-                        </Button>
+                        <form action={submitPushReceiptCheck}>
+                          <input
+                            type="hidden"
+                            name="sendId"
+                            value={send.id}
+                          />
+                          <Button
+                            type="submit"
+                            variant="outline"
+                            size="xs"
+                            disabled={send.receiptIdCount === 0}
+                          >
+                            {send.receiptIdCount === 0
+                              ? "No receipts"
+                              : "Check receipts"}
+                          </Button>
+                        </form>
                       </TableCell>
                     </TableRow>
                   ))

--- a/admin/src/app/(admin)/push-notifications/page.tsx
+++ b/admin/src/app/(admin)/push-notifications/page.tsx
@@ -1,5 +1,9 @@
-import { pushNotificationSends, pushTokens } from "@loyal-labs/db-core/schema";
-import { and, count, desc, eq, isNotNull } from "drizzle-orm";
+import {
+  pushNotificationSends,
+  pushNotificationTickets,
+  pushTokens,
+} from "@loyal-labs/db-core/schema";
+import { and, count, desc, eq, inArray, isNotNull } from "drizzle-orm";
 
 import { PageContainer } from "@/components/layout/page-container";
 import { SectionHeader } from "@/components/layout/section-header";
@@ -25,7 +29,45 @@ type RecentSendRow = {
   receiptsCheckedAt: Date | null;
   createdAt: Date;
   createdBy: string | null;
+  receiptIdCount: number;
+  lastTicketError: string | null;
 };
+
+type RecentSendBaseRow = Omit<
+  RecentSendRow,
+  "receiptIdCount" | "lastTicketError"
+>;
+
+type PushNotificationsPageProps = {
+  searchParams?: Promise<{
+    result?: string | string[];
+    message?: string | string[];
+  }>;
+};
+
+function toSingleValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function getActionMessage(result: string | undefined, message: string | undefined) {
+  if (!message) return null;
+  if (result === "success") return { kind: "success" as const, message };
+  if (result === "error") return { kind: "error" as const, message };
+  return null;
+}
+
+function getTicketError(row: {
+  ticketError: string | null;
+  ticketMessage: string | null;
+}) {
+  if (row.ticketError && row.ticketMessage) {
+    return `${row.ticketError}: ${row.ticketMessage}`;
+  }
+  return row.ticketError ?? row.ticketMessage;
+}
 
 async function getPushTokenCount(platform?: "ios" | "android") {
   const db = getDatabase();
@@ -44,9 +86,15 @@ async function getPushTokenCount(platform?: "ios" | "android") {
   return row?.count ?? 0;
 }
 
-export default async function PushNotificationsPage() {
+export default async function PushNotificationsPage({
+  searchParams,
+}: PushNotificationsPageProps) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const result = toSingleValue(resolvedSearchParams.result);
+  const message = toSingleValue(resolvedSearchParams.message);
+  const actionMessage = getActionMessage(result, message);
   const db = getDatabase();
-  const [all, ios, android, recentSends] = await Promise.all([
+  const [all, ios, android, recentSendRows] = await Promise.all([
     getPushTokenCount(),
     getPushTokenCount("ios"),
     getPushTokenCount("android"),
@@ -70,9 +118,51 @@ export default async function PushNotificationsPage() {
         createdBy: pushNotificationSends.createdBy,
       })
       .from(pushNotificationSends)
+      .where(eq(pushNotificationSends.source, "admin"))
       .orderBy(desc(pushNotificationSends.createdAt))
-      .limit(20) as Promise<RecentSendRow[]>,
+      .limit(20) as Promise<RecentSendBaseRow[]>,
   ]);
+  const ticketRows =
+    recentSendRows.length > 0
+      ? await db
+          .select({
+            sendId: pushNotificationTickets.sendId,
+            ticketId: pushNotificationTickets.ticketId,
+            ticketStatus: pushNotificationTickets.ticketStatus,
+            ticketMessage: pushNotificationTickets.ticketMessage,
+            ticketError: pushNotificationTickets.ticketError,
+          })
+          .from(pushNotificationTickets)
+          .where(
+            inArray(
+              pushNotificationTickets.sendId,
+              recentSendRows.map((send) => send.id)
+            )
+          )
+      : [];
+  const ticketMetaBySendId = new Map<
+    string,
+    { receiptIdCount: number; lastTicketError: string | null }
+  >();
+
+  for (const row of ticketRows) {
+    const meta = ticketMetaBySendId.get(row.sendId) ?? {
+      receiptIdCount: 0,
+      lastTicketError: null,
+    };
+    if (row.ticketId) {
+      meta.receiptIdCount += 1;
+    }
+    if (row.ticketStatus === "error") {
+      meta.lastTicketError = getTicketError(row);
+    }
+    ticketMetaBySendId.set(row.sendId, meta);
+  }
+  const recentSends = recentSendRows.map((send) => ({
+    ...send,
+    receiptIdCount: ticketMetaBySendId.get(send.id)?.receiptIdCount ?? 0,
+    lastTicketError: ticketMetaBySendId.get(send.id)?.lastTicketError ?? null,
+  }));
 
   return (
     <PageContainer>
@@ -83,6 +173,7 @@ export default async function PushNotificationsPage() {
       />
       <ManualPushPanel
         counts={{ all, ios, android }}
+        actionMessage={actionMessage}
         recentSends={recentSends.map((send) => ({
           ...send,
           sentAt: send.sentAt?.toISOString() ?? null,


### PR DESCRIPTION
Removes the client-state dependency from the manual push page, makes wallet test input always active with server-side validation, wires sends and receipt checks through server-action forms, and filters Recent sends to admin-created sends only.