### PR TITLE
chore(seo): drop per-page SoftwareApplication, add FinancialProduct on /yield

### DIFF
--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -64,22 +64,6 @@ export const metadata: Metadata = {
   },
 };
 
-const softwareApplicationJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "Loyal",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Web, Chrome, Android",
-  url: "https://askloyal.com/agents",
-  description: PAGE_DESCRIPTION,
-  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  creator: {
-    "@type": "Organization",
-    name: "Loyal",
-    url: "https://askloyal.com",
-  },
-};
-
 const breadcrumbJsonLd = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
@@ -147,9 +131,6 @@ export default function AgentsPage() {
   return (
     <main className="min-h-screen overflow-x-clip bg-white text-black">
       {/* JSON-LD as script children (XSS-safe; React escapes <>&) — schema has no such chars */}
-      <script type="application/ld+json">
-        {JSON.stringify(softwareApplicationJsonLd)}
-      </script>
       <script type="application/ld+json">
         {JSON.stringify(breadcrumbJsonLd)}
       </script>

--- a/frontend/src/app/earn/page.tsx
+++ b/frontend/src/app/earn/page.tsx
@@ -57,22 +57,6 @@ export const metadata: Metadata = {
   },
 };
 
-const softwareApplicationJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "Loyal",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Web, Chrome, Android",
-  url: "https://askloyal.com/earn",
-  description: PAGE_DESCRIPTION,
-  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  creator: {
-    "@type": "Organization",
-    name: "Loyal",
-    url: "https://askloyal.com",
-  },
-};
-
 const techArticleJsonLd = {
   "@context": "https://schema.org",
   "@type": "TechArticle",
@@ -182,9 +166,6 @@ export default function EarnPage() {
   return (
     <main className="min-h-screen overflow-x-clip bg-white text-black">
       {/* JSON-LD as script children (XSS-safe; React escapes <>&) — schema has no such chars */}
-      <script type="application/ld+json">
-        {JSON.stringify(softwareApplicationJsonLd)}
-      </script>
       <script type="application/ld+json">
         {JSON.stringify(techArticleJsonLd)}
       </script>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -64,8 +64,9 @@ const siteJsonLd = {
       "@id": "https://askloyal.com/#app",
       name: "Loyal",
       url: "https://askloyal.com",
+      image: "https://askloyal.com/og-image.png",
       applicationCategory: "FinanceApplication",
-      operatingSystem: "Web, Chrome, Android",
+      operatingSystem: "Android",
       description:
         "Solana wallet with smart-account guardrails for AI agents, private transfers, and yield on shielded balances. Available on web, Chrome extension, Telegram mini app, Android (Google Play), and Solana Mobile (Seeker).",
       publisher: { "@id": "https://askloyal.com/#organization" },

--- a/frontend/src/app/private-payments/page.tsx
+++ b/frontend/src/app/private-payments/page.tsx
@@ -59,22 +59,6 @@ export const metadata: Metadata = {
   },
 };
 
-const softwareApplicationJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "Loyal",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Web, Chrome, Android",
-  url: "https://askloyal.com/private-payments",
-  description: PAGE_DESCRIPTION,
-  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  creator: {
-    "@type": "Organization",
-    name: "Loyal",
-    url: "https://askloyal.com",
-  },
-};
-
 const breadcrumbJsonLd = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
@@ -151,9 +135,6 @@ export default function PrivatePaymentsPage() {
   return (
     <main className="min-h-screen overflow-x-clip bg-white text-black">
       {/* JSON-LD as script children (XSS-safe; React escapes <>&) — schema has no such chars */}
-      <script type="application/ld+json">
-        {JSON.stringify(softwareApplicationJsonLd)}
-      </script>
       <script type="application/ld+json">
         {JSON.stringify(breadcrumbJsonLd)}
       </script>

--- a/frontend/src/app/yield/page.tsx
+++ b/frontend/src/app/yield/page.tsx
@@ -55,19 +55,20 @@ export const metadata: Metadata = {
   },
 };
 
-const softwareApplicationJsonLd = {
+const financialProductJsonLd = {
   "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "Loyal",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Web, Chrome, Android",
+  "@type": "FinancialProduct",
+  name: "Yield on Shielded USDC",
   url: "https://askloyal.com/yield",
   description: PAGE_DESCRIPTION,
-  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  creator: {
-    "@type": "Organization",
-    name: "Loyal",
-    url: "https://askloyal.com",
+  category: "Stablecoin lending",
+  provider: { "@id": "https://askloyal.com/#organization" },
+  feesAndCommissionsSpecification:
+    "No platform fees on yield. Underlying yield is sourced from Kamino lending vaults; rates float with on-chain supply and demand.",
+  interestRate: {
+    "@type": "QuantitativeValue",
+    description:
+      "Variable APY from Kamino's single-asset lending vaults on Solana. The current rate is displayed in the app before deposit.",
   },
 };
 
@@ -149,7 +150,7 @@ export default function YieldPage() {
     <main className="min-h-screen overflow-x-clip bg-white text-black">
       {/* JSON-LD as script children (XSS-safe; React escapes <>&) — schema has no such chars */}
       <script type="application/ld+json">
-        {JSON.stringify(softwareApplicationJsonLd)}
+        {JSON.stringify(financialProductJsonLd)}
       </script>
       <script type="application/ld+json">
         {JSON.stringify(breadcrumbJsonLd)}


### PR DESCRIPTION
## Summary

Schema entity-model cleanup from the 2026-05-27 post-ship audit (`audits/_summary-2026-05-27.md`, PR A of 3 sequenced cleanup PRs).

- **Drop per-page `SoftwareApplication`** on `/agents`, `/earn`, `/private-payments`, `/yield`. The apex `@graph` in the root `layout.tsx` already publishes the canonical entity at `@id: "https://askloyal.com/#app"`; per-page copies duplicated it with conflicting page-specific `url`s — worse entity graph, not better. Per-page `BreadcrumbList` is page-specific and kept.
- **Add `FinancialProduct` JSON-LD on `/yield`** in place of the dropped `SoftwareApplication`. Correct schema.org type for the stablecoin-lending mechanism the page describes; provider links back to apex `Organization` via `@id`.
- **Apex `SoftwareApplication` polish**: add `image` (Google rich-result spec requires it; `Organization.logo` does not auto-inherit), trim `operatingSystem: "Web, Chrome, Android"` → `"Android"` (schema.org expects OS values; runtimes are conveyed by `applicationCategory` + `description`).

Closes audit findings: HIGH-NEW-5, M-NEW-1, M-NEW-2, M-NEW-4.

`TechArticle` on `/earn` is intentionally untouched here — it's addressed in the follow-on punch-list PR.

## Test plan

- [ ] Vercel preview renders all 4 marketing pages with the expected JSON-LD blocks (BreadcrumbList everywhere; FinancialProduct on /yield; TechArticle still on /earn; no per-page SoftwareApplication).
- [ ] Apex `/` SSR HTML carries the polished `@graph` SoftwareApplication entity (`image`, `operatingSystem: "Android"`).
- [ ] [Schema validator](https://validator.schema.org/) on the apex page returns no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)