### PR TITLE
fix(earn): show fresh vault total for mobile Earn balance

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/state/route.ts
@@ -12,6 +12,8 @@ import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/serv
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getCurrentReserveUpdatesByReserve } from "@/lib/kamino/timescale-reserve-client.server";
 import {
+  findCurrentNonzeroYieldVaultReservePositions,
+  findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type UserYieldPositionRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
@@ -65,6 +67,49 @@ function resolveTimescaleReserveForPosition(position: UserYieldPositionRecord) {
     return mainnetEarnTarget.reserve.toBase58();
   }
   return position.currentReserve;
+}
+
+// The position record's stored `currentAmountRaw` can lag the latest vault
+// snapshot (it's refreshed by a separate reconcile pass), which made the native
+// Earn balance read stale vs the web. The headline balance is therefore the
+// freshly-summed on-chain total — Kamino reserve positions + idle vault token
+// balances — identical to the session `earn-state` route's `currentTotalAmountRaw`.
+// Falls back to the position amount if no fresh snapshot rows exist.
+async function loadCurrentTotalAmountRaw(args: {
+  cluster: ReturnType<typeof resolveConfiguredCluster>;
+  position: UserYieldPositionRecord;
+  settings: string;
+  walletAddress: string;
+}): Promise<bigint> {
+  try {
+    const [reserveRows, idleRows] = await Promise.all([
+      findCurrentNonzeroYieldVaultReservePositions({
+        cluster: args.cluster,
+        settings: args.settings,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: args.position.vaultPubkey,
+        walletAddress: args.walletAddress,
+      }),
+      findCurrentYieldVaultIdleTokenBalances({
+        cluster: args.cluster,
+        settings: args.settings,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: args.position.vaultPubkey,
+        walletAddress: args.walletAddress,
+      }),
+    ]);
+    const total = [...reserveRows, ...idleRows].reduce(
+      (sum, row) => sum + row.amountRaw,
+      BigInt(0)
+    );
+    return total > BigInt(0) ? total : args.position.currentAmountRaw;
+  } catch (error) {
+    console.warn(
+      "[mobile-earn-state] failed to load current holdings total",
+      error
+    );
+    return args.position.currentAmountRaw;
+  }
 }
 
 // Best-effort: the funded balance is the headline number; APY is supplementary,
@@ -138,11 +183,19 @@ export async function GET(request: Request) {
       });
     }
 
-    const currentSupplyApyBps = await loadCurrentSupplyApyBps(position);
+    const [currentSupplyApyBps, currentTotalAmountRaw] = await Promise.all([
+      loadCurrentSupplyApyBps(position),
+      loadCurrentTotalAmountRaw({
+        cluster,
+        position,
+        settings: account.settingsPda,
+        walletAddress,
+      }),
+    ]);
 
     return NextResponse.json({
       position: {
-        currentAmountRaw: position.currentAmountRaw.toString(),
+        currentAmountRaw: currentTotalAmountRaw.toString(),
         currentSupplyApyBps,
         principalAmountRaw: position.principalAmountRaw.toString(),
         status: position.status,


### PR DESCRIPTION
The mobile Earn state route returned the position record's stale `current_amount_raw` (could read $5 while the web showed $10). It now sums the fresh reserve + idle vault holdings, mirroring the web `earn-state` route's `currentTotalAmountRaw` — fixing all existing app installs on deploy with no client change.