### PR TITLE
fix(extension): prevent swap quote loading from hanging

### DIFF
--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -920,10 +920,14 @@ export function SwapContent({
   }, [toAmount, toToken.price]);
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
+  const quoteUnavailable =
+    hasAmount && !isQuoting && !quote && Boolean(swapError);
 
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
+    let isCurrentQuote = true;
+
     if (!hasAmount || insufficientFunds || phase !== "form") {
       resetQuote();
       setIsQuoting(false);
@@ -939,9 +943,14 @@ export function SwapContent({
         undefined,
         undefined,
         toToken.mint
-      ).finally(() => setIsQuoting(false));
+      ).finally(() => {
+        if (isCurrentQuote) {
+          setIsQuoting(false);
+        }
+      });
     }, 500);
     return () => {
+      isCurrentQuote = false;
       if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     };
   }, [
@@ -966,6 +975,8 @@ export function SwapContent({
     ? "Insufficient Funds"
     : isQuoting
     ? "Getting quote..."
+    : quoteUnavailable
+    ? "Quote unavailable. Try again"
     : !quote
     ? "Enter Amount"
     : "Confirm and Swap";
@@ -1072,7 +1083,10 @@ export function SwapContent({
     (pct: number) => {
       let val =
         pct === 100 ? fromToken.balance : fromToken.balance * (pct / 100);
-      if (fromToken.symbol.toUpperCase() === "SOL" && fromToken.balance - val < 0.00005) {
+      if (
+        fromToken.symbol.toUpperCase() === "SOL" &&
+        fromToken.balance - val < 0.00005
+      ) {
         val = Math.max(0, fromToken.balance - 0.00005);
       }
       setFromAmount(val > 0 ? String(Number(val.toFixed(6))) : "");

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -877,7 +877,10 @@ export function SwapContent({
   const { signer, connection } = useWalletContext();
 
   // Jupiter public API does not require a key for basic operations.
-  const swapConfig: SwapConfig = { mode: "enabled", apiKey: "" };
+  const swapConfig = useMemo<SwapConfig>(
+    () => ({ mode: "enabled", apiKey: "" }),
+    []
+  );
 
   const {
     getQuote,

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -896,6 +896,7 @@ export function SwapContent({
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [isQuoting, setIsQuoting] = useState(false);
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const quoteUiRequestIdRef = useRef(0);
 
   useEffect(() => {
     onFormActiveChange?.(phase === "form");
@@ -923,10 +924,42 @@ export function SwapContent({
   const quoteUnavailable =
     hasAmount && !isQuoting && !quote && Boolean(swapError);
 
+  const requestQuote = useCallback(() => {
+    if (!hasAmount || insufficientFunds || phase !== "form") return;
+
+    const quoteUiRequestId = quoteUiRequestIdRef.current + 1;
+    quoteUiRequestIdRef.current = quoteUiRequestId;
+    setIsQuoting(true);
+
+    void getQuote(
+      fromToken.symbol,
+      toToken.symbol,
+      String(numericFrom),
+      fromToken.mint,
+      undefined,
+      undefined,
+      toToken.mint
+    ).finally(() => {
+      if (quoteUiRequestIdRef.current === quoteUiRequestId) {
+        setIsQuoting(false);
+      }
+    });
+  }, [
+    fromToken.symbol,
+    fromToken.mint,
+    getQuote,
+    hasAmount,
+    insufficientFunds,
+    numericFrom,
+    phase,
+    toToken.symbol,
+    toToken.mint,
+  ]);
+
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
-    let isCurrentQuote = true;
+    quoteUiRequestIdRef.current += 1;
 
     if (!hasAmount || insufficientFunds || phase !== "form") {
       resetQuote();
@@ -935,37 +968,13 @@ export function SwapContent({
     }
     setIsQuoting(true);
     quoteTimerRef.current = setTimeout(() => {
-      void getQuote(
-        fromToken.symbol,
-        toToken.symbol,
-        String(numericFrom),
-        fromToken.mint,
-        undefined,
-        undefined,
-        toToken.mint
-      ).finally(() => {
-        if (isCurrentQuote) {
-          setIsQuoting(false);
-        }
-      });
+      requestQuote();
     }, 500);
     return () => {
-      isCurrentQuote = false;
+      quoteUiRequestIdRef.current += 1;
       if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     };
-  }, [
-    fromAmount,
-    fromToken.symbol,
-    fromToken.mint,
-    toToken.symbol,
-    toToken.mint,
-    hasAmount,
-    insufficientFunds,
-    phase,
-    getQuote,
-    resetQuote,
-    numericFrom,
-  ]);
+  }, [hasAmount, insufficientFunds, phase, requestQuote, resetQuote]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"
@@ -981,7 +990,11 @@ export function SwapContent({
     ? "Enter Amount"
     : "Confirm and Swap";
   const buttonDisabled =
-    !isAvailable || !hasAmount || insufficientFunds || isQuoting || !quote;
+    !isAvailable ||
+    !hasAmount ||
+    insufficientFunds ||
+    isQuoting ||
+    (!quote && !quoteUnavailable);
   const amountColor = insufficientFunds && hasAmount ? red : "#000";
 
   const handleSwapTokens = useCallback(() => {
@@ -1049,6 +1062,15 @@ export function SwapContent({
     resetQuote,
   ]);
 
+  const handleFormButtonClick = useCallback(() => {
+    if (quoteUnavailable) {
+      requestQuote();
+      return;
+    }
+
+    void handleConfirm();
+  }, [handleConfirm, quoteUnavailable, requestQuote]);
+
   // Report form button props to parent when chrome is managed externally
   useEffect(() => {
     if (!hideFormChrome || !onFormButtonChange) return;
@@ -1059,7 +1081,7 @@ export function SwapContent({
     onFormButtonChange({
       label: buttonLabel,
       disabled: buttonDisabled,
-      onClick: handleConfirm,
+      onClick: handleFormButtonClick,
     });
   });
 
@@ -1591,7 +1613,7 @@ export function SwapContent({
             <button
               className="confirm-btn"
               disabled={buttonDisabled}
-              onClick={handleConfirm}
+              onClick={handleFormButtonClick}
               style={{
                 width: "100%",
                 padding: "12px 16px",

--- a/packages/wallet-core/src/hooks/use-swap.ts
+++ b/packages/wallet-core/src/hooks/use-swap.ts
@@ -133,6 +133,10 @@ export function useSwap(
   connection: Connection,
   swapConfig: SwapConfig
 ) {
+  const swapMode = swapConfig.mode;
+  const swapApiKey = swapConfig.mode === "enabled" ? swapConfig.apiKey : "";
+  const swapUnavailableReason =
+    swapConfig.mode === "disabled" ? swapConfig.reason : null;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [quote, setQuote] = useState<SwapQuote | null>(null);
@@ -181,8 +185,8 @@ export function useSwap(
         setQuoteResponse(null);
         setError(null);
 
-        if (swapConfig.mode === "disabled") {
-          throw new Error(swapConfig.reason);
+        if (swapMode === "disabled") {
+          throw new Error(swapUnavailableReason ?? "Swap unavailable");
         }
 
         const inputMint = fromTokenMint || getTokenMint(fromToken);
@@ -230,7 +234,7 @@ export function useSwap(
             logger.debug("Fetching quote from Jupiter API:", url);
 
             const response = await fetch(url, {
-              headers: buildJupiterHeaders(swapConfig.apiKey),
+              headers: buildJupiterHeaders(swapApiKey),
               signal,
             });
 
@@ -290,13 +294,14 @@ export function useSwap(
         return null;
       }
     },
-    [getTokenDecimals, swapConfig]
+    [getTokenDecimals, swapApiKey, swapMode, swapUnavailableReason]
   );
 
   const executeSwap = useCallback(async (): Promise<SwapResult> => {
-    if (swapConfig.mode === "disabled") {
-      setError(swapConfig.reason);
-      return { success: false, error: swapConfig.reason };
+    if (swapMode === "disabled") {
+      const errorMessage = swapUnavailableReason ?? "Swap unavailable";
+      setError(errorMessage);
+      return { success: false, error: errorMessage };
     }
 
     if (!signer) {
@@ -319,10 +324,9 @@ export function useSwap(
 
       const swapResponse = await fetch(JUPITER_SWAP_API_URL, {
         method: "POST",
-        headers: buildJupiterHeaders(
-          (swapConfig as { apiKey: string }).apiKey,
-          { "Content-Type": "application/json" }
-        ),
+        headers: buildJupiterHeaders(swapApiKey, {
+          "Content-Type": "application/json",
+        }),
         body: JSON.stringify({
           userPublicKey: signer.publicKey.toBase58(),
           quoteResponse,
@@ -405,7 +409,14 @@ export function useSwap(
       setLoading(false);
       return { success: false, error: errorMessage };
     }
-  }, [connection, signer, quoteResponse, swapConfig]);
+  }, [
+    connection,
+    signer,
+    quoteResponse,
+    swapApiKey,
+    swapMode,
+    swapUnavailableReason,
+  ]);
 
   const resetQuote = useCallback(() => {
     quoteRequestIdRef.current += 1;
@@ -421,8 +432,7 @@ export function useSwap(
     quote,
     loading,
     error,
-    isAvailable: swapConfig.mode === "enabled",
-    unavailableReason:
-      swapConfig.mode === "disabled" ? swapConfig.reason : null,
+    isAvailable: swapMode === "enabled",
+    unavailableReason: swapUnavailableReason,
   };
 }

--- a/packages/wallet-core/src/hooks/use-swap.ts
+++ b/packages/wallet-core/src/hooks/use-swap.ts
@@ -1,8 +1,8 @@
 import type { Connection, ParsedAccountData } from "@solana/web3.js";
 import { PublicKey, VersionedTransaction } from "@solana/web3.js";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
-import { TOKEN_MINTS } from "../constants/token-mints";
+import { TOKEN_DECIMALS, TOKEN_MINTS } from "../constants/token-mints";
 import type { WalletSigner } from "../types/signer";
 
 // Debug logger that only emits in development
@@ -40,6 +40,9 @@ export type SwapConfig =
 
 const JUPITER_QUOTE_API_URL = "https://lite-api.jup.ag/swap/v1/quote";
 const JUPITER_SWAP_API_URL = "https://lite-api.jup.ag/swap/v1/swap";
+const JUPITER_QUOTE_TIMEOUT_MS = 10_000;
+const JUPITER_QUOTE_TIMEOUT_ERROR =
+  "Quote request timed out. Please try again.";
 
 const buildJupiterHeaders = (
   apiKey: string,
@@ -86,6 +89,33 @@ const getTokenMint = (symbol: string): string | undefined => {
   return TOKEN_MINTS[symbol.toUpperCase()];
 };
 
+const getKnownTokenDecimals = (symbol: string): number | undefined => {
+  return TOKEN_DECIMALS[symbol.toUpperCase()];
+};
+
+function withTimeout<T>(
+  operation: (signal: AbortSignal | undefined) => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T> {
+  const controller =
+    typeof AbortController === "undefined" ? undefined : new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return new Promise<T>((resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      controller?.abort();
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+
+    operation(controller?.signal).then(resolve, reject);
+  }).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
 async function sendTransactionViaSigner(
   signer: WalletSigner,
   connection: Connection,
@@ -108,6 +138,7 @@ export function useSwap(
   const [quote, setQuote] = useState<SwapQuote | null>(null);
   const [quoteResponse, setQuoteResponse] =
     useState<JupiterQuoteResponse | null>(null);
+  const quoteRequestIdRef = useRef(0);
 
   const getTokenDecimals = useCallback(
     async (mintAddress: string): Promise<number> => {
@@ -140,7 +171,14 @@ export function useSwap(
       toTokenDecimals?: number,
       toTokenMint?: string
     ): Promise<SwapQuote | null> => {
+      const quoteRequestId = quoteRequestIdRef.current + 1;
+      quoteRequestIdRef.current = quoteRequestId;
+      const isCurrentQuoteRequest = () =>
+        quoteRequestIdRef.current === quoteRequestId;
+
       try {
+        setQuote(null);
+        setQuoteResponse(null);
         setError(null);
 
         if (swapConfig.mode === "disabled") {
@@ -159,71 +197,95 @@ export function useSwap(
           throw new Error(`Unknown token: ${toToken}`);
         }
 
-        const inputDecimalsPromise = fromTokenDecimals
-          ? Promise.resolve(fromTokenDecimals)
-          : getTokenDecimals(inputMint);
-        const outputDecimalsPromise = toTokenDecimals
-          ? Promise.resolve(toTokenDecimals)
-          : getTokenDecimals(outputMint);
-        const inputDecimals = await inputDecimalsPromise;
-        const amountInSmallestUnit = Math.floor(
-          Number.parseFloat(amount) * 10 ** inputDecimals
-        ).toString();
+        const { data, quoteData } = await withTimeout(
+          async (signal) => {
+            const knownInputDecimals =
+              fromTokenDecimals ?? getKnownTokenDecimals(fromToken);
+            const knownOutputDecimals =
+              toTokenDecimals ?? getKnownTokenDecimals(toToken);
+            const inputDecimalsPromise =
+              typeof knownInputDecimals === "number"
+                ? Promise.resolve(knownInputDecimals)
+                : getTokenDecimals(inputMint);
+            const outputDecimalsPromise =
+              typeof knownOutputDecimals === "number"
+                ? Promise.resolve(knownOutputDecimals)
+                : getTokenDecimals(outputMint);
+            const inputDecimals = await inputDecimalsPromise;
+            const amountInSmallestUnit = Math.floor(
+              Number.parseFloat(amount) * 10 ** inputDecimals
+            ).toString();
 
-        logger.debug("Token conversion:", {
-          fromToken,
-          inputMint,
-          toToken,
-          outputMint,
-          amount,
-          amountInSmallestUnit,
-          decimals: inputDecimals,
-        });
+            logger.debug("Token conversion:", {
+              fromToken,
+              inputMint,
+              toToken,
+              outputMint,
+              amount,
+              amountInSmallestUnit,
+              decimals: inputDecimals,
+            });
 
-        const url = `${JUPITER_QUOTE_API_URL}?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amountInSmallestUnit}&slippageBps=50`;
-        logger.debug("Fetching quote from Jupiter API:", url);
+            const url = `${JUPITER_QUOTE_API_URL}?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amountInSmallestUnit}&slippageBps=50`;
+            logger.debug("Fetching quote from Jupiter API:", url);
 
-        const response = await fetch(url, {
-          headers: buildJupiterHeaders(swapConfig.apiKey),
-        });
+            const response = await fetch(url, {
+              headers: buildJupiterHeaders(swapConfig.apiKey),
+              signal,
+            });
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          logger.debug("Quote API error:", errorText);
-          throw new Error(`Failed to get quote: ${response.statusText}`);
-        }
+            if (!response.ok) {
+              const errorText = await response.text();
+              logger.debug("Quote API error:", errorText);
+              throw new Error(`Failed to get quote: ${response.statusText}`);
+            }
 
-        const data: JupiterQuoteResponse = await response.json();
-        logger.debug("Jupiter Quote response:", data);
+            const data: JupiterQuoteResponse = await response.json();
+            logger.debug("Jupiter Quote response:", data);
 
-        setQuoteResponse(data);
+            const outputDecimals = await outputDecimalsPromise;
+            const outputAmount = (
+              Number.parseInt(data.outAmount, 10) /
+              10 ** outputDecimals
+            ).toFixed(outputDecimals);
 
-        const outputDecimals = await outputDecimalsPromise;
-        const outputAmount = (
-          Number.parseInt(data.outAmount, 10) /
-          10 ** outputDecimals
-        ).toFixed(outputDecimals);
+            const priceImpact = `${(
+              Number.parseFloat(data.priceImpactPct) * PERCENTAGE_MULTIPLIER
+            ).toFixed(2)}%`;
 
-        const priceImpact = `${(
-          Number.parseFloat(data.priceImpactPct) * PERCENTAGE_MULTIPLIER
-        ).toFixed(2)}%`;
+            const quoteData: SwapQuote = {
+              inputAmount: amount,
+              outputAmount,
+              inputToken: fromToken,
+              outputToken: toToken,
+              priceImpact,
+              fee: undefined,
+            };
 
-        const quoteData: SwapQuote = {
-          inputAmount: amount,
-          outputAmount,
-          inputToken: fromToken,
-          outputToken: toToken,
-          priceImpact,
-          fee: undefined,
-        };
+            return { data, quoteData };
+          },
+          JUPITER_QUOTE_TIMEOUT_MS,
+          JUPITER_QUOTE_TIMEOUT_ERROR
+        );
 
         logger.debug("Parsed quote data:", quoteData);
-        setQuote(quoteData);
+        if (isCurrentQuoteRequest()) {
+          setQuoteResponse(data);
+          setQuote(quoteData);
+        }
         return quoteData;
       } catch (err) {
         const errorMessage =
-          err instanceof Error ? err.message : "Failed to get quote";
-        setError(errorMessage);
+          err instanceof Error && err.name === "AbortError"
+            ? JUPITER_QUOTE_TIMEOUT_ERROR
+            : err instanceof Error
+            ? err.message
+            : "Failed to get quote";
+        if (isCurrentQuoteRequest()) {
+          setQuote(null);
+          setQuoteResponse(null);
+          setError(errorMessage);
+        }
         logger.debug("Quote error:", err);
         return null;
       }
@@ -346,6 +408,7 @@ export function useSwap(
   }, [connection, signer, quoteResponse, swapConfig]);
 
   const resetQuote = useCallback(() => {
+    quoteRequestIdRef.current += 1;
     setQuote(null);
     setQuoteResponse(null);
     setError(null);


### PR DESCRIPTION
Adds a bounded quote path for extension swaps so failed Jupiter/RPC quote attempts clear stale state and stop the loading button. Also shows an explicit quote-unavailable state when a quote cannot be fetched.