### PR TITLE
feat(earn): add mobile wallet-signed withdraw and autodeposit endpoints

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
@@ -1,0 +1,349 @@
+import { NextResponse } from "next/server";
+import {
+  normalizeLoyalCluster,
+  resolveLoyalClusterForSolanaEnv,
+} from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import {
+  buildEarnAutodepositCloseConfirmRequestBody,
+  hydratePreparedEarnUsdcAutodepositClose,
+  parseEarnAutodepositCloseConfirmRequestBody,
+  type EarnAutodepositCloseConfirmResponse,
+  type WireSmartAccountPreparedEarnUsdcAutodepositClose,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import {
+  recordClosedAutodepositTarget,
+  type BalanceSweepTargetRecord,
+  type ConfirmedEarnAutodepositCloseInput,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+
+// Mobile twin of `yield-optimization/autodeposit/close/confirm`. The device
+// echoes the serialized prepared close it signed + signature/slot; this route
+// rebuilds the canonical confirm payload server-side and records the closed
+// target. The canonicalization mirrors the session route — keep in sync.
+const EARN_DEPOSIT_VAULT_INDEX = 1 as const;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+type MobileCloseConfirmFields = {
+  preparedClose: WireSmartAccountPreparedEarnUsdcAutodepositClose;
+  closeSignature: string;
+  confirmedSlot: string;
+};
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+function assertCanonicalField(
+  actual: string | bigint | number | null,
+  expected: string | bigint | number | null,
+  label: string
+) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label} does not match canonical Earn autodeposit metadata.`
+    );
+  }
+}
+
+function createCanonicalAutodepositCloseInput(
+  requestInput: ConfirmedEarnAutodepositCloseInput
+): ConfirmedEarnAutodepositCloseInput {
+  const cluster = normalizeLoyalCluster(requestInput.cluster);
+  const normalizedRequestInput = { ...requestInput, cluster };
+  const settings = new PublicKey(requestInput.settings);
+  const expectedVault = pda.getSmartAccountPda({
+    settingsPda: settings,
+    accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+  })[0];
+  const expectedPolicySigner = getDeploymentPolicySignerPublicKey().toBase58();
+  const canonicalInput = {
+    ...normalizedRequestInput,
+    cluster,
+    delegatedSigner: expectedPolicySigner,
+    vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+    vaultPubkey: expectedVault.toBase58(),
+  };
+
+  assertCanonicalField(
+    normalizedRequestInput.cluster,
+    canonicalInput.cluster,
+    "cluster"
+  );
+  assertCanonicalField(
+    requestInput.delegatedSigner,
+    canonicalInput.delegatedSigner,
+    "delegatedSigner"
+  );
+  assertCanonicalField(
+    requestInput.vaultIndex,
+    canonicalInput.vaultIndex,
+    "vaultIndex"
+  );
+  assertCanonicalField(
+    requestInput.vaultPubkey,
+    canonicalInput.vaultPubkey,
+    "vaultPubkey"
+  );
+  new PublicKey(requestInput.policyAccount);
+  new PublicKey(requestInput.recurringDelegation);
+
+  return canonicalInput;
+}
+
+async function resolveConfirmedSignatureSlot(args: {
+  cluster: SolanaEnv;
+  signature: string;
+}): Promise<bigint> {
+  const { value } = await getConnection(args.cluster).getSignatureStatuses(
+    [args.signature],
+    { searchTransactionHistory: true }
+  );
+  const status = value[0];
+
+  if (!status || status.err) {
+    throw new Error("Autodeposit close transaction is not confirmed.");
+  }
+
+  if (
+    status.confirmationStatus !== "confirmed" &&
+    status.confirmationStatus !== "finalized"
+  ) {
+    throw new Error("Autodeposit close transaction is not confirmed.");
+  }
+
+  if (typeof status.slot !== "number") {
+    throw new Error("Confirmed transaction slot is unavailable.");
+  }
+
+  return BigInt(status.slot);
+}
+
+function serializeTarget(
+  target: BalanceSweepTargetRecord
+): EarnAutodepositCloseConfirmResponse["target"] {
+  return {
+    active: target.active,
+    balanceSweepPolicyId: target.balanceSweepPolicyId?.toString() ?? null,
+    id: target.id.toString(),
+    lifecycleStatus: target.lifecycleStatus,
+    policyAccount: target.policyAccount,
+    recurringDelegation: target.recurringDelegation,
+    walletBalanceFloorRaw: target.walletBalanceFloorRaw?.toString() ?? null,
+  };
+}
+
+function parseMobileCloseConfirmFields(
+  body: unknown
+): MobileCloseConfirmFields {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("Request body must be an object.");
+  }
+  const record = body as Record<string, unknown>;
+  if (typeof record.preparedClose !== "object" || record.preparedClose === null) {
+    throw new Error("preparedClose is required.");
+  }
+  if (typeof record.closeSignature !== "string" || !record.closeSignature) {
+    throw new Error("closeSignature is required.");
+  }
+  if (typeof record.confirmedSlot !== "string" || !record.confirmedSlot) {
+    throw new Error("confirmedSlot is required.");
+  }
+  return {
+    preparedClose:
+      record.preparedClose as WireSmartAccountPreparedEarnUsdcAutodepositClose,
+    closeSignature: record.closeSignature,
+    confirmedSlot: record.confirmedSlot,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-close-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let fields: MobileCloseConfirmFields;
+  try {
+    fields = parseMobileCloseConfirmFields(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-close-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  let input: ConfirmedEarnAutodepositCloseInput;
+  try {
+    const prepared = hydratePreparedEarnUsdcAutodepositClose(
+      fields.preparedClose
+    );
+    const confirmBody = buildEarnAutodepositCloseConfirmRequestBody({
+      confirmedSlot: fields.confirmedSlot,
+      preparedClose: prepared,
+      signature: fields.closeSignature,
+    });
+    input = parseEarnAutodepositCloseConfirmRequestBody(confirmBody);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid prepared close."
+    );
+  }
+
+  if (input.walletAddress !== walletAddress || input.settings !== settingsPda) {
+    return jsonError(
+      403,
+      "principal_mismatch",
+      "Confirmed autodeposit close does not match the authenticated wallet."
+    );
+  }
+
+  try {
+    input = createCanonicalAutodepositCloseInput(input);
+  } catch (error) {
+    return jsonError(
+      400,
+      "metadata_mismatch",
+      error instanceof Error
+        ? error.message
+        : "Confirmed autodeposit close metadata is invalid."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const configuredCluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+  if (input.cluster !== configuredCluster) {
+    return jsonError(
+      400,
+      "cluster_mismatch",
+      "Confirmed autodeposit close cluster does not match the configured Solana environment."
+    );
+  }
+
+  let confirmedSlot: bigint;
+  try {
+    confirmedSlot = await resolveConfirmedSignatureSlot({
+      cluster: solanaEnv,
+      signature: input.closeSignature,
+    });
+  } catch (error) {
+    return jsonError(
+      400,
+      "unconfirmed_signature",
+      error instanceof Error
+        ? error.message
+        : "Autodeposit close transaction is not confirmed."
+    );
+  }
+
+  if (input.confirmedSlot !== confirmedSlot) {
+    return jsonError(
+      400,
+      "slot_mismatch",
+      "Confirmed autodeposit close slot does not match the transaction status."
+    );
+  }
+
+  try {
+    const target = await recordClosedAutodepositTarget(input);
+    return NextResponse.json({ target: serializeTarget(target) });
+  } catch (error) {
+    return jsonError(
+      400,
+      "record_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to record confirmed autodeposit close."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/prepare/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import {
+  parseEarnAutodepositClosePrepareRequestBody,
+  serializePreparedEarnUsdcAutodepositClose,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+
+// Mobile twin of `yield-optimization/autodeposit/close/prepare`. Wallet-sig auth
+// + self-resolved smart account; the device signs the returned close op and
+// confirms it via `autodeposit/close/confirm`. Keep in sync with the session
+// route.
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-close-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let parsed: ReturnType<typeof parseEarnAutodepositClosePrepareRequestBody>;
+  try {
+    parsed = parseEarnAutodepositClosePrepareRequestBody(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-close-prepare] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  try {
+    const serverEnv = getServerEnv();
+    const policySigner = getDeploymentPolicySignerPublicKey();
+    const client = createSmartAccountVaultsClient({
+      connection: getConnection(solanaEnv),
+      programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
+    });
+    const preparedClose = await client.prepareEarnUsdcAutodepositClose({
+      cluster,
+      feePayer: new PublicKey(walletAddress),
+      policy: new PublicKey(parsed.policy),
+      policySigner,
+      recurringDelegation: new PublicKey(parsed.recurringDelegation),
+      settingsPda: new PublicKey(settingsPda),
+      signer: new PublicKey(walletAddress),
+      walletAddress: new PublicKey(walletAddress),
+    });
+
+    return NextResponse.json({
+      preparedClose: serializePreparedEarnUsdcAutodepositClose(preparedClose),
+    });
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-close-prepare] prepare failed", {
+      cluster,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown prepare error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      policy: parsed.policy,
+      recurringDelegation: parsed.recurringDelegation,
+      settings: settingsPda,
+      solanaEnv,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "prepare_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to prepare Earn autodeposit close."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from "next/server";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import {
+  parseEarnAutodepositFloorUpdateConfirmRequestBody,
+  type EarnAutodepositSetupConfirmResponse,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import {
+  updateAutodepositWalletBalanceFloor,
+  type BalanceSweepTargetRecord,
+  type PendingEarnAutodepositScheduledSweepRecord,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+
+// Mobile twin of `yield-optimization/autodeposit/floor/confirm`. Changing the
+// threshold (walletBalanceFloorRaw) is a DB-only update — no on-chain signing —
+// so this is just wallet-sig auth + self-resolved smart account in front of the
+// shared repository call. Keep in sync with the session route.
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function serializeTarget(
+  target: BalanceSweepTargetRecord
+): EarnAutodepositSetupConfirmResponse["target"] {
+  return {
+    active: target.active,
+    balanceSweepPolicyId: target.balanceSweepPolicyId?.toString() ?? null,
+    id: target.id.toString(),
+    lifecycleStatus: target.lifecycleStatus,
+    policyAccount: target.policyAccount,
+    recurringDelegation: target.recurringDelegation,
+    walletBalanceFloorRaw: target.walletBalanceFloorRaw?.toString() ?? null,
+  };
+}
+
+function serializeScheduledSweep(
+  sweep: PendingEarnAutodepositScheduledSweepRecord
+): NonNullable<EarnAutodepositSetupConfirmResponse["rebaselineSweep"]>["sweep"] {
+  return {
+    classification: sweep.classification,
+    confidence: sweep.confidence,
+    eligibleAfter: sweep.eligibleAfter.toISOString(),
+    id: sweep.id.toString(),
+    originalAmountRaw: sweep.originalAmountRaw.toString(),
+    reason: sweep.reason,
+    remainingAmountRaw: sweep.remainingAmountRaw.toString(),
+    status: sweep.status,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-floor-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let input: ReturnType<typeof parseEarnAutodepositFloorUpdateConfirmRequestBody>;
+  try {
+    input = parseEarnAutodepositFloorUpdateConfirmRequestBody(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-floor-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  try {
+    const result = await updateAutodepositWalletBalanceFloor({
+      policyAccount: input.policyAccount,
+      recurringDelegation: input.recurringDelegation,
+      settings: settingsPda,
+      vaultIndex: input.vaultIndex,
+      walletAddress,
+      walletBalanceFloorRaw: input.walletBalanceFloorRaw,
+    });
+
+    return NextResponse.json({
+      rebaselineSweep:
+        result.rebaselineSweep.status === "scheduled"
+          ? {
+              status: result.rebaselineSweep.status,
+              sweep: serializeScheduledSweep(result.rebaselineSweep.sweep),
+            }
+          : result.rebaselineSweep,
+      target: serializeTarget(result.target),
+    });
+  } catch (error) {
+    return jsonError(
+      400,
+      "update_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to update autodeposit wallet balance floor."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
@@ -1,0 +1,608 @@
+import { createHash } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import {
+  deriveRecurringDelegation,
+  deriveSubscriptionAuthority,
+  getKaminoUsdcEarnTargetForCluster,
+  normalizeLoyalCluster,
+  resolveLoyalClusterForSolanaEnv,
+} from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+  unpackAccount,
+} from "@solana/spl-token";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import {
+  buildEarnAutodepositSetupConfirmRequestBody,
+  hydratePreparedEarnUsdcAutodepositSetup,
+  parseEarnAutodepositSetupConfirmRequestBody,
+  type EarnAutodepositSetupConfirmResponse,
+  type WireSmartAccountPreparedEarnUsdcAutodepositSetup,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import {
+  recordConfirmedAutodepositDelegation,
+  recordPendingAutodepositSetup,
+  scheduleBootstrapEarnAutodepositSweep,
+  type BalanceSweepTargetRecord,
+  type ConfirmedEarnAutodepositSetupInput,
+  type EarnAutodepositBootstrapWalletBalanceSnapshot,
+  type PendingEarnAutodepositScheduledSweepRecord,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+
+// Mobile twin of `yield-optimization/autodeposit/setup/confirm`. The device
+// echoes the serialized prepared setup it signed + signature/slot + the chosen
+// threshold; this route rebuilds the canonical confirm payload server-side. The
+// canonicalization + bootstrap-sweep scheduling mirror the session route — keep
+// in sync.
+const EARN_DEPOSIT_VAULT_INDEX = 1 as const;
+const MONTH_PERIOD_SECONDS = BigInt(30 * 24 * 60 * 60);
+const BOOTSTRAP_BALANCE_SOURCE = "app_autodeposit_setup_confirm";
+const BOOTSTRAP_BALANCE_SOURCE_COMMITMENT = "confirmed";
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+type MobileSetupConfirmFields = {
+  preparedSetup: WireSmartAccountPreparedEarnUsdcAutodepositSetup;
+  setupSignature: string;
+  confirmedSlot: string;
+  walletBalanceFloorRaw: bigint;
+};
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function assertCanonicalField(
+  actual: string | bigint | number | null,
+  expected: string | bigint | number | null,
+  label: string
+) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label} does not match canonical Earn autodeposit metadata.`
+    );
+  }
+}
+
+function toSafePolicySeed(policySeed: bigint): number {
+  if (policySeed <= BigInt(0) || policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("policySeed is outside the supported autodeposit range.");
+  }
+
+  return Number(policySeed);
+}
+
+function createCanonicalAutodepositSetupInput(
+  requestInput: ConfirmedEarnAutodepositSetupInput
+): ConfirmedEarnAutodepositSetupInput {
+  const cluster = normalizeLoyalCluster(requestInput.cluster);
+  const normalizedRequestInput = { ...requestInput, cluster };
+  const settings = new PublicKey(requestInput.settings);
+  const wallet = new PublicKey(requestInput.walletAddress);
+  const expectedPolicyAccount = pda.getPolicyPda({
+    settingsPda: settings,
+    policySeed: toSafePolicySeed(requestInput.policySeed),
+  })[0];
+  const expectedVault = pda.getSmartAccountPda({
+    settingsPda: settings,
+    accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+  })[0];
+  const earnTarget = getKaminoUsdcEarnTargetForCluster(cluster);
+  const usdcMint = earnTarget.liquidityMint;
+  const expectedSubscriptionAuthority = deriveSubscriptionAuthority(
+    wallet,
+    usdcMint
+  );
+  const expectedRecurringDelegation = deriveRecurringDelegation(
+    expectedSubscriptionAuthority,
+    wallet,
+    expectedVault,
+    requestInput.nonce
+  );
+  const expectedWalletUsdcAta = getAssociatedTokenAddressSync(
+    usdcMint,
+    wallet,
+    false,
+    TOKEN_PROGRAM_ID
+  );
+  const expectedVaultUsdcAta = getAssociatedTokenAddressSync(
+    usdcMint,
+    expectedVault,
+    true,
+    TOKEN_PROGRAM_ID
+  );
+  const expectedPolicySigner = getDeploymentPolicySignerPublicKey().toBase58();
+  const canonicalInput = {
+    ...normalizedRequestInput,
+    delegatedSigner: expectedPolicySigner,
+    liquidityMint: usdcMint.toBase58(),
+    policyAccount: expectedPolicyAccount.toBase58(),
+    policyId: requestInput.policySeed,
+    policySeed: requestInput.policySeed,
+    recurringDelegation: expectedRecurringDelegation.toBase58(),
+    subscriptionAuthority: expectedSubscriptionAuthority.toBase58(),
+    subscriptionDelegatee: expectedVault.toBase58(),
+    vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+    vaultPubkey: expectedVault.toBase58(),
+    vaultUsdcAta: expectedVaultUsdcAta.toBase58(),
+    walletUsdcAta: expectedWalletUsdcAta.toBase58(),
+  };
+
+  assertCanonicalField(
+    normalizedRequestInput.cluster,
+    canonicalInput.cluster,
+    "cluster"
+  );
+  assertCanonicalField(
+    requestInput.delegatedSigner,
+    canonicalInput.delegatedSigner,
+    "delegatedSigner"
+  );
+  assertCanonicalField(
+    requestInput.liquidityMint,
+    canonicalInput.liquidityMint,
+    "liquidityMint"
+  );
+  assertCanonicalField(
+    requestInput.periodLengthSeconds,
+    MONTH_PERIOD_SECONDS,
+    "periodLengthSeconds"
+  );
+  assertCanonicalField(
+    requestInput.policyAccount,
+    canonicalInput.policyAccount,
+    "policyAccount"
+  );
+  assertCanonicalField(
+    requestInput.policyId,
+    requestInput.policySeed,
+    "policyId"
+  );
+  assertCanonicalField(
+    requestInput.policyId,
+    canonicalInput.policyId,
+    "policyId"
+  );
+  assertCanonicalField(
+    requestInput.recurringDelegation,
+    canonicalInput.recurringDelegation,
+    "recurringDelegation"
+  );
+  assertCanonicalField(
+    requestInput.subscriptionAuthority,
+    canonicalInput.subscriptionAuthority,
+    "subscriptionAuthority"
+  );
+  assertCanonicalField(
+    requestInput.subscriptionDelegatee,
+    canonicalInput.subscriptionDelegatee,
+    "subscriptionDelegatee"
+  );
+  assertCanonicalField(
+    requestInput.vaultIndex,
+    canonicalInput.vaultIndex,
+    "vaultIndex"
+  );
+  assertCanonicalField(
+    requestInput.vaultPubkey,
+    canonicalInput.vaultPubkey,
+    "vaultPubkey"
+  );
+  assertCanonicalField(
+    requestInput.vaultUsdcAta,
+    canonicalInput.vaultUsdcAta,
+    "vaultUsdcAta"
+  );
+  assertCanonicalField(
+    requestInput.walletUsdcAta,
+    canonicalInput.walletUsdcAta,
+    "walletUsdcAta"
+  );
+
+  if (requestInput.amountPerPeriodRaw <= BigInt(0)) {
+    throw new Error("amountPerPeriodRaw must be greater than 0.");
+  }
+  if (requestInput.walletBalanceFloorRaw < BigInt(0)) {
+    throw new Error("walletBalanceFloorRaw cannot be negative.");
+  }
+
+  return canonicalInput;
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+async function resolveConfirmedSignatureSlot(args: {
+  cluster: SolanaEnv;
+  signature: string;
+}): Promise<bigint> {
+  const { value } = await getConnection(args.cluster).getSignatureStatuses(
+    [args.signature],
+    { searchTransactionHistory: true }
+  );
+  const status = value[0];
+
+  if (!status || status.err) {
+    throw new Error("Autodeposit setup transaction is not confirmed.");
+  }
+
+  if (
+    status.confirmationStatus !== "confirmed" &&
+    status.confirmationStatus !== "finalized"
+  ) {
+    throw new Error("Autodeposit setup transaction is not confirmed.");
+  }
+
+  if (typeof status.slot !== "number") {
+    throw new Error("Confirmed transaction slot is unavailable.");
+  }
+
+  return BigInt(status.slot);
+}
+
+function serializeTarget(
+  target: BalanceSweepTargetRecord
+): EarnAutodepositSetupConfirmResponse["target"] {
+  return {
+    active: target.active,
+    balanceSweepPolicyId: target.balanceSweepPolicyId?.toString() ?? null,
+    id: target.id.toString(),
+    lifecycleStatus: target.lifecycleStatus,
+    policyAccount: target.policyAccount,
+    recurringDelegation: target.recurringDelegation,
+    walletBalanceFloorRaw: target.walletBalanceFloorRaw?.toString() ?? null,
+  };
+}
+
+function serializeScheduledSweep(
+  sweep: PendingEarnAutodepositScheduledSweepRecord
+): {
+  classification: string;
+  confidence: string;
+  eligibleAfter: string;
+  id: string;
+  originalAmountRaw: string;
+  reason: string;
+  remainingAmountRaw: string;
+  status: string;
+} {
+  return {
+    classification: sweep.classification,
+    confidence: sweep.confidence,
+    eligibleAfter: sweep.eligibleAfter.toISOString(),
+    id: sweep.id.toString(),
+    originalAmountRaw: sweep.originalAmountRaw.toString(),
+    reason: sweep.reason,
+    remainingAmountRaw: sweep.remainingAmountRaw.toString(),
+    status: sweep.status,
+  };
+}
+
+async function readBootstrapWalletBalanceSnapshot(args: {
+  connection: Connection;
+  input: ConfirmedEarnAutodepositSetupInput;
+}): Promise<
+  | {
+      snapshot: EarnAutodepositBootstrapWalletBalanceSnapshot;
+      status: "ok";
+    }
+  | {
+      reason: string;
+      status: "skipped";
+    }
+> {
+  const walletUsdcAta = new PublicKey(args.input.walletUsdcAta);
+  const account = await args.connection.getAccountInfoAndContext(
+    walletUsdcAta,
+    BOOTSTRAP_BALANCE_SOURCE_COMMITMENT
+  );
+
+  if (!account.value) {
+    return { reason: "wallet_usdc_ata_missing", status: "skipped" };
+  }
+
+  if (!account.value.owner.equals(TOKEN_PROGRAM_ID)) {
+    return { reason: "wallet_usdc_ata_invalid_owner", status: "skipped" };
+  }
+
+  let tokenAccount: ReturnType<typeof unpackAccount>;
+  try {
+    tokenAccount = unpackAccount(walletUsdcAta, account.value, TOKEN_PROGRAM_ID);
+  } catch {
+    return { reason: "wallet_usdc_ata_invalid_data", status: "skipped" };
+  }
+
+  const tokenMint = tokenAccount.mint.toBase58();
+  if (tokenMint !== args.input.liquidityMint) {
+    return { reason: "wallet_usdc_ata_non_usdc", status: "skipped" };
+  }
+
+  const tokenOwner = tokenAccount.owner.toBase58();
+  if (tokenOwner !== args.input.walletAddress) {
+    return { reason: "wallet_usdc_ata_wallet_mismatch", status: "skipped" };
+  }
+
+  const accountDataHash = createHash("sha256")
+    .update(account.value.data)
+    .digest("hex");
+  const observedAt = new Date();
+
+  return {
+    snapshot: {
+      accountDataHash,
+      amountRaw: tokenAccount.amount,
+      mint: tokenMint,
+      observedAt,
+      observedSlot: BigInt(account.context.slot),
+      owner: tokenOwner,
+      rawEvidence: {
+        accountLamports: account.value.lamports.toString(),
+        accountOwner: account.value.owner.toBase58(),
+        bootstrap: true,
+        setupSignature: args.input.setupSignature,
+      },
+      source: BOOTSTRAP_BALANCE_SOURCE,
+      sourceCommitment: BOOTSTRAP_BALANCE_SOURCE_COMMITMENT,
+    },
+    status: "ok",
+  };
+}
+
+function parseMobileSetupConfirmFields(body: unknown): MobileSetupConfirmFields {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("Request body must be an object.");
+  }
+  const record = body as Record<string, unknown>;
+  if (
+    typeof record.preparedSetup !== "object" ||
+    record.preparedSetup === null
+  ) {
+    throw new Error("preparedSetup is required.");
+  }
+  if (typeof record.setupSignature !== "string" || !record.setupSignature) {
+    throw new Error("setupSignature is required.");
+  }
+  if (typeof record.confirmedSlot !== "string" || !record.confirmedSlot) {
+    throw new Error("confirmedSlot is required.");
+  }
+  if (
+    typeof record.walletBalanceFloorRaw !== "string" ||
+    !/^\d+$/.test(record.walletBalanceFloorRaw.trim())
+  ) {
+    throw new Error("walletBalanceFloorRaw must be an unsigned integer string.");
+  }
+  return {
+    preparedSetup:
+      record.preparedSetup as WireSmartAccountPreparedEarnUsdcAutodepositSetup,
+    setupSignature: record.setupSignature,
+    confirmedSlot: record.confirmedSlot,
+    walletBalanceFloorRaw: BigInt(record.walletBalanceFloorRaw.trim()),
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-setup-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let fields: MobileSetupConfirmFields;
+  try {
+    fields = parseMobileSetupConfirmFields(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-setup-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  let input: ConfirmedEarnAutodepositSetupInput;
+  try {
+    const prepared = hydratePreparedEarnUsdcAutodepositSetup(
+      fields.preparedSetup
+    );
+    const confirmBody = buildEarnAutodepositSetupConfirmRequestBody({
+      confirmedSlot: fields.confirmedSlot,
+      preparedSetup: prepared,
+      signature: fields.setupSignature,
+      walletBalanceFloorRaw: fields.walletBalanceFloorRaw,
+    });
+    input = parseEarnAutodepositSetupConfirmRequestBody(confirmBody);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid prepared setup."
+    );
+  }
+
+  if (input.walletAddress !== walletAddress || input.settings !== settingsPda) {
+    return jsonError(
+      403,
+      "principal_mismatch",
+      "Confirmed autodeposit setup does not match the authenticated wallet."
+    );
+  }
+
+  try {
+    input = createCanonicalAutodepositSetupInput(input);
+  } catch (error) {
+    return jsonError(
+      400,
+      "metadata_mismatch",
+      error instanceof Error
+        ? error.message
+        : "Confirmed autodeposit setup metadata is invalid."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const configuredCluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+  if (input.cluster !== configuredCluster) {
+    return jsonError(
+      400,
+      "cluster_mismatch",
+      "Confirmed autodeposit setup cluster does not match the configured Solana environment."
+    );
+  }
+
+  let confirmedSlot: bigint;
+  try {
+    confirmedSlot = await resolveConfirmedSignatureSlot({
+      cluster: solanaEnv,
+      signature: input.setupSignature,
+    });
+  } catch (error) {
+    return jsonError(
+      400,
+      "unconfirmed_signature",
+      error instanceof Error
+        ? error.message
+        : "Autodeposit setup transaction is not confirmed."
+    );
+  }
+
+  if (input.confirmedSlot !== confirmedSlot) {
+    return jsonError(
+      400,
+      "slot_mismatch",
+      "Confirmed autodeposit setup slot does not match the transaction status."
+    );
+  }
+
+  const target =
+    input.setupStage === "create_recurring_delegation"
+      ? await recordConfirmedAutodepositDelegation(input)
+      : await recordPendingAutodepositSetup(input);
+  let bootstrapSweep: EarnAutodepositSetupConfirmResponse["bootstrapSweep"];
+  if (input.setupStage === "create_recurring_delegation") {
+    try {
+      const snapshotResult = await readBootstrapWalletBalanceSnapshot({
+        connection: getConnection(solanaEnv),
+        input,
+      });
+      if (snapshotResult.status === "skipped") {
+        bootstrapSweep = snapshotResult;
+      } else {
+        const result = await scheduleBootstrapEarnAutodepositSweep({
+          snapshot: snapshotResult.snapshot,
+          target,
+        });
+        if (result.status === "skipped") {
+          bootstrapSweep = result;
+        } else {
+          bootstrapSweep = {
+            status: result.status,
+            sweep: serializeScheduledSweep(result.sweep),
+          };
+        }
+      }
+    } catch (error) {
+      console.warn("[mobile-autodeposit-setup-confirm] bootstrap failed", {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown bootstrap error.",
+        policyAccount: input.policyAccount,
+        setupSignature: input.setupSignature,
+        walletAddress: input.walletAddress,
+      });
+      bootstrapSweep = {
+        reason:
+          error instanceof Error
+            ? error.message
+            : "Bootstrap scheduling failed.",
+        status: "failed",
+      };
+    }
+  }
+
+  return NextResponse.json({
+    ...(bootstrapSweep ? { bootstrapSweep } : {}),
+    target: serializeTarget(target),
+  });
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import {
+  parseEarnAutodepositSetupPrepareRequestBody,
+  serializePreparedEarnUsdcAutodepositSetup,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+
+// Mobile twin of `yield-optimization/autodeposit/setup/prepare`. Wallet-sig auth
+// + self-resolved smart account; the SDK returns the next setup stage's prepared
+// op (initialize_subscription_authority -> create_policy ->
+// create_recurring_delegation) for the device to sign. The orchestrator threads
+// the returned nonce/policySeed back into subsequent stages. Keep in sync with
+// the session route.
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-setup-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let parsed: ReturnType<typeof parseEarnAutodepositSetupPrepareRequestBody>;
+  try {
+    parsed = parseEarnAutodepositSetupPrepareRequestBody(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-setup-prepare] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  try {
+    const serverEnv = getServerEnv();
+    const policySigner = getDeploymentPolicySignerPublicKey();
+    const client = createSmartAccountVaultsClient({
+      connection: getConnection(solanaEnv),
+      programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
+    });
+    const preparedSetup = await client.prepareEarnUsdcAutodepositSetup({
+      amountRaw: parsed.amountRaw,
+      cluster,
+      feePayer: new PublicKey(walletAddress),
+      nonce: parsed.nonce,
+      policySigner,
+      policySeed: parsed.policySeed,
+      settingsPda: new PublicKey(settingsPda),
+      signer: new PublicKey(walletAddress),
+      walletAddress: new PublicKey(walletAddress),
+    });
+
+    return NextResponse.json({
+      preparedSetup: serializePreparedEarnUsdcAutodepositSetup(preparedSetup),
+    });
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-setup-prepare] prepare failed", {
+      amountRaw: parsed.amountRaw.toString(),
+      cluster,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown prepare error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      settings: settingsPda,
+      solanaEnv,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "prepare_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to prepare Earn autodeposit setup."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+
+import { findCurrentUser } from "@/features/chat/server/app-user";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-signature";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+
+// Read-only mobile autodeposit state, keyed by wallet address (no signature, no
+// provisioning) — mirrors `mobile/earn/state`. Drives the native Autodeposit
+// control: whether it's set up, the threshold (walletBalanceFloorRaw), the
+// on/off state, and the policy/delegation the floor/toggle/close calls need.
+const EARN_VAULT_INDEX = 1 as const;
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export async function GET(request: Request) {
+  const walletAddress =
+    new URL(request.url).searchParams.get("walletAddress")?.trim() ?? "";
+  if (!walletAddress) {
+    return jsonError(400, "invalid_request", "walletAddress is required.");
+  }
+  try {
+    decodeWalletAddress(walletAddress);
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(400, "invalid_request", "walletAddress is invalid.");
+  }
+
+  const emptyState = {
+    autodeposit: null,
+    settingsPda: null,
+    smartAccountAddress: null,
+  };
+
+  try {
+    const user = await findCurrentUser({
+      authMethod: "wallet",
+      provider: "solana",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    if (!user) {
+      return NextResponse.json(emptyState);
+    }
+
+    const account = await findReadyCurrentUserSmartAccount({ userId: user.id });
+    if (!account) {
+      return NextResponse.json(emptyState);
+    }
+
+    const state = await findCurrentEarnAutodepositState({
+      settings: account.settingsPda,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress,
+    });
+    if (!state) {
+      return NextResponse.json({
+        autodeposit: null,
+        settingsPda: account.settingsPda,
+        smartAccountAddress: account.smartAccountAddress,
+      });
+    }
+
+    return NextResponse.json({
+      autodeposit: {
+        active: state.target.active,
+        status: state.status,
+        policyAccount: state.target.policyAccount,
+        recurringDelegation: state.target.recurringDelegation,
+        walletBalanceFloorRaw:
+          state.target.walletBalanceFloorRaw?.toString() ?? null,
+        lifecycleStatus: state.target.lifecycleStatus,
+        vaultIndex: EARN_VAULT_INDEX,
+      },
+      settingsPda: account.settingsPda,
+      smartAccountAddress: account.smartAccountAddress,
+    });
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-state] read failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown read error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "autodeposit_state_failed",
+      "Failed to load Autodeposit state."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import {
+  parseEarnAutodepositToggleConfirmRequestBody,
+  type EarnAutodepositToggleConfirmResponse,
+} from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import {
+  updateAutodepositTargetActive,
+  type BalanceSweepTargetRecord,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+
+// Mobile twin of `yield-optimization/autodeposit/toggle/confirm`. Enable/disable
+// is a DB-only flag flip (no on-chain signing); the recurring delegation stays
+// in place and the sweep worker honors `active`. Keep in sync with the session
+// route.
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function serializeTarget(
+  target: BalanceSweepTargetRecord
+): EarnAutodepositToggleConfirmResponse["target"] {
+  return {
+    active: target.active,
+    balanceSweepPolicyId: target.balanceSweepPolicyId?.toString() ?? null,
+    id: target.id.toString(),
+    lifecycleStatus: target.lifecycleStatus,
+    policyAccount: target.policyAccount,
+    recurringDelegation: target.recurringDelegation,
+    walletBalanceFloorRaw: target.walletBalanceFloorRaw?.toString() ?? null,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-autodeposit-toggle-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let input: ReturnType<typeof parseEarnAutodepositToggleConfirmRequestBody>;
+  try {
+    input = parseEarnAutodepositToggleConfirmRequestBody(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-autodeposit-toggle-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  try {
+    const target = await updateAutodepositTargetActive({
+      active: input.active,
+      policyAccount: input.policyAccount,
+      recurringDelegation: input.recurringDelegation,
+      settings: settingsPda,
+      vaultIndex: input.vaultIndex,
+      walletAddress,
+    });
+
+    return NextResponse.json({ target: serializeTarget(target) });
+  } catch (error) {
+    return jsonError(
+      400,
+      "toggle_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to update Autodeposit active state."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
@@ -1,0 +1,222 @@
+import { NextResponse } from "next/server";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import {
+  buildEarnWithdrawalConfirmRequestBody,
+  parseEarnWithdrawalConfirmRequestBody,
+} from "@/lib/yield-optimization/earn-confirm-contracts.shared";
+import {
+  EarnWithdrawConfirmError,
+  recordConfirmedEarnWithdrawal,
+} from "@/lib/yield-optimization/earn-withdraw-confirm.server";
+import {
+  hydratePreparedEarnUsdcWithdraw,
+  type WireSmartAccountPreparedEarnUsdcWithdraw,
+} from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+
+// Mobile twin of `yield-optimization/withdrawals/confirm`. The device echoes
+// back the serialized prepared withdraw it signed plus, for one step at a time,
+// that step's signature + slot (and the optional autodeposit-close signature).
+// This route rebuilds the canonical confirm payload server-side (the web client
+// does this in-browser) and defers to the shared `recordConfirmedEarnWithdrawal`
+// core so the security-critical canonicalization can't drift.
+type MobileWithdrawConfirmFields = {
+  preparedWithdraw: WireSmartAccountPreparedEarnUsdcWithdraw;
+  stepIndex?: number;
+  withdrawalSignature: string;
+  confirmedSlot: string;
+  autodepositCloseSignature?: string;
+  autodepositCloseConfirmedSlot?: string;
+};
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseMobileWithdrawConfirmFields(
+  body: unknown
+): MobileWithdrawConfirmFields {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("Request body must be an object.");
+  }
+  const record = body as Record<string, unknown>;
+  if (
+    typeof record.preparedWithdraw !== "object" ||
+    record.preparedWithdraw === null
+  ) {
+    throw new Error("preparedWithdraw is required.");
+  }
+  if (
+    typeof record.withdrawalSignature !== "string" ||
+    !record.withdrawalSignature
+  ) {
+    throw new Error("withdrawalSignature is required.");
+  }
+  if (typeof record.confirmedSlot !== "string" || !record.confirmedSlot) {
+    throw new Error("confirmedSlot is required.");
+  }
+  let stepIndex: number | undefined;
+  if (record.stepIndex !== undefined && record.stepIndex !== null) {
+    if (
+      typeof record.stepIndex !== "number" ||
+      !Number.isInteger(record.stepIndex) ||
+      record.stepIndex < 0
+    ) {
+      throw new Error("stepIndex must be a non-negative integer.");
+    }
+    stepIndex = record.stepIndex;
+  }
+  return {
+    preparedWithdraw:
+      record.preparedWithdraw as WireSmartAccountPreparedEarnUsdcWithdraw,
+    stepIndex,
+    withdrawalSignature: record.withdrawalSignature,
+    confirmedSlot: record.confirmedSlot,
+    autodepositCloseSignature: optionalString(record.autodepositCloseSignature),
+    autodepositCloseConfirmedSlot: optionalString(
+      record.autodepositCloseConfirmedSlot
+    ),
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-withdraw-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let fields: MobileWithdrawConfirmFields;
+  try {
+    fields = parseMobileWithdrawConfirmFields(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  // Resolve the account (must already exist — prepare required it).
+  let smartAccountAddress: string;
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    smartAccountAddress = existing.smartAccountAddress;
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  try {
+    const prepared = hydratePreparedEarnUsdcWithdraw(fields.preparedWithdraw);
+    let preparedStep:
+      | NonNullable<typeof prepared.withdrawSteps>[number]
+      | undefined;
+    if (fields.stepIndex !== undefined) {
+      const step = prepared.withdrawSteps?.[fields.stepIndex];
+      if (!step) {
+        return jsonError(
+          400,
+          "invalid_request",
+          "stepIndex is out of range for this prepared withdrawal."
+        );
+      }
+      preparedStep = step;
+    }
+
+    const confirmBody = buildEarnWithdrawalConfirmRequestBody({
+      preparedWithdraw: prepared,
+      preparedStep,
+      signature: fields.withdrawalSignature,
+      confirmedSlot: fields.confirmedSlot,
+      smartAccountAddress,
+      autodepositCloseSignature: fields.autodepositCloseSignature,
+      autodepositCloseConfirmedSlot: fields.autodepositCloseConfirmedSlot,
+    });
+    const input = parseEarnWithdrawalConfirmRequestBody(confirmBody);
+
+    const position = await recordConfirmedEarnWithdrawal({
+      principal: { walletAddress, smartAccountAddress, settingsPda },
+      input,
+      solanaEnv: getConfiguredSolanaEnv(),
+    });
+    return NextResponse.json({ position });
+  } catch (error) {
+    if (error instanceof EarnWithdrawConfirmError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    console.error("[mobile-earn-withdraw-confirm] build/record failed", {
+      withdrawalSignature: fields.withdrawalSignature,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown confirm error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      400,
+      "confirm_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to confirm Earn withdrawal."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -1,0 +1,625 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import {
+  parseEarnWithdrawPrepareRequestBody,
+  serializePreparedEarnUsdcWithdraw,
+} from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  findActiveYieldRoutePolicyPair,
+  findCurrentNonzeroYieldVaultReservePositions,
+  findCurrentYieldVaultIdleTokenBalances,
+  findReconciledActiveYieldPositionForVault,
+  type CurrentYieldVaultIdleTokenBalanceRecord,
+  type CurrentYieldVaultReservePositionRecord,
+  type RoutePolicyRecord,
+  type UserYieldPositionRecord,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Mobile twin of `yield-optimization/withdrawals/prepare`. Identical source
+// selection + prepare logic, but authenticated by a wallet signature (no
+// Turnstile/session) and it resolves the caller's smart account itself instead
+// of reading it from a session principal. Withdrawing requires an existing
+// account, so (unlike deposit) it never provisions. Keep the prepare body below
+// in sync with the session route.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+type EarnWithdrawSourceRequest = ReturnType<
+  typeof parseEarnWithdrawPrepareRequestBody
+>["source"];
+
+type SelectedEarnWithdrawSource =
+  | {
+      amountRaw: bigint;
+      id: string;
+      liquidityMint: string;
+      market: string;
+      reserve: string;
+      type: "reserve";
+    }
+  | {
+      amountRaw: bigint;
+      id: string;
+      mint: string;
+      tokenAccount: string;
+      type: "idle";
+    };
+
+function publicKeyFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  keys: string[]
+): PublicKey | null {
+  if (!metadata) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      continue;
+    }
+    try {
+      return new PublicKey(value);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function isNonEmptyString(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function sourceMatchesDirectIdentifier(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawSourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [
+    request.id,
+    request.reserve,
+    request.tokenAccount,
+  ].filter(isNonEmptyString);
+
+  if (identifiers.includes(source.id)) {
+    return true;
+  }
+
+  return source.type === "reserve"
+    ? identifiers.includes(source.reserve)
+    : identifiers.includes(source.tokenAccount);
+}
+
+function sourceMatchesStableMint(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawSourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [
+    request.id,
+    request.liquidityMint,
+    request.mint,
+  ].filter(isNonEmptyString);
+
+  return source.type === "reserve"
+    ? identifiers.includes(source.liquidityMint)
+    : identifiers.includes(source.mint);
+}
+
+function selectRequestedEarnWithdrawSource(
+  sources: SelectedEarnWithdrawSource[],
+  request: EarnWithdrawSourceRequest
+): SelectedEarnWithdrawSource | null {
+  if (!request) {
+    return sources.length === 1 ? sources[0] ?? null : null;
+  }
+
+  const directMatch = sources.find((source) =>
+    sourceMatchesDirectIdentifier(source, request)
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const stableMintMatches = sources.filter((source) =>
+    sourceMatchesStableMint(source, request)
+  );
+  if (stableMintMatches.length === 1) {
+    return stableMintMatches[0] ?? null;
+  }
+
+  const amountMatchedStableMintMatches = stableMintMatches.filter(
+    (source) => request.amountRaw === source.amountRaw.toString()
+  );
+
+  return amountMatchedStableMintMatches.length === 1
+    ? amountMatchedStableMintMatches[0] ?? null
+    : null;
+}
+
+function selectEarnWithdrawSource(args: {
+  amountRaw: bigint;
+  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
+  mode: "partial" | "full";
+  position: UserYieldPositionRecord;
+  request: EarnWithdrawSourceRequest;
+  reserveRows: CurrentYieldVaultReservePositionRecord[];
+}): SelectedEarnWithdrawSource {
+  const reserveSources = args.reserveRows
+    .filter((row) => row.amountRaw > BigInt(0))
+    .map((row) => {
+      if (!row.market) {
+        throw new Error("Reconciled Earn reserve row is missing a market.");
+      }
+      return {
+        amountRaw: row.amountRaw,
+        id: row.reserve,
+        liquidityMint: row.liquidityMint,
+        market: row.market,
+        reserve: row.reserve,
+        type: "reserve" as const,
+      };
+    });
+  const idleSources = args.idleRows
+    .filter((row) => row.amountRaw > BigInt(0))
+    .map((row) => ({
+      amountRaw: row.amountRaw,
+      id: row.tokenAccount,
+      mint: row.mint,
+      tokenAccount: row.tokenAccount,
+      type: "idle" as const,
+    }));
+  const positionFallbackSources =
+    reserveSources.length === 0 &&
+    idleSources.length === 0 &&
+    isNonEmptyString(args.position.currentMarket) &&
+    args.position.currentAmountRaw > BigInt(0)
+      ? [
+          {
+            amountRaw: args.position.currentAmountRaw,
+            id: args.position.currentReserve,
+            liquidityMint: args.position.currentLiquidityMint,
+            market: args.position.currentMarket,
+            reserve: args.position.currentReserve,
+            type: "reserve" as const,
+          },
+        ]
+      : [];
+  const sources = [
+    ...reserveSources,
+    ...idleSources,
+    ...positionFallbackSources,
+  ];
+
+  if (sources.length === 0) {
+    throw new Error("No active Earn withdrawal source was found.");
+  }
+
+  const selected = selectRequestedEarnWithdrawSource(sources, args.request);
+
+  if (!selected) {
+    throw new Error("Select an Earn source before withdrawing.");
+  }
+  if (args.mode === "partial" && args.amountRaw > selected.amountRaw) {
+    throw new Error("Withdrawal exceeds the selected Earn source amount.");
+  }
+
+  return selected;
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-withdraw-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let amountRaw: bigint;
+  let mode: "partial" | "full";
+  let selectedSourceRequest: EarnWithdrawSourceRequest;
+  try {
+    ({
+      amountRaw,
+      mode,
+      source: selectedSourceRequest,
+    } = parseEarnWithdrawPrepareRequestBody(body));
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  // Withdrawing requires an already-provisioned smart account (you can't
+  // withdraw from one that was never created). Resolve it; never provision.
+  let settingsPda: string;
+  let smartAccountAddress: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+    smartAccountAddress = existing.smartAccountAddress;
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-prepare] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+  let policy: RoutePolicyRecord | null = null;
+  let effectiveAmountRaw: bigint | null = null;
+
+  try {
+    const serverEnv = getServerEnv();
+    const programId = new PublicKey(serverEnv.loyalSmartAccounts.programId);
+    const settingsPdaKey = new PublicKey(settingsPda);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+      programId,
+      settingsPda: settingsPdaKey,
+    });
+    const [policyResult, position, currentReserveRows, currentIdleRows] =
+      await Promise.all([
+        findActiveYieldRoutePolicyPair({
+          authority: walletAddress,
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          vaultPubkey: earnVaultPda.toBase58(),
+        }),
+        findReconciledActiveYieldPositionForVault({
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        }),
+        findCurrentNonzeroYieldVaultReservePositions({
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          vaultPubkey: earnVaultPda.toBase58(),
+          walletAddress,
+        }),
+        findCurrentYieldVaultIdleTokenBalances({
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          vaultPubkey: earnVaultPda.toBase58(),
+          walletAddress,
+        }),
+      ]);
+    policy = policyResult?.routePolicy ?? null;
+    if (!policy) {
+      console.warn("[mobile-earn-withdraw-prepare] missing active Earn policy", {
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        walletAddress,
+      });
+      return jsonError(
+        409,
+        "missing_earn_policy",
+        "Set up the Earn policy before withdrawing USDC."
+      );
+    }
+
+    if (!position) {
+      console.warn(
+        "[mobile-earn-withdraw-prepare] missing active Earn position",
+        {
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        }
+      );
+      return jsonError(
+        409,
+        "missing_earn_position",
+        "No active Earn position was found for this withdrawal."
+      );
+    }
+
+    const selectedSource = selectEarnWithdrawSource({
+      amountRaw,
+      idleRows: currentIdleRows,
+      mode,
+      position,
+      request: selectedSourceRequest,
+      reserveRows: currentReserveRows,
+    });
+    effectiveAmountRaw = mode === "full" ? selectedSource.amountRaw : amountRaw;
+    const remainingSourceAmountRaw =
+      currentReserveRows.reduce(
+        (total, row) =>
+          total +
+          (selectedSource.type === "reserve" &&
+          row.reserve === selectedSource.reserve
+            ? row.amountRaw - effectiveAmountRaw!
+            : row.amountRaw),
+        BigInt(0)
+      ) +
+      currentIdleRows.reduce(
+        (total, row) =>
+          total +
+          (selectedSource.type === "idle" &&
+          row.tokenAccount === selectedSource.tokenAccount
+            ? row.amountRaw - effectiveAmountRaw!
+            : row.amountRaw),
+        BigInt(0)
+      );
+    const isFinalExit = remainingSourceAmountRaw <= BigInt(0);
+
+    const policySigner = getDeploymentPolicySignerPublicKey();
+    const client = createSmartAccountVaultsClient({
+      connection: getConnection(solanaEnv),
+      programId,
+    });
+    const yieldRoutingPolicy = {
+      account: new PublicKey(policy.policyAccount),
+      seed: policy.policySeed,
+      ...(policyResult?.setupPolicy
+        ? {
+            setupPolicy: {
+              account: new PublicKey(policyResult.setupPolicy.policyAccount),
+              seed: policyResult.setupPolicy.policySeed,
+            },
+          }
+        : {}),
+    };
+    const autodepositState =
+      mode === "full" && isFinalExit
+        ? await findCurrentEarnAutodepositState({
+            settings: settingsPda,
+            vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+            walletAddress,
+          })
+        : null;
+    const autodepositClose =
+      autodepositState?.policy.policyAccount &&
+      autodepositState.target.recurringDelegation
+        ? {
+            policy: new PublicKey(autodepositState.policy.policyAccount),
+            recurringDelegation: new PublicKey(
+              autodepositState.target.recurringDelegation
+            ),
+          }
+        : undefined;
+
+    if (
+      mode === "full" &&
+      isFinalExit &&
+      autodepositState &&
+      !autodepositClose
+    ) {
+      console.warn(
+        "[mobile-earn-withdraw-prepare] active autodeposit state is missing close metadata",
+        {
+          cluster,
+          policyAccount: autodepositState.policy.policyAccount,
+          recurringDelegation: autodepositState.target.recurringDelegation,
+          settings: settingsPda,
+          targetId: autodepositState.target.id.toString(),
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        }
+      );
+    }
+
+    const withdrawInput = {
+      amountRaw: effectiveAmountRaw,
+      cluster,
+      feePayer: new PublicKey(walletAddress),
+      policySigner,
+      settingsPda: settingsPdaKey,
+      target: earnReserveTargetFromActivePosition(position),
+      ...(mode === "full" && selectedSource.type === "reserve"
+        ? {
+            fullWithdrawalTargets: currentReserveRows
+              .filter((row) => row.reserve === selectedSource.reserve)
+              .map((row) => {
+                if (!row.market) {
+                  throw new Error(
+                    "Reconciled Earn reserve row is missing a Kamino market."
+                  );
+                }
+                const reserveCollateralMint = publicKeyFromMetadata(
+                  row.planningMetadata,
+                  [
+                    "reserveCollateralMint",
+                    "reserve_collateral_mint",
+                    "collateralMint",
+                    "collateral_mint",
+                  ]
+                );
+                const reserveLiquiditySupply = publicKeyFromMetadata(
+                  row.planningMetadata,
+                  [
+                    "reserveLiquiditySupply",
+                    "reserve_liquidity_supply",
+                    "liquiditySupply",
+                    "liquidity_supply",
+                  ]
+                );
+                const vaultCollateralAta = publicKeyFromMetadata(
+                  row.planningMetadata,
+                  [
+                    "vaultCollateralAta",
+                    "vault_collateral_ata",
+                    "collateralAta",
+                    "collateral_ata",
+                  ]
+                );
+
+                return {
+                  amountRaw: row.amountRaw,
+                  liquidityMint: new PublicKey(row.liquidityMint),
+                  market: new PublicKey(row.market),
+                  reserve: new PublicKey(row.reserve),
+                  ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
+                  ...(reserveLiquiditySupply ? { reserveLiquiditySupply } : {}),
+                  supplyApyBps: row.supplyApyBps ?? null,
+                  ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
+                };
+              }),
+          }
+        : {}),
+      closePoliciesOnFullWithdrawal: isFinalExit,
+      source:
+        selectedSource.type === "idle"
+          ? {
+              amountRaw: selectedSource.amountRaw,
+              id: selectedSource.id,
+              mint: new PublicKey(selectedSource.mint),
+              tokenAccount: new PublicKey(selectedSource.tokenAccount),
+              type: "idle" as const,
+            }
+          : {
+              amountRaw: selectedSource.amountRaw,
+              id: selectedSource.id,
+              liquidityMint: new PublicKey(selectedSource.liquidityMint),
+              market: new PublicKey(selectedSource.market),
+              reserve: new PublicKey(selectedSource.reserve),
+              type: "reserve" as const,
+            },
+      walletAddress: new PublicKey(walletAddress),
+      yieldRoutingPolicy,
+    };
+    const preparedWithdraw =
+      mode === "full"
+        ? await client.prepareEarnUsdcWithdraw({
+            ...withdrawInput,
+            ...(autodepositClose ? { autodepositClose } : {}),
+            mode,
+          })
+        : await client.prepareEarnUsdcWithdraw({
+            ...withdrawInput,
+            mode,
+          });
+
+    return NextResponse.json({
+      cluster,
+      programId: serverEnv.loyalSmartAccounts.programId,
+      settingsPda,
+      smartAccountAddress,
+      preparedWithdraw: serializePreparedEarnUsdcWithdraw(preparedWithdraw),
+    });
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-prepare] prepare failed", {
+      amountRaw: amountRaw.toString(),
+      effectiveAmountRaw: effectiveAmountRaw?.toString() ?? null,
+      cluster,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown prepare error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      mode,
+      policyAccount: policy?.policyAccount ?? null,
+      policySeed: policy?.policySeed.toString() ?? null,
+      settings: settingsPda,
+      solanaEnv,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "prepare_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to prepare Earn withdrawal."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
@@ -1,0 +1,196 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { PublicKey } from "@solana/web3.js";
+
+import { findCurrentUser } from "@/features/chat/server/app-user";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-signature";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import {
+  findCurrentNonzeroYieldVaultReservePositions,
+  findCurrentYieldVaultIdleTokenBalances,
+  findReconciledActiveYieldPositionForVault,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Read-only list of the wallet's Earn withdrawal sources (per-reserve positions
+// + idle vault USDC), keyed by wallet address (no signature, no provisioning).
+// Mirrors the source set the withdraw/prepare route builds, so the mobile
+// source picker offers exactly the sources a `withdraw/prepare` call will
+// accept. Each item carries both display fields (amount/label) and the
+// prepare-source identifiers (type/id/reserve/tokenAccount/mint).
+const EARN_VAULT_INDEX = 1 as const;
+
+type WithdrawSource = {
+  type: "reserve" | "idle";
+  id: string;
+  label: string;
+  amountRaw: string;
+  liquidityMint: string;
+  market: string | null;
+  reserve: string | null;
+  tokenAccount: string | null;
+};
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function shortenAddress(address: string): string {
+  return address.length <= 8
+    ? address
+    : `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+export async function GET(request: Request) {
+  const walletAddress =
+    new URL(request.url).searchParams.get("walletAddress")?.trim() ?? "";
+  if (!walletAddress) {
+    return jsonError(400, "invalid_request", "walletAddress is required.");
+  }
+  try {
+    decodeWalletAddress(walletAddress);
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(400, "invalid_request", "walletAddress is invalid.");
+  }
+
+  const emptyState = {
+    sources: [] as WithdrawSource[],
+    settingsPda: null,
+    smartAccountAddress: null,
+  };
+
+  try {
+    const user = await findCurrentUser({
+      authMethod: "wallet",
+      provider: "solana",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    if (!user) {
+      return NextResponse.json(emptyState);
+    }
+
+    const account = await findReadyCurrentUserSmartAccount({ userId: user.id });
+    if (!account) {
+      return NextResponse.json(emptyState);
+    }
+
+    const solanaEnv = getConfiguredSolanaEnv();
+    const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+    const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: EARN_VAULT_INDEX,
+      programId,
+      settingsPda: new PublicKey(account.settingsPda),
+    });
+
+    const [reserveRows, idleRows, position] = await Promise.all([
+      findCurrentNonzeroYieldVaultReservePositions({
+        cluster,
+        settings: account.settingsPda,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+        walletAddress,
+      }),
+      findCurrentYieldVaultIdleTokenBalances({
+        cluster,
+        settings: account.settingsPda,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+        walletAddress,
+      }),
+      findReconciledActiveYieldPositionForVault({
+        cluster,
+        settings: account.settingsPda,
+        vaultIndex: EARN_VAULT_INDEX,
+        walletAddress,
+      }),
+    ]);
+
+    const reserveRowsWithBalance = reserveRows.filter(
+      (row) => row.amountRaw > BigInt(0) && row.market
+    );
+    const multipleReserves = reserveRowsWithBalance.length > 1;
+    const reserveSources: WithdrawSource[] = reserveRowsWithBalance.map(
+      (row) => ({
+        type: "reserve",
+        id: row.reserve,
+        label: multipleReserves
+          ? `USDC reserve ${shortenAddress(row.reserve)}`
+          : "USDC reserve",
+        amountRaw: row.amountRaw.toString(),
+        liquidityMint: row.liquidityMint,
+        market: row.market,
+        reserve: row.reserve,
+        tokenAccount: null,
+      })
+    );
+    const idleSources: WithdrawSource[] = idleRows
+      .filter((row) => row.amountRaw > BigInt(0))
+      .map((row) => ({
+        type: "idle",
+        id: row.tokenAccount,
+        label: "Idle USDC",
+        amountRaw: row.amountRaw.toString(),
+        liquidityMint: row.mint,
+        market: null,
+        reserve: null,
+        tokenAccount: row.tokenAccount,
+      }));
+
+    let sources: WithdrawSource[] = [...reserveSources, ...idleSources];
+    if (
+      sources.length === 0 &&
+      position &&
+      position.currentAmountRaw > BigInt(0) &&
+      position.currentMarket
+    ) {
+      sources = [
+        {
+          type: "reserve",
+          id: position.currentReserve,
+          label: "USDC reserve",
+          amountRaw: position.currentAmountRaw.toString(),
+          liquidityMint: position.currentLiquidityMint,
+          market: position.currentMarket,
+          reserve: position.currentReserve,
+          tokenAccount: null,
+        },
+      ];
+    }
+
+    return NextResponse.json({
+      sources,
+      settingsPda: account.settingsPda,
+      smartAccountAddress: account.smartAccountAddress,
+    });
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-sources] read failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown read error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "withdraw_sources_failed",
+      "Failed to load Earn withdrawal sources."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
@@ -1,29 +1,19 @@
 import { NextResponse } from "next/server";
-import {
-  normalizeLoyalCluster,
-  resolveLoyalClusterForSolanaEnv,
-} from "@loyal-labs/actions";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
-import { Connection, PublicKey } from "@solana/web3.js";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
-import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
-import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { parseEarnWithdrawalConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
-import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
-import { assertSafeUsdcEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
-  recordConfirmedYieldWithdrawal,
-  type ConfirmedYieldWithdrawalInput,
-  type UserYieldPositionRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+  EarnWithdrawConfirmError,
+  recordConfirmedEarnWithdrawal,
+} from "@/lib/yield-optimization/earn-withdraw-confirm.server";
+import type { ConfirmedYieldWithdrawalInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
-const EARN_DEPOSIT_VAULT_INDEX = 1;
-
-const connectionCache = new Map<SolanaEnv, Connection>();
-
+// Session (web) Earn withdrawal confirm. Auth comes from the wallet session;
+// the validation + recording is the shared `recordConfirmedEarnWithdrawal`
+// core, which the mobile twin (`mobile/earn/withdraw/confirm`) also uses so the
+// security-critical canonicalization can't drift between the two.
 function jsonError(
   status: number,
   code: string,
@@ -34,227 +24,6 @@ function jsonError(
 
 function getConfiguredSolanaEnv(): SolanaEnv {
   return resolveLoyalWebSolanaEnvFromEnv(process.env);
-}
-
-function assertCanonicalField(
-  actual: string | bigint | number | null,
-  expected: string | bigint | number | null,
-  label: string
-) {
-  if (actual !== expected) {
-    throw new Error(
-      `${label} does not match the canonical earn withdrawal metadata.`
-    );
-  }
-}
-
-function toSafePolicySeed(policySeed: bigint): number {
-  if (policySeed <= BigInt(0) || policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error("policySeed is outside the supported earn policy range.");
-  }
-
-  return Number(policySeed);
-}
-
-function createCanonicalWithdrawalInput(
-  requestInput: ConfirmedYieldWithdrawalInput
-): ConfirmedYieldWithdrawalInput {
-  const cluster = normalizeLoyalCluster(requestInput.cluster);
-  const normalizedRequestInput = { ...requestInput, cluster };
-  const settings = new PublicKey(requestInput.settings);
-  const expectedSetupPolicySeed = requestInput.policySeed + BigInt(1);
-  const expectedPolicyAccount = pda.getPolicyPda({
-    settingsPda: settings,
-    policySeed: toSafePolicySeed(requestInput.policySeed),
-  })[0];
-  const expectedSetupPolicyAccount = pda.getPolicyPda({
-    settingsPda: settings,
-    policySeed: toSafePolicySeed(expectedSetupPolicySeed),
-  })[0];
-  const expectedVault = pda.getSmartAccountPda({
-    settingsPda: settings,
-    accountIndex: EARN_DEPOSIT_VAULT_INDEX,
-  })[0];
-  const hasSetupPolicyMetadata =
-    (requestInput.setupPolicyId !== undefined &&
-      requestInput.setupPolicyId !== null) ||
-    (requestInput.setupPolicyAccount !== undefined &&
-      requestInput.setupPolicyAccount !== null) ||
-    (requestInput.setupPolicySeed !== undefined &&
-      requestInput.setupPolicySeed !== null);
-  const target = assertSafeUsdcEarnReserveMetadata({
-    cluster,
-    liquidityMint: requestInput.liquidityMint,
-    market: requestInput.market,
-    targetReserve: requestInput.targetReserve,
-  });
-  const canonicalInput = {
-    ...normalizedRequestInput,
-    cluster,
-    liquidityMint: target.liquidityMint,
-    market: target.market,
-    policyAccount: expectedPolicyAccount.toBase58(),
-    policyId: requestInput.policySeed,
-    policySeed: requestInput.policySeed,
-    ...(hasSetupPolicyMetadata
-      ? {
-          setupPolicyAccount: expectedSetupPolicyAccount.toBase58(),
-          setupPolicyId: expectedSetupPolicySeed,
-          setupPolicySeed: expectedSetupPolicySeed,
-        }
-      : {}),
-    targetReserve: target.targetReserve,
-    vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-    vaultPubkey: expectedVault.toBase58(),
-  };
-
-  assertCanonicalField(
-    normalizedRequestInput.cluster,
-    canonicalInput.cluster,
-    "cluster"
-  );
-  assertCanonicalField(
-    requestInput.liquidityMint,
-    canonicalInput.liquidityMint,
-    "liquidityMint"
-  );
-  assertCanonicalField(requestInput.market, canonicalInput.market, "market");
-  assertCanonicalField(
-    requestInput.policyAccount,
-    canonicalInput.policyAccount,
-    "policyAccount"
-  );
-  assertCanonicalField(
-    requestInput.policyId,
-    requestInput.policySeed,
-    "policyId"
-  );
-  assertCanonicalField(
-    requestInput.policyId,
-    canonicalInput.policyId,
-    "policyId"
-  );
-  assertCanonicalField(
-    requestInput.policySeed,
-    canonicalInput.policySeed,
-    "policySeed"
-  );
-  if (hasSetupPolicyMetadata) {
-    assertCanonicalField(
-      requestInput.setupPolicyAccount ?? null,
-      canonicalInput.setupPolicyAccount ?? null,
-      "setupPolicyAccount"
-    );
-    assertCanonicalField(
-      requestInput.setupPolicyId ?? null,
-      canonicalInput.setupPolicyId ?? null,
-      "setupPolicyId"
-    );
-    assertCanonicalField(
-      requestInput.setupPolicySeed ?? null,
-      canonicalInput.setupPolicySeed ?? null,
-      "setupPolicySeed"
-    );
-  }
-  assertCanonicalField(
-    requestInput.targetReserve,
-    canonicalInput.targetReserve,
-    "targetReserve"
-  );
-  assertCanonicalField(
-    requestInput.vaultIndex,
-    canonicalInput.vaultIndex,
-    "vaultIndex"
-  );
-  assertCanonicalField(
-    requestInput.vaultPubkey,
-    canonicalInput.vaultPubkey,
-    "vaultPubkey"
-  );
-  if (requestInput.mode !== "full" && requestInput.autodepositClose) {
-    throw new Error(
-      "autodepositClose can only be confirmed with full withdrawals."
-    );
-  }
-
-  return canonicalInput;
-}
-
-function getConnection(cluster: SolanaEnv): Connection {
-  const cached = connectionCache.get(cluster);
-  if (cached) {
-    return cached;
-  }
-
-  const { rpcEndpoint, websocketEndpoint } =
-    getFrontendSolanaEndpoints(cluster);
-  const connection = new Connection(rpcEndpoint, {
-    commitment: "confirmed",
-    disableRetryOnRateLimit: true,
-    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
-    wsEndpoint: websocketEndpoint,
-  });
-  connectionCache.set(cluster, connection);
-  return connection;
-}
-
-async function resolveConfirmedSignatureSlot(args: {
-  cluster: SolanaEnv;
-  operation: "autodeposit close" | "withdrawal";
-  signature: string;
-}): Promise<bigint> {
-  const { value } = await getConnection(args.cluster).getSignatureStatuses(
-    [args.signature],
-    { searchTransactionHistory: true }
-  );
-  const status = value[0];
-
-  if (!status || status.err) {
-    throw new Error(`${args.operation} transaction is not confirmed.`);
-  }
-
-  if (
-    status.confirmationStatus !== "confirmed" &&
-    status.confirmationStatus !== "finalized"
-  ) {
-    throw new Error(`${args.operation} transaction is not confirmed.`);
-  }
-
-  if (typeof status.slot !== "number") {
-    throw new Error(
-      `Confirmed ${args.operation} transaction slot is unavailable.`
-    );
-  }
-
-  return BigInt(status.slot);
-}
-
-function serializePosition(position: UserYieldPositionRecord) {
-  return {
-    currentHolding: {
-      amountRaw: position.currentAmountRaw.toString(),
-      liquidityMint: position.currentLiquidityMint,
-      market: position.currentMarket,
-      observedAt: position.currentObservedAt.toISOString(),
-      observedSlot: position.currentObservedSlot.toString(),
-      provenance: {
-        lastHoldingEventId: position.lastHoldingEventId?.toString() ?? null,
-        lastRebalanceDecisionId:
-          position.lastRebalanceDecisionId?.toString() ?? null,
-      },
-      reserve: position.currentReserve,
-    },
-    id: position.id.toString(),
-    initialHolding: {
-      liquidityMint: position.initialLiquidityMint,
-      market: position.initialMarket,
-      reserve: position.initialReserve,
-      supplyApyBps: position.initialSupplyApyBps?.toString() ?? null,
-    },
-    currentTotalAmountRaw: position.currentAmountRaw.toString(),
-    principalAmountRaw: position.principalAmountRaw.toString(),
-    status: position.status,
-  };
 }
 
 export async function POST(request: Request) {
@@ -275,137 +44,27 @@ export async function POST(request: Request) {
     );
   }
 
-  if (
-    input.walletAddress !== principal.walletAddress ||
-    input.smartAccountAddress !== principal.smartAccountAddress ||
-    input.settings !== principal.settingsPda
-  ) {
-    return jsonError(
-      403,
-      "principal_mismatch",
-      "Confirmed yield withdrawal does not match the authenticated wallet session."
-    );
-  }
-
   try {
-    input = createCanonicalWithdrawalInput(input);
+    const position = await recordConfirmedEarnWithdrawal({
+      principal: {
+        walletAddress: principal.walletAddress,
+        smartAccountAddress: principal.smartAccountAddress,
+        settingsPda: principal.settingsPda,
+      },
+      input,
+      solanaEnv: getConfiguredSolanaEnv(),
+    });
+    return NextResponse.json({ position });
   } catch (error) {
+    if (error instanceof EarnWithdrawConfirmError) {
+      return jsonError(error.status, error.code, error.message);
+    }
     return jsonError(
-      400,
-      "metadata_mismatch",
+      500,
+      "record_failed",
       error instanceof Error
         ? error.message
-        : "Confirmed yield withdrawal metadata is invalid."
+        : "Confirmed yield withdrawal could not be recorded."
     );
   }
-
-  const solanaEnv = getConfiguredSolanaEnv();
-  const configuredCluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
-  if (input.cluster !== configuredCluster) {
-    return jsonError(
-      400,
-      "cluster_mismatch",
-      "Confirmed yield withdrawal cluster does not match the configured Solana environment."
-    );
-  }
-
-  let confirmedSlot: bigint;
-  try {
-    confirmedSlot = await resolveConfirmedSignatureSlot({
-      cluster: solanaEnv,
-      operation: "withdrawal",
-      signature: input.withdrawalSignature,
-    });
-  } catch (error) {
-    return jsonError(
-      400,
-      "unconfirmed_signature",
-      error instanceof Error
-        ? error.message
-        : "Withdrawal transaction is not confirmed."
-    );
-  }
-
-  if (input.confirmedSlot !== confirmedSlot) {
-    return jsonError(
-      400,
-      "slot_mismatch",
-      "Confirmed yield withdrawal slot does not match the transaction status."
-    );
-  }
-
-  if (input.mode === "full" && input.autodepositClose) {
-    let autodepositCloseConfirmedSlot: bigint;
-    try {
-      autodepositCloseConfirmedSlot = await resolveConfirmedSignatureSlot({
-        cluster: solanaEnv,
-        operation: "autodeposit close",
-        signature: input.autodepositClose.closeSignature,
-      });
-    } catch (error) {
-      return jsonError(
-        400,
-        "unconfirmed_autodeposit_close_signature",
-        error instanceof Error
-          ? error.message
-          : "Autodeposit close transaction is not confirmed."
-      );
-    }
-
-    if (
-      input.autodepositClose.confirmedSlot !== autodepositCloseConfirmedSlot
-    ) {
-      return jsonError(
-        400,
-        "autodeposit_close_slot_mismatch",
-        "Confirmed autodeposit close slot does not match the transaction status."
-      );
-    }
-
-    await recordClosedAutodepositTarget({
-      cluster: input.cluster,
-      closeSignature: input.autodepositClose.closeSignature,
-      confirmedSlot: input.autodepositClose.confirmedSlot,
-      delegatedSigner: input.autodepositClose.delegatedSigner,
-      policyAccount: input.autodepositClose.policyAccount,
-      recurringDelegation: input.autodepositClose.recurringDelegation,
-      settings: input.settings,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      vaultPubkey: input.vaultPubkey,
-      walletAddress: input.walletAddress,
-    });
-  }
-
-  let position: UserYieldPositionRecord;
-  try {
-    position = await recordConfirmedYieldWithdrawal(input);
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Confirmed yield withdrawal could not be recorded.";
-    if (
-      message.startsWith("Duplicate withdrawal ") ||
-      message.includes("Withdrawal target does not match") ||
-      message.includes("Withdrawal exceeds")
-    ) {
-      return jsonError(409, "withdrawal_conflict", message);
-    }
-
-    console.error("[earn-withdraw-confirm] record failed", {
-      cluster: input.cluster,
-      errorMessage: message,
-      errorName: error instanceof Error ? error.name : typeof error,
-      settings: input.settings,
-      signature: input.withdrawalSignature,
-      stack: error instanceof Error ? error.stack : undefined,
-      vaultIndex: input.vaultIndex,
-      walletAddress: input.walletAddress,
-    });
-    return jsonError(500, "record_failed", message);
-  }
-
-  return NextResponse.json({
-    position: serializePosition(position),
-  });
 }

--- a/frontend/src/features/identity/server/mobile-wallet-auth.ts
+++ b/frontend/src/features/identity/server/mobile-wallet-auth.ts
@@ -23,7 +23,15 @@ const MOBILE_AUTH_MAX_FUTURE_SKEW_MS = 60 * 1000;
 
 export type MobileWalletAuthPurpose =
   | "earn-deposit-prepare"
-  | "earn-deposit-confirm";
+  | "earn-deposit-confirm"
+  | "earn-withdraw-prepare"
+  | "earn-withdraw-confirm"
+  | "earn-autodeposit-setup-prepare"
+  | "earn-autodeposit-setup-confirm"
+  | "earn-autodeposit-floor-confirm"
+  | "earn-autodeposit-toggle-confirm"
+  | "earn-autodeposit-close-prepare"
+  | "earn-autodeposit-close-confirm";
 
 export type MobileWalletAuthFields = {
   walletAddress: string;

--- a/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
@@ -1,0 +1,413 @@
+import "server-only";
+
+import {
+  normalizeLoyalCluster,
+  resolveLoyalClusterForSolanaEnv,
+} from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getFrontendSolanaEndpoints } from "@/lib/solana/rpc-endpoints";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { assertSafeUsdcEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  recordConfirmedYieldWithdrawal,
+  type ConfirmedYieldWithdrawalInput,
+  type UserYieldPositionRecord,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Shared core for confirming an Earn withdrawal, used by BOTH the session
+// (`yield-optimization/withdrawals/confirm`) and mobile
+// (`mobile/earn/withdraw/confirm`) routes. The canonicalization here is
+// security-critical (it re-derives every PDA/reserve from the settings and
+// rejects any client-supplied metadata that doesn't match), so it must not
+// drift between the two entry points — hence the single shared module.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+export type EarnWithdrawConfirmPrincipal = {
+  walletAddress: string;
+  smartAccountAddress: string;
+  settingsPda: string;
+};
+
+export class EarnWithdrawConfirmError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "EarnWithdrawConfirmError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getFrontendSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+function assertCanonicalField(
+  actual: string | bigint | number | null,
+  expected: string | bigint | number | null,
+  label: string
+) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label} does not match the canonical earn withdrawal metadata.`
+    );
+  }
+}
+
+function toSafePolicySeed(policySeed: bigint): number {
+  if (policySeed <= BigInt(0) || policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("policySeed is outside the supported earn policy range.");
+  }
+
+  return Number(policySeed);
+}
+
+// Re-derives the canonical withdrawal metadata from the settings PDA and
+// asserts every client-supplied field matches. Throws on any mismatch.
+export function createCanonicalWithdrawalInput(
+  requestInput: ConfirmedYieldWithdrawalInput
+): ConfirmedYieldWithdrawalInput {
+  const cluster = normalizeLoyalCluster(requestInput.cluster);
+  const normalizedRequestInput = { ...requestInput, cluster };
+  const settings = new PublicKey(requestInput.settings);
+  const expectedSetupPolicySeed = requestInput.policySeed + BigInt(1);
+  const expectedPolicyAccount = pda.getPolicyPda({
+    settingsPda: settings,
+    policySeed: toSafePolicySeed(requestInput.policySeed),
+  })[0];
+  const expectedSetupPolicyAccount = pda.getPolicyPda({
+    settingsPda: settings,
+    policySeed: toSafePolicySeed(expectedSetupPolicySeed),
+  })[0];
+  const expectedVault = pda.getSmartAccountPda({
+    settingsPda: settings,
+    accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+  })[0];
+  const hasSetupPolicyMetadata =
+    (requestInput.setupPolicyId !== undefined &&
+      requestInput.setupPolicyId !== null) ||
+    (requestInput.setupPolicyAccount !== undefined &&
+      requestInput.setupPolicyAccount !== null) ||
+    (requestInput.setupPolicySeed !== undefined &&
+      requestInput.setupPolicySeed !== null);
+  const target = assertSafeUsdcEarnReserveMetadata({
+    cluster,
+    liquidityMint: requestInput.liquidityMint,
+    market: requestInput.market,
+    targetReserve: requestInput.targetReserve,
+  });
+  const canonicalInput = {
+    ...normalizedRequestInput,
+    cluster,
+    liquidityMint: target.liquidityMint,
+    market: target.market,
+    policyAccount: expectedPolicyAccount.toBase58(),
+    policyId: requestInput.policySeed,
+    policySeed: requestInput.policySeed,
+    ...(hasSetupPolicyMetadata
+      ? {
+          setupPolicyAccount: expectedSetupPolicyAccount.toBase58(),
+          setupPolicyId: expectedSetupPolicySeed,
+          setupPolicySeed: expectedSetupPolicySeed,
+        }
+      : {}),
+    targetReserve: target.targetReserve,
+    vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+    vaultPubkey: expectedVault.toBase58(),
+  };
+
+  assertCanonicalField(
+    normalizedRequestInput.cluster,
+    canonicalInput.cluster,
+    "cluster"
+  );
+  assertCanonicalField(
+    requestInput.liquidityMint,
+    canonicalInput.liquidityMint,
+    "liquidityMint"
+  );
+  assertCanonicalField(requestInput.market, canonicalInput.market, "market");
+  assertCanonicalField(
+    requestInput.policyAccount,
+    canonicalInput.policyAccount,
+    "policyAccount"
+  );
+  assertCanonicalField(
+    requestInput.policyId,
+    requestInput.policySeed,
+    "policyId"
+  );
+  assertCanonicalField(
+    requestInput.policyId,
+    canonicalInput.policyId,
+    "policyId"
+  );
+  assertCanonicalField(
+    requestInput.policySeed,
+    canonicalInput.policySeed,
+    "policySeed"
+  );
+  if (hasSetupPolicyMetadata) {
+    assertCanonicalField(
+      requestInput.setupPolicyAccount ?? null,
+      canonicalInput.setupPolicyAccount ?? null,
+      "setupPolicyAccount"
+    );
+    assertCanonicalField(
+      requestInput.setupPolicyId ?? null,
+      canonicalInput.setupPolicyId ?? null,
+      "setupPolicyId"
+    );
+    assertCanonicalField(
+      requestInput.setupPolicySeed ?? null,
+      canonicalInput.setupPolicySeed ?? null,
+      "setupPolicySeed"
+    );
+  }
+  assertCanonicalField(
+    requestInput.targetReserve,
+    canonicalInput.targetReserve,
+    "targetReserve"
+  );
+  assertCanonicalField(
+    requestInput.vaultIndex,
+    canonicalInput.vaultIndex,
+    "vaultIndex"
+  );
+  assertCanonicalField(
+    requestInput.vaultPubkey,
+    canonicalInput.vaultPubkey,
+    "vaultPubkey"
+  );
+  if (requestInput.mode !== "full" && requestInput.autodepositClose) {
+    throw new Error(
+      "autodepositClose can only be confirmed with full withdrawals."
+    );
+  }
+
+  return canonicalInput;
+}
+
+async function resolveConfirmedSignatureSlot(args: {
+  cluster: SolanaEnv;
+  operation: "autodeposit close" | "withdrawal";
+  signature: string;
+}): Promise<bigint> {
+  const { value } = await getConnection(args.cluster).getSignatureStatuses(
+    [args.signature],
+    { searchTransactionHistory: true }
+  );
+  const status = value[0];
+
+  if (!status || status.err) {
+    throw new Error(`${args.operation} transaction is not confirmed.`);
+  }
+
+  if (
+    status.confirmationStatus !== "confirmed" &&
+    status.confirmationStatus !== "finalized"
+  ) {
+    throw new Error(`${args.operation} transaction is not confirmed.`);
+  }
+
+  if (typeof status.slot !== "number") {
+    throw new Error(
+      `Confirmed ${args.operation} transaction slot is unavailable.`
+    );
+  }
+
+  return BigInt(status.slot);
+}
+
+export function serializeWithdrawPosition(position: UserYieldPositionRecord) {
+  return {
+    currentHolding: {
+      amountRaw: position.currentAmountRaw.toString(),
+      liquidityMint: position.currentLiquidityMint,
+      market: position.currentMarket,
+      observedAt: position.currentObservedAt.toISOString(),
+      observedSlot: position.currentObservedSlot.toString(),
+      provenance: {
+        lastHoldingEventId: position.lastHoldingEventId?.toString() ?? null,
+        lastRebalanceDecisionId:
+          position.lastRebalanceDecisionId?.toString() ?? null,
+      },
+      reserve: position.currentReserve,
+    },
+    id: position.id.toString(),
+    initialHolding: {
+      liquidityMint: position.initialLiquidityMint,
+      market: position.initialMarket,
+      reserve: position.initialReserve,
+      supplyApyBps: position.initialSupplyApyBps?.toString() ?? null,
+    },
+    currentTotalAmountRaw: position.currentAmountRaw.toString(),
+    principalAmountRaw: position.principalAmountRaw.toString(),
+    status: position.status,
+  };
+}
+
+// Validates + records a confirmed Earn withdrawal against the authenticated
+// principal. Throws `EarnWithdrawConfirmError` (with an HTTP status) on any
+// validation failure; returns the serialized post-withdrawal position.
+export async function recordConfirmedEarnWithdrawal(args: {
+  principal: EarnWithdrawConfirmPrincipal;
+  input: ConfirmedYieldWithdrawalInput;
+  solanaEnv: SolanaEnv;
+}): Promise<ReturnType<typeof serializeWithdrawPosition>> {
+  const { principal, solanaEnv } = args;
+
+  if (
+    args.input.walletAddress !== principal.walletAddress ||
+    args.input.smartAccountAddress !== principal.smartAccountAddress ||
+    args.input.settings !== principal.settingsPda
+  ) {
+    throw new EarnWithdrawConfirmError(
+      403,
+      "principal_mismatch",
+      "Confirmed yield withdrawal does not match the authenticated wallet."
+    );
+  }
+
+  let input: ConfirmedYieldWithdrawalInput;
+  try {
+    input = createCanonicalWithdrawalInput(args.input);
+  } catch (error) {
+    throw new EarnWithdrawConfirmError(
+      400,
+      "metadata_mismatch",
+      error instanceof Error
+        ? error.message
+        : "Confirmed yield withdrawal metadata is invalid."
+    );
+  }
+
+  const configuredCluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+  if (input.cluster !== configuredCluster) {
+    throw new EarnWithdrawConfirmError(
+      400,
+      "cluster_mismatch",
+      "Confirmed yield withdrawal cluster does not match the configured Solana environment."
+    );
+  }
+
+  let confirmedSlot: bigint;
+  try {
+    confirmedSlot = await resolveConfirmedSignatureSlot({
+      cluster: solanaEnv,
+      operation: "withdrawal",
+      signature: input.withdrawalSignature,
+    });
+  } catch (error) {
+    throw new EarnWithdrawConfirmError(
+      400,
+      "unconfirmed_signature",
+      error instanceof Error
+        ? error.message
+        : "Withdrawal transaction is not confirmed."
+    );
+  }
+
+  if (input.confirmedSlot !== confirmedSlot) {
+    throw new EarnWithdrawConfirmError(
+      400,
+      "slot_mismatch",
+      "Confirmed yield withdrawal slot does not match the transaction status."
+    );
+  }
+
+  if (input.mode === "full" && input.autodepositClose) {
+    let autodepositCloseConfirmedSlot: bigint;
+    try {
+      autodepositCloseConfirmedSlot = await resolveConfirmedSignatureSlot({
+        cluster: solanaEnv,
+        operation: "autodeposit close",
+        signature: input.autodepositClose.closeSignature,
+      });
+    } catch (error) {
+      throw new EarnWithdrawConfirmError(
+        400,
+        "unconfirmed_autodeposit_close_signature",
+        error instanceof Error
+          ? error.message
+          : "Autodeposit close transaction is not confirmed."
+      );
+    }
+
+    if (
+      input.autodepositClose.confirmedSlot !== autodepositCloseConfirmedSlot
+    ) {
+      throw new EarnWithdrawConfirmError(
+        400,
+        "autodeposit_close_slot_mismatch",
+        "Confirmed autodeposit close slot does not match the transaction status."
+      );
+    }
+
+    await recordClosedAutodepositTarget({
+      cluster: input.cluster,
+      closeSignature: input.autodepositClose.closeSignature,
+      confirmedSlot: input.autodepositClose.confirmedSlot,
+      delegatedSigner: input.autodepositClose.delegatedSigner,
+      policyAccount: input.autodepositClose.policyAccount,
+      recurringDelegation: input.autodepositClose.recurringDelegation,
+      settings: input.settings,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: input.vaultPubkey,
+      walletAddress: input.walletAddress,
+    });
+  }
+
+  let position: UserYieldPositionRecord;
+  try {
+    position = await recordConfirmedYieldWithdrawal(input);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Confirmed yield withdrawal could not be recorded.";
+    if (
+      message.startsWith("Duplicate withdrawal ") ||
+      message.includes("Withdrawal target does not match") ||
+      message.includes("Withdrawal exceeds")
+    ) {
+      throw new EarnWithdrawConfirmError(409, "withdrawal_conflict", message);
+    }
+
+    console.error("[earn-withdraw-confirm] record failed", {
+      cluster: input.cluster,
+      errorMessage: message,
+      errorName: error instanceof Error ? error.name : typeof error,
+      settings: input.settings,
+      signature: input.withdrawalSignature,
+      stack: error instanceof Error ? error.stack : undefined,
+      vaultIndex: input.vaultIndex,
+      walletAddress: input.walletAddress,
+    });
+    throw new EarnWithdrawConfirmError(500, "record_failed", message);
+  }
+
+  return serializeWithdrawPosition(position);
+}


### PR DESCRIPTION
Adds mobile wallet-signed (no-Turnstile) twin endpoints for Earn withdraw (prepare/confirm, plus a shared confirm core the web withdraw route now delegates to) and autodeposit (state, setup, floor, toggle, close), plus a withdraw-sources read endpoint for the mobile source picker. New routes are additive and mobile-only; the only web-runtime change is the session withdraw-confirm route refactored to use the shared core — behavior-preserving, with the existing withdraw-confirm tests green.