### PR TITLE
fix(mirror): register loyal-actions package in sync packageDirs

### DIFF
--- a/scripts/mirror-repos/package-rewrites.ts
+++ b/scripts/mirror-repos/package-rewrites.ts
@@ -8,6 +8,7 @@ const packageDirs = [
   "packages/flags",
   "packages/llm-core",
   "packages/llm-server",
+  "packages/loyal-actions",
   "packages/shared",
   "packages/smart-account-vaults",
   "packages/solana-instruction-decoder",


### PR DESCRIPTION
The Mirrors Sync workflow failed with `Cannot rewrite @loyal-labs/actions@workspace:*; package version is unknown` because `packages/loyal-actions` was missing from the `packageDirs` version map in `scripts/mirror-repos/package-rewrites.ts`, even though `frontend` and `smart-account-vaults` depend on it via `workspace:*`. This adds it so the dependency range rewrite resolves; verified with `bun run scripts/mirror-repos/sync.ts --dry-run` (all 8 mirrors generate, `@loyal-labs/actions` pins to `^0.1.1`).