### PR TITLE
chore(daemons): add pr-merge-drift-advisor and track .agents/daemons

### DIFF
--- a/.agents/daemons/pr-merge-drift-advisor/DAEMON.md
+++ b/.agents/daemons/pr-merge-drift-advisor/DAEMON.md
@@ -1,0 +1,68 @@
+---
+id: pr-merge-drift-advisor
+purpose: Advise on merge drift for open non-draft pull requests by flagging base-branch file overlap and posting a concrete, context-gathered conflict-resolution plan. Comment-only — never edits PR branches.
+watch:
+  - A GitHub push updates the repository default branch (main).
+  - A non-draft pull request is opened, reopened, or synchronized with new commits.
+routines:
+  - Run `bun .agents/daemons/pr-merge-drift-advisor/scripts/find-drift-candidates.ts` to list open non-draft PRs with their mergeability, merge-base, PR-changed files, base-changed-since-merge-base files, computed file overlap, and drift tier.
+  - Treat the script output as a candidate list. Re-confirm the current remote PR head SHA before composing any comment.
+  - For tier 2 (conflicting) candidates, gather context — the conflicting/overlapping files, and the base commits or PRs (with their merging author, for coordination only) that changed each overlapping file — then write a per-file resolution recommendation plus a copy-paste rebase/merge command sequence.
+  - For tier 1 (behind with overlap, not yet conflicting) candidates, write a concise early-warning listing the overlapping files and the base PRs that touched them, recommending an early rebase.
+  - Post or update exactly one managed advisory comment per PR, identified by a hidden marker, editing it in place across runs.
+  - When a previously flagged PR returns to no-overlap and not-conflicting, replace its advisory body with a short resolved note instead of leaving stale guidance.
+deny:
+  - Do not push, commit, rebase, merge, cherry-pick, force-push, or otherwise modify any PR branch, the base branch, or any file contents. This daemon only advises; it never resolves conflicts.
+  - Do not open new pull requests or issues; do not submit PR reviews, approvals, or change requests.
+  - Do not comment on draft pull requests.
+  - Do not comment on PRs that are up to date, or that are behind/clean with zero file overlap (tier 0). Stay silent for these — restating GitHub's native "this branch is behind" banner is noise.
+  - Do not post a second advisory comment on a PR; always edit the single managed comment identified by its marker.
+  - Do not frame overlapping base changes as blame. Attribute them by linking the merging PR or commit, for coordination only.
+  - Skip PRs whose mergeability is UNKNOWN after the script's retries; do not guess a tier.
+  - Do not continue on a PR whose head SHA changed during the run; re-evaluate on the next event.
+  - Do not assert that the suggested resolution steps are verified or safe to apply blindly; they are advisory starting points.
+---
+
+# PR Merge Drift Advisor
+
+This daemon answers one question for each open PR: *is this PR drifting from its base in a way that will create merge work, and if so, what concretely should the author do?* It is **comment-only**. It does not touch branches. If you later want automated resolution of clear conflicts, pair it with a separate `pr-merge-conflict-repair`-style daemon — keep the advisory (low-risk) and repair (higher-risk) roles split.
+
+## Candidate discovery
+
+Run the discovery script before any reasoning. Treat its output as a candidate list, not as authority to comment.
+
+A default-branch push is a survey trigger, not proof that a given PR is affected. The script may surface PRs targeting any base branch; evaluate each PR against its own current base. A PR `synchronize` event re-evaluates that single PR.
+
+If no PR is in tier 1 or tier 2, stop/no-op without commenting.
+
+## Drift classification — overlap, not magnitude
+
+Significant drift is **not** commit distance or staleness in days. A PR can be hundreds of commits behind base and still merge cleanly if none of those commits touched its files. The signal that predicts merge work is **file overlap** between the PR's diff and what changed on base since the PR's merge-base, combined with GitHub's own mergeability state.
+
+| Tier | Condition | Posture |
+| --- | --- | --- |
+| **0 — ignore** | Behind base (or current), **zero** overlap between PR files and base-since-merge-base files | Say nothing. |
+| **1 — early warning** | Behind base, **overlapping** files, mergeability not `CONFLICTING` | Update the managed comment with a concise heads-up: which files overlap, which base PRs touched them, and "rebase soon." |
+| **2 — act** | Mergeability `CONFLICTING` (`mergeStateStatus` `DIRTY`) | The core payload: gather context and post a concrete resolution plan. |
+
+`UNKNOWN` mergeability after retry is skipped, not classified.
+
+**Out of scope for v1 (deliberate):** textually-clean merges that are *semantically* wrong (passes on the PR, passes on base, breaks when combined). True detection there is judgment-heavy and noisy. If this proves valuable, a later specialization can add a narrow "tier 3" gated to a hardcoded sensitive-path allowlist (e.g. `packages/db-core/src/schema.ts`, migrations, lockfiles, `scripts/mirror-repos/package-rewrites.ts`, shared-package public entrypoints) — not general semantic analysis.
+
+## Context gathering (tier 2)
+
+The value over GitHub's native conflict banner is the context the banner never gives. A tier-2 advisory should include:
+
+- the conflicting/overlapping files;
+- for each, the base commit(s) or PR(s) that changed it since the merge-base, linked, with the merging author noted for coordination (not blame);
+- a per-file resolution recommendation grounded in PR intent and what base changed (take-ours / take-theirs / a described manual merge);
+- a copy-paste command sequence to update the branch and start resolving.
+
+Keep recommendations advisory and proportionate. Do not invent product decisions to make a file "resolve."
+
+## Advisory comment policy
+
+- Maintain **exactly one** managed advisory comment per PR. Identify it with a hidden marker (e.g. an HTML comment such as `<!-- pr-merge-drift-advisor -->`) and edit it in place across runs. Never post a duplicate.
+- Comment only for tier 1 and tier 2. Stay silent for tier 0, up-to-date PRs, drafts, and `UNKNOWN` mergeability.
+- When a flagged PR returns to tier 0 / not-conflicting, replace the comment body with a short resolved note rather than leaving stale guidance.
+- If the PR head SHA changed mid-run, stop and let the next event re-trigger; do not comment against a stale head.

--- a/.agents/daemons/pr-merge-drift-advisor/scripts/find-drift-candidates.ts
+++ b/.agents/daemons/pr-merge-drift-advisor/scripts/find-drift-candidates.ts
@@ -1,0 +1,345 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Read-only discovery for the pr-merge-drift-advisor daemon.
+ *
+ * For every open, non-draft pull request it reports:
+ *   - GitHub mergeability (mergeable / mergeStateStatus)
+ *   - the merge-base between the PR head and its current base
+ *   - the PR's own changed files (head vs merge-base)
+ *   - the files changed on base since the merge-base (with attributing commits)
+ *   - the overlap between those two file sets
+ *   - a drift tier: 0 (ignore), 1 (early warning), 2 (conflicting)
+ *
+ * The daemon uses this as a candidate list; it does not mutate anything.
+ *
+ * Usage:
+ *   bun .agents/daemons/pr-merge-drift-advisor/scripts/find-drift-candidates.ts \
+ *     [--repo <owner/repo>] [--max-pages N] [--unknown-retries N] [--unknown-retry-delay-ms N]
+ */
+
+const USAGE =
+  "Usage: bun .agents/daemons/pr-merge-drift-advisor/scripts/find-drift-candidates.ts [--repo <owner/repo>] [--max-pages N] [--unknown-retries N] [--unknown-retry-delay-ms N]";
+
+const DEFAULT_MAX_PAGES = 25;
+const DEFAULT_UNKNOWN_RETRIES = 2;
+const DEFAULT_UNKNOWN_RETRY_DELAY_MS = 1500;
+// GitHub's compare endpoint paginates files; cap the per-PR file scan.
+const COMPARE_FILE_LIMIT = 300;
+
+type Args = {
+  owner: string;
+  repo: string;
+  maxPages: number;
+  unknownRetries: number;
+  unknownRetryDelayMs: number;
+};
+
+type PullRequest = {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  baseRefName: string;
+  headRefName: string;
+  headRefOid: string;
+  isCrossRepository: boolean;
+  mergeable: string; // MERGEABLE | CONFLICTING | UNKNOWN
+  mergeStateStatus: string; // CLEAN | DIRTY | BEHIND | BLOCKED | ...
+};
+
+type Attribution = {
+  file: string;
+  commits: { sha: string; author: string | null; pr: number | null; message: string }[];
+};
+
+type Candidate = {
+  number: number;
+  title: string;
+  url: string;
+  base: string;
+  headOid: string;
+  isCrossRepository: boolean;
+  mergeable: string;
+  mergeStateStatus: string;
+  mergeBase: string | null;
+  prFileCount: number;
+  baseSinceMergeBaseFileCount: number;
+  overlapFiles: string[];
+  tier: 0 | 1 | 2;
+  attributions: Attribution[];
+  error?: string;
+};
+
+const PULLS_QUERY = `
+query OpenPulls($owner: String!, $repo: String!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 100, after: $cursor, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title url isDraft
+        baseRefName headRefName headRefOid
+        isCrossRepository mergeable mergeStateStatus
+      }
+    }
+  }
+}`;
+
+function fail(message: string): never {
+  throw new TypeError(message);
+}
+
+function gh(args: string[]): string {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  if (result.error) {
+    fail(`gh ${args[0]} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    fail(stderr.length > 0 ? `gh ${args.join(" ")} failed: ${stderr}` : `gh ${args.join(" ")} failed`);
+  }
+  return result.stdout;
+}
+
+function parseArgs(argv: string[]): Args {
+  let repoRaw: string | null = null;
+  let maxPages = DEFAULT_MAX_PAGES;
+  let unknownRetries = DEFAULT_UNKNOWN_RETRIES;
+  let unknownRetryDelayMs = DEFAULT_UNKNOWN_RETRY_DELAY_MS;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "-h" || token === "--help") {
+      process.stdout.write(`${USAGE}\n`);
+      process.exit(0);
+    }
+    const value = argv[i + 1];
+    if (!value || value.startsWith("-")) {
+      fail(`Missing value for ${token}.\n${USAGE}`);
+    }
+    if (token === "--repo") {
+      repoRaw = value;
+    } else if (token === "--max-pages") {
+      maxPages = Number(value);
+    } else if (token === "--unknown-retries") {
+      unknownRetries = Number(value);
+    } else if (token === "--unknown-retry-delay-ms") {
+      unknownRetryDelayMs = Number(value);
+    } else {
+      fail(`Unknown argument: ${token}\n${USAGE}`);
+    }
+    i += 1;
+  }
+
+  if (!Number.isInteger(maxPages) || maxPages <= 0) fail("--max-pages must be a positive integer.");
+  if (!Number.isInteger(unknownRetries) || unknownRetries < 0) fail("--unknown-retries must be >= 0.");
+  if (!Number.isInteger(unknownRetryDelayMs) || unknownRetryDelayMs < 0)
+    fail("--unknown-retry-delay-ms must be >= 0.");
+
+  if (!repoRaw) {
+    repoRaw = gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]).trim();
+  }
+  const [owner, repo, extra] = repoRaw.split("/");
+  if (!owner || !repo || extra) fail(`Invalid --repo value: ${repoRaw}. Expected owner/repo.`);
+
+  return { owner, repo, maxPages, unknownRetries, unknownRetryDelayMs };
+}
+
+function fetchOpenPulls(args: Args): PullRequest[] {
+  const pulls: PullRequest[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; ; page += 1) {
+    if (page >= args.maxPages) {
+      fail(`Open PR scan exceeded --max-pages=${args.maxPages}.`);
+    }
+    const ghArgs = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${PULLS_QUERY}`,
+      "-F",
+      `owner=${args.owner}`,
+      "-F",
+      `repo=${args.repo}`,
+    ];
+    if (cursor) ghArgs.push("-F", `cursor=${cursor}`);
+
+    const parsed = JSON.parse(gh(ghArgs)) as {
+      errors?: unknown[];
+      data?: { repository?: { pullRequests?: { pageInfo: { hasNextPage: boolean; endCursor: string | null }; nodes: PullRequest[] } } };
+    };
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      fail(`GitHub GraphQL errors: ${JSON.stringify(parsed.errors)}`);
+    }
+    const connection = parsed.data?.repository?.pullRequests;
+    if (!connection) fail("GitHub response missing repository.pullRequests.");
+    pulls.push(...connection.nodes);
+    if (!connection.pageInfo.hasNextPage) break;
+    cursor = connection.pageInfo.endCursor;
+    if (!cursor) fail("hasNextPage=true without endCursor.");
+  }
+  return pulls;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchOpenPullsWithRetry(args: Args): Promise<PullRequest[]> {
+  let pulls = fetchOpenPulls(args);
+  let attempts = 0;
+  while (
+    attempts < args.unknownRetries &&
+    pulls.some((p) => !p.isDraft && p.mergeable === "UNKNOWN")
+  ) {
+    await sleep(args.unknownRetryDelayMs);
+    pulls = fetchOpenPulls(args);
+    attempts += 1;
+  }
+  return pulls;
+}
+
+/** GET /repos/{o}/{r}/compare/{base}...{head} (three-dot: head vs merge-base). */
+function compare(args: Args, base: string, head: string): {
+  mergeBaseSha: string | null;
+  files: string[];
+  commits: { sha: string; author: string | null; message: string }[];
+} {
+  const raw = gh([
+    "api",
+    `repos/${args.owner}/${args.repo}/compare/${base}...${head}?per_page=${COMPARE_FILE_LIMIT}`,
+  ]);
+  const parsed = JSON.parse(raw) as {
+    merge_base_commit?: { sha?: string };
+    files?: { filename: string }[];
+    commits?: { sha: string; commit: { message: string }; author: { login: string } | null }[];
+  };
+  return {
+    mergeBaseSha: parsed.merge_base_commit?.sha ?? null,
+    files: (parsed.files ?? []).map((f) => f.filename),
+    commits: (parsed.commits ?? []).map((c) => ({
+      sha: c.sha,
+      author: c.author?.login ?? null,
+      message: c.commit.message.split("\n", 1)[0] ?? "",
+    })),
+  };
+}
+
+const PR_IN_MESSAGE = /\(#(\d+)\)/;
+
+function attribute(
+  overlapFiles: string[],
+  baseFiles: string[],
+  baseCommits: { sha: string; author: string | null; message: string }[],
+): Attribution[] {
+  // Coarse attribution: we know which files changed on base and which commits
+  // landed on base since the merge-base, but the compare endpoint does not map
+  // file -> commit. Attach the candidate base commits to each overlapping file
+  // so the daemon can link them for coordination.
+  const overlapSet = new Set(overlapFiles);
+  if (overlapSet.size === 0) return [];
+  const commits = baseCommits.map((c) => ({
+    sha: c.sha.slice(0, 12),
+    author: c.author,
+    pr: PR_IN_MESSAGE.exec(c.message)?.[1] ? Number(PR_IN_MESSAGE.exec(c.message)?.[1]) : null,
+    message: c.message,
+  }));
+  return overlapFiles
+    .filter((f) => baseFiles.includes(f))
+    .map((file) => ({ file, commits }));
+}
+
+function classify(pr: PullRequest, overlapCount: number, baseAhead: boolean): 0 | 1 | 2 {
+  if (pr.mergeable === "CONFLICTING") return 2;
+  if (baseAhead && overlapCount > 0) return 1;
+  return 0;
+}
+
+function buildCandidate(args: Args, pr: PullRequest): Candidate {
+  const head = pr.headRefOid;
+  const base = pr.baseRefName;
+  const baseline: Candidate = {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    base,
+    headOid: head,
+    isCrossRepository: pr.isCrossRepository,
+    mergeable: pr.mergeable,
+    mergeStateStatus: pr.mergeStateStatus,
+    mergeBase: null,
+    prFileCount: 0,
+    baseSinceMergeBaseFileCount: 0,
+    overlapFiles: [],
+    tier: 0,
+    attributions: [],
+  };
+
+  try {
+    // PR diff (head vs merge-base) + the merge-base sha.
+    const prCompare = compare(args, base, head);
+    const mergeBase = prCompare.mergeBaseSha;
+    if (!mergeBase) return { ...baseline, error: "no merge-base" };
+
+    // What changed on base since the merge-base.
+    const baseCompare = compare(args, mergeBase, base);
+    const baseAhead = baseCompare.commits.length > 0;
+
+    const prFiles = new Set(prCompare.files);
+    const overlapFiles = baseCompare.files.filter((f) => prFiles.has(f));
+    const tier = classify(pr, overlapFiles.length, baseAhead);
+
+    return {
+      ...baseline,
+      mergeBase,
+      prFileCount: prCompare.files.length,
+      baseSinceMergeBaseFileCount: baseCompare.files.length,
+      overlapFiles,
+      tier,
+      attributions: tier === 0 ? [] : attribute(overlapFiles, baseCompare.files, baseCompare.commits),
+    };
+  } catch (error) {
+    return { ...baseline, error: error instanceof Error ? error.message : "compare failed" };
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const pulls = await fetchOpenPullsWithRetry(args);
+
+  const nonDraft = pulls.filter((p) => !p.isDraft);
+  const unknown = nonDraft.filter((p) => p.mergeable === "UNKNOWN");
+  const evaluable = nonDraft.filter((p) => p.mergeable !== "UNKNOWN");
+
+  const candidates = evaluable.map((pr) => buildCandidate(args, pr));
+  const tier1 = candidates.filter((c) => c.tier === 1);
+  const tier2 = candidates.filter((c) => c.tier === 2);
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        repo: `${args.owner}/${args.repo}`,
+        collectedAt: new Date().toISOString(),
+        scan: {
+          openNonDraft: nonDraft.length,
+          unknownMergeability: unknown.length,
+          tier1Count: tier1.length,
+          tier2Count: tier2.length,
+        },
+        unknownPullRequests: unknown.map((p) => ({ number: p.number, url: p.url })),
+        // Tier-2 first: conflicting PRs are the priority payload.
+        candidates: [...tier2, ...tier1],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : "drift scan failed"}\n`);
+  process.exitCode = 1;
+});

--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,7 @@ docs/superpowers
 .superpowers
 
 .agents/**
+# Track shared Charlie daemon config (must live on the default branch to be ingested)
+!.agents/daemons/
+!.agents/daemons/**
 AGENTS.override.md


### PR DESCRIPTION
Adds a comment-only Charlie daemon that flags when an open PR drifts from its base by *file overlap* (not commit distance) and posts a concrete conflict-resolution plan. Un-ignores `.agents/daemons/` so the shared daemon config can live on `main` and be ingested.