### PR TITLE
feat(earn): add Solana Week quest-completion reporting

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,3 +12,20 @@ SOLANA_DEVNET_RPC_URL=
 SOLANA_DEVNET_WEBSOCKET_URL=
 NEXT_PUBLIC_SKILLS_ENABLED=true
 NEXT_PUBLIC_DEMO_RECIPE=false
+
+# Solana Week — Challenge Quest Completion API (backend-only; never NEXT_PUBLIC_).
+# Reporter no-ops until endpoint + key + the relevant quest id are set.
+# Use production for now (Solana swaps the key at launch):
+# https://publish.solanamobile.com/api/challenges/quest-completions
+SOLANA_WEEK_QUESTS_COMPLETION_ENDPOINT=
+SOLANA_WEEK_QUESTS_API_KEY=
+# Optional: only if Solana requires request signing (base58/base64 Ed25519 key).
+SOLANA_WEEK_QUESTS_SIGNING_KEY=
+# Quest 1 "connect wallet and deposit in Earn" — tracked via the manual Earn deposit.
+SOLANA_WEEK_QUEST_ID_EARN_DEPOSIT=
+# Quest 2 "first Earn deposit via autodeposit" — tracked via the balance sweep.
+SOLANA_WEEK_QUEST_ID_FIRST_AUTODEPOSIT=
+# Optional lookback (hours) for the reconciliation cron's sweep backfill; default 168 (7d).
+SOLANA_WEEK_SWEEP_LOOKBACK_HOURS=
+# Bearer secret the autodeposit sweep worker uses to call /api/solana-week/sweep-notify.
+SOLANA_WEEK_NOTIFY_SECRET=

--- a/frontend/src/app/api/cron/solana-week-quest-completions/route.ts
+++ b/frontend/src/app/api/cron/solana-week-quest-completions/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { reconcileQuestCompletions } from "@/features/solana-week/server/quest-completion-service";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+// Reconciliation backstop for Solana Week quest reporting. Real-time reporting
+// already happens inline at manual deposit confirm (Quest 1) and via the sweep
+// worker's notify call (Quest 2); this cron only retries rows not yet reported
+// and backfills autodeposit sweeps that never produced a row (e.g. a missed
+// notify). Fully idempotent — already-reported wallets cost a cheap DB read.
+const DEFAULT_SWEEP_LOOKBACK_HOURS = 168; // 7 days — covers a week-long event.
+
+function resolveSweepLookbackMs(): number {
+  const raw = process.env.SOLANA_WEEK_SWEEP_LOOKBACK_HOURS;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  const hours =
+    Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_SWEEP_LOOKBACK_HOURS;
+  return hours * 60 * 60 * 1000;
+}
+
+async function handleCronRequest(request: Request) {
+  const authError = validateCronAuthHeader(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const summary = await reconcileQuestCompletions({
+      sweepLookbackMs: resolveSweepLookbackMs(),
+    });
+    return NextResponse.json(summary);
+  } catch (error) {
+    console.error("[cron/solana-week-quest-completions] failed", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "solana_week_quest_reconcile_failed",
+          message: "Failed to reconcile Solana Week quest completions.",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = handleCronRequest;
+export const POST = handleCronRequest;

--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -8,6 +8,7 @@ import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { reportEarnDepositQuestCompletion } from "@/features/solana-week/server/quest-completion-service";
 import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import {
@@ -226,6 +227,14 @@ export async function POST(request: Request) {
       principal: { walletAddress, smartAccountAddress, settingsPda },
       input,
     });
+
+    // Best-effort Solana Week attribution: Quest 1 ("connect wallet and deposit
+    // in Earn"). Idempotent on Solana's side; never blocks the deposit confirm.
+    await reportEarnDepositQuestCompletion(walletAddress, {
+      source: "mobile-earn-deposit-confirm",
+      solanaEnv,
+    });
+
     return NextResponse.json({ position });
   } catch (error) {
     if (error instanceof EarnDepositConfirmError) {

--- a/frontend/src/app/api/solana-week/progress/route.ts
+++ b/frontend/src/app/api/solana-week/progress/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { getQuestProgress } from "@/features/solana-week/server/quest-completion-service";
+
+// Read-only Solana Week quest progress for the in-app quest page. Keyed by a
+// supplied wallet address (no signature) — mirrors the read-only mobile Earn
+// twins: it returns only this wallet's own quest-completion status, which is
+// low-sensitivity and already implied by that wallet's on-chain activity.
+// Solana's catalog GET stays authoritative for badge earned/locked/claim state.
+export async function GET(request: Request) {
+  const walletAddress =
+    new URL(request.url).searchParams.get("walletAddress")?.trim() ?? "";
+  if (!walletAddress) {
+    return NextResponse.json(
+      {
+        error: { code: "invalid_request", message: "walletAddress is required." },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const quests = await getQuestProgress(walletAddress);
+    return NextResponse.json({ walletAddress, quests });
+  } catch (error) {
+    console.error("[solana-week] quest progress lookup failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown lookup error.",
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "internal_error",
+          message: "Failed to load quest progress.",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/solana-week/sweep-notify/route.ts
+++ b/frontend/src/app/api/solana-week/sweep-notify/route.ts
@@ -1,0 +1,56 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+
+import { reportFirstAutodepositSweepQuestCompletion } from "@/features/solana-week/server/quest-completion-service";
+import { getOptionalEnv } from "@/lib/core/config/shared";
+
+// Internal backend-to-backend endpoint the autodeposit sweep worker calls the
+// moment it records a confirmed sweep, so Quest 2 ("first Earn deposit via
+// autodeposit") is reported in real time instead of waiting for the cron.
+// Authenticated with SOLANA_WEEK_NOTIFY_SECRET (Bearer). Body: { walletAddress }.
+function isAuthorized(request: Request): boolean {
+  const secret = getOptionalEnv(process.env, "SOLANA_WEEK_NOTIFY_SECRET");
+  if (!secret) {
+    return false;
+  }
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return false;
+  }
+  const expected = Buffer.from(`Bearer ${secret}`);
+  const provided = Buffer.from(header);
+  return (
+    expected.length === provided.length && timingSafeEqual(expected, provided)
+  );
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const walletAddress =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>).walletAddress
+      : undefined;
+  if (typeof walletAddress !== "string" || !walletAddress.trim()) {
+    return NextResponse.json(
+      { error: "invalid_request", message: "walletAddress is required." },
+      { status: 400 }
+    );
+  }
+
+  // Best-effort + idempotent; never throws.
+  await reportFirstAutodepositSweepQuestCompletion(walletAddress, {
+    source: "sweep-worker-notify",
+  });
+
+  return NextResponse.json({ status: "accepted" });
+}

--- a/frontend/src/features/solana-week/server/quest-completion-reporter.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-reporter.ts
@@ -1,0 +1,238 @@
+import "server-only";
+
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+
+import { getOptionalEnv } from "@/lib/core/config/shared";
+
+/**
+ * Reports Solana Week "challenge quest" completions to the Solana dApp Store
+ * Quests API (see `mobile/solana-week.md` → "Challenge Quest Completion API").
+ *
+ * Backend-only by mandate: the completion API key must never reach the mobile
+ * client. Only call this from server code (route handlers, server actions,
+ * workers).
+ *
+ * Feature-gated: if the endpoint, API key, or the relevant quest id is not
+ * configured the reporter no-ops (`status: "disabled"`). That makes it safe to
+ * ship before Solana finalizes the per-integration credentials and quest ids —
+ * fill the env vars in and it starts reporting with no code change.
+ *
+ * The completion API is idempotent per `(wallet_id, quest_id)`; both
+ * `completed` (201) and `already_completed` (200) are success.
+ */
+
+// Server-only secrets/config. Never expose any of these with NEXT_PUBLIC_.
+const ENDPOINT_ENV = "SOLANA_WEEK_QUESTS_COMPLETION_ENDPOINT";
+const API_KEY_ENV = "SOLANA_WEEK_QUESTS_API_KEY";
+// Optional Ed25519 secret key, base58 or base64. Only some credentials require
+// request signing; leave unset unless Solana tells us to sign.
+const SIGNING_KEY_ENV = "SOLANA_WEEK_QUESTS_SIGNING_KEY";
+// Quest 1 ("connect wallet and deposit in Earn") is tracked via the user's
+// manual Earn deposit, which is a prerequisite for autodeposit.
+const QUEST_ID_EARN_DEPOSIT_ENV = "SOLANA_WEEK_QUEST_ID_EARN_DEPOSIT";
+const QUEST_ID_FIRST_AUTODEPOSIT_ENV =
+  "SOLANA_WEEK_QUEST_ID_FIRST_AUTODEPOSIT";
+
+const MAX_WALLET_ID_LENGTH = 128;
+const MAX_QUEST_ID_LENGTH = 120;
+
+export type QuestKind = "earn_deposit" | "first_autodeposit_sweep";
+
+const QUEST_ID_ENV_BY_KIND: Record<QuestKind, string> = {
+  earn_deposit: QUEST_ID_EARN_DEPOSIT_ENV,
+  first_autodeposit_sweep: QUEST_ID_FIRST_AUTODEPOSIT_ENV,
+};
+
+export type QuestCompletionResult =
+  // Configured and accepted by Solana (idempotent: both map to success).
+  | { status: "completed" | "already_completed" }
+  // Not configured (endpoint/key/quest id missing) — intentional no-op.
+  | { status: "disabled"; reason: string }
+  // Caller-side guard tripped (e.g. empty/oversized wallet id) — do not retry.
+  | { status: "skipped"; reason: string }
+  // 4xx from Solana: bad payload/key/scope/quest. Do NOT retry without a fix.
+  | {
+      status: "permanent_error";
+      httpStatus: number;
+      error: string;
+      message: string;
+    }
+  // Network failure or 5xx: safe to retry with backoff.
+  | { status: "retryable_error"; httpStatus?: number; error: string };
+
+export type QuestCompletionMetadata = Record<string, unknown>;
+
+type ReporterConfig = {
+  endpoint: string;
+  apiKey: string;
+  signingSecretKey: Uint8Array | null;
+  questIdByKind: Record<QuestKind, string | undefined>;
+};
+
+// Accepts a base58 or base64 Ed25519 secret key. A 64-byte value is used as the
+// full secret key; a 32-byte value is treated as a seed and expanded.
+function decodeSigningSecretKey(raw: string): Uint8Array {
+  const tryDecoders: Array<(value: string) => Uint8Array> = [
+    (value) => bs58.decode(value),
+    (value) => new Uint8Array(Buffer.from(value, "base64")),
+  ];
+
+  for (const decode of tryDecoders) {
+    let bytes: Uint8Array;
+    try {
+      bytes = decode(raw);
+    } catch {
+      continue;
+    }
+    if (bytes.length === nacl.sign.secretKeyLength) {
+      return bytes;
+    }
+    if (bytes.length === nacl.sign.seedLength) {
+      return nacl.sign.keyPair.fromSeed(bytes).secretKey;
+    }
+  }
+
+  throw new Error(
+    `${SIGNING_KEY_ENV} must be a base58/base64 Ed25519 secret key (32-byte seed or 64-byte key).`
+  );
+}
+
+function loadReporterConfig(
+  env: NodeJS.ProcessEnv = process.env
+): ReporterConfig | null {
+  const endpoint = getOptionalEnv(env, ENDPOINT_ENV);
+  const apiKey = getOptionalEnv(env, API_KEY_ENV);
+  if (!endpoint || !apiKey) {
+    return null;
+  }
+
+  const signingKeyRaw = getOptionalEnv(env, SIGNING_KEY_ENV);
+
+  return {
+    endpoint,
+    apiKey,
+    signingSecretKey: signingKeyRaw
+      ? decodeSigningSecretKey(signingKeyRaw)
+      : null,
+    questIdByKind: {
+      earn_deposit: getOptionalEnv(env, QUEST_ID_EARN_DEPOSIT_ENV),
+      first_autodeposit_sweep: getOptionalEnv(
+        env,
+        QUEST_ID_FIRST_AUTODEPOSIT_ENV
+      ),
+    },
+  };
+}
+
+function buildHeaders(
+  config: ReporterConfig,
+  bodyBytes: Uint8Array
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-api-key": config.apiKey,
+  };
+  if (config.signingSecretKey) {
+    const signature = nacl.sign.detached(bodyBytes, config.signingSecretKey);
+    // The API accepts base64, base58, or hex; base64 is the simplest universal.
+    headers["x-signature"] = Buffer.from(signature).toString("base64");
+  }
+  return headers;
+}
+
+async function postCompletion(
+  config: ReporterConfig,
+  questId: string,
+  walletId: string,
+  metadata: QuestCompletionMetadata | undefined
+): Promise<QuestCompletionResult> {
+  const body = JSON.stringify({
+    wallet_id: walletId,
+    quest_id: questId,
+    ...(metadata ? { metadata } : {}),
+  });
+  const bodyBytes = new TextEncoder().encode(body);
+
+  let response: Response;
+  try {
+    response = await fetch(config.endpoint, {
+      method: "POST",
+      headers: buildHeaders(config, bodyBytes),
+      body,
+    });
+  } catch (cause) {
+    return {
+      status: "retryable_error",
+      error: cause instanceof Error ? cause.message : "Network request failed.",
+    };
+  }
+
+  if (response.status === 201) {
+    return { status: "completed" };
+  }
+  if (response.status === 200) {
+    return { status: "already_completed" };
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    error?: string;
+    message?: string;
+  } | null;
+
+  if (response.status >= 500) {
+    return {
+      status: "retryable_error",
+      httpStatus: response.status,
+      error: payload?.error ?? "internal_error",
+    };
+  }
+
+  return {
+    status: "permanent_error",
+    httpStatus: response.status,
+    error: payload?.error ?? "unknown_error",
+    message: payload?.message ?? response.statusText,
+  };
+}
+
+/**
+ * Reports a single quest completion. Returns a discriminated result instead of
+ * throwing; callers decide whether to retry (see `retryable_error`). For
+ * fire-and-forget call sites, prefer the best-effort wrappers below.
+ */
+export async function reportQuestCompletion(args: {
+  kind: QuestKind;
+  walletId: string;
+  metadata?: QuestCompletionMetadata;
+  env?: NodeJS.ProcessEnv;
+}): Promise<QuestCompletionResult> {
+  const config = loadReporterConfig(args.env);
+  if (!config) {
+    return {
+      status: "disabled",
+      reason: `${ENDPOINT_ENV}/${API_KEY_ENV} not configured`,
+    };
+  }
+
+  const questId = config.questIdByKind[args.kind];
+  if (!questId) {
+    return {
+      status: "disabled",
+      reason: `${QUEST_ID_ENV_BY_KIND[args.kind]} not configured`,
+    };
+  }
+  if (questId.length > MAX_QUEST_ID_LENGTH) {
+    return { status: "skipped", reason: "quest_id exceeds 120 chars" };
+  }
+
+  const walletId = args.walletId.trim();
+  if (!walletId) {
+    return { status: "skipped", reason: "empty wallet_id" };
+  }
+  if (walletId.length > MAX_WALLET_ID_LENGTH) {
+    return { status: "skipped", reason: "wallet_id exceeds 128 chars" };
+  }
+
+  return postCompletion(config, questId, walletId, args.metadata);
+}

--- a/frontend/src/features/solana-week/server/quest-completion-service.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-service.ts
@@ -300,3 +300,72 @@ export async function reconcileQuestCompletions(args: {
 
   return summary;
 }
+
+const QUEST_KINDS: QuestKind[] = ["earn_deposit", "first_autodeposit_sweep"];
+
+export type QuestProgressStatus =
+  | "reported"
+  | "pending"
+  | "failed"
+  | "not_started";
+
+export type QuestProgressItem = {
+  kind: QuestKind;
+  status: QuestProgressStatus;
+  solanaStatus: string | null;
+  reportedAt: string | null;
+  attempts: number;
+};
+
+// Persisted rows are only ever pending/reported/failed (see applyReportResult);
+// anything unexpected collapses to "pending" so the UI never shows a raw value.
+function normalizeRowStatus(status: string): QuestProgressStatus {
+  return status === "reported" || status === "failed" ? status : "pending";
+}
+
+/**
+ * Read-only quest progress for one wallet, for the in-app quest page. Returns
+ * one item per quest kind ("not_started" when no row exists yet). Solana stays
+ * authoritative for badge earned/locked and claim state; this only mirrors "the
+ * wallet did the action + our local reporting status".
+ */
+export async function getQuestProgress(
+  walletId: string
+): Promise<QuestProgressItem[]> {
+  const wallet = walletId.trim();
+  const rowByKind = new Map<QuestKind, CompletionRow>();
+  if (wallet) {
+    const rows = await db()
+      .select()
+      .from(solanaWeekQuestCompletions)
+      .where(eq(solanaWeekQuestCompletions.walletAddress, wallet));
+    for (const row of rows) {
+      if (
+        row.questKind === "earn_deposit" ||
+        row.questKind === "first_autodeposit_sweep"
+      ) {
+        rowByKind.set(row.questKind, row);
+      }
+    }
+  }
+
+  return QUEST_KINDS.map((kind) => {
+    const row = rowByKind.get(kind);
+    if (!row) {
+      return {
+        kind,
+        status: "not_started" as const,
+        solanaStatus: null,
+        reportedAt: null,
+        attempts: 0,
+      };
+    }
+    return {
+      kind,
+      status: normalizeRowStatus(row.status),
+      solanaStatus: row.solanaStatus,
+      reportedAt: row.reportedAt ? row.reportedAt.toISOString() : null,
+      attempts: row.attempts,
+    };
+  });
+}

--- a/frontend/src/features/solana-week/server/quest-completion-service.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-service.ts
@@ -1,0 +1,302 @@
+import "server-only";
+
+import { and, eq, ne, sql } from "drizzle-orm";
+
+import { findWalletAddressesWithBalanceSweepsSince } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import {
+  getYieldOptimizationClient,
+  solanaWeekQuestCompletions,
+} from "@/lib/yield-optimization/yield-neon-client.server";
+
+import {
+  reportQuestCompletion,
+  type QuestCompletionMetadata,
+  type QuestCompletionResult,
+  type QuestKind,
+} from "./quest-completion-reporter";
+
+/**
+ * DB-backed orchestration around the stateless quest-completion reporter.
+ *
+ * Every qualifying event (manual Earn deposit; autodeposit sweep) is recorded in
+ * `loyal_yield.solana_week_quest_completions` keyed by (wallet, quest_kind) and
+ * then reported to Solana. The local row is:
+ *   - the idempotency guard (a 'reported' row never re-hits Solana),
+ *   - the retry state for the reconciliation cron,
+ *   - the data source for in-app quest progress (no per-view Solana GET).
+ *
+ * Solana stays authoritative for badge earned/locked and claim state; this table
+ * only mirrors "the user did the action + our reporting status".
+ */
+
+type CompletionRow = typeof solanaWeekQuestCompletions.$inferSelect;
+
+export type RecordAndReportStatus =
+  | "reported"
+  | "pending"
+  | "failed"
+  | "skipped";
+
+function db() {
+  return getYieldOptimizationClient().db;
+}
+
+async function findCompletionRow(
+  walletId: string,
+  kind: QuestKind
+): Promise<CompletionRow | null> {
+  const [row] = await db()
+    .select()
+    .from(solanaWeekQuestCompletions)
+    .where(
+      and(
+        eq(solanaWeekQuestCompletions.walletAddress, walletId),
+        eq(solanaWeekQuestCompletions.questKind, kind)
+      )
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+// Insert a pending row (idempotent) and return the current row.
+async function ensureCompletionRow(
+  walletId: string,
+  kind: QuestKind,
+  metadata: QuestCompletionMetadata | undefined
+): Promise<CompletionRow> {
+  await db()
+    .insert(solanaWeekQuestCompletions)
+    .values({
+      walletAddress: walletId,
+      questKind: kind,
+      status: "pending",
+      metadata: metadata ?? null,
+    })
+    .onConflictDoNothing({
+      target: [
+        solanaWeekQuestCompletions.walletAddress,
+        solanaWeekQuestCompletions.questKind,
+      ],
+    });
+
+  const row = await findCompletionRow(walletId, kind);
+  if (!row) {
+    throw new Error("Failed to persist Solana Week quest completion row.");
+  }
+  return row;
+}
+
+// Apply a report result to a row and normalize the outcome.
+async function applyReportResult(
+  rowId: bigint,
+  result: QuestCompletionResult
+): Promise<RecordAndReportStatus> {
+  const now = new Date();
+  const base = {
+    attempts: sql`${solanaWeekQuestCompletions.attempts} + 1`,
+    updatedAt: now,
+  };
+
+  switch (result.status) {
+    case "completed":
+    case "already_completed":
+      await db()
+        .update(solanaWeekQuestCompletions)
+        .set({
+          ...base,
+          status: "reported",
+          solanaStatus: result.status,
+          reportedAt: now,
+          lastErrorCode: null,
+          lastErrorMessage: null,
+        })
+        .where(eq(solanaWeekQuestCompletions.id, rowId));
+      return "reported";
+    case "permanent_error":
+      await db()
+        .update(solanaWeekQuestCompletions)
+        .set({
+          ...base,
+          status: "failed",
+          lastErrorCode: result.error,
+          lastErrorMessage: result.message,
+        })
+        .where(eq(solanaWeekQuestCompletions.id, rowId));
+      return "failed";
+    case "disabled":
+    case "skipped":
+      // Not configured / guard tripped — leave pending for the reconciler.
+      await db()
+        .update(solanaWeekQuestCompletions)
+        .set({ ...base, status: "pending", lastErrorCode: result.reason })
+        .where(eq(solanaWeekQuestCompletions.id, rowId));
+      return "pending";
+    case "retryable_error":
+      await db()
+        .update(solanaWeekQuestCompletions)
+        .set({ ...base, status: "pending", lastErrorCode: result.error })
+        .where(eq(solanaWeekQuestCompletions.id, rowId));
+      return "pending";
+  }
+}
+
+/**
+ * Records the quest completion locally (idempotent) and reports it to Solana
+ * unless already reported. Returns the normalized local status.
+ */
+export async function recordAndReportQuestCompletion(args: {
+  walletId: string;
+  kind: QuestKind;
+  metadata?: QuestCompletionMetadata;
+}): Promise<RecordAndReportStatus> {
+  const walletId = args.walletId.trim();
+  if (!walletId) {
+    return "skipped";
+  }
+
+  const row = await ensureCompletionRow(walletId, args.kind, args.metadata);
+  if (row.status === "reported") {
+    return "reported";
+  }
+
+  const result = await reportQuestCompletion({
+    kind: args.kind,
+    walletId,
+    metadata: args.metadata,
+  });
+  return applyReportResult(row.id, result);
+}
+
+async function reportBestEffort(
+  kind: QuestKind,
+  walletId: string,
+  metadata: QuestCompletionMetadata | undefined
+): Promise<void> {
+  try {
+    const status = await recordAndReportQuestCompletion({
+      kind,
+      walletId,
+      metadata,
+    });
+    if (status === "failed") {
+      console.error("[solana-week] quest completion permanently failed", {
+        kind,
+        walletId,
+      });
+    }
+  } catch (error) {
+    // Best-effort: never break the calling flow on a reporting/DB failure.
+    console.error("[solana-week] quest completion threw", {
+      kind,
+      walletId,
+      errorName: error instanceof Error ? error.name : typeof error,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown reporting error.",
+    });
+  }
+}
+
+/** Best-effort Quest 1 (connect wallet + Earn deposit). Never throws. */
+export function reportEarnDepositQuestCompletion(
+  walletId: string,
+  metadata?: QuestCompletionMetadata
+): Promise<void> {
+  return reportBestEffort("earn_deposit", walletId, metadata);
+}
+
+/** Best-effort Quest 2 (first Earn deposit via autodeposit). Never throws. */
+export function reportFirstAutodepositSweepQuestCompletion(
+  walletId: string,
+  metadata?: QuestCompletionMetadata
+): Promise<void> {
+  return reportBestEffort("first_autodeposit_sweep", walletId, metadata);
+}
+
+export type ReconcileSummary = {
+  retriedRows: number;
+  backfilledWallets: number;
+  reported: number;
+  stillPending: number;
+  failed: number;
+};
+
+const RETRY_BATCH_LIMIT = 500;
+
+/**
+ * Reconciliation backstop for the cron: (1) retry every row not yet reported,
+ * (2) backfill autodeposit sweeps that never produced a row (e.g. a missed
+ * real-time worker notify) within `sweepLookbackMs`. Idempotent throughout —
+ * already-reported wallets short-circuit without a Solana call.
+ */
+export async function reconcileQuestCompletions(args: {
+  sweepLookbackMs: number;
+}): Promise<ReconcileSummary> {
+  const summary: ReconcileSummary = {
+    retriedRows: 0,
+    backfilledWallets: 0,
+    reported: 0,
+    stillPending: 0,
+    failed: 0,
+  };
+
+  const tally = (status: RecordAndReportStatus) => {
+    if (status === "reported") {
+      summary.reported += 1;
+    } else if (status === "failed") {
+      summary.failed += 1;
+    } else if (status === "pending") {
+      summary.stillPending += 1;
+    }
+  };
+
+  // (1) Retry rows that aren't reported yet.
+  const pendingRows = await db()
+    .select()
+    .from(solanaWeekQuestCompletions)
+    .where(ne(solanaWeekQuestCompletions.status, "reported"))
+    .limit(RETRY_BATCH_LIMIT);
+
+  for (const row of pendingRows) {
+    summary.retriedRows += 1;
+    try {
+      const result = await reportQuestCompletion({
+        kind: row.questKind as QuestKind,
+        walletId: row.walletAddress,
+        metadata: row.metadata ?? undefined,
+      });
+      tally(await applyReportResult(row.id, result));
+    } catch (error) {
+      summary.stillPending += 1;
+      console.error("[solana-week] reconcile retry threw", {
+        rowId: row.id.toString(),
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown retry error.",
+      });
+    }
+  }
+
+  // (2) Backfill autodeposit sweeps lacking a completion row (idempotent).
+  const since = new Date(Date.now() - args.sweepLookbackMs);
+  const sweptWallets = await findWalletAddressesWithBalanceSweepsSince(since);
+  for (const wallet of sweptWallets) {
+    summary.backfilledWallets += 1;
+    try {
+      tally(
+        await recordAndReportQuestCompletion({
+          kind: "first_autodeposit_sweep",
+          walletId: wallet,
+          metadata: { source: "cron:reconcile-backfill" },
+        })
+      );
+    } catch (error) {
+      summary.stillPending += 1;
+      console.error("[solana-week] reconcile backfill threw", {
+        wallet,
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown backfill error.",
+      });
+    }
+  }
+
+  return summary;
+}

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, asc, desc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, ne, sql } from "drizzle-orm";
 
 import type {
   ConfirmedEarnAutodepositCloseInput,
@@ -1685,4 +1685,27 @@ export async function recordBalanceSweepExecution(
   }
 
   return existing;
+}
+
+// Distinct wallet addresses with a balance-sweep execution recorded since
+// `since` (DB insert time). Used by the Solana Week attribution cron to report
+// "first Earn deposit via autodeposit" quest completions. The completion API is
+// idempotent per (wallet, quest), so a generous lookback window is safe.
+export async function findWalletAddressesWithBalanceSweepsSince(
+  since: Date,
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client"
+  > = createDependencies()
+): Promise<string[]> {
+  const rows = await dependencies.client.db
+    .selectDistinct({ wallet: balanceSweepTargets.wallet })
+    .from(balanceSweepExecutions)
+    .innerJoin(
+      balanceSweepTargets,
+      eq(balanceSweepExecutions.targetId, balanceSweepTargets.id)
+    )
+    .where(gte(balanceSweepExecutions.insertedAt, since));
+
+  return rows.map((row) => row.wallet);
 }

--- a/frontend/src/lib/yield-optimization/migrations/0016_add_solana_week_quest_completions.sql
+++ b/frontend/src/lib/yield-optimization/migrations/0016_add_solana_week_quest_completions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS loyal_yield.solana_week_quest_completions (
+  id BIGSERIAL PRIMARY KEY,
+  wallet_address TEXT NOT NULL,
+  quest_kind TEXT NOT NULL,
+  quest_id TEXT,
+  status TEXT NOT NULL,
+  solana_status TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  metadata JSONB,
+  reported_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS solana_week_quest_completion_wallet_kind_uidx
+  ON loyal_yield.solana_week_quest_completions (wallet_address, quest_kind);
+
+CREATE INDEX IF NOT EXISTS solana_week_quest_completion_unreported_idx
+  ON loyal_yield.solana_week_quest_completions (updated_at)
+  WHERE status <> 'reported';

--- a/frontend/src/lib/yield-optimization/yield-neon-client.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-neon-client.server.ts
@@ -862,6 +862,46 @@ export const rebalanceDecisions = loyalYieldSchema.table(
   }
 );
 
+// Solana Week (dApp Store quests) attribution: our local mirror of the quest
+// completions we report to Solana. Idempotent per (wallet, quest_kind); also the
+// data source for in-app quest progress without hitting Solana's read API.
+export const solanaWeekQuestCompletions = loyalYieldSchema.table(
+  "solana_week_quest_completions",
+  {
+    id: bigserial("id", { mode: "bigint" }).primaryKey(),
+    walletAddress: text("wallet_address").notNull(),
+    // Internal quest identifier: 'earn_deposit' | 'first_autodeposit_sweep'.
+    questKind: text("quest_kind").notNull(),
+    // The Solana quest_id we reported (recorded once known/configured).
+    questId: text("quest_id"),
+    // Our reporting state: 'pending' | 'reported' | 'failed'.
+    status: text("status").notNull(),
+    // Solana's success kind, when reported: 'completed' | 'already_completed'.
+    solanaStatus: text("solana_status"),
+    attempts: integer("attempts").notNull().default(0),
+    lastErrorCode: text("last_error_code"),
+    lastErrorMessage: text("last_error_message"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    reportedAt: timestamp("reported_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("solana_week_quest_completion_wallet_kind_uidx").on(
+      table.walletAddress,
+      table.questKind
+    ),
+    // Lets the reconciler cheaply find rows still needing a (re)report.
+    index("solana_week_quest_completion_unreported_idx")
+      .on(table.updatedAt)
+      .where(sql`${table.status} <> 'reported'`),
+  ]
+);
+
 export const yieldOptimizationSchema = {
   balanceSweepExecutions,
   balanceSweepLotClaimItems,
@@ -877,6 +917,7 @@ export const yieldOptimizationSchema = {
   managedVaults,
   rebalanceDecisions,
   routePolicies,
+  solanaWeekQuestCompletions,
   userYieldPositionDeposits,
   userYieldPositionHoldingEvents,
   userYieldPositionWithdrawals,
@@ -909,6 +950,7 @@ export type YieldOptimizationClientTables = {
   managedVaults: typeof managedVaults;
   rebalanceDecisions: typeof rebalanceDecisions;
   routePolicies: typeof routePolicies;
+  solanaWeekQuestCompletions: typeof solanaWeekQuestCompletions;
   userYieldPositionDeposits: typeof userYieldPositionDeposits;
   userYieldPositionHoldingEvents: typeof userYieldPositionHoldingEvents;
   userYieldPositionWithdrawals: typeof userYieldPositionWithdrawals;
@@ -935,6 +977,7 @@ export class YieldOptimizationClient {
     managedVaults,
     rebalanceDecisions,
     routePolicies,
+    solanaWeekQuestCompletions,
     userYieldPositionDeposits,
     userYieldPositionHoldingEvents,
     userYieldPositionWithdrawals,

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/earn-forecast-snapshot",
       "schedule": "17 8 * * *"
+    },
+    {
+      "path": "/api/cron/solana-week-quest-completions",
+      "schedule": "0 * * * *"
     }
   ],
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ] || ! git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null; then exit 1; fi; git diff \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD --quiet -- . ../packages ../sdk",


### PR DESCRIPTION
Backend-only Solana Week quest-completion reporting: reports the Earn-deposit quest inline at the mobile deposit/confirm route and the autodeposit-sweep quest via a new worker-called notify endpoint (`/api/solana-week/sweep-notify`), with an hourly reconciliation cron and a `loyal_yield.solana_week_quest_completions` table (migration 0016) for idempotent reporting/retry and in-app progress. Feature-gated — no-ops until the `SOLANA_WEEK_*` env vars are set; going live also needs migration 0016 applied and the sweep worker calling the notify endpoint.