### PR TITLE
feat(frontend): add marketing block system and Features dropdown

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,6 +6,10 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  --font-sans:
+    var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono:
+    var(--font-geist-mono), ui-monospace, "SFMono-Regular", "Menlo", monospace;
   --font-family-manrope:
     var(--font-manrope), ui-sans-serif, system-ui, sans-serif;
   --color-background: var(--background);

--- a/frontend/src/app/smart-accounts/page.tsx
+++ b/frontend/src/app/smart-accounts/page.tsx
@@ -1,0 +1,278 @@
+import {
+  BotMessageSquare,
+  Cpu,
+  Eye,
+  KeyRound,
+  ListChecks,
+  RotateCcw,
+  ShieldCheck,
+  Sparkles,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+import { LandingFaq } from "@/components/landing-faq";
+import { LandingFooter } from "@/components/landing-footer";
+import { LandingHeader } from "@/components/landing-header";
+import { LandingScrollAnimations } from "@/components/landing-scroll-animations";
+import { CardsGrid } from "@/features/marketing/blocks/cards-grid";
+import { CardsThree } from "@/features/marketing/blocks/cards-three";
+import { CardsTwo } from "@/features/marketing/blocks/cards-two";
+import { Hero } from "@/features/marketing/blocks/hero";
+import { Section } from "@/features/marketing/blocks/section";
+import { TextImageHero } from "@/features/marketing/blocks/text-image";
+
+export const metadata: Metadata = {
+  title: "Smart Accounts for AI Agents — Loyal",
+  description:
+    "Loyal turns every wallet address into a Smart Account with scoped, on-chain guardrails for AI agents — permission tiers, spending caps, and address allowlists.",
+  alternates: { canonical: "/smart-accounts" },
+};
+
+export default function SmartAccountsPage() {
+  return (
+    <main className="min-h-screen overflow-x-clip bg-white text-black">
+      <LandingScrollAnimations />
+      <LandingHeader />
+
+      {/* Hero-3 — brand red hero */}
+      <Hero
+        body="Every wallet address in Loyal is a Smart Account with its own policies and spending caps — so your agents can't spend more or send funds somewhere you didn't approve."
+        cta={{ label: "Get started", href: "/chat" }}
+        image={{
+          src: "/marketing/smart-accounts/hero.png",
+          alt: "Agent access controls and spending limit settings",
+        }}
+        title="Smart Accounts for AI Agents"
+        tone="red"
+      />
+
+      {/* Section — two-paragraph narrative */}
+      <Section
+        cards={[
+          {
+            size: "lg",
+            body: "If the agent's tier is Can Suggest, the SDK returns a pending proposal the user can sign in the wallet UI. If the tier is Can Execute and the destination is on the allowlist and within the spending cap, the SDK co-signs and submits.",
+          },
+          {
+            size: "lg",
+            body: (
+              <>
+                Permission tier sets how an agent can transact. Spending limits
+                and allowlists set what it can transact on.
+                <br />
+                <br />
+                Together, permission tier plus{" "}
+                <strong>spending limits</strong> plus address allowlists form
+                the <strong>agent guardrails</strong> every transaction is
+                checked against on-chain.
+              </>
+            ),
+          },
+        ]}
+        title="What an agent wallet on Loyal is"
+      />
+
+      {/* Section-5 — three permission tiers (bold tone progression) */}
+      <CardsThree
+        cards={[
+          {
+            icon: (
+              <Eye
+                className="size-16 text-[#f9363c]"
+                strokeWidth={1.5}
+              />
+            ),
+            title: "Can Suggest",
+            body: (
+              <>
+                Propose a transaction. You sign each one. No autonomy, full
+                visibility.
+                <br />
+                <br />
+                Best for new agents you&apos;re evaluating; advisory bots.
+              </>
+            ),
+          },
+          {
+            icon: <KeyRound className="size-16 text-[#f9363c]" />,
+            title: "Can Sign",
+            body: (
+              <>
+                Co-sign alongside you. The transaction lands when both
+                signatures are present.
+                <br />
+                <br />
+                Best for high-value flows where you want the agent&apos;s
+                signature and your approval.
+              </>
+            ),
+          },
+          {
+            icon: <Sparkles className="size-16 text-white" />,
+            title: "Can Execute",
+            body: (
+              <>
+                Sign autonomously within the spending cap and allowlist.
+                <br />
+                <br />
+                Best for trusted agents on routine flows: subscriptions,
+                micropayments, vetted strategies.
+              </>
+            ),
+          },
+        ]}
+        description="You don't trust every agent the same way. Loyal's permission model has three levels, set per agent:"
+        title="The three permission tiers"
+        variant="bold"
+      />
+
+      {/* Section-7 — spending limits and allowlists (muted, two cards) */}
+      <CardsTwo
+        cards={[
+          {
+            icon: <Wallet className="size-16 text-[#f9363c]" />,
+            title: "Spending cap",
+            body: "A dollar amount per day, per week, or per month. The agent cannot exceed the cap, even with Can Execute. Caps reset on the schedule you set.",
+          },
+          {
+            icon: <ListChecks className="size-16 text-[#f9363c]" />,
+            title: "Address allowlist",
+            body: (
+              <>
+                A list of pre-approved destinations: specific routers, payees,
+                or contracts. Off-list destinations are rejected at the Smart
+                Account layer.
+                <br />
+                <br />
+                The two are orthogonal. Combine them for fully scoped autonomy
+                — for example, Buddy can execute up to $500/month, only to
+                these three addresses.
+              </>
+            ),
+          },
+        ]}
+        description={
+          <>
+            Permission tier sets how an agent can transact. Spending limits
+            and allowlists set what it can transact on.
+            <br />
+            <br />
+            Together, permission tier plus spending limits plus address
+            allowlists form the agent guardrails every transaction is checked
+            against on-chain.
+          </>
+        }
+        title="Spending limits and allowlists"
+        variant="muted"
+      />
+
+      {/* Section-14 — what you can build (muted grid, 5 cards) */}
+      <CardsGrid
+        cards={[
+          {
+            icon: <Cpu className="size-16 text-[#f9363c]" />,
+            title: "Subscription agents",
+            body: "Autonomous bots paying for API credits, RPC endpoints, model inference. Can Execute with a monthly cap means a runaway agent can't drain the wallet.",
+          },
+          {
+            icon: <TrendingUp className="size-16 text-[#f9363c]" />,
+            title: "Trading bots",
+            body: "DEX-routing strategies. An allowlist limits the agent to vetted routers — Jupiter, Phoenix, Raydium — so it can't bridge funds to an attacker-controlled venue.",
+          },
+          {
+            icon: <Sparkles className="size-16 text-[#f9363c]" />,
+            title: "Social and content bots",
+            body: "Agents that tip, reward, or pay creators on Solana. The cap limits the monthly budget; the allowlist restricts to known creator addresses.",
+          },
+          {
+            icon: <BotMessageSquare className="size-16 text-[#f9363c]" />,
+            title: "MCP-driven assistants",
+            body: "Claude, ChatGPT, or any MCP-connected assistant signing transactions on the user's behalf. The user defines the tier and the cap; the assistant operates within them.",
+          },
+          {
+            icon: <Wallet className="size-16 text-[#f9363c]" />,
+            title: "Treasury operations",
+            body: "A DAO or team treasury that delegates routine payouts to an agent (payroll, vendor invoices) while keeping principal signers on the multisig. Can Sign is the natural fit.",
+          },
+        ]}
+        columns={3}
+        description="With scoped, on-chain enforcement, entire categories of agent behavior become safe to deploy without supervision."
+        title="What you can build"
+        variant="muted"
+      />
+
+      {/* Section-16 — security model (muted 2-col + closing statement) */}
+      <CardsGrid
+        cards={[
+          {
+            icon: <ShieldCheck className="size-16 text-[#f9363c]" />,
+            title: "On-chain enforcement",
+            body: (
+              <>
+                Permission tier, cap, and allowlist are all evaluated by the
+                Smart Account&apos;s Anchor program before a transaction
+                lands.
+                <br />
+                <br />
+                There&apos;s no off-chain rule-checker that can be
+                compromised.
+              </>
+            ),
+          },
+          {
+            icon: <Sparkles className="size-16 text-[#f9363c]" />,
+            title: "Squads underneath",
+            body: (
+              <>
+                The Smart Account is a Squads multisig — the most-deployed
+                smart-account framework on Solana — extended with a policy
+                module.
+                <br />
+                <br />
+                The signing model has been battle-tested across thousands of
+                teams.
+              </>
+            ),
+          },
+          {
+            icon: <KeyRound className="size-16 text-[#f9363c]" />,
+            title: "Self-custodial",
+            body: "Each agent holds its own signing key. You hold the Smart Account control key. Neither Loyal nor any third party can move funds without one of those keys.",
+          },
+          {
+            icon: <RotateCcw className="size-16 text-[#f9363c]" />,
+            title: "Revocable",
+            body: "You can revoke an agent's permissions at any time from the wallet UI. The change takes effect on the next transaction.",
+          },
+          {
+            icon: <Eye className="size-16 text-[#f9363c]" />,
+            title: "No hidden execution",
+            body: "Every action the agent takes is a regular Solana transaction with the agent's signature on it. Block explorers see exactly what happened.",
+          },
+        ]}
+        closingStatement="The result is a safe wallet for autonomous agent behavior at scale: every constraint is in code, on-chain, with no off-chain authority Loyal or anyone else can override."
+        columns={2}
+        description="Every constraint is enforced on Solana, not on a Loyal server:"
+        title="Security model"
+        variant="muted"
+      />
+
+      {/* Section-19 — for developers (image-left, text-right hero row) */}
+      <TextImageHero
+        body="The Smart Account SDK ships as a TypeScript package — drop it into a Next.js, Node, or worker codebase and you're proposing transactions inside an hour. Open source under Apache 2.0."
+        cta={{ label: "Read the docs", href: "https://docs.askloyal.com" }}
+        image={{
+          src: "/marketing/smart-accounts/sdk.png",
+          alt: "Loyal Smart Account SDK code snippet",
+        }}
+        layout="text-right"
+        title="For developers"
+      />
+
+      <LandingFaq />
+      <LandingFooter />
+    </main>
+  );
+}

--- a/frontend/src/components/landing-header.tsx
+++ b/frontend/src/components/landing-header.tsx
@@ -2,14 +2,23 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-const navLinks = [
-  { href: "#features", label: "Features" },
-  { href: "#developers", label: "Developers" },
-  { href: "#roadmap", label: "Roadmap" },
-  { href: "#blog", label: "Blog" },
-  { href: "#footer", label: "Links" },
+import {
+  MARKETING_PAGES,
+  type MarketingPage,
+} from "@/features/marketing/registry";
+
+type FeaturesNavItem = { kind: "dropdown"; label: "Features" };
+type AnchorNavItem = { kind: "anchor"; label: string; href: string };
+type NavItem = FeaturesNavItem | AnchorNavItem;
+
+const navLinks: NavItem[] = [
+  { kind: "dropdown", label: "Features" },
+  { kind: "anchor", href: "/#developers", label: "Developers" },
+  { kind: "anchor", href: "/#roadmap", label: "Roadmap" },
+  { kind: "anchor", href: "/#blog", label: "Blog" },
+  { kind: "anchor", href: "/#footer", label: "Links" },
 ];
 
 const neutralPupilOffset = 49 - 61.3298;
@@ -223,16 +232,27 @@ function HeaderContent({
           className="hidden max-w-[800px] items-end p-1 lg:flex"
         >
           <div className="flex items-center">
-            {navLinks.map((link) => (
-              <Link
-                className="flex items-center justify-center rounded-full px-4 py-2 text-center text-[16px] font-normal leading-5 text-white transition duration-150 ease-out hover:-translate-y-0.5 hover:bg-white hover:text-[#f9363c] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white active:translate-y-0"
-                href={link.href}
-                key={link.label}
-                tabIndex={linkTabIndex}
-              >
-                {link.label}
-              </Link>
-            ))}
+            {navLinks.map((link) => {
+              if (link.kind === "dropdown") {
+                return (
+                  <FeaturesDesktopMenu
+                    interactive={interactive}
+                    key={link.label}
+                    pages={MARKETING_PAGES}
+                  />
+                );
+              }
+              return (
+                <Link
+                  className="flex items-center justify-center rounded-full px-4 py-2 text-center text-[16px] font-normal leading-5 text-white transition duration-150 ease-out hover:-translate-y-0.5 hover:bg-white hover:text-[#f9363c] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white active:translate-y-0"
+                  href={link.href}
+                  key={link.label}
+                  tabIndex={linkTabIndex}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
           </div>
         </nav>
       </div>
@@ -341,19 +361,196 @@ function HeaderContent({
         id={menuId}
       >
         <nav aria-label="Mobile navigation" className="grid p-2">
-          {navLinks.map((link) => (
-            <Link
-              className="flex items-center justify-between rounded-[18px] px-4 py-3 text-[20px] font-normal leading-6 transition duration-150 ease-out hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              href={link.href}
-              key={link.label}
-              onClick={closeMenu}
-              tabIndex={isMenuOpen && interactive ? undefined : -1}
-            >
-              {link.label}
-            </Link>
-          ))}
+          {navLinks.map((link) => {
+            if (link.kind === "dropdown") {
+              return (
+                <FeaturesMobileMenu
+                  closeMenu={closeMenu}
+                  isMenuOpen={isMenuOpen && interactive}
+                  key={link.label}
+                  pages={MARKETING_PAGES}
+                />
+              );
+            }
+            return (
+              <Link
+                className="flex items-center justify-between rounded-[18px] px-4 py-3 text-[20px] font-normal leading-6 transition duration-150 ease-out hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                href={link.href}
+                key={link.label}
+                onClick={closeMenu}
+                tabIndex={isMenuOpen && interactive ? undefined : -1}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
       </div>
+    </div>
+  );
+}
+
+function FeaturesDesktopMenu({
+  interactive,
+  pages,
+}: {
+  interactive: boolean;
+  pages: readonly MarketingPage[];
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeTimerRef = useRef<number | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const clearCloseTimer = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const open = () => {
+    clearCloseTimer();
+    setIsOpen(true);
+  };
+
+  const scheduleClose = () => {
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => setIsOpen(false), 140);
+  };
+
+  useEffect(() => () => clearCloseTimer(), []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen]);
+
+  const hasPages = pages.length > 0;
+
+  return (
+    <div
+      className="relative"
+      onBlur={(e) => {
+        if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
+          scheduleClose();
+        }
+      }}
+      onFocus={open}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+      ref={containerRef}
+    >
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        className="flex items-center justify-center rounded-full px-4 py-2 text-center text-[16px] font-normal leading-5 text-white transition duration-150 ease-out hover:-translate-y-0.5 hover:bg-white hover:text-[#f9363c] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white active:translate-y-0"
+        tabIndex={interactive ? undefined : -1}
+        type="button"
+      >
+        Features
+      </button>
+      <div
+        className={`absolute left-0 top-full z-50 mt-2 w-[320px] overflow-hidden rounded-3xl bg-white p-2 text-black shadow-[0_18px_60px_rgba(0,0,0,0.18)] transition duration-150 ease-out ${
+          isOpen && interactive
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none -translate-y-2 opacity-0"
+        }`}
+        role="menu"
+      >
+        {hasPages ? (
+          pages.map((page) => (
+            <Link
+              className="flex flex-col gap-1 rounded-[18px] px-4 py-3 transition duration-150 ease-out hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f9363c]"
+              href={`/${page.slug}`}
+              key={page.slug}
+              onClick={() => setIsOpen(false)}
+              role="menuitem"
+              tabIndex={isOpen && interactive ? undefined : -1}
+            >
+              <span className="text-[16px] font-medium leading-5">
+                {page.title}
+              </span>
+              {page.description ? (
+                <span className="text-[14px] leading-[1.3] text-black/60">
+                  {page.description}
+                </span>
+              ) : null}
+            </Link>
+          ))
+        ) : (
+          <p className="px-4 py-3 text-[14px] leading-[1.3] text-black/60">
+            No marketing pages yet.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FeaturesMobileMenu({
+  isMenuOpen,
+  closeMenu,
+  pages,
+}: {
+  isMenuOpen: boolean;
+  closeMenu: () => void;
+  pages: readonly MarketingPage[];
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasPages = pages.length > 0;
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      setIsExpanded(false);
+    }
+  }, [isMenuOpen]);
+
+  return (
+    <div>
+      <button
+        aria-expanded={isExpanded}
+        className="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-[20px] font-normal leading-6 text-white transition duration-150 ease-out hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        disabled={!hasPages}
+        onClick={() => setIsExpanded((prev) => !prev)}
+        tabIndex={isMenuOpen ? undefined : -1}
+        type="button"
+      >
+        <span>Features</span>
+        <span
+          aria-hidden="true"
+          className={`text-[20px] leading-none transition-transform duration-150 ${isExpanded ? "rotate-45" : "rotate-0"}`}
+        >
+          +
+        </span>
+      </button>
+      {hasPages && isExpanded ? (
+        <div className="ml-2 grid gap-1 border-l border-white/20 pl-3">
+          {pages.map((page) => (
+            <Link
+              className="flex flex-col gap-1 rounded-[14px] px-3 py-2 text-[16px] font-normal leading-5 transition duration-150 ease-out hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              href={`/${page.slug}`}
+              key={page.slug}
+              onClick={closeMenu}
+              tabIndex={isMenuOpen ? undefined : -1}
+            >
+              <span>{page.title}</span>
+              {page.description ? (
+                <span className="text-[14px] leading-[1.3] text-white/60">
+                  {page.description}
+                </span>
+              ) : null}
+            </Link>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/marketing/blocks/banner-cards-two.tsx
+++ b/frontend/src/features/marketing/blocks/banner-cards-two.tsx
@@ -1,0 +1,76 @@
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+import type { CardsTwoCard } from "@/features/marketing/blocks/cards-two";
+
+export type BannerCardsTwoProps = {
+  title: string;
+  description: ReactNode;
+  banner: { src: string; alt: string; bg?: string };
+  cards: [CardsTwoCard, CardsTwoCard];
+};
+
+export function BannerCardsTwo({
+  title,
+  description,
+  banner,
+  cards,
+}: BannerCardsTwoProps) {
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-marketing-block="banner-cards-two"
+    >
+      <div className="flex w-full max-w-[1560px] flex-col gap-16 px-6 py-20 lg:gap-[96px] lg:px-6 lg:py-[128px]">
+        <div className="grid grid-cols-1 items-center gap-10 lg:grid-cols-12 lg:gap-x-6">
+          <div className="flex flex-col gap-8 lg:col-span-5 lg:pr-10">
+            <h2 className="text-[48px] font-semibold leading-none tracking-[-0.02em] text-black lg:text-[72px] lg:tracking-[-1.44px]">
+              {title}
+            </h2>
+            <div className="text-[18px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+              {description}
+            </div>
+          </div>
+          <div
+            className="relative aspect-[4/3] w-full overflow-hidden rounded-3xl lg:col-span-6 lg:col-start-7"
+            style={banner.bg ? { background: banner.bg } : undefined}
+          >
+            <Image
+              alt={banner.alt}
+              className="object-cover"
+              fill
+              sizes="(min-width: 1024px) 50vw, 100vw"
+              src={banner.src}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-12">
+          {cards.map((card, i) => (
+            <div
+              className="flex flex-col gap-6"
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+              key={i}
+            >
+              {card.icon ? (
+                <div
+                  aria-hidden="true"
+                  className="flex size-[64px] items-center justify-center"
+                >
+                  {card.icon}
+                </div>
+              ) : null}
+              <div className="flex flex-col gap-4 lg:pr-8">
+                <h3 className="max-w-[400px] text-[24px] font-semibold leading-[1.2] tracking-[-0.02em] text-black lg:text-[32px] lg:tracking-[-0.64px]">
+                  {card.title}
+                </h3>
+                <div className="max-w-[500px] text-[16px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+                  {card.body}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/marketing/blocks/cards-grid.tsx
+++ b/frontend/src/features/marketing/blocks/cards-grid.tsx
@@ -1,0 +1,128 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type CardsGridVariant = "bare" | "muted";
+export type CardsGridColumns = 2 | 3;
+
+export type CardsGridCard = {
+  icon?: ReactNode;
+  title: string;
+  body: ReactNode;
+};
+
+export type CardsGridProps = {
+  title: string;
+  description?: ReactNode;
+  variant: CardsGridVariant;
+  cards: CardsGridCard[];
+  columns?: CardsGridColumns;
+  closingStatement?: ReactNode;
+  compactBottom?: boolean;
+};
+
+export function CardsGrid({
+  title,
+  description,
+  variant,
+  cards,
+  columns = 3,
+  closingStatement,
+  compactBottom = false,
+}: CardsGridProps) {
+  const hasFiveCards = cards.length === 5;
+  const gridColsClass = columns === 2 ? "md:grid-cols-2" : "md:grid-cols-3";
+  const verticalPadding = compactBottom
+    ? "py-20 lg:pb-[96px] lg:pt-[128px]"
+    : "py-20 lg:py-[128px]";
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-columns={columns}
+      data-marketing-block="cards-grid"
+      data-variant={variant}
+    >
+      <div
+        className={cn(
+          "flex w-full max-w-[1560px] flex-col px-6 lg:px-6",
+          verticalPadding
+        )}
+      >
+        <div className="grid grid-cols-1 gap-5 pb-12 md:grid-cols-2 md:items-start md:gap-x-6 md:pb-16">
+          <h2 className="text-[40px] font-semibold leading-none tracking-[-0.02em] text-black md:max-w-[600px] md:text-[56px] md:leading-[0.95] md:tracking-[-1.12px] lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+            {title}
+          </h2>
+          {description ? (
+            <div className="text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:max-w-[700px] md:pr-10 md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]">
+              {description}
+            </div>
+          ) : (
+            <div aria-hidden="true" className="hidden md:block" />
+          )}
+        </div>
+        <div
+          className={cn(
+            "grid grid-cols-1 md:gap-x-6",
+            gridColsClass,
+            variant === "bare" ? "gap-10 md:gap-y-12" : "gap-6"
+          )}
+        >
+          {cards.map((card, i) => (
+            <CardView
+              card={card}
+              forceCol3={columns === 3 && hasFiveCards && i === 4}
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+              key={i}
+              variant={variant}
+            />
+          ))}
+          {closingStatement ? (
+            <div className="flex items-end pr-10">
+              <p className="max-w-[700px] text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]">
+                {closingStatement}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CardView({
+  card,
+  variant,
+  forceCol3,
+}: {
+  card: CardsGridCard;
+  variant: CardsGridVariant;
+  forceCol3: boolean;
+}) {
+  const wrapperClass = cn(
+    variant === "muted"
+      ? "flex flex-col gap-6 rounded-3xl bg-[#f5f5f5] p-8"
+      : "flex flex-col gap-6",
+    forceCol3 ? "md:col-start-3" : ""
+  );
+
+  return (
+    <div className={wrapperClass}>
+      {card.icon ? (
+        <div
+          aria-hidden="true"
+          className="flex size-[64px] items-center justify-center"
+        >
+          {card.icon}
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-4 md:pr-8">
+        <h3 className="max-w-[400px] text-[24px] font-semibold leading-[1.2] tracking-[-0.02em] text-black md:text-[28px] md:tracking-[-0.56px] lg:text-[32px] lg:tracking-[-0.64px]">
+          {card.title}
+        </h3>
+        <div className="max-w-[500px] text-[16px] leading-[1.2] tracking-[-0.02em] text-black/60 md:text-[20px] md:tracking-[-0.4px] lg:text-[24px] lg:tracking-[-0.48px]">
+          {card.body}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/marketing/blocks/cards-three-image.tsx
+++ b/frontend/src/features/marketing/blocks/cards-three-image.tsx
@@ -1,0 +1,72 @@
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+export type CardsThreeImageCard = {
+  image: { src: string; alt: string; bg?: string };
+  title: string;
+  body: ReactNode;
+};
+
+export type CardsThreeImageProps = {
+  title: string;
+  description?: ReactNode;
+  cards: [CardsThreeImageCard, CardsThreeImageCard, CardsThreeImageCard];
+};
+
+export function CardsThreeImage({
+  title,
+  description,
+  cards,
+}: CardsThreeImageProps) {
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-marketing-block="cards-three-image"
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-20 lg:px-6 lg:py-[96px]">
+        <div className="flex flex-col gap-5 pb-12 lg:flex-row lg:items-start lg:gap-5 lg:pb-16">
+          <h2 className="max-w-[600px] text-[40px] font-semibold leading-none tracking-[-0.02em] text-black lg:flex-1 lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+            {title}
+          </h2>
+          {description ? (
+            <div className="text-[20px] leading-[1.2] tracking-[-0.02em] text-black lg:max-w-[700px] lg:flex-1 lg:pr-10 lg:text-[32px] lg:tracking-[-0.64px]">
+              {description}
+            </div>
+          ) : (
+            <div aria-hidden="true" className="hidden lg:block lg:flex-1" />
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-10 lg:grid-cols-3 lg:gap-x-6 lg:gap-y-12">
+          {cards.map((card, i) => (
+            <div
+              className="flex flex-col gap-6"
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+              key={i}
+            >
+              <div
+                className="relative aspect-square w-full overflow-hidden rounded-3xl"
+                style={card.image.bg ? { background: card.image.bg } : undefined}
+              >
+                <Image
+                  alt={card.image.alt}
+                  className="object-cover"
+                  fill
+                  sizes="(min-width: 1024px) 33vw, 100vw"
+                  src={card.image.src}
+                />
+              </div>
+              <div className="flex flex-col gap-4 lg:pr-8">
+                <h3 className="max-w-[400px] text-[24px] font-semibold leading-[1.2] tracking-[-0.02em] text-black lg:text-[32px] lg:tracking-[-0.64px]">
+                  {card.title}
+                </h3>
+                <div className="max-w-[600px] text-[16px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+                  {card.body}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/marketing/blocks/cards-three.tsx
+++ b/frontend/src/features/marketing/blocks/cards-three.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type CardsThreeVariant = "bare" | "muted" | "bold";
+export type CardTone = "dark" | "light" | "red";
+
+export type CardsThreeCard = {
+  icon?: ReactNode;
+  title: string;
+  body: ReactNode;
+  tone?: CardTone;
+};
+
+export type CardsThreeProps = {
+  title: string;
+  description?: ReactNode;
+  variant: CardsThreeVariant;
+  cards: CardsThreeCard[];
+};
+
+const TONE_STYLES: Record<
+  CardTone,
+  { bg: string; title: string; body: string }
+> = {
+  dark: { bg: "bg-black", title: "text-white", body: "text-white/60" },
+  light: { bg: "bg-[#f5f5f5]", title: "text-black", body: "text-black/60" },
+  red: { bg: "bg-[#f9363c]", title: "text-white", body: "text-white/80" },
+};
+
+const DEFAULT_BOLD_TONES: readonly CardTone[] = ["dark", "light", "red"];
+
+const VARIANT_GAP_Y: Record<CardsThreeVariant, string> = {
+  bare: "md:gap-y-12",
+  muted: "md:gap-y-6",
+  bold: "md:gap-y-6",
+};
+
+export function CardsThree({
+  title,
+  description,
+  variant,
+  cards,
+}: CardsThreeProps) {
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-marketing-block="cards-three"
+      data-variant={variant}
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-20 lg:px-6 lg:py-[128px]">
+        <div className="grid grid-cols-1 gap-5 pb-12 md:grid-cols-2 md:items-start md:gap-x-6 md:pb-16">
+          <h2 className="text-[40px] font-semibold leading-none tracking-[-0.02em] text-black md:max-w-[600px] md:text-[56px] md:leading-[0.95] md:tracking-[-1.12px] lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+            {title}
+          </h2>
+          {description ? (
+            <div className="text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:max-w-[700px] md:pr-10 md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]">
+              {description}
+            </div>
+          ) : (
+            <div aria-hidden="true" className="hidden md:block" />
+          )}
+        </div>
+        <div
+          className={cn(
+            "grid grid-cols-1 gap-6 md:grid-cols-3 md:gap-x-6",
+            VARIANT_GAP_Y[variant]
+          )}
+        >
+          {cards.map((card, i) => (
+            <CardView
+              card={card}
+              index={i}
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+              key={i}
+              variant={variant}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CardView({
+  card,
+  variant,
+  index,
+}: {
+  card: CardsThreeCard;
+  variant: CardsThreeVariant;
+  index: number;
+}) {
+  if (variant === "bare") {
+    return (
+      <CardInner
+        bodyClassName="text-black/60"
+        body={card.body}
+        icon={card.icon}
+        titleClassName="text-black"
+        title={card.title}
+      />
+    );
+  }
+
+  if (variant === "muted") {
+    return (
+      <div className="flex flex-col gap-6 rounded-3xl bg-[#f5f5f5] p-8">
+        <CardInner
+          bodyClassName="text-black/60"
+          body={card.body}
+          icon={card.icon}
+          titleClassName="text-black"
+          title={card.title}
+        />
+      </div>
+    );
+  }
+
+  const tone = card.tone ?? DEFAULT_BOLD_TONES[index] ?? "dark";
+  const styles = TONE_STYLES[tone];
+  return (
+    <div
+      className={cn(
+        "flex flex-col justify-between gap-6 rounded-3xl p-8 lg:h-[500px]",
+        styles.bg
+      )}
+    >
+      <CardInner
+        bodyClassName={styles.body}
+        body={card.body}
+        icon={card.icon}
+        titleClassName={styles.title}
+        title={card.title}
+      />
+    </div>
+  );
+}
+
+function CardInner({
+  icon,
+  title,
+  body,
+  titleClassName,
+  bodyClassName,
+}: {
+  icon?: ReactNode;
+  title: string;
+  body: ReactNode;
+  titleClassName: string;
+  bodyClassName: string;
+}) {
+  return (
+    <>
+      {icon ? (
+        <div
+          aria-hidden="true"
+          className="flex size-[64px] items-center justify-center"
+        >
+          {icon}
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-4 md:pr-8">
+        <h3
+          className={cn(
+            "max-w-[400px] text-[24px] font-semibold leading-[1.2] tracking-[-0.02em] md:text-[28px] md:tracking-[-0.56px] lg:text-[32px] lg:tracking-[-0.64px]",
+            titleClassName
+          )}
+        >
+          {title}
+        </h3>
+        <div
+          className={cn(
+            "max-w-[400px] text-[16px] leading-[1.2] tracking-[-0.02em] md:text-[20px] md:tracking-[-0.4px] lg:text-[24px] lg:tracking-[-0.48px]",
+            bodyClassName
+          )}
+        >
+          {body}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/features/marketing/blocks/cards-two.tsx
+++ b/frontend/src/features/marketing/blocks/cards-two.tsx
@@ -1,0 +1,200 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type CardsTwoVariant = "bare" | "muted";
+export type CardsTwoLayout = "stacked" | "inline";
+export type CardsTwoTitlePosition = "left" | "right";
+
+export type CardsTwoCard = {
+  icon?: ReactNode;
+  title: string;
+  body: ReactNode;
+};
+
+export type CardsTwoProps = {
+  title: string;
+  description?: ReactNode;
+  layout?: CardsTwoLayout;
+  titlePosition?: CardsTwoTitlePosition;
+  variant: CardsTwoVariant;
+  cards: [CardsTwoCard, CardsTwoCard];
+};
+
+export function CardsTwo({
+  title,
+  description,
+  layout = "stacked",
+  titlePosition = "left",
+  variant,
+  cards,
+}: CardsTwoProps) {
+  if (layout === "inline") {
+    return (
+      <InlineCardsTwo
+        cards={cards}
+        description={description}
+        title={title}
+        variant={variant}
+      />
+    );
+  }
+  return (
+    <StackedCardsTwo
+      cards={cards}
+      description={description}
+      title={title}
+      titlePosition={titlePosition}
+      variant={variant}
+    />
+  );
+}
+
+function StackedCardsTwo({
+  title,
+  description,
+  titlePosition,
+  variant,
+  cards,
+}: {
+  title: string;
+  description?: ReactNode;
+  titlePosition: CardsTwoTitlePosition;
+  variant: CardsTwoVariant;
+  cards: [CardsTwoCard, CardsTwoCard];
+}) {
+  const heading = (
+    <h2 className="text-[40px] font-semibold leading-none tracking-[-0.02em] text-black md:max-w-[600px] md:text-[56px] md:leading-[0.95] md:tracking-[-1.12px] lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+      {title}
+    </h2>
+  );
+  const descriptionBlock = description ? (
+    <div className="text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:max-w-[700px] md:pr-10 md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]">
+      {description}
+    </div>
+  ) : (
+    <div aria-hidden="true" className="hidden md:block" />
+  );
+
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-layout="stacked"
+      data-marketing-block="cards-two"
+      data-variant={variant}
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-20 lg:px-6 lg:py-[128px]">
+        <div className="grid grid-cols-1 gap-5 pb-12 md:grid-cols-2 md:items-start md:gap-x-6 md:pb-16">
+          {titlePosition === "right" ? (
+            <>
+              {descriptionBlock}
+              {heading}
+            </>
+          ) : (
+            <>
+              {heading}
+              {descriptionBlock}
+            </>
+          )}
+        </div>
+        <div
+          className={cn(
+            "grid grid-cols-1 md:grid-cols-2 md:gap-x-6",
+            variant === "bare" ? "gap-10 md:gap-y-12" : "gap-6"
+          )}
+        >
+          {cards.map((card, i) => (
+            <CardView
+              card={card}
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+              key={i}
+              variant={variant}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function InlineCardsTwo({
+  title,
+  description,
+  variant,
+  cards,
+}: {
+  title: string;
+  description?: ReactNode;
+  variant: CardsTwoVariant;
+  cards: [CardsTwoCard, CardsTwoCard];
+}) {
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-layout="inline"
+      data-marketing-block="cards-two"
+      data-variant={variant}
+    >
+      <div className="flex w-full max-w-[1560px] flex-col gap-10 px-6 py-20 md:grid md:grid-cols-3 md:items-stretch md:gap-6 lg:px-6 lg:py-[128px]">
+        <div className="flex flex-col gap-6 md:justify-center md:pr-10">
+          <h2 className="text-[40px] font-semibold leading-none tracking-[-0.02em] text-black md:max-w-[600px] md:text-[48px] md:leading-[0.95] md:tracking-[-0.96px] lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+            {title}
+          </h2>
+          {description ? (
+            <div className="text-[18px] leading-[1.2] tracking-[-0.02em] text-black/60 md:text-[20px] md:tracking-[-0.4px] lg:text-[24px] lg:tracking-[-0.48px]">
+              {description}
+            </div>
+          ) : null}
+        </div>
+        {cards.map((card, i) => (
+          <CardView
+            card={card}
+            // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful
+            key={i}
+            stretch
+            variant={variant}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CardView({
+  card,
+  variant,
+  stretch,
+}: {
+  card: CardsTwoCard;
+  variant: CardsTwoVariant;
+  stretch?: boolean;
+}) {
+  const wrapperClass =
+    variant === "muted"
+      ? cn(
+          "flex flex-col gap-6 rounded-3xl bg-[#f5f5f5] p-8",
+          stretch ? "lg:flex-1" : ""
+        )
+      : cn("flex flex-col gap-6", stretch ? "lg:flex-1" : "");
+
+  return (
+    <div className={wrapperClass}>
+      {card.icon ? (
+        <div
+          aria-hidden="true"
+          className="flex size-[64px] items-center justify-center"
+        >
+          {card.icon}
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-4 lg:pr-8">
+        <h3 className="max-w-[400px] text-[24px] font-semibold leading-[1.2] tracking-[-0.02em] text-black lg:text-[32px] lg:tracking-[-0.64px]">
+          {card.title}
+        </h3>
+        <div className="max-w-[500px] text-[16px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+          {card.body}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/marketing/blocks/hero.tsx
+++ b/frontend/src/features/marketing/blocks/hero.tsx
@@ -1,0 +1,175 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+export type HeroTone = "dark" | "light" | "white" | "red";
+
+export type HeroProps = {
+  tone: HeroTone;
+  title: string;
+  body: string;
+  cta: { label: string; href: string };
+  image: { src: string; alt: string };
+};
+
+const TONE_STYLES: Record<
+  HeroTone,
+  {
+    section: string;
+    title: string;
+    body: string;
+    button: string;
+    imageBg: string;
+  }
+> = {
+  dark: {
+    section: "bg-black",
+    title: "text-white",
+    body: "text-white/60",
+    button: "bg-white text-black",
+    imageBg: "bg-[#f5f5f5]",
+  },
+  light: {
+    section: "bg-[#f5f5f5]",
+    title: "text-black",
+    body: "text-black/60",
+    button: "bg-black text-white",
+    imageBg: "bg-white",
+  },
+  white: {
+    section: "bg-white",
+    title: "text-black",
+    body: "text-black/60",
+    button: "bg-black text-white",
+    imageBg: "bg-[#f5f5f5]",
+  },
+  red: {
+    section: "bg-[#f9363c]",
+    title: "text-white",
+    body: "text-white",
+    button: "bg-black text-white",
+    imageBg: "bg-white/10",
+  },
+};
+
+export function Hero(props: HeroProps) {
+  if (props.tone === "red") {
+    return <HeroSplit {...props} />;
+  }
+  return <HeroDefault {...props} />;
+}
+
+function HeroDefault({ tone, title, body, cta, image }: HeroProps) {
+  const styles = TONE_STYLES[tone];
+  return (
+    <section
+      className={cn("flex w-full justify-center", styles.section)}
+      data-marketing-block="hero"
+      data-tone={tone}
+    >
+      <div className="grid w-full max-w-[1560px] grid-cols-1 items-center gap-y-12 px-6 py-16 lg:grid-cols-12 lg:gap-x-6 lg:py-[120px]">
+        <div className="flex flex-col gap-12 lg:col-span-5">
+          <div className="flex flex-col gap-8">
+            <h1
+              className={cn(
+                "text-[48px] font-semibold leading-none tracking-[-0.02em] lg:text-[72px] lg:tracking-[-1.44px]",
+                styles.title
+              )}
+            >
+              {title}
+            </h1>
+            <p
+              className={cn(
+                "text-[18px] leading-[1.2] tracking-[-0.02em] lg:max-w-[517px] lg:text-[24px] lg:tracking-[-0.48px]",
+                styles.body
+              )}
+            >
+              {body}
+            </p>
+          </div>
+          <Link
+            className={cn(
+              "inline-flex h-[52px] w-fit items-center justify-center rounded-full px-6 text-[20px] font-medium leading-5 transition-transform duration-150 ease-out hover:-translate-y-0.5 active:translate-y-0 lg:text-[24px]",
+              styles.button
+            )}
+            href={cta.href}
+          >
+            {cta.label}
+          </Link>
+        </div>
+        <div
+          className={cn(
+            "relative aspect-square w-full overflow-hidden rounded-3xl lg:col-span-6 lg:col-start-7 lg:aspect-auto lg:h-[732px]",
+            styles.imageBg
+          )}
+        >
+          <Image
+            alt={image.alt}
+            className="object-cover"
+            fill
+            sizes="(min-width: 1024px) 50vw, 100vw"
+            src={image.src}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HeroSplit({ title, body, cta, image }: HeroProps) {
+  const styles = TONE_STYLES.red;
+  return (
+    <section
+      className={cn("flex w-full justify-center", styles.section)}
+      data-marketing-block="hero"
+      data-tone="red"
+    >
+      <div className="grid w-full max-w-[1560px] grid-cols-1 items-center gap-y-12 px-6 py-16 lg:grid-cols-12 lg:gap-x-6 lg:py-[120px]">
+        <div className="flex flex-col justify-center lg:col-span-4">
+          <h1
+            className={cn(
+              "max-w-[420px] text-[44px] font-semibold leading-none tracking-[-0.02em] lg:text-[64px] lg:tracking-[-1.28px]",
+              styles.title
+            )}
+          >
+            {title}
+          </h1>
+        </div>
+        <div
+          className={cn(
+            "relative aspect-[3/4] w-full overflow-hidden rounded-3xl lg:col-span-4 lg:col-start-5 lg:aspect-auto lg:h-[600px]",
+            styles.imageBg
+          )}
+        >
+          <Image
+            alt={image.alt}
+            className="object-cover"
+            fill
+            sizes="(min-width: 1024px) 33vw, 100vw"
+            src={image.src}
+          />
+        </div>
+        <div className="flex flex-col gap-8 lg:col-span-3 lg:col-start-10">
+          <p
+            className={cn(
+              "text-[18px] leading-[1.1] tracking-[-0.02em] lg:max-w-[300px] lg:text-[20px] lg:tracking-[-0.4px]",
+              styles.body
+            )}
+          >
+            {body}
+          </p>
+          <Link
+            className={cn(
+              "inline-flex w-fit items-center justify-center rounded-full px-5 py-3 text-[16px] font-normal leading-5 transition-transform duration-150 ease-out hover:-translate-y-0.5 active:translate-y-0",
+              styles.button
+            )}
+            href={cta.href}
+          >
+            {cta.label}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/marketing/blocks/section.tsx
+++ b/frontend/src/features/marketing/blocks/section.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type SectionCardSize = "lg" | "md";
+
+export type SectionCard = {
+  size: SectionCardSize;
+  body: ReactNode;
+};
+
+export type SectionProps = {
+  title: string;
+  description?: ReactNode;
+  cards: [SectionCard, SectionCard];
+};
+
+const CARD_STYLES: Record<SectionCardSize, string> = {
+  lg: "text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:max-w-[700px] md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]",
+  md: "text-[16px] leading-[1.2] tracking-[-0.02em] text-black/60 md:max-w-[600px] md:text-[20px] md:tracking-[-0.4px] lg:text-[24px] lg:tracking-[-0.48px]",
+};
+
+export function Section({ title, description, cards }: SectionProps) {
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-marketing-block="section"
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-16 lg:px-6 lg:py-[96px]">
+        <div className="grid grid-cols-1 gap-5 pb-12 md:grid-cols-2 md:items-start md:gap-x-6 md:pb-16">
+          <h2 className="text-[40px] font-semibold leading-none tracking-[-0.02em] text-black md:max-w-[600px] md:text-[56px] md:leading-[0.95] md:tracking-[-1.12px] lg:text-[64px] lg:leading-[64px] lg:tracking-[-1.28px]">
+            {title}
+          </h2>
+          {description ? (
+            <div className="text-[20px] leading-[1.2] tracking-[-0.02em] text-black md:max-w-[700px] md:pr-10 md:text-[24px] md:tracking-[-0.48px] lg:text-[32px] lg:tracking-[-0.64px]">
+              {description}
+            </div>
+          ) : (
+            <div aria-hidden="true" className="hidden md:block" />
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-2 md:gap-x-6">
+          {cards.map((card, i) => (
+            <div
+              className="flex flex-col md:pr-10"
+              data-card-size={card.size}
+              // biome-ignore lint/suspicious/noArrayIndexKey: cards are positionally meaningful and length-fixed
+              key={i}
+            >
+              <p className={cn("font-normal", CARD_STYLES[card.size])}>
+                {card.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/marketing/blocks/text-image.tsx
+++ b/frontend/src/features/marketing/blocks/text-image.tsx
@@ -1,0 +1,141 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextImageLayout = "text-left" | "text-right";
+
+export type TextImageMedia = {
+  src: string;
+  alt: string;
+  bg?: string;
+};
+
+export type TextImageHeroProps = {
+  layout?: TextImageLayout;
+  title: string;
+  body: ReactNode;
+  cta: { label: string; href: string };
+  image: TextImageMedia;
+};
+
+export function TextImageHero({
+  layout = "text-left",
+  title,
+  body,
+  cta,
+  image,
+}: TextImageHeroProps) {
+  const isReverse = layout === "text-right";
+  const imageStyle: CSSProperties = {
+    background: image.bg ?? "#f5f5f5",
+  };
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-layout={layout}
+      data-marketing-block="text-image-hero"
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-20 lg:px-6 lg:py-[128px]">
+        <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-12 lg:gap-x-6">
+          <div
+            className={cn(
+              "flex flex-col gap-12 lg:col-span-4 lg:row-start-1 lg:pr-10",
+              isReverse ? "lg:col-start-9" : "lg:col-start-1"
+            )}
+          >
+            <div className="flex flex-col gap-8">
+              <h2 className="text-[48px] font-semibold leading-none tracking-[-0.02em] text-black lg:text-[72px] lg:tracking-[-1.44px]">
+                {title}
+              </h2>
+              <p className="text-[18px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+                {body}
+              </p>
+            </div>
+            <Link
+              className="inline-flex h-[52px] w-fit items-center justify-center rounded-full bg-black px-6 text-[20px] font-medium leading-5 text-white transition-transform duration-150 ease-out hover:-translate-y-0.5 active:translate-y-0 lg:text-[24px]"
+              href={cta.href}
+            >
+              {cta.label}
+            </Link>
+          </div>
+          <div
+            className={cn(
+              "relative aspect-[4/3] w-full overflow-hidden rounded-3xl lg:col-span-7 lg:row-start-1",
+              isReverse ? "lg:col-start-1" : "lg:col-start-6"
+            )}
+            style={imageStyle}
+          >
+            <Image
+              alt={image.alt}
+              className="object-cover"
+              fill
+              sizes="(min-width: 1024px) 58vw, 100vw"
+              src={image.src}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export type TextImageStatementProps = {
+  layout?: TextImageLayout;
+  eyebrow: string;
+  statement: ReactNode;
+  image: TextImageMedia;
+};
+
+export function TextImageStatement({
+  layout = "text-left",
+  eyebrow,
+  statement,
+  image,
+}: TextImageStatementProps) {
+  const isReverse = layout === "text-right";
+  const imageStyle: CSSProperties = {
+    background: image.bg ?? "#f5f5f5",
+  };
+  return (
+    <section
+      className="flex w-full justify-center bg-white"
+      data-layout={layout}
+      data-marketing-block="text-image-statement"
+    >
+      <div className="flex w-full max-w-[1560px] flex-col px-6 py-20 lg:px-6 lg:py-[128px]">
+        <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-12 lg:gap-x-6">
+          <div
+            className={cn(
+              "flex flex-col gap-4 lg:col-span-4 lg:row-start-1 lg:pr-10",
+              isReverse ? "lg:col-start-9" : "lg:col-start-1"
+            )}
+          >
+            <p className="text-[18px] leading-[1.1] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+              {eyebrow}
+            </p>
+            <p className="text-[24px] font-medium leading-[1.1] tracking-[-0.02em] text-black lg:text-[32px] lg:tracking-[-0.64px]">
+              {statement}
+            </p>
+          </div>
+          <div
+            className={cn(
+              "relative aspect-[4/3] w-full overflow-hidden rounded-3xl lg:col-span-7 lg:row-start-1",
+              isReverse ? "lg:col-start-1" : "lg:col-start-6"
+            )}
+            style={imageStyle}
+          >
+            <Image
+              alt={image.alt}
+              className="object-cover"
+              fill
+              sizes="(min-width: 1024px) 58vw, 100vw"
+              src={image.src}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/marketing/registry.ts
+++ b/frontend/src/features/marketing/registry.ts
@@ -1,0 +1,23 @@
+export type MarketingPage = {
+  /** URL slug (used in /<slug>). No leading slash. */
+  slug: string;
+  /** Display name shown in the header Features dropdown. */
+  title: string;
+  /** One-line subtitle shown under the title in the dropdown (optional). */
+  description?: string;
+};
+
+/**
+ * Every marketing page lives at the root URL (askloyal.com/<slug>) and is
+ * registered here so the Features dropdown in the header can list it.
+ *
+ * Add an entry whenever you create a new src/app/<slug>/page.tsx via the
+ * /marketing-page skill. Order in this array == order in the dropdown.
+ */
+export const MARKETING_PAGES: MarketingPage[] = [
+  {
+    slug: "smart-accounts",
+    title: "Smart Accounts",
+    description: "Scoped on-chain guardrails for AI agents",
+  },
+];


### PR DESCRIPTION
## Summary
- Adds 8 reusable marketing block components under `src/features/marketing/blocks/` that cover all section variants (Hero, Section, CardsTwo, CardsThree, CardsThreeImage, CardsGrid, BannerCardsTwo, TextImage).
- Marketing pages live at root URLs (e.g. `/smart-accounts`) and self-register via `src/features/marketing/registry.ts` so the header Features menu lists them.
- Header "Features" anchor becomes a hover/touch dropdown; remaining nav anchors now use `/#section` so they navigate from any page. Sample page at `/smart-accounts` exercises 7 of the block families end-to-end.
- Wires Geist Sans to Tailwind's `font-sans` utility globally via `@theme`.

## Test plan
- [ ] `cd frontend && bun dev` and verify `/` renders unchanged with the Features dropdown showing "Smart Accounts"
- [ ] Visit `/smart-accounts` and confirm Hero / sections / FAQ / footer all render with Geist
- [ ] From `/smart-accounts`, click Developers / Roadmap / Blog / Links and confirm they navigate back to the home anchors
- [ ] Resize to ~800px and confirm title-left + text-right sections still render as 2 columns