### PR TITLE
fix(wallet): drain web unshield max exactly

### DIFF
--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -451,6 +451,7 @@ export function ShieldContent({
     initialDirection
   );
   const [amount, setAmount] = useState("");
+  const [isMaxSelected, setIsMaxSelected] = useState(false);
   const [phase, setPhase] = useState<ShieldPhase>("form");
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [resultAmount, setResultAmount] = useState("");
@@ -502,6 +503,7 @@ export function ShieldContent({
   const handlePercentage = useCallback(
     (pct: number) => {
       const bal = sourceBalance;
+      const isMax = pct === 100;
       let val = pct === 100 ? bal : bal * (pct / 100);
       // Reserve a small SOL buffer for gas only when shielding (public → vault).
       // Unshield drains the vault and pays fees from the public wallet, so
@@ -513,10 +515,15 @@ export function ShieldContent({
       ) {
         val = Math.max(0, bal - 0.00005);
       }
+      setIsMaxSelected(isMax && val > 0);
       setAmount(val > 0 ? formatAmountInputValue(val, token.symbol) : "");
     },
     [direction, sourceBalance, token.symbol]
   );
+
+  useEffect(() => {
+    setIsMaxSelected(false);
+  }, [direction, token.mint]);
 
   const handleConfirm = useCallback(async () => {
     if (!hasAmount || insufficientFunds) return;
@@ -549,7 +556,10 @@ export function ShieldContent({
               direction,
             },
           })
-        : await unshieldFn(params);
+        : await unshieldFn({
+            ...params,
+            isMax: isMaxSelected,
+          });
 
     if (result.success) {
       setPhase("success");
@@ -575,6 +585,7 @@ export function ShieldContent({
     shieldFn,
     unshieldFn,
     usdValue,
+    isMaxSelected,
   ]);
 
   // Report form button props to parent when chrome is managed externally
@@ -1308,7 +1319,10 @@ export function ShieldContent({
                   inputMode="decimal"
                   onChange={(e) => {
                     const v = e.target.value;
-                    if (v === "" || /^\d*\.?\d*$/.test(v)) setAmount(v);
+                    if (v === "" || /^\d*\.?\d*$/.test(v)) {
+                      setIsMaxSelected(false);
+                      setAmount(v);
+                    }
                   }}
                   placeholder="0"
                   style={{

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -6,6 +6,7 @@ import {
 } from "@loyal-labs/private-transactions";
 import type { AnalyticsProperties } from "@loyal-labs/shared/analytics";
 import { TOKEN_DECIMALS, TOKEN_MINTS } from "@loyal-labs/wallet-core/constants";
+import { computeUnshieldModifyAmount } from "@loyal-labs/wallet-core/lib";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
@@ -211,6 +212,7 @@ export function useShield() {
     async (params: {
       tokenSymbol: string;
       amount: number;
+      isMax?: boolean;
       tokenMint?: string;
     }): Promise<ShieldResult> => {
       if (!(wallet.connected && wallet.publicKey && wallet.signTransaction)) {
@@ -234,40 +236,34 @@ export function useShield() {
         const decimals = TOKEN_DECIMALS[params.tokenSymbol.toUpperCase()] ?? 6;
         const rawAmount = Math.floor(params.amount * 10 ** decimals);
         const user = wallet.publicKey;
-        // For tracked Kamino positions, the vault stores collateral shares and
-        // the SDK plan amount for unshield is denominated in shares. The user
-        // supplies a liquidity amount (USDC), so convert via the Kamino reserve
-        // exchange rate and clamp to the current shares balance.
+        // For tracked Kamino positions, the vault stores collateral shares.
+        // Partial unshields quote user-entered liquidity into shares; Max burns
+        // the live deposit shares directly so it can fully drain the account.
         const trackedKaminoMint = resolveTrackedKaminoUsdcMint(
           publicEnv.solanaEnv
         );
         const isTrackedKaminoToken = trackedKaminoMint === tokenMint.toBase58();
+        const wantsMax = params.isMax === true;
 
         const collateralSharesBefore = isTrackedKaminoToken
           ? await getDepositAmount({ client, tokenMint, user })
           : BigInt(0);
 
-        let planAmount: bigint = BigInt(rawAmount);
-        if (isTrackedKaminoToken) {
-          const quotedShares =
-            await client.getKaminoCollateralSharesForLiquidityAmount({
-              tokenMint,
-              liquidityAmountRaw: BigInt(rawAmount),
-            });
-          if (quotedShares === null) {
-            throw new Error(
-              "Could not quote the current USDC shielded exchange rate. Please retry."
-            );
-          }
-          planAmount = quotedShares;
-
-          if (
-            collateralSharesBefore > BigInt(0) &&
-            planAmount > collateralSharesBefore
-          ) {
-            planAmount = collateralSharesBefore;
-          }
-        }
+        const requestedRawAmount = BigInt(rawAmount);
+        const quotedShares =
+          isTrackedKaminoToken && !wantsMax
+            ? await client.getKaminoCollateralSharesForLiquidityAmount({
+                tokenMint,
+                liquidityAmountRaw: requestedRawAmount,
+              })
+            : null;
+        const planAmount = computeUnshieldModifyAmount({
+          currentDepositRaw: collateralSharesBefore,
+          isMax: wantsMax,
+          isTrackedKaminoToken,
+          kaminoQuotedShares: quotedShares,
+          requestedRawAmount,
+        });
 
         const plan = await client.buildUnshieldTokensTransactionPlan({
           tokenMint,

--- a/packages/wallet-core/src/hooks/use-shield.ts
+++ b/packages/wallet-core/src/hooks/use-shield.ts
@@ -16,6 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useCallback, useRef, useState } from "react";
 
 import { TOKEN_DECIMALS, TOKEN_MINTS } from "../constants/token-mints";
+import { computeUnshieldModifyAmount } from "../lib/shielding";
 import type { WalletSigner } from "../types/signer";
 
 export type ShieldResult = {
@@ -60,44 +61,6 @@ async function getDepositAmount(params: {
   ]);
 
   return ephemeralDeposit?.amount ?? baseDeposit?.amount ?? BigInt(0);
-}
-
-function computeUnshieldModifyAmount(params: {
-  currentDepositRaw: bigint;
-  isMax: boolean;
-  isTrackedKaminoToken: boolean;
-  kaminoQuotedShares: bigint | null;
-  requestedRawAmount: bigint;
-}): bigint {
-  if (params.isMax) {
-    if (params.currentDepositRaw > BigInt(0)) {
-      return params.currentDepositRaw;
-    }
-    if (params.isTrackedKaminoToken) {
-      throw new Error(
-        "Could not read the current USDC shielded balance. Please retry."
-      );
-    }
-    return params.requestedRawAmount;
-  }
-
-  if (params.isTrackedKaminoToken) {
-    if (params.kaminoQuotedShares === null) {
-      throw new Error(
-        "Could not quote the current USDC shielded exchange rate. Please retry."
-      );
-    }
-
-    if (
-      params.currentDepositRaw > BigInt(0) &&
-      params.kaminoQuotedShares > params.currentDepositRaw
-    ) {
-      return params.currentDepositRaw;
-    }
-    return params.kaminoQuotedShares;
-  }
-
-  return params.requestedRawAmount;
 }
 
 export function useShield(

--- a/packages/wallet-core/src/lib/__tests__/shielding.test.ts
+++ b/packages/wallet-core/src/lib/__tests__/shielding.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+
+import { computeUnshieldModifyAmount } from "../shielding";
+
+describe("computeUnshieldModifyAmount", () => {
+  it("drains tracked Kamino USDC Max from the current deposit shares", () => {
+    const result = computeUnshieldModifyAmount({
+      currentDepositRaw: BigInt(4_000_000),
+      isMax: true,
+      isTrackedKaminoToken: true,
+      kaminoQuotedShares: BigInt(3_921_569),
+      requestedRawAmount: BigInt(4_000_000),
+    });
+
+    expect(result).toBe(BigInt(4_000_000));
+  });
+
+  it("uses quoted Kamino shares for partial unshields", () => {
+    const result = computeUnshieldModifyAmount({
+      currentDepositRaw: BigInt(4_000_000),
+      isMax: false,
+      isTrackedKaminoToken: true,
+      kaminoQuotedShares: BigInt(1_960_784),
+      requestedRawAmount: BigInt(2_000_000),
+    });
+
+    expect(result).toBe(BigInt(1_960_784));
+  });
+
+  it("fails closed for partial tracked Kamino USDC when quote is unavailable", () => {
+    expect(() =>
+      computeUnshieldModifyAmount({
+        currentDepositRaw: BigInt(4_000_000),
+        isMax: false,
+        isTrackedKaminoToken: true,
+        kaminoQuotedShares: null,
+        requestedRawAmount: BigInt(2_000_000),
+      })
+    ).toThrow("Could not quote the current USDC shielded exchange rate");
+  });
+
+  it("keeps non-Kamino partial unshield amounts raw and unchanged", () => {
+    const result = computeUnshieldModifyAmount({
+      currentDepositRaw: BigInt(0),
+      isMax: false,
+      isTrackedKaminoToken: false,
+      kaminoQuotedShares: null,
+      requestedRawAmount: BigInt(10_000_000),
+    });
+
+    expect(result).toBe(BigInt(10_000_000));
+  });
+
+  it("keeps web non-Kamino Max fallback on the requested raw amount when no deposit is provided", () => {
+    const result = computeUnshieldModifyAmount({
+      currentDepositRaw: BigInt(0),
+      isMax: true,
+      isTrackedKaminoToken: false,
+      kaminoQuotedShares: null,
+      requestedRawAmount: BigInt(10_000_000),
+    });
+
+    expect(result).toBe(BigInt(10_000_000));
+  });
+});

--- a/packages/wallet-core/src/lib/index.ts
+++ b/packages/wallet-core/src/lib/index.ts
@@ -1,5 +1,9 @@
 export * from "./jupiter/client";
 export * from "./jupiter/types";
+export {
+  computeUnshieldModifyAmount,
+  type ComputeUnshieldModifyAmountParams,
+} from "./shielding";
 export { getTokenIconUrl } from "./token-icon";
 export * from "./solana/sign-in";
 export * from "./solana/constants";

--- a/packages/wallet-core/src/lib/shielding.ts
+++ b/packages/wallet-core/src/lib/shielding.ts
@@ -1,0 +1,48 @@
+export type ComputeUnshieldModifyAmountParams = {
+  isMax: boolean;
+  requestedRawAmount: bigint;
+  currentDepositRaw: bigint;
+  isTrackedKaminoToken: boolean;
+  kaminoQuotedShares: bigint | null;
+};
+
+/**
+ * Decide how many raw units to burn from a shielded deposit.
+ *
+ * For tracked Kamino USDC, deposit amounts are collateral shares while user
+ * input/display is liquidity. Max intent should burn the live deposit amount
+ * directly; partial intent should use a fresh Kamino liquidity-to-share quote.
+ */
+export function computeUnshieldModifyAmount(
+  params: ComputeUnshieldModifyAmountParams
+): bigint {
+  if (params.isMax) {
+    if (params.currentDepositRaw > BigInt(0)) {
+      return params.currentDepositRaw;
+    }
+    if (params.isTrackedKaminoToken) {
+      throw new Error(
+        "Could not read the current USDC shielded balance. Please retry."
+      );
+    }
+    return params.requestedRawAmount;
+  }
+
+  if (params.isTrackedKaminoToken) {
+    if (params.kaminoQuotedShares === null) {
+      throw new Error(
+        "Could not quote the current USDC shielded exchange rate. Please retry."
+      );
+    }
+
+    if (
+      params.currentDepositRaw > BigInt(0) &&
+      params.kaminoQuotedShares > params.currentDepositRaw
+    ) {
+      return params.currentDepositRaw;
+    }
+    return params.kaminoQuotedShares;
+  }
+
+  return params.requestedRawAmount;
+}


### PR DESCRIPTION
Preserves Max intent in the web shield form and routes tracked Kamino USDC Max unshields through the live deposit share amount so the position drains exactly. Also centralizes the unshield amount helper in wallet-core with focused regression coverage.

Manual test steps:
1. Open the Loyal web frontend and connect a wallet that has a shielded tracked Kamino USDC balance.
2. Open the wallet Shield flow, switch to Unshield for the secured USDC row, click Max, confirm the transaction, and verify the secured USDC balance drains to zero with no dust/residual balance.
3. Repeat Unshield for secured USDC with a partial amount and verify it still succeeds via the quote path and leaves the expected remaining secured balance.
4. Try a non-Kamino secured token/SOL Unshield flow and verify the amount behavior is unchanged.