### PR TITLE
feat(earn): require $10 minimum deposit for Solana Week Quest 1

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -229,11 +229,17 @@ export async function POST(request: Request) {
     });
 
     // Best-effort Solana Week attribution: Quest 1 ("connect wallet and deposit
-    // in Earn"). Idempotent on Solana's side; never blocks the deposit confirm.
-    await reportEarnDepositQuestCompletion(walletAddress, {
-      source: "mobile-earn-deposit-confirm",
-      solanaEnv,
-    });
+    // $10+ in Earn"). Deposits under the threshold are a no-op. Idempotent on
+    // Solana's side; never blocks the deposit confirm.
+    await reportEarnDepositQuestCompletion(
+      walletAddress,
+      input.principalAmountRaw,
+      {
+        source: "mobile-earn-deposit-confirm",
+        solanaEnv,
+        depositUsdcRaw: input.principalAmountRaw.toString(),
+      }
+    );
 
     return NextResponse.json({ position });
   } catch (error) {

--- a/frontend/src/features/solana-week/server/quest-completion-service.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-service.ts
@@ -196,11 +196,24 @@ async function reportBestEffort(
   }
 }
 
-/** Best-effort Quest 1 (connect wallet + Earn deposit). Never throws. */
+/**
+ * Minimum qualifying deposit for Quest 1: $10 USDC (6 decimals). Deposits below
+ * this don't earn the badge, so we neither create a completion row nor report.
+ */
+export const MIN_EARN_DEPOSIT_QUEST_USDC_RAW = 10_000_000n;
+
+/**
+ * Best-effort Quest 1 (connect wallet + Earn deposit of at least $10). A deposit
+ * under the threshold is not a qualifying action and is a no-op. Never throws.
+ */
 export function reportEarnDepositQuestCompletion(
   walletId: string,
+  depositedUsdcRaw: bigint,
   metadata?: QuestCompletionMetadata
 ): Promise<void> {
+  if (depositedUsdcRaw < MIN_EARN_DEPOSIT_QUEST_USDC_RAW) {
+    return Promise.resolve();
+  }
   return reportBestEffort("earn_deposit", walletId, metadata);
 }
 

--- a/frontend/src/features/solana-week/server/quest-completion-service.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-service.ts
@@ -200,7 +200,7 @@ async function reportBestEffort(
  * Minimum qualifying deposit for Quest 1: $10 USDC (6 decimals). Deposits below
  * this don't earn the badge, so we neither create a completion row nor report.
  */
-export const MIN_EARN_DEPOSIT_QUEST_USDC_RAW = 10_000_000n;
+export const MIN_EARN_DEPOSIT_QUEST_USDC_RAW = BigInt(10_000_000);
 
 /**
  * Best-effort Quest 1 (connect wallet + Earn deposit of at least $10). A deposit


### PR DESCRIPTION
Quest 1 now only completes when the Earn deposit is $10 USDC or more; smaller deposits are a no-op (no completion row, no Solana report). Gated at the mobile deposit-confirm hook via a shared `MIN_EARN_DEPOSIT_QUEST_USDC_RAW` (10_000_000 raw) threshold.