### PR TITLE
fix(docs): align FAQ Organization JSON-LD sameAs with canonical URLs

### DIFF
--- a/user-docs/faq/index.mdx
+++ b/user-docs/faq/index.mdx
@@ -165,9 +165,8 @@ export const orgSchema = {
   "sameAs": [
     "https://x.com/loyal_hq",
     "https://github.com/loyal-labs",
-    "https://discord.gg/HSeXaVhzWU",
-    "https://tg.askloyal.com",
-    "https://docs.askloyal.com"
+    "https://discord.com/invite/tAwXsXwTv6",
+    "https://t.me/loyal_tgchat"
   ]
 };
 


### PR DESCRIPTION
## Summary

Three-line `sameAs` fix to the Organization JSON-LD in `user-docs/faq/index.mdx`. The block shipped in [#327 / commit `71e5fcd`](https://github.com/loyal-labs/loyal-app/commit/71e5fcd) had stale URLs that diverged from the canonical brand sources and from the new Organization block being added in [#344](https://github.com/loyal-labs/loyal-app/pull/344).

## Why this matters

Google's entity reconciliation merges multiple `Organization` JSON-LD blocks across same-site surfaces using `url` + `sameAs` overlap as the linking signal. When two blocks describe the same entity with conflicting `sameAs` URLs, confidence drops and the entity may be downweighted in Knowledge Graph and AI-engine citations — the exact opposite of what shipping structured data is supposed to do.

## Specific changes

| Field | Before | After | Reason |
|---|---|---|---|
| Discord | `https://discord.gg/HSeXaVhzWU` | `https://discord.com/invite/tAwXsXwTv6` | Different invite codes resolve to different invites — `tAwXsXwTv6` matches the brand canonical |
| Telegram | `https://tg.askloyal.com` | `https://t.me/loyal_tgchat` | `tg.askloyal.com` 301s to `t.me/+6xDxLBU_Y29kY2Nl` (private/invite-hash chat), not the public community |
| docs.askloyal.com | listed in `sameAs` | removed | Content sub-domain of the same entity, not an identity profile — misuse of `sameAs` semantics per Schema.org docs |

## Verification

\`\`\`
$ curl -sI https://tg.askloyal.com | grep -i location
location: https://t.me/+6xDxLBU_Y29kY2Nl

$ curl -sI https://discord.gg/HSeXaVhzWU | grep -i location
location: https://discord.com/invite/HSeXaVhzWU
\`\`\`

`HSeXaVhzWU` and `tAwXsXwTv6` are independent Discord invite codes.

## Test plan
- [ ] CI passes (Mintlify build / typecheck if applicable)
- [ ] After merge: `curl -s https://docs.askloyal.com/faq | grep -o '"sameAs":\[[^]]*\]'` returns the new array
- [ ] Paste live URL into Google Rich Results Test — Organization detected, sameAs URLs match brand canonical
- [ ] Sanity-check both Organization blocks (askloyal.com root + docs FAQ) share consistent `sameAs` and `url` fields

## Followup (not in this PR)

The W21 weekly note flagged that the canonical Q&As are kept in sync by hand across three surfaces (loyal-app README, frontend llms.txt, /faq). The Organization schema now has the same problem across two surfaces. The proper fix is extracting `orgSchema` to a single source — bundled into the queued P0 FAQ rebuild scope, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)