### PR TITLE
feat(frontend): add Organization JSON-LD to root layout

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,6 +16,21 @@ import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
 const geistSans = GeistSans;
 const geistMono = GeistMono;
 
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Loyal",
+  legalName: "Loyal DAO LLC",
+  url: "https://askloyal.com",
+  logo: "https://askloyal.com/android-chrome-512x512.png",
+  sameAs: [
+    "https://x.com/loyal_hq",
+    "https://github.com/loyal-labs",
+    "https://discord.com/invite/tAwXsXwTv6",
+    "https://t.me/loyal_tgchat",
+  ],
+};
+
 export const metadata: Metadata = {
   title: "Loyal: Solana Wallet with Agent Guardrails",
   description:
@@ -81,6 +96,15 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd).replace(
+              /</g,
+              "\\u003c"
+            ),
+          }}
+        />
         <PublicEnvProvider value={publicEnv}>{children}</PublicEnvProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Adds a static `<script type="application/ld+json">` block with Schema.org **Organization** for "Loyal" / legal "Loyal DAO LLC" in `frontend/src/app/layout.tsx`. Rendered server-side, ships in initial HTML payload (visible to AI crawlers that don't execute JS — GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot, etc.).

Closes **NEW P1** carried from `LoyalGEO/weekly/2026-W20-*` → confirmed in W21 punch list.

### Why askloyal.com (not docs.askloyal.com)
The W20 note originally pointed at Mintlify `docs.json` because the live `WebSite.creator: "Mintlify"` block looked wrong. On review:
- Mintlify has no native JSON-LD config; only JS injection is available — and JS-injected schema is invisible to most AI crawlers, which defeats the GEO goal.
- Google's own guidance puts `Organization` on the brand homepage, not docs subdomains.
- Multiple JSON-LD blocks per page coexist via Schema.org entity graph — adding `Organization` on `askloyal.com` doesn't conflict with Mintlify's `WebSite` on docs.

### Schema payload
- `@type: Organization`, `name: "Loyal"`, `legalName: "Loyal DAO LLC"` per brand standing decision
- `url: https://askloyal.com`, `logo: /android-chrome-512x512.png` (square PNG meets Google rich-results spec)
- `sameAs`: X, GitHub, Discord, Telegram community
- **MetaDAO omitted** — `metadao.fi` alone doesn't identify Loyal as a `sameAs` entity per Schema.org semantics. Add when a Loyal-specific URL exists.

### Security
Uses `dangerouslySetInnerHTML` — required for JSON-LD inlining per Next.js team's official pattern. Content is a static const, not user input. Added `< → <` escape as OWASP defense-in-depth against script-closing sequences.

## Test plan
- [ ] CI typecheck passes
- [ ] After merge: curl askloyal.com and grep for the ld+json script tag
- [ ] Paste live URL into Google Rich Results Test — expect Organization detected, no errors
- [ ] Confirm no conflict with Mintlify's WebSite block on docs subdomain

🤖 Generated with [Claude Code](https://claude.com/claude-code)