### PR TITLE
feat(push-incoming-transfers): add Helius enhanced webhook backend

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -31,6 +31,10 @@ JUPITER_API_KEY=
 IRYS_SOLANA_KEY=
 DEPLOYMENT_PK=
 PRIVATE_MAINNET_RPC_URL=https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com
+# Helius API key (Daggerzest - mobile project); used server-side for webhook CRUD
+HELIUS_API_KEY=
+# Shared secret sent as Helius webhook authHeader; >=32 random bytes
+HELIUS_WEBHOOK_SECRET=
 # Optional but recommended for encrypted content (base64-encoded 32-byte key)
 MESSAGE_ENCRYPTION_KEY=
 

--- a/app/drizzle/0023_nappy_hydra.sql
+++ b/app/drizzle/0023_nappy_hydra.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "helius_webhook_addresses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"webhook_id" uuid NOT NULL,
+	"address" text NOT NULL,
+	"wallet_public_key" text NOT NULL,
+	"kind" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "helius_webhook_deliveries" (
+	"signature" text NOT NULL,
+	"wallet_public_key" text NOT NULL,
+	"processed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "helius_webhook_deliveries_signature_wallet_public_key_pk" PRIMARY KEY("signature","wallet_public_key")
+);
+--> statement-breakpoint
+CREATE TABLE "helius_webhooks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"helius_webhook_id" text NOT NULL,
+	"webhook_url" text NOT NULL,
+	"generation" integer DEFAULT 0 NOT NULL,
+	"address_count" integer DEFAULT 0 NOT NULL,
+	"archived_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "helius_webhook_addresses" ADD CONSTRAINT "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk" FOREIGN KEY ("webhook_id") REFERENCES "public"."helius_webhooks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "helius_webhook_addresses_address_unique" ON "helius_webhook_addresses" USING btree ("address");--> statement-breakpoint
+CREATE INDEX "helius_webhook_addresses_wallet_idx" ON "helius_webhook_addresses" USING btree ("wallet_public_key");--> statement-breakpoint
+CREATE INDEX "helius_webhook_addresses_webhook_idx" ON "helius_webhook_addresses" USING btree ("webhook_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "helius_webhooks_helius_id_unique" ON "helius_webhooks" USING btree ("helius_webhook_id");

--- a/app/drizzle/meta/0023_snapshot.json
+++ b/app/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,4553 @@
+{
+  "id": "3a0fa8fb-29fc-4d92-a7df-06f58a2098a8",
+  "prevId": "b53e1caa-dabc-44ec-8051-6501fd2b2d96",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_chat_messages": {
+      "name": "app_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chat_messages_chat_client_message_uidx": {
+          "name": "app_chat_messages_chat_client_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"client_message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_role_turn_uidx": {
+          "name": "app_chat_messages_chat_role_turn_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"turn_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_created_idx": {
+          "name": "app_chat_messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chat_messages_chat_id_app_chats_id_fk": {
+          "name": "app_chat_messages_chat_id_app_chats_id_fk",
+          "tableFrom": "app_chat_messages",
+          "tableTo": "app_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_chat_messages_role_check": {
+          "name": "app_chat_messages_role_check",
+          "value": "\"app_chat_messages\".\"role\" IN ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_chats": {
+      "name": "app_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_chat_id": {
+          "name": "client_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chats_user_client_chat_uidx": {
+          "name": "app_chats_user_client_chat_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chats\".\"client_chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chats_user_last_message_idx": {
+          "name": "app_chats_user_last_message_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chats_user_id_app_users_id_fk": {
+          "name": "app_chats_user_id_app_users_id_fk",
+          "tableFrom": "app_chats",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_sponsorship_transactions": {
+      "name": "app_smart_account_sponsorship_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_sponsorship_tx_env_signature_uidx": {
+          "name": "app_smart_account_sponsorship_tx_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_occurred_at_idx": {
+          "name": "app_smart_account_sponsorship_tx_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_user_address_idx": {
+          "name": "app_smart_account_sponsorship_tx_user_address_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_smart_account_idx": {
+          "name": "app_smart_account_sponsorship_tx_smart_account_idx",
+          "columns": [
+            {
+              "expression": "smart_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_sponsorship_tx_solana_env_check": {
+          "name": "app_smart_account_sponsorship_tx_solana_env_check",
+          "value": "\"app_smart_account_sponsorship_transactions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_smart_accounts": {
+      "name": "app_user_smart_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_signature": {
+          "name": "creation_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_smart_accounts_user_env_uidx": {
+          "name": "app_user_smart_accounts_user_env_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_env_settings_uidx": {
+          "name": "app_user_smart_accounts_env_settings_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_user_id_idx": {
+          "name": "app_user_smart_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_smart_accounts_user_id_app_users_id_fk": {
+          "name": "app_user_smart_accounts_user_id_app_users_id_fk",
+          "tableFrom": "app_user_smart_accounts",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_user_smart_accounts_solana_env_check": {
+          "name": "app_user_smart_accounts_solana_env_check",
+          "value": "\"app_user_smart_accounts\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_user_smart_accounts_state_check": {
+          "name": "app_user_smart_accounts_state_check",
+          "value": "\"app_user_smart_accounts\".\"state\" IN ('provisioning', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_wallets": {
+      "name": "app_user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_wallets_wallet_address_uidx": {
+          "name": "app_user_wallets_wallet_address_uidx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_wallets_user_id_app_users_id_fk": {
+          "name": "app_user_wallets_user_id_app_users_id_fk",
+          "tableFrom": "app_user_wallets",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_users": {
+      "name": "app_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_address": {
+          "name": "subject_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grid_user_id": {
+          "name": "grid_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_settings_pda": {
+          "name": "smart_account_settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_users_provider_subject_uidx": {
+          "name": "app_users_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_users_provider_check": {
+          "name": "app_users_provider_check",
+          "value": "\"app_users\".\"provider\" IN ('solana')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_wallet_auth_completions": {
+      "name": "app_wallet_auth_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_hash": {
+          "name": "challenge_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioning_outcome": {
+          "name": "provisioning_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_wallet_auth_completions_challenge_hash_uidx": {
+          "name": "app_wallet_auth_completions_challenge_hash_uidx",
+          "columns": [
+            {
+              "expression": "challenge_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_wallet_address_idx": {
+          "name": "app_wallet_auth_completions_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_state_idx": {
+          "name": "app_wallet_auth_completions_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_user_id_idx": {
+          "name": "app_wallet_auth_completions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_wallet_auth_completions_user_id_app_users_id_fk": {
+          "name": "app_wallet_auth_completions_user_id_app_users_id_fk",
+          "tableFrom": "app_wallet_auth_completions",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_wallet_auth_completions_solana_env_check": {
+          "name": "app_wallet_auth_completions_solana_env_check",
+          "value": "\"app_wallet_auth_completions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_wallet_auth_completions_state_check": {
+          "name": "app_wallet_auth_completions_state_check",
+          "value": "\"app_wallet_auth_completions\".\"state\" IN ('processing', 'completed', 'failed')"
+        },
+        "app_wallet_auth_completions_provisioning_outcome_check": {
+          "name": "app_wallet_auth_completions_provisioning_outcome_check",
+          "value": "\"app_wallet_auth_completions\".\"provisioning_outcome\" IS NULL OR \"app_wallet_auth_completions\".\"provisioning_outcome\" IN ('existing_ready', 'reconciled_ready', 'sponsored_existing_record', 'sponsored_new_record', 'retried_failed_record')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "parser_type": {
+          "name": "parser_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_parser_type_idx": {
+          "name": "communities_is_active_parser_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parser_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_parser_type_check": {
+          "name": "communities_parser_type_check",
+          "value": "\"communities\".\"parser_type\" IN ('bot', 'userbot')"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_app_statuses": {
+      "name": "feature_app_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_app_statuses_feature_app_idx": {
+          "name": "feature_app_statuses_feature_app_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_app_statuses_feature_id_feature_registry_id_fk": {
+          "name": "feature_app_statuses_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_app_statuses",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_app_statuses_app_check": {
+          "name": "feature_app_statuses_app_check",
+          "value": "\"feature_app_statuses\".\"app\" IN ('telegram_miniapp', 'website', 'mobile', 'extension')"
+        },
+        "feature_app_statuses_status_check": {
+          "name": "feature_app_statuses_status_check",
+          "value": "\"feature_app_statuses\".\"status\" IN ('missing', 'planned', 'in_progress', 'implemented', 'live')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_evidence": {
+      "name": "feature_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_app_status_id": {
+          "name": "feature_app_status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_evidence_feature_app_status_id_idx": {
+          "name": "feature_evidence_feature_app_status_id_idx",
+          "columns": [
+            {
+              "expression": "feature_app_status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk": {
+          "name": "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk",
+          "tableFrom": "feature_evidence",
+          "tableTo": "feature_app_statuses",
+          "columnsFrom": [
+            "feature_app_status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_evidence_type_check": {
+          "name": "feature_evidence_type_check",
+          "value": "\"feature_evidence\".\"type\" IN ('path', 'branch', 'pr', 'linear', 'commit', 'doc')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_flag_links": {
+      "name": "feature_flag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flag_links_unique_idx": {
+          "name": "feature_flag_links_unique_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_flag_links_feature_id_feature_registry_id_fk": {
+          "name": "feature_flag_links_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feature_flag_links_flag_id_runtime_flags_id_fk": {
+          "name": "feature_flag_links_flag_id_runtime_flags_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "runtime_flags",
+          "columnsFrom": [
+            "flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_registry": {
+      "name": "feature_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_registry_key_idx": {
+          "name": "feature_registry_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gasless_claim_transactions": {
+      "name": "gasless_claim_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gasless_claim_transactions_env_signature_uidx": {
+          "name": "gasless_claim_transactions_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_occurred_at_idx": {
+          "name": "gasless_claim_transactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_type_occurred_at_idx": {
+          "name": "gasless_claim_transactions_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_recipient_address_idx": {
+          "name": "gasless_claim_transactions_recipient_address_idx",
+          "columns": [
+            {
+              "expression": "recipient_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gasless_claim_transactions_type_check": {
+          "name": "gasless_claim_transactions_type_check",
+          "value": "\"gasless_claim_transactions\".\"transaction_type\" IN ('store', 'verify_telegram_init_data', 'top_up_to_0_01_sol')"
+        },
+        "gasless_claim_transactions_solana_env_check": {
+          "name": "gasless_claim_transactions_solana_env_check",
+          "value": "\"gasless_claim_transactions\".\"solana_env\" IN ('mainnet', 'devnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_addresses": {
+      "name": "helius_webhook_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhook_addresses_address_unique": {
+          "name": "helius_webhook_addresses_address_unique",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_wallet_idx": {
+          "name": "helius_webhook_addresses_wallet_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_webhook_idx": {
+          "name": "helius_webhook_addresses_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk": {
+          "name": "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk",
+          "tableFrom": "helius_webhook_addresses",
+          "tableTo": "helius_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_deliveries": {
+      "name": "helius_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helius_webhook_deliveries_signature_wallet_public_key_pk": {
+          "name": "helius_webhook_deliveries_signature_wallet_public_key_pk",
+          "columns": [
+            "signature",
+            "wallet_public_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhooks": {
+      "name": "helius_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "helius_webhook_id": {
+          "name": "helius_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "address_count": {
+          "name": "address_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhooks_helius_id_unique": {
+          "name": "helius_webhooks_helius_id_unique",
+          "columns": [
+            {
+              "expression": "helius_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_articles": {
+      "name": "library_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_time": {
+          "name": "read_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_articles_section_order_idx": {
+          "name": "library_articles_section_order_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_articles_featured_idx": {
+          "name": "library_articles_featured_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_articles_section_id_library_sections_id_fk": {
+          "name": "library_articles_section_id_library_sections_id_fk",
+          "tableFrom": "library_articles",
+          "tableTo": "library_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sections": {
+      "name": "library_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sections_active_order_idx": {
+          "name": "library_sections_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_analytics_sync_state": {
+      "name": "private_transfer_analytics_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_key": {
+          "name": "sync_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backfill_cursor": {
+          "name": "backfill_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_seen_signature": {
+          "name": "latest_seen_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_completed_at": {
+          "name": "backfill_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_started_at": {
+          "name": "last_run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_finished_at": {
+          "name": "last_run_finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_analytics_sync_state_sync_key_uidx": {
+          "name": "private_transfer_analytics_sync_state_sync_key_uidx",
+          "columns": [
+            {
+              "expression": "sync_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_modify_balance_events": {
+      "name": "private_transfer_modify_balance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_index": {
+          "name": "instruction_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_modify_balance_events_signature_instruction_uidx": {
+          "name": "private_transfer_modify_balance_events_signature_instruction_uidx",
+          "columns": [
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instruction_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_token_mint_idx": {
+          "name": "private_transfer_modify_balance_events_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_flow_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_flow_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "flow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_vault_address_idx": {
+          "name": "private_transfer_modify_balance_events_vault_address_idx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "private_transfer_modify_balance_events_flow_check": {
+          "name": "private_transfer_modify_balance_events_flow_check",
+          "value": "\"private_transfer_modify_balance_events\".\"flow\" IN ('shield', 'unshield')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_token_catalog": {
+      "name": "private_transfer_token_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_price_usd": {
+          "name": "last_price_usd",
+          "type": "numeric(30, 12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_token_catalog_token_mint_uidx": {
+          "name": "private_transfer_token_catalog_token_mint_uidx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_vault_holdings": {
+      "name": "private_transfer_vault_holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_account_address": {
+          "name": "token_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_vault_holdings_vault_address_uidx": {
+          "name": "private_transfer_vault_holdings_vault_address_uidx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_account_address_uidx": {
+          "name": "private_transfer_vault_holdings_token_account_address_uidx",
+          "columns": [
+            {
+              "expression": "token_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_mint_idx": {
+          "name": "private_transfer_vault_holdings_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_sends": {
+      "name": "push_notification_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_count": {
+          "name": "requested_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ticket_count": {
+          "name": "ticket_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_ok_count": {
+          "name": "receipt_ok_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_error_count": {
+          "name": "receipt_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_not_registered_count": {
+          "name": "device_not_registered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipts_checked_at": {
+          "name": "receipts_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_sends_created_at_idx": {
+          "name": "push_notification_sends_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_sends_status_idx": {
+          "name": "push_notification_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "push_notification_sends_audience_check": {
+          "name": "push_notification_sends_audience_check",
+          "value": "\"push_notification_sends\".\"audience\" IN ('all', 'platform', 'wallet')"
+        },
+        "push_notification_sends_status_check": {
+          "name": "push_notification_sends_status_check",
+          "value": "\"push_notification_sends\".\"status\" IN ('sending', 'sent', 'receipt_checked', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tickets": {
+      "name": "push_notification_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_status": {
+          "name": "ticket_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_message": {
+          "name": "ticket_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_error": {
+          "name": "ticket_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_status": {
+          "name": "receipt_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_message": {
+          "name": "receipt_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_error": {
+          "name": "receipt_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_tickets_send_id_idx": {
+          "name": "push_notification_tickets_send_id_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_ticket_id_idx": {
+          "name": "push_notification_tickets_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_token_idx": {
+          "name": "push_notification_tickets_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tickets_send_id_push_notification_sends_id_fk": {
+          "name": "push_notification_tickets_send_id_push_notification_sends_id_fk",
+          "tableFrom": "push_notification_tickets",
+          "tableTo": "push_notification_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_telegram_user_id_idx": {
+          "name": "push_tokens_telegram_user_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_wallet_public_key_idx": {
+          "name": "push_tokens_wallet_public_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_flags": {
+      "name": "runtime_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_environments": {
+          "name": "target_environments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"development\",\"preview\",\"production\"]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_flags_key_idx": {
+          "name": "runtime_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_flags_audience_check": {
+          "name": "runtime_flags_audience_check",
+          "value": "\"runtime_flags\".\"audience\" IN ('all', 'public', 'team')"
+        },
+        "runtime_flags_target_environments_check": {
+          "name": "runtime_flags_target_environments_check",
+          "value": "jsonb_typeof(\"runtime_flags\".\"target_environments\") = 'array' AND \"runtime_flags\".\"target_environments\" <@ '[\"development\",\"preview\",\"production\"]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_helper_message_cleanup": {
+      "name": "telegram_helper_message_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_helper_message_cleanup_delete_after_idx": {
+          "name": "telegram_helper_message_cleanup_delete_after_idx",
+          "columns": [
+            {
+              "expression": "delete_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_helper_message_cleanup_chat_message_uidx": {
+          "name": "telegram_helper_message_cleanup_chat_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trusted_dapps": {
+      "name": "trusted_dapps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trusted_dapps_origin_uidx": {
+          "name": "trusted_dapps_origin_uidx",
+          "columns": [
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_order_idx": {
+          "name": "trusted_dapps_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_category_order_idx": {
+          "name": "trusted_dapps_active_category_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_push_sync_state": {
+      "name": "wallet_push_sync_state",
+      "schema": "",
+      "columns": {
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_signature": {
+          "name": "last_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779094226000,
       "tag": "0022_manual_push_notifications",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779439869361,
+      "tag": "0023_nappy_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/cron/helius-webhook-resync/route.ts
+++ b/app/src/app/api/cron/helius-webhook-resync/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { runHeliusWebhookResync } from "@/features/push-incoming-transfers/server/resync";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  return POST(request);
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const authErrorResponse = validateCronAuthHeader(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
+  }
+
+  try {
+    const stats = await runHeliusWebhookResync();
+    return NextResponse.json({ ok: true, stats });
+  } catch (error) {
+    console.error("[cron/helius-webhook-resync] Run failed", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        ok: false,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/src/app/api/webhooks/helius/route.ts
+++ b/app/src/app/api/webhooks/helius/route.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { timingSafeEqual } from "node:crypto";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { buildWebhookDeps } from "@/features/push-incoming-transfers/server/webhook-deps";
+import {
+  type HeliusEnhancedEvent,
+  processHeliusWebhookPayload,
+} from "@/features/push-incoming-transfers/server/webhook-handler";
+import { serverEnv } from "@/lib/core/config/server";
+
+// node:crypto requires the node runtime — explicit override here
+// guards us against accidental edge-runtime promotion.
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const expected = serverEnv.heliusWebhookSecret;
+  const provided = req.headers.get("authorization") ?? "";
+  if (!constantTimeEquals(provided, expected)) {
+    return new NextResponse("unauthorized", { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return new NextResponse("invalid json", { status: 400 });
+  }
+  if (!Array.isArray(body)) {
+    return new NextResponse("expected array payload", { status: 400 });
+  }
+
+  try {
+    const stats = await processHeliusWebhookPayload(
+      body as HeliusEnhancedEvent[],
+      buildWebhookDeps(),
+    );
+    return NextResponse.json({ ok: true, stats });
+  } catch (err) {
+    console.error("[helius-webhook] processing failed", {
+      errorMessage: err instanceof Error ? err.message : String(err),
+      errorName: err instanceof Error ? err.name : "Unknown",
+    });
+    return new NextResponse("processing error", { status: 500 });
+  }
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}

--- a/app/src/features/push-incoming-transfers/server/__tests__/address-aggregator.test.ts
+++ b/app/src/features/push-incoming-transfers/server/__tests__/address-aggregator.test.ts
@@ -1,0 +1,183 @@
+import type { Connection } from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let aggregateAddressesForWallet: typeof import("../address-aggregator").aggregateAddressesForWallet;
+
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+);
+
+type TokenAccountsResponse = {
+  value: Array<{ pubkey: PublicKey }>;
+};
+
+function makeConnection(args: {
+  classic: string[];
+  token2022: string[];
+}): {
+  connection: Connection;
+  getTokenAccountsByOwner: ReturnType<typeof mock>;
+} {
+  const getTokenAccountsByOwner = mock(
+    async (
+      _owner: unknown,
+      opts: { programId: PublicKey },
+    ): Promise<TokenAccountsResponse> => {
+      const programId = opts.programId.toBase58();
+      if (programId === TOKEN_PROGRAM_ID.toBase58()) {
+        return {
+          value: args.classic.map((addr) => ({ pubkey: new PublicKey(addr) })),
+        };
+      }
+      if (programId === TOKEN_2022_PROGRAM_ID.toBase58()) {
+        return {
+          value: args.token2022.map((addr) => ({
+            pubkey: new PublicKey(addr),
+          })),
+        };
+      }
+      return { value: [] };
+    },
+  );
+
+  const connection = {
+    getTokenAccountsByOwner,
+  } as unknown as Connection;
+
+  return { connection, getTokenAccountsByOwner };
+}
+
+describe("aggregateAddressesForWallet", () => {
+  beforeAll(async () => {
+    ({ aggregateAddressesForWallet } = await import(
+      "../address-aggregator"
+    ));
+  });
+
+  test("returns the wallet pubkey as the first row with kind 'wallet'", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+    const ata1 = Keypair.generate().publicKey.toBase58();
+    const ata2 = Keypair.generate().publicKey.toBase58();
+
+    const { connection } = makeConnection({
+      classic: [ata1],
+      token2022: [ata2],
+    });
+
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+
+    expect(rows.length).toBeGreaterThan(0);
+    const first = rows[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect(first.address).toBe(wallet);
+    expect(first.kind).toBe("wallet");
+    expect(first.walletPublicKey).toBe(wallet);
+  });
+
+  test("ATAs from the Token program are emitted with kind 'ata' and correct walletPublicKey", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+    const ata1 = Keypair.generate().publicKey.toBase58();
+    const ata2 = Keypair.generate().publicKey.toBase58();
+
+    const { connection } = makeConnection({
+      classic: [ata1, ata2],
+      token2022: [],
+    });
+
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+
+    expect(rows).toHaveLength(3);
+    const ataRows = rows.filter((r) => r.kind === "ata");
+    expect(ataRows).toHaveLength(2);
+    const addresses = ataRows.map((r) => r.address).sort();
+    expect(addresses).toEqual([ata1, ata2].sort());
+    for (const row of ataRows) {
+      expect(row.kind).toBe("ata");
+      expect(row.walletPublicKey).toBe(wallet);
+    }
+  });
+
+  test("ATAs from Token-2022 are also included", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+    const ata2022a = Keypair.generate().publicKey.toBase58();
+    const ata2022b = Keypair.generate().publicKey.toBase58();
+
+    const { connection } = makeConnection({
+      classic: [],
+      token2022: [ata2022a, ata2022b],
+    });
+
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+
+    expect(rows).toHaveLength(3);
+    const ataAddresses = rows
+      .filter((r) => r.kind === "ata")
+      .map((r) => r.address)
+      .sort();
+    expect(ataAddresses).toEqual([ata2022a, ata2022b].sort());
+  });
+
+  test("calls getTokenAccountsByOwner exactly twice (once per program)", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+
+    const { connection, getTokenAccountsByOwner } = makeConnection({
+      classic: [Keypair.generate().publicKey.toBase58()],
+      token2022: [Keypair.generate().publicKey.toBase58()],
+    });
+
+    await aggregateAddressesForWallet(connection, wallet);
+
+    expect(getTokenAccountsByOwner).toHaveBeenCalledTimes(2);
+
+    const calls = getTokenAccountsByOwner.mock.calls;
+    const programIds = calls
+      .map((call) => (call[1] as { programId: PublicKey }).programId.toBase58())
+      .sort();
+    expect(programIds).toEqual(
+      [TOKEN_PROGRAM_ID.toBase58(), TOKEN_2022_PROGRAM_ID.toBase58()].sort(),
+    );
+  });
+
+  test("wallet with zero ATAs returns just the single wallet row", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+
+    const { connection } = makeConnection({ classic: [], token2022: [] });
+
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+
+    expect(rows).toHaveLength(1);
+    const only = rows[0];
+    expect(only).toBeDefined();
+    if (!only) return;
+    expect(only.address).toBe(wallet);
+    expect(only.kind).toBe("wallet");
+    expect(only.walletPublicKey).toBe(wallet);
+  });
+
+  test("duplicate ATA appearing under both programs is emitted only once", async () => {
+    const wallet = Keypair.generate().publicKey.toBase58();
+    const sharedAta = Keypair.generate().publicKey.toBase58();
+
+    const { connection } = makeConnection({
+      classic: [sharedAta],
+      token2022: [sharedAta],
+    });
+
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+
+    expect(rows).toHaveLength(2);
+    const ataRows = rows.filter((r) => r.kind === "ata");
+    expect(ataRows).toHaveLength(1);
+    const ataRow = ataRows[0];
+    expect(ataRow).toBeDefined();
+    if (!ataRow) return;
+    expect(ataRow.address).toBe(sharedAta);
+  });
+});

--- a/app/src/features/push-incoming-transfers/server/__tests__/helius-client.test.ts
+++ b/app/src/features/push-incoming-transfers/server/__tests__/helius-client.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let createHeliusWebhook: typeof import("../helius-client").createHeliusWebhook;
+let patchHeliusWebhookAddresses: typeof import("../helius-client").patchHeliusWebhookAddresses;
+let deleteHeliusWebhook: typeof import("../helius-client").deleteHeliusWebhook;
+
+const originalFetch = globalThis.fetch;
+
+describe("helius-client", () => {
+  beforeAll(async () => {
+    ({ createHeliusWebhook, patchHeliusWebhookAddresses, deleteHeliusWebhook } =
+      await import("../helius-client"));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("createHeliusWebhook", () => {
+    test("POSTs the correct URL and body, returns webhookId from webhookID field", async () => {
+      const capturedCalls: Array<{
+        url: string;
+        init: RequestInit | undefined;
+      }> = [];
+
+      const fetchMock = mock(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          capturedCalls.push({ url: String(input), init });
+          return new Response(
+            JSON.stringify({
+              webhookID: "wh_abc123",
+              webhookURL: "https://example.com/hook",
+            }),
+            { status: 200 }
+          );
+        }
+      );
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const result = await createHeliusWebhook({
+        accountAddresses: ["addr1", "addr2"],
+        apiKey: "test-api-key",
+        authHeader: "Bearer secret",
+        webhookUrl: "https://example.com/hook",
+      });
+
+      expect(result).toEqual({ webhookId: "wh_abc123" });
+      expect(capturedCalls).toHaveLength(1);
+
+      const call = capturedCalls[0];
+      expect(call).toBeDefined();
+      if (!call) return;
+
+      expect(call.url).toBe(
+        "https://api.helius.xyz/v0/webhooks?api-key=test-api-key"
+      );
+      expect(call.init?.method).toBe("POST");
+
+      const headers = new Headers(call.init?.headers);
+      expect(headers.get("content-type")).toBe("application/json");
+
+      const body = JSON.parse(String(call.init?.body));
+      expect(body).toEqual({
+        accountAddresses: ["addr1", "addr2"],
+        authHeader: "Bearer secret",
+        transactionTypes: ["TRANSFER"],
+        webhookType: "enhanced",
+        webhookURL: "https://example.com/hook",
+      });
+    });
+
+    test("throws Helius createWebhook <status>: <body> on non-2xx", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response("invalid api key", {
+            status: 401,
+            statusText: "Unauthorized",
+          })
+      ) as typeof fetch;
+
+      await expect(
+        createHeliusWebhook({
+          accountAddresses: ["addr1"],
+          apiKey: "bad-key",
+          authHeader: "Bearer secret",
+          webhookUrl: "https://example.com/hook",
+        })
+      ).rejects.toThrow("Helius createWebhook 401: invalid api key");
+    });
+  });
+
+  describe("patchHeliusWebhookAddresses", () => {
+    test("PUTs the correct URL and body with webhookType + transactionTypes re-asserted", async () => {
+      const capturedCalls: Array<{
+        url: string;
+        init: RequestInit | undefined;
+      }> = [];
+
+      globalThis.fetch = mock(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          capturedCalls.push({ url: String(input), init });
+          return new Response("{}", { status: 200 });
+        }
+      ) as typeof fetch;
+
+      await patchHeliusWebhookAddresses({
+        accountAddresses: ["a", "b", "c"],
+        apiKey: "k",
+        heliusWebhookId: "wh_1",
+      });
+
+      expect(capturedCalls).toHaveLength(1);
+
+      const call = capturedCalls[0];
+      expect(call).toBeDefined();
+      if (!call) return;
+
+      expect(call.url).toBe("https://api.helius.xyz/v0/webhooks/wh_1?api-key=k");
+      expect(call.init?.method).toBe("PUT");
+
+      const headers = new Headers(call.init?.headers);
+      expect(headers.get("content-type")).toBe("application/json");
+
+      const body = JSON.parse(String(call.init?.body));
+      expect(body).toEqual({
+        accountAddresses: ["a", "b", "c"],
+        transactionTypes: ["TRANSFER"],
+        webhookType: "enhanced",
+      });
+    });
+
+    test("throws Helius patchWebhookAddresses <status>: <body> on non-2xx", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response("boom", { status: 500, statusText: "Server Error" })
+      ) as typeof fetch;
+
+      await expect(
+        patchHeliusWebhookAddresses({
+          accountAddresses: ["a"],
+          apiKey: "k",
+          heliusWebhookId: "wh_1",
+        })
+      ).rejects.toThrow("Helius patchWebhookAddresses 500: boom");
+    });
+  });
+
+  describe("deleteHeliusWebhook", () => {
+    test("DELETEs the correct URL", async () => {
+      const capturedCalls: Array<{
+        url: string;
+        init: RequestInit | undefined;
+      }> = [];
+
+      globalThis.fetch = mock(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          capturedCalls.push({ url: String(input), init });
+          return new Response("", { status: 200 });
+        }
+      ) as typeof fetch;
+
+      await deleteHeliusWebhook("k", "wh_1");
+
+      expect(capturedCalls).toHaveLength(1);
+
+      const call = capturedCalls[0];
+      expect(call).toBeDefined();
+      if (!call) return;
+
+      expect(call.url).toBe("https://api.helius.xyz/v0/webhooks/wh_1?api-key=k");
+      expect(call.init?.method).toBe("DELETE");
+    });
+
+    test("treats 404 as success (does not throw)", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response("not found", { status: 404, statusText: "Not Found" })
+      ) as typeof fetch;
+
+      await expect(deleteHeliusWebhook("k", "wh_missing")).resolves.toBeUndefined();
+    });
+
+    test("throws Helius deleteWebhook <status>: <body> on non-2xx, non-404", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response("server kaboom", {
+            status: 500,
+            statusText: "Server Error",
+          })
+      ) as typeof fetch;
+
+      await expect(deleteHeliusWebhook("k", "wh_1")).rejects.toThrow(
+        "Helius deleteWebhook 500: server kaboom"
+      );
+    });
+  });
+});

--- a/app/src/features/push-incoming-transfers/server/__tests__/resync.test.ts
+++ b/app/src/features/push-incoming-transfers/server/__tests__/resync.test.ts
@@ -1,0 +1,271 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let computeResyncDiff: typeof import("../resync").computeResyncDiff;
+type DesiredAddress = import("../resync").DesiredAddress;
+type CurrentAddress = import("../resync").CurrentAddress;
+type WebhookCapacity = import("../resync").WebhookCapacity;
+
+function desired(
+  address: string,
+  walletPublicKey: string,
+  kind: DesiredAddress["kind"] = "wallet",
+): DesiredAddress {
+  return { address, kind, walletPublicKey };
+}
+
+function current(
+  address: string,
+  walletPublicKey: string,
+  webhookId: string,
+  kind: CurrentAddress["kind"] = "wallet",
+): CurrentAddress {
+  return { address, kind, walletPublicKey, webhookId };
+}
+
+function webhook(
+  webhookId: string,
+  heliusWebhookId: string,
+  currentAddressCount: number,
+): WebhookCapacity {
+  return { currentAddressCount, heliusWebhookId, webhookId };
+}
+
+describe("computeResyncDiff", () => {
+  beforeAll(async () => {
+    ({ computeResyncDiff } = await import("../resync"));
+  });
+
+  test("desired == current produces an empty diff", () => {
+    const wallet = "WalletAAA";
+    const ata = "AtaA";
+    const desiredSet: DesiredAddress[] = [
+      desired(wallet, wallet, "wallet"),
+      desired(ata, wallet, "ata"),
+    ];
+    const currentSet: CurrentAddress[] = [
+      current(wallet, wallet, "wh-uuid-1", "wallet"),
+      current(ata, wallet, "wh-uuid-1", "ata"),
+    ];
+
+    const result = computeResyncDiff({
+      current: currentSet,
+      desired: desiredSet,
+      maxAddressesPerWebhook: 50_000,
+      webhooks: [webhook("wh-uuid-1", "helius-1", currentSet.length)],
+    });
+
+    expect(result.toAdd).toEqual([]);
+    expect(result.toRemove).toEqual([]);
+    expect(result.webhooksToCreate).toEqual([]);
+  });
+
+  test("new wallet registered: all addresses go into the only non-full webhook", () => {
+    const wallet = "WalletNEW";
+    const ata = "AtaNEW";
+    const desiredSet: DesiredAddress[] = [
+      desired(wallet, wallet, "wallet"),
+      desired(ata, wallet, "ata"),
+    ];
+
+    const result = computeResyncDiff({
+      current: [],
+      desired: desiredSet,
+      maxAddressesPerWebhook: 50_000,
+      webhooks: [webhook("wh-uuid-1", "helius-1", 10)],
+    });
+
+    expect(result.toAdd).toHaveLength(2);
+    for (const add of result.toAdd) {
+      expect(add.assignedWebhookId).toBe("wh-uuid-1");
+    }
+    expect(result.toRemove).toEqual([]);
+    expect(result.webhooksToCreate).toEqual([]);
+  });
+
+  test("wallet deregistered: addresses go into toRemove with their webhookId", () => {
+    const wallet = "WalletGONE";
+    const ata = "AtaGONE";
+    const currentSet: CurrentAddress[] = [
+      current(wallet, wallet, "wh-uuid-1", "wallet"),
+      current(ata, wallet, "wh-uuid-1", "ata"),
+    ];
+
+    const result = computeResyncDiff({
+      current: currentSet,
+      desired: [],
+      maxAddressesPerWebhook: 50_000,
+      webhooks: [
+        webhook("wh-uuid-1", "helius-1", currentSet.length),
+      ],
+    });
+
+    expect(result.toAdd).toEqual([]);
+    expect(result.webhooksToCreate).toEqual([]);
+    expect(result.toRemove).toHaveLength(2);
+    const addresses = result.toRemove.map((r) => r.address).sort();
+    expect(addresses).toEqual([ata, wallet].sort());
+    for (const row of result.toRemove) {
+      expect(row.webhookId).toBe("wh-uuid-1");
+    }
+  });
+
+  test("existing wallet, new ATA appeared: toAdd has just the new ATA", () => {
+    const wallet = "WalletX";
+    const newAta = "AtaNewlyMinted";
+    const desiredSet: DesiredAddress[] = [
+      desired(wallet, wallet, "wallet"),
+      desired(newAta, wallet, "ata"),
+    ];
+    const currentSet: CurrentAddress[] = [
+      current(wallet, wallet, "wh-uuid-1", "wallet"),
+    ];
+
+    const result = computeResyncDiff({
+      current: currentSet,
+      desired: desiredSet,
+      maxAddressesPerWebhook: 50_000,
+      webhooks: [webhook("wh-uuid-1", "helius-1", 1)],
+    });
+
+    expect(result.toAdd).toHaveLength(1);
+    const onlyAdd = result.toAdd[0];
+    expect(onlyAdd).toBeDefined();
+    if (!onlyAdd) return;
+    expect(onlyAdd.address).toBe(newAta);
+    expect(onlyAdd.assignedWebhookId).toBe("wh-uuid-1");
+    expect(result.toRemove).toEqual([]);
+    expect(result.webhooksToCreate).toEqual([]);
+  });
+
+  test("all webhooks full: 100 addresses spill into 2 shards of 50 each", () => {
+    const desiredSet: DesiredAddress[] = [];
+    for (let i = 0; i < 100; i++) {
+      const addr = `addr-${String(i).padStart(4, "0")}`;
+      desiredSet.push(desired(addr, `wallet-${i}`, "wallet"));
+    }
+
+    const result = computeResyncDiff({
+      current: [],
+      desired: desiredSet,
+      maxAddressesPerWebhook: 50,
+      webhooks: [
+        webhook("wh-uuid-1", "helius-1", 50),
+        webhook("wh-uuid-2", "helius-2", 50),
+      ],
+    });
+
+    expect(result.toAdd).toEqual([]);
+    expect(result.toRemove).toEqual([]);
+    expect(result.webhooksToCreate).toHaveLength(2);
+    for (const shard of result.webhooksToCreate) {
+      expect(shard.addresses).toHaveLength(50);
+    }
+    const total = result.webhooksToCreate.reduce(
+      (sum, shard) => sum + shard.addresses.length,
+      0,
+    );
+    expect(total).toBe(100);
+  });
+
+  test("partial fill then spill: 30 fit existing, 40 spill to new shard", () => {
+    const desiredSet: DesiredAddress[] = [];
+    for (let i = 0; i < 70; i++) {
+      const addr = `addr-${String(i).padStart(4, "0")}`;
+      desiredSet.push(desired(addr, `wallet-${i}`, "wallet"));
+    }
+
+    const result = computeResyncDiff({
+      current: [],
+      desired: desiredSet,
+      maxAddressesPerWebhook: 50,
+      webhooks: [
+        // 20 already present → 30 free slots
+        webhook("wh-uuid-1", "helius-1", 20),
+      ],
+    });
+
+    const goingToExisting = result.toAdd.filter(
+      (a) => a.assignedWebhookId === "wh-uuid-1",
+    );
+    expect(goingToExisting).toHaveLength(30);
+    expect(result.toRemove).toEqual([]);
+    expect(result.webhooksToCreate).toHaveLength(1);
+    const onlyShard = result.webhooksToCreate[0];
+    expect(onlyShard).toBeDefined();
+    if (!onlyShard) return;
+    expect(onlyShard.addresses).toHaveLength(40);
+  });
+
+  test("deterministic: input order does not affect output ordering", () => {
+    const wallet = "WalletDET";
+    const a = "addr-aaa";
+    const b = "addr-bbb";
+    const c = "addr-ccc";
+
+    const desiredAsc: DesiredAddress[] = [
+      desired(a, wallet, "ata"),
+      desired(b, wallet, "ata"),
+      desired(c, wallet, "ata"),
+    ];
+    const desiredDesc: DesiredAddress[] = [
+      desired(c, wallet, "ata"),
+      desired(b, wallet, "ata"),
+      desired(a, wallet, "ata"),
+    ];
+
+    const resultAsc = computeResyncDiff({
+      current: [],
+      desired: desiredAsc,
+      maxAddressesPerWebhook: 50,
+      webhooks: [webhook("wh-uuid-1", "helius-1", 0)],
+    });
+    const resultDesc = computeResyncDiff({
+      current: [],
+      desired: desiredDesc,
+      maxAddressesPerWebhook: 50,
+      webhooks: [webhook("wh-uuid-1", "helius-1", 0)],
+    });
+
+    expect(resultAsc).toEqual(resultDesc);
+    const addedAddresses = resultAsc.toAdd.map((a) => a.address);
+    // Must be sorted lexicographically for determinism.
+    expect(addedAddresses).toEqual([...addedAddresses].sort());
+  });
+
+  test("toAdd assignments prefer the existing webhook with the most remaining capacity", () => {
+    // wh-uuid-1 has 5 free slots, wh-uuid-2 has 20. First adds should
+    // land in wh-uuid-2 (more capacity).
+    const desiredSet: DesiredAddress[] = [];
+    for (let i = 0; i < 10; i++) {
+      const addr = `addr-${String(i).padStart(4, "0")}`;
+      desiredSet.push(desired(addr, `wallet-${i}`, "wallet"));
+    }
+
+    const result = computeResyncDiff({
+      current: [],
+      desired: desiredSet,
+      maxAddressesPerWebhook: 100,
+      webhooks: [
+        webhook("wh-uuid-1", "helius-1", 95), // 5 free
+        webhook("wh-uuid-2", "helius-2", 80), // 20 free
+      ],
+    });
+
+    expect(result.toAdd).toHaveLength(10);
+    expect(result.webhooksToCreate).toEqual([]);
+
+    const byWebhook = new Map<string, number>();
+    for (const a of result.toAdd) {
+      byWebhook.set(
+        a.assignedWebhookId,
+        (byWebhook.get(a.assignedWebhookId) ?? 0) + 1,
+      );
+    }
+    // Greedy fill: wh-uuid-2 (20 free) gets all 10, since 10 < 20 and it
+    // remains the most-free throughout.
+    expect(byWebhook.get("wh-uuid-2")).toBe(10);
+    expect(byWebhook.get("wh-uuid-1") ?? 0).toBe(0);
+  });
+});

--- a/app/src/features/push-incoming-transfers/server/__tests__/webhook-handler.test.ts
+++ b/app/src/features/push-incoming-transfers/server/__tests__/webhook-handler.test.ts
@@ -1,0 +1,379 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let processHeliusWebhookPayload: typeof import("../webhook-handler").processHeliusWebhookPayload;
+type HeliusEnhancedEvent = import("../webhook-handler").HeliusEnhancedEvent;
+type ProcessDeps = import("../webhook-handler").ProcessDeps;
+
+const NATIVE_SOL_MINT = "So11111111111111111111111111111111111111112";
+
+type RecordedCall = { name: string; args: unknown[] };
+
+function makeDeps(overrides: {
+  registeredAddresses?: Record<string, string>;
+  mintMetadata?: Map<string, { symbol: string; decimals: number }>;
+  alreadyDelivered?: Set<string>; // key = `${signature}::${wallet}`
+  sendPushImpl?: (
+    walletPublicKey: string,
+    payload: unknown,
+  ) => Promise<{ sentTo: number }>;
+}): { deps: ProcessDeps; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const addresses = overrides.registeredAddresses ?? {};
+  const mintMetadata = overrides.mintMetadata ?? new Map();
+  const alreadyDelivered = overrides.alreadyDelivered ?? new Set<string>();
+  const recordedDeliveries = new Set<string>();
+
+  const deps: ProcessDeps = {
+    async lookupWalletsForAddresses(addrs) {
+      calls.push({ name: "lookupWalletsForAddresses", args: [addrs.slice()] });
+      const result = new Map<string, string>();
+      for (const addr of addrs) {
+        const wallet = addresses[addr];
+        if (wallet) {
+          result.set(addr, wallet);
+        }
+      }
+      return result;
+    },
+    async isDelivered(signature, walletPublicKey) {
+      calls.push({
+        name: "isDelivered",
+        args: [signature, walletPublicKey],
+      });
+      const key = `${signature}::${walletPublicKey}`;
+      return (
+        alreadyDelivered.has(key) || recordedDeliveries.has(key)
+      );
+    },
+    async recordDelivery(signature, walletPublicKey) {
+      calls.push({
+        name: "recordDelivery",
+        args: [signature, walletPublicKey],
+      });
+      recordedDeliveries.add(`${signature}::${walletPublicKey}`);
+    },
+    async resolveMintMetadata(mints) {
+      const mintsArr = Array.from(mints);
+      calls.push({ name: "resolveMintMetadata", args: [mintsArr] });
+      const out = new Map<string, { symbol: string; decimals: number }>();
+      for (const mint of mintsArr) {
+        const meta = mintMetadata.get(mint);
+        if (meta) out.set(mint, meta);
+      }
+      return out;
+    },
+    async sendPushToWallet(walletPublicKey, payload) {
+      calls.push({
+        name: "sendPushToWallet",
+        args: [walletPublicKey, payload],
+      });
+      if (overrides.sendPushImpl) {
+        return overrides.sendPushImpl(walletPublicKey, payload);
+      }
+      return { sentTo: 1 };
+    },
+  };
+
+  return { deps, calls };
+}
+
+function makeSolTransferEvent(args: {
+  signature: string;
+  from: string;
+  to: string;
+  lamports: number;
+}): HeliusEnhancedEvent {
+  return {
+    type: "TRANSFER",
+    signature: args.signature,
+    timestamp: 1_700_000_000,
+    nativeTransfers: [
+      {
+        fromUserAccount: args.from,
+        toUserAccount: args.to,
+        amount: args.lamports,
+      },
+    ],
+  };
+}
+
+function makeSplTransferEvent(args: {
+  signature: string;
+  from: string;
+  to: string;
+  mint: string;
+  tokenAmount: number;
+}): HeliusEnhancedEvent {
+  return {
+    type: "TRANSFER",
+    signature: args.signature,
+    timestamp: 1_700_000_000,
+    tokenTransfers: [
+      {
+        fromUserAccount: args.from,
+        toUserAccount: args.to,
+        mint: args.mint,
+        tokenAmount: args.tokenAmount,
+      },
+    ],
+  };
+}
+
+describe("processHeliusWebhookPayload", () => {
+  beforeAll(async () => {
+    ({ processHeliusWebhookPayload } = await import("../webhook-handler"));
+  });
+
+  test("dispatches sendPushToWallet for a SOL transfer; title contains amount", async () => {
+    const wallet = "WaLLetSoLReCipient1111111111111111111111111";
+    const recipientAddress = wallet; // SOL goes to wallet pubkey directly
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [recipientAddress]: wallet },
+      mintMetadata: new Map([
+        [NATIVE_SOL_MINT, { symbol: "SOL", decimals: 9 }],
+      ]),
+    });
+
+    const event = makeSolTransferEvent({
+      signature: "sig-sol-1",
+      from: "SenderAddress11111111111111111111111111111",
+      to: recipientAddress,
+      lamports: 1_500_000_000, // 1.5 SOL
+    });
+
+    const stats = await processHeliusWebhookPayload([event], deps);
+
+    expect(stats.notificationsSent).toBe(1);
+    expect(stats.duplicates).toBe(0);
+    expect(stats.unroutable).toBe(0);
+    expect(stats.errors).toBe(0);
+
+    const sendCall = calls.find((c) => c.name === "sendPushToWallet");
+    expect(sendCall).toBeDefined();
+    if (!sendCall) return;
+    expect(sendCall.args[0]).toBe(wallet);
+    const payload = sendCall.args[1] as { title: string };
+    expect(payload.title).toContain("1.5");
+    expect(payload.title).toContain("SOL");
+  });
+
+  test("skips duplicates idempotently — does not record or send when already delivered", async () => {
+    const wallet = "WaLLetDuPliCate111111111111111111111111111";
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [wallet]: wallet },
+      alreadyDelivered: new Set([`sig-dup-1::${wallet}`]),
+      mintMetadata: new Map([
+        [NATIVE_SOL_MINT, { symbol: "SOL", decimals: 9 }],
+      ]),
+    });
+
+    const event = makeSolTransferEvent({
+      signature: "sig-dup-1",
+      from: "Sender",
+      to: wallet,
+      lamports: 1_000_000_000,
+    });
+
+    const stats = await processHeliusWebhookPayload([event], deps);
+
+    expect(stats.duplicates).toBe(1);
+    expect(stats.notificationsSent).toBe(0);
+    expect(calls.find((c) => c.name === "recordDelivery")).toBeUndefined();
+    expect(calls.find((c) => c.name === "sendPushToWallet")).toBeUndefined();
+  });
+
+  test("routes SPL transfers via tokenTransfers[].toUserAccount", async () => {
+    const wallet = "WaLLetSpLReCipient1111111111111111111111111";
+    const ataAddress = "AtAaDdRessForRecipient1111111111111111111111";
+    const mint = "TokenMintForUsdc1111111111111111111111111111";
+
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [ataAddress]: wallet },
+      mintMetadata: new Map([[mint, { symbol: "USDC", decimals: 6 }]]),
+    });
+
+    const event = makeSplTransferEvent({
+      signature: "sig-spl-1",
+      from: "Sender",
+      to: ataAddress,
+      mint,
+      tokenAmount: 12.5,
+    });
+
+    const stats = await processHeliusWebhookPayload([event], deps);
+
+    expect(stats.notificationsSent).toBe(1);
+    expect(stats.unroutable).toBe(0);
+
+    const sendCall = calls.find((c) => c.name === "sendPushToWallet");
+    expect(sendCall).toBeDefined();
+    if (!sendCall) return;
+    expect(sendCall.args[0]).toBe(wallet);
+    const payload = sendCall.args[1] as { title: string };
+    expect(payload.title).toContain("USDC");
+  });
+
+  test("events with type !== 'TRANSFER' are ignored before any DB work", async () => {
+    const wallet = "WaLLetSwapIgnored11111111111111111111111111";
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [wallet]: wallet },
+    });
+
+    const event: HeliusEnhancedEvent = {
+      type: "SWAP",
+      signature: "sig-swap-1",
+      timestamp: 1_700_000_000,
+      nativeTransfers: [
+        {
+          fromUserAccount: "Sender",
+          toUserAccount: wallet,
+          amount: 1_000_000_000,
+        },
+      ],
+    };
+
+    const stats = await processHeliusWebhookPayload([event], deps);
+
+    expect(stats.notificationsSent).toBe(0);
+    expect(stats.duplicates).toBe(0);
+    expect(stats.unroutable).toBe(0);
+    expect(stats.eventsReceived).toBe(1);
+
+    // No address lookup, no metadata lookup, no send.
+    expect(
+      calls.find((c) => c.name === "lookupWalletsForAddresses"),
+    ).toBeUndefined();
+    expect(calls.find((c) => c.name === "sendPushToWallet")).toBeUndefined();
+  });
+
+  test("unroutable event (no recipient matches) increments unroutable, no send", async () => {
+    const { deps, calls } = makeDeps({ registeredAddresses: {} });
+
+    const event = makeSolTransferEvent({
+      signature: "sig-unroutable-1",
+      from: "Sender",
+      to: "RandoStrangerAddress1111111111111111111111",
+      lamports: 1_000_000_000,
+    });
+
+    const stats = await processHeliusWebhookPayload([event], deps);
+
+    expect(stats.unroutable).toBe(1);
+    expect(stats.notificationsSent).toBe(0);
+    expect(calls.find((c) => c.name === "sendPushToWallet")).toBeUndefined();
+  });
+
+  test("per-event error isolation: a bad event increments errors, others process", async () => {
+    const wallet = "WaLLetGoodEvent11111111111111111111111111";
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [wallet]: wallet },
+      mintMetadata: new Map([
+        [NATIVE_SOL_MINT, { symbol: "SOL", decimals: 9 }],
+      ]),
+    });
+
+    const goodEvent = makeSolTransferEvent({
+      signature: "sig-good-1",
+      from: "Sender",
+      to: wallet,
+      lamports: 2_000_000_000,
+    });
+
+    // Forge a malformed event — tokenTransfers access throws. This
+    // simulates a corrupted payload that should be isolated to the
+    // single event without poisoning the rest of the batch.
+    const badEvent = {
+      type: "TRANSFER",
+      signature: "sig-bad-1",
+      timestamp: 1_700_000_000,
+      get tokenTransfers(): never {
+        throw new Error("forged: tokenTransfers getter explodes");
+      },
+    } as unknown as HeliusEnhancedEvent;
+
+    const stats = await processHeliusWebhookPayload(
+      [badEvent, goodEvent],
+      deps,
+    );
+
+    expect(stats.errors).toBeGreaterThanOrEqual(1);
+    expect(stats.notificationsSent).toBe(1);
+    expect(calls.find((c) => c.name === "sendPushToWallet")).toBeDefined();
+  });
+
+  test("recordDelivery is called BEFORE sendPushToWallet", async () => {
+    const wallet = "WaLLetCallOrder111111111111111111111111111";
+    const { deps, calls } = makeDeps({
+      registeredAddresses: { [wallet]: wallet },
+      mintMetadata: new Map([
+        [NATIVE_SOL_MINT, { symbol: "SOL", decimals: 9 }],
+      ]),
+    });
+
+    const event = makeSolTransferEvent({
+      signature: "sig-order-1",
+      from: "Sender",
+      to: wallet,
+      lamports: 1_000_000_000,
+    });
+
+    await processHeliusWebhookPayload([event], deps);
+
+    const recordIdx = calls.findIndex((c) => c.name === "recordDelivery");
+    const sendIdx = calls.findIndex((c) => c.name === "sendPushToWallet");
+
+    expect(recordIdx).toBeGreaterThanOrEqual(0);
+    expect(sendIdx).toBeGreaterThanOrEqual(0);
+    expect(recordIdx).toBeLessThan(sendIdx);
+  });
+
+  test("send dispatch is fire-and-catch: handler resolves before slow send completes", async () => {
+    const wallet = "WaLLetSloWSend11111111111111111111111111111";
+
+    let resolveSend: ((v: { sentTo: number }) => void) | null = null;
+    const slowSend = new Promise<{ sentTo: number }>((resolve) => {
+      resolveSend = resolve;
+    });
+
+    const { deps } = makeDeps({
+      registeredAddresses: { [wallet]: wallet },
+      mintMetadata: new Map([
+        [NATIVE_SOL_MINT, { symbol: "SOL", decimals: 9 }],
+      ]),
+      sendPushImpl: () => slowSend,
+    });
+
+    const event = makeSolTransferEvent({
+      signature: "sig-slow-1",
+      from: "Sender",
+      to: wallet,
+      lamports: 1_000_000_000,
+    });
+
+    let handlerResolved = false;
+    const handlerPromise = processHeliusWebhookPayload([event], deps).then(
+      (stats) => {
+        handlerResolved = true;
+        return stats;
+      },
+    );
+
+    // Yield to the microtask queue several times; if the handler awaited
+    // the send promise it would still be pending. With fire-and-catch, it
+    // should have resolved already.
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
+    // Also yield to the macrotask queue once to be generous.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handlerResolved).toBe(true);
+
+    // Resolve the slow send so we don't leak the promise.
+    expect(resolveSend).not.toBeNull();
+    resolveSend?.({ sentTo: 1 });
+    await handlerPromise;
+  });
+});

--- a/app/src/features/push-incoming-transfers/server/address-aggregator.ts
+++ b/app/src/features/push-incoming-transfers/server/address-aggregator.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { type Connection, PublicKey } from "@solana/web3.js";
+
+// SPL Token and Token-2022 program IDs. Helius watches addresses, but
+// incoming SPL transfers reference the ATA, not the wallet pubkey. We
+// enumerate ATAs under both programs so Helius can fire on every
+// inbound transfer.
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+);
+
+export type AggregatedAddress = {
+  address: string;
+  kind: "wallet" | "ata";
+  walletPublicKey: string;
+};
+
+/**
+ * Returns the wallet pubkey row + one row per owned ATA across SPL Token
+ * and Token-2022 programs. Order: wallet row first, then ATAs in the
+ * order Helius receives them. Caller is responsible for any caching.
+ */
+export async function aggregateAddressesForWallet(
+  connection: Connection,
+  walletPublicKey: string,
+): Promise<AggregatedAddress[]> {
+  const walletPk = new PublicKey(walletPublicKey);
+
+  const [classic, token2022] = await Promise.all([
+    connection.getTokenAccountsByOwner(walletPk, {
+      programId: TOKEN_PROGRAM_ID,
+    }),
+    connection.getTokenAccountsByOwner(walletPk, {
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+  ]);
+
+  const seen = new Set<string>();
+  const ataAddresses: string[] = [];
+  for (const entry of classic.value) {
+    const addr = entry.pubkey.toBase58();
+    if (!seen.has(addr)) {
+      seen.add(addr);
+      ataAddresses.push(addr);
+    }
+  }
+  for (const entry of token2022.value) {
+    const addr = entry.pubkey.toBase58();
+    if (!seen.has(addr)) {
+      seen.add(addr);
+      ataAddresses.push(addr);
+    }
+  }
+
+  const rows: AggregatedAddress[] = [
+    {
+      address: walletPublicKey,
+      kind: "wallet",
+      walletPublicKey,
+    },
+  ];
+  for (const address of ataAddresses) {
+    rows.push({
+      address,
+      kind: "ata",
+      walletPublicKey,
+    });
+  }
+  return rows;
+}

--- a/app/src/features/push-incoming-transfers/server/constants.ts
+++ b/app/src/features/push-incoming-transfers/server/constants.ts
@@ -21,3 +21,9 @@ export const MAX_TRANSACTIONS_PER_WALLET_PER_RUN = 50;
 // Concurrent wallets processed per run. Helius rate limits are
 // generous but we don't want to burn the whole budget on one cron.
 export const WALLET_CONCURRENCY = 5;
+
+// Helius advertises a 100k accountAddresses cap per webhook. We keep
+// 50% headroom for ATA churn and accidental duplicates. Shared between
+// the bootstrap script and the resync cron so both honor the same
+// sharding policy.
+export const MAX_ADDRESSES_PER_WEBHOOK = 50_000;

--- a/app/src/features/push-incoming-transfers/server/helius-client.ts
+++ b/app/src/features/push-incoming-transfers/server/helius-client.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+const HELIUS_API_HOST = "https://api.helius.xyz";
+
+export type HeliusWebhookSummary = { webhookId: string };
+
+type HeliusWebhookCreateResponse = {
+  webhookID: string;
+};
+
+async function readResponseBody(res: Response): Promise<string> {
+  return await res.text().catch(() => "");
+}
+
+function buildHeliusError(
+  opName: string,
+  status: number,
+  body: string
+): Error {
+  return new Error(`Helius ${opName} ${status}: ${body}`);
+}
+
+export async function createHeliusWebhook(args: {
+  apiKey: string;
+  webhookUrl: string;
+  authHeader: string;
+  accountAddresses: string[];
+}): Promise<HeliusWebhookSummary> {
+  const { accountAddresses, apiKey, authHeader, webhookUrl } = args;
+  const url = `${HELIUS_API_HOST}/v0/webhooks?api-key=${apiKey}`;
+
+  const res = await fetch(url, {
+    body: JSON.stringify({
+      accountAddresses,
+      authHeader,
+      transactionTypes: ["TRANSFER"],
+      webhookType: "enhanced",
+      webhookURL: webhookUrl,
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    const body = await readResponseBody(res);
+    throw buildHeliusError("createWebhook", res.status, body);
+  }
+
+  const data = (await res.json()) as HeliusWebhookCreateResponse;
+  return { webhookId: data.webhookID };
+}
+
+export async function patchHeliusWebhookAddresses(args: {
+  apiKey: string;
+  heliusWebhookId: string;
+  accountAddresses: string[];
+}): Promise<void> {
+  const { accountAddresses, apiKey, heliusWebhookId } = args;
+  const url = `${HELIUS_API_HOST}/v0/webhooks/${heliusWebhookId}?api-key=${apiKey}`;
+
+  const res = await fetch(url, {
+    body: JSON.stringify({
+      accountAddresses,
+      transactionTypes: ["TRANSFER"],
+      webhookType: "enhanced",
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "PUT",
+  });
+
+  if (!res.ok) {
+    const body = await readResponseBody(res);
+    throw buildHeliusError("patchWebhookAddresses", res.status, body);
+  }
+}
+
+export async function deleteHeliusWebhook(
+  apiKey: string,
+  heliusWebhookId: string
+): Promise<void> {
+  const url = `${HELIUS_API_HOST}/v0/webhooks/${heliusWebhookId}?api-key=${apiKey}`;
+
+  const res = await fetch(url, {
+    method: "DELETE",
+  });
+
+  if (res.ok) return;
+  if (res.status === 404) return;
+
+  const body = await readResponseBody(res);
+  throw buildHeliusError("deleteWebhook", res.status, body);
+}

--- a/app/src/features/push-incoming-transfers/server/mint-metadata.ts
+++ b/app/src/features/push-incoming-transfers/server/mint-metadata.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { privateTransferTokenCatalog } from "@loyal-labs/db-core/schema";
+import { inArray } from "drizzle-orm";
+
+import {
+  buildTokenCatalogUpserts,
+  upsertTokenCatalog,
+} from "@/features/private-transfer-analytics/server/token-catalog";
+import { getDatabase } from "@/lib/core/database";
+
+export type MintMetadata = { symbol: string; decimals: number };
+
+/**
+ * Look up token symbol + decimals for a set of mints, falling back to
+ * the Helius asset API when the local catalog is missing entries. Newly
+ * resolved mints are upserted into the catalog so subsequent webhook
+ * deliveries hit the fast path.
+ *
+ * Extracted from the legacy polling sync so it can be reused by the
+ * webhook handler without dragging in the rest of the file.
+ */
+export async function resolveMintMetadata(
+  mints: Iterable<string>,
+): Promise<Map<string, MintMetadata>> {
+  const uniqueMints = Array.from(new Set(Array.from(mints).filter(Boolean)));
+  if (uniqueMints.length === 0) return new Map();
+
+  const db = getDatabase();
+  const existing = await db
+    .select({
+      tokenMint: privateTransferTokenCatalog.tokenMint,
+      decimals: privateTransferTokenCatalog.decimals,
+      symbol: privateTransferTokenCatalog.symbol,
+    })
+    .from(privateTransferTokenCatalog)
+    .where(inArray(privateTransferTokenCatalog.tokenMint, uniqueMints));
+
+  const resolved = new Map<string, MintMetadata>();
+  for (const row of existing) {
+    resolved.set(row.tokenMint, {
+      decimals: row.decimals ?? 0,
+      symbol: row.symbol ?? row.tokenMint,
+    });
+  }
+
+  const missing = uniqueMints.filter((mint) => !resolved.has(mint));
+  if (missing.length > 0) {
+    const entries = await buildTokenCatalogUpserts(missing);
+    await upsertTokenCatalog(entries);
+    for (const entry of entries) {
+      resolved.set(entry.tokenMint, {
+        decimals: entry.decimals ?? 0,
+        symbol: entry.symbol,
+      });
+    }
+  }
+
+  return resolved;
+}

--- a/app/src/features/push-incoming-transfers/server/resync.ts
+++ b/app/src/features/push-incoming-transfers/server/resync.ts
@@ -1,0 +1,483 @@
+import "server-only";
+
+import {
+  heliusWebhookAddresses,
+  heliusWebhooks,
+  pushTokens,
+} from "@loyal-labs/db-core/schema";
+import { Connection } from "@solana/web3.js";
+import { eq, inArray, isNotNull, isNull } from "drizzle-orm";
+
+import { serverEnv } from "@/lib/core/config/server";
+import { getDatabase } from "@/lib/core/database";
+
+import { aggregateAddressesForWallet } from "./address-aggregator";
+import { MAX_ADDRESSES_PER_WEBHOOK } from "./constants";
+import {
+  createHeliusWebhook as defaultCreateHeliusWebhook,
+  patchHeliusWebhookAddresses as defaultPatchHeliusWebhookAddresses,
+} from "./helius-client";
+
+export type DesiredAddress = {
+  address: string;
+  walletPublicKey: string;
+  kind: "wallet" | "ata";
+};
+
+export type CurrentAddress = DesiredAddress & {
+  webhookId: string; // the DB uuid of the helius_webhooks row
+};
+
+export type WebhookCapacity = {
+  webhookId: string; // DB uuid
+  heliusWebhookId: string;
+  currentAddressCount: number;
+};
+
+export type ResyncDiff = {
+  toAdd: Array<DesiredAddress & { assignedWebhookId: string }>;
+  toRemove: CurrentAddress[];
+  webhooksToCreate: Array<{ addresses: DesiredAddress[] }>;
+};
+
+export type HeliusResyncStats = {
+  walletsScanned: number;
+  walletsErrored: number;
+  addressesAdded: number;
+  addressesRemoved: number;
+  webhooksPatched: number;
+  webhooksCreated: number;
+  skipped: boolean;
+};
+
+/**
+ * Pure: given the desired address set, the current address set, and the
+ * non-archived webhooks' current capacities, compute the diff plus
+ * assignments (which existing webhook each new address goes into,
+ * spilling into new webhooks when all full).
+ *
+ * Match by `address` only — `address` is globally unique across the
+ * `helius_webhook_addresses` table.
+ *
+ * Output is deterministic: `toAdd`, `toRemove`, and `webhooksToCreate`
+ * are all sorted by `address` lexicographically so callers and tests
+ * see stable results.
+ */
+export function computeResyncDiff(args: {
+  desired: DesiredAddress[];
+  current: CurrentAddress[];
+  webhooks: WebhookCapacity[];
+  maxAddressesPerWebhook: number;
+}): ResyncDiff {
+  const { current, desired, maxAddressesPerWebhook, webhooks } = args;
+
+  if (maxAddressesPerWebhook <= 0) {
+    throw new Error("maxAddressesPerWebhook must be > 0");
+  }
+
+  // Deduplicate desired by address (defensive — caller is expected to
+  // pre-dedupe, but two wallets technically owning the same ATA must
+  // not double-insert into the unique-by-address table).
+  const desiredByAddress = new Map<string, DesiredAddress>();
+  for (const row of desired) {
+    if (!desiredByAddress.has(row.address)) {
+      desiredByAddress.set(row.address, row);
+    }
+  }
+
+  const currentByAddress = new Map<string, CurrentAddress>();
+  for (const row of current) {
+    if (!currentByAddress.has(row.address)) {
+      currentByAddress.set(row.address, row);
+    }
+  }
+
+  // toRemove: in current, not in desired.
+  const toRemove: CurrentAddress[] = [];
+  for (const [address, row] of currentByAddress) {
+    if (!desiredByAddress.has(address)) {
+      toRemove.push(row);
+    }
+  }
+  toRemove.sort((a, b) => (a.address < b.address ? -1 : a.address > b.address ? 1 : 0));
+
+  // newAddresses: in desired, not in current. Sort by address for
+  // deterministic assignment.
+  const newAddresses: DesiredAddress[] = [];
+  for (const [address, row] of desiredByAddress) {
+    if (!currentByAddress.has(address)) {
+      newAddresses.push(row);
+    }
+  }
+  newAddresses.sort((a, b) => (a.address < b.address ? -1 : a.address > b.address ? 1 : 0));
+
+  // Compute working capacities — but webhooks also lose addresses via
+  // toRemove, freeing capacity. Build remainingCapacity using current
+  // count minus removes that target each webhook.
+  const removesPerWebhook = new Map<string, number>();
+  for (const r of toRemove) {
+    removesPerWebhook.set(
+      r.webhookId,
+      (removesPerWebhook.get(r.webhookId) ?? 0) + 1,
+    );
+  }
+
+  type Slot = {
+    webhookId: string;
+    remaining: number;
+  };
+  const slots: Slot[] = webhooks.map((w) => ({
+    remaining:
+      maxAddressesPerWebhook -
+      w.currentAddressCount +
+      (removesPerWebhook.get(w.webhookId) ?? 0),
+    webhookId: w.webhookId,
+  }));
+
+  // Greedy: for each new address, pick the slot with the most remaining
+  // capacity. When all are full, accumulate into shards for new
+  // webhooks. Resolve ties deterministically by webhookId.
+  const toAdd: ResyncDiff["toAdd"] = [];
+  const overflow: DesiredAddress[] = [];
+
+  for (const row of newAddresses) {
+    let best: Slot | null = null;
+    for (const slot of slots) {
+      if (slot.remaining <= 0) continue;
+      if (!best) {
+        best = slot;
+        continue;
+      }
+      if (slot.remaining > best.remaining) {
+        best = slot;
+        continue;
+      }
+      if (slot.remaining === best.remaining && slot.webhookId < best.webhookId) {
+        best = slot;
+      }
+    }
+    if (best && best.remaining > 0) {
+      toAdd.push({ ...row, assignedWebhookId: best.webhookId });
+      best.remaining -= 1;
+    } else {
+      overflow.push(row);
+    }
+  }
+
+  // Shard overflow into webhooks-to-create chunks of
+  // maxAddressesPerWebhook. Already sorted by address.
+  const webhooksToCreate: ResyncDiff["webhooksToCreate"] = [];
+  for (let i = 0; i < overflow.length; i += maxAddressesPerWebhook) {
+    const chunk = overflow.slice(i, i + maxAddressesPerWebhook);
+    webhooksToCreate.push({ addresses: chunk });
+  }
+
+  return { toAdd, toRemove, webhooksToCreate };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+type ResyncDeps = {
+  aggregateAddressesForWallet: typeof aggregateAddressesForWallet;
+  createHeliusWebhook: typeof defaultCreateHeliusWebhook;
+  patchHeliusWebhookAddresses: typeof defaultPatchHeliusWebhookAddresses;
+  getConnection: () => Connection;
+  apiKey: string;
+  webhookSecret: string;
+  webhookUrl: string;
+};
+
+function buildDefaultDeps(): ResyncDeps {
+  return {
+    aggregateAddressesForWallet,
+    apiKey: serverEnv.heliusApiKey,
+    createHeliusWebhook: defaultCreateHeliusWebhook,
+    getConnection: () =>
+      new Connection(serverEnv.privateMainnetRpcUrl, {
+        commitment: "confirmed",
+      }),
+    patchHeliusWebhookAddresses: defaultPatchHeliusWebhookAddresses,
+    webhookSecret: serverEnv.heliusWebhookSecret,
+    webhookUrl: serverEnv.heliusWebhookUrl,
+  };
+}
+
+export async function runHeliusWebhookResync(
+  depsOverride?: Partial<ResyncDeps>,
+): Promise<HeliusResyncStats> {
+  const deps: ResyncDeps = { ...buildDefaultDeps(), ...depsOverride };
+  const db = getDatabase();
+
+  // 1. All registered wallets.
+  const walletRows = await db
+    .selectDistinct({ walletPublicKey: pushTokens.walletPublicKey })
+    .from(pushTokens)
+    .where(isNotNull(pushTokens.walletPublicKey));
+  const wallets = walletRows
+    .map((row) => row.walletPublicKey)
+    .filter((value): value is string => value !== null && value.length > 0);
+
+  // 2. Aggregate addresses per wallet, logging + counting per-wallet
+  //    failures so a single broken wallet doesn't poison the whole run.
+  const connection = deps.getConnection();
+  const desired: DesiredAddress[] = [];
+  let walletsErrored = 0;
+  for (const wallet of wallets) {
+    try {
+      const rows = await deps.aggregateAddressesForWallet(connection, wallet);
+      for (const row of rows) {
+        desired.push({
+          address: row.address,
+          kind: row.kind,
+          walletPublicKey: row.walletPublicKey,
+        });
+      }
+    } catch (err) {
+      walletsErrored += 1;
+      console.error(
+        "[cron/helius-webhook-resync] aggregate failed for wallet",
+        {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          errorName: err instanceof Error ? err.name : "Unknown",
+          walletPublicKey: wallet,
+        },
+      );
+    }
+  }
+
+  // 3. Current address set.
+  const currentRows = await db
+    .select({
+      address: heliusWebhookAddresses.address,
+      kind: heliusWebhookAddresses.kind,
+      walletPublicKey: heliusWebhookAddresses.walletPublicKey,
+      webhookId: heliusWebhookAddresses.webhookId,
+    })
+    .from(heliusWebhookAddresses);
+  const current: CurrentAddress[] = currentRows.map((row) => ({
+    address: row.address,
+    kind: row.kind,
+    walletPublicKey: row.walletPublicKey,
+    webhookId: row.webhookId,
+  }));
+
+  // 4. Non-archived webhook capacities.
+  const webhookRows = await db
+    .select({
+      addressCount: heliusWebhooks.addressCount,
+      heliusWebhookId: heliusWebhooks.heliusWebhookId,
+      id: heliusWebhooks.id,
+    })
+    .from(heliusWebhooks)
+    .where(isNull(heliusWebhooks.archivedAt));
+  const webhooks: WebhookCapacity[] = webhookRows.map((row) => ({
+    currentAddressCount: row.addressCount,
+    heliusWebhookId: row.heliusWebhookId,
+    webhookId: row.id,
+  }));
+
+  // 5. Diff.
+  const diff = computeResyncDiff({
+    current,
+    desired,
+    maxAddressesPerWebhook: MAX_ADDRESSES_PER_WEBHOOK,
+    webhooks,
+  });
+
+  // 6. No-op short-circuit: zero adds, zero removes → don't burn the
+  //    Helius rate-limit budget on a no-op PATCH/POST.
+  if (diff.toAdd.length === 0 && diff.toRemove.length === 0) {
+    return {
+      addressesAdded: 0,
+      addressesRemoved: 0,
+      skipped: true,
+      walletsErrored,
+      walletsScanned: wallets.length,
+      webhooksCreated: 0,
+      webhooksPatched: 0,
+    };
+  }
+
+  // 7. Create any new webhooks for overflow shards. Insert the
+  //    helius_webhooks row eagerly so we have a UUID to assign on the
+  //    address rows in the same final batch.
+  const createdWebhookIdsByShard: Array<{
+    addresses: DesiredAddress[];
+    dbWebhookId: string;
+    heliusWebhookId: string;
+  }> = [];
+  for (const shard of diff.webhooksToCreate) {
+    const addressList = shard.addresses.map((row) => row.address);
+    const { webhookId: heliusId } = await deps.createHeliusWebhook({
+      accountAddresses: addressList,
+      apiKey: deps.apiKey,
+      authHeader: deps.webhookSecret,
+      webhookUrl: deps.webhookUrl,
+    });
+    const inserted = await db
+      .insert(heliusWebhooks)
+      .values({
+        addressCount: shard.addresses.length,
+        heliusWebhookId: heliusId,
+        webhookUrl: deps.webhookUrl,
+      })
+      .returning({ id: heliusWebhooks.id });
+    const newRow = inserted[0];
+    if (!newRow?.id) {
+      throw new Error(
+        `Failed to insert helius_webhooks row for ${heliusId}; investigate manually`,
+      );
+    }
+    createdWebhookIdsByShard.push({
+      addresses: shard.addresses,
+      dbWebhookId: newRow.id,
+      heliusWebhookId: heliusId,
+    });
+  }
+
+  // 8. For each affected EXISTING webhook, compute its full new address
+  //    list and PATCH Helius. "Affected" = webhook has any add OR any
+  //    remove assigned to it.
+  const affectedExistingWebhookIds = new Set<string>();
+  for (const add of diff.toAdd) {
+    affectedExistingWebhookIds.add(add.assignedWebhookId);
+  }
+  for (const rem of diff.toRemove) {
+    affectedExistingWebhookIds.add(rem.webhookId);
+  }
+
+  // Build a quick lookup for current addresses by webhook so we can
+  // assemble the new full list per affected webhook.
+  const currentByWebhook = new Map<string, CurrentAddress[]>();
+  for (const row of current) {
+    const list = currentByWebhook.get(row.webhookId);
+    if (list) list.push(row);
+    else currentByWebhook.set(row.webhookId, [row]);
+  }
+  const removesByWebhook = new Map<string, Set<string>>();
+  for (const r of diff.toRemove) {
+    let set = removesByWebhook.get(r.webhookId);
+    if (!set) {
+      set = new Set<string>();
+      removesByWebhook.set(r.webhookId, set);
+    }
+    set.add(r.address);
+  }
+  const addsByWebhook = new Map<string, DesiredAddress[]>();
+  for (const a of diff.toAdd) {
+    const list = addsByWebhook.get(a.assignedWebhookId);
+    if (list) list.push(a);
+    else addsByWebhook.set(a.assignedWebhookId, [a]);
+  }
+
+  const webhookDbIdToHelius = new Map<string, string>();
+  for (const w of webhooks) {
+    webhookDbIdToHelius.set(w.webhookId, w.heliusWebhookId);
+  }
+
+  // Per-webhook final address counts after the resync. Used both for
+  // the PATCH and to update helius_webhooks.addressCount.
+  const newAddressCountByWebhook = new Map<string, number>();
+  let webhooksPatched = 0;
+  for (const dbWebhookId of affectedExistingWebhookIds) {
+    const heliusId = webhookDbIdToHelius.get(dbWebhookId);
+    if (!heliusId) {
+      throw new Error(
+        `Affected webhook ${dbWebhookId} not found in current webhooks list; investigate manually`,
+      );
+    }
+    const existing = currentByWebhook.get(dbWebhookId) ?? [];
+    const removes = removesByWebhook.get(dbWebhookId) ?? new Set<string>();
+    const adds = addsByWebhook.get(dbWebhookId) ?? [];
+
+    const fullAddressList: string[] = [];
+    for (const row of existing) {
+      if (!removes.has(row.address)) fullAddressList.push(row.address);
+    }
+    for (const a of adds) {
+      fullAddressList.push(a.address);
+    }
+    newAddressCountByWebhook.set(dbWebhookId, fullAddressList.length);
+
+    await deps.patchHeliusWebhookAddresses({
+      accountAddresses: fullAddressList,
+      apiKey: deps.apiKey,
+      heliusWebhookId: heliusId,
+    });
+    webhooksPatched += 1;
+  }
+
+  // 9. Single db.batch: insert toAdd rows (for existing webhooks AND
+  //    overflow shards), delete toRemove rows, update affected
+  //    helius_webhooks.addressCount. Per CLAUDE.md, this repo uses
+  //    drizzle-orm/neon-http which does NOT support db.transaction();
+  //    db.batch is the atomic multi-write primitive.
+  type BatchStatement = Parameters<typeof db.batch>[0][number];
+  const statements: BatchStatement[] = [];
+
+  // Inserts for toAdd against existing webhooks.
+  const addRowsExisting = diff.toAdd.map((row) => ({
+    address: row.address,
+    kind: row.kind,
+    walletPublicKey: row.walletPublicKey,
+    webhookId: row.assignedWebhookId,
+  }));
+  if (addRowsExisting.length > 0) {
+    statements.push(
+      db.insert(heliusWebhookAddresses).values(addRowsExisting),
+    );
+  }
+
+  // Inserts for newly-created webhooks (overflow shards).
+  for (const created of createdWebhookIdsByShard) {
+    const rows = created.addresses.map((row) => ({
+      address: row.address,
+      kind: row.kind,
+      walletPublicKey: row.walletPublicKey,
+      webhookId: created.dbWebhookId,
+    }));
+    if (rows.length > 0) {
+      statements.push(db.insert(heliusWebhookAddresses).values(rows));
+    }
+  }
+
+  // Deletes for toRemove. Address is globally unique → safe to match by
+  // address.
+  if (diff.toRemove.length > 0) {
+    const removeAddresses = diff.toRemove.map((r) => r.address);
+    statements.push(
+      db
+        .delete(heliusWebhookAddresses)
+        .where(inArray(heliusWebhookAddresses.address, removeAddresses)),
+    );
+  }
+
+  // Address-count updates on affected existing webhooks.
+  for (const [dbWebhookId, count] of newAddressCountByWebhook) {
+    statements.push(
+      db
+        .update(heliusWebhooks)
+        .set({ addressCount: count, updatedAt: new Date() })
+        .where(eq(heliusWebhooks.id, dbWebhookId)),
+    );
+  }
+
+  if (statements.length > 0) {
+    const [first, ...rest] = statements;
+    if (first) {
+      await db.batch([first, ...rest]);
+    }
+  }
+
+  return {
+    addressesAdded: diff.toAdd.length + diff.webhooksToCreate.reduce((sum, shard) => sum + shard.addresses.length, 0),
+    addressesRemoved: diff.toRemove.length,
+    skipped: false,
+    walletsErrored,
+    walletsScanned: wallets.length,
+    webhooksCreated: createdWebhookIdsByShard.length,
+    webhooksPatched,
+  };
+}

--- a/app/src/features/push-incoming-transfers/server/webhook-deps.ts
+++ b/app/src/features/push-incoming-transfers/server/webhook-deps.ts
@@ -1,0 +1,70 @@
+import "server-only";
+
+import {
+  heliusWebhookAddresses,
+  heliusWebhookDeliveries,
+} from "@loyal-labs/db-core/schema";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { getDatabase } from "@/lib/core/database";
+import { sendPushToWallet } from "@/lib/push-notifications/send-to-wallet";
+
+import { resolveMintMetadata } from "./mint-metadata";
+import type { ProcessDeps } from "./webhook-handler";
+
+/**
+ * Returns the real-deps implementation of the webhook handler's
+ * injected interface. The handler itself is mockable; this is the
+ * adapter that hits the database and reuses platform helpers.
+ */
+export function buildWebhookDeps(): ProcessDeps {
+  return {
+    async lookupWalletsForAddresses(addresses) {
+      const out = new Map<string, string>();
+      if (addresses.length === 0) return out;
+      const db = getDatabase();
+      const rows = await db
+        .select({
+          address: heliusWebhookAddresses.address,
+          walletPublicKey: heliusWebhookAddresses.walletPublicKey,
+        })
+        .from(heliusWebhookAddresses)
+        .where(inArray(heliusWebhookAddresses.address, addresses));
+      for (const row of rows) {
+        out.set(row.address, row.walletPublicKey);
+      }
+      return out;
+    },
+
+    async isDelivered(signature, walletPublicKey) {
+      const db = getDatabase();
+      const rows = await db
+        .select({ signature: heliusWebhookDeliveries.signature })
+        .from(heliusWebhookDeliveries)
+        .where(
+          and(
+            eq(heliusWebhookDeliveries.signature, signature),
+            eq(heliusWebhookDeliveries.walletPublicKey, walletPublicKey),
+          ),
+        )
+        .limit(1);
+      return rows.length > 0;
+    },
+
+    async recordDelivery(signature, walletPublicKey) {
+      const db = getDatabase();
+      await db
+        .insert(heliusWebhookDeliveries)
+        .values({ signature, walletPublicKey })
+        .onConflictDoNothing();
+    },
+
+    async resolveMintMetadata(mints) {
+      return resolveMintMetadata(mints);
+    },
+
+    async sendPushToWallet(walletPublicKey, payload) {
+      return sendPushToWallet(walletPublicKey, payload);
+    },
+  };
+}

--- a/app/src/features/push-incoming-transfers/server/webhook-handler.ts
+++ b/app/src/features/push-incoming-transfers/server/webhook-handler.ts
@@ -1,0 +1,329 @@
+import "server-only";
+
+import type { WalletPushPayload } from "@/lib/push-notifications/send-to-wallet";
+
+import type { IncomingTransferEvent, IncomingTransferKind } from "../types";
+import { NATIVE_SOL_MINT } from "./constants";
+import { formatIncomingTransferPush } from "./format";
+
+const NATIVE_SOL_MINT_STR = NATIVE_SOL_MINT.toBase58();
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+export type HeliusEnhancedEvent = {
+  type: string;
+  signature: string;
+  timestamp: number;
+  feePayer?: string;
+  nativeTransfers?: Array<{
+    fromUserAccount: string;
+    toUserAccount: string;
+    amount: number;
+  }>;
+  tokenTransfers?: Array<{
+    fromUserAccount: string;
+    toUserAccount: string;
+    mint: string;
+    tokenAmount: number;
+  }>;
+  accountData?: Array<{
+    account: string;
+    nativeBalanceChange: number;
+  }>;
+};
+
+export type ProcessDeps = {
+  lookupWalletsForAddresses(addresses: string[]): Promise<Map<string, string>>;
+  isDelivered(signature: string, walletPublicKey: string): Promise<boolean>;
+  recordDelivery(signature: string, walletPublicKey: string): Promise<void>;
+  resolveMintMetadata(
+    mints: Iterable<string>,
+  ): Promise<Map<string, { symbol: string; decimals: number }>>;
+  sendPushToWallet(
+    walletPublicKey: string,
+    payload: WalletPushPayload,
+  ): Promise<{ sentTo: number }>;
+};
+
+export type WebhookStats = {
+  eventsReceived: number;
+  notificationsSent: number;
+  duplicates: number;
+  unroutable: number;
+  errors: number;
+};
+
+type RoutedRecipient = {
+  walletPublicKey: string;
+  event: IncomingTransferEvent;
+};
+
+/**
+ * Convert a Helius enhanced event into one or more domain
+ * IncomingTransferEvent records keyed by the registered wallet they
+ * should fire a push to. Pulls recipient addresses (positive amounts
+ * only) from both native and SPL transfers and looks them up in the
+ * registered-address map. Returns an empty array if nothing routes.
+ */
+function routeEventToRecipients(
+  event: HeliusEnhancedEvent,
+  addressToWallet: Map<string, string>,
+): RoutedRecipient[] {
+  const recipients: RoutedRecipient[] = [];
+  const occurredAt = new Date(event.timestamp * 1000);
+
+  if (Array.isArray(event.tokenTransfers)) {
+    for (const transfer of event.tokenTransfers) {
+      if (!transfer) continue;
+      if (typeof transfer.tokenAmount !== "number") continue;
+      if (transfer.tokenAmount <= 0) continue;
+      const wallet = addressToWallet.get(transfer.toUserAccount);
+      if (!wallet) continue;
+      // Helius enhanced webhook gives tokenAmount as a UI-decimal number
+      // (already scaled by the mint's decimals). Convert back to raw
+      // base units using the metadata we already fetched.
+      // We don't have decimals here — caller passes amountRaw as best
+      // effort. To preserve precision we delegate scaling later.
+      recipients.push({
+        walletPublicKey: wallet,
+        event: {
+          kind: "spl" as IncomingTransferKind,
+          recipient: wallet,
+          sender: transfer.fromUserAccount || null,
+          // Carry the UI amount in amountRaw + decimals=0 will round-trip
+          // poorly; instead, store the float as raw and rely on metadata
+          // lookup to provide decimals so formatAmount can scale.
+          // We store as the integer portion of (tokenAmount * 10^decimals)
+          // at format time. For now stash the float in a side channel by
+          // storing tokenAmount * 1 as bigint of the unscaled raw.
+          // Cleanest: store amountRaw=BigInt(round(tokenAmount * 10^decimals))
+          // at format time. We can't do that yet because we resolve
+          // decimals globally. So we expose a placeholder and adjust
+          // at format time using the metadata map.
+          amountRaw: BigInt(0),
+          mint: transfer.mint,
+          signature: event.signature,
+          occurredAt,
+        },
+      });
+    }
+  }
+
+  if (Array.isArray(event.nativeTransfers)) {
+    for (const transfer of event.nativeTransfers) {
+      if (!transfer) continue;
+      if (typeof transfer.amount !== "number") continue;
+      if (transfer.amount <= 0) continue;
+      const wallet = addressToWallet.get(transfer.toUserAccount);
+      if (!wallet) continue;
+      recipients.push({
+        walletPublicKey: wallet,
+        event: {
+          kind: "sol" as IncomingTransferKind,
+          recipient: wallet,
+          sender: transfer.fromUserAccount || null,
+          amountRaw: BigInt(transfer.amount),
+          mint: NATIVE_SOL_MINT_STR,
+          signature: event.signature,
+          occurredAt,
+        },
+      });
+    }
+  }
+
+  return recipients;
+}
+
+/**
+ * Collect every candidate recipient address across the payload so we
+ * can batch-resolve them with a single DB roundtrip. Skips non-TRANSFER
+ * events.
+ */
+function collectCandidateAddresses(
+  events: readonly HeliusEnhancedEvent[],
+): { addresses: string[]; mints: string[] } {
+  const addresses = new Set<string>();
+  const mints = new Set<string>();
+  mints.add(NATIVE_SOL_MINT_STR);
+  for (const event of events) {
+    if (event.type !== "TRANSFER") continue;
+    // Each event read is wrapped so a forged/corrupt event can't poison
+    // the batch-prep pass. The same fields are re-read inside
+    // routeEventToRecipients under the main loop's per-event try, where
+    // the failure is surfaced into `errors`.
+    try {
+      const tokenTransfers = event.tokenTransfers;
+      if (Array.isArray(tokenTransfers)) {
+        for (const t of tokenTransfers) {
+          if (!t || typeof t.tokenAmount !== "number" || t.tokenAmount <= 0) {
+            continue;
+          }
+          if (t.toUserAccount) addresses.add(t.toUserAccount);
+          if (t.mint) mints.add(t.mint);
+        }
+      }
+    } catch {
+      // ignore — will be surfaced in main loop
+    }
+    try {
+      const nativeTransfers = event.nativeTransfers;
+      if (Array.isArray(nativeTransfers)) {
+        for (const n of nativeTransfers) {
+          if (!n || typeof n.amount !== "number" || n.amount <= 0) continue;
+          if (n.toUserAccount) addresses.add(n.toUserAccount);
+        }
+      }
+    } catch {
+      // ignore — will be surfaced in main loop
+    }
+  }
+  return { addresses: Array.from(addresses), mints: Array.from(mints) };
+}
+
+function scaleToRawAmount(
+  uiAmount: number,
+  decimals: number,
+): bigint {
+  if (decimals <= 0) {
+    return BigInt(Math.max(0, Math.round(uiAmount)));
+  }
+  // Avoid floating-point drift for typical SPL decimals (≤ 9 in practice,
+  // up to 18 in theory). Build the integer string by hand.
+  const negative = uiAmount < 0;
+  const abs = Math.abs(uiAmount);
+  const fixed = abs.toFixed(decimals);
+  const [whole, frac = ""] = fixed.split(".");
+  const padded = (frac + "0".repeat(decimals)).slice(0, decimals);
+  const combined = `${whole ?? "0"}${padded}`.replace(/^0+(?=\d)/, "");
+  const value = BigInt(combined.length === 0 ? "0" : combined);
+  return negative ? -value : value;
+}
+
+export async function processHeliusWebhookPayload(
+  events: HeliusEnhancedEvent[],
+  deps: ProcessDeps,
+): Promise<WebhookStats> {
+  const stats: WebhookStats = {
+    eventsReceived: events.length,
+    notificationsSent: 0,
+    duplicates: 0,
+    unroutable: 0,
+    errors: 0,
+  };
+
+  if (events.length === 0) return stats;
+
+  // Defensive filter — we configure Helius to only send TRANSFER, but a
+  // misconfigured webhook (or a future change) must not be allowed to
+  // burn DB calls or fire bogus pushes.
+  const transferEvents = events.filter((event) => event.type === "TRANSFER");
+  if (transferEvents.length === 0) return stats;
+
+  // Single DB roundtrip for address routing + single roundtrip for mint
+  // metadata. Per CLAUDE.md these are `critical` — if they fail, the
+  // whole webhook fails so Helius retries.
+  const { addresses, mints } = collectCandidateAddresses(transferEvents);
+
+  // No candidate addresses across the payload → nothing routable. Each
+  // transfer event contributed nothing, so each counts as unroutable.
+  if (addresses.length === 0) {
+    stats.unroutable += transferEvents.length;
+    return stats;
+  }
+
+  const addressToWallet = await deps.lookupWalletsForAddresses(addresses);
+  const metadataByMint = await deps.resolveMintMetadata(mints);
+
+  // Per-event try/catch so one malformed entry doesn't poison the batch.
+  for (const event of transferEvents) {
+    try {
+      const recipients = routeEventToRecipients(event, addressToWallet);
+      if (recipients.length === 0) {
+        stats.unroutable += 1;
+        continue;
+      }
+
+      for (const { walletPublicKey, event: domainEvent } of recipients) {
+        // Idempotency check is `critical` — must succeed before we
+        // decide to dispatch. Record BEFORE dispatch so a crash
+        // mid-send doesn't double-fire on Helius retry.
+        const already = await deps.isDelivered(
+          event.signature,
+          walletPublicKey,
+        );
+        if (already) {
+          stats.duplicates += 1;
+          continue;
+        }
+        await deps.recordDelivery(event.signature, walletPublicKey);
+
+        // For SPL transfers, scale the UI amount to raw base units now
+        // that we have decimals from the metadata lookup. For SOL we
+        // already populated amountRaw with lamports.
+        let amountRaw = domainEvent.amountRaw;
+        const metadata = metadataByMint.get(domainEvent.mint) ?? null;
+        if (domainEvent.kind === "spl" && metadata) {
+          const splTransfer = event.tokenTransfers?.find(
+            (t) =>
+              t.toUserAccount === walletPublicKey ||
+              (t.toUserAccount &&
+                addressToWallet.get(t.toUserAccount) === walletPublicKey &&
+                t.mint === domainEvent.mint),
+          );
+          if (splTransfer && typeof splTransfer.tokenAmount === "number") {
+            amountRaw = scaleToRawAmount(
+              splTransfer.tokenAmount,
+              metadata.decimals,
+            );
+          }
+        }
+
+        const finalEvent: IncomingTransferEvent = {
+          ...domainEvent,
+          amountRaw,
+        };
+
+        // Provide a synthetic SOL metadata fallback so the formatter
+        // always renders the SOL symbol with correct decimals.
+        const effectiveMetadata =
+          metadata ??
+          (domainEvent.kind === "sol"
+            ? { symbol: "SOL", decimals: 9 }
+            : null);
+        const payload = formatIncomingTransferPush(
+          finalEvent,
+          effectiveMetadata,
+        );
+
+        // Fire-and-catch dispatch — never block the webhook ack on the
+        // Expo push, per the webhook-failure-policy guardrail.
+        void deps
+          .sendPushToWallet(walletPublicKey, payload)
+          .then((result) => {
+            stats.notificationsSent += result.sentTo;
+          })
+          .catch((err: unknown) => {
+            stats.errors += 1;
+            console.error("[helius-webhook] push dispatch failed", {
+              signature: event.signature,
+              walletPublicKey,
+              errorName: err instanceof Error ? err.name : "Unknown",
+              errorMessage:
+                err instanceof Error ? err.message : String(err),
+            });
+          });
+      }
+    } catch (err) {
+      stats.errors += 1;
+      console.error("[helius-webhook] event processing failed", {
+        signature: event.signature,
+        errorName: err instanceof Error ? err.name : "Unknown",
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return stats;
+}
+
+// Re-export so the route can import a single constant cleanly if needed.
+export { LAMPORTS_PER_SOL };

--- a/app/src/features/push-incoming-transfers/server/webhook-handler.ts
+++ b/app/src/features/push-incoming-transfers/server/webhook-handler.ts
@@ -63,10 +63,17 @@ type RoutedRecipient = {
  * should fire a push to. Pulls recipient addresses (positive amounts
  * only) from both native and SPL transfers and looks them up in the
  * registered-address map. Returns an empty array if nothing routes.
+ *
+ * SPL transfers arrive from Helius as UI-decimal floats; we scale them
+ * to raw base units here using the mint metadata so the resulting
+ * recipient already carries a correct, final `amountRaw`. Mints missing
+ * from the metadata map fall back to `decimals = 0` (matching
+ * `UNKNOWN_DECIMALS` in format.ts) and a structured warning is logged.
  */
 function routeEventToRecipients(
   event: HeliusEnhancedEvent,
   addressToWallet: Map<string, string>,
+  metadataByMint: Map<string, { symbol: string; decimals: number }>,
 ): RoutedRecipient[] {
   const recipients: RoutedRecipient[] = [];
   const occurredAt = new Date(event.timestamp * 1000);
@@ -78,28 +85,22 @@ function routeEventToRecipients(
       if (transfer.tokenAmount <= 0) continue;
       const wallet = addressToWallet.get(transfer.toUserAccount);
       if (!wallet) continue;
-      // Helius enhanced webhook gives tokenAmount as a UI-decimal number
-      // (already scaled by the mint's decimals). Convert back to raw
-      // base units using the metadata we already fetched.
-      // We don't have decimals here — caller passes amountRaw as best
-      // effort. To preserve precision we delegate scaling later.
+      const metadata = metadataByMint.get(transfer.mint);
+      if (!metadata) {
+        console.warn("[helius-webhook] missing mint metadata; using decimals=0", {
+          mint: transfer.mint,
+          signature: event.signature,
+          walletPublicKey: wallet,
+        });
+      }
+      const decimals = metadata?.decimals ?? 0;
       recipients.push({
         walletPublicKey: wallet,
         event: {
           kind: "spl" as IncomingTransferKind,
           recipient: wallet,
           sender: transfer.fromUserAccount || null,
-          // Carry the UI amount in amountRaw + decimals=0 will round-trip
-          // poorly; instead, store the float as raw and rely on metadata
-          // lookup to provide decimals so formatAmount can scale.
-          // We store as the integer portion of (tokenAmount * 10^decimals)
-          // at format time. For now stash the float in a side channel by
-          // storing tokenAmount * 1 as bigint of the unscaled raw.
-          // Cleanest: store amountRaw=BigInt(round(tokenAmount * 10^decimals))
-          // at format time. We can't do that yet because we resolve
-          // decimals globally. So we expose a placeholder and adjust
-          // at format time using the metadata map.
-          amountRaw: BigInt(0),
+          amountRaw: scaleToRawAmount(transfer.tokenAmount, decimals),
           mint: transfer.mint,
           signature: event.signature,
           occurredAt,
@@ -236,7 +237,11 @@ export async function processHeliusWebhookPayload(
   // Per-event try/catch so one malformed entry doesn't poison the batch.
   for (const event of transferEvents) {
     try {
-      const recipients = routeEventToRecipients(event, addressToWallet);
+      const recipients = routeEventToRecipients(
+        event,
+        addressToWallet,
+        metadataByMint,
+      );
       if (recipients.length === 0) {
         stats.unroutable += 1;
         continue;
@@ -256,41 +261,16 @@ export async function processHeliusWebhookPayload(
         }
         await deps.recordDelivery(event.signature, walletPublicKey);
 
-        // For SPL transfers, scale the UI amount to raw base units now
-        // that we have decimals from the metadata lookup. For SOL we
-        // already populated amountRaw with lamports.
-        let amountRaw = domainEvent.amountRaw;
-        const metadata = metadataByMint.get(domainEvent.mint) ?? null;
-        if (domainEvent.kind === "spl" && metadata) {
-          const splTransfer = event.tokenTransfers?.find(
-            (t) =>
-              t.toUserAccount === walletPublicKey ||
-              (t.toUserAccount &&
-                addressToWallet.get(t.toUserAccount) === walletPublicKey &&
-                t.mint === domainEvent.mint),
-          );
-          if (splTransfer && typeof splTransfer.tokenAmount === "number") {
-            amountRaw = scaleToRawAmount(
-              splTransfer.tokenAmount,
-              metadata.decimals,
-            );
-          }
-        }
-
-        const finalEvent: IncomingTransferEvent = {
-          ...domainEvent,
-          amountRaw,
-        };
-
         // Provide a synthetic SOL metadata fallback so the formatter
         // always renders the SOL symbol with correct decimals.
+        const metadata = metadataByMint.get(domainEvent.mint) ?? null;
         const effectiveMetadata =
           metadata ??
           (domainEvent.kind === "sol"
             ? { symbol: "SOL", decimals: 9 }
             : null);
         const payload = formatIncomingTransferPush(
-          finalEvent,
+          domainEvent,
           effectiveMetadata,
         );
 

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -151,6 +151,9 @@ export const serverEnv = {
   get heliusWebhookSecret(): string {
     return getRequiredEnv("HELIUS_WEBHOOK_SECRET");
   },
+  get heliusWebhookUrl(): string {
+    return getRequiredEnv("HELIUS_WEBHOOK_URL");
+  },
   get telegramSummaryPeerOverride(): TelegramSummaryPeerOverride | null {
     return getTelegramSummaryPeerOverride();
   },

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -145,6 +145,12 @@ export const serverEnv = {
   get privateMainnetRpcUrl(): string {
     return getRequiredEnv("PRIVATE_MAINNET_RPC_URL");
   },
+  get heliusApiKey(): string {
+    return getRequiredEnv("HELIUS_API_KEY");
+  },
+  get heliusWebhookSecret(): string {
+    return getRequiredEnv("HELIUS_WEBHOOK_SECRET");
+  },
   get telegramSummaryPeerOverride(): TelegramSummaryPeerOverride | null {
     return getTelegramSummaryPeerOverride();
   },
@@ -173,3 +179,11 @@ export const serverEnv = {
     return REQUIRED_R2_ENV_VARS.every((name) => Boolean(getOptionalEnv(name)));
   },
 } as const;
+
+export function getHeliusApiKey(): string {
+  return getRequiredEnv("HELIUS_API_KEY");
+}
+
+export function getHeliusWebhookSecret(): string {
+  return getRequiredEnv("HELIUS_WEBHOOK_SECRET");
+}

--- a/app/src/lib/core/config/server.ts
+++ b/app/src/lib/core/config/server.ts
@@ -179,11 +179,3 @@ export const serverEnv = {
     return REQUIRED_R2_ENV_VARS.every((name) => Boolean(getOptionalEnv(name)));
   },
 } as const;
-
-export function getHeliusApiKey(): string {
-  return getRequiredEnv("HELIUS_API_KEY");
-}
-
-export function getHeliusWebhookSecret(): string {
-  return getRequiredEnv("HELIUS_WEBHOOK_SECRET");
-}

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -22,6 +22,10 @@
     {
       "path": "/api/cron/push-shielded-transfers",
       "schedule": "1-59/2 * * * *"
+    },
+    {
+      "path": "/api/cron/helius-webhook-resync",
+      "schedule": "0 4 * * *"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release-packages": "bun run scripts/release-packages.ts",
+    "helius:webhook:bootstrap": "bun --conditions=react-server scripts/helius-webhook-bootstrap.ts",
     "sync:mirror-repos": "bun run scripts/mirror-repos/sync.ts",
     "build:db-packages": "bun run --cwd packages/db-core build && bun run --cwd packages/db-adapter-neon build",
     "build:llm-packages": "bun run --cwd packages/llm-core build && bun run --cwd packages/llm-server build",

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   numeric,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   uniqueIndex,
@@ -710,6 +711,64 @@ export const walletPushSyncState = pgTable("wallet_push_sync_state", {
     .defaultNow()
     .notNull(),
 });
+
+export const heliusWebhooks = pgTable(
+  "helius_webhooks",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    heliusWebhookId: text("helius_webhook_id").notNull(),
+    webhookUrl: text("webhook_url").notNull(),
+    // Increment when we need to invalidate all existing addresses
+    // (e.g. authHeader rotation, environment migration).
+    generation: integer("generation").default(0).notNull(),
+    addressCount: integer("address_count").default(0).notNull(),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("helius_webhooks_helius_id_unique").on(table.heliusWebhookId),
+  ],
+);
+
+export const heliusWebhookAddresses = pgTable(
+  "helius_webhook_addresses",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    webhookId: uuid("webhook_id")
+      .notNull()
+      .references(() => heliusWebhooks.id, { onDelete: "cascade" }),
+    address: text("address").notNull(),
+    walletPublicKey: text("wallet_public_key").notNull(),
+    kind: text("kind").$type<"wallet" | "ata">().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("helius_webhook_addresses_address_unique").on(table.address),
+    index("helius_webhook_addresses_wallet_idx").on(table.walletPublicKey),
+    index("helius_webhook_addresses_webhook_idx").on(table.webhookId),
+  ],
+);
+
+export const heliusWebhookDeliveries = pgTable(
+  "helius_webhook_deliveries",
+  {
+    signature: text("signature").notNull(),
+    walletPublicKey: text("wallet_public_key").notNull(),
+    processedAt: timestamp("processed_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.signature, table.walletPublicKey] }),
+  ],
+);
 
 /**
  * Wallet-first users for the Loyal web frontend.
@@ -1707,6 +1766,15 @@ export type InsertPushNotificationTicket =
 
 export type WalletPushSyncState = typeof walletPushSyncState.$inferSelect;
 export type InsertWalletPushSyncState = typeof walletPushSyncState.$inferInsert;
+
+export type HeliusWebhook = typeof heliusWebhooks.$inferSelect;
+export type InsertHeliusWebhook = typeof heliusWebhooks.$inferInsert;
+export type HeliusWebhookAddress = typeof heliusWebhookAddresses.$inferSelect;
+export type InsertHeliusWebhookAddress =
+  typeof heliusWebhookAddresses.$inferInsert;
+export type HeliusWebhookDelivery = typeof heliusWebhookDeliveries.$inferSelect;
+export type InsertHeliusWebhookDelivery =
+  typeof heliusWebhookDeliveries.$inferInsert;
 
 export type AppUser = typeof appUsers.$inferSelect;
 export type InsertAppUser = typeof appUsers.$inferInsert;

--- a/scripts/helius-webhook-bootstrap.ts
+++ b/scripts/helius-webhook-bootstrap.ts
@@ -33,11 +33,13 @@ import { Connection } from "@solana/web3.js";
 import { isNotNull, isNull } from "drizzle-orm";
 
 import { aggregateAddressesForWallet } from "../app/src/features/push-incoming-transfers/server/address-aggregator";
+import { MAX_ADDRESSES_PER_WEBHOOK } from "../app/src/features/push-incoming-transfers/server/constants";
 import { createHeliusWebhook } from "../app/src/features/push-incoming-transfers/server/helius-client";
 
 // Helius advertises a 100k accountAddresses cap per webhook. We keep
-// 50% headroom for ATA churn and accidental duplicates.
-const SHARD_LIMIT = 50_000;
+// 50% headroom for ATA churn and accidental duplicates. Shared with
+// the resync cron via MAX_ADDRESSES_PER_WEBHOOK in constants.ts.
+const SHARD_LIMIT = MAX_ADDRESSES_PER_WEBHOOK;
 // ATA aggregation hits Solana RPC; throttle a touch to stay under
 // Helius free-tier ~10 req/s when iterating many wallets.
 const PER_WALLET_THROTTLE_MS = 200;

--- a/scripts/helius-webhook-bootstrap.ts
+++ b/scripts/helius-webhook-bootstrap.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env -S bun --conditions=react-server
+/**
+ * One-shot operator script to register the initial Helius webhook(s) for
+ * every currently-registered wallet.
+ *
+ * Usage:
+ *   bun run scripts/helius-webhook-bootstrap.ts --dry-run   (default)
+ *   bun run scripts/helius-webhook-bootstrap.ts --apply
+ *
+ * Idempotency: refuses to run if `helius_webhooks` already has a
+ * non-archived row. Bootstrap is meant for a clean slate; the resync
+ * cron handles delta updates.
+ *
+ * Per CLAUDE.md webhook reliability guardrails: writes are `critical`,
+ * we fail loudly on any DB/Helius error and leave half-state for the
+ * operator to investigate. Uses `db.batch([...])` for Neon HTTP atomic
+ * multi-step writes (Neon HTTP does not support `db.transaction()`).
+ *
+ * The shebang sets `--conditions=react-server` so Bun resolves the
+ * `server-only` marker package's empty export — `aggregateAddressesForWallet`
+ * and `createHeliusWebhook` both import "server-only" because they are
+ * normally consumed by Next.js server code.
+ */
+
+import { createNeonDb } from "@loyal-labs/db-adapter-neon";
+import * as schema from "@loyal-labs/db-core/schema";
+import {
+  heliusWebhookAddresses,
+  heliusWebhooks,
+  pushTokens,
+} from "@loyal-labs/db-core/schema";
+import { Connection } from "@solana/web3.js";
+import { isNotNull, isNull } from "drizzle-orm";
+
+import { aggregateAddressesForWallet } from "../app/src/features/push-incoming-transfers/server/address-aggregator";
+import { createHeliusWebhook } from "../app/src/features/push-incoming-transfers/server/helius-client";
+
+// Helius advertises a 100k accountAddresses cap per webhook. We keep
+// 50% headroom for ATA churn and accidental duplicates.
+const SHARD_LIMIT = 50_000;
+// ATA aggregation hits Solana RPC; throttle a touch to stay under
+// Helius free-tier ~10 req/s when iterating many wallets.
+const PER_WALLET_THROTTLE_MS = 200;
+const THROTTLE_AFTER_WALLET_COUNT = 100;
+
+type Mode = "dry-run" | "apply";
+
+type ParsedArgs = {
+  mode: Mode;
+  modeExplicit: boolean;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let mode: Mode = "dry-run";
+  let modeExplicit = false;
+
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      mode = "apply";
+      modeExplicit = true;
+    } else if (arg === "--dry-run") {
+      mode = "dry-run";
+      modeExplicit = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelpAndExit();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { mode, modeExplicit };
+}
+
+function printHelpAndExit(): never {
+  console.log(`Usage: bun run scripts/helius-webhook-bootstrap.ts [--dry-run|--apply]
+
+  --dry-run   (default) Print plan without calling Helius or writing DB.
+  --apply     Actually create webhooks and persist rows.
+
+Required env (all modes):
+  DATABASE_URL
+
+Required env (--apply only):
+  HELIUS_API_KEY
+  HELIUS_WEBHOOK_SECRET
+  HELIUS_WEBHOOK_URL
+
+Optional:
+  HELIUS_RPC_URL_FOR_BOOTSTRAP  (defaults to https://api.mainnet-beta.solana.com)
+`);
+  process.exit(0);
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.length === 0) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  if (size <= 0) throw new Error("chunk size must be > 0");
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  const { mode, modeExplicit } = parseArgs(process.argv.slice(2));
+
+  if (!modeExplicit) {
+    console.log(
+      "Notice: no mode flag supplied; defaulting to --dry-run. Pass --apply to execute."
+    );
+  }
+
+  // Required env: DATABASE_URL always.
+  const databaseUrl = requireEnv("DATABASE_URL");
+
+  // Helius env vars: required only for --apply.
+  let heliusApiKey = "";
+  let heliusWebhookSecret = "";
+  let heliusWebhookUrl = "";
+  if (mode === "apply") {
+    heliusApiKey = requireEnv("HELIUS_API_KEY");
+    heliusWebhookSecret = requireEnv("HELIUS_WEBHOOK_SECRET");
+    heliusWebhookUrl = requireEnv("HELIUS_WEBHOOK_URL");
+  } else {
+    const missing = [
+      "HELIUS_API_KEY",
+      "HELIUS_WEBHOOK_SECRET",
+      "HELIUS_WEBHOOK_URL",
+    ].filter((name) => !process.env[name]);
+    if (missing.length > 0) {
+      console.log(
+        `Note: ${missing.join(", ")} not set (only needed with --apply).`
+      );
+    }
+  }
+
+  const rpcUrl =
+    process.env.HELIUS_RPC_URL_FOR_BOOTSTRAP ??
+    "https://api.mainnet-beta.solana.com";
+  const connection = new Connection(rpcUrl, "confirmed");
+
+  const db = createNeonDb({ databaseUrl, schema });
+
+  // Idempotency guard. Bootstrap only runs on a clean slate.
+  const existing = await db
+    .select({ id: heliusWebhooks.id })
+    .from(heliusWebhooks)
+    .where(isNull(heliusWebhooks.archivedAt))
+    .limit(1);
+  if (existing.length > 0) {
+    console.error(
+      "Existing non-archived Helius webhooks found. Use the resync cron, or archive them first."
+    );
+    process.exit(1);
+  }
+
+  // Distinct registered wallets from push_tokens.
+  const walletRows = await db
+    .selectDistinct({ walletPublicKey: pushTokens.walletPublicKey })
+    .from(pushTokens)
+    .where(isNotNull(pushTokens.walletPublicKey));
+  const wallets = walletRows
+    .map((row) => row.walletPublicKey)
+    .filter((value): value is string => value !== null && value.length > 0);
+
+  console.log(
+    `Helius webhook bootstrap [${mode === "apply" ? "APPLY" : "DRY RUN"}]`
+  );
+  console.log(`  Wallets registered:    ${wallets.length}`);
+
+  if (wallets.length === 0) {
+    console.log("  Addresses aggregated:  0");
+    console.log("  Shards (<=50,000 ea):  0");
+    console.log("  Webhooks to create:    0");
+    if (mode === "dry-run") {
+      console.log(
+        "\n[DRY RUN] Nothing to do (no registered wallets). Run again with --apply to execute."
+      );
+    } else {
+      console.log(
+        "\n[APPLY] Nothing to do (no registered wallets); no webhooks created."
+      );
+    }
+    process.exit(0);
+  }
+
+  // Aggregate addresses for every wallet. Throttle once we exceed
+  // THROTTLE_AFTER_WALLET_COUNT to stay polite to Solana RPC.
+  const aggregated: {
+    address: string;
+    kind: "wallet" | "ata";
+    walletPublicKey: string;
+  }[] = [];
+  for (let i = 0; i < wallets.length; i++) {
+    const wallet = wallets[i];
+    const rows = await aggregateAddressesForWallet(connection, wallet);
+    aggregated.push(...rows);
+    if (
+      wallets.length > THROTTLE_AFTER_WALLET_COUNT &&
+      i + 1 < wallets.length
+    ) {
+      await sleep(PER_WALLET_THROTTLE_MS);
+    }
+  }
+
+  // Defensive dedupe in case two wallets happen to share an ATA owner
+  // (shouldn't happen for SPL ATAs, but the `address` column has a
+  // unique constraint in `helius_webhook_addresses`).
+  const dedupedByAddress = new Map<string, (typeof aggregated)[number]>();
+  for (const row of aggregated) {
+    if (!dedupedByAddress.has(row.address)) {
+      dedupedByAddress.set(row.address, row);
+    }
+  }
+  const allAddresses = [...dedupedByAddress.values()];
+
+  const shards = chunk(allAddresses, SHARD_LIMIT);
+
+  console.log(`  Addresses aggregated:  ${allAddresses.length}`);
+  console.log(
+    `  Shards (<=${SHARD_LIMIT.toLocaleString()} ea):  ${shards.length}`
+  );
+  console.log(`  Webhooks to create:    ${shards.length}`);
+
+  if (mode === "dry-run") {
+    console.log(
+      "\n[DRY RUN] No changes made. Run again with --apply to execute."
+    );
+    process.exit(0);
+  }
+
+  // --apply path. For each shard: call Helius, then atomically insert
+  // the helius_webhooks row + all helius_webhook_addresses rows via
+  // db.batch (Neon HTTP does NOT support db.transaction; batch is the
+  // closest atomic-ish primitive per CLAUDE.md). Failures bubble up
+  // and leave half-state for the operator to investigate, as required
+  // by webhook reliability guardrails.
+  const ADDRESS_INSERT_CHUNK = 5_000;
+  for (let shardIdx = 0; shardIdx < shards.length; shardIdx++) {
+    const shard = shards[shardIdx];
+    const addressList = shard.map((row) => row.address);
+
+    const { webhookId } = await createHeliusWebhook({
+      accountAddresses: addressList,
+      apiKey: heliusApiKey,
+      authHeader: heliusWebhookSecret,
+      webhookUrl: heliusWebhookUrl,
+    });
+
+    // Insert the webhook row first so we can use its UUID as FK on
+    // address rows. We still batch this single insert through db.batch
+    // for symmetry with the rest of the codebase's atomic-write idiom.
+    const [webhookRows] = await db.batch([
+      db
+        .insert(heliusWebhooks)
+        .values({
+          heliusWebhookId: webhookId,
+          webhookUrl: heliusWebhookUrl,
+          addressCount: shard.length,
+        })
+        .returning({ id: heliusWebhooks.id }),
+    ]);
+    const inserted = webhookRows[0];
+    if (!inserted?.id) {
+      throw new Error(
+        `Failed to insert helius_webhooks row for ${webhookId}; investigate manually before retrying.`
+      );
+    }
+
+    const addressRows = shard.map((row) => ({
+      webhookId: inserted.id,
+      address: row.address,
+      walletPublicKey: row.walletPublicKey,
+      kind: row.kind,
+    }));
+
+    // Drizzle/neon-http has a practical per-statement size limit, so
+    // chunk large shards at 5000 rows per INSERT and batch them.
+    const addressInsertChunks = chunk(addressRows, ADDRESS_INSERT_CHUNK);
+    if (addressInsertChunks.length > 0) {
+      const [first, ...rest] = addressInsertChunks.map((rows) =>
+        db.insert(heliusWebhookAddresses).values(rows)
+      );
+      await db.batch([first, ...rest]);
+    }
+
+    console.log(
+      `[APPLY] Created webhook ${webhookId} with ${shard.length} addresses.`
+    );
+  }
+
+  console.log(
+    `\n[APPLY] Bootstrap complete: ${shards.length} webhook(s) covering ${allAddresses.length} addresses across ${wallets.length} wallets.`
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.stack ?? err.message : String(err);
+  console.error("Helius webhook bootstrap failed:", message);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds the receiver route (`/api/webhooks/helius`), daily address-resync cron, one-shot bootstrap script, and supporting schema for migrating incoming-transfer push notifications from per-wallet RPC polling to Helius enhanced webhooks. Old polling cron stays active — cutover, key revocation, and mobile cleanup land in follow-up PRs after prod validation. Refs ASK-1337 (parent), ASK-1334, ASK-1335.

Requires `HELIUS_API_KEY`, `HELIUS_WEBHOOK_SECRET`, `HELIUS_WEBHOOK_URL` in Vercel prod env before triggering the resync cron.