### PR TITLE
chore(extension): bump version to 0.5.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -519,7 +519,7 @@
     },
     "sdk/private-transactions": {
       "name": "@loyal-labs/private-transactions",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "devDependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@solana/web3.js": "^1.95.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@loyal-labs/extension",
   "description": "Loyal wallet browser extension",
   "private": true,
-  "version": "0.5.11",
+  "version": "0.5.12",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Bump the browser extension package version to 0.5.12 and sync bun.lock for the private-transactions SDK 0.2.10 release.