### PR TITLE
chore(seo): add marketing-cluster pages to sitemap.xml

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,14 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://askloyal.com/</loc>
-    <lastmod>2026-05-26</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://askloyal.com/agents</loc>
+    <lastmod>2026-05-28</lastmod>
+  </url>
+  <url>
+    <loc>https://askloyal.com/private-payments</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://askloyal.com/yield</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://askloyal.com/earn</loc>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://askloyal.com/privacy-policy</loc>
     <lastmod>2026-02-23</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## What

`sitemap.xml` listed only `/` and `/privacy-policy`. The four marketing pages had no sitemap discovery signal, so Google had no direct path to them.

- Add `/agents`, `/private-payments`, `/yield`, `/earn` (all self-canonical, `robots index:true`, verified live 200)
- Set `<lastmod>` per page from its last git content change instead of one shared stale date (`/` 2026-05-26 → 2026-06-01 for the copy rework)
- Drop deprecated `<priority>`/`<changefreq>` (ignored by Google)

## Excluded (intentional)

- `/landing` — internal dev chatbot demo (points at `localhost:8000`, no metadata); should not be indexed
- `/app`, `/500` — robots-disallowed

## Verification

- `xmllint --noout` passes
- All 6 URLs return live 200
- Surfaced from the 2026-06-02 SEO/GEO audit (sitemap was the top technical gap)