### PR TITLE
perf(marketing): mark hero Image as priority to fix LCP regression

### DIFF
--- a/frontend/src/features/marketing/blocks/hero.tsx
+++ b/frontend/src/features/marketing/blocks/hero.tsx
@@ -108,6 +108,7 @@ function HeroDefault({ tone, title, body, cta, image }: HeroProps) {
             alt={image.alt}
             className="object-cover"
             fill
+            priority
             sizes="(min-width: 1024px) 50vw, 100vw"
             src={image.src}
           />
@@ -146,6 +147,7 @@ function HeroSplit({ title, body, cta, image }: HeroProps) {
             alt={image.alt}
             className="object-cover"
             fill
+            priority
             sizes="(min-width: 1024px) 33vw, 100vw"
             src={image.src}
           />


### PR DESCRIPTION
## Summary

Cluster-wide LCP fix from the 2026-05-27 post-ship audit (`audits/_summary-2026-05-27.md`, PR B of 3 sequenced cleanup PRs).

The hero `<Image>` in `features/marketing/blocks/hero.tsx` is the LCP element on all four marketing pages (`/agents`, `/earn`, `/private-payments`, `/yield`) but shipped without `priority`, so Next defaults to `loading=\"lazy\"`. The audit flagged this on `/agents` and `/yield`; same shared component, so `/earn` and `/private-payments` are affected too.

One-line `priority` prop add on both `HeroDefault` and `HeroSplit`:
- Removes `loading=\"lazy\"`
- Adds `fetchPriority=\"high\"`
- Adds a `<link rel=\"preload\">` hint Next emits in `<head>`

Closes audit finding HIGH-NEW-1 across the full cluster in one PR.

## Test plan

- [ ] Vercel preview Lighthouse on `/agents` and `/yield` shows LCP element no longer lazy-loaded
- [ ] HTML `<head>` of all 4 marketing pages contains a `<link rel=\"preload\" as=\"image\">` for the hero image
- [ ] Hero `<img>` in rendered HTML has `fetchpriority=\"high\"` (not `loading=\"lazy\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)