### PR TITLE
fix(earn): restore mobile withdraw reserve source past idle dust

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
@@ -153,26 +153,38 @@ export async function GET(request: Request) {
         tokenAccount: row.tokenAccount,
       }));
 
-    let sources: WithdrawSource[] = [...reserveSources, ...idleSources];
-    if (
-      sources.length === 0 &&
+    // When no user-facing RESERVE rows surfaced, fall back to the reconciled
+    // position's reserve holding. Keyed off `reserveSources.length === 0` (NOT
+    // total sources) and merged alongside idle — mirroring `withdraw/prepare`'s
+    // own fallback. The old `sources.length === 0` guard meant a dust idle
+    // balance suppressed this fallback, dropping the (filtered-out) reserve
+    // position entirely and leaving the sheet showing only idle dust. The
+    // reserve row gets filtered out when the snapshot stores the Kamino position
+    // under collateral semantics (`kamino_obligation_collateral_deposited_amount`)
+    // instead of `kamino_redeemable_liquidity`.
+    const positionFallbackSources: WithdrawSource[] =
+      reserveSources.length === 0 &&
       position &&
       position.currentAmountRaw > BigInt(0) &&
       position.currentMarket
-    ) {
-      sources = [
-        {
-          type: "reserve",
-          id: position.currentReserve,
-          label: "USDC reserve",
-          amountRaw: position.currentAmountRaw.toString(),
-          liquidityMint: position.currentLiquidityMint,
-          market: position.currentMarket,
-          reserve: position.currentReserve,
-          tokenAccount: null,
-        },
-      ];
-    }
+        ? [
+            {
+              type: "reserve",
+              id: position.currentReserve,
+              label: "USDC reserve",
+              amountRaw: position.currentAmountRaw.toString(),
+              liquidityMint: position.currentLiquidityMint,
+              market: position.currentMarket,
+              reserve: position.currentReserve,
+              tokenAccount: null,
+            },
+          ]
+        : [];
+    const sources: WithdrawSource[] = [
+      ...reserveSources,
+      ...positionFallbackSources,
+      ...idleSources,
+    ];
 
     return NextResponse.json({
       sources,


### PR DESCRIPTION
Mobile `/withdraw/sources` returned only an idle-dust source for a vault holding ~$10 in OnRe, so the Withdraw sheet showed ~$0. The reserve row is filtered out (it's stored under collateral semantics, not `kamino_redeemable_liquidity`), so `reserveSources` is empty — and the position fallback that should supply the reserve was guarded by `sources.length === 0`, which the dust idle balance made non-zero, suppressing it.

Fix: build the position fallback on `reserveSources.length === 0` (matching `withdraw/prepare`'s own guard) and merge it alongside idle, so the reserve position is offered even when a dust idle balance exists.

Mobile-only route — the web withdraw path (`yield-optimization/withdrawals/*` + shared helpers) is untouched. Backend-only, no app release needed.