### PR TITLE
chore(rpc): migrate Helius secure RPC endpoints to new project

### DIFF
--- a/admin/src/app/(admin)/transfers/transfers-data.ts
+++ b/admin/src/app/(admin)/transfers/transfers-data.ts
@@ -15,7 +15,7 @@ import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
 import { fetchTokenPricesByMints } from "@/lib/market/token-prices.server";
 
 const SOLANA_MAINNET_RPC_URL =
-  "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com";
+  "https://fredra-z7l52f-fast-mainnet.helius-rpc.com";
 const USDC_MINT_MAINNET = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const KAMINO_USDC_RESERVE = "9GJ9GBRwCp4pHmWrQ43L5xpc9Vykg7jnfwcFGN8FoHYu";
 const KAMINO_USDC_COLLATERAL_MINT =

--- a/app/.env.example
+++ b/app/.env.example
@@ -30,8 +30,8 @@ AX_SUMMARY_ENABLE_TELEMETRY=
 JUPITER_API_KEY=
 IRYS_SOLANA_KEY=
 DEPLOYMENT_PK=
-PRIVATE_MAINNET_RPC_URL=https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com
-# Helius API key (Daggerzest - mobile project); used server-side for webhook CRUD
+PRIVATE_MAINNET_RPC_URL=https://fredra-z7l52f-fast-mainnet.helius-rpc.com
+# Helius API key for the active Helius project; used server-side for webhook CRUD
 HELIUS_API_KEY=
 # Shared secret sent as Helius webhook authHeader; >=32 random bytes
 HELIUS_WEBHOOK_SECRET=

--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
     },
     "extension": {
       "name": "@loyal-labs/extension",
-      "version": "0.5.11",
+      "version": "0.5.13",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-react": "^0.15.39",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@loyal-labs/extension",
   "description": "Loyal wallet browser extension",
   "private": true,
-  "version": "0.5.12",
+  "version": "0.5.13",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/extension/src/components/wallet/wallet-provider.tsx
+++ b/extension/src/components/wallet/wallet-provider.tsx
@@ -39,8 +39,8 @@ import {
 type Network = "mainnet" | "devnet";
 
 const RPC_ENDPOINTS: Record<Network, string> = {
-  mainnet: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-  devnet: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
+  mainnet: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+  devnet: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
 };
 
 function getRpcUrl(network: Network): string {

--- a/frontend/src/lib/core/config/__tests__/public.test.ts
+++ b/frontend/src/lib/core/config/__tests__/public.test.ts
@@ -72,7 +72,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("devnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://aurora-o23cd4-fast-devnet.helius-rpc.com"
+      "https://karlotta-a6micy-fast-devnet.helius-rpc.com"
     );
   });
 
@@ -83,7 +83,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("mainnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com"
+      "https://fredra-z7l52f-fast-mainnet.helius-rpc.com"
     );
   });
 
@@ -94,7 +94,7 @@ describe("public config", () => {
 
     expect(env.solanaEnv).toBe("devnet");
     expect(env.solanaRpcEndpoint).toBe(
-      "https://aurora-o23cd4-fast-devnet.helius-rpc.com"
+      "https://karlotta-a6micy-fast-devnet.helius-rpc.com"
     );
   });
 

--- a/frontend/src/lib/solana/rpc-endpoints.ts
+++ b/frontend/src/lib/solana/rpc-endpoints.ts
@@ -8,12 +8,12 @@ const FRONTEND_SOLANA_ENDPOINTS_BY_ENV: Partial<
   Record<SolanaEnv, SolanaEndpoints>
 > = {
   devnet: {
-    rpcEndpoint: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
-    websocketEndpoint: "wss://aurora-o23cd4-fast-devnet.helius-rpc.com",
+    rpcEndpoint: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
+    websocketEndpoint: "wss://karlotta-a6micy-fast-devnet.helius-rpc.com",
   },
   mainnet: {
-    rpcEndpoint: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-    websocketEndpoint: "wss://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
+    rpcEndpoint: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+    websocketEndpoint: "wss://fredra-z7l52f-fast-mainnet.helius-rpc.com",
   },
 };
 

--- a/packages/solana-rpc/src/__tests__/solana-rpc.test.ts
+++ b/packages/solana-rpc/src/__tests__/solana-rpc.test.ts
@@ -32,15 +32,15 @@ describe("resolveSolanaEnv", () => {
 describe("getSolanaEndpoints", () => {
   test("returns the mainnet helius endpoints", () => {
     expect(getSolanaEndpoints("mainnet")).toEqual({
-      rpcEndpoint: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-      websocketEndpoint: "wss://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
+      rpcEndpoint: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+      websocketEndpoint: "wss://fredra-z7l52f-fast-mainnet.helius-rpc.com",
     });
   });
 
   test("returns the devnet helius endpoints", () => {
     expect(getSolanaEndpoints("devnet")).toEqual({
-      rpcEndpoint: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
-      websocketEndpoint: "wss://aurora-o23cd4-fast-devnet.helius-rpc.com",
+      rpcEndpoint: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
+      websocketEndpoint: "wss://karlotta-a6micy-fast-devnet.helius-rpc.com",
     });
   });
 

--- a/packages/solana-rpc/src/solana-rpc.ts
+++ b/packages/solana-rpc/src/solana-rpc.ts
@@ -19,12 +19,12 @@ export type PerEndpoints = {
 
 const DEFAULT_SOLANA_ENV: SolanaEnv = "devnet";
 const MAINNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
-  rpcEndpoint: "https://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
-  websocketEndpoint: "wss://guendolen-nvqjc4-fast-mainnet.helius-rpc.com",
+  rpcEndpoint: "https://fredra-z7l52f-fast-mainnet.helius-rpc.com",
+  websocketEndpoint: "wss://fredra-z7l52f-fast-mainnet.helius-rpc.com",
 };
 const DEVNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
-  rpcEndpoint: "https://aurora-o23cd4-fast-devnet.helius-rpc.com",
-  websocketEndpoint: "wss://aurora-o23cd4-fast-devnet.helius-rpc.com",
+  rpcEndpoint: "https://karlotta-a6micy-fast-devnet.helius-rpc.com",
+  websocketEndpoint: "wss://karlotta-a6micy-fast-devnet.helius-rpc.com",
 };
 const TESTNET_SOLANA_ENDPOINTS: SolanaEndpoints = {
   rpcEndpoint: "https://api.testnet.solana.com",

--- a/sdk/private-transactions/tests/private-transactions-shield.test.ts
+++ b/sdk/private-transactions/tests/private-transactions-shield.test.ts
@@ -133,9 +133,9 @@ const PER_RPC_ENDPOINT = "https://devnet-tee.magicblock.app";
 const PER_WS_ENDPOINT = "wss://devnet-tee.magicblock.app";
 
 export const SECURE_DEVNET_RPC_URL =
-  "https://aurora-o23cd4-fast-devnet.helius-rpc.com";
+  "https://karlotta-a6micy-fast-devnet.helius-rpc.com";
 export const SECURE_DEVNET_RPC_WS =
-  "wss://aurora-o23cd4-fast-devnet.helius-rpc.com";
+  "wss://karlotta-a6micy-fast-devnet.helius-rpc.com";
 
 const solanaConnection = new Connection(SECURE_DEVNET_RPC_URL, {
   wsEndpoint: SECURE_DEVNET_RPC_WS,


### PR DESCRIPTION
Switches the Helius secure RPC hosts to the new project (mainnet guendolen-nvqjc4 → fredra-z7l52f, devnet aurora-o23cd4 → karlotta-a6micy) across solana-rpc, frontend, admin, extension, and sdk tests, and bumps the extension to 0.5.13. Mobile is handled on a separate branch; HELIUS_API_KEY (Vercel) and webhook re-registration are follow-up ops steps. Refs ASK-1516.