### PR TITLE
fix(earn): make Earn RPC holdings reader server-importable

### DIFF
--- a/frontend/src/lib/yield-optimization/earn-rpc-holdings.client.ts
+++ b/frontend/src/lib/yield-optimization/earn-rpc-holdings.client.ts
@@ -1,4 +1,10 @@
-"use client";
+// NOTE: intentionally NOT a "use client" module despite the .client.ts name.
+// `fetchEarnRpcHoldingsSnapshot` is a pure RPC computation (no React/browser
+// APIs) that must also be callable from server routes — e.g. the mobile
+// `/api/.../mobile/earn/holdings` twin. A "use client" directive makes Next.js
+// treat these exports as client references and throws "Attempted to call
+// fetchEarnRpcHoldingsSnapshot() from the server" at runtime (tsc can't catch
+// it). The client hook imports it just the same.
 
 import {
   KAMINO_VANILLA_OBLIGATION_ID,


### PR DESCRIPTION
Fixes the runtime 502 from PR #403's `/mobile/earn/holdings`: the route imports `fetchEarnRpcHoldingsSnapshot`, but `earn-rpc-holdings.client.ts` was a `"use client"` module, so Next.js treated the export as a client reference and threw `Attempted to call fetchEarnRpcHoldingsSnapshot() from the server` (tsc didn't catch it). The function is pure RPC (no React/browser APIs); dropping the directive makes it server-importable. The web client hook imports it unchanged.