### PR TITLE
chore(seo): add marketing-cluster pages to llms.txt

### DIFF
--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -10,6 +10,13 @@ Loyal is a non-custodial Solana wallet built around two ideas: programmable smar
 - [Loyal Web App](https://app.askloyal.com): the authenticated wallet (passkey + smart-account onboarding)
 - [Chrome Web Store extension](https://chromewebstore.google.com/detail/cdienfadefhlaknmedckgifkjdbioack): browser extension build
 
+## Features
+
+- [Agent wallet on Solana](https://askloyal.com/agents): Smart Accounts with on-chain policies and spending caps that keep AI agents within bounds
+- [Anonymous crypto wallet](https://askloyal.com/private-payments): private USDC, SOL, and USDT transfers via Confidential VM-shielded balances
+- [Yield on shielded USDC](https://askloyal.com/yield): shielded USDC routed into Kamino lending vaults so your balance earns while it stays private
+- [Best available stablecoin yield](https://askloyal.com/earn): routes stablecoins to the highest-paying Solana lending reserve, bounded by an on-chain policy, non-custodial
+
 ## Documentation
 
 - [docs.askloyal.com](https://docs.askloyal.com): canonical product and developer docs


### PR DESCRIPTION
## What

`llms.txt` linked only `/` and `/privacy-policy`. The four marketing pages were absent from the AI-discovery surface: the same omission #372 fixes for the XML `sitemap.xml`, but on the file that actually feeds ChatGPT / Claude / Perplexity.

Adds a `## Features` section linking all four:

- `/agents`: Agent wallet on Solana
- `/private-payments`: Anonymous crypto wallet
- `/yield`: Yield on shielded USDC
- `/earn`: Best available stablecoin yield

Descriptions are derived from each page's own `PAGE_DESCRIPTION`, so the llms.txt anchor text mirrors the destination page's title (consistent signal for AI engines).

## Sibling

Pairs with #372 (sitemap). Together they close the marketing-cluster discovery gap on both machine surfaces (Google + AI engines).

Surfaced by the 2026-06-02 SEO/GEO audit.