### PR TITLE
chore(security): add response security headers (M-3)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -55,6 +55,24 @@ const nextConfig: NextConfig = {
     ],
   },
   productionBrowserSourceMaps: true,
+  async headers() {
+    return [
+      {
+        // Applied to every route. HSTS is already set by Vercel at the
+        // platform level; these three add the clickjacking / MIME-sniffing /
+        // sensor-permission protections that were missing (audit M-3).
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Adds three response security headers to the askloyal.com frontend via `next.config.ts` `headers()`, applied to every route (`source: "/:path*"`):

- `X-Content-Type-Options: nosniff` — stops MIME-sniffing
- `X-Frame-Options: SAMEORIGIN` — anti-clickjacking (same-origin embeds still allowed)
- `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables sensor APIs the site never uses

## Scope notes
- `Strict-Transport-Security` is already set by Vercel at the platform level — left as-is.
- `Referrer-Policy` and `Content-Security-Policy` are intentionally **out of scope** for this PR.
- Deliberately does **not** set `publickey-credentials-*` in the Permissions-Policy, so passkey / WebAuthn flows are unaffected.

Closes GEO audit finding **M-3** (the in-scope headers; Referrer-Policy dropped, Report-Only CSP parked).

## Verification (run locally on this branch)
- `bun run lint` → exit 0
- `bun run build` → exit 0
- `bun run start` + `curl -sI` → all three headers present on `/`, `/agents`, and an API route