### PR TITLE
chore(docs): refresh Anthropic crawler UAs in robots.txt

### DIFF
--- a/user-docs/robots.txt
+++ b/user-docs/robots.txt
@@ -20,7 +20,10 @@ Allow: /
 User-agent: ClaudeBot
 Allow: /
 
-User-agent: Claude-Web
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
 Allow: /
 
 User-agent: anthropic-ai


### PR DESCRIPTION
## Summary

- Drop deprecated `Claude-Web` UA and add the current Anthropic UAs (`Claude-User`, `Claude-SearchBot`) to `user-docs/robots.txt`.
- Keeps the docs explicitly discoverable as Anthropic's UA fleet evolves.

## Context

Closes top-5 item #5 from the [2026-05-26 LoyalGEO audit](https://github.com/loyal-labs/loyal-app/pull/355) (apex `robots.txt` already current; only docs lagged on the Anthropic UA fleet).

`Claude-Web` was retired mid-2025 and split into:

- `Claude-User` — interactive Claude searches (real-time fetches initiated by a user query in Claude.ai)
- `Claude-SearchBot` — Claude's search-index crawler

Both should be explicitly allowed if we want docs.askloyal.com to be discoverable in Claude search experiences.

## Test plan

- [x] `robots.txt` diff is the intended 4-line change (drop one UA stanza, add two).
- [ ] After deploy, `curl https://docs.askloyal.com/robots.txt` should return the new UAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)