### PR TITLE
chore(seo): cleanup sub-threshold nits from PR #341

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -49,6 +49,7 @@ Disallow: /app
 Disallow: /app/
 Disallow: /500
 Disallow: /_next/
+Disallow: /*.json$
 
 Sitemap: https://askloyal.com/sitemap.xml
-Host: https://askloyal.com
+Host: askloyal.com

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
   icons: {
     icon: "/icon.svg",
     shortcut: "/icon.svg",
-    apple: "/icon.svg",
+    apple: "/apple-touch-icon.png",
   },
   openGraph: {
     type: "website",


### PR DESCRIPTION
## Summary

Bundles the four parked sub-threshold code-review nits from PR #341 (robots/sitemap/llms) plus one carryover from PR #227.

- **robots.txt** — Yandex `Host:` directive: dropped `https://` scheme. Yandex spec requires bare hostname; with scheme, Yandex silently ignores the line.
- **robots.txt** — added `Disallow: /*.json$` to the named-UA block so it matches the `User-agent: *` block. The two blocks now have identical rule sets, just under different UA scopes.
- **layout.tsx** — `icons.apple` switched from `/icon.svg` → `/apple-touch-icon.png`. iOS Safari doesn't render SVG home-screen icons; the PNG already exists in `public/`.

The fourth nit ("`/*.json$` non-RFC syntax") is actually fine per RFC 9309 §2.2.2, which lists `*` and `$` as MAY-implement path components. No change needed.

The `/landing` canonical conflict (also flagged on PR #341) is out of scope — `/landing/page.tsx` is a `"use client"` component and can't export `metadata` directly. That needs a server/client split refactor and will be tracked as its own ticket.

## Test plan

- [ ] `curl https://askloyal.com/robots.txt` after deploy — verify `Host: askloyal.com` (no scheme) and that named-UA block ends with `Disallow: /*.json$`
- [ ] DevTools → check apple-touch-icon resolves to `/apple-touch-icon.png` (200, not the SVG)
- [ ] Add iOS home-screen shortcut to confirm icon renders as expected
- [ ] No GSC/Bing regressions in 24-48h