### PR TITLE
fix(wallet): keep shield max amount valid

### DIFF
--- a/frontend/src/components/wallet-sidebar/shield-amount.ts
+++ b/frontend/src/components/wallet-sidebar/shield-amount.ts
@@ -1,0 +1,31 @@
+import { TOKEN_DECIMALS } from "@loyal-labs/wallet-core/constants";
+import { toRoundedTokenRawAmount } from "@loyal-labs/wallet-core/lib";
+
+export function formatShieldAmountInputValue(
+  value: number,
+  tokenSymbol: string
+): string {
+  const decimals = TOKEN_DECIMALS[tokenSymbol.toUpperCase()] ?? 6;
+  const fractionDigits = Math.min(Math.max(decimals, 0), 9);
+
+  return String(Number(value.toFixed(fractionDigits)));
+}
+
+export function toRoundedTokenRawUnits(
+  value: number,
+  tokenSymbol: string
+): bigint {
+  const decimals = TOKEN_DECIMALS[tokenSymbol.toUpperCase()] ?? 6;
+  return toRoundedTokenRawAmount(value, decimals);
+}
+
+export function isShieldAmountOverBalance(params: {
+  amount: number;
+  sourceBalance: number;
+  tokenSymbol: string;
+}): boolean {
+  return (
+    toRoundedTokenRawUnits(params.amount, params.tokenSymbol) >
+    toRoundedTokenRawUnits(params.sourceBalance, params.tokenSymbol)
+  );
+}

--- a/frontend/src/components/wallet-sidebar/shield-content.test.ts
+++ b/frontend/src/components/wallet-sidebar/shield-content.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatShieldAmountInputValue,
+  isShieldAmountOverBalance,
+} from "./shield-amount";
+
+describe("ShieldContent amount helpers", () => {
+  test("does not mark its own USDC Max value as insufficient from float drift", () => {
+    const sourceBalance = 0.6372369999999999;
+    const maxInput = formatShieldAmountInputValue(sourceBalance, "USDC");
+
+    expect(maxInput).toBe("0.637237");
+    expect(
+      isShieldAmountOverBalance({
+        amount: Number.parseFloat(maxInput),
+        sourceBalance,
+        tokenSymbol: "USDC",
+      })
+    ).toBe(false);
+  });
+
+  test("still marks amounts above the token raw balance as insufficient", () => {
+    expect(
+      isShieldAmountOverBalance({
+        amount: 0.637238,
+        sourceBalance: 0.6372369999999999,
+        tokenSymbol: "USDC",
+      })
+    ).toBe(true);
+  });
+});

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -1,24 +1,20 @@
 "use client";
 
-import { TOKEN_DECIMALS } from "@loyal-labs/wallet-core/constants";
 import { ArrowLeft, ChevronRight, X } from "lucide-react";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useShield } from "@/hooks/use-shield";
 
+import {
+  formatShieldAmountInputValue,
+  isShieldAmountOverBalance,
+} from "./shield-amount";
 import type { FormButtonProps, SubView, SwapMode, SwapToken } from "./types";
 
 const font = "var(--font-geist-sans), sans-serif";
 const secondary = "rgba(60, 60, 67, 0.6)";
 const red = "#F9363C";
-
-function formatAmountInputValue(value: number, tokenSymbol: string): string {
-  const decimals = TOKEN_DECIMALS[tokenSymbol.toUpperCase()] ?? 6;
-  const fractionDigits = Math.min(Math.max(decimals, 0), 9);
-
-  return String(Number(value.toFixed(fractionDigits)));
-}
 
 function SwapShieldTabs({
   mode,
@@ -451,6 +447,7 @@ export function ShieldContent({
     initialDirection
   );
   const [amount, setAmount] = useState("");
+  const [isMaxSelected, setIsMaxSelected] = useState(false);
   const [phase, setPhase] = useState<ShieldPhase>("form");
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [resultAmount, setResultAmount] = useState("");
@@ -469,7 +466,15 @@ export function ShieldContent({
   const hasAmount = numericAmount > 0;
 
   const sourceBalance = direction === "shield" ? token.balance : securedBalance;
-  const insufficientFunds = numericAmount > sourceBalance;
+  const insufficientFunds = useMemo(
+    () =>
+      isShieldAmountOverBalance({
+        amount: numericAmount,
+        sourceBalance,
+        tokenSymbol: token.symbol,
+      }),
+    [numericAmount, sourceBalance, token.symbol]
+  );
 
   const usdValue = useMemo(
     () =>
@@ -502,6 +507,7 @@ export function ShieldContent({
   const handlePercentage = useCallback(
     (pct: number) => {
       const bal = sourceBalance;
+      const isMax = pct === 100;
       let val = pct === 100 ? bal : bal * (pct / 100);
       // Reserve a small SOL buffer for gas only when shielding (public → vault).
       // Unshield drains the vault and pays fees from the public wallet, so
@@ -513,10 +519,15 @@ export function ShieldContent({
       ) {
         val = Math.max(0, bal - 0.00005);
       }
-      setAmount(val > 0 ? formatAmountInputValue(val, token.symbol) : "");
+      setIsMaxSelected(isMax && val > 0);
+      setAmount(val > 0 ? formatShieldAmountInputValue(val, token.symbol) : "");
     },
     [direction, sourceBalance, token.symbol]
   );
+
+  useEffect(() => {
+    setIsMaxSelected(false);
+  }, [direction, token.mint]);
 
   const handleConfirm = useCallback(async () => {
     if (!hasAmount || insufficientFunds) return;
@@ -549,7 +560,10 @@ export function ShieldContent({
               direction,
             },
           })
-        : await unshieldFn(params);
+        : await unshieldFn({
+            ...params,
+            isMax: isMaxSelected,
+          });
 
     if (result.success) {
       setPhase("success");
@@ -575,6 +589,7 @@ export function ShieldContent({
     shieldFn,
     unshieldFn,
     usdValue,
+    isMaxSelected,
   ]);
 
   // Report form button props to parent when chrome is managed externally
@@ -1308,7 +1323,10 @@ export function ShieldContent({
                   inputMode="decimal"
                   onChange={(e) => {
                     const v = e.target.value;
-                    if (v === "" || /^\d*\.?\d*$/.test(v)) setAmount(v);
+                    if (v === "" || /^\d*\.?\d*$/.test(v)) {
+                      setIsMaxSelected(false);
+                      setAmount(v);
+                    }
                   }}
                   placeholder="0"
                   style={{

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -6,6 +6,10 @@ import {
 } from "@loyal-labs/private-transactions";
 import type { AnalyticsProperties } from "@loyal-labs/shared/analytics";
 import { TOKEN_DECIMALS, TOKEN_MINTS } from "@loyal-labs/wallet-core/constants";
+import {
+  computeUnshieldModifyAmount,
+  toRoundedTokenRawAmount,
+} from "@loyal-labs/wallet-core/lib";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
@@ -121,7 +125,7 @@ export function useShield() {
         }
         const tokenMint = new PublicKey(resolvedMint);
         const decimals = TOKEN_DECIMALS[params.tokenSymbol.toUpperCase()] ?? 6;
-        const rawAmount = Math.floor(params.amount * 10 ** decimals);
+        const rawAmount = toRoundedTokenRawAmount(params.amount, decimals);
         const user = wallet.publicKey;
         const trackedKaminoMint = resolveTrackedKaminoUsdcMint(
           publicEnv.solanaEnv
@@ -133,7 +137,7 @@ export function useShield() {
 
         const plan = await client.buildShieldTokensTransactionPlan({
           tokenMint,
-          amount: BigInt(rawAmount),
+          amount: rawAmount,
           user,
           payer: user,
         });
@@ -159,7 +163,7 @@ export function useShield() {
               recordKaminoUsdcShield({
                 publicKey: user.toBase58(),
                 solanaEnv: publicEnv.solanaEnv,
-                addedPrincipalLiquidityAmountRaw: BigInt(rawAmount),
+                addedPrincipalLiquidityAmountRaw: rawAmount,
                 addedCollateralSharesAmountRaw,
               });
             } catch (persistError) {
@@ -211,6 +215,7 @@ export function useShield() {
     async (params: {
       tokenSymbol: string;
       amount: number;
+      isMax?: boolean;
       tokenMint?: string;
     }): Promise<ShieldResult> => {
       if (!(wallet.connected && wallet.publicKey && wallet.signTransaction)) {
@@ -232,42 +237,36 @@ export function useShield() {
         }
         const tokenMint = new PublicKey(resolvedMint);
         const decimals = TOKEN_DECIMALS[params.tokenSymbol.toUpperCase()] ?? 6;
-        const rawAmount = Math.floor(params.amount * 10 ** decimals);
+        const rawAmount = toRoundedTokenRawAmount(params.amount, decimals);
         const user = wallet.publicKey;
-        // For tracked Kamino positions, the vault stores collateral shares and
-        // the SDK plan amount for unshield is denominated in shares. The user
-        // supplies a liquidity amount (USDC), so convert via the Kamino reserve
-        // exchange rate and clamp to the current shares balance.
+        // For tracked Kamino positions, the vault stores collateral shares.
+        // Partial unshields quote user-entered liquidity into shares; Max burns
+        // the live deposit shares directly so it can fully drain the account.
         const trackedKaminoMint = resolveTrackedKaminoUsdcMint(
           publicEnv.solanaEnv
         );
         const isTrackedKaminoToken = trackedKaminoMint === tokenMint.toBase58();
+        const wantsMax = params.isMax === true;
 
         const collateralSharesBefore = isTrackedKaminoToken
           ? await getDepositAmount({ client, tokenMint, user })
           : BigInt(0);
 
-        let planAmount: bigint = BigInt(rawAmount);
-        if (isTrackedKaminoToken) {
-          const quotedShares =
-            await client.getKaminoCollateralSharesForLiquidityAmount({
-              tokenMint,
-              liquidityAmountRaw: BigInt(rawAmount),
-            });
-          if (quotedShares === null) {
-            throw new Error(
-              "Could not quote the current USDC shielded exchange rate. Please retry."
-            );
-          }
-          planAmount = quotedShares;
-
-          if (
-            collateralSharesBefore > BigInt(0) &&
-            planAmount > collateralSharesBefore
-          ) {
-            planAmount = collateralSharesBefore;
-          }
-        }
+        const requestedRawAmount = rawAmount;
+        const quotedShares =
+          isTrackedKaminoToken && !wantsMax
+            ? await client.getKaminoCollateralSharesForLiquidityAmount({
+                tokenMint,
+                liquidityAmountRaw: requestedRawAmount,
+              })
+            : null;
+        const planAmount = computeUnshieldModifyAmount({
+          currentDepositRaw: collateralSharesBefore,
+          isMax: wantsMax,
+          isTrackedKaminoToken,
+          kaminoQuotedShares: quotedShares,
+          requestedRawAmount,
+        });
 
         const plan = await client.buildUnshieldTokensTransactionPlan({
           tokenMint,

--- a/packages/wallet-core/src/hooks/use-shield.ts
+++ b/packages/wallet-core/src/hooks/use-shield.ts
@@ -16,6 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useCallback, useRef, useState } from "react";
 
 import { TOKEN_DECIMALS, TOKEN_MINTS } from "../constants/token-mints";
+import { toRoundedTokenRawAmount } from "../lib/shielding";
 import type { WalletSigner } from "../types/signer";
 
 export type ShieldResult = {
@@ -174,12 +175,12 @@ export function useShield(
         }
         const tokenMint = new PublicKey(resolvedMint);
         const decimals = TOKEN_DECIMALS[params.tokenSymbol.toUpperCase()] ?? 6;
-        const rawAmount = Math.floor(params.amount * 10 ** decimals);
+        const rawAmount = toRoundedTokenRawAmount(params.amount, decimals);
         const user = signer.publicKey;
 
         const plan = await client.buildShieldTokensTransactionPlan({
           tokenMint,
-          amount: BigInt(rawAmount),
+          amount: rawAmount,
           user,
           payer: user,
           magicProgram: MAGIC_PROGRAM_ID,
@@ -235,7 +236,7 @@ export function useShield(
         }
         const tokenMint = new PublicKey(resolvedMint);
         const decimals = TOKEN_DECIMALS[params.tokenSymbol.toUpperCase()] ?? 6;
-        const rawAmount = Math.floor(params.amount * 10 ** decimals);
+        const rawAmount = toRoundedTokenRawAmount(params.amount, decimals);
         const user = signer.publicKey;
         const isTrackedKaminoToken = isKaminoUsdcMint(tokenMint, solanaEnv);
         const wantsMax = params.isMax === true;
@@ -243,7 +244,7 @@ export function useShield(
           wantsMax || isTrackedKaminoToken
             ? await getDepositAmount({ client, tokenMint, user })
             : BigInt(0);
-        const requestedRawAmount = BigInt(rawAmount);
+        const requestedRawAmount = rawAmount;
         const kaminoQuotedShares =
           isTrackedKaminoToken && !wantsMax
             ? await client.getKaminoCollateralSharesForLiquidityAmount({

--- a/packages/wallet-core/src/lib/__tests__/shielding.test.ts
+++ b/packages/wallet-core/src/lib/__tests__/shielding.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeUnshieldModifyAmount,
+  toRoundedTokenRawAmount,
+} from "../shielding";
+
+describe("toRoundedTokenRawAmount", () => {
+  test("keeps decimal drift from reducing Max by one raw unit", () => {
+    expect(toRoundedTokenRawAmount(1.005, 6)).toBe(1_005_000n);
+  });
+});
+
+describe("computeUnshieldModifyAmount", () => {
+  test("burns the live tracked Kamino deposit amount for Max", () => {
+    expect(
+      computeUnshieldModifyAmount({
+        currentDepositRaw: 1_234_567n,
+        isMax: true,
+        isTrackedKaminoToken: true,
+        kaminoQuotedShares: null,
+        requestedRawAmount: 1_200_000n,
+      })
+    ).toBe(1_234_567n);
+  });
+
+  test("uses quoted shares for partial tracked Kamino unshield", () => {
+    expect(
+      computeUnshieldModifyAmount({
+        currentDepositRaw: 1_234_567n,
+        isMax: false,
+        isTrackedKaminoToken: true,
+        kaminoQuotedShares: 617_000n,
+        requestedRawAmount: 600_000n,
+      })
+    ).toBe(617_000n);
+  });
+
+  test("clamps partial tracked Kamino unshield to the live deposit", () => {
+    expect(
+      computeUnshieldModifyAmount({
+        currentDepositRaw: 1_234_567n,
+        isMax: false,
+        isTrackedKaminoToken: true,
+        kaminoQuotedShares: 1_234_568n,
+        requestedRawAmount: 1_200_000n,
+      })
+    ).toBe(1_234_567n);
+  });
+});

--- a/packages/wallet-core/src/lib/index.ts
+++ b/packages/wallet-core/src/lib/index.ts
@@ -4,3 +4,4 @@ export { getTokenIconUrl } from "./token-icon";
 export * from "./solana/sign-in";
 export * from "./solana/constants";
 export * from "./solana/types";
+export * from "./shielding";

--- a/packages/wallet-core/src/lib/shielding.ts
+++ b/packages/wallet-core/src/lib/shielding.ts
@@ -1,0 +1,54 @@
+export type ComputeUnshieldModifyAmountParams = {
+  currentDepositRaw: bigint;
+  isMax: boolean;
+  isTrackedKaminoToken: boolean;
+  kaminoQuotedShares: bigint | null;
+  requestedRawAmount: bigint;
+};
+
+export function toRoundedTokenRawAmount(
+  value: number,
+  decimals: number
+): bigint {
+  if (!Number.isFinite(value) || value <= 0) {
+    return BigInt(0);
+  }
+
+  const multiplier = 10 ** Math.min(Math.max(decimals, 0), 9);
+
+  return BigInt(Math.round(value * multiplier));
+}
+
+export function computeUnshieldModifyAmount(
+  params: ComputeUnshieldModifyAmountParams
+): bigint {
+  if (params.isMax) {
+    if (params.currentDepositRaw > 0n) {
+      return params.currentDepositRaw;
+    }
+    if (params.isTrackedKaminoToken) {
+      throw new Error(
+        "Could not read the current USDC shielded balance. Please retry."
+      );
+    }
+    return params.requestedRawAmount;
+  }
+
+  if (params.isTrackedKaminoToken) {
+    if (params.kaminoQuotedShares === null) {
+      throw new Error(
+        "Could not quote the current USDC shielded exchange rate. Please retry."
+      );
+    }
+
+    if (
+      params.currentDepositRaw > 0n &&
+      params.kaminoQuotedShares > params.currentDepositRaw
+    ) {
+      return params.currentDepositRaw;
+    }
+    return params.kaminoQuotedShares;
+  }
+
+  return params.requestedRawAmount;
+}


### PR DESCRIPTION
Keeps Shield/Unshield Max from putting the form into an insufficient-funds state due to decimal drift, while preserving selected-token Max behavior. Unshield Max now carries explicit Max intent through to the shield plan so tracked USDC burns the live deposit amount instead of re-quoting the displayed liquidity.