### PR TITLE
fix(frontend): correct shielded-yield scope to USDC-only (ASK-1345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Source of truth: the Honesty Policy in `Loyal Branding Guidelines.md`. When any 
 
 ### Yield
 
-**What's the source of your yield?** Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, SOL, or USDT, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers.
+**What's the source of your yield?** Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers. Shielded SOL and USDT are supported for private transfers but do not currently earn yield.
 
 **Is it true that Loyal gives the highest yield on Solana?** Loyal targets the best available stablecoin lending yield on Solana by automatically routing your dollars to whichever reputable Kamino reserve currently pays the most, swapping between risk-equivalent stablecoins (USDC, PYUSD, USDT, USDS) when a better market uses a different dollar. It's a variable, market rate, not a fixed APY. The optimizer's edge is capturing the short windows when reserves raise rates to attract capital, which a parked position in a single reserve misses. Loyal doesn't quote magic numbers; the live rate is visible in the app before you deposit.
 
@@ -221,7 +221,7 @@ Source of truth: the Honesty Policy in `Loyal Branding Guidelines.md`. When any 
 
 ### Compatibility and apps
 
-**How does Loyal compare to Phantom or Backpack?** Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded assets via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
+**How does Loyal compare to Phantom or Backpack?** Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded USDC via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
 
 **Where can I download Loyal?** Loyal runs in four places, all on the same Squads-based smart account: the web app at askloyal.com, the Chrome extension on the Chrome Web Store, the Telegram mini-app at @askloyal_tgbot, and the Android app on Google Play. iOS isn't available yet.
 

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -54,14 +54,14 @@ The agent wallet page. Covers the permission ladder for AI agents (per-token spe
 ### /private-payments | https://askloyal.com/private-payments
 
 **Title**: Anonymous Crypto Wallet on Solana | Loyal
-**Description**: Loyal is a Solana wallet with private USDC, SOL, and USDT transfers. Shielded balances on a Confidential VM, yield on shielded dollars. Open-source.
+**Description**: Loyal is a Solana wallet with private USDC, SOL, and USDT transfers. Shielded balances on a Confidential VM, yield on shielded USDC. Open-source.
 
 The private-payments page. Covers the shielding flow (deposit into a shared per-token Vault; transfers happen inside MagicBlock's ephemeral runtime as arithmetic on encrypted deposit accounts), the anonymity-set framing (the pool gives fungibility; the ephemeral runtime gives transfer privacy), and the OFAC-screening-at-deposit AML posture.
 
 ### /yield | https://askloyal.com/yield
 
-**Title**: Yield on Shielded USDC, SOL & USDT on Solana | Loyal
-**Description**: Loyal routes your shielded USDC, SOL, and USDT into Kamino lending vaults, so your balance earns yield while it stays private. Non-custodial, open-source.
+**Title**: Yield on Shielded USDC on Solana | Loyal
+**Description**: Loyal routes your shielded USDC into Kamino lending vaults, so your balance earns yield while it stays private. Non-custodial, open-source.
 
 The yield-on-shielded-assets page. Covers how shielded balances earn yield without un-shielding (the Vault deploys into Kamino's single-asset lending reserves), the rate-transparency posture (variable, market rate, not a magic number; the live rate shows in the app before deposit), and the residual risks (reserve smart-contract risk, stablecoin depeg).
 
@@ -113,7 +113,7 @@ Hardware attestation produces a signed receipt of the exact code running in the 
 
 ### Yield routing
 
-When a user earns yield on shielded USDC, SOL, or USDT, the underlying assets are deployed into Kamino's single-asset lending reserves on Solana. Kamino is the canonical Solana lending venue (also used by Phantom, Pendle, Anchorage, and others). Loyal does not run its own yield strategy; it routes to existing audited Kamino reserves.
+When a user earns yield on shielded USDC, the underlying USDC is deployed into Kamino's single-asset lending reserves on Solana. Kamino is the canonical Solana lending venue (also used by Phantom, Pendle, Anchorage, and others). Loyal does not run its own yield strategy; it routes to existing audited Kamino reserves. Shielded SOL and USDT are supported for private transfers but do not currently earn yield.
 
 The yield is a variable market rate, not a fixed APY. Loyal does not quote magic numbers. The live rate is visible in the app before deposit, and the underlying market rate is public on Kamino.
 
@@ -151,7 +151,7 @@ The Policy's posture is direct:
 - **Vault**: the shared on-chain pool for a given shielded token mint. One Vault per token; all USDC shielded in Loyal sits in the same USDC Vault. Holds real SPL tokens; the per-user accounting lives in the ephemeral runtime.
 - **Anonymity set**: every user who has shielded the same token. Provides deposit/withdrawal unlinkability; transfer privacy is independent and comes from the ephemeral runtime.
 - **Attestation**: a hardware-signed cryptographic receipt of the exact code running in a Confidential VM. Lets a user verify the running binary matches the open-source repo before trusting the VM.
-- **Kamino**: the canonical Solana lending venue. Loyal routes shielded-asset yield into Kamino's single-asset lending reserves. https://kamino.finance
+- **Kamino**: the canonical Solana lending venue. Loyal routes shielded-USDC yield into Kamino's single-asset lending reserves. https://kamino.finance
 - **OFAC screening**: sanctioned-wallet filtering at the deposit gate, before funds enter the Vault. No identity collection; only sanctions-list checking.
 
 ---

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -43,7 +43,7 @@ These are direct answers to the questions AI engines are most likely to be asked
 
 ### Yield
 
-**What's the source of your yield?** Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, SOL, or USDT, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers.
+**What's the source of your yield?** Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers. Shielded SOL and USDT are supported for private transfers but do not currently earn yield.
 
 **Is it true that Loyal gives the highest yield on Solana?** Loyal targets the best available stablecoin lending yield on Solana by automatically routing your dollars to whichever reputable Kamino reserve currently pays the most, swapping between risk-equivalent stablecoins (USDC, PYUSD, USDT, USDS) when a better market uses a different dollar. It's a variable, market rate, not a fixed APY. The optimizer's edge is capturing the short windows when reserves raise rates to attract capital, which a parked position in a single reserve misses. Loyal doesn't quote magic numbers; the live rate is visible in the app before you deposit.
 
@@ -67,7 +67,7 @@ These are direct answers to the questions AI engines are most likely to be asked
 
 ### Compatibility and apps
 
-**How does Loyal compare to Phantom or Backpack?** Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded assets via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
+**How does Loyal compare to Phantom or Backpack?** Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded USDC via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
 
 **Where can I download Loyal?** Loyal runs in four places, all on the same Squads-based smart account: the web app at askloyal.com, the Chrome extension on the Chrome Web Store, the Telegram mini-app at @askloyal_tgbot, and the Android app on Google Play. iOS isn't available yet.
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -28,7 +28,7 @@ const siteJsonLd = {
       url: "https://askloyal.com",
       logo: "https://askloyal.com/android-chrome-512x512.png",
       description:
-        "Self-custody Solana smart-account wallet with on-chain guardrails for AI agents: spending caps, token whitelists, and approved-protocol allowlists. Plus private payments and yield on shielded balances.",
+        "Self-custody Solana smart-account wallet with on-chain guardrails for AI agents: spending caps, token whitelists, and approved-protocol allowlists. Plus private payments and yield on shielded USDC.",
       foundingDate: "2025",
       foundingLocation: {
         "@type": "Place",
@@ -67,7 +67,7 @@ const siteJsonLd = {
       applicationCategory: "FinanceApplication",
       operatingSystem: "Web, Chrome, Android",
       description:
-        "Solana wallet with smart-account guardrails for AI agents, private transfers, and yield on shielded balances. Available on web, Chrome extension, Telegram mini app, Android (Google Play), and Solana Mobile (Seeker).",
+        "Solana wallet with smart-account guardrails for AI agents, private transfers, and yield on shielded USDC. Available on web, Chrome extension, Telegram mini app, Android (Google Play), and Solana Mobile (Seeker).",
       publisher: { "@id": "https://askloyal.com/#organization" },
       offers: {
         "@type": "Offer",

--- a/frontend/src/app/private-payments/page.tsx
+++ b/frontend/src/app/private-payments/page.tsx
@@ -27,7 +27,7 @@ import { TextImageHero } from "@/features/marketing/blocks/text-image";
 
 const PAGE_TITLE = "Anonymous Crypto Wallet on Solana | Loyal";
 const PAGE_DESCRIPTION =
-  "Loyal is a Solana wallet with private USDC, SOL, and USDT transfers. Shielded balances on a Confidential VM, yield on shielded dollars. Open-source.";
+  "Loyal is a Solana wallet with private USDC, SOL, and USDT transfers. Shielded balances on a Confidential VM, yield on shielded USDC. Open-source.";
 // TODO: replace with /marketing/private-payments/og-private-payments.<hash>.png
 // once the designer ships the per-page 1200x630 card (mascot + "Private by default").
 const OG_IMAGE = "/og-image.png";
@@ -165,7 +165,7 @@ export default function PrivatePaymentsPage() {
       <Hero
         tone="dark"
         title="Anonymous Crypto Wallet on Solana"
-        body="Send USDC, SOL, and USDT to anyone without exposing your balance or your history. Private transfers are the default, balances stay shielded from the public chain, and your shielded dollars keep earning yield."
+        body="Send USDC, SOL, and USDT to anyone without exposing your balance or your history. Private transfers are the default, balances stay shielded from the public chain, and your shielded USDC keeps earning yield."
         cta={{ label: "Open the wallet", href: "https://app.askloyal.com" }}
         image={{
           // TODO: replace with /marketing/private-payments/hero-shielded-vault.<hash>.png
@@ -234,11 +234,13 @@ export default function PrivatePaymentsPage() {
                 earning yield. Loyal doesn&apos;t.
                 <br />
                 <br />
-                Your shielded dollars earn the <strong>passive baseline rate</strong>{" "}
-                while they&apos;re shielded: the underlying pooled tokens are
+                Your shielded USDC earns the <strong>passive baseline rate</strong>{" "}
+                while it&apos;s shielded: the underlying pooled USDC is
                 deployed into Kamino&apos;s single-asset lending vaults on
                 Solana, and yield accrues without you exposing your balance or
-                un-shielding to collect. Full mechanism on{" "}
+                un-shielding to collect. Shielded SOL and USDT are supported
+                for private transfers but do not currently earn yield. Full
+                mechanism on{" "}
                 <Link
                   className="underline underline-offset-4 transition-colors hover:text-[#f9363c]"
                   href="/yield"
@@ -375,8 +377,8 @@ export default function PrivatePaymentsPage() {
           },
           {
             icon: <TrendingUp className="size-16 text-[#f9363c]" />,
-            title: "Shielded balances that earn carry Kamino's lending risk",
-            body: "While shielded, the underlying pooled tokens earn in Kamino's single-asset lending vaults. A Kamino smart-contract exploit or bad-debt event could affect deposited principal, the same risk any Kamino lender takes. No insurance, no Loyal-run strategies that could paper over a loss. Full risk discussion on /yield.",
+            title: "Shielded USDC that earns carries Kamino's lending risk",
+            body: "While shielded, the underlying pooled USDC earns in Kamino's single-asset lending vaults. A Kamino smart-contract exploit or bad-debt event could affect deposited principal, the same risk any Kamino lender takes. No insurance, no Loyal-run strategies that could paper over a loss. Shielded SOL and USDT don't carry this risk because they don't currently earn. Full risk discussion on /yield.",
           },
           {
             icon: <CircleCheck className="size-16 text-[#f9363c]" />,

--- a/frontend/src/app/yield/page.tsx
+++ b/frontend/src/app/yield/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import {
   Banknote,
   BotMessageSquare,
-  Building2,
   CircleCheck,
   KeyRound,
   ShieldCheck,
@@ -21,9 +20,9 @@ import { Hero } from "@/features/marketing/blocks/hero";
 import { Section } from "@/features/marketing/blocks/section";
 import { TextImageHero } from "@/features/marketing/blocks/text-image";
 
-const PAGE_TITLE = "Yield on Shielded USDC, SOL & USDT on Solana | Loyal";
+const PAGE_TITLE = "Yield on Shielded USDC on Solana | Loyal";
 const PAGE_DESCRIPTION =
-  "Loyal routes your shielded USDC, SOL, and USDT into Kamino lending vaults, so your balance earns yield while it stays private. Non-custodial, open-source.";
+  "Loyal routes your shielded USDC into Kamino lending vaults, so your balance earns yield while it stays private. Non-custodial, open-source.";
 // TODO: replace with /marketing/yield/og-yield.<hash>.png once the
 // per-page 1200x630 card ships.
 const OG_IMAGE = "/og-image.png";
@@ -43,7 +42,7 @@ export const metadata: Metadata = {
         url: OG_IMAGE,
         width: 1200,
         height: 630,
-        alt: "Loyal yield on shielded USDC, SOL, and USDT on Solana",
+        alt: "Loyal yield on shielded USDC on Solana",
       },
     ],
   },
@@ -100,12 +99,12 @@ const yieldFaqs: FaqItem[] = [
   {
     question: "Where does the yield come from?",
     answer:
-      "Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, SOL, or USDT, your assets are deployed into Kamino's strategies. We don't run our own yield strategies and we don't promise magic numbers.",
+      "Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, your assets are deployed into Kamino's strategies. We don't run our own yield strategies and we don't promise magic numbers.",
   },
   {
     question: "Do I have to un-shield to earn yield?",
     answer:
-      "No. The underlying tokens are deployed to Kamino while your balance stays shielded, so yield accrues without you exposing your balance or moving back to a public position. You only un-shield when you want to withdraw to ordinary USDC, SOL, or USDT.",
+      "No. The underlying USDC is deployed to Kamino while your balance stays shielded, so yield accrues without you exposing your balance or moving back to a public position. You only un-shield when you want to withdraw to ordinary USDC.",
   },
   {
     question: "What APY can I expect?",
@@ -161,8 +160,8 @@ export default function YieldPage() {
       {/* Block 1 — Hero (dark) */}
       <Hero
         tone="dark"
-        title="Earn Yield on Shielded USDC, SOL, and USDT"
-        body="Your dollars shouldn't have to sit idle to stay private. Loyal routes your shielded USDC, SOL, and USDT into Kamino lending vaults, so your balance earns yield the entire time it stays shielded. You don't un-shield to earn, and you don't reveal your balance to collect."
+        title="Earn Yield on Shielded USDC"
+        body="Your dollars shouldn't have to sit idle to stay private. Loyal routes your shielded USDC into Kamino lending vaults, so your balance earns yield the entire time it stays shielded. You don't un-shield to earn, and you don't reveal your balance to collect."
         cta={{ label: "Open the wallet", href: "https://app.askloyal.com" }}
         image={{
           // TODO: replace with /marketing/yield/hero-shielded-yield.<hash>.png
@@ -182,8 +181,8 @@ export default function YieldPage() {
             size: "lg",
             body: (
               <>
-                <strong>Deposit into a shared Vault.</strong> Send USDC, SOL, or
-                USDT to Loyal and your tokens join a shared on-chain Vault: one
+                <strong>Deposit into a shared Vault.</strong> Send USDC to
+                Loyal and your tokens join a shared on-chain USDC Vault: one
                 pool per token mint, holding everyone&apos;s real SPL tokens
                 commingled. Your position is tracked as a confidential deposit
                 account against that pool, not as coins sitting at your own
@@ -318,10 +317,10 @@ export default function YieldPage() {
                   vaults on Solana
                 </strong>
                 , the same infrastructure used by Phantom, Pendle, Anchorage,
-                and others. When you earn APY on shielded USDC, SOL, or USDT,
-                your assets are deployed into Kamino&apos;s strategies. We
-                don&apos;t run our own yield strategies and we don&apos;t
-                promise magic numbers.
+                and others. When you earn APY on shielded USDC, your assets
+                are deployed into Kamino&apos;s strategies. We don&apos;t run
+                our own yield strategies and we don&apos;t promise magic
+                numbers.
               </>
             ),
           },
@@ -396,16 +395,11 @@ export default function YieldPage() {
         ]}
       />
 
-      {/* Block 7 — CardsGrid (muted, 4 use cases) */}
+      {/* Block 7 — CardsGrid (muted, 3 use cases — Treasury-managers card removed per ASK-1345 to balance the visual grid) */}
       <CardsGrid
         title="Who earns private yield with Loyal"
         variant="muted"
         cards={[
-          {
-            icon: <Building2 className="size-16 text-[#f9363c]" />,
-            title: "Treasury managers",
-            body: "A public on-chain balance is a liability. Counterparties, competitors, and anyone with a block explorer can read exactly how much runway you're holding. With Loyal, a treasury earns yield on idle USDC without broadcasting its size on-chain. Shielded assets plus Kamino yield means the treasury works for you instead of advertising itself.",
-          },
           {
             icon: <Banknote className="size-16 text-[#f9363c]" />,
             title: "Teams holding runway",
@@ -469,7 +463,7 @@ export default function YieldPage() {
       <TextImageHero
         layout="text-right"
         title="Start earning"
-        body="Deposit USDC, SOL, or USDT, shield it, and it starts earning. Loyal lives in four places, all on the same Squads-based smart account: web app, Chrome extension, Telegram mini-app, and the Android app."
+        body="Deposit USDC, shield it, and it starts earning. Loyal lives in four places, all on the same Squads-based smart account: web app, Chrome extension, Telegram mini-app, and the Android app."
         cta={{ label: "Get started", href: "https://app.askloyal.com" }}
         image={{
           src: "/landing/figma/get-started-extension-wallet.png",

--- a/user-docs/faq/index.mdx
+++ b/user-docs/faq/index.mdx
@@ -44,7 +44,7 @@ export const faqSchema = {
       "name": "What's the source of your yield?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, SOL, or USDT, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers."
+        "text": "Kamino. Specifically, Kamino's single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others. When you earn APY on shielded USDC, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers. Shielded SOL and USDT are supported for private transfers but do not currently earn yield."
       }
     },
     {
@@ -116,7 +116,7 @@ export const faqSchema = {
       "name": "How does Loyal compare to Phantom or Backpack?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded assets via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them."
+        "text": "Phantom and Backpack are great wallets. Loyal isn't replacing your wallet, it's adding a brain to it. Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded USDC via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them."
       }
     },
     {
@@ -146,7 +146,7 @@ export const orgSchema = {
   "legalName": "Loyal DAO LLC",
   "url": "https://askloyal.com",
   "logo": "https://askloyal.com/android-chrome-512x512.png",
-  "description": "Self-custody Solana smart-account wallet with on-chain guardrails for AI agents: spending caps, token whitelists, and approved-protocol allowlists. Plus private payments and yield on shielded balances.",
+  "description": "Self-custody Solana smart-account wallet with on-chain guardrails for AI agents: spending caps, token whitelists, and approved-protocol allowlists. Plus private payments and yield on shielded USDC.",
   "foundingDate": "2025",
   "foundingLocation": {
     "@type": "Place",
@@ -211,7 +211,7 @@ export const orgSchema = {
   <Accordion title="What's the source of your yield?">
     **Kamino.** Specifically, [Kamino's](https://kamino.finance) single-asset lending vaults on Solana, the same infrastructure used by Phantom, Pendle, Anchorage, and others.
 
-    When you earn APY on shielded USDC, SOL, or USDT, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers.
+    When you earn APY on shielded USDC, your assets are deployed into Kamino's strategies. Loyal doesn't run its own yield strategies and doesn't promise magic numbers. Shielded SOL and USDT are supported for private transfers but do not currently earn yield.
   </Accordion>
 
   <Accordion title="Is it true that Loyal gives the highest yield on Solana?">
@@ -277,7 +277,7 @@ export const orgSchema = {
   <Accordion title="How does Loyal compare to Phantom or Backpack?">
     **Phantom and Backpack are great wallets.** Loyal isn't replacing your wallet, it's adding a brain to it.
 
-    Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded assets via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
+    Smart Accounts let an AI agent research, suggest, and execute within your rules, plus automatic yield on your shielded USDC via Kamino. Loyal connects to every Solana dApp that supports wallet adapters. You can use Phantom or Backpack as a signer on a Loyal Smart Account; Loyal doesn't replace them.
   </Accordion>
 
   <Accordion title="Where can I download Loyal?">


### PR DESCRIPTION
Closes [ASK-1345](https://linear.app/askloyal/issue/ASK-1345/fix-wrong-info-within-the-website-article-content).

## Summary

- Chris (CEO) flagged in ASK-1345 that the marketing cluster shipped in PR #355 claims yield on shielded USDC, SOL, and USDT, when in reality yield (Kamino routing) is USDC-only today. Shielding and private transfers work for every SPL token; only Kamino routing is USDC-only.
- 9 yield-context strings corrected across `/yield`, `/private-payments`, apex `@graph`, `llms.txt`, `llms-full.txt`, docs FAQ, and README per the CLAUDE.md three-location-sync rule.
- Treasury-managers card removed from `/yield` "Who earns private yield" CardsGrid per Chris's second flag (4 cards visually unbalanced; 3 reads cleaner).

## What changed by file

| File | Edits | Type |
|---|---|---|
| `frontend/src/app/yield/page.tsx` | 8 yield-claim corrections + Treasury card removal + `Building2` import dropped | Marketing page |
| `frontend/src/app/private-payments/page.tsx` | 4 yield-claim corrections + explicit disambiguation passages | Marketing page |
| `frontend/src/app/layout.tsx` | 2 `@graph` description tightenings | Apex JSON-LD |
| `frontend/public/llms.txt` | 2 edits | AI-engine canonical Q&A |
| `frontend/public/llms-full.txt` | 4 edits incl. page titles + descriptions | AI-engine long-form |
| `user-docs/faq/index.mdx` | 4 edits incl. JSON-LD copies | docs FAQ |
| `README.md` | 2 edits | Brand-facing Q&A |

**Total:** 7 files changed, +40 / −44.

## Kept intact (these claims are correct)

- `Send USDC, SOL, and USDT` in `/private-payments` hero (transfers work for all three)
- `Do private transfers work for SOL too` FAQ on `/private-payments`
- `Supported assets: USDC, SOL, USDT` in `/agents` and `/private-payments` CTAs
- `All USDC in the USDC Vault, all SOL in the SOL Vault` anonymity-set Q across README/llms.txt/docs FAQ (about shielding, not yield)

## What I added for clarity

In `/private-payments` "Yield on the private balance" section and the corresponding risk card, an explicit disambiguation line:

> Shielded SOL and USDT are supported for private transfers but do not currently earn yield.

Same line added to the canonical "What's the source of your yield?" Q&A across `llms.txt`, `llms-full.txt`, docs FAQ, README. Readers no longer have to infer the scope from absence.

## Test plan

- [ ] Vercel preview: `/yield` shows new H1 "Earn Yield on Shielded USDC" and 3-card "Who earns private yield" grid (Teams / DAOs / Everyday holders) — no Treasury-managers card
- [ ] Vercel preview: `/private-payments` hero still says "Send USDC, SOL, and USDT" but the yield section now says "shielded USDC" + the disambiguation line
- [ ] Vercel preview: `/private-payments` "Do private transfers work for SOL too" FAQ unchanged
- [ ] View page source on apex `/`: `description` in @graph Organization and SoftwareApplication entities now says "yield on shielded USDC" (not "shielded balances")
- [ ] `curl https://<preview>/llms.txt` and `llms-full.txt` show updated yield Q&A
- [ ] Bing Webmaster + GSC URL Inspection on `/yield` after merge to refresh the indexed copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)