### PR TITLE
chore(cron): pause push-incoming-transfers polling for webhook cutover

### DIFF
--- a/app/vercel.json
+++ b/app/vercel.json
@@ -16,10 +16,6 @@
       "schedule": "*/15 * * * *"
     },
     {
-      "path": "/api/cron/push-incoming-transfers",
-      "schedule": "*/2 * * * *"
-    },
-    {
       "path": "/api/cron/push-shielded-transfers",
       "schedule": "1-59/2 * * * *"
     },


### PR DESCRIPTION
Removes the every-2-min `/api/cron/push-incoming-transfers` entry so the bootstrap script can run without RPC bucket contention. The webhook receiver from #350 is the replacement — once bootstrap registers addresses and end-to-end push delivery is verified, a follow-up PR deletes the cron route + sync code. Refs ASK-1335.

Push delivery for incoming SOL/SPL transfers is paused on this deploy until the Helius webhook is registered (run the bootstrap script after merge).