### PR TITLE
feat(frontend): install X Pixel on askloyal.com

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono";
 import { GeistSans } from "geist/font/sans";
 import { cookies } from "next/headers";
 
+import { XPixelBootstrap } from "@/components/analytics/x-pixel-bootstrap";
 import { PublicEnvProvider } from "@/contexts/public-env-context";
 import { createPublicEnv } from "@/lib/core/config/public";
 import {
@@ -105,7 +106,10 @@ export default async function RootLayout({
             ),
           }}
         />
-        <PublicEnvProvider value={publicEnv}>{children}</PublicEnvProvider>
+        <PublicEnvProvider value={publicEnv}>
+          <XPixelBootstrap />
+          {children}
+        </PublicEnvProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/analytics/AnalyticsBootstrap.tsx
+++ b/frontend/src/components/analytics/AnalyticsBootstrap.tsx
@@ -13,6 +13,7 @@ import {
   trackAuthSignInSucceeded,
   trackPageView,
 } from "@/lib/core/analytics";
+import { X_PIXEL_EVENTS, xPixelEvent } from "@/lib/core/x-pixel";
 
 export type ShouldTrackFrontendPageViewParams = {
   pathname: string | null;
@@ -36,6 +37,39 @@ export function shouldTrackAuthSignInSuccess({
   previousUser,
 }: ShouldTrackAuthSignInSuccessParams): boolean {
   return previousUser === null && nextUser !== null;
+}
+
+const X_PIXEL_SIGNUP_STORAGE_KEY = "loyal_x_pixel_signup_fired_v1";
+
+function hasXPixelSignupBeenFired(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(X_PIXEL_SIGNUP_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markXPixelSignupFired(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(X_PIXEL_SIGNUP_STORAGE_KEY, "1");
+  } catch {
+    // Storage may be unavailable; we accept that the event may fire again on
+    // a future session rather than swallowing the conversion entirely.
+  }
+}
+
+export function fireXPixelSignupIfNeeded(): void {
+  if (hasXPixelSignupBeenFired()) {
+    return;
+  }
+  xPixelEvent(X_PIXEL_EVENTS.signup);
+  markXPixelSignupFired();
 }
 
 export function AnalyticsBootstrap() {
@@ -78,6 +112,7 @@ export function AnalyticsBootstrap() {
       })
     ) {
       trackAuthSignInSucceeded(publicEnv, user!);
+      fireXPixelSignupIfNeeded();
     }
 
     previousUserRef.current = user;

--- a/frontend/src/components/analytics/__tests__/cookie-consent-state.test.ts
+++ b/frontend/src/components/analytics/__tests__/cookie-consent-state.test.ts
@@ -1,0 +1,139 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import {
+  COOKIE_CONSENT_CHANGED_EVENT,
+  COOKIE_CONSENT_STORAGE_KEY,
+  hasMarketingConsent,
+  persistCookieConsent,
+  readStoredCookieConsent,
+} from "../cookie-consent-state";
+
+type FakeWindow = {
+  localStorage: {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+  };
+  addEventListener: (...args: unknown[]) => void;
+  removeEventListener: (...args: unknown[]) => void;
+  dispatchEvent: ReturnType<typeof mock>;
+};
+
+function setupFakeWindow(): FakeWindow {
+  const store = new Map<string, string>();
+  const fakeWindow: FakeWindow = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: mock(),
+  };
+  (globalThis as { window?: unknown }).window = fakeWindow;
+  return fakeWindow;
+}
+
+describe("cookie-consent-state", () => {
+  let fakeWindow: FakeWindow;
+
+  beforeEach(() => {
+    fakeWindow = setupFakeWindow();
+    (globalThis as { CustomEvent?: unknown }).CustomEvent = class FakeCustomEvent {
+      type: string;
+      detail: unknown;
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+    delete (globalThis as { CustomEvent?: unknown }).CustomEvent;
+  });
+
+  test("readStoredCookieConsent returns all-false when storage is empty", () => {
+    expect(readStoredCookieConsent()).toEqual({
+      analytics: false,
+      marketing: false,
+      personalization: false,
+    });
+  });
+
+  test("readStoredCookieConsent parses persisted choices", () => {
+    fakeWindow.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({ analytics: true, marketing: true })
+    );
+
+    expect(readStoredCookieConsent()).toEqual({
+      analytics: true,
+      marketing: true,
+      personalization: false,
+    });
+  });
+
+  test("readStoredCookieConsent ignores malformed JSON", () => {
+    fakeWindow.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, "{not json");
+
+    expect(readStoredCookieConsent()).toEqual({
+      analytics: false,
+      marketing: false,
+      personalization: false,
+    });
+  });
+
+  test("persistCookieConsent writes to storage and dispatches event", () => {
+    persistCookieConsent({
+      analytics: true,
+      marketing: true,
+      personalization: false,
+    });
+
+    expect(fakeWindow.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBe(
+      JSON.stringify({
+        analytics: true,
+        marketing: true,
+        personalization: false,
+      })
+    );
+
+    expect(fakeWindow.dispatchEvent).toHaveBeenCalledTimes(1);
+    const dispatched = fakeWindow.dispatchEvent.mock.calls[0]?.[0] as {
+      type: string;
+      detail: unknown;
+    };
+    expect(dispatched.type).toBe(COOKIE_CONSENT_CHANGED_EVENT);
+    expect(dispatched.detail).toEqual({
+      analytics: true,
+      marketing: true,
+      personalization: false,
+    });
+  });
+
+  test("hasMarketingConsent reflects persisted marketing flag", () => {
+    expect(hasMarketingConsent()).toBe(false);
+
+    persistCookieConsent({
+      analytics: false,
+      marketing: true,
+      personalization: false,
+    });
+
+    expect(hasMarketingConsent()).toBe(true);
+  });
+});

--- a/frontend/src/components/analytics/cookie-consent-state.ts
+++ b/frontend/src/components/analytics/cookie-consent-state.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ConsentChoices } from "./landing-cookie-consent";
+
+export const COOKIE_CONSENT_STORAGE_KEY = "loyal_cookie_consent_v1";
+export const COOKIE_CONSENT_CHANGED_EVENT = "loyal:cookie-consent-changed";
+
+const DEFAULT_CHOICES: ConsentChoices = {
+  analytics: false,
+  marketing: false,
+  personalization: false,
+};
+
+export function readStoredCookieConsent(): ConsentChoices {
+  if (typeof window === "undefined") {
+    return { ...DEFAULT_CHOICES };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY);
+    if (!raw) {
+      return { ...DEFAULT_CHOICES };
+    }
+
+    const parsed = JSON.parse(raw) as Partial<ConsentChoices>;
+    return {
+      analytics: parsed.analytics === true,
+      marketing: parsed.marketing === true,
+      personalization: parsed.personalization === true,
+    };
+  } catch {
+    return { ...DEFAULT_CHOICES };
+  }
+}
+
+export function persistCookieConsent(choices: ConsentChoices): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify(choices)
+    );
+  } catch {
+    // Storage may be unavailable (private mode, quota exceeded). The DOM event
+    // below still lets in-memory listeners react during the current session.
+  }
+
+  window.dispatchEvent(
+    new CustomEvent(COOKIE_CONSENT_CHANGED_EVENT, { detail: choices })
+  );
+}
+
+export function hasMarketingConsent(): boolean {
+  return readStoredCookieConsent().marketing;
+}

--- a/frontend/src/components/analytics/landing-cookie-consent.tsx
+++ b/frontend/src/components/analytics/landing-cookie-consent.tsx
@@ -5,7 +5,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { PublicEnv } from "@/lib/core/config/public";
 
-const LOCAL_CONSENT_KEY = "loyal_cookie_consent_v1";
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  persistCookieConsent,
+  readStoredCookieConsent,
+} from "./cookie-consent-state";
+
 const COOKIE_PREFERENCES_EVENT = "loyal:open-cookie-preferences";
 
 export type ConsentCategoryId = "analytics" | "marketing" | "personalization";
@@ -186,25 +191,13 @@ export function buildUsercentricsDecisions(
 }
 
 function getStoredLocalChoices(): ConsentChoices | null {
-  try {
-    const storedValue = window.localStorage.getItem(LOCAL_CONSENT_KEY);
-    if (!storedValue) {
-      return null;
-    }
-
-    const parsedValue = JSON.parse(storedValue) as Partial<ConsentChoices>;
-    return {
-      analytics: parsedValue.analytics === true,
-      marketing: parsedValue.marketing === true,
-      personalization: parsedValue.personalization === true,
-    };
-  } catch {
+  if (typeof window === "undefined") {
     return null;
   }
-}
-
-function persistLocalChoices(choices: ConsentChoices) {
-  window.localStorage.setItem(LOCAL_CONSENT_KEY, JSON.stringify(choices));
+  if (window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY) === null) {
+    return null;
+  }
+  return readStoredCookieConsent();
 }
 
 function CookieSwitch({
@@ -420,12 +413,13 @@ export function LandingCookieConsent({
     [onAnalyticsConsentChange]
   );
 
-  const syncChoicesFromServices = useCallback(() => {
+  const syncChoicesFromServices = useCallback((): ConsentChoices => {
     const services = usercentricsRef.current?.getServicesBaseInfo() ?? [];
     servicesRef.current = services;
     const nextChoices = getChoicesFromServices(services);
     setChoices(nextChoices);
     onAnalyticsConsentChange(getAnalyticsConsentFromServices(services));
+    return nextChoices;
   }, [onAnalyticsConsentChange]);
 
   useEffect(() => {
@@ -478,7 +472,8 @@ export function LandingCookieConsent({
 
         usercentricsRef.current = usercentrics;
         setSdkModule(importedModule);
-        syncChoicesFromServices();
+        const initialChoices = syncChoicesFromServices();
+        persistCookieConsent(initialChoices);
 
         if (
           initialValues.variant === importedModule.UI_VARIANT.DEFAULT &&
@@ -511,15 +506,16 @@ export function LandingCookieConsent({
 
   const confirmChoices = useCallback(
     async (nextChoices: ConsentChoices) => {
+      let persistedChoices = nextChoices;
       if (usercentricsRef.current) {
         await usercentricsRef.current.updateServices(
           buildUsercentricsDecisions(servicesRef.current, nextChoices)
         );
-        syncChoicesFromServices();
+        persistedChoices = syncChoicesFromServices();
       } else {
-        persistLocalChoices(nextChoices);
         applyChoices(nextChoices);
       }
+      persistCookieConsent(persistedChoices);
 
       setPreferencesSource(null);
       setView(null);
@@ -528,32 +524,34 @@ export function LandingCookieConsent({
   );
 
   const acceptAll = useCallback(async () => {
-    const nextChoices = {
+    const allAccepted: ConsentChoices = {
       analytics: true,
       marketing: true,
       personalization: true,
     };
 
+    let persistedChoices = allAccepted;
     if (usercentricsRef.current) {
       await usercentricsRef.current.acceptAllServices();
-      syncChoicesFromServices();
+      persistedChoices = syncChoicesFromServices();
     } else {
-      persistLocalChoices(nextChoices);
-      applyChoices(nextChoices);
+      applyChoices(allAccepted);
     }
+    persistCookieConsent(persistedChoices);
 
     setPreferencesSource(null);
     setView(null);
   }, [applyChoices, syncChoicesFromServices]);
 
   const rejectAll = useCallback(async () => {
+    let persistedChoices: ConsentChoices = DEFAULT_CHOICES;
     if (usercentricsRef.current) {
       await usercentricsRef.current.denyAllServices();
-      syncChoicesFromServices();
+      persistedChoices = syncChoicesFromServices();
     } else {
-      persistLocalChoices(DEFAULT_CHOICES);
       applyChoices(DEFAULT_CHOICES);
     }
+    persistCookieConsent(persistedChoices);
 
     setPreferencesSource(null);
     setView(null);

--- a/frontend/src/components/analytics/x-pixel-bootstrap.tsx
+++ b/frontend/src/components/analytics/x-pixel-bootstrap.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { loadXPixel } from "@/lib/core/x-pixel";
+
+import {
+  COOKIE_CONSENT_CHANGED_EVENT,
+  hasMarketingConsent,
+} from "./cookie-consent-state";
+
+export function XPixelBootstrap() {
+  useEffect(() => {
+    const tryLoad = () => {
+      if (hasMarketingConsent()) {
+        loadXPixel();
+      }
+    };
+
+    tryLoad();
+    window.addEventListener(COOKIE_CONSENT_CHANGED_EVENT, tryLoad);
+    return () => {
+      window.removeEventListener(COOKIE_CONSENT_CHANGED_EVENT, tryLoad);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/landing-get-started.tsx
+++ b/frontend/src/components/landing-get-started.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useRef, useState } from "react";
 
+import { X_PIXEL_EVENTS, xPixelEvent } from "@/lib/core/x-pixel";
+
 type Segment = "Extension" | "Mobile" | "Web";
 
 const appUrl = "https://app.askloyal.com";
@@ -14,23 +16,30 @@ const telegramMiniAppUrl =
   "https://t.me/askloyal_tgbot/app?startapp=askloyalcom";
 const seekerDappStoreUrl = "solanadappstore://details?id=com.loyal.app";
 
+function fireInstallExtensionConversion(browser: string) {
+  xPixelEvent(X_PIXEL_EVENTS.installExtension, { browser });
+}
+
 const browserCards = [
   {
     href: chromeWebStoreUrl,
     icon: "/landing/figma/get-started-chrome.svg",
     label: "Chrome",
+    onClick: () => fireInstallExtensionConversion("Chrome"),
     shape: "rounded-[24px]",
   },
   {
     href: chromeWebStoreUrl,
     icon: "/landing/figma/get-started-brave.svg",
     label: "Brave",
+    onClick: () => fireInstallExtensionConversion("Brave"),
     shape: "rounded-[400px]",
   },
   {
     href: chromeWebStoreUrl,
     icon: "/landing/figma/get-started-edge.svg",
     label: "Edge",
+    onClick: () => fireInstallExtensionConversion("Edge"),
     shape: "rounded-[400px]",
   },
   {
@@ -421,6 +430,7 @@ function PlatformCard({
     icon: string;
     label: string;
     note?: string;
+    onClick?: () => void;
     shape: string;
   };
   preserveAspect?: boolean;
@@ -482,6 +492,7 @@ function PlatformCard({
       data-reveal="scale"
       data-reveal-delay={dataRevealDelay}
       href={platform.href ?? appUrl}
+      onClick={platform.onClick}
     >
       {content}
     </Link>

--- a/frontend/src/lib/core/__tests__/x-pixel.test.ts
+++ b/frontend/src/lib/core/__tests__/x-pixel.test.ts
@@ -1,0 +1,143 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+let xPixel: typeof import("../x-pixel");
+
+type CreatedScript = { async: boolean; src: string };
+const createdScripts: CreatedScript[] = [];
+
+type Twq = ((...args: unknown[]) => void) & {
+  exe?: (...args: unknown[]) => void;
+  queue?: unknown[][];
+  version?: string;
+};
+
+function getTwq(): Twq | undefined {
+  return (globalThis as unknown as { window: { twq?: Twq } }).window.twq;
+}
+
+function setupFakeDom() {
+  const headChildren: unknown[] = [];
+
+  const fakeDocument = {
+    createElement: () => {
+      const script: Record<string, unknown> = {};
+      Object.defineProperty(script, "async", {
+        get: () => script._async,
+        set: (value: boolean) => {
+          script._async = value;
+        },
+      });
+      Object.defineProperty(script, "src", {
+        get: () => script._src,
+        set: (value: string) => {
+          script._src = value;
+          createdScripts.push({
+            async: script._async as boolean,
+            src: value,
+          });
+        },
+      });
+      return script;
+    },
+    getElementsByTagName: () => [],
+    head: {
+      appendChild: (child: unknown) => {
+        headChildren.push(child);
+      },
+    },
+  };
+
+  (globalThis as { window?: unknown }).window = {};
+  (globalThis as { document?: unknown }).document = fakeDocument;
+}
+
+describe("x-pixel module", () => {
+  beforeAll(async () => {
+    xPixel = await import("../x-pixel");
+  });
+
+  beforeEach(() => {
+    createdScripts.length = 0;
+    setupFakeDom();
+    xPixel.__resetXPixelForTests();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+    delete (globalThis as { document?: unknown }).document;
+  });
+
+  test("loadXPixel injects uwt.js, sets up twq stub, and calls config", () => {
+    xPixel.loadXPixel();
+
+    expect(createdScripts).toHaveLength(1);
+    expect(createdScripts[0]).toEqual({
+      async: true,
+      src: xPixel.X_PIXEL_SCRIPT_SRC,
+    });
+
+    const twq = getTwq();
+    expect(twq).toBeDefined();
+    expect(typeof twq).toBe("function");
+    expect(twq?.version).toBe("1.1");
+    expect(twq?.queue).toEqual([["config", xPixel.X_PIXEL_ID]]);
+
+    expect(xPixel.isXPixelLoaded()).toBe(true);
+  });
+
+  test("loadXPixel is idempotent", () => {
+    xPixel.loadXPixel();
+    xPixel.loadXPixel();
+    xPixel.loadXPixel();
+
+    expect(createdScripts).toHaveLength(1);
+    expect(getTwq()?.queue).toEqual([["config", xPixel.X_PIXEL_ID]]);
+  });
+
+  test("xPixelEvent queues events after load (before uwt.js executes)", () => {
+    xPixel.loadXPixel();
+    xPixel.xPixelEvent(xPixel.X_PIXEL_EVENTS.signup);
+    xPixel.xPixelEvent(xPixel.X_PIXEL_EVENTS.installExtension, { browser: "Chrome" });
+
+    expect(getTwq()?.queue).toEqual([
+      ["config", xPixel.X_PIXEL_ID],
+      ["event", xPixel.X_PIXEL_EVENTS.signup, {}],
+      [
+        "event",
+        xPixel.X_PIXEL_EVENTS.installExtension,
+        { browser: "Chrome" },
+      ],
+    ]);
+  });
+
+  test("xPixelEvent routes through twq.exe once uwt.js executes", () => {
+    xPixel.loadXPixel();
+    const twq = getTwq();
+    if (!twq) {
+      throw new Error("twq stub should exist after loadXPixel");
+    }
+    const exeCalls: unknown[][] = [];
+    twq.exe = (...args: unknown[]) => {
+      exeCalls.push(args);
+    };
+
+    xPixel.xPixelEvent(xPixel.X_PIXEL_EVENTS.signup);
+    expect(exeCalls).toEqual([
+      ["event", xPixel.X_PIXEL_EVENTS.signup, {}],
+    ]);
+  });
+
+  test("xPixelEvent no-ops when pixel has not been loaded", () => {
+    xPixel.xPixelEvent(xPixel.X_PIXEL_EVENTS.installExtension);
+
+    expect(getTwq()).toBeUndefined();
+    expect(createdScripts).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/core/x-pixel.ts
+++ b/frontend/src/lib/core/x-pixel.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import type { AnalyticsProperties } from "@loyal-labs/shared/analytics";
+
+export const X_PIXEL_ID = "qsgmc";
+export const X_PIXEL_SCRIPT_SRC = "https://static.ads-twitter.com/uwt.js";
+
+export const X_PIXEL_EVENTS = {
+  signup: "tw-qsgmc-qsgme",
+  installExtension: "tw-qsgmc-qsgmf",
+} as const;
+
+export type XPixelEventId =
+  (typeof X_PIXEL_EVENTS)[keyof typeof X_PIXEL_EVENTS];
+
+type Twq = ((...args: unknown[]) => void) & {
+  exe?: (...args: unknown[]) => void;
+  queue?: unknown[][];
+  version?: string;
+};
+
+declare global {
+  interface Window {
+    twq?: Twq;
+  }
+}
+
+let hasInitialized = false;
+
+function ensureTwqStub(): Twq {
+  if (window.twq) {
+    return window.twq;
+  }
+
+  const stub: Twq = function (...args: unknown[]) {
+    if (stub.exe) {
+      stub.exe(...args);
+      return;
+    }
+    stub.queue?.push(args);
+  } as Twq;
+
+  stub.version = "1.1";
+  stub.queue = [];
+  window.twq = stub;
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = X_PIXEL_SCRIPT_SRC;
+
+  const firstScript = document.getElementsByTagName("script")[0];
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript);
+  } else {
+    document.head.appendChild(script);
+  }
+
+  return stub;
+}
+
+export function loadXPixel(pixelId: string = X_PIXEL_ID): void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+  if (hasInitialized) {
+    return;
+  }
+
+  const twq = ensureTwqStub();
+  twq("config", pixelId);
+  hasInitialized = true;
+}
+
+export function isXPixelLoaded(): boolean {
+  return hasInitialized;
+}
+
+export function xPixelEvent(
+  eventId: XPixelEventId | string,
+  properties: AnalyticsProperties = {}
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (!hasInitialized || !window.twq) {
+    return;
+  }
+  window.twq("event", eventId, properties);
+}
+
+export function __resetXPixelForTests(): void {
+  hasInitialized = false;
+  if (typeof window !== "undefined") {
+    delete (window as { twq?: unknown }).twq;
+  }
+}


### PR DESCRIPTION
## Summary

Installs the X (Twitter) conversion pixel (`qsgmc`) on askloyal.com, gated by the existing marketing-consent category. Fires `tw-qsgmc-qsgme` once per browser on first successful sign-in and `tw-qsgmc-qsgmf` on Chrome/Brave/Edge install clicks.

Closes ASK-1333.

## Test plan

- [ ] Accept marketing cookies on landing → confirm `uwt.js` loads and `twq('config','qsgmc')` queues in the network tab
- [ ] Reject marketing cookies → confirm pixel does not load
- [ ] Click Chrome/Brave/Edge install card → confirm `tw-qsgmc-qsgmf` event fires
- [ ] Sign in via the SignInModal for the first time → confirm `tw-qsgmc-qsgme` event fires once; second sign-in does not refire
- [ ] Verify in X Ads conversion dashboard