### PR TITLE
feat(extension): soften password lockout policy

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@loyal-labs/extension",
   "description": "Loyal wallet browser extension",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/extension/src/lib/keypair-storage.ts
+++ b/extension/src/lib/keypair-storage.ts
@@ -11,21 +11,19 @@ const walletPublicKey = storage.defineItem<string | null>("local:walletPublicKey
   fallback: null,
 });
 
-// Lockout durations in ms, indexed by (failedAttempts - 4).
-// Attempts 1–3 have no lockout. 4 → 30s, 5 → 1m, 6 → 5m, ...
+// Lockout durations in ms, indexed by (failedAttempts - 6).
+// Attempts 1–5 have no lockout. 6 → 15s, 7 → 30s, 8 → 1m, 9 → 5m, 10+ → 15m.
 const LOCKOUT_DURATIONS_MS = [
-  30_000,      // 4th failure  → 30 s
-  60_000,      // 5th failure  → 1 min
-  300_000,     // 6th failure  → 5 min
-  900_000,     // 7th failure  → 15 min
-  3_600_000,   // 8th failure  → 1 hour
-  14_400_000,  // 9th failure  → 4 hours
-  86_400_000,  // 10th+ failure → 24 hours
+  15_000,   // 6th failure   → 15 s
+  30_000,   // 7th failure   → 30 s
+  60_000,   // 8th failure   → 1 min
+  300_000,  // 9th failure   → 5 min
+  900_000,  // 10th+ failure → 15 min
 ];
 
 function getLockoutDuration(attempts: number): number {
-  if (attempts < 4) return 0;
-  const index = Math.min(attempts - 4, LOCKOUT_DURATIONS_MS.length - 1);
+  if (attempts < 6) return 0;
+  const index = Math.min(attempts - 6, LOCKOUT_DURATIONS_MS.length - 1);
   return LOCKOUT_DURATIONS_MS[index];
 }
 


### PR DESCRIPTION
Softens the unlock-attempt lockout schedule in the browser extension. Bumps free attempts from 3 to 5 and caps the lockout at 15 minutes (was 24 hours), trading negligible brute-force risk for materially less friction on fat-finger mistypes.

| Failed attempts | Before | After |
|---|---|---|
| 1–3 | free | free |
| 4 | 30s | free |
| 5 | 1 min | free |
| 6 | 5 min | 15s |
| 7 | 15 min | 30s |
| 8 | 1 h | 1 min |
| 9 | 4 h | 5 min |
| 10+ | 24 h | 15 min (cap) |

PBKDF2 600k + AES-GCM continue to handle the cryptographic heavy lifting; lockouts are only there to throttle online guessing.