### PR TITLE
fix(earn): use earn vault as smartAccountAddress in mobile confirm twins

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -138,8 +138,18 @@ export async function POST(request: Request) {
         "No provisioned smart account for this wallet."
       );
     }
-    smartAccountAddress = existing.smartAccountAddress;
     settingsPda = existing.settingsPda;
+    // Earn confirm keys on the vault (smart-account index 1), not the wallet's
+    // main account (index 0) that findReadyCurrentUserSmartAccount returns. The
+    // web client derives the vault from the prepared op; mirror that here so the
+    // canonical `smartAccountAddress` check passes and the vault-keyed position
+    // is matched. (Same derivation the deposit-confirm canonical uses.)
+    smartAccountAddress = pda
+      .getSmartAccountPda({
+        settingsPda: new PublicKey(settingsPda),
+        accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+      })[0]
+      .toBase58();
   } catch (error) {
     console.error("[mobile-earn-deposit-confirm] resolve failed", {
       errorMessage:

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { PublicKey } from "@solana/web3.js";
 
 import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
@@ -44,6 +46,23 @@ function jsonError(
 
 function getConfiguredSolanaEnv(): SolanaEnv {
   return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+// The Earn deposit/withdraw smart-account vault lives at index 1; index 0 is the
+// wallet's main account. The confirm canonical keys on this vault.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+// Re-derive the Earn vault address (index 1) from the settings PDA — the value
+// the confirm canonical expects as `smartAccountAddress`. findReadyCurrentUser-
+// SmartAccount returns the main account (index 0), which would fail the canonical
+// check and miss the vault-keyed position.
+function deriveEarnVaultAddress(settingsPda: string): string {
+  return pda
+    .getSmartAccountPda({
+      settingsPda: new PublicKey(settingsPda),
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+    })[0]
+    .toBase58();
 }
 
 function optionalString(value: unknown): string | undefined {
@@ -148,8 +167,9 @@ export async function POST(request: Request) {
         "No provisioned smart account for this wallet."
       );
     }
-    smartAccountAddress = existing.smartAccountAddress;
     settingsPda = existing.settingsPda;
+    // Earn confirm keys on the vault (index 1), not the main account (index 0).
+    smartAccountAddress = deriveEarnVaultAddress(settingsPda);
   } catch (error) {
     console.error("[mobile-earn-withdraw-confirm] resolve failed", {
       errorMessage:


### PR DESCRIPTION
Mobile Earn deposit/withdraw confirm routes now send the earn vault (smart-account index 1) as `smartAccountAddress` instead of the wallet's main account (index 0), so they satisfy the hardened confirm canonical and the vault-keyed read-model updates — fixing mobile Earn showing stale balances after a deposit/withdraw while web (which reads live on-chain) showed the correct value. Backend-only; mirrors the web client's behavior, no session-route or mobile-client changes.