### PR TITLE
fix(earn): diagnose policy creation simulation failures

### DIFF
--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -4721,7 +4721,7 @@ export function AppWalletWorkspace({
         haystack.includes("insufficient lamports") ||
         haystack.includes("would result in account being unable to pay rent");
       setProposalActionError(
-        isRentError
+        isRentError && !haystack.includes("top up")
           ? "Stash must keep a minimum SOL balance for rent. Try a smaller amount."
           : raw
       );

--- a/frontend/src/lib/smart-accounts/prepared-operation-wire.shared.test.ts
+++ b/frontend/src/lib/smart-accounts/prepared-operation-wire.shared.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+
+import {
+  hydratePreparedOperation,
+  serializePreparedOperation,
+} from "./prepared-operation-wire.shared";
+
+const programId = new PublicKey("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG");
+const settingsPda = new PublicKey("11111111111111111111111111111112");
+const payer = new PublicKey("11111111111111111111111111111113");
+const recipient = new PublicKey("11111111111111111111111111111114");
+
+describe("prepared operation wire format", () => {
+  test("preserves simulation diagnostics metadata", () => {
+    const prepared: PreparedLoyalSmartAccountsOperation<string> = {
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: payer,
+          lamports: 1,
+          toPubkey: recipient,
+        }),
+      ],
+      lookupTableAccounts: [],
+      operation: "testOperation",
+      payer,
+      programId,
+      requiresConfirmation: true,
+      simulationDiagnostics: {
+        includedPolicyAccounts: [recipient.toBase58()],
+        kind: "earnPolicyCreateMissingAccount",
+        policyAccount: recipient.toBase58(),
+        policySeed: "3",
+        policyStage: "setup",
+        programId: programId.toBase58(),
+        settingsPda: settingsPda.toBase58(),
+      },
+    };
+
+    const hydrated = hydratePreparedOperation(
+      serializePreparedOperation(prepared)
+    );
+
+    expect(hydrated.simulationDiagnostics).toEqual(
+      prepared.simulationDiagnostics
+    );
+  });
+});

--- a/frontend/src/lib/smart-accounts/prepared-operation-wire.shared.ts
+++ b/frontend/src/lib/smart-accounts/prepared-operation-wire.shared.ts
@@ -1,4 +1,5 @@
 import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts";
+import type { PreparedOperationSimulationDiagnosticsMetadata } from "@loyal-labs/loyal-smart-accounts-core";
 import {
   AddressLookupTableAccount,
   PublicKey,
@@ -34,6 +35,7 @@ export type WirePreparedLoyalSmartAccountsOperation = {
   payer: string;
   programId: string;
   requiresConfirmation: boolean;
+  simulationDiagnostics?: PreparedOperationSimulationDiagnosticsMetadata;
 };
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -85,6 +87,9 @@ export function serializePreparedOperation(
     payer: prepared.payer.toBase58(),
     programId: prepared.programId.toBase58(),
     requiresConfirmation: prepared.requiresConfirmation,
+    ...(prepared.simulationDiagnostics
+      ? { simulationDiagnostics: prepared.simulationDiagnostics }
+      : {}),
   };
 }
 
@@ -126,5 +131,8 @@ export function hydratePreparedOperation(
     payer: new PublicKey(wire.payer),
     programId: new PublicKey(wire.programId),
     requiresConfirmation: wire.requiresConfirmation,
+    ...(wire.simulationDiagnostics
+      ? { simulationDiagnostics: wire.simulationDiagnostics }
+      : {}),
   };
 }

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -871,6 +871,24 @@ describe("prepareEarnUsdcDeposit", () => {
       result.setupPolicy!.account,
       { isSigner: false, isWritable: true }
     );
+    expect(result.policySetupPrepared?.simulationDiagnostics).toEqual({
+      includedPolicyAccounts: [result.policy.account.toBase58()],
+      kind: "earnPolicyCreateMissingAccount",
+      policyAccount: result.policy.account.toBase58(),
+      policySeed: "7",
+      policyStage: "route",
+      programId: programId.toBase58(),
+      settingsPda: settingsPda.toBase58(),
+    });
+    expect(result.policyFinalizePrepared?.simulationDiagnostics).toEqual({
+      includedPolicyAccounts: [result.setupPolicy!.account.toBase58()],
+      kind: "earnPolicyCreateMissingAccount",
+      policyAccount: result.setupPolicy!.account.toBase58(),
+      policySeed: "8",
+      policyStage: "setup",
+      programId: programId.toBase58(),
+      settingsPda: settingsPda.toBase58(),
+    });
     expect(result.prepared.instructions).toHaveLength(4);
     expect(result.prepared.instructions[0]?.programId.toBase58()).toBe(
       ASSOCIATED_TOKEN_PROGRAM_ID.toBase58()
@@ -1104,6 +1122,24 @@ describe("prepareEarnUsdcDeposit", () => {
     expectEarnPolicyInitializationUsesSafeUniverse({
       finalizePrepared: result.finalizePrepared,
       setupPrepared: result.prepared,
+    });
+    expect(result.prepared.simulationDiagnostics).toEqual({
+      includedPolicyAccounts: [result.policy.account.toBase58()],
+      kind: "earnPolicyCreateMissingAccount",
+      policyAccount: result.policy.account.toBase58(),
+      policySeed: "7",
+      policyStage: "route",
+      programId: programId.toBase58(),
+      settingsPda: settingsPda.toBase58(),
+    });
+    expect(result.finalizePrepared?.simulationDiagnostics).toEqual({
+      includedPolicyAccounts: [result.setupPolicy.account.toBase58()],
+      kind: "earnPolicyCreateMissingAccount",
+      policyAccount: result.setupPolicy.account.toBase58(),
+      policySeed: "8",
+      policyStage: "setup",
+      programId: programId.toBase58(),
+      settingsPda: settingsPda.toBase58(),
     });
     expect(result.policy.seed).toBe(BigInt(7));
     expect(result.vault).toMatchObject({

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -154,6 +154,7 @@ import {
   tokenAmountToNumber,
   type SmartAccountSpendingLimitPeriod,
 } from "./spending-limits";
+import type { EarnPolicyCreateSimulationDiagnosticsMetadata } from "./simulation-diagnostics";
 
 const SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET = BigInt(64);
 
@@ -1490,6 +1491,39 @@ function mergePreparedOperations(args: {
         (operation) => operation.lookupTableAccounts ?? []
       )
     ),
+  });
+}
+
+function withEarnPolicyCreateSimulationDiagnostics(
+  operation: PreparedLoyalSmartAccountsOperation<string>,
+  args: {
+    policyAccount: PublicKey;
+    policySeed: bigint;
+    policyStage: EarnPolicyCreateSimulationDiagnosticsMetadata["policyStage"];
+    programId: PublicKey;
+    settingsPda: PublicKey;
+  }
+): PreparedLoyalSmartAccountsOperation<string> {
+  const policyAccount = args.policyAccount.toBase58();
+  const instructionAccounts = new Set(
+    operation.instructions.flatMap((instruction) =>
+      instruction.keys.map((meta) => meta.pubkey.toBase58())
+    )
+  );
+
+  return freezePreparedOperation({
+    ...operation,
+    simulationDiagnostics: {
+      includedPolicyAccounts: instructionAccounts.has(policyAccount)
+        ? [policyAccount]
+        : [],
+      kind: "earnPolicyCreateMissingAccount",
+      policyAccount,
+      policySeed: args.policySeed.toString(),
+      policyStage: args.policyStage,
+      programId: args.programId.toBase58(),
+      settingsPda: args.settingsPda.toBase58(),
+    },
   });
 }
 
@@ -4828,41 +4862,53 @@ export function createSmartAccountVaultsClient(
     })[0];
     const earnTarget = resolveKaminoEarnTarget(args.cluster);
     const earnUniverse = earnPolicyUniverseFromPlan(plan);
-    const createPolicyOperation = (policyArgs: {
+    const createPolicyOperation = async (policyArgs: {
       policyAccount: PublicKey;
       policySeed: bigint;
+      policyStage: EarnPolicyCreateSimulationDiagnosticsMetadata["policyStage"];
       payload: generated.PolicyCreationPayload;
-    }) =>
-      smartAccountsClient.features.execution.prepare.executeSettingsTransactionSync(
-        {
-          feePayer: args.feePayer,
-          settingsPda: args.settingsPda,
-          signers: [args.signer],
-          actions: [
-            {
-              __kind: "PolicyCreate",
-              seed: toBn(policyArgs.policySeed),
-              policyCreationPayload: policyArgs.payload,
-              signers: [createPolicySigner(args.policySigner)],
-              threshold: 1,
-              timeLock: 0,
-              startTimestamp: null,
-              expirationArgs: null,
-            },
-          ],
-          remainingAccounts: [
-            {
-              pubkey: policyArgs.policyAccount,
-              isWritable: true,
-              isSigner: false,
-            },
-          ],
-        } as never
-      );
+    }) => {
+      const operation =
+        await smartAccountsClient.features.execution.prepare.executeSettingsTransactionSync(
+          {
+            feePayer: args.feePayer,
+            settingsPda: args.settingsPda,
+            signers: [args.signer],
+            actions: [
+              {
+                __kind: "PolicyCreate",
+                seed: toBn(policyArgs.policySeed),
+                policyCreationPayload: policyArgs.payload,
+                signers: [createPolicySigner(args.policySigner)],
+                threshold: 1,
+                timeLock: 0,
+                startTimestamp: null,
+                expirationArgs: null,
+              },
+            ],
+            remainingAccounts: [
+              {
+                pubkey: policyArgs.policyAccount,
+                isWritable: true,
+                isSigner: false,
+              },
+            ],
+          } as never
+        );
+
+      return withEarnPolicyCreateSimulationDiagnostics(operation, {
+        policyAccount: policyArgs.policyAccount,
+        policySeed: policyArgs.policySeed,
+        policyStage: policyArgs.policyStage,
+        programId: smartAccountsClient.programId,
+        settingsPda: args.settingsPda,
+      });
+    };
 
     const operation = await createPolicyOperation({
       policyAccount,
       policySeed: args.policySeed,
+      policyStage: "route",
       payload: createEarnProgramInteractionPolicyCreationPayload({
         target: earnTarget,
         universe: earnUniverse,
@@ -4882,6 +4928,7 @@ export function createSmartAccountVaultsClient(
     const setupOperation = await createPolicyOperation({
       policyAccount: setupPolicyAccount,
       policySeed: setupPolicySeed,
+      policyStage: "setup",
       payload: createEarnInitObligationPolicyCreationPayload({
         target: earnTarget,
         universe: earnUniverse,

--- a/packages/smart-account-vaults/src/index.ts
+++ b/packages/smart-account-vaults/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./messages";
+export * from "./simulation-diagnostics";
 export * from "./spending-limits";
 export * from "./types";
 export * from "./wallet";

--- a/packages/smart-account-vaults/src/simulation-diagnostics.test.ts
+++ b/packages/smart-account-vaults/src/simulation-diagnostics.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  generated,
+  pda,
+  type PreparedLoyalSmartAccountsOperation,
+} from "@loyal-labs/loyal-smart-accounts-core";
+import type { Connection, VersionedTransaction } from "@solana/web3.js";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+import BN from "bn.js";
+
+import { getPreparedSimulationDiagnosticError } from "./simulation-diagnostics";
+
+const programId = new PublicKey("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG");
+const settingsPda = new PublicKey("11111111111111111111111111111112");
+const feePayer = new PublicKey("11111111111111111111111111111113");
+const recipient = new PublicKey("11111111111111111111111111111114");
+
+function createSettingsAccount(policySeed: BN | null) {
+  const [data] = generated.Settings.fromArgs({
+    accountUtilization: 0,
+    archivalAuthority: null,
+    archivableAfter: new BN(0),
+    bump: 255,
+    policySeed,
+    reserved2: 0,
+    seed: new BN(0),
+    settingsAuthority: feePayer,
+    signers: [],
+    staleTransactionIndex: new BN(0),
+    threshold: 1,
+    timeLock: 0,
+    transactionIndex: new BN(0),
+  }).serialize();
+
+  return {
+    data,
+    executable: false,
+    lamports: 1,
+    owner: programId,
+    rentEpoch: 0,
+  };
+}
+
+function createPrepared(
+  simulationDiagnostics: PreparedLoyalSmartAccountsOperation<string>["simulationDiagnostics"]
+): PreparedLoyalSmartAccountsOperation<string> {
+  return {
+    instructions: [
+      SystemProgram.transfer({
+        fromPubkey: feePayer,
+        lamports: 1,
+        toPubkey: recipient,
+      }),
+    ],
+    lookupTableAccounts: [],
+    operation: "testOperation",
+    payer: feePayer,
+    programId,
+    requiresConfirmation: true,
+    ...(simulationDiagnostics ? { simulationDiagnostics } : {}),
+  };
+}
+
+describe("prepared simulation diagnostics", () => {
+  test("identifies the missing policy PDA for a stale Earn setup PolicyCreate", async () => {
+    const expectedPolicyPda = pda.getPolicyPda({
+      policySeed: 2,
+      programId,
+      settingsPda,
+    })[0];
+    const includedPolicyPda = pda.getPolicyPda({
+      policySeed: 3,
+      programId,
+      settingsPda,
+    })[0];
+    const getAccountInfo = mock(async () => createSettingsAccount(new BN(1)));
+    const connection = {
+      getAccountInfo,
+    } as unknown as Connection;
+
+    const diagnostic = await getPreparedSimulationDiagnosticError({
+      connection,
+      logs: [
+        `Program ${programId.toBase58()} failed: custom program error: 0x1788`,
+      ],
+      originalError: new Error("wallet rejected"),
+      prepared: createPrepared({
+        includedPolicyAccounts: [includedPolicyPda.toBase58()],
+        kind: "earnPolicyCreateMissingAccount",
+        policyAccount: includedPolicyPda.toBase58(),
+        policySeed: "3",
+        policyStage: "setup",
+        programId: programId.toBase58(),
+        settingsPda: settingsPda.toBase58(),
+      }),
+      simulationErr: { InstructionError: [0, { Custom: 0x1788 }] },
+      transaction: {} as VersionedTransaction,
+      translatedError: Object.assign(new Error("MissingAccount"), {
+        name: "MissingAccount",
+      }),
+    });
+
+    expect(diagnostic).toBeInstanceOf(Error);
+    expect(diagnostic?.message).toContain(
+      `Missing policy account ${expectedPolicyPda.toBase58()} for expected next policy seed 2`
+    );
+    expect(diagnostic?.message).toContain(
+      `includes policy account(s): ${includedPolicyPda.toBase58()}`
+    );
+    expect(getAccountInfo).toHaveBeenCalledWith(settingsPda, "confirmed");
+  });
+});

--- a/packages/smart-account-vaults/src/simulation-diagnostics.ts
+++ b/packages/smart-account-vaults/src/simulation-diagnostics.ts
@@ -1,0 +1,224 @@
+import {
+  generated,
+  pda,
+  toBigInt,
+} from "@loyal-labs/loyal-smart-accounts-core";
+import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts-core";
+import { PublicKey } from "@solana/web3.js";
+import type { Connection, VersionedTransaction } from "@solana/web3.js";
+
+const SQUADS_MISSING_ACCOUNT_ERROR_CODE = 0x1788;
+
+type SimulationDiagnosticContext = {
+  connection: Connection;
+  logs: readonly string[];
+  originalError: unknown;
+  prepared: PreparedLoyalSmartAccountsOperation<string>;
+  simulationErr: unknown;
+  transaction: VersionedTransaction;
+  translatedError: Error | null;
+};
+
+export type EarnPolicyCreateSimulationDiagnosticsMetadata = Readonly<{
+  includedPolicyAccounts: readonly string[];
+  kind: "earnPolicyCreateMissingAccount";
+  policyAccount: string;
+  policySeed: string;
+  policyStage: "route" | "setup";
+  programId: string;
+  settingsPda: string;
+}>;
+
+function createErrorWithCause(args: {
+  cause: unknown;
+  logs?: readonly string[];
+  message: string;
+  name: string;
+}): Error {
+  const error = new Error(args.message);
+  error.name = args.name;
+  (error as Error & { cause?: unknown; logs?: readonly string[] }).cause =
+    args.cause;
+  if (args.logs) {
+    (error as Error & { cause?: unknown; logs?: readonly string[] }).logs =
+      args.logs;
+  }
+  return error;
+}
+
+function formatPubkeys(pubkeys: readonly string[]): string {
+  return pubkeys.length > 0 ? pubkeys.join(", ") : "none";
+}
+
+function isEarnPolicyCreateMetadata(
+  metadata: PreparedLoyalSmartAccountsOperation<string>["simulationDiagnostics"]
+): metadata is EarnPolicyCreateSimulationDiagnosticsMetadata {
+  return (
+    !!metadata &&
+    metadata.kind === "earnPolicyCreateMissingAccount" &&
+    typeof metadata.policyAccount === "string" &&
+    typeof metadata.policySeed === "string" &&
+    typeof metadata.programId === "string" &&
+    typeof metadata.settingsPda === "string" &&
+    (metadata.policyStage === "route" || metadata.policyStage === "setup") &&
+    Array.isArray(metadata.includedPolicyAccounts) &&
+    metadata.includedPolicyAccounts.every(
+      (account) => typeof account === "string"
+    )
+  );
+}
+
+export function simulationIndicatesMissingAccount(args: {
+  logs: readonly string[];
+  simulationErr: unknown;
+  translatedError: Error | null;
+}): boolean {
+  if (args.translatedError?.name === "MissingAccount") {
+    return true;
+  }
+
+  const haystack = [
+    args.translatedError?.name,
+    args.translatedError?.message,
+    JSON.stringify(args.simulationErr),
+    args.logs.join("\n"),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    /\bMissingAccount\b/i.test(haystack) ||
+    /custom program error:\s*0x1788/i.test(haystack) ||
+    new RegExp(`"Custom"\\s*:\\s*${SQUADS_MISSING_ACCOUNT_ERROR_CODE}`).test(
+      haystack
+    )
+  );
+}
+
+function policyPdaForSeed(args: {
+  policySeed: bigint;
+  programId: PublicKey;
+  settingsPda: PublicKey;
+}): string | null {
+  if (args.policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return null;
+  }
+
+  return pda
+    .getPolicyPda({
+      programId: args.programId,
+      settingsPda: args.settingsPda,
+      policySeed: Number(args.policySeed),
+    })[0]
+    .toBase58();
+}
+
+async function fetchNextPolicySeed(args: {
+  connection: Connection;
+  settingsPda: PublicKey;
+}): Promise<bigint | null> {
+  if (typeof args.connection.getAccountInfo !== "function") {
+    return null;
+  }
+
+  const account = await args.connection.getAccountInfo(
+    args.settingsPda,
+    "confirmed"
+  );
+  if (!account) {
+    return null;
+  }
+
+  const [settings] = generated.Settings.fromAccountInfo({
+    ...account,
+    data: Buffer.from(account.data),
+  });
+  const currentPolicySeed =
+    settings.policySeed == null ? BigInt(0) : toBigInt(settings.policySeed);
+  return currentPolicySeed + BigInt(1);
+}
+
+async function getEarnPolicyCreateMissingAccountMessage(args: {
+  connection: Connection;
+  metadata: EarnPolicyCreateSimulationDiagnosticsMetadata;
+}): Promise<string> {
+  const settingsPda = new PublicKey(args.metadata.settingsPda);
+  const programId = new PublicKey(args.metadata.programId);
+  const policySeed = BigInt(args.metadata.policySeed);
+  const policyDescription =
+    args.metadata.policyStage === "setup" ? "setup policy" : "route policy";
+  const includedAccounts = args.metadata.includedPolicyAccounts;
+  const includedAccountSet = new Set(includedAccounts);
+  const nextPolicySeed = await fetchNextPolicySeed({
+    connection: args.connection,
+    settingsPda,
+  }).catch(() => null);
+
+  if (nextPolicySeed != null) {
+    const expectedPolicyPda = policyPdaForSeed({
+      policySeed: nextPolicySeed,
+      programId,
+      settingsPda,
+    });
+    if (expectedPolicyPda && !includedAccountSet.has(expectedPolicyPda)) {
+      return (
+        `Squads could not find the policy account required by PolicyCreate. ` +
+        `Missing policy account ${expectedPolicyPda} for expected next policy seed ${nextPolicySeed.toString()}. ` +
+        `The prepared Earn ${policyDescription} action uses seed ${policySeed.toString()} ` +
+        `and includes policy account(s): ${formatPubkeys(includedAccounts)}. ` +
+        `This usually means the route/setup policy stage is stale or a resumed onboarding flow is sending the setup-policy transaction before the route policy exists on chain.`
+      );
+    }
+  }
+
+  if (!includedAccountSet.has(args.metadata.policyAccount)) {
+    return (
+      `Squads could not find the policy account required by PolicyCreate. ` +
+      `Missing policy account ${
+        args.metadata.policyAccount
+      } for prepared ${policyDescription} seed ${policySeed.toString()}. ` +
+      `The transaction includes policy account(s): ${formatPubkeys(
+        includedAccounts
+      )}.`
+    );
+  }
+
+  return (
+    `Squads reported MissingAccount while creating the prepared Earn ${policyDescription}. ` +
+    `The transaction includes the action-derived policy PDA ${
+      args.metadata.policyAccount
+    } for seed ${policySeed.toString()}, ` +
+    `so the most likely missing account is the current next policy PDA from on-chain settings. Refresh the Earn policy state and retry.`
+  );
+}
+
+export async function getPreparedSimulationDiagnosticError(
+  context: SimulationDiagnosticContext
+): Promise<Error | null> {
+  if (
+    !simulationIndicatesMissingAccount({
+      logs: context.logs,
+      simulationErr: context.simulationErr,
+      translatedError: context.translatedError,
+    })
+  ) {
+    return null;
+  }
+
+  const metadata = context.prepared.simulationDiagnostics;
+  if (!isEarnPolicyCreateMetadata(metadata)) {
+    return null;
+  }
+
+  const message = await getEarnPolicyCreateMissingAccountMessage({
+    connection: context.connection,
+    metadata,
+  });
+
+  return createErrorWithCause({
+    cause: context.originalError,
+    logs: context.logs,
+    message,
+    name: "SquadsMissingAccountSimulationError",
+  });
+}

--- a/packages/smart-account-vaults/src/wallet.test.ts
+++ b/packages/smart-account-vaults/src/wallet.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts";
+import type { Connection, VersionedTransaction } from "@solana/web3.js";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+
+import {
+  sendPreparedBatchWithWallet,
+  sendPreparedWithWallet,
+} from "./wallet";
+
+const payer = new PublicKey("11111111111111111111111111111112");
+const recipient = new PublicKey("11111111111111111111111111111113");
+const blockhash = "11111111111111111111111111111111";
+
+function createPreparedOperation(): PreparedLoyalSmartAccountsOperation<string> {
+  return {
+    instructions: [
+      SystemProgram.transfer({
+        fromPubkey: payer,
+        lamports: 1,
+        toPubkey: recipient,
+      }),
+    ],
+    lookupTableAccounts: [],
+    operation: "testOperation",
+    payer,
+    programId: SystemProgram.programId,
+    requiresConfirmation: false,
+  };
+}
+
+function createConnectionMock(logs: string[]) {
+  const simulateTransaction = mock(async () => ({
+    value: {
+      err: { InstructionError: [0, { Custom: 1 }] },
+      logs,
+    },
+  }));
+
+  return {
+    confirmTransaction: mock(async () => ({ value: { err: null } })),
+    getLatestBlockhash: mock(async () => ({
+      blockhash,
+      lastValidBlockHeight: 123,
+    })),
+    sendRawTransaction: mock(async () => "raw-signature"),
+    simulateTransaction,
+  } as unknown as Connection & {
+    simulateTransaction: typeof simulateTransaction;
+  };
+}
+
+describe("wallet prepared sends", () => {
+  test("simulates after wallet send failure and surfaces insufficient SOL top-up", async () => {
+    const connection = createConnectionMock([
+      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Transfer: insufficient lamports 236920, need 2268960",
+      "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+    ]);
+    const walletError = new Error("WalletSendTransactionError: failed");
+    const sendTransaction = mock(async () => {
+      throw walletError;
+    });
+
+    await expect(
+      sendPreparedWithWallet({
+        connection,
+        prepared: createPreparedOperation(),
+        wallet: {
+          publicKey: payer,
+          sendTransaction,
+          signTransaction: mock(
+            async <T extends VersionedTransaction>(transaction: T) =>
+              transaction
+          ),
+        },
+      })
+    ).rejects.toThrow("Top up at least 0.00203204 SOL");
+
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+    expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the original wallet send failure when simulation is inconclusive", async () => {
+    const connection = createConnectionMock([
+      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG failed: custom program error: 0x1788",
+    ]);
+    const walletError = new Error("WalletSendTransactionError: failed");
+
+    try {
+      await sendPreparedWithWallet({
+        connection,
+        prepared: createPreparedOperation(),
+        wallet: {
+          publicKey: payer,
+          sendTransaction: mock(async () => {
+            throw walletError;
+          }),
+          signTransaction: mock(
+            async <T extends VersionedTransaction>(transaction: T) =>
+              transaction
+          ),
+        },
+      });
+      throw new Error("expected sendPreparedWithWallet to throw");
+    } catch (error) {
+      expect(error).toBe(walletError);
+    }
+
+    expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("simulates prepared batch transactions after wallet signing failure", async () => {
+    const connection = createConnectionMock([
+      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Transfer: insufficient lamports 236920, need 2268960",
+      "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+    ]);
+    const signAllTransactions = mock(async () => {
+      throw new Error("WalletSignTransactionError: failed");
+    });
+
+    await expect(
+      sendPreparedBatchWithWallet({
+        connection,
+        prepared: [createPreparedOperation()],
+        wallet: {
+          publicKey: payer,
+          signAllTransactions,
+          signTransaction: mock(
+            async <T extends VersionedTransaction>(transaction: T) =>
+              transaction
+          ),
+        },
+      })
+    ).rejects.toThrow("Top up at least 0.00203204 SOL");
+
+    expect(signAllTransactions).toHaveBeenCalledTimes(1);
+    expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/smart-account-vaults/src/wallet.test.ts
+++ b/packages/smart-account-vaults/src/wallet.test.ts
@@ -1,46 +1,96 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts";
+import {
+  generated,
+  pda,
+  type PreparedLoyalSmartAccountsOperation,
+} from "@loyal-labs/loyal-smart-accounts-core";
 import type { Connection, VersionedTransaction } from "@solana/web3.js";
 import { PublicKey, SystemProgram } from "@solana/web3.js";
+import BN from "bn.js";
 
-import {
-  sendPreparedBatchWithWallet,
-  sendPreparedWithWallet,
-} from "./wallet";
+import type { WalletAdapterLike } from "./types";
+import { sendPreparedBatchWithWallet, sendPreparedWithWallet } from "./wallet";
 
-const payer = new PublicKey("11111111111111111111111111111112");
-const recipient = new PublicKey("11111111111111111111111111111113");
-const blockhash = "11111111111111111111111111111111";
+const programId = new PublicKey("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG");
+const settingsPda = new PublicKey("11111111111111111111111111111112");
+const feePayer = new PublicKey("11111111111111111111111111111113");
+const recipient = new PublicKey("11111111111111111111111111111114");
+const recentBlockhash = "11111111111111111111111111111111";
 
-function createPreparedOperation(): PreparedLoyalSmartAccountsOperation<string> {
+function createPrepared(
+  instructions = [
+    SystemProgram.transfer({
+      fromPubkey: feePayer,
+      lamports: 1,
+      toPubkey: recipient,
+    }),
+  ]
+): PreparedLoyalSmartAccountsOperation<string> {
   return {
-    instructions: [
-      SystemProgram.transfer({
-        fromPubkey: payer,
-        lamports: 1,
-        toPubkey: recipient,
-      }),
-    ],
+    instructions,
     lookupTableAccounts: [],
     operation: "testOperation",
-    payer,
-    programId: SystemProgram.programId,
-    requiresConfirmation: false,
+    payer: feePayer,
+    programId,
+    requiresConfirmation: true,
   };
 }
 
-function createConnectionMock(logs: string[]) {
-  const simulateTransaction = mock(async () => ({
-    value: {
-      err: { InstructionError: [0, { Custom: 1 }] },
-      logs,
-    },
-  }));
+function createRejectingWallet(error = new Error("wallet rejected")) {
+  return {
+    publicKey: feePayer,
+    signTransaction: mock(async () => {
+      throw error;
+    }),
+  } as unknown as WalletAdapterLike;
+}
+
+function createSettingsAccount(policySeed: BN | null) {
+  const [data] = generated.Settings.fromArgs({
+    accountUtilization: 0,
+    archivalAuthority: null,
+    archivableAfter: new BN(0),
+    bump: 255,
+    policySeed,
+    reserved2: 0,
+    seed: new BN(0),
+    settingsAuthority: feePayer,
+    signers: [],
+    staleTransactionIndex: new BN(0),
+    threshold: 1,
+    timeLock: 0,
+    transactionIndex: new BN(0),
+  }).serialize();
+
+  return {
+    data,
+    executable: false,
+    lamports: 1,
+    owner: programId,
+    rentEpoch: 0,
+  };
+}
+
+function createConnection(args: {
+  getAccountInfo?: ReturnType<typeof mock>;
+  logs?: string[];
+  simulateTransaction?: ReturnType<typeof mock>;
+}) {
+  const simulateTransaction =
+    args.simulateTransaction ??
+    mock(async () => ({
+      context: { slot: 1 },
+      value: {
+        err: { InstructionError: [0, { Custom: 1 }] },
+        logs: args.logs ?? [],
+      },
+    }));
 
   return {
     confirmTransaction: mock(async () => ({ value: { err: null } })),
+    getAccountInfo: args.getAccountInfo,
     getLatestBlockhash: mock(async () => ({
-      blockhash,
+      blockhash: recentBlockhash,
       lastValidBlockHeight: 123,
     })),
     sendRawTransaction: mock(async () => "raw-signature"),
@@ -50,14 +100,86 @@ function createConnectionMock(logs: string[]) {
   };
 }
 
+function createProgramInteractionPolicyPayload(
+  instructionConstraintCount: number
+): generated.PolicyCreationPayload {
+  return {
+    __kind: "ProgramInteraction",
+    fields: [
+      {
+        accountIndex: 1,
+        instructionsConstraints: Array.from(
+          { length: instructionConstraintCount },
+          () => ({
+            accountConstraints: [],
+            dataConstraints: [],
+            programId: SystemProgram.programId,
+          })
+        ),
+        postHook: null,
+        preHook: null,
+        spendingLimits: [],
+      },
+    ],
+  };
+}
+
+function createPolicyCreateInstruction(args: {
+  actionSeed: number;
+  includedPolicySeed: number;
+  instructionConstraintCount?: number;
+}) {
+  const includedPolicyPda = pda.getPolicyPda({
+    policySeed: args.includedPolicySeed,
+    programId,
+    settingsPda,
+  })[0];
+  const instruction = generated.createExecuteSettingsTransactionSyncInstruction(
+    {
+      consensusAccount: settingsPda,
+      program: programId,
+      rentPayer: feePayer,
+      systemProgram: SystemProgram.programId,
+    },
+    {
+      args: {
+        actions: [
+          {
+            __kind: "PolicyCreate",
+            expirationArgs: null,
+            policyCreationPayload: createProgramInteractionPolicyPayload(
+              args.instructionConstraintCount ?? 1
+            ),
+            seed: new BN(args.actionSeed),
+            signers: [],
+            startTimestamp: null,
+            threshold: 1,
+            timeLock: 0,
+          },
+        ],
+        memo: null,
+        numSigners: 1,
+      },
+    },
+    programId
+  );
+  instruction.keys.push(
+    { isSigner: true, isWritable: false, pubkey: feePayer },
+    { isSigner: false, isWritable: true, pubkey: includedPolicyPda }
+  );
+  return instruction;
+}
+
 describe("wallet prepared sends", () => {
   test("simulates after wallet send failure and surfaces insufficient SOL top-up", async () => {
-    const connection = createConnectionMock([
-      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
-      "Program 11111111111111111111111111111111 invoke [2]",
-      "Transfer: insufficient lamports 236920, need 2268960",
-      "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
-    ]);
+    const connection = createConnection({
+      logs: [
+        "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+        "Program 11111111111111111111111111111111 invoke [2]",
+        "Transfer: insufficient lamports 236920, need 2268960",
+        "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+      ],
+    });
     const walletError = new Error("WalletSendTransactionError: failed");
     const sendTransaction = mock(async () => {
       throw walletError;
@@ -66,9 +188,9 @@ describe("wallet prepared sends", () => {
     await expect(
       sendPreparedWithWallet({
         connection,
-        prepared: createPreparedOperation(),
+        prepared: createPrepared(),
         wallet: {
-          publicKey: payer,
+          publicKey: feePayer,
           sendTransaction,
           signTransaction: mock(
             async <T extends VersionedTransaction>(transaction: T) =>
@@ -83,18 +205,20 @@ describe("wallet prepared sends", () => {
   });
 
   test("keeps the original wallet send failure when simulation is inconclusive", async () => {
-    const connection = createConnectionMock([
-      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
-      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG failed: custom program error: 0x1788",
-    ]);
+    const connection = createConnection({
+      logs: [
+        "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+        "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG failed: custom program error: 0x1788",
+      ],
+    });
     const walletError = new Error("WalletSendTransactionError: failed");
 
     try {
       await sendPreparedWithWallet({
         connection,
-        prepared: createPreparedOperation(),
+        prepared: createPrepared(),
         wallet: {
-          publicKey: payer,
+          publicKey: feePayer,
           sendTransaction: mock(async () => {
             throw walletError;
           }),
@@ -113,12 +237,14 @@ describe("wallet prepared sends", () => {
   });
 
   test("simulates prepared batch transactions after wallet signing failure", async () => {
-    const connection = createConnectionMock([
-      "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
-      "Program 11111111111111111111111111111111 invoke [2]",
-      "Transfer: insufficient lamports 236920, need 2268960",
-      "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
-    ]);
+    const connection = createConnection({
+      logs: [
+        "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+        "Program 11111111111111111111111111111111 invoke [2]",
+        "Transfer: insufficient lamports 236920, need 2268960",
+        "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+      ],
+    });
     const signAllTransactions = mock(async () => {
       throw new Error("WalletSignTransactionError: failed");
     });
@@ -126,9 +252,9 @@ describe("wallet prepared sends", () => {
     await expect(
       sendPreparedBatchWithWallet({
         connection,
-        prepared: [createPreparedOperation()],
+        prepared: [createPrepared()],
         wallet: {
-          publicKey: payer,
+          publicKey: feePayer,
           signAllTransactions,
           signTransaction: mock(
             async <T extends VersionedTransaction>(transaction: T) =>
@@ -140,5 +266,89 @@ describe("wallet prepared sends", () => {
 
     expect(signAllTransactions).toHaveBeenCalledTimes(1);
     expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("simulates the same prepared transaction after wallet signing fails", async () => {
+    const simulateTransaction = mock(async () => ({
+      context: { slot: 1 },
+      value: { err: null, logs: [] },
+    }));
+    const connection = createConnection({ simulateTransaction });
+
+    await expect(
+      sendPreparedWithWallet({
+        connection,
+        wallet: createRejectingWallet(),
+        prepared: createPrepared(),
+      })
+    ).rejects.toThrow("wallet rejected");
+
+    expect(simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces exact SOL top-up amount from simulation logs", async () => {
+    const connection = createConnection({
+      logs: ["Transfer: insufficient lamports 100, need 250"],
+    });
+
+    await expect(
+      sendPreparedWithWallet({
+        connection,
+        wallet: createRejectingWallet(),
+        prepared: createPrepared(),
+      })
+    ).rejects.toThrow("Top up at least 0.00000015 SOL");
+  });
+
+  test("identifies the missing policy PDA for Squads MissingAccount", async () => {
+    const expectedPolicyPda = pda.getPolicyPda({
+      policySeed: 2,
+      programId,
+      settingsPda,
+    })[0];
+    const includedPolicyPda = pda.getPolicyPda({
+      policySeed: 3,
+      programId,
+      settingsPda,
+    })[0];
+    const simulateTransaction = mock(async () => ({
+      context: { slot: 1 },
+      value: {
+        err: { InstructionError: [0, { Custom: 0x1788 }] },
+        logs: [
+          `Program ${programId.toBase58()} failed: custom program error: 0x1788`,
+        ],
+      },
+    }));
+    const getAccountInfo = mock(async () => createSettingsAccount(new BN(1)));
+    const connection = createConnection({
+      getAccountInfo,
+      simulateTransaction,
+    });
+
+    let thrown: unknown;
+    try {
+      await sendPreparedWithWallet({
+        connection,
+        wallet: createRejectingWallet(),
+        prepared: createPrepared([
+          createPolicyCreateInstruction({
+            actionSeed: 3,
+            includedPolicySeed: 3,
+          }),
+        ]),
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(
+      `Missing policy account ${expectedPolicyPda.toBase58()} for expected next policy seed 2`
+    );
+    expect((thrown as Error).message).toContain(
+      `includes policy account(s): ${includedPolicyPda.toBase58()}`
+    );
+    expect(getAccountInfo).toHaveBeenCalledWith(settingsPda, "confirmed");
   });
 });

--- a/packages/smart-account-vaults/src/wallet.test.ts
+++ b/packages/smart-account-vaults/src/wallet.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
-import {
-  generated,
-  pda,
-  type PreparedLoyalSmartAccountsOperation,
-} from "@loyal-labs/loyal-smart-accounts-core";
+import type { PreparedLoyalSmartAccountsOperation } from "@loyal-labs/loyal-smart-accounts-core";
 import type { Connection, VersionedTransaction } from "@solana/web3.js";
 import { PublicKey, SystemProgram } from "@solana/web3.js";
-import BN from "bn.js";
 
 import type { WalletAdapterLike } from "./types";
 import { sendPreparedBatchWithWallet, sendPreparedWithWallet } from "./wallet";
@@ -24,7 +19,8 @@ function createPrepared(
       lamports: 1,
       toPubkey: recipient,
     }),
-  ]
+  ],
+  simulationDiagnostics?: PreparedLoyalSmartAccountsOperation<string>["simulationDiagnostics"]
 ): PreparedLoyalSmartAccountsOperation<string> {
   return {
     instructions,
@@ -33,6 +29,7 @@ function createPrepared(
     payer: feePayer,
     programId,
     requiresConfirmation: true,
+    ...(simulationDiagnostics ? { simulationDiagnostics } : {}),
   };
 }
 
@@ -43,32 +40,6 @@ function createRejectingWallet(error = new Error("wallet rejected")) {
       throw error;
     }),
   } as unknown as WalletAdapterLike;
-}
-
-function createSettingsAccount(policySeed: BN | null) {
-  const [data] = generated.Settings.fromArgs({
-    accountUtilization: 0,
-    archivalAuthority: null,
-    archivableAfter: new BN(0),
-    bump: 255,
-    policySeed,
-    reserved2: 0,
-    seed: new BN(0),
-    settingsAuthority: feePayer,
-    signers: [],
-    staleTransactionIndex: new BN(0),
-    threshold: 1,
-    timeLock: 0,
-    transactionIndex: new BN(0),
-  }).serialize();
-
-  return {
-    data,
-    executable: false,
-    lamports: 1,
-    owner: programId,
-    rentEpoch: 0,
-  };
 }
 
 function createConnection(args: {
@@ -98,76 +69,6 @@ function createConnection(args: {
   } as unknown as Connection & {
     simulateTransaction: typeof simulateTransaction;
   };
-}
-
-function createProgramInteractionPolicyPayload(
-  instructionConstraintCount: number
-): generated.PolicyCreationPayload {
-  return {
-    __kind: "ProgramInteraction",
-    fields: [
-      {
-        accountIndex: 1,
-        instructionsConstraints: Array.from(
-          { length: instructionConstraintCount },
-          () => ({
-            accountConstraints: [],
-            dataConstraints: [],
-            programId: SystemProgram.programId,
-          })
-        ),
-        postHook: null,
-        preHook: null,
-        spendingLimits: [],
-      },
-    ],
-  };
-}
-
-function createPolicyCreateInstruction(args: {
-  actionSeed: number;
-  includedPolicySeed: number;
-  instructionConstraintCount?: number;
-}) {
-  const includedPolicyPda = pda.getPolicyPda({
-    policySeed: args.includedPolicySeed,
-    programId,
-    settingsPda,
-  })[0];
-  const instruction = generated.createExecuteSettingsTransactionSyncInstruction(
-    {
-      consensusAccount: settingsPda,
-      program: programId,
-      rentPayer: feePayer,
-      systemProgram: SystemProgram.programId,
-    },
-    {
-      args: {
-        actions: [
-          {
-            __kind: "PolicyCreate",
-            expirationArgs: null,
-            policyCreationPayload: createProgramInteractionPolicyPayload(
-              args.instructionConstraintCount ?? 1
-            ),
-            seed: new BN(args.actionSeed),
-            signers: [],
-            startTimestamp: null,
-            threshold: 1,
-            timeLock: 0,
-          },
-        ],
-        memo: null,
-        numSigners: 1,
-      },
-    },
-    programId
-  );
-  instruction.keys.push(
-    { isSigner: true, isWritable: false, pubkey: feePayer },
-    { isSigner: false, isWritable: true, pubkey: includedPolicyPda }
-  );
-  return instruction;
 }
 
 describe("wallet prepared sends", () => {
@@ -300,17 +201,8 @@ describe("wallet prepared sends", () => {
     ).rejects.toThrow("Top up at least 0.00000015 SOL");
   });
 
-  test("identifies the missing policy PDA for Squads MissingAccount", async () => {
-    const expectedPolicyPda = pda.getPolicyPda({
-      policySeed: 2,
-      programId,
-      settingsPda,
-    })[0];
-    const includedPolicyPda = pda.getPolicyPda({
-      policySeed: 3,
-      programId,
-      settingsPda,
-    })[0];
+  test("uses prepared diagnostics for Squads MissingAccount", async () => {
+    const missingPolicyAccount = recipient.toBase58();
     const simulateTransaction = mock(async () => ({
       context: { slot: 1 },
       value: {
@@ -320,35 +212,26 @@ describe("wallet prepared sends", () => {
         ],
       },
     }));
-    const getAccountInfo = mock(async () => createSettingsAccount(new BN(1)));
     const connection = createConnection({
-      getAccountInfo,
       simulateTransaction,
     });
 
-    let thrown: unknown;
-    try {
-      await sendPreparedWithWallet({
+    await expect(
+      sendPreparedWithWallet({
         connection,
         wallet: createRejectingWallet(),
-        prepared: createPrepared([
-          createPolicyCreateInstruction({
-            actionSeed: 3,
-            includedPolicySeed: 3,
-          }),
-        ]),
-      });
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as Error).message).toContain(
-      `Missing policy account ${expectedPolicyPda.toBase58()} for expected next policy seed 2`
+        prepared: createPrepared(undefined, {
+          includedPolicyAccounts: [],
+          kind: "earnPolicyCreateMissingAccount",
+          policyAccount: missingPolicyAccount,
+          policySeed: "3",
+          policyStage: "setup",
+          programId: programId.toBase58(),
+          settingsPda: settingsPda.toBase58(),
+        }),
+      })
+    ).rejects.toThrow(
+      `Missing policy account ${missingPolicyAccount} for prepared setup policy seed 3`
     );
-    expect((thrown as Error).message).toContain(
-      `includes policy account(s): ${includedPolicyPda.toBase58()}`
-    );
-    expect(getAccountInfo).toHaveBeenCalledWith(settingsPda, "confirmed");
   });
 });

--- a/packages/smart-account-vaults/src/wallet.ts
+++ b/packages/smart-account-vaults/src/wallet.ts
@@ -1,42 +1,23 @@
 import {
   compilePreparedOperation,
-  generated,
-  pda,
-  toBigInt,
   translateAndThrowAnchorError,
 } from "@loyal-labs/loyal-smart-accounts-core";
-import { VersionedTransaction } from "@solana/web3.js";
+import type { VersionedTransaction } from "@solana/web3.js";
+import {
+  getPreparedSimulationDiagnosticError,
+  simulationIndicatesMissingAccount,
+} from "./simulation-diagnostics";
 import type {
   SendPreparedBatchWithWalletArgs,
   SendPreparedWithWalletArgs,
   WalletAdapterLike,
 } from "./types";
 
-const SQUADS_MISSING_ACCOUNT_ERROR_CODE = 0x1788;
-const SQUADS_MISSING_ACCOUNT_ERROR_DECIMAL = SQUADS_MISSING_ACCOUNT_ERROR_CODE;
-
 type PreparedOperation = SendPreparedWithWalletArgs["prepared"];
 type PreparedConnection = SendPreparedWithWalletArgs["connection"];
 type SimulatedTransactionValue = Awaited<
   ReturnType<PreparedConnection["simulateTransaction"]>
 >["value"];
-
-function createErrorWithCause(args: {
-  cause: unknown;
-  logs?: string[];
-  message: string;
-  name?: string;
-}): Error {
-  const error = new Error(args.message);
-  if (args.name) {
-    error.name = args.name;
-  }
-  (error as Error & { cause?: unknown; logs?: string[] }).cause = args.cause;
-  if (args.logs) {
-    (error as Error & { cause?: unknown; logs?: string[] }).logs = args.logs;
-  }
-  return error;
-}
 
 function attachCause(error: Error, cause: unknown, logs?: string[]): Error {
   (error as Error & { cause?: unknown; logs?: string[] }).cause ??= cause;
@@ -58,207 +39,6 @@ function translateSimulationLogs(logs: string[]): Error | null {
   } catch (error) {
     return error instanceof Error ? error : null;
   }
-}
-
-function simulationIndicatesMissingAccount(
-  simulation: SimulatedTransactionValue,
-  logs: string[],
-  translatedError: Error | null
-): boolean {
-  if (translatedError?.name === "MissingAccount") {
-    return true;
-  }
-
-  const haystack = [
-    translatedError?.name,
-    translatedError?.message,
-    JSON.stringify(simulation.err),
-    logs.join("\n"),
-  ]
-    .filter(Boolean)
-    .join("\n");
-
-  return (
-    /\bMissingAccount\b/i.test(haystack) ||
-    /custom program error:\s*0x1788/i.test(haystack) ||
-    new RegExp(`"Custom"\\s*:\\s*${SQUADS_MISSING_ACCOUNT_ERROR_DECIMAL}`).test(
-      haystack
-    )
-  );
-}
-
-function isExecuteSettingsTransactionSyncInstruction(
-  instruction: PreparedOperation["instructions"][number]
-): boolean {
-  if (
-    instruction.data.length <
-    generated.executeSettingsTransactionSyncInstructionDiscriminator.length
-  ) {
-    return false;
-  }
-
-  return generated.executeSettingsTransactionSyncInstructionDiscriminator.every(
-    (byte, index) => instruction.data[index] === byte
-  );
-}
-
-function formatPubkeys(pubkeys: readonly string[]): string {
-  return pubkeys.length > 0 ? pubkeys.join(", ") : "none";
-}
-
-function describePolicyCreate(
-  action: generated.SettingsAction & { __kind: "PolicyCreate" }
-): string {
-  if (action.policyCreationPayload.__kind !== "ProgramInteraction") {
-    return "policy";
-  }
-
-  const [payload] = action.policyCreationPayload.fields;
-  const constraintCount = payload.instructionsConstraints.length;
-  if (constraintCount === 1) {
-    return "setup policy";
-  }
-  if (constraintCount > 1) {
-    return "route policy";
-  }
-  return "policy";
-}
-
-function policyPdaForSeed(args: {
-  policySeed: bigint;
-  programId: Parameters<typeof pda.getPolicyPda>[0]["programId"];
-  settingsPda: Parameters<typeof pda.getPolicyPda>[0]["settingsPda"];
-}): string | null {
-  if (args.policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
-    return null;
-  }
-
-  return pda
-    .getPolicyPda({
-      programId: args.programId,
-      settingsPda: args.settingsPda,
-      policySeed: Number(args.policySeed),
-    })[0]
-    .toBase58();
-}
-
-async function fetchNextPolicySeed(args: {
-  connection: PreparedConnection;
-  settingsPda: Parameters<typeof pda.getPolicyPda>[0]["settingsPda"];
-}): Promise<bigint | null> {
-  if (typeof args.connection.getAccountInfo !== "function") {
-    return null;
-  }
-
-  const account = await args.connection.getAccountInfo(
-    args.settingsPda,
-    "confirmed"
-  );
-  if (!account) {
-    return null;
-  }
-
-  const [settings] = generated.Settings.fromAccountInfo({
-    ...account,
-    data: Buffer.from(account.data),
-  });
-  const currentPolicySeed =
-    settings.policySeed == null ? BigInt(0) : toBigInt(settings.policySeed);
-  return currentPolicySeed + BigInt(1);
-}
-
-async function getPolicyCreateMissingAccountDiagnostic(args: {
-  connection: PreparedConnection;
-  prepared: PreparedOperation;
-}): Promise<string | null> {
-  for (const instruction of args.prepared.instructions) {
-    if (!isExecuteSettingsTransactionSyncInstruction(instruction)) {
-      continue;
-    }
-
-    let decoded: generated.ExecuteSettingsTransactionSyncInstructionArgs & {
-      instructionDiscriminator: number[];
-    };
-    try {
-      [decoded] = generated.executeSettingsTransactionSyncStruct.deserialize(
-        Buffer.from(instruction.data)
-      );
-    } catch {
-      continue;
-    }
-
-    const settingsPda = instruction.keys[0]?.pubkey;
-    if (!settingsPda) {
-      continue;
-    }
-
-    const remainingPolicyAccounts = instruction.keys
-      .slice(4 + decoded.args.numSigners)
-      .map((meta) => meta.pubkey.toBase58());
-    const allInstructionAccounts = new Set(
-      instruction.keys.map((meta) => meta.pubkey.toBase58())
-    );
-    const nextPolicySeed = await fetchNextPolicySeed({
-      connection: args.connection,
-      settingsPda,
-    }).catch(() => null);
-
-    for (const action of decoded.args.actions) {
-      if (action.__kind !== "PolicyCreate") {
-        continue;
-      }
-
-      const actionSeed = toBigInt(action.seed);
-      const actionPolicyPda = policyPdaForSeed({
-        policySeed: actionSeed,
-        programId: instruction.programId,
-        settingsPda,
-      });
-      const policyDescription = describePolicyCreate(action);
-
-      if (nextPolicySeed != null) {
-        const expectedPolicyPda = policyPdaForSeed({
-          policySeed: nextPolicySeed,
-          programId: instruction.programId,
-          settingsPda,
-        });
-        if (
-          expectedPolicyPda &&
-          !allInstructionAccounts.has(expectedPolicyPda)
-        ) {
-          return (
-            `Squads could not find the policy account required by PolicyCreate. ` +
-            `Missing policy account ${expectedPolicyPda} for expected next policy seed ${nextPolicySeed.toString()}. ` +
-            `The prepared Earn ${policyDescription} action uses seed ${actionSeed.toString()} ` +
-            `and includes policy account(s): ${formatPubkeys(
-              remainingPolicyAccounts
-            )}. ` +
-            `This usually means the route/setup policy stage is stale or a resumed onboarding flow is sending the setup-policy transaction before the route policy exists on chain.`
-          );
-        }
-      }
-
-      if (actionPolicyPda && !allInstructionAccounts.has(actionPolicyPda)) {
-        return (
-          `Squads could not find the policy account required by PolicyCreate. ` +
-          `Missing policy account ${actionPolicyPda} for prepared ${policyDescription} seed ${actionSeed.toString()}. ` +
-          `The transaction includes policy account(s): ${formatPubkeys(
-            remainingPolicyAccounts
-          )}.`
-        );
-      }
-
-      if (actionPolicyPda) {
-        return (
-          `Squads reported MissingAccount while creating the prepared Earn ${policyDescription}. ` +
-          `The transaction includes the action-derived policy PDA ${actionPolicyPda} for seed ${actionSeed.toString()}, ` +
-          `so the most likely missing account is the current next policy PDA from on-chain settings. Refresh the Earn policy state and retry.`
-        );
-      }
-    }
-  }
-
-  return null;
 }
 
 async function getSimulationDiagnosticError(args: {
@@ -300,26 +80,32 @@ async function getSimulationDiagnosticError(args: {
   const translatedError = translateSimulationLogs(logs);
   if (
     translatedError &&
-    !simulationIndicatesMissingAccount(simulation, logs, translatedError)
+    !simulationIndicatesMissingAccount({
+      logs,
+      simulationErr: simulation.err,
+      translatedError,
+    })
   ) {
     return attachCause(translatedError, args.error, logs);
   }
 
-  if (simulationIndicatesMissingAccount(simulation, logs, translatedError)) {
-    const diagnostic = await getPolicyCreateMissingAccountDiagnostic({
-      connection: args.connection,
-      prepared: args.prepared,
-    });
-    if (!diagnostic) {
-      return null;
-    }
-
-    return createErrorWithCause({
-      cause: args.error,
+  if (
+    simulationIndicatesMissingAccount({
       logs,
-      message: diagnostic,
-      name: "SquadsMissingAccountSimulationError",
+      simulationErr: simulation.err,
+      translatedError,
+    })
+  ) {
+    const diagnostic = await getPreparedSimulationDiagnosticError({
+      connection: args.connection,
+      logs,
+      originalError: args.error,
+      prepared: args.prepared,
+      simulationErr: simulation.err,
+      transaction: args.transaction,
+      translatedError,
     });
+    return diagnostic;
   }
 
   if (translatedError) {
@@ -337,6 +123,24 @@ async function throwWithSimulationDiagnostic(args: {
 }): Promise<never> {
   const diagnostic = await getSimulationDiagnosticError(args);
   throw diagnostic ?? args.error;
+}
+
+async function withSimulationDiagnostic<T>(
+  fn: () => Promise<T>,
+  args: {
+    connection: PreparedConnection;
+    prepared: PreparedOperation;
+    transaction: VersionedTransaction;
+  }
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    return throwWithSimulationDiagnostic({
+      ...args,
+      error,
+    });
+  }
 }
 
 async function sendVersionedTransaction(args: {
@@ -372,49 +176,50 @@ export async function sendPreparedWithWallet({
     prepared,
     blockhash: latestBlockhash.blockhash,
   });
-  let signature: string;
-  try {
-    signature = await sendVersionedTransaction({
-      wallet,
+  const signature = await withSimulationDiagnostic(
+    () =>
+      sendVersionedTransaction({
+        wallet,
+        connection,
+        transaction,
+        sendOptions,
+      }),
+    {
       connection,
-      transaction,
-      sendOptions,
-    });
-  } catch (error) {
-    return throwWithSimulationDiagnostic({
-      connection,
-      error,
       prepared,
       transaction,
-    });
-  }
+    }
+  );
 
   const shouldConfirm =
     confirm === true || (confirm !== false && prepared.requiresConfirmation);
 
   if (shouldConfirm) {
-    const confirmation = await connection.confirmTransaction(
-      {
-        signature,
-        blockhash: latestBlockhash.blockhash,
-        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-      },
-      "confirmed"
-    );
+    await withSimulationDiagnostic(
+      async () => {
+        const confirmation = await connection.confirmTransaction(
+          {
+            signature,
+            blockhash: latestBlockhash.blockhash,
+            lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+          },
+          "confirmed"
+        );
 
-    if (confirmation.value.err) {
-      const error = new Error(
-        `Transaction ${signature} failed to confirm: ${JSON.stringify(
-          confirmation.value.err
-        )}`
-      );
-      return throwWithSimulationDiagnostic({
+        if (confirmation.value.err) {
+          throw new Error(
+            `Transaction ${signature} failed to confirm: ${JSON.stringify(
+              confirmation.value.err
+            )}`
+          );
+        }
+      },
+      {
         connection,
-        error,
         prepared,
         transaction,
-      });
-    }
+      }
+    );
   }
 
   return signature;
@@ -477,20 +282,18 @@ export async function sendPreparedBatchWithWallet({
       );
     }
 
-    let signature: string;
-    try {
-      signature = await connection.sendRawTransaction(
-        signedTransaction.serialize(),
-        sendOptions
-      );
-    } catch (error) {
-      return throwWithSimulationDiagnostic({
+    const signature = await withSimulationDiagnostic(
+      () =>
+        connection.sendRawTransaction(
+          signedTransaction.serialize(),
+          sendOptions
+        ),
+      {
         connection,
-        error,
         prepared: operation,
         transaction: signedTransaction,
-      });
-    }
+      }
+    );
     signatures.push(signature);
     await onTransactionSent?.({
       index,
@@ -502,28 +305,31 @@ export async function sendPreparedBatchWithWallet({
       confirm === true || (confirm !== false && operation.requiresConfirmation);
 
     if (shouldConfirm) {
-      const confirmation = await connection.confirmTransaction(
-        {
-          signature,
-          blockhash: latestBlockhash.blockhash,
-          lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-        },
-        "confirmed"
-      );
+      await withSimulationDiagnostic(
+        async () => {
+          const confirmation = await connection.confirmTransaction(
+            {
+              signature,
+              blockhash: latestBlockhash.blockhash,
+              lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+            },
+            "confirmed"
+          );
 
-      if (confirmation.value.err) {
-        const error = new Error(
-          `Transaction ${signature} failed to confirm: ${JSON.stringify(
-            confirmation.value.err
-          )}`
-        );
-        return throwWithSimulationDiagnostic({
+          if (confirmation.value.err) {
+            throw new Error(
+              `Transaction ${signature} failed to confirm: ${JSON.stringify(
+                confirmation.value.err
+              )}`
+            );
+          }
+        },
+        {
           connection,
-          error,
           prepared: operation,
           transaction: signedTransaction,
-        });
-      }
+        }
+      );
     }
 
     await onTransactionConfirmed?.({

--- a/packages/smart-account-vaults/src/wallet.ts
+++ b/packages/smart-account-vaults/src/wallet.ts
@@ -1,6 +1,8 @@
 import {
-  SolanaTransactionLogError,
   compilePreparedOperation,
+  generated,
+  pda,
+  toBigInt,
   translateAndThrowAnchorError,
 } from "@loyal-labs/loyal-smart-accounts-core";
 import { VersionedTransaction } from "@solana/web3.js";
@@ -10,96 +12,331 @@ import type {
   WalletAdapterLike,
 } from "./types";
 
-function isInsufficientSolTopUpError(
-  error: unknown
-): error is SolanaTransactionLogError {
-  return (
-    error instanceof SolanaTransactionLogError &&
-    error.message.includes("Top up at least")
-  );
+const SQUADS_MISSING_ACCOUNT_ERROR_CODE = 0x1788;
+const SQUADS_MISSING_ACCOUNT_ERROR_DECIMAL = SQUADS_MISSING_ACCOUNT_ERROR_CODE;
+
+type PreparedOperation = SendPreparedWithWalletArgs["prepared"];
+type PreparedConnection = SendPreparedWithWalletArgs["connection"];
+type SimulatedTransactionValue = Awaited<
+  ReturnType<PreparedConnection["simulateTransaction"]>
+>["value"];
+
+function createErrorWithCause(args: {
+  cause: unknown;
+  logs?: string[];
+  message: string;
+  name?: string;
+}): Error {
+  const error = new Error(args.message);
+  if (args.name) {
+    error.name = args.name;
+  }
+  (error as Error & { cause?: unknown; logs?: string[] }).cause = args.cause;
+  if (args.logs) {
+    (error as Error & { cause?: unknown; logs?: string[] }).logs = args.logs;
+  }
+  return error;
 }
 
-function translateSimulationLogs(
-  logs: readonly string[] | null | undefined
-): SolanaTransactionLogError | null {
-  if (!logs?.length) {
+function attachCause(error: Error, cause: unknown, logs?: string[]): Error {
+  (error as Error & { cause?: unknown; logs?: string[] }).cause ??= cause;
+  if (logs) {
+    (error as Error & { cause?: unknown; logs?: string[] }).logs = logs;
+  }
+  return error;
+}
+
+function translateSimulationLogs(logs: string[]): Error | null {
+  if (logs.length === 0) {
     return null;
   }
 
   try {
     translateAndThrowAnchorError(
-      Object.assign(new Error("Transaction simulation failed."), {
-        logs: [...logs],
-      })
+      Object.assign(new Error("Transaction simulation failed."), { logs })
     );
   } catch (error) {
-    return isInsufficientSolTopUpError(error) ? error : null;
+    return error instanceof Error ? error : null;
   }
-
-  return null;
 }
 
-async function getPostFailureSimulationError(args: {
-  connection: SendPreparedWithWalletArgs["connection"];
-  transaction: VersionedTransaction;
-}): Promise<SolanaTransactionLogError | null> {
-  try {
-    const simulation = await args.connection.simulateTransaction(
-      args.transaction,
-      {
-        commitment: "confirmed",
-        replaceRecentBlockhash: true,
-        sigVerify: false,
-      }
-    );
+function simulationIndicatesMissingAccount(
+  simulation: SimulatedTransactionValue,
+  logs: string[],
+  translatedError: Error | null
+): boolean {
+  if (translatedError?.name === "MissingAccount") {
+    return true;
+  }
 
-    return translateSimulationLogs(simulation.value.logs);
-  } catch {
+  const haystack = [
+    translatedError?.name,
+    translatedError?.message,
+    JSON.stringify(simulation.err),
+    logs.join("\n"),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    /\bMissingAccount\b/i.test(haystack) ||
+    /custom program error:\s*0x1788/i.test(haystack) ||
+    new RegExp(`"Custom"\\s*:\\s*${SQUADS_MISSING_ACCOUNT_ERROR_DECIMAL}`).test(
+      haystack
+    )
+  );
+}
+
+function isExecuteSettingsTransactionSyncInstruction(
+  instruction: PreparedOperation["instructions"][number]
+): boolean {
+  if (
+    instruction.data.length <
+    generated.executeSettingsTransactionSyncInstructionDiscriminator.length
+  ) {
+    return false;
+  }
+
+  return generated.executeSettingsTransactionSyncInstructionDiscriminator.every(
+    (byte, index) => instruction.data[index] === byte
+  );
+}
+
+function formatPubkeys(pubkeys: readonly string[]): string {
+  return pubkeys.length > 0 ? pubkeys.join(", ") : "none";
+}
+
+function describePolicyCreate(
+  action: generated.SettingsAction & { __kind: "PolicyCreate" }
+): string {
+  if (action.policyCreationPayload.__kind !== "ProgramInteraction") {
+    return "policy";
+  }
+
+  const [payload] = action.policyCreationPayload.fields;
+  const constraintCount = payload.instructionsConstraints.length;
+  if (constraintCount === 1) {
+    return "setup policy";
+  }
+  if (constraintCount > 1) {
+    return "route policy";
+  }
+  return "policy";
+}
+
+function policyPdaForSeed(args: {
+  policySeed: bigint;
+  programId: Parameters<typeof pda.getPolicyPda>[0]["programId"];
+  settingsPda: Parameters<typeof pda.getPolicyPda>[0]["settingsPda"];
+}): string | null {
+  if (args.policySeed > BigInt(Number.MAX_SAFE_INTEGER)) {
     return null;
   }
+
+  return pda
+    .getPolicyPda({
+      programId: args.programId,
+      settingsPda: args.settingsPda,
+      policySeed: Number(args.policySeed),
+    })[0]
+    .toBase58();
 }
 
-async function getFirstPostFailureSimulationError(args: {
-  connection: SendPreparedWithWalletArgs["connection"];
-  transactions: readonly VersionedTransaction[];
-}): Promise<SolanaTransactionLogError | null> {
-  for (const transaction of args.transactions) {
-    const simulationError = await getPostFailureSimulationError({
+async function fetchNextPolicySeed(args: {
+  connection: PreparedConnection;
+  settingsPda: Parameters<typeof pda.getPolicyPda>[0]["settingsPda"];
+}): Promise<bigint | null> {
+  if (typeof args.connection.getAccountInfo !== "function") {
+    return null;
+  }
+
+  const account = await args.connection.getAccountInfo(
+    args.settingsPda,
+    "confirmed"
+  );
+  if (!account) {
+    return null;
+  }
+
+  const [settings] = generated.Settings.fromAccountInfo({
+    ...account,
+    data: Buffer.from(account.data),
+  });
+  const currentPolicySeed =
+    settings.policySeed == null ? BigInt(0) : toBigInt(settings.policySeed);
+  return currentPolicySeed + BigInt(1);
+}
+
+async function getPolicyCreateMissingAccountDiagnostic(args: {
+  connection: PreparedConnection;
+  prepared: PreparedOperation;
+}): Promise<string | null> {
+  for (const instruction of args.prepared.instructions) {
+    if (!isExecuteSettingsTransactionSyncInstruction(instruction)) {
+      continue;
+    }
+
+    let decoded: generated.ExecuteSettingsTransactionSyncInstructionArgs & {
+      instructionDiscriminator: number[];
+    };
+    try {
+      [decoded] = generated.executeSettingsTransactionSyncStruct.deserialize(
+        Buffer.from(instruction.data)
+      );
+    } catch {
+      continue;
+    }
+
+    const settingsPda = instruction.keys[0]?.pubkey;
+    if (!settingsPda) {
+      continue;
+    }
+
+    const remainingPolicyAccounts = instruction.keys
+      .slice(4 + decoded.args.numSigners)
+      .map((meta) => meta.pubkey.toBase58());
+    const allInstructionAccounts = new Set(
+      instruction.keys.map((meta) => meta.pubkey.toBase58())
+    );
+    const nextPolicySeed = await fetchNextPolicySeed({
       connection: args.connection,
-      transaction,
-    });
-    if (simulationError) {
-      return simulationError;
+      settingsPda,
+    }).catch(() => null);
+
+    for (const action of decoded.args.actions) {
+      if (action.__kind !== "PolicyCreate") {
+        continue;
+      }
+
+      const actionSeed = toBigInt(action.seed);
+      const actionPolicyPda = policyPdaForSeed({
+        policySeed: actionSeed,
+        programId: instruction.programId,
+        settingsPda,
+      });
+      const policyDescription = describePolicyCreate(action);
+
+      if (nextPolicySeed != null) {
+        const expectedPolicyPda = policyPdaForSeed({
+          policySeed: nextPolicySeed,
+          programId: instruction.programId,
+          settingsPda,
+        });
+        if (
+          expectedPolicyPda &&
+          !allInstructionAccounts.has(expectedPolicyPda)
+        ) {
+          return (
+            `Squads could not find the policy account required by PolicyCreate. ` +
+            `Missing policy account ${expectedPolicyPda} for expected next policy seed ${nextPolicySeed.toString()}. ` +
+            `The prepared Earn ${policyDescription} action uses seed ${actionSeed.toString()} ` +
+            `and includes policy account(s): ${formatPubkeys(
+              remainingPolicyAccounts
+            )}. ` +
+            `This usually means the route/setup policy stage is stale or a resumed onboarding flow is sending the setup-policy transaction before the route policy exists on chain.`
+          );
+        }
+      }
+
+      if (actionPolicyPda && !allInstructionAccounts.has(actionPolicyPda)) {
+        return (
+          `Squads could not find the policy account required by PolicyCreate. ` +
+          `Missing policy account ${actionPolicyPda} for prepared ${policyDescription} seed ${actionSeed.toString()}. ` +
+          `The transaction includes policy account(s): ${formatPubkeys(
+            remainingPolicyAccounts
+          )}.`
+        );
+      }
+
+      if (actionPolicyPda) {
+        return (
+          `Squads reported MissingAccount while creating the prepared Earn ${policyDescription}. ` +
+          `The transaction includes the action-derived policy PDA ${actionPolicyPda} for seed ${actionSeed.toString()}, ` +
+          `so the most likely missing account is the current next policy PDA from on-chain settings. Refresh the Earn policy state and retry.`
+        );
+      }
     }
   }
 
   return null;
 }
 
-async function throwPostFailureSimulationErrorOrOriginal(args: {
-  connection: SendPreparedWithWalletArgs["connection"];
-  originalError: unknown;
+async function getSimulationDiagnosticError(args: {
+  connection: PreparedConnection;
+  error: unknown;
+  prepared: PreparedOperation;
   transaction: VersionedTransaction;
-}): Promise<never> {
-  const simulationError = await getPostFailureSimulationError({
-    connection: args.connection,
-    transaction: args.transaction,
-  });
+}): Promise<Error | null> {
+  if (typeof args.connection.simulateTransaction !== "function") {
+    return null;
+  }
 
-  throw simulationError ?? args.originalError;
+  let simulation: SimulatedTransactionValue;
+  try {
+    ({ value: simulation } = await args.connection.simulateTransaction(
+      args.transaction,
+      {
+        commitment: "confirmed",
+        replaceRecentBlockhash: false,
+        sigVerify: false,
+      }
+    ));
+  } catch (simulationError) {
+    console.warn("[smart-account-vaults] post-failure simulation failed", {
+      errorMessage:
+        simulationError instanceof Error
+          ? simulationError.message
+          : "Unknown simulation error.",
+      errorName:
+        simulationError instanceof Error
+          ? simulationError.name
+          : typeof simulationError,
+      operation: args.prepared.operation,
+    });
+    return null;
+  }
+
+  const logs = simulation.logs ?? [];
+  const translatedError = translateSimulationLogs(logs);
+  if (
+    translatedError &&
+    !simulationIndicatesMissingAccount(simulation, logs, translatedError)
+  ) {
+    return attachCause(translatedError, args.error, logs);
+  }
+
+  if (simulationIndicatesMissingAccount(simulation, logs, translatedError)) {
+    const diagnostic = await getPolicyCreateMissingAccountDiagnostic({
+      connection: args.connection,
+      prepared: args.prepared,
+    });
+    if (!diagnostic) {
+      return null;
+    }
+
+    return createErrorWithCause({
+      cause: args.error,
+      logs,
+      message: diagnostic,
+      name: "SquadsMissingAccountSimulationError",
+    });
+  }
+
+  if (translatedError) {
+    return attachCause(translatedError, args.error, logs);
+  }
+
+  return null;
 }
 
-async function throwFirstPostFailureSimulationErrorOrOriginal(args: {
-  connection: SendPreparedWithWalletArgs["connection"];
-  originalError: unknown;
-  transactions: readonly VersionedTransaction[];
+async function throwWithSimulationDiagnostic(args: {
+  connection: PreparedConnection;
+  error: unknown;
+  prepared: PreparedOperation;
+  transaction: VersionedTransaction;
 }): Promise<never> {
-  const simulationError = await getFirstPostFailureSimulationError({
-    connection: args.connection,
-    transactions: args.transactions,
-  });
-
-  throw simulationError ?? args.originalError;
+  const diagnostic = await getSimulationDiagnosticError(args);
+  throw diagnostic ?? args.error;
 }
 
 async function sendVersionedTransaction(args: {
@@ -135,18 +372,23 @@ export async function sendPreparedWithWallet({
     prepared,
     blockhash: latestBlockhash.blockhash,
   });
-  const signature = await sendVersionedTransaction({
-    wallet,
-    connection,
-    transaction,
-    sendOptions,
-  }).catch((error) =>
-    throwPostFailureSimulationErrorOrOriginal({
+  let signature: string;
+  try {
+    signature = await sendVersionedTransaction({
+      wallet,
       connection,
-      originalError: error,
       transaction,
-    })
-  );
+      sendOptions,
+    });
+  } catch (error) {
+    return throwWithSimulationDiagnostic({
+      connection,
+      error,
+      prepared,
+      transaction,
+    });
+  }
+
   const shouldConfirm =
     confirm === true || (confirm !== false && prepared.requiresConfirmation);
 
@@ -166,9 +408,10 @@ export async function sendPreparedWithWallet({
           confirmation.value.err
         )}`
       );
-      await throwPostFailureSimulationErrorOrOriginal({
+      return throwWithSimulationDiagnostic({
         connection,
-        originalError: error,
+        error,
+        prepared,
         transaction,
       });
     }
@@ -200,15 +443,27 @@ export async function sendPreparedBatchWithWallet({
       blockhash: latestBlockhash.blockhash,
     })
   );
-  const signedTransactions = await wallet
-    .signAllTransactions(transactions)
-    .catch((error) =>
-      throwFirstPostFailureSimulationErrorOrOriginal({
+  let signedTransactions: VersionedTransaction[];
+  try {
+    signedTransactions = await wallet.signAllTransactions(transactions);
+  } catch (error) {
+    for (const [index, transaction] of transactions.entries()) {
+      const operation = prepared[index];
+      if (!operation) {
+        continue;
+      }
+      const diagnostic = await getSimulationDiagnosticError({
         connection,
-        originalError: error,
-        transactions,
-      })
-    );
+        error,
+        prepared: operation,
+        transaction,
+      });
+      if (diagnostic) {
+        throw diagnostic;
+      }
+    }
+    throw error;
+  }
   if (signedTransactions.length !== prepared.length) {
     throw new Error("Signed transaction count does not match prepared count.");
   }
@@ -217,18 +472,25 @@ export async function sendPreparedBatchWithWallet({
   for (const [index, signedTransaction] of signedTransactions.entries()) {
     const operation = prepared[index];
     if (!operation) {
-      throw new Error("Signed transaction count does not match prepared count.");
+      throw new Error(
+        "Signed transaction count does not match prepared count."
+      );
     }
 
-    const signature = await connection
-      .sendRawTransaction(signedTransaction.serialize(), sendOptions)
-      .catch((error) =>
-        throwPostFailureSimulationErrorOrOriginal({
-          connection,
-          originalError: error,
-          transaction: signedTransaction,
-        })
+    let signature: string;
+    try {
+      signature = await connection.sendRawTransaction(
+        signedTransaction.serialize(),
+        sendOptions
       );
+    } catch (error) {
+      return throwWithSimulationDiagnostic({
+        connection,
+        error,
+        prepared: operation,
+        transaction: signedTransaction,
+      });
+    }
     signatures.push(signature);
     await onTransactionSent?.({
       index,
@@ -237,8 +499,7 @@ export async function sendPreparedBatchWithWallet({
     });
 
     const shouldConfirm =
-      confirm === true ||
-      (confirm !== false && operation.requiresConfirmation);
+      confirm === true || (confirm !== false && operation.requiresConfirmation);
 
     if (shouldConfirm) {
       const confirmation = await connection.confirmTransaction(
@@ -256,9 +517,10 @@ export async function sendPreparedBatchWithWallet({
             confirmation.value.err
           )}`
         );
-        await throwPostFailureSimulationErrorOrOriginal({
+        return throwWithSimulationDiagnostic({
           connection,
-          originalError: error,
+          error,
+          prepared: operation,
           transaction: signedTransaction,
         });
       }

--- a/packages/smart-account-vaults/src/wallet.ts
+++ b/packages/smart-account-vaults/src/wallet.ts
@@ -1,10 +1,106 @@
-import { compilePreparedOperation } from "@loyal-labs/loyal-smart-accounts-core";
+import {
+  SolanaTransactionLogError,
+  compilePreparedOperation,
+  translateAndThrowAnchorError,
+} from "@loyal-labs/loyal-smart-accounts-core";
 import { VersionedTransaction } from "@solana/web3.js";
 import type {
   SendPreparedBatchWithWalletArgs,
   SendPreparedWithWalletArgs,
   WalletAdapterLike,
 } from "./types";
+
+function isInsufficientSolTopUpError(
+  error: unknown
+): error is SolanaTransactionLogError {
+  return (
+    error instanceof SolanaTransactionLogError &&
+    error.message.includes("Top up at least")
+  );
+}
+
+function translateSimulationLogs(
+  logs: readonly string[] | null | undefined
+): SolanaTransactionLogError | null {
+  if (!logs?.length) {
+    return null;
+  }
+
+  try {
+    translateAndThrowAnchorError(
+      Object.assign(new Error("Transaction simulation failed."), {
+        logs: [...logs],
+      })
+    );
+  } catch (error) {
+    return isInsufficientSolTopUpError(error) ? error : null;
+  }
+
+  return null;
+}
+
+async function getPostFailureSimulationError(args: {
+  connection: SendPreparedWithWalletArgs["connection"];
+  transaction: VersionedTransaction;
+}): Promise<SolanaTransactionLogError | null> {
+  try {
+    const simulation = await args.connection.simulateTransaction(
+      args.transaction,
+      {
+        commitment: "confirmed",
+        replaceRecentBlockhash: true,
+        sigVerify: false,
+      }
+    );
+
+    return translateSimulationLogs(simulation.value.logs);
+  } catch {
+    return null;
+  }
+}
+
+async function getFirstPostFailureSimulationError(args: {
+  connection: SendPreparedWithWalletArgs["connection"];
+  transactions: readonly VersionedTransaction[];
+}): Promise<SolanaTransactionLogError | null> {
+  for (const transaction of args.transactions) {
+    const simulationError = await getPostFailureSimulationError({
+      connection: args.connection,
+      transaction,
+    });
+    if (simulationError) {
+      return simulationError;
+    }
+  }
+
+  return null;
+}
+
+async function throwPostFailureSimulationErrorOrOriginal(args: {
+  connection: SendPreparedWithWalletArgs["connection"];
+  originalError: unknown;
+  transaction: VersionedTransaction;
+}): Promise<never> {
+  const simulationError = await getPostFailureSimulationError({
+    connection: args.connection,
+    transaction: args.transaction,
+  });
+
+  throw simulationError ?? args.originalError;
+}
+
+async function throwFirstPostFailureSimulationErrorOrOriginal(args: {
+  connection: SendPreparedWithWalletArgs["connection"];
+  originalError: unknown;
+  transactions: readonly VersionedTransaction[];
+}): Promise<never> {
+  const simulationError = await getFirstPostFailureSimulationError({
+    connection: args.connection,
+    transactions: args.transactions,
+  });
+
+  throw simulationError ?? args.originalError;
+}
 
 async function sendVersionedTransaction(args: {
   wallet: WalletAdapterLike;
@@ -44,7 +140,13 @@ export async function sendPreparedWithWallet({
     connection,
     transaction,
     sendOptions,
-  });
+  }).catch((error) =>
+    throwPostFailureSimulationErrorOrOriginal({
+      connection,
+      originalError: error,
+      transaction,
+    })
+  );
   const shouldConfirm =
     confirm === true || (confirm !== false && prepared.requiresConfirmation);
 
@@ -59,11 +161,16 @@ export async function sendPreparedWithWallet({
     );
 
     if (confirmation.value.err) {
-      throw new Error(
+      const error = new Error(
         `Transaction ${signature} failed to confirm: ${JSON.stringify(
           confirmation.value.err
         )}`
       );
+      await throwPostFailureSimulationErrorOrOriginal({
+        connection,
+        originalError: error,
+        transaction,
+      });
     }
   }
 
@@ -93,7 +200,15 @@ export async function sendPreparedBatchWithWallet({
       blockhash: latestBlockhash.blockhash,
     })
   );
-  const signedTransactions = await wallet.signAllTransactions(transactions);
+  const signedTransactions = await wallet
+    .signAllTransactions(transactions)
+    .catch((error) =>
+      throwFirstPostFailureSimulationErrorOrOriginal({
+        connection,
+        originalError: error,
+        transactions,
+      })
+    );
   if (signedTransactions.length !== prepared.length) {
     throw new Error("Signed transaction count does not match prepared count.");
   }
@@ -105,10 +220,15 @@ export async function sendPreparedBatchWithWallet({
       throw new Error("Signed transaction count does not match prepared count.");
     }
 
-    const signature = await connection.sendRawTransaction(
-      signedTransaction.serialize(),
-      sendOptions
-    );
+    const signature = await connection
+      .sendRawTransaction(signedTransaction.serialize(), sendOptions)
+      .catch((error) =>
+        throwPostFailureSimulationErrorOrOriginal({
+          connection,
+          originalError: error,
+          transaction: signedTransaction,
+        })
+      );
     signatures.push(signature);
     await onTransactionSent?.({
       index,
@@ -131,11 +251,16 @@ export async function sendPreparedBatchWithWallet({
       );
 
       if (confirmation.value.err) {
-        throw new Error(
+        const error = new Error(
           `Transaction ${signature} failed to confirm: ${JSON.stringify(
             confirmation.value.err
           )}`
         );
+        await throwPostFailureSimulationErrorOrOriginal({
+          connection,
+          originalError: error,
+          transaction: signedTransaction,
+        });
       }
     }
 

--- a/sdk/loyal-smart-accounts-core/src/core/transport/index.ts
+++ b/sdk/loyal-smart-accounts-core/src/core/transport/index.ts
@@ -11,6 +11,11 @@ import type {
 import { PROGRAM_ID } from "../generated/index.js";
 import { translateAndThrowAnchorError } from "../errors/index.js";
 
+export type PreparedOperationSimulationDiagnosticsMetadata = Readonly<{
+  kind: string;
+  [key: string]: unknown;
+}>;
+
 export type PreparedLoyalSmartAccountsOperation<Name extends string = string> =
   Readonly<{
     operation: Name;
@@ -19,6 +24,7 @@ export type PreparedLoyalSmartAccountsOperation<Name extends string = string> =
     requiresConfirmation: boolean;
     instructions: readonly TransactionInstruction[];
     lookupTableAccounts: readonly AddressLookupTableAccount[];
+    simulationDiagnostics?: PreparedOperationSimulationDiagnosticsMetadata;
   }>;
 
 export type LoyalSmartAccountsConfirmationContext = {


### PR DESCRIPTION
Adds post-failure simulation for prepared wallet transactions so Earn policy creation can surface exact SOL top-up amounts or Squads MissingAccount policy-PDA diagnostics. Also preserves the original wallet error when simulation is inconclusive.