### PR TITLE
docs: home landing page + usecases heading structure (audit C-4/M-5, M-4)

### DIFF
--- a/user-docs/Introduction/usecases.mdx
+++ b/user-docs/Introduction/usecases.mdx
@@ -4,28 +4,26 @@ description: "Our key audience are the people who are looking to be left alone, 
 mode: "wide"
 ---
 
-<Tabs>
-    <Tab title="Privacy freaks">
-        Loyal gives you private compute for the prompts you never want turning up in discovery or an ad profile. Every request runs inside attested TEEs, pays on-chain, and never touches a centralized logging stack.
+## Privacy freaks
 
-        - Ask sensitive legal, medical, or personal questions without creating a subpoena-ready data trail.
-        - Keep your conversation history portable: export it from our interface, load it into a self-hosted fork, or delete it outright.
-        - Pay from your wallet with no credit card metadata, cookies, or retargeting pixels following you around.
-    </Tab>
+Loyal gives you private compute for the prompts you never want turning up in discovery or an ad profile. Every request runs inside attested TEEs, pays on-chain, and never touches a centralized logging stack.
 
-    <Tab title="Users & developers">
-        Your chats, agents, and automations live on an open stack. Because inference contracts and state are permissionless, you can treat Loyal like another protocol in your toolbox.
+- Ask sensitive legal, medical, or personal questions without creating a subpoena-ready data trail.
+- Keep your conversation history portable: export it from our interface, load it into a self-hosted fork, or delete it outright.
+- Pay from your wallet with no credit card metadata, cookies, or retargeting pixels following you around.
 
-        - Fork our frontend repo, remix the UX, ship a CLI: we do not care and encourage you to do whatever you want with it. Everything stays compatible because the state is on-chain.
-        - Plug your own smart contracts into ours to orchestrate agents, enforce spend limits, or trigger downstream actions.
-        - Build multi-agent systems that handshake through wallets, instead of API keys, with verifiable execution proofs.
-    </Tab>
+## Users & developers
 
-    <Tab title="Businesses">
-        High-sensitivity teams finally get AI without leaking deal flow, trade secrets, or customer data. Loyal is the privacy-preserving inference layer for finance, custody, and regulated operators.
+Your chats, agents, and automations live on an open stack. Because inference contracts and state are permissionless, you can treat Loyal like another protocol in your toolbox.
 
-        - Run compliance, risk, and ops workloads in confidential compute with auditable attestations for regulators or partners.
-        - Let clients keep custody of their data while your service still delivers personalized insights or automation.
-        - Standardize on the same infrastructure your developers use—no vendor lock-in, easy to extend with your own contracts and policies.
-    </Tab>
-</Tabs>
+- Fork our frontend repo, remix the UX, ship a CLI: we do not care and encourage you to do whatever you want with it. Everything stays compatible because the state is on-chain.
+- Plug your own smart contracts into ours to orchestrate agents, enforce spend limits, or trigger downstream actions.
+- Build multi-agent systems that handshake through wallets, instead of API keys, with verifiable execution proofs.
+
+## Businesses
+
+High-sensitivity teams finally get AI without leaking deal flow, trade secrets, or customer data. Loyal is the privacy-preserving inference layer for finance, custody, and regulated operators.
+
+- Run compliance, risk, and ops workloads in confidential compute with auditable attestations for regulators or partners.
+- Let clients keep custody of their data while your service still delivers personalized insights or automation.
+- Standardize on the same infrastructure your developers use—no vendor lock-in, easy to extend with your own contracts and policies.

--- a/user-docs/docs.json
+++ b/user-docs/docs.json
@@ -14,6 +14,12 @@
         "tab": "DeFi",
         "groups": [
           {
+            "group": "Home",
+            "pages": [
+              "index"
+            ]
+          },
+          {
             "group": "Private Transactions",
             "pages": [
               "sdk/private-transactions/quick-start",

--- a/user-docs/index.mdx
+++ b/user-docs/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "Loyal"
+description: "Financial tools for the agentic era."
+mode: "wide"
+---
+
+Loyal is private payments and AI finance guardrails on Solana. Agents are becoming the interface for finance, but they lack the trust to touch sensitive data and move real money. Loyal is the execution layer that lets them handle payments, transfers, and capital workflows, with a human in the loop for every critical action.
+
+<Columns cols={2}>
+  <Card title="Private Transactions" icon="shield-halved" href="/sdk/private-transactions/quick-start">
+    Shield and send SPL tokens without exposing wallet addresses or balances. Start with the SDK quick-start.
+  </Card>
+  <Card title="Smart Accounts" icon="robot" href="/smart-accounts/overview">
+    Agentic wallets with on-chain policies and spending limits. Agents act; you approve every critical action.
+  </Card>
+  <Card title="Learn" icon="book-open" href="/Introduction/solution">
+    How Loyal works: confidential compute, hardware attestation, and the architecture underneath.
+  </Card>
+  <Card title="Transparency" icon="scale-balanced" href="/Introduction/team">
+    Who builds Loyal, plus the quarterly transparency reports.
+  </Card>
+</Columns>
+
+Stay Loyal.


### PR DESCRIPTION
Mintlify docs structural fixes from the 2026-05-27 post-ship audit.

**Home landing page (C-4/M-5).** `docs.askloyal.com/` previously 308-redirected to the Private Transactions SDK quick-start. Adds `user-docs/index.mdx` as a real front door that renders at the bare `/` (Mintlify serves a file named `index` at root — no redirect), with canonical positioning and a card grid to the four docs areas. Listed as its own `Home` nav group so it isn't mislabeled under another section.

**usecases heading structure (M-4).** `Introduction/usecases.mdx` kept all content inside three `<Tab>` panels (zero headings, two audiences behind tab clicks). Converted to three `##` sections so content is always in the DOM with a real heading hierarchy for AI extraction.

**Verified locally** (`mint dev`, Node 22): `/` serves the home natively (200, no redirect, H1 "Loyal" + subtitle + 4 cards), usecases renders as 3 `<h2>` sections, all sibling pages 200, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)