### PR TITLE
fix(wallet): show simulated swap fees

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -435,6 +435,7 @@
         "@loyal-labs/private-transactions": "workspace:*",
         "@loyal-labs/solana-rpc": "workspace:*",
         "@loyal-labs/solana-wallet": "workspace:*",
+        "buffer": "^6.0.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -5254,9 +5255,19 @@
 
     "@loyal-labs/flags/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
+    "@loyal-labs/private-transactions/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@loyal-labs/shared/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@loyal-labs/solana-rpc/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@loyal-labs/solana-wallet/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@loyal-labs/userbot-worker/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@loyal-labs/userbot-worker/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
+
+    "@loyal-labs/wallet-core/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -6376,9 +6387,19 @@
 
     "@loyal-labs/flags/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "@loyal-labs/private-transactions/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@loyal-labs/shared/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@loyal-labs/solana-rpc/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@loyal-labs/solana-wallet/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@loyal-labs/userbot-worker/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@loyal-labs/userbot-worker/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@loyal-labs/wallet-core/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -12,6 +12,8 @@ import { useSwap } from "@loyal-labs/wallet-core/hooks";
 import type { SwapConfig } from "@loyal-labs/wallet-core/hooks";
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateKey,
+  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
   type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 
@@ -1056,6 +1058,13 @@ export function SwapContent({
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feeEstimateRequestRef = useRef<{
+    key: string;
+    quoteResponse: NonNullable<typeof quoteResponse>;
+    userPublicKey: string;
+    apiKey?: string;
+    baseUrl?: string;
+  } | null>(null);
 
   useEffect(() => {
     onFormActiveChange?.(phase === "form");
@@ -1084,12 +1093,33 @@ export function SwapContent({
   );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
+  const isSameMint = fromToken.mint === toToken.mint;
   const feeUserPublicKey = signer?.publicKey.toBase58() ?? null;
+  const feeEstimateRequest = useMemo(() => {
+    if (!quoteResponse || !feeUserPublicKey) return null;
+    const apiKey = swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined;
+    const baseUrl =
+      swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined;
+    return {
+      key: getJupiterSwapFeeEstimateKey({
+        connection,
+        quoteResponse,
+        userPublicKey: feeUserPublicKey,
+        baseUrl,
+      }),
+      quoteResponse,
+      userPublicKey: feeUserPublicKey,
+      apiKey,
+      baseUrl,
+    };
+  }, [connection, feeUserPublicKey, quoteResponse, swapConfig]);
+  feeEstimateRequestRef.current = feeEstimateRequest;
+  const feeEstimateKey = feeEstimateRequest?.key ?? null;
 
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
-    if (!hasAmount || insufficientFunds || phase !== "form") {
+    if (!hasAmount || insufficientFunds || isSameMint || phase !== "form") {
       resetQuote();
       setIsQuoting(false);
       setFeeEstimateState({ status: "idle" });
@@ -1118,6 +1148,7 @@ export function SwapContent({
     toToken.mint,
     hasAmount,
     insufficientFunds,
+    isSameMint,
     phase,
     getQuote,
     resetQuote,
@@ -1125,31 +1156,41 @@ export function SwapContent({
   ]);
 
   useEffect(() => {
-    if (!quoteResponse || !feeUserPublicKey || phase !== "form") {
+    if (!feeEstimateKey || phase !== "form") {
       setFeeEstimateState({ status: "idle" });
       return;
     }
 
     let cancelled = false;
+    const abortController = new AbortController();
     setFeeEstimateState({ status: "loading" });
 
-    void (async () => {
-      const nextState = await estimateJupiterSwapFeeState({
-        connection,
-        quoteResponse,
-        userPublicKey: feeUserPublicKey,
-        apiKey:
-          swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
-        baseUrl:
-          swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
-      });
-      if (!cancelled) setFeeEstimateState(nextState);
-    })();
+    const timer = setTimeout(() => {
+      const request = feeEstimateRequestRef.current;
+      if (!request || request.key !== feeEstimateKey) {
+        return;
+      }
+      void (async () => {
+        const nextState = await estimateJupiterSwapFeeState({
+          connection,
+          quoteResponse: request.quoteResponse,
+          userPublicKey: request.userPublicKey,
+          apiKey: request.apiKey,
+          baseUrl: request.baseUrl,
+          signal: abortController.signal,
+        });
+        if (!cancelled && !abortController.signal.aborted) {
+          setFeeEstimateState(nextState);
+        }
+      })();
+    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
+      abortController.abort();
     };
-  }, [connection, feeUserPublicKey, phase, quoteResponse, swapConfig]);
+  }, [connection, feeEstimateKey, phase]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -1125,6 +1125,9 @@ export function SwapContent({
       setFeeEstimateState({ status: "idle" });
       return;
     }
+    feeEstimateRequestRef.current = null;
+    resetQuote();
+    setFeeEstimateState({ status: "idle" });
     setIsQuoting(true);
     quoteTimerRef.current = setTimeout(() => {
       void getQuote(

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -12,8 +12,11 @@ import { useSwap } from "@loyal-labs/wallet-core/hooks";
 import type { SwapConfig } from "@loyal-labs/wallet-core/hooks";
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateFlowKey,
   getJupiterSwapFeeEstimateKey,
-  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
+  getSwapFeeEstimateDebounceMs,
+  getSwapFeeEstimateDisplayState,
+  isNonEmptySwapFeeEstimateState,
   type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 
@@ -1058,12 +1061,15 @@ export function SwapContent({
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSuccessfulFeeEstimateStateRef =
+    useRef<SwapFeeEstimateState | null>(null);
+  const feeEstimateFlowKeyRef = useRef<string | null>(null);
   const feeEstimateRequestRef = useRef<{
     key: string;
     quoteResponse: NonNullable<typeof quoteResponse>;
     userPublicKey: string;
-    apiKey?: string;
-    baseUrl?: string;
+    apiKey: string | undefined;
+    baseUrl: string | undefined;
   } | null>(null);
 
   useEffect(() => {
@@ -1115,19 +1121,40 @@ export function SwapContent({
   }, [connection, feeUserPublicKey, quoteResponse, swapConfig]);
   feeEstimateRequestRef.current = feeEstimateRequest;
   const feeEstimateKey = feeEstimateRequest?.key ?? null;
+  const feeEstimateFlowKey = useMemo(() => {
+    const baseUrl =
+      swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined;
+    return getJupiterSwapFeeEstimateFlowKey({
+      inputMint: fromToken.mint,
+      outputMint: toToken.mint,
+      userPublicKey: feeUserPublicKey,
+      baseUrl,
+    });
+  }, [feeUserPublicKey, fromToken.mint, swapConfig, toToken.mint]);
+  const displayFeeEstimateState = getSwapFeeEstimateDisplayState(
+    feeEstimateState,
+    lastSuccessfulFeeEstimateStateRef.current
+  );
 
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     if (!hasAmount || insufficientFunds || isSameMint || phase !== "form") {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       resetQuote();
       setIsQuoting(false);
       setFeeEstimateState({ status: "idle" });
       return;
     }
     feeEstimateRequestRef.current = null;
+    if (feeEstimateFlowKeyRef.current !== feeEstimateFlowKey) {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+    }
     resetQuote();
-    setFeeEstimateState({ status: "idle" });
+    setFeeEstimateState({ status: "loading" });
     setIsQuoting(true);
     quoteTimerRef.current = setTimeout(() => {
       void getQuote(
@@ -1152,6 +1179,7 @@ export function SwapContent({
     hasAmount,
     insufficientFunds,
     isSameMint,
+    feeEstimateFlowKey,
     phase,
     getQuote,
     resetQuote,
@@ -1183,17 +1211,21 @@ export function SwapContent({
           signal: abortController.signal,
         });
         if (!cancelled && !abortController.signal.aborted) {
+          if (isNonEmptySwapFeeEstimateState(nextState)) {
+            lastSuccessfulFeeEstimateStateRef.current = nextState;
+            feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          }
           setFeeEstimateState(nextState);
         }
       })();
-    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
+    }, getSwapFeeEstimateDebounceMs(lastSuccessfulFeeEstimateStateRef.current));
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
       abortController.abort();
     };
-  }, [connection, feeEstimateKey, phase]);
+  }, [connection, feeEstimateFlowKey, feeEstimateKey, phase]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"
@@ -1239,8 +1271,8 @@ export function SwapContent({
     );
     setResultSignature(undefined);
     setResultFeeEstimateState(
-      feeEstimateState.status === "success"
-        ? feeEstimateState
+      displayFeeEstimateState.status === "success"
+        ? displayFeeEstimateState
         : { status: "error", error: "Swap fee unavailable" }
     );
     setErrorMessage(undefined);
@@ -1276,7 +1308,7 @@ export function SwapContent({
     fromToken.symbol,
     numericFrom,
     quote,
-    feeEstimateState,
+    displayFeeEstimateState,
     executeSwap,
     resetQuote,
   ]);
@@ -1791,7 +1823,7 @@ export function SwapContent({
                 </span>
               </div>
               <SwapFeeRows
-                feeEstimateState={feeEstimateState}
+                feeEstimateState={displayFeeEstimateState}
                 solPriceUsd={feeSolPriceUsd}
               />
             </div>

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -120,6 +120,34 @@ function formatLamportsAsSol(lamports: number): string {
   });
 }
 
+function getFeeSolPriceUsd(
+  fromToken: SwapToken,
+  toToken: SwapToken
+): number | null {
+  const solToken = [fromToken, toToken].find(
+    (token) =>
+      token.symbol.toUpperCase() === "SOL" ||
+      token.mint === "So11111111111111111111111111111111111111112"
+  );
+  return solToken && Number.isFinite(solToken.price) && solToken.price > 0
+    ? solToken.price
+    : null;
+}
+
+function formatFeeUsdEstimate(
+  lamports: number,
+  solPriceUsd?: number | null
+): string | null {
+  if (!solPriceUsd || !Number.isFinite(solPriceUsd) || solPriceUsd <= 0) {
+    return null;
+  }
+  const usd = (lamports / 1_000_000_000) * solPriceUsd;
+  return `≈ $${usd.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  })}`;
+}
+
 function SwapStatusHeader({
   fromToken,
   toToken,
@@ -540,18 +568,32 @@ function FeeSkeleton() {
   );
 }
 
-function FeeValue({ lamports }: { lamports: number }) {
+function FeeValue({
+  lamports,
+  solPriceUsd,
+}: {
+  lamports: number;
+  solPriceUsd?: number | null;
+}) {
+  const usdEstimate = formatFeeUsdEstimate(lamports, solPriceUsd);
   return (
-    <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+    <>
+      <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+      {usdEstimate ? (
+        <span style={{ color: secondary }}>{usdEstimate}</span>
+      ) : null}
+    </>
   );
 }
 
 function SwapFeeRows({
   feeEstimateState,
   compact = false,
+  solPriceUsd,
 }: {
   feeEstimateState: SwapFeeEstimateState;
   compact?: boolean;
+  solPriceUsd?: number | null;
 }) {
   const rowPadding = compact ? "9px 12px" : "10px 12px";
   const labelStyle = {
@@ -586,20 +628,32 @@ function SwapFeeRows({
       return (
         <>
           {renderRow(
-            "Network",
-            <FeeValue lamports={estimate.transactionFeeLamports} />
+            "Network Fee",
+            <FeeValue
+              lamports={estimate.transactionFeeLamports}
+              solPriceUsd={solPriceUsd}
+            />
           )}
-          {renderRow("ATA rent", <FeeValue lamports={estimate.rentLamports} />)}
           {renderRow(
-            "Total fee",
-            <FeeValue lamports={estimate.totalLamports} />
+            "Rent Fee",
+            <FeeValue
+              lamports={estimate.rentLamports}
+              solPriceUsd={solPriceUsd}
+            />
+          )}
+          {renderRow(
+            "Total Fee",
+            <FeeValue
+              lamports={estimate.totalLamports}
+              solPriceUsd={solPriceUsd}
+            />
           )}
         </>
       );
     }
     return renderRow(
       "Network Fee",
-      <FeeValue lamports={estimate.totalLamports} />
+      <FeeValue lamports={estimate.totalLamports} solPriceUsd={solPriceUsd} />
     );
   }
 
@@ -629,6 +683,7 @@ function SwapTransactionDetail({
   onClose: () => void;
   onDone: () => void;
 }) {
+  const feeSolPriceUsd = getFeeSolPriceUsd(fromToken, toToken);
   const now = new Date();
   const dateStr = now.toLocaleDateString("en-US", {
     month: "short",
@@ -783,7 +838,11 @@ function SwapTransactionDetail({
                 Completed
               </span>
             </div>
-            <SwapFeeRows compact feeEstimateState={feeEstimateState} />
+            <SwapFeeRows
+              compact
+              feeEstimateState={feeEstimateState}
+              solPriceUsd={feeSolPriceUsd}
+            />
           </div>
         </div>
 
@@ -1003,6 +1062,10 @@ export function SwapContent({
     const val = toAmount * toToken.price;
     return Number.isFinite(val) ? val.toFixed(2) : "0.00";
   }, [toAmount, toToken.price]);
+  const feeSolPriceUsd = useMemo(
+    () => getFeeSolPriceUsd(fromToken, toToken),
+    [fromToken, toToken]
+  );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
   const feeUserPublicKey = signer?.publicKey.toBase58() ?? null;
@@ -1666,7 +1729,10 @@ export function SwapContent({
                   1%
                 </span>
               </div>
-              <SwapFeeRows feeEstimateState={feeEstimateState} />
+              <SwapFeeRows
+                feeEstimateState={feeEstimateState}
+                solPriceUsd={feeSolPriceUsd}
+              />
             </div>
           )}
         </div>

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -122,8 +122,16 @@ function formatLamportsAsSol(lamports: number): string {
 
 function getFeeSolPriceUsd(
   fromToken: SwapToken,
-  toToken: SwapToken
+  toToken: SwapToken,
+  fallbackSolPriceUsd?: number | null
 ): number | null {
+  if (
+    typeof fallbackSolPriceUsd === "number" &&
+    Number.isFinite(fallbackSolPriceUsd) &&
+    fallbackSolPriceUsd > 0
+  ) {
+    return fallbackSolPriceUsd;
+  }
   const solToken = [fromToken, toToken].find(
     (token) =>
       token.symbol.toUpperCase() === "SOL" ||
@@ -673,6 +681,7 @@ function SwapTransactionDetail({
   feeEstimateState,
   onClose,
   onDone,
+  feeSolPriceUsd: feeSolPriceUsdProp,
 }: {
   fromToken: SwapToken;
   toToken: SwapToken;
@@ -682,8 +691,13 @@ function SwapTransactionDetail({
   feeEstimateState: SwapFeeEstimateState;
   onClose: () => void;
   onDone: () => void;
+  feeSolPriceUsd?: number | null;
 }) {
-  const feeSolPriceUsd = getFeeSolPriceUsd(fromToken, toToken);
+  const feeSolPriceUsd = getFeeSolPriceUsd(
+    fromToken,
+    toToken,
+    feeSolPriceUsdProp
+  );
   const now = new Date();
   const dateStr = now.toLocaleDateString("en-US", {
     month: "short",
@@ -997,6 +1011,7 @@ export function SwapContent({
   hideFormChrome,
   onFormActiveChange,
   onFormButtonChange,
+  feeSolPriceUsd: feeSolPriceUsdProp,
 }: {
   onClose: () => void;
   onDone: () => void;
@@ -1010,6 +1025,7 @@ export function SwapContent({
   hideFormChrome?: boolean;
   onFormActiveChange?: (isForm: boolean) => void;
   onFormButtonChange?: (props: FormButtonProps | null) => void;
+  feeSolPriceUsd?: number | null;
 }) {
   const { signer, connection } = useWalletContext();
 
@@ -1063,8 +1079,8 @@ export function SwapContent({
     return Number.isFinite(val) ? val.toFixed(2) : "0.00";
   }, [toAmount, toToken.price]);
   const feeSolPriceUsd = useMemo(
-    () => getFeeSolPriceUsd(fromToken, toToken),
-    [fromToken, toToken]
+    () => getFeeSolPriceUsd(fromToken, toToken, feeSolPriceUsdProp),
+    [fromToken, toToken, feeSolPriceUsdProp]
   );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
@@ -1305,6 +1321,7 @@ export function SwapContent({
           signature={resultSignature}
           toToken={toToken}
           usdValue={resultUsd}
+          feeSolPriceUsd={feeSolPriceUsd}
         />
       );
     }

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -11,10 +11,8 @@ import {
 import { useSwap } from "@loyal-labs/wallet-core/hooks";
 import type { SwapConfig } from "@loyal-labs/wallet-core/hooks";
 import {
-  estimateSwapTransactionFee,
-  getJupiterSwapInstructions,
-  getJupiterSwapTransaction,
-  type SwapFeeEstimate,
+  estimateJupiterSwapFeeState,
+  type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 
 import { SwapShieldTabs } from "~/src/components/wallet/shield-content";
@@ -112,12 +110,6 @@ function TokenPill({
 }
 
 type SwapPhase = "form" | "processing" | "success" | "error" | "details";
-
-type SwapFeeEstimateState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "success"; estimate: SwapFeeEstimate }
-  | { status: "error"; error: string };
 
 const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
 
@@ -1063,49 +1055,16 @@ export function SwapContent({
     setFeeEstimateState({ status: "loading" });
 
     void (async () => {
-      try {
-        const [swapTxResponse, swapInstructions] = await Promise.all([
-          getJupiterSwapTransaction({
-            quoteResponse,
-            userPublicKey: feeUserPublicKey,
-            apiKey:
-              swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
-            baseUrl:
-              swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
-          }),
-          getJupiterSwapInstructions({
-            quoteResponse,
-            userPublicKey: feeUserPublicKey,
-            apiKey:
-              swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
-            baseUrl:
-              swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
-          }).catch(() => undefined),
-        ]);
-        const estimate = await estimateSwapTransactionFee({
-          connection,
-          swapResponse: swapTxResponse,
-          swapInstructions,
-          userPublicKey: feeUserPublicKey,
-        });
-
-        if (cancelled) return;
-        if (estimate.simulation.status === "passed") {
-          setFeeEstimateState({ status: "success", estimate });
-        } else {
-          setFeeEstimateState({
-            status: "error",
-            error: "Swap fee simulation failed",
-          });
-        }
-      } catch (error) {
-        if (cancelled) return;
-        setFeeEstimateState({
-          status: "error",
-          error:
-            error instanceof Error ? error.message : "Swap fee unavailable",
-        });
-      }
+      const nextState = await estimateJupiterSwapFeeState({
+        connection,
+        quoteResponse,
+        userPublicKey: feeUserPublicKey,
+        apiKey:
+          swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
+        baseUrl:
+          swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
+      });
+      if (!cancelled) setFeeEstimateState(nextState);
     })();
 
     return () => {

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -1,8 +1,21 @@
 import { ArrowDownUp, ChevronRight, Globe, Share, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { useSwap } from "@loyal-labs/wallet-core/hooks";
 import type { SwapConfig } from "@loyal-labs/wallet-core/hooks";
+import {
+  estimateSwapTransactionFee,
+  getJupiterSwapInstructions,
+  getJupiterSwapTransaction,
+  type SwapFeeEstimate,
+} from "@loyal-labs/wallet-core/lib";
 
 import { SwapShieldTabs } from "~/src/components/wallet/shield-content";
 import type {
@@ -99,6 +112,21 @@ function TokenPill({
 }
 
 type SwapPhase = "form" | "processing" | "success" | "error" | "details";
+
+type SwapFeeEstimateState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; estimate: SwapFeeEstimate }
+  | { status: "error"; error: string };
+
+const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
+
+function formatLamportsAsSol(lamports: number): string {
+  return (lamports / 1_000_000_000).toLocaleString(undefined, {
+    maximumFractionDigits: 9,
+    minimumFractionDigits: 0,
+  });
+}
 
 function SwapStatusHeader({
   fromToken,
@@ -506,12 +534,97 @@ function SwapResult({
   );
 }
 
+function FeeSkeleton() {
+  return (
+    <span
+      style={{
+        width: "92px",
+        height: "18px",
+        borderRadius: "9px",
+        background: "rgba(60, 60, 67, 0.14)",
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+function FeeValue({ lamports }: { lamports: number }) {
+  return (
+    <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+  );
+}
+
+function SwapFeeRows({
+  feeEstimateState,
+  compact = false,
+}: {
+  feeEstimateState: SwapFeeEstimateState;
+  compact?: boolean;
+}) {
+  const rowPadding = compact ? "9px 12px" : "10px 12px";
+  const labelStyle = {
+    fontFamily: font,
+    fontSize: "13px",
+    fontWeight: 400,
+    lineHeight: "16px",
+    color: secondary,
+    display: "block",
+  } as const;
+  const valueStyle = {
+    display: "flex",
+    gap: "4px",
+    alignItems: "center",
+    fontFamily: font,
+    fontSize: "16px",
+    fontWeight: 400,
+    lineHeight: "20px",
+    marginTop: compact ? "2px" : undefined,
+  } as const;
+
+  const renderRow = (label: string, children: ReactNode) => (
+    <div style={{ padding: rowPadding }}>
+      <span style={labelStyle}>{label}</span>
+      <div style={valueStyle}>{children}</div>
+    </div>
+  );
+
+  if (feeEstimateState.status === "success") {
+    const { estimate } = feeEstimateState;
+    if (estimate.rentLamports > 0) {
+      return (
+        <>
+          {renderRow(
+            "Network",
+            <FeeValue lamports={estimate.transactionFeeLamports} />
+          )}
+          {renderRow("ATA rent", <FeeValue lamports={estimate.rentLamports} />)}
+          {renderRow(
+            "Total fee",
+            <FeeValue lamports={estimate.totalLamports} />
+          )}
+        </>
+      );
+    }
+    return renderRow(
+      "Network Fee",
+      <FeeValue lamports={estimate.totalLamports} />
+    );
+  }
+
+  if (feeEstimateState.status === "error") {
+    return renderRow("Network Fee", <span style={{ color: "#000" }}>-</span>);
+  }
+
+  return renderRow("Network Fee", <FeeSkeleton />);
+}
+
 function SwapTransactionDetail({
   fromToken,
   toToken,
   receivedAmount,
   usdValue,
   signature,
+  feeEstimateState,
   onClose,
   onDone,
 }: {
@@ -520,6 +633,7 @@ function SwapTransactionDetail({
   receivedAmount: string;
   usdValue: string;
   signature?: string;
+  feeEstimateState: SwapFeeEstimateState;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -677,35 +791,7 @@ function SwapTransactionDetail({
                 Completed
               </span>
             </div>
-            <div style={{ padding: "9px 12px" }}>
-              <span
-                style={{
-                  fontFamily: font,
-                  fontSize: "13px",
-                  fontWeight: 400,
-                  lineHeight: "16px",
-                  color: secondary,
-                  display: "block",
-                }}
-              >
-                Network Fee
-              </span>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "4px",
-                  marginTop: "2px",
-                  fontFamily: font,
-                  fontSize: "16px",
-                  fontWeight: 400,
-                  lineHeight: "20px",
-                }}
-              >
-                <span style={{ color: "#000" }}>0.00005 SOL</span>
-                <span style={{ color: secondary }}>≈ $0.00</span>
-              </div>
-            </div>
+            <SwapFeeRows compact feeEstimateState={feeEstimateState} />
           </div>
         </div>
 
@@ -877,24 +963,31 @@ export function SwapContent({
   const { signer, connection } = useWalletContext();
 
   // Jupiter public API does not require a key for basic operations.
-  const swapConfig: SwapConfig = { mode: "enabled", apiKey: "" };
+  const swapConfig = useMemo<SwapConfig>(
+    () => ({ mode: "enabled", apiKey: "" }),
+    []
+  );
 
   const {
     getQuote,
     executeSwap,
     resetQuote,
     quote,
+    quoteResponse,
     isAvailable,
     unavailableReason,
-    error: swapError,
   } = useSwap(signer, connection, swapConfig);
   const [fromAmount, setFromAmount] = useState("");
   const [phase, setPhase] = useState<SwapPhase>("form");
   const [resultAmount, setResultAmount] = useState("");
   const [resultUsd, setResultUsd] = useState("");
   const [resultSignature, setResultSignature] = useState<string | undefined>();
+  const [resultFeeEstimateState, setResultFeeEstimateState] =
+    useState<SwapFeeEstimateState>({ status: "idle" });
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [isQuoting, setIsQuoting] = useState(false);
+  const [feeEstimateState, setFeeEstimateState] =
+    useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -920,6 +1013,7 @@ export function SwapContent({
   }, [toAmount, toToken.price]);
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
+  const feeUserPublicKey = signer?.publicKey.toBase58() ?? null;
 
   // Debounced quote fetching
   useEffect(() => {
@@ -927,6 +1021,7 @@ export function SwapContent({
     if (!hasAmount || insufficientFunds || phase !== "form") {
       resetQuote();
       setIsQuoting(false);
+      setFeeEstimateState({ status: "idle" });
       return;
     }
     setIsQuoting(true);
@@ -957,6 +1052,66 @@ export function SwapContent({
     resetQuote,
     numericFrom,
   ]);
+
+  useEffect(() => {
+    if (!quoteResponse || !feeUserPublicKey || phase !== "form") {
+      setFeeEstimateState({ status: "idle" });
+      return;
+    }
+
+    let cancelled = false;
+    setFeeEstimateState({ status: "loading" });
+
+    void (async () => {
+      try {
+        const [swapTxResponse, swapInstructions] = await Promise.all([
+          getJupiterSwapTransaction({
+            quoteResponse,
+            userPublicKey: feeUserPublicKey,
+            apiKey:
+              swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
+            baseUrl:
+              swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
+          }),
+          getJupiterSwapInstructions({
+            quoteResponse,
+            userPublicKey: feeUserPublicKey,
+            apiKey:
+              swapConfig.mode === "enabled" ? swapConfig.apiKey : undefined,
+            baseUrl:
+              swapConfig.mode === "enabled" ? swapConfig.baseUrl : undefined,
+          }).catch(() => undefined),
+        ]);
+        const estimate = await estimateSwapTransactionFee({
+          connection,
+          swapResponse: swapTxResponse,
+          swapInstructions,
+          userPublicKey: feeUserPublicKey,
+        });
+
+        if (cancelled) return;
+        if (estimate.simulation.status === "passed") {
+          setFeeEstimateState({ status: "success", estimate });
+        } else {
+          setFeeEstimateState({
+            status: "error",
+            error: "Swap fee simulation failed",
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setFeeEstimateState({
+          status: "error",
+          error:
+            error instanceof Error ? error.message : "Swap fee unavailable",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connection, feeUserPublicKey, phase, quoteResponse, swapConfig]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"
@@ -1001,6 +1156,11 @@ export function SwapContent({
       }`
     );
     setResultSignature(undefined);
+    setResultFeeEstimateState(
+      feeEstimateState.status === "success"
+        ? feeEstimateState
+        : { status: "error", error: "Swap fee unavailable" }
+    );
     setErrorMessage(undefined);
     setPhase("processing");
 
@@ -1034,6 +1194,7 @@ export function SwapContent({
     fromToken.symbol,
     numericFrom,
     quote,
+    feeEstimateState,
     executeSwap,
     resetQuote,
   ]);
@@ -1072,12 +1233,19 @@ export function SwapContent({
     (pct: number) => {
       let val =
         pct === 100 ? fromToken.balance : fromToken.balance * (pct / 100);
-      if (fromToken.symbol.toUpperCase() === "SOL" && fromToken.balance - val < 0.00005) {
-        val = Math.max(0, fromToken.balance - 0.00005);
+      const feeReserveSol =
+        feeEstimateState.status === "success"
+          ? feeEstimateState.estimate.totalLamports / 1_000_000_000
+          : DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS / 1_000_000_000;
+      if (
+        fromToken.symbol.toUpperCase() === "SOL" &&
+        fromToken.balance - val < feeReserveSol
+      ) {
+        val = Math.max(0, fromToken.balance - feeReserveSol);
       }
       setFromAmount(val > 0 ? String(Number(val.toFixed(6))) : "");
     },
-    [fromToken.balance, fromToken.symbol]
+    [feeEstimateState, fromToken.balance, fromToken.symbol]
   );
 
   const renderPhaseContent = (p: SwapPhase) => {
@@ -1107,6 +1275,7 @@ export function SwapContent({
     if (p === "details") {
       return (
         <SwapTransactionDetail
+          feeEstimateState={resultFeeEstimateState}
           fromToken={fromToken}
           onClose={onClose}
           onDone={onDone}
@@ -1538,35 +1707,7 @@ export function SwapContent({
                   1%
                 </span>
               </div>
-              <div style={{ padding: "10px 12px" }}>
-                <span
-                  style={{
-                    fontFamily: font,
-                    fontSize: "13px",
-                    fontWeight: 400,
-                    lineHeight: "16px",
-                    color: secondary,
-                    display: "block",
-                  }}
-                >
-                  Network Fee
-                </span>
-                <div
-                  style={{
-                    display: "flex",
-                    gap: "4px",
-                    alignItems: "center",
-                    fontFamily: font,
-                    fontSize: "16px",
-                    fontWeight: 400,
-                    lineHeight: "20px",
-                    marginTop: "2px",
-                  }}
-                >
-                  <span style={{ color: "#000" }}>0.00005 SOL</span>
-                  <span style={{ color: secondary }}>≈ $0.00</span>
-                </div>
-              </div>
+              <SwapFeeRows feeEstimateState={feeEstimateState} />
             </div>
           )}
         </div>

--- a/extension/src/components/wallet/swap-content.tsx
+++ b/extension/src/components/wallet/swap-content.tsx
@@ -1148,6 +1148,7 @@ export function SwapContent({
       setFeeEstimateState({ status: "idle" });
       return;
     }
+    let cancelled = false;
     feeEstimateRequestRef.current = null;
     if (feeEstimateFlowKeyRef.current !== feeEstimateFlowKey) {
       lastSuccessfulFeeEstimateStateRef.current = null;
@@ -1165,9 +1166,21 @@ export function SwapContent({
         undefined,
         undefined,
         toToken.mint
-      ).finally(() => setIsQuoting(false));
+      )
+        .then((nextQuote) => {
+          if (cancelled) return;
+          if (nextQuote) return;
+          lastSuccessfulFeeEstimateStateRef.current = null;
+          feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          feeEstimateRequestRef.current = null;
+          setFeeEstimateState({ status: "idle" });
+        })
+        .finally(() => {
+          if (!cancelled) setIsQuoting(false);
+        });
     }, 500);
     return () => {
+      cancelled = true;
       if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     };
   }, [

--- a/extension/src/components/wallet/wallet-app.tsx
+++ b/extension/src/components/wallet/wallet-app.tsx
@@ -82,6 +82,16 @@ const SOL_TOKEN: SwapToken = {
   balance: 0,
 };
 
+function findSolPriceUsd(tokens: SwapToken[]): number | null {
+  const solToken = tokens.find(
+    (token) =>
+      token.symbol.toUpperCase() === "SOL" || token.mint === SOL_TOKEN.mint
+  );
+  return solToken && Number.isFinite(solToken.price) && solToken.price > 0
+    ? solToken.price
+    : null;
+}
+
 // ---------------------------------------------------------------------------
 // Tab definitions
 // ---------------------------------------------------------------------------
@@ -1397,6 +1407,10 @@ function WalletInterface() {
     );
     return [...swapTokens, ...extras];
   }, [swapTokens, popularTokens]);
+  const swapFeeSolPriceUsd = useMemo(
+    () => findSolPriceUsd(swapTargetTokens),
+    [swapTargetTokens]
+  );
 
   // Sync token state when real positions load
   useEffect(() => {
@@ -1536,6 +1550,7 @@ function WalletInterface() {
             onDone={handleDone}
             swapMode={swapMode}
             onSwapModeChange={handleSwapModeChange}
+            feeSolPriceUsd={swapFeeSolPriceUsd}
           />
         );
       case "shield":

--- a/frontend/src/components/wallet-sidebar/index.tsx
+++ b/frontend/src/components/wallet-sidebar/index.tsx
@@ -59,6 +59,18 @@ import { LOYL_TOKEN, swapTokens as fallbackSwapTokens } from "./types";
 
 export type { RightSidebarTab } from "./types";
 
+const NATIVE_SOL_MINT = "So11111111111111111111111111111111111111112";
+
+function findSolPriceUsd(tokens: SwapToken[]): number | null {
+  const solToken = tokens.find(
+    (token) =>
+      token.symbol.toUpperCase() === "SOL" || token.mint === NATIVE_SOL_MINT
+  );
+  return solToken && Number.isFinite(solToken.price) && solToken.price > 0
+    ? solToken.price
+    : null;
+}
+
 export interface HeroRightSidebarProps {
   isOpen: boolean;
   activeTab: RightSidebarTab;
@@ -271,6 +283,14 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
     );
     return [...selectedVaultSwapTokens, ...extras];
   }, [popularTokens, selectedVaultSwapTokens]);
+  const mainSwapFeeSolPriceUsd = useMemo(
+    () => findSolPriceUsd(swapTargetTokens),
+    [swapTargetTokens]
+  );
+  const vaultSwapFeeSolPriceUsd = useMemo(
+    () => findSolPriceUsd(vaultSwapTargetTokens) ?? mainSwapFeeSolPriceUsd,
+    [mainSwapFeeSolPriceUsd, vaultSwapTargetTokens]
+  );
   const executeVaultSwap = props.smartAccountData.executeVaultSwap;
   const selectedVaultSwapExecutionContext = useMemo<
     SwapExecutionContext | undefined
@@ -965,6 +985,11 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
                 onSwapModeChange={handleSwapModeChange}
                 onToTokenChange={setSwapToToken}
                 executionContext={vaultSwapExecutionContext}
+                feeSolPriceUsd={
+                  isVaultSubview
+                    ? vaultSwapFeeSolPriceUsd
+                    : mainSwapFeeSolPriceUsd
+                }
                 swapMode={swapMode}
                 toToken={swapToToken}
               />
@@ -1378,6 +1403,7 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
                         onNavigate={pushView}
                         onSwapModeChange={handleSwapModeChange}
                         onToTokenChange={setSwapToToken}
+                        feeSolPriceUsd={mainSwapFeeSolPriceUsd}
                         swapMode={swapMode}
                         toToken={swapToToken}
                       />

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -125,8 +125,16 @@ function formatLamportsAsSol(lamports: number): string {
 
 function getFeeSolPriceUsd(
   fromToken: SwapToken,
-  toToken: SwapToken
+  toToken: SwapToken,
+  fallbackSolPriceUsd?: number | null
 ): number | null {
+  if (
+    typeof fallbackSolPriceUsd === "number" &&
+    Number.isFinite(fallbackSolPriceUsd) &&
+    fallbackSolPriceUsd > 0
+  ) {
+    return fallbackSolPriceUsd;
+  }
   const solToken = [fromToken, toToken].find(
     (token) =>
       token.symbol.toUpperCase() === "SOL" ||
@@ -712,6 +720,7 @@ function SwapTransactionDetail({
   onClose,
   onDone,
   onBack,
+  feeSolPriceUsd: feeSolPriceUsdProp,
 }: {
   fromToken: SwapToken;
   toToken: SwapToken;
@@ -722,9 +731,14 @@ function SwapTransactionDetail({
   onClose: () => void;
   onDone: () => void;
   onBack?: () => void;
+  feeSolPriceUsd?: number | null;
 }) {
   const publicEnv = usePublicEnv();
-  const feeSolPriceUsd = getFeeSolPriceUsd(fromToken, toToken);
+  const feeSolPriceUsd = getFeeSolPriceUsd(
+    fromToken,
+    toToken,
+    feeSolPriceUsdProp
+  );
   const now = new Date();
   const dateStr = now.toLocaleDateString("en-US", {
     month: "short",
@@ -1042,6 +1056,7 @@ export function SwapContent({
   onFormActiveChange,
   onFormButtonChange,
   executionContext,
+  feeSolPriceUsd: feeSolPriceUsdProp,
 }: {
   onClose: () => void;
   onDone: () => void;
@@ -1057,6 +1072,7 @@ export function SwapContent({
   onFormActiveChange?: (isForm: boolean) => void;
   onFormButtonChange?: (props: FormButtonProps | null) => void;
   executionContext?: SwapExecutionContext;
+  feeSolPriceUsd?: number | null;
 }) {
   const { connection } = useConnection();
   const publicEnv = usePublicEnv();
@@ -1107,8 +1123,8 @@ export function SwapContent({
     return Number.isFinite(val) ? val.toFixed(2) : "0.00";
   }, [toAmount, toToken.price]);
   const feeSolPriceUsd = useMemo(
-    () => getFeeSolPriceUsd(fromToken, toToken),
-    [fromToken, toToken]
+    () => getFeeSolPriceUsd(fromToken, toToken, feeSolPriceUsdProp),
+    [fromToken, toToken, feeSolPriceUsdProp]
   );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
@@ -1391,6 +1407,7 @@ export function SwapContent({
           signature={resultSignature}
           toToken={toToken}
           usdValue={resultUsd}
+          feeSolPriceUsd={feeSolPriceUsd}
         />
       );
     }

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import {
-  estimateSwapTransactionFee,
-  getJupiterSwapInstructions,
-  getJupiterSwapTransaction,
-  type SwapFeeEstimate,
+  estimateJupiterSwapFeeState,
+  type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 import { useConnection } from "@solana/wallet-adapter-react";
 import {
@@ -115,12 +113,6 @@ function TokenPill({
 }
 
 type SwapPhase = "form" | "processing" | "success" | "error" | "details";
-
-type SwapFeeEstimateState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "success"; estimate: SwapFeeEstimate }
-  | { status: "error"; error: string };
 
 const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
 
@@ -1115,45 +1107,14 @@ export function SwapContent({
     setFeeEstimateState({ status: "loading" });
 
     void (async () => {
-      try {
-        const [swapTxResponse, swapInstructions] = await Promise.all([
-          getJupiterSwapTransaction({
-            quoteResponse,
-            userPublicKey: feeUserPublicKey,
-            apiKey: swapApiKey,
-            baseUrl: swapApiBaseUrl,
-          }),
-          getJupiterSwapInstructions({
-            quoteResponse,
-            userPublicKey: feeUserPublicKey,
-            apiKey: swapApiKey,
-            baseUrl: swapApiBaseUrl,
-          }).catch(() => undefined),
-        ]);
-        const estimate = await estimateSwapTransactionFee({
-          connection,
-          swapResponse: swapTxResponse,
-          swapInstructions,
-          userPublicKey: feeUserPublicKey,
-        });
-
-        if (cancelled) return;
-        if (estimate.simulation.status === "passed") {
-          setFeeEstimateState({ status: "success", estimate });
-        } else {
-          setFeeEstimateState({
-            status: "error",
-            error: "Swap fee simulation failed",
-          });
-        }
-      } catch (error) {
-        if (cancelled) return;
-        setFeeEstimateState({
-          status: "error",
-          error:
-            error instanceof Error ? error.message : "Swap fee unavailable",
-        });
-      }
+      const nextState = await estimateJupiterSwapFeeState({
+        connection,
+        quoteResponse,
+        userPublicKey: feeUserPublicKey,
+        apiKey: swapApiKey,
+        baseUrl: swapApiBaseUrl,
+      });
+      if (!cancelled) setFeeEstimateState(nextState);
     })();
 
     return () => {

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -1180,6 +1180,9 @@ export function SwapContent({
       setFeeEstimateState({ status: "idle" });
       return;
     }
+    feeEstimateRequestRef.current = null;
+    resetQuote();
+    setFeeEstimateState({ status: "idle" });
     setIsQuoting(true);
     quoteTimerRef.current = setTimeout(() => {
       void getQuote(

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -2,8 +2,11 @@
 
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateFlowKey,
   getJupiterSwapFeeEstimateKey,
-  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
+  getSwapFeeEstimateDebounceMs,
+  getSwapFeeEstimateDisplayState,
+  isNonEmptySwapFeeEstimateState,
   type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 import { useConnection } from "@solana/wallet-adapter-react";
@@ -1102,12 +1105,15 @@ export function SwapContent({
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSuccessfulFeeEstimateStateRef =
+    useRef<SwapFeeEstimateState | null>(null);
+  const feeEstimateFlowKeyRef = useRef<string | null>(null);
   const feeEstimateRequestRef = useRef<{
     key: string;
     quoteResponse: NonNullable<typeof quoteResponse>;
     userPublicKey: string;
-    apiKey?: string;
-    baseUrl?: string;
+    apiKey: string | undefined;
+    baseUrl: string | undefined;
   } | null>(null);
 
   useEffect(() => {
@@ -1170,19 +1176,40 @@ export function SwapContent({
   ]);
   feeEstimateRequestRef.current = feeEstimateRequest;
   const feeEstimateKey = feeEstimateRequest?.key ?? null;
+  const feeEstimateFlowKey = useMemo(
+    () =>
+      getJupiterSwapFeeEstimateFlowKey({
+        inputMint: fromToken.mint,
+        outputMint: toToken.mint,
+        userPublicKey: feeUserPublicKey,
+        baseUrl: swapApiBaseUrl,
+      }),
+    [feeUserPublicKey, fromToken.mint, swapApiBaseUrl, toToken.mint]
+  );
+  const displayFeeEstimateState = getSwapFeeEstimateDisplayState(
+    feeEstimateState,
+    lastSuccessfulFeeEstimateStateRef.current
+  );
 
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     if (!hasAmount || insufficientFunds || isSameMint || phase !== "form") {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       resetQuote();
       setIsQuoting(false);
       setFeeEstimateState({ status: "idle" });
       return;
     }
     feeEstimateRequestRef.current = null;
+    if (feeEstimateFlowKeyRef.current !== feeEstimateFlowKey) {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+    }
     resetQuote();
-    setFeeEstimateState({ status: "idle" });
+    setFeeEstimateState({ status: "loading" });
     setIsQuoting(true);
     quoteTimerRef.current = setTimeout(() => {
       void getQuote(
@@ -1207,6 +1234,7 @@ export function SwapContent({
     hasAmount,
     insufficientFunds,
     isSameMint,
+    feeEstimateFlowKey,
     phase,
     getQuote,
     resetQuote,
@@ -1238,17 +1266,21 @@ export function SwapContent({
           signal: abortController.signal,
         });
         if (!cancelled && !abortController.signal.aborted) {
+          if (isNonEmptySwapFeeEstimateState(nextState)) {
+            lastSuccessfulFeeEstimateStateRef.current = nextState;
+            feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          }
           setFeeEstimateState(nextState);
         }
       })();
-    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
+    }, getSwapFeeEstimateDebounceMs(lastSuccessfulFeeEstimateStateRef.current));
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
       abortController.abort();
     };
-  }, [connection, feeEstimateKey, phase]);
+  }, [connection, feeEstimateFlowKey, feeEstimateKey, phase]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"
@@ -1309,8 +1341,8 @@ export function SwapContent({
     setResultUsd(completedUsd);
     setResultSignature(undefined);
     setResultFeeEstimateState(
-      feeEstimateState.status === "success"
-        ? feeEstimateState
+      displayFeeEstimateState.status === "success"
+        ? displayFeeEstimateState
         : { status: "error", error: "Swap fee unavailable" }
     );
     setErrorMessage(undefined);
@@ -1341,7 +1373,7 @@ export function SwapContent({
   }, [
     executeSwap,
     executionContext,
-    feeEstimateState,
+    displayFeeEstimateState,
     fromAmount,
     fromToken.mint,
     fromToken.symbol,
@@ -1874,7 +1906,7 @@ export function SwapContent({
                 </span>
               </div>
               <SwapFeeRows
-                feeEstimateState={feeEstimateState}
+                feeEstimateState={displayFeeEstimateState}
                 solPriceUsd={feeSolPriceUsd}
               />
             </div>

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -1203,6 +1203,7 @@ export function SwapContent({
       setFeeEstimateState({ status: "idle" });
       return;
     }
+    let cancelled = false;
     feeEstimateRequestRef.current = null;
     if (feeEstimateFlowKeyRef.current !== feeEstimateFlowKey) {
       lastSuccessfulFeeEstimateStateRef.current = null;
@@ -1220,9 +1221,21 @@ export function SwapContent({
         undefined,
         undefined,
         toToken.mint
-      ).finally(() => setIsQuoting(false));
+      )
+        .then((nextQuote) => {
+          if (cancelled) return;
+          if (nextQuote) return;
+          lastSuccessfulFeeEstimateStateRef.current = null;
+          feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          feeEstimateRequestRef.current = null;
+          setFeeEstimateState({ status: "idle" });
+        })
+        .finally(() => {
+          if (!cancelled) setIsQuoting(false);
+        });
     }, 500);
     return () => {
+      cancelled = true;
       if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
     };
   }, [

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -2,6 +2,8 @@
 
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateKey,
+  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
   type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 import { useConnection } from "@solana/wallet-adapter-react";
@@ -1100,6 +1102,13 @@ export function SwapContent({
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feeEstimateRequestRef = useRef<{
+    key: string;
+    quoteResponse: NonNullable<typeof quoteResponse>;
+    userPublicKey: string;
+    apiKey?: string;
+    baseUrl?: string;
+  } | null>(null);
 
   useEffect(() => {
     onFormActiveChange?.(phase === "form");
@@ -1128,6 +1137,7 @@ export function SwapContent({
   );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
+  const isSameMint = fromToken.mint === toToken.mint;
   const feeUserPublicKey = useMemo(() => {
     const contextKey = executionContext?.userPublicKey;
     if (contextKey) {
@@ -1137,11 +1147,34 @@ export function SwapContent({
     }
     return userPublicKey?.toBase58() ?? null;
   }, [executionContext?.userPublicKey, userPublicKey]);
+  const feeEstimateRequest = useMemo(() => {
+    if (!quoteResponse || !feeUserPublicKey) return null;
+    return {
+      key: getJupiterSwapFeeEstimateKey({
+        connection,
+        quoteResponse,
+        userPublicKey: feeUserPublicKey,
+        baseUrl: swapApiBaseUrl,
+      }),
+      quoteResponse,
+      userPublicKey: feeUserPublicKey,
+      apiKey: swapApiKey,
+      baseUrl: swapApiBaseUrl,
+    };
+  }, [
+    connection,
+    feeUserPublicKey,
+    quoteResponse,
+    swapApiBaseUrl,
+    swapApiKey,
+  ]);
+  feeEstimateRequestRef.current = feeEstimateRequest;
+  const feeEstimateKey = feeEstimateRequest?.key ?? null;
 
   // Debounced quote fetching
   useEffect(() => {
     if (quoteTimerRef.current) clearTimeout(quoteTimerRef.current);
-    if (!hasAmount || insufficientFunds || phase !== "form") {
+    if (!hasAmount || insufficientFunds || isSameMint || phase !== "form") {
       resetQuote();
       setIsQuoting(false);
       setFeeEstimateState({ status: "idle" });
@@ -1170,6 +1203,7 @@ export function SwapContent({
     toToken.mint,
     hasAmount,
     insufficientFunds,
+    isSameMint,
     phase,
     getQuote,
     resetQuote,
@@ -1177,36 +1211,41 @@ export function SwapContent({
   ]);
 
   useEffect(() => {
-    if (!quoteResponse || !feeUserPublicKey || phase !== "form") {
+    if (!feeEstimateKey || phase !== "form") {
       setFeeEstimateState({ status: "idle" });
       return;
     }
 
     let cancelled = false;
+    const abortController = new AbortController();
     setFeeEstimateState({ status: "loading" });
 
-    void (async () => {
-      const nextState = await estimateJupiterSwapFeeState({
-        connection,
-        quoteResponse,
-        userPublicKey: feeUserPublicKey,
-        apiKey: swapApiKey,
-        baseUrl: swapApiBaseUrl,
-      });
-      if (!cancelled) setFeeEstimateState(nextState);
-    })();
+    const timer = setTimeout(() => {
+      const request = feeEstimateRequestRef.current;
+      if (!request || request.key !== feeEstimateKey) {
+        return;
+      }
+      void (async () => {
+        const nextState = await estimateJupiterSwapFeeState({
+          connection,
+          quoteResponse: request.quoteResponse,
+          userPublicKey: request.userPublicKey,
+          apiKey: request.apiKey,
+          baseUrl: request.baseUrl,
+          signal: abortController.signal,
+        });
+        if (!cancelled && !abortController.signal.aborted) {
+          setFeeEstimateState(nextState);
+        }
+      })();
+    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
+      abortController.abort();
     };
-  }, [
-    connection,
-    feeUserPublicKey,
-    phase,
-    quoteResponse,
-    swapApiBaseUrl,
-    swapApiKey,
-  ]);
+  }, [connection, feeEstimateKey, phase]);
 
   const buttonLabel = !isAvailable
     ? unavailableReason ?? "Swap unavailable"

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import {
+  estimateSwapTransactionFee,
+  getJupiterSwapInstructions,
+  getJupiterSwapTransaction,
+  type SwapFeeEstimate,
+} from "@loyal-labs/wallet-core/lib";
+import { useConnection } from "@solana/wallet-adapter-react";
+import {
   ArrowDownUp,
   ArrowLeft,
   ChevronRight,
@@ -9,7 +16,14 @@ import {
   X,
 } from "lucide-react";
 import Image from "next/image";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { useSwap, type SwapExecutionContext } from "@/hooks/use-swap";
@@ -101,6 +115,21 @@ function TokenPill({
 }
 
 type SwapPhase = "form" | "processing" | "success" | "error" | "details";
+
+type SwapFeeEstimateState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; estimate: SwapFeeEstimate }
+  | { status: "error"; error: string };
+
+const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
+
+function formatLamportsAsSol(lamports: number): string {
+  return (lamports / 1_000_000_000).toLocaleString(undefined, {
+    maximumFractionDigits: 9,
+    minimumFractionDigits: 0,
+  });
+}
 
 function SwapStatusHeader({
   fromToken,
@@ -543,12 +572,97 @@ function SwapResult({
   );
 }
 
+function FeeSkeleton() {
+  return (
+    <span
+      style={{
+        width: "92px",
+        height: "18px",
+        borderRadius: "9px",
+        background: "rgba(60, 60, 67, 0.14)",
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+function FeeValue({ lamports }: { lamports: number }) {
+  return (
+    <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+  );
+}
+
+function SwapFeeRows({
+  feeEstimateState,
+  compact = false,
+}: {
+  feeEstimateState: SwapFeeEstimateState;
+  compact?: boolean;
+}) {
+  const rowPadding = compact ? "9px 12px" : "10px 12px";
+  const labelStyle = {
+    fontFamily: font,
+    fontSize: "13px",
+    fontWeight: 400,
+    lineHeight: "16px",
+    color: secondary,
+    display: "block",
+  } as const;
+  const valueStyle = {
+    display: "flex",
+    gap: "4px",
+    alignItems: "center",
+    fontFamily: font,
+    fontSize: "16px",
+    fontWeight: 400,
+    lineHeight: "20px",
+    marginTop: compact ? "2px" : undefined,
+  } as const;
+
+  const renderRow = (label: string, children: ReactNode) => (
+    <div style={{ padding: rowPadding }}>
+      <span style={labelStyle}>{label}</span>
+      <div style={valueStyle}>{children}</div>
+    </div>
+  );
+
+  if (feeEstimateState.status === "success") {
+    const { estimate } = feeEstimateState;
+    if (estimate.rentLamports > 0) {
+      return (
+        <>
+          {renderRow(
+            "Network",
+            <FeeValue lamports={estimate.transactionFeeLamports} />
+          )}
+          {renderRow("ATA rent", <FeeValue lamports={estimate.rentLamports} />)}
+          {renderRow(
+            "Total fee",
+            <FeeValue lamports={estimate.totalLamports} />
+          )}
+        </>
+      );
+    }
+    return renderRow(
+      "Network Fee",
+      <FeeValue lamports={estimate.totalLamports} />
+    );
+  }
+
+  if (feeEstimateState.status === "error") {
+    return renderRow("Network Fee", <span style={{ color: "#000" }}>-</span>);
+  }
+
+  return renderRow("Network Fee", <FeeSkeleton />);
+}
+
 function SwapTransactionDetail({
   fromToken,
   toToken,
   receivedAmount,
   usdValue,
   signature,
+  feeEstimateState,
   onClose,
   onDone,
   onBack,
@@ -558,6 +672,7 @@ function SwapTransactionDetail({
   receivedAmount: string;
   usdValue: string;
   signature?: string;
+  feeEstimateState: SwapFeeEstimateState;
   onClose: () => void;
   onDone: () => void;
   onBack?: () => void;
@@ -719,35 +834,7 @@ function SwapTransactionDetail({
                 Completed
               </span>
             </div>
-            <div style={{ padding: "9px 12px" }}>
-              <span
-                style={{
-                  fontFamily: font,
-                  fontSize: "13px",
-                  fontWeight: 400,
-                  lineHeight: "16px",
-                  color: secondary,
-                  display: "block",
-                }}
-              >
-                Network Fee
-              </span>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "4px",
-                  marginTop: "2px",
-                  fontFamily: font,
-                  fontSize: "16px",
-                  fontWeight: 400,
-                  lineHeight: "20px",
-                }}
-              >
-                <span style={{ color: "#000" }}>0.00005 SOL</span>
-                <span style={{ color: secondary }}>≈ $0.00</span>
-              </div>
-            </div>
+            <SwapFeeRows compact feeEstimateState={feeEstimateState} />
           </div>
         </div>
 
@@ -920,23 +1007,31 @@ export function SwapContent({
   onFormButtonChange?: (props: FormButtonProps | null) => void;
   executionContext?: SwapExecutionContext;
 }) {
+  const { connection } = useConnection();
   const publicEnv = usePublicEnv();
   const {
     getQuote,
     executeSwap,
     resetQuote,
     quote,
+    quoteResponse,
+    userPublicKey,
+    swapApiBaseUrl,
+    swapApiKey,
     isAvailable,
     unavailableReason,
-    error: swapError,
   } = useSwap();
   const [fromAmount, setFromAmount] = useState("");
   const [phase, setPhase] = useState<SwapPhase>("form");
   const [resultAmount, setResultAmount] = useState("");
   const [resultUsd, setResultUsd] = useState("");
   const [resultSignature, setResultSignature] = useState<string | undefined>();
+  const [resultFeeEstimateState, setResultFeeEstimateState] =
+    useState<SwapFeeEstimateState>({ status: "idle" });
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [isQuoting, setIsQuoting] = useState(false);
+  const [feeEstimateState, setFeeEstimateState] =
+    useState<SwapFeeEstimateState>({ status: "idle" });
   const quoteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -962,6 +1057,15 @@ export function SwapContent({
   }, [toAmount, toToken.price]);
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
+  const feeUserPublicKey = useMemo(() => {
+    const contextKey = executionContext?.userPublicKey;
+    if (contextKey) {
+      return typeof contextKey === "string"
+        ? contextKey
+        : contextKey.toBase58();
+    }
+    return userPublicKey?.toBase58() ?? null;
+  }, [executionContext?.userPublicKey, userPublicKey]);
 
   // Debounced quote fetching
   useEffect(() => {
@@ -969,6 +1073,7 @@ export function SwapContent({
     if (!hasAmount || insufficientFunds || phase !== "form") {
       resetQuote();
       setIsQuoting(false);
+      setFeeEstimateState({ status: "idle" });
       return;
     }
     setIsQuoting(true);
@@ -998,6 +1103,69 @@ export function SwapContent({
     getQuote,
     resetQuote,
     numericFrom,
+  ]);
+
+  useEffect(() => {
+    if (!quoteResponse || !feeUserPublicKey || phase !== "form") {
+      setFeeEstimateState({ status: "idle" });
+      return;
+    }
+
+    let cancelled = false;
+    setFeeEstimateState({ status: "loading" });
+
+    void (async () => {
+      try {
+        const [swapTxResponse, swapInstructions] = await Promise.all([
+          getJupiterSwapTransaction({
+            quoteResponse,
+            userPublicKey: feeUserPublicKey,
+            apiKey: swapApiKey,
+            baseUrl: swapApiBaseUrl,
+          }),
+          getJupiterSwapInstructions({
+            quoteResponse,
+            userPublicKey: feeUserPublicKey,
+            apiKey: swapApiKey,
+            baseUrl: swapApiBaseUrl,
+          }).catch(() => undefined),
+        ]);
+        const estimate = await estimateSwapTransactionFee({
+          connection,
+          swapResponse: swapTxResponse,
+          swapInstructions,
+          userPublicKey: feeUserPublicKey,
+        });
+
+        if (cancelled) return;
+        if (estimate.simulation.status === "passed") {
+          setFeeEstimateState({ status: "success", estimate });
+        } else {
+          setFeeEstimateState({
+            status: "error",
+            error: "Swap fee simulation failed",
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setFeeEstimateState({
+          status: "error",
+          error:
+            error instanceof Error ? error.message : "Swap fee unavailable",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    connection,
+    feeUserPublicKey,
+    phase,
+    quoteResponse,
+    swapApiBaseUrl,
+    swapApiKey,
   ]);
 
   const buttonLabel = !isAvailable
@@ -1058,6 +1226,11 @@ export function SwapContent({
     setResultAmount(completedAmount);
     setResultUsd(completedUsd);
     setResultSignature(undefined);
+    setResultFeeEstimateState(
+      feeEstimateState.status === "success"
+        ? feeEstimateState
+        : { status: "error", error: "Swap fee unavailable" }
+    );
     setErrorMessage(undefined);
     setPhase("processing");
 
@@ -1086,6 +1259,7 @@ export function SwapContent({
   }, [
     executeSwap,
     executionContext,
+    feeEstimateState,
     fromAmount,
     fromToken.mint,
     fromToken.symbol,
@@ -1140,15 +1314,19 @@ export function SwapContent({
     (pct: number) => {
       let val =
         pct === 100 ? fromToken.balance : fromToken.balance * (pct / 100);
+      const feeReserveSol =
+        feeEstimateState.status === "success"
+          ? feeEstimateState.estimate.totalLamports / 1_000_000_000
+          : DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS / 1_000_000_000;
       if (
         fromToken.symbol.toUpperCase() === "SOL" &&
-        fromToken.balance - val < 0.00005
+        fromToken.balance - val < feeReserveSol
       ) {
-        val = Math.max(0, fromToken.balance - 0.00005);
+        val = Math.max(0, fromToken.balance - feeReserveSol);
       }
       setFromAmount(val > 0 ? String(Number(val.toFixed(6))) : "");
     },
-    [fromToken.balance, fromToken.symbol]
+    [feeEstimateState, fromToken.balance, fromToken.symbol]
   );
 
   const renderPhaseContent = (p: SwapPhase) => {
@@ -1180,6 +1358,7 @@ export function SwapContent({
     if (p === "details") {
       return (
         <SwapTransactionDetail
+          feeEstimateState={resultFeeEstimateState}
           fromToken={fromToken}
           onBack={onBack}
           onClose={onClose}
@@ -1611,35 +1790,7 @@ export function SwapContent({
                   1%
                 </span>
               </div>
-              <div style={{ padding: "10px 12px" }}>
-                <span
-                  style={{
-                    fontFamily: font,
-                    fontSize: "13px",
-                    fontWeight: 400,
-                    lineHeight: "16px",
-                    color: secondary,
-                    display: "block",
-                  }}
-                >
-                  Network Fee
-                </span>
-                <div
-                  style={{
-                    display: "flex",
-                    gap: "4px",
-                    alignItems: "center",
-                    fontFamily: font,
-                    fontSize: "16px",
-                    fontWeight: 400,
-                    lineHeight: "20px",
-                    marginTop: "2px",
-                  }}
-                >
-                  <span style={{ color: "#000" }}>0.00005 SOL</span>
-                  <span style={{ color: secondary }}>≈ $0.00</span>
-                </div>
-              </div>
+              <SwapFeeRows feeEstimateState={feeEstimateState} />
             </div>
           )}
         </div>

--- a/frontend/src/components/wallet-sidebar/swap-content.tsx
+++ b/frontend/src/components/wallet-sidebar/swap-content.tsx
@@ -123,6 +123,34 @@ function formatLamportsAsSol(lamports: number): string {
   });
 }
 
+function getFeeSolPriceUsd(
+  fromToken: SwapToken,
+  toToken: SwapToken
+): number | null {
+  const solToken = [fromToken, toToken].find(
+    (token) =>
+      token.symbol.toUpperCase() === "SOL" ||
+      token.mint === "So11111111111111111111111111111111111111112"
+  );
+  return solToken && Number.isFinite(solToken.price) && solToken.price > 0
+    ? solToken.price
+    : null;
+}
+
+function formatFeeUsdEstimate(
+  lamports: number,
+  solPriceUsd?: number | null
+): string | null {
+  if (!solPriceUsd || !Number.isFinite(solPriceUsd) || solPriceUsd <= 0) {
+    return null;
+  }
+  const usd = (lamports / 1_000_000_000) * solPriceUsd;
+  return `≈ $${usd.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  })}`;
+}
+
 function SwapStatusHeader({
   fromToken,
   toToken,
@@ -578,18 +606,32 @@ function FeeSkeleton() {
   );
 }
 
-function FeeValue({ lamports }: { lamports: number }) {
+function FeeValue({
+  lamports,
+  solPriceUsd,
+}: {
+  lamports: number;
+  solPriceUsd?: number | null;
+}) {
+  const usdEstimate = formatFeeUsdEstimate(lamports, solPriceUsd);
   return (
-    <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+    <>
+      <span style={{ color: "#000" }}>{formatLamportsAsSol(lamports)} SOL</span>
+      {usdEstimate ? (
+        <span style={{ color: secondary }}>{usdEstimate}</span>
+      ) : null}
+    </>
   );
 }
 
 function SwapFeeRows({
   feeEstimateState,
   compact = false,
+  solPriceUsd,
 }: {
   feeEstimateState: SwapFeeEstimateState;
   compact?: boolean;
+  solPriceUsd?: number | null;
 }) {
   const rowPadding = compact ? "9px 12px" : "10px 12px";
   const labelStyle = {
@@ -624,20 +666,32 @@ function SwapFeeRows({
       return (
         <>
           {renderRow(
-            "Network",
-            <FeeValue lamports={estimate.transactionFeeLamports} />
+            "Network Fee",
+            <FeeValue
+              lamports={estimate.transactionFeeLamports}
+              solPriceUsd={solPriceUsd}
+            />
           )}
-          {renderRow("ATA rent", <FeeValue lamports={estimate.rentLamports} />)}
           {renderRow(
-            "Total fee",
-            <FeeValue lamports={estimate.totalLamports} />
+            "Rent Fee",
+            <FeeValue
+              lamports={estimate.rentLamports}
+              solPriceUsd={solPriceUsd}
+            />
+          )}
+          {renderRow(
+            "Total Fee",
+            <FeeValue
+              lamports={estimate.totalLamports}
+              solPriceUsd={solPriceUsd}
+            />
           )}
         </>
       );
     }
     return renderRow(
       "Network Fee",
-      <FeeValue lamports={estimate.totalLamports} />
+      <FeeValue lamports={estimate.totalLamports} solPriceUsd={solPriceUsd} />
     );
   }
 
@@ -670,6 +724,7 @@ function SwapTransactionDetail({
   onBack?: () => void;
 }) {
   const publicEnv = usePublicEnv();
+  const feeSolPriceUsd = getFeeSolPriceUsd(fromToken, toToken);
   const now = new Date();
   const dateStr = now.toLocaleDateString("en-US", {
     month: "short",
@@ -826,7 +881,11 @@ function SwapTransactionDetail({
                 Completed
               </span>
             </div>
-            <SwapFeeRows compact feeEstimateState={feeEstimateState} />
+            <SwapFeeRows
+              compact
+              feeEstimateState={feeEstimateState}
+              solPriceUsd={feeSolPriceUsd}
+            />
           </div>
         </div>
 
@@ -1047,6 +1106,10 @@ export function SwapContent({
     const val = toAmount * toToken.price;
     return Number.isFinite(val) ? val.toFixed(2) : "0.00";
   }, [toAmount, toToken.price]);
+  const feeSolPriceUsd = useMemo(
+    () => getFeeSolPriceUsd(fromToken, toToken),
+    [fromToken, toToken]
+  );
   const hasAmount = numericFrom > 0;
   const insufficientFunds = numericFrom > fromToken.balance;
   const feeUserPublicKey = useMemo(() => {
@@ -1751,7 +1814,10 @@ export function SwapContent({
                   1%
                 </span>
               </div>
-              <SwapFeeRows feeEstimateState={feeEstimateState} />
+              <SwapFeeRows
+                feeEstimateState={feeEstimateState}
+                solPriceUsd={feeSolPriceUsd}
+              />
             </div>
           )}
         </div>

--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -103,6 +103,18 @@ import {
   type WalletCommandGroup,
 } from "./wallet-command-menu";
 
+const NATIVE_SOL_MINT = "So11111111111111111111111111111111111111112";
+
+function findSolPriceUsd(tokens: SwapToken[]): number | null {
+  const solToken = tokens.find(
+    (token) =>
+      token.symbol.toUpperCase() === "SOL" || token.mint === NATIVE_SOL_MINT
+  );
+  return solToken && Number.isFinite(solToken.price) && solToken.price > 0
+    ? solToken.price
+    : null;
+}
+
 type WorkspaceAction = "receive" | "send" | "swap" | "shield";
 type WorkspaceSection = "policies" | "settings" | "wallet";
 type DetailTab = "activity" | "tokens";
@@ -980,6 +992,15 @@ export function AppWalletWorkspace({
 
     return [...derivedTokens, ...extras];
   }, [derivedTokens, popularTokens]);
+  const swapFeeSolPriceUsd = useMemo(
+    () =>
+      findSolPriceUsd([
+        ...derivedTokens,
+        ...vaultDerivedTokens,
+        ...swapTargetTokens,
+      ]),
+    [derivedTokens, swapTargetTokens, vaultDerivedTokens]
+  );
   const shieldSecuredBalance = useMemo(() => {
     if (!shieldToken.mint) return 0;
 
@@ -2931,6 +2952,7 @@ export function AppWalletWorkspace({
                 onNavigate={pushView}
                 onSwapModeChange={handleSwapModeChange}
                 onToTokenChange={setSwapToToken}
+                feeSolPriceUsd={swapFeeSolPriceUsd}
                 swapMode={swapMode}
                 toToken={swapToToken}
               />

--- a/frontend/src/hooks/use-swap.ts
+++ b/frontend/src/hooks/use-swap.ts
@@ -1,4 +1,11 @@
 import { TOKEN_MINTS } from "@loyal-labs/wallet-core/constants";
+import {
+  DEFAULT_JUPITER_SWAP_API_BASE_URL,
+  deserializeJupiterSwapTransaction,
+  getJupiterQuote,
+  getJupiterSwapTransaction,
+  type JupiterQuoteResponse,
+} from "@loyal-labs/wallet-core/lib";
 import type { AnalyticsProperties } from "@loyal-labs/shared/analytics";
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import {
@@ -55,9 +62,8 @@ export type SwapExecutionContext = {
   userPublicKey: PublicKey | string | null;
 };
 
-// Use Jupiter Swap v1 API with paid tier endpoint
-const JUPITER_QUOTE_API_URL = "https://api.jup.ag/swap/v1/quote";
-const JUPITER_SWAP_API_URL = "https://api.jup.ag/swap/v1/swap";
+// Use Jupiter Swap v1 API with paid tier endpoint when frontend config allows it.
+export const FRONTEND_JUPITER_SWAP_API_BASE_URL = "https://api.jup.ag/swap/v1";
 
 /**
  * Convert token symbol to mint address
@@ -69,47 +75,18 @@ const getTokenMint = (symbol: string): string | undefined => {
   return TOKEN_MINTS[normalizedSymbol];
 };
 
-type JupiterQuoteResponse = {
-  inputMint: string;
-  inAmount: string;
-  outputMint: string;
-  outAmount: string;
-  otherAmountThreshold: string;
-  swapMode: string;
-  slippageBps: number;
-  platformFee: null | {
-    amount: string;
-    feeBps: number;
-  };
-  priceImpactPct: string;
-  routePlan: Array<{
-    swapInfo: {
-      ammKey: string;
-      label: string;
-      inputMint: string;
-      outputMint: string;
-      inAmount: string;
-      outAmount: string;
-      feeAmount: string;
-      feeMint: string;
-    };
-    percent: number;
-  }>;
-  contextSlot?: number;
-  timeTaken?: number;
-};
-
-type JupiterSwapResponse = {
-  swapTransaction: string;
-  lastValidBlockHeight: number;
-  prioritizationFeeLamports: number;
-};
-
 export function useSwap() {
   const { connection } = useConnection();
   const { publicKey, connected: isConnected, sendTransaction } = useWallet();
   const publicEnv = usePublicEnv();
   const { swap: swapConfig } = publicEnv;
+  const isSwapEnabled = swapConfig.mode === "enabled";
+  const swapApiKey = isSwapEnabled ? swapConfig.apiKey : undefined;
+  const swapUnavailableReason =
+    swapConfig.mode === "disabled" ? swapConfig.reason : null;
+  const swapApiBaseUrl = isSwapEnabled
+    ? FRONTEND_JUPITER_SWAP_API_BASE_URL
+    : DEFAULT_JUPITER_SWAP_API_BASE_URL;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [quote, setQuote] = useState<SwapQuote | null>(null);
@@ -149,8 +126,8 @@ export function useSwap() {
       try {
         setError(null);
 
-        if (swapConfig.mode === "disabled") {
-          throw new Error(swapConfig.reason);
+        if (!isSwapEnabled) {
+          throw new Error(swapUnavailableReason ?? "Swap unavailable");
         }
 
         // Convert token symbols to mint addresses
@@ -190,23 +167,14 @@ export function useSwap() {
           decimals: inputDecimals,
         });
 
-        // Build Jupiter Quote API URL
-        const url = `${JUPITER_QUOTE_API_URL}?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amountInSmallestUnit}&slippageBps=50`;
-        logger.debug("Fetching quote from Jupiter API:", url);
-
-        const response = await fetch(url, {
-          headers: {
-            "x-api-key": swapConfig.apiKey,
-          },
+        const data = await getJupiterQuote({
+          inputMint,
+          outputMint,
+          amount: amountInSmallestUnit,
+          slippageBps: 50,
+          apiKey: swapApiKey,
+          baseUrl: swapApiBaseUrl,
         });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          logger.debug("Quote API error:", errorText);
-          throw new Error(`Failed to get quote: ${response.statusText}`);
-        }
-
-        const data: JupiterQuoteResponse = await response.json();
         logger.debug("Jupiter Quote response:", data);
 
         // Store the full quote response for later use in executeSwap
@@ -243,7 +211,13 @@ export function useSwap() {
         return null;
       }
     },
-    [getTokenDecimals, swapConfig]
+    [
+      getTokenDecimals,
+      isSwapEnabled,
+      swapApiBaseUrl,
+      swapApiKey,
+      swapUnavailableReason,
+    ]
   );
 
   const executeSwap = useCallback(
@@ -251,9 +225,10 @@ export function useSwap() {
       successTrackingProperties?: AnalyticsProperties,
       executionContext?: SwapExecutionContext
     ): Promise<SwapResult> => {
-      if (swapConfig.mode === "disabled") {
-        setError(swapConfig.reason);
-        return { success: false, error: swapConfig.reason };
+      if (!isSwapEnabled) {
+        const errorMsg = swapUnavailableReason ?? "Swap unavailable";
+        setError(errorMsg);
+        return { success: false, error: errorMsg };
       }
 
       const swapUserPublicKey = executionContext?.userPublicKey
@@ -280,39 +255,12 @@ export function useSwap() {
       try {
         logger.debug("Executing swap with quote:", quoteResponse);
 
-        // Step 1: Call Jupiter Swap API to get transaction
-        logger.debug("Calling Jupiter Swap API...");
-
-        const swapResponse = await fetch(JUPITER_SWAP_API_URL, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": swapConfig.apiKey,
-          },
-          body: JSON.stringify({
-            userPublicKey: swapUserPublicKey.toBase58(),
-            quoteResponse,
-            wrapAndUnwrapSol: true,
-            dynamicComputeUnitLimit: true,
-            prioritizationFeeLamports: {
-              priorityLevelWithMaxLamports: {
-                priorityLevel: "veryHigh",
-                maxLamports: 50_000_000, // 0.05 SOL max for priority
-                global: true, // Use global fee market
-              },
-            },
-          }),
+        const swapData = await getJupiterSwapTransaction({
+          userPublicKey: swapUserPublicKey.toBase58(),
+          quoteResponse,
+          apiKey: swapApiKey,
+          baseUrl: swapApiBaseUrl,
         });
-
-        if (!swapResponse.ok) {
-          const errorText = await swapResponse.text();
-          logger.debug("Jupiter Swap API error:", errorText);
-          throw new Error(
-            `Jupiter Swap API failed: ${swapResponse.statusText}`
-          );
-        }
-
-        const swapData: JupiterSwapResponse = await swapResponse.json();
         logger.debug("Jupiter Swap transaction response:", swapData);
 
         const { swapTransaction: serializedTx } = swapData;
@@ -320,11 +268,8 @@ export function useSwap() {
           throw new Error("No transaction returned from Jupiter Swap API");
         }
 
-        // Step 2: Deserialize transaction
-        const txBuffer = Buffer.from(serializedTx, "base64");
-        const transaction = VersionedTransaction.deserialize(txBuffer);
+        const transaction = deserializeJupiterSwapTransaction(serializedTx);
 
-        // Step 3: Sign and send transaction using wallet-adapter
         logger.debug("Signing and sending transaction...");
         const executionResult = executionContext
           ? await executionContext.executeTransaction(transaction)
@@ -407,11 +352,14 @@ export function useSwap() {
     [
       connection,
       isConnected,
+      isSwapEnabled,
       publicEnv,
       publicKey,
       quoteResponse,
       sendTransaction,
-      swapConfig,
+      swapApiBaseUrl,
+      swapApiKey,
+      swapUnavailableReason,
     ]
   );
 
@@ -426,10 +374,13 @@ export function useSwap() {
     executeSwap,
     resetQuote,
     quote,
+    quoteResponse,
     loading,
     error,
-    isAvailable: swapConfig.mode === "enabled",
-    unavailableReason:
-      swapConfig.mode === "disabled" ? swapConfig.reason : null,
+    userPublicKey: publicKey,
+    swapApiBaseUrl,
+    swapApiKey,
+    isAvailable: isSwapEnabled,
+    unavailableReason: swapUnavailableReason,
   };
 }

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -4,6 +4,8 @@ module.exports = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^@loyal-labs/shared$": "<rootDir>/../packages/shared/src/index",
+    "^@loyal-labs/wallet-core/lib$":
+      "<rootDir>/../packages/wallet-core/src/lib/index",
     "^@loyal-labs/private-transactions$": "<rootDir>/../sdk/private-transactions/index",
     "^expo-seed-vault$": "<rootDir>/modules/expo-seed-vault/src/index",
     "\\.(png|jpg|jpeg|gif|webp|svg)$": "<rootDir>/test/fileMock.js",

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -10,6 +10,7 @@ const config = getDefaultConfig(__dirname);
 // Resolve monorepo packages outside /mobile
 const sharedRoot = path.resolve(__dirname, "../packages/shared");
 const solanaRpcRoot = path.resolve(__dirname, "../packages/solana-rpc/src");
+const walletCoreRoot = path.resolve(__dirname, "../packages/wallet-core/src");
 const privateTransactionsRoot = path.resolve(__dirname, "../sdk/private-transactions");
 const privateTransactionsEntryCandidates = [
   path.resolve(
@@ -29,8 +30,8 @@ const privateTransactionsEntryCandidates = [
     "../sdk/private-transactions/index.ts",
   ),
 ];
-const privateTransactionsEntry = privateTransactionsEntryCandidates.find((candidate) =>
-  fs.existsSync(candidate),
+const privateTransactionsEntry = privateTransactionsEntryCandidates.find(
+  (candidate) => fs.existsSync(candidate),
 );
 
 if (!privateTransactionsEntry) {
@@ -38,13 +39,19 @@ if (!privateTransactionsEntry) {
     "Unable to resolve @loyal-labs/private-transactions entry file from Metro config.",
   );
 }
-config.watchFolders = [sharedRoot, solanaRpcRoot, privateTransactionsRoot];
+config.watchFolders = [
+  sharedRoot,
+  solanaRpcRoot,
+  walletCoreRoot,
+  privateTransactionsRoot,
+];
 config.resolver.nodeModulesPaths = [
   path.resolve(__dirname, "node_modules"),
   path.resolve(__dirname, ".."),
 ];
 config.resolver.extraNodeModules = {
   "@loyal-labs/solana-rpc": solanaRpcRoot,
+  "@loyal-labs/wallet-core/lib": path.resolve(walletCoreRoot, "lib/index.ts"),
 };
 
 // SVG transformer

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -46,12 +46,11 @@ import {
   SOLANA_USDC_MINT_MAINNET,
 } from "@/lib/solana/constants";
 import {
+  estimateJupiterSwapFeeState,
   getJupiterQuote,
-  getJupiterSwapInstructions,
   getJupiterSwapTransaction,
-  estimateSwapTransactionFee,
   type JupiterQuoteResponse,
-  type SwapFeeEstimate,
+  type SwapFeeEstimateState,
 } from "@/lib/solana/jupiter";
 import { getConnection, getSolanaEnv } from "@/lib/solana/rpc/connection";
 import { DEFAULT_TOKEN_ICON } from "@/lib/solana/token-holdings/constants";
@@ -76,12 +75,6 @@ const SWAP_SNAP_POINTS = ["94%"];
 const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
 
 type SwapStep = "form" | "confirm" | "result";
-
-type SwapFeeEstimateState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "success"; estimate: SwapFeeEstimate }
-  | { status: "error"; error: string };
 
 type SwapSheetProps = {
   open: boolean;
@@ -417,42 +410,12 @@ export function SwapSheet({
     setFeeEstimateState({ status: "loading" });
 
     void (async () => {
-      try {
-        const [swapTxResponse, swapInstructions] = await Promise.all([
-          getJupiterSwapTransaction({
-            quoteResponse: quote,
-            userPublicKey: walletAddress,
-          }),
-          getJupiterSwapInstructions({
-            quoteResponse: quote,
-            userPublicKey: walletAddress,
-          }).catch(() => undefined),
-        ]);
-
-        const estimate = await estimateSwapTransactionFee({
-          connection: getConnection(),
-          swapResponse: swapTxResponse,
-          swapInstructions,
-          userPublicKey: walletAddress,
-        });
-
-        if (cancelled) return;
-        if (estimate.simulation.status === "passed") {
-          setFeeEstimateState({ status: "success", estimate });
-        } else {
-          setFeeEstimateState({
-            status: "error",
-            error: "Swap fee simulation failed",
-          });
-        }
-      } catch (error) {
-        if (cancelled) return;
-        setFeeEstimateState({
-          status: "error",
-          error:
-            error instanceof Error ? error.message : "Swap fee unavailable",
-        });
-      }
+      const nextState = await estimateJupiterSwapFeeState({
+        connection: getConnection(),
+        quoteResponse: quote,
+        userPublicKey: walletAddress,
+      });
+      if (!cancelled) setFeeEstimateState(nextState);
     })();
 
     return () => {

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -42,6 +42,7 @@ import { track } from "@/lib/analytics/analytics";
 import { SWAP_EVENTS } from "@/lib/analytics/swap-events";
 import {
   NATIVE_SOL_MINT,
+  SOL_PRICE_USD,
   SOLANA_USDC_MINT_DEVNET,
   SOLANA_USDC_MINT_MAINNET,
 } from "@/lib/solana/constants";
@@ -155,6 +156,38 @@ function formatSolAmount(value: number): string {
 
 function formatLamportsAsSol(lamports: number): string {
   return formatSolAmount(lamports / 1_000_000_000);
+}
+
+function getFeeSolPriceUsd(
+  fromHolding: TokenHolding | null,
+  toHolding: TokenHolding | null
+): number | null {
+  const solHolding = [fromHolding, toHolding].find(
+    (holding) =>
+      holding &&
+      (holding.symbol.toUpperCase() === "SOL" ||
+        holding.mint === NATIVE_SOL_MINT)
+  );
+  if (
+    typeof solHolding?.priceUsd === "number" &&
+    Number.isFinite(solHolding.priceUsd) &&
+    solHolding.priceUsd > 0
+  ) {
+    return solHolding.priceUsd;
+  }
+  return Number.isFinite(SOL_PRICE_USD) && SOL_PRICE_USD > 0
+    ? SOL_PRICE_USD
+    : null;
+}
+
+function formatFeeUsdEstimate(
+  lamports: number,
+  solPriceUsd?: number | null
+): string | null {
+  if (!solPriceUsd || !Number.isFinite(solPriceUsd) || solPriceUsd <= 0) {
+    return null;
+  }
+  return `≈ ${formatUsdAmount((lamports / 1_000_000_000) * solPriceUsd)}`;
 }
 
 // Unit price for the picker's right column. Prices ≥ $1 show 2 decimals with
@@ -1532,6 +1565,7 @@ function ConfirmStep({
     ? Number((quote.slippageBps / 100).toFixed(2))
     : null;
   const dim = { color: "rgba(60,60,67,0.6)" } as const;
+  const feeSolPriceUsd = getFeeSolPriceUsd(fromHolding, toHolding);
 
   return (
     <View style={{ flex: 1 }}>
@@ -1656,7 +1690,10 @@ function ConfirmStep({
               {slippagePct != null ? `${slippagePct}%` : "—"}
             </Text>
           </ConfirmRow>
-          <FeeBreakdownRows feeEstimateState={feeEstimateState} />
+          <FeeBreakdownRows
+            feeEstimateState={feeEstimateState}
+            solPriceUsd={feeSolPriceUsd}
+          />
         </View>
       </View>
 
@@ -1698,20 +1735,30 @@ function ConfirmStep({
 function FeeValue({
   lamports,
   muted = false,
+  solPriceUsd,
 }: {
   lamports: number;
   muted?: boolean;
+  solPriceUsd?: number | null;
 }) {
+  const usdEstimate = formatFeeUsdEstimate(lamports, solPriceUsd);
   return (
-    <Text
-      className="text-[17px] text-black"
-      style={{
-        lineHeight: 22,
-        color: muted ? "rgba(60,60,67,0.6)" : "#000",
-      }}
-    >
-      {formatLamportsAsSol(lamports)} SOL
-    </Text>
+    <>
+      <Text
+        className="text-[17px] text-black"
+        style={{
+          lineHeight: 22,
+          color: muted ? "rgba(60,60,67,0.6)" : "#000",
+        }}
+      >
+        {formatLamportsAsSol(lamports)} SOL
+      </Text>
+      {usdEstimate ? (
+        <Text className="text-[17px]" style={{ color: "rgba(60,60,67,0.6)" }}>
+          {` ${usdEstimate}`}
+        </Text>
+      ) : null}
+    </>
   );
 }
 
@@ -1730,29 +1777,40 @@ function FeeSkeleton() {
 
 function FeeBreakdownRows({
   feeEstimateState,
+  solPriceUsd,
 }: {
   feeEstimateState: SwapFeeEstimateState;
+  solPriceUsd?: number | null;
 }) {
   if (feeEstimateState.status === "success") {
     const { estimate } = feeEstimateState;
     if (estimate.rentLamports > 0) {
       return (
         <>
-          <ConfirmRow label="Network">
-            <FeeValue lamports={estimate.transactionFeeLamports} />
+          <ConfirmRow label="Network Fee">
+            <FeeValue
+              lamports={estimate.transactionFeeLamports}
+              solPriceUsd={solPriceUsd}
+            />
           </ConfirmRow>
-          <ConfirmRow label="ATA rent">
-            <FeeValue lamports={estimate.rentLamports} />
+          <ConfirmRow label="Rent Fee">
+            <FeeValue
+              lamports={estimate.rentLamports}
+              solPriceUsd={solPriceUsd}
+            />
           </ConfirmRow>
-          <ConfirmRow label="Total fee">
-            <FeeValue lamports={estimate.totalLamports} />
+          <ConfirmRow label="Total Fee">
+            <FeeValue
+              lamports={estimate.totalLamports}
+              solPriceUsd={solPriceUsd}
+            />
           </ConfirmRow>
         </>
       );
     }
     return (
       <ConfirmRow label="Network Fee">
-        <FeeValue lamports={estimate.totalLamports} />
+        <FeeValue lamports={estimate.totalLamports} solPriceUsd={solPriceUsd} />
       </ConfirmRow>
     );
   }

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -47,8 +47,11 @@ import {
 } from "@/lib/solana/constants";
 import {
   getJupiterQuote,
+  getJupiterSwapInstructions,
   getJupiterSwapTransaction,
+  estimateSwapTransactionFee,
   type JupiterQuoteResponse,
+  type SwapFeeEstimate,
 } from "@/lib/solana/jupiter";
 import { getConnection, getSolanaEnv } from "@/lib/solana/rpc/connection";
 import { DEFAULT_TOKEN_ICON } from "@/lib/solana/token-holdings/constants";
@@ -70,8 +73,15 @@ const shieldBadge = require("../../../assets/images/shield-badge.png");
 const SCREEN_HEIGHT = Dimensions.get("screen").height;
 const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 const SWAP_SNAP_POINTS = ["94%"];
+const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
 
 type SwapStep = "form" | "confirm" | "result";
+
+type SwapFeeEstimateState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; estimate: SwapFeeEstimate }
+  | { status: "error"; error: string };
 
 type SwapSheetProps = {
   open: boolean;
@@ -91,7 +101,7 @@ const getDefaultUsdcMint = (): string => {
 
 const getTokenIcon = (
   holding: TokenHolding,
-  detailLogoUrl?: string | null,
+  detailLogoUrl?: string | null
 ): string =>
   resolveTokenIcon({
     mint: holding.mint,
@@ -101,13 +111,19 @@ const getTokenIcon = (
 
 function getFriendlyError(raw: string): string {
   const lower = raw.toLowerCase();
-  if (lower.includes("insufficient lamports") || lower.includes("not enough sol"))
+  if (
+    lower.includes("insufficient lamports") ||
+    lower.includes("not enough sol")
+  )
     return "You don't have enough SOL to complete this swap.";
   if (lower.includes("insufficient funds"))
     return "Insufficient funds for this swap.";
   if (lower.includes("slippage") || lower.includes("exceeds"))
     return "Price moved too much. Try increasing slippage or retry.";
-  if (lower.includes("blockhash not found") || lower.includes("block height exceeded"))
+  if (
+    lower.includes("blockhash not found") ||
+    lower.includes("block height exceeded")
+  )
     return "The transaction expired. Please try again.";
   if (lower.includes("timeout") || lower.includes("timed out"))
     return "The transaction timed out. Please try again.";
@@ -117,7 +133,11 @@ function getFriendlyError(raw: string): string {
 
 // Number formatting + amount-field helpers, mirrored from SendSheet so the Swap
 // amount field behaves identically (thousands separators, mid-typing dot, etc.).
-function formatWithCommas(value: number, minFrac: number, maxFrac: number): string {
+function formatWithCommas(
+  value: number,
+  minFrac: number,
+  maxFrac: number
+): string {
   const safe = Number.isFinite(value) ? value : 0;
   const [intPart, fracPartRaw = ""] = safe.toFixed(maxFrac).split(".");
   let fracPart = fracPartRaw;
@@ -138,6 +158,10 @@ function formatUsdAmount(value: number): string {
 
 function formatSolAmount(value: number): string {
   return formatWithCommas(value, 0, 6);
+}
+
+function formatLamportsAsSol(lamports: number): string {
+  return formatSolAmount(lamports / 1_000_000_000);
 }
 
 // Unit price for the picker's right column. Prices ≥ $1 show 2 decimals with
@@ -180,12 +204,12 @@ function resolveInitialSwapMints(params: {
 }) {
   const defaultToMint = getDefaultUsdcMint();
   const requestedFromMint = params.publicHoldings.some(
-    (holding) => holding.mint === params.initialFromMint,
+    (holding) => holding.mint === params.initialFromMint
   )
     ? (params.initialFromMint as string)
     : null;
   const requestedToMint = params.toPickerTokens.some(
-    (holding) => holding.mint === params.initialToMint,
+    (holding) => holding.mint === params.initialToMint
   )
     ? (params.initialToMint as string)
     : null;
@@ -195,12 +219,16 @@ function resolveInitialSwapMints(params: {
 
   if (fromMint === toMint) {
     if (requestedFromMint) {
-      const nextTo = params.toPickerTokens.find((holding) => holding.mint !== fromMint);
+      const nextTo = params.toPickerTokens.find(
+        (holding) => holding.mint !== fromMint
+      );
       if (nextTo) {
         toMint = nextTo.mint;
       }
     } else {
-      const nextFrom = params.publicHoldings.find((holding) => holding.mint !== toMint);
+      const nextFrom = params.publicHoldings.find(
+        (holding) => holding.mint !== toMint
+      );
       if (nextFrom) {
         fromMint = nextFrom.mint;
       }
@@ -208,7 +236,9 @@ function resolveInitialSwapMints(params: {
   }
 
   if (fromMint === toMint) {
-    const nextTo = params.toPickerTokens.find((holding) => holding.mint !== fromMint);
+    const nextTo = params.toPickerTokens.find(
+      (holding) => holding.mint !== fromMint
+    );
     if (nextTo) {
       toMint = nextTo.mint;
     }
@@ -239,11 +269,13 @@ export function SwapSheet({
   // can still display it. Without this, picking a searched token leaves
   // toHolding null and the selector falls back to the "Select" placeholder.
   const [selectedToToken, setSelectedToToken] = useState<TokenHolding | null>(
-    null,
+    null
   );
   const [amountStr, setAmountStr] = useState("");
   const [currencyMode, setCurrencyMode] = useState<"TOKEN" | "USD">("TOKEN");
   const [quote, setQuote] = useState<JupiterQuoteResponse | null>(null);
+  const [feeEstimateState, setFeeEstimateState] =
+    useState<SwapFeeEstimateState>({ status: "idle" });
   const [isFetchingQuote, setIsFetchingQuote] = useState(false);
   const [isSwapping, setIsSwapping] = useState(false);
   const [swapError, setSwapError] = useState<string | null>(null);
@@ -264,11 +296,11 @@ export function SwapSheet({
   // — Jupiter routes deposit into the user's public token account.
   const publicHoldings = useMemo(
     () => tokenHoldings.filter((t) => !t.isSecured),
-    [tokenHoldings],
+    [tokenHoldings]
   );
   const fromHoldings = useMemo(
     () => tokenHoldings.filter((t) => t.balance > 0),
-    [tokenHoldings],
+    [tokenHoldings]
   );
   const toPickerTokens = useMemo(() => {
     const heldMints = new Set(publicHoldings.map((t) => t.mint));
@@ -280,7 +312,7 @@ export function SwapSheet({
 
   const fromHolding =
     tokenHoldings.find(
-      (t) => t.mint === fromMint && Boolean(t.isSecured) === fromIsSecured,
+      (t) => t.mint === fromMint && Boolean(t.isSecured) === fromIsSecured
     ) ??
     tokenHoldings.find((t) => t.mint === fromMint) ??
     null;
@@ -324,6 +356,7 @@ export function SwapSheet({
       setAmountStr("");
       setCurrencyMode("TOKEN");
       setQuote(null);
+      setFeeEstimateState({ status: "idle" });
       setSwapError(null);
       setTxSignature(null);
       setIsSwapping(false);
@@ -339,6 +372,7 @@ export function SwapSheet({
   useEffect(() => {
     if (amountNum <= 0 || fromMint === toMint || !fromHolding) {
       setQuote(null);
+      setFeeEstimateState({ status: "idle" });
       return;
     }
 
@@ -373,6 +407,59 @@ export function SwapSheet({
     };
   }, [amountNum, fromMint, toMint, fromHolding]);
 
+  useEffect(() => {
+    if (!quote || !walletAddress) {
+      setFeeEstimateState({ status: "idle" });
+      return;
+    }
+
+    let cancelled = false;
+    setFeeEstimateState({ status: "loading" });
+
+    void (async () => {
+      try {
+        const [swapTxResponse, swapInstructions] = await Promise.all([
+          getJupiterSwapTransaction({
+            quoteResponse: quote,
+            userPublicKey: walletAddress,
+          }),
+          getJupiterSwapInstructions({
+            quoteResponse: quote,
+            userPublicKey: walletAddress,
+          }).catch(() => undefined),
+        ]);
+
+        const estimate = await estimateSwapTransactionFee({
+          connection: getConnection(),
+          swapResponse: swapTxResponse,
+          swapInstructions,
+          userPublicKey: walletAddress,
+        });
+
+        if (cancelled) return;
+        if (estimate.simulation.status === "passed") {
+          setFeeEstimateState({ status: "success", estimate });
+        } else {
+          setFeeEstimateState({
+            status: "error",
+            error: "Swap fee simulation failed",
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setFeeEstimateState({
+          status: "error",
+          error:
+            error instanceof Error ? error.message : "Swap fee unavailable",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [quote, walletAddress]);
+
   // Focus the amount input once the sheet has settled at its snap point.
   // Focusing during the present animation pushes the keyboard above the sheet.
   const focusActiveInput = useCallback(() => {
@@ -388,7 +475,7 @@ export function SwapSheet({
         setTimeout(focusActiveInput, 120);
       }
     },
-    [focusActiveInput],
+    [focusActiveInput]
   );
 
   // Re-focus the right input on step / picker transitions (the sheet is
@@ -438,6 +525,7 @@ export function SwapSheet({
     setAmountStr("");
     setCurrencyMode("TOKEN");
     setQuote(null);
+    setFeeEstimateState({ status: "idle" });
   }, [fromMint, toMint]);
 
   const toggleCurrency = useCallback(() => {
@@ -457,8 +545,15 @@ export function SwapSheet({
     if (!fromHolding) return;
     let val = fromBalance;
     // Reserve the network fee when maxing out SOL.
-    if (fromHolding.symbol.toUpperCase() === "SOL" && fromBalance - val < 0.00005) {
-      val = Math.max(0, fromBalance - 0.00005);
+    const feeReserveSol =
+      feeEstimateState.status === "success"
+        ? feeEstimateState.estimate.totalLamports / 1_000_000_000
+        : DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS / 1_000_000_000;
+    if (
+      fromHolding.symbol.toUpperCase() === "SOL" &&
+      fromBalance - val < feeReserveSol
+    ) {
+      val = Math.max(0, fromBalance - feeReserveSol);
     }
     // Truncate (never round) so float rounding can't push past the balance.
     const truncated = Math.floor(val * 1e6) / 1e6;
@@ -470,7 +565,7 @@ export function SwapSheet({
       setAmountStr(String(truncated));
     }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-  }, [fromHolding, fromBalance, currencyMode, fromPrice]);
+  }, [fromHolding, fromBalance, feeEstimateState, currencyMode, fromPrice]);
 
   const handleSwap = useCallback(async () => {
     if (!isFormValid || isSwapping || !walletAddress || !quote || !fromHolding)
@@ -527,8 +622,7 @@ export function SwapSheet({
       });
       onSwapComplete?.();
     } catch (error) {
-      const msg =
-        error instanceof Error ? error.message : "Swap failed";
+      const msg = error instanceof Error ? error.message : "Swap failed";
       const friendly = getFriendlyError(msg);
       const stageAtFailure = swapStage;
       const recovery =
@@ -572,7 +666,7 @@ export function SwapSheet({
         opacity={0.3}
       />
     ),
-    [],
+    []
   );
 
   const selectFromToken = useCallback(
@@ -581,11 +675,12 @@ export function SwapSheet({
       setFromIsSecured(isSecured);
       setShowFromPicker(false);
       setQuote(null);
+      setFeeEstimateState({ status: "idle" });
       if (mint === toMint) {
         setToMint(fromMint);
       }
     },
-    [toMint, fromMint],
+    [toMint, fromMint]
   );
 
   const selectToToken = useCallback(
@@ -594,12 +689,13 @@ export function SwapSheet({
       setSelectedToToken(token);
       setShowToPicker(false);
       setQuote(null);
+      setFeeEstimateState({ status: "idle" });
       if (token.mint === fromMint) {
         setFromMint(toMint);
         setFromIsSecured(false);
       }
     },
-    [fromMint, toMint],
+    [fromMint, toMint]
   );
 
   const showForm = step === "form" && !showFromPicker && !showToPicker;
@@ -702,6 +798,7 @@ export function SwapSheet({
             outAmount={outAmount}
             outUsd={outUsd}
             quote={quote}
+            feeEstimateState={feeEstimateState}
             isSwapping={isSwapping}
             onConfirm={handleSwap}
             onBack={() => setStep("form")}
@@ -734,7 +831,9 @@ function SwapTokenPill({
   detailLogoUrl?: string | null;
   onPress: () => void;
 }) {
-  const icon = holding ? getTokenIcon(holding, detailLogoUrl) : DEFAULT_TOKEN_ICON;
+  const icon = holding
+    ? getTokenIcon(holding, detailLogoUrl)
+    : DEFAULT_TOKEN_ICON;
   const symbol = holding?.symbol ?? "Select";
   const isSecured = Boolean(holding?.isSecured);
 
@@ -839,7 +938,7 @@ function TokenPicker({
       (t) =>
         t.symbol.toLowerCase().includes(lower) ||
         t.name.toLowerCase().includes(lower) ||
-        t.mint.toLowerCase().includes(lower),
+        t.mint.toLowerCase().includes(lower)
     );
   }, [tokenHoldings, search]);
 
@@ -954,7 +1053,7 @@ function TokenPicker({
       {displayTokens.map((token) => {
         const icon = getTokenIcon(
           token,
-          tokenDetailsByMint?.[token.mint]?.token.logoUrl,
+          tokenDetailsByMint?.[token.mint]?.token.logoUrl
         );
         const isSecured = Boolean(token.isSecured);
         // "To" picker chooses what to receive → show the unit price. "From"
@@ -1136,7 +1235,8 @@ function FormStep({
       ? `${formatTokenAmount(amountNum)} ${fromSymbol}`
       : formatUsdAmount(fromPrice ? amountNum * fromPrice : 0);
 
-  const receiveBig = outAmount != null ? formatWithCommas(outAmount, 0, 6) : "0";
+  const receiveBig =
+    outAmount != null ? formatWithCommas(outAmount, 0, 6) : "0";
   const receiveSub = outUsd != null ? `≈${formatUsdAmount(outUsd)}` : "$0";
 
   const labelStyle = { color: "rgba(60,60,67,0.6)", lineHeight: 20 } as const;
@@ -1206,9 +1306,16 @@ function FormStep({
           <Text className="text-[15px] font-normal" style={labelStyle}>
             You swap
           </Text>
-          <View className="flex-row items-center" style={{ height: 48, gap: 4 }}>
+          <View
+            className="flex-row items-center"
+            style={{ height: 48, gap: 4 }}
+          >
             <Pressable
-              style={{ flex: 1, position: "relative", justifyContent: "center" }}
+              style={{
+                flex: 1,
+                position: "relative",
+                justifyContent: "center",
+              }}
               onPress={() => swapInputRef.current?.focus()}
             >
               <View
@@ -1339,7 +1446,10 @@ function FormStep({
           <Text className="text-[15px] font-normal" style={labelStyle}>
             You receive
           </Text>
-          <View className="flex-row items-center" style={{ height: 48, gap: 4 }}>
+          <View
+            className="flex-row items-center"
+            style={{ height: 48, gap: 4 }}
+          >
             <View style={{ flex: 1, justifyContent: "center" }}>
               {isFetchingQuote && outAmount == null ? (
                 <ActivityIndicator
@@ -1414,10 +1524,6 @@ function FormStep({
   );
 }
 
-// --- Confirm Step ---
-// Approximate Solana network fee surfaced on the swap review row.
-const NETWORK_FEE_SOL = 0.00005;
-
 function ConfirmStep({
   fromHolding,
   toHolding,
@@ -1426,6 +1532,7 @@ function ConfirmStep({
   outAmount,
   outUsd,
   quote,
+  feeEstimateState,
   isSwapping,
   onConfirm,
   onBack,
@@ -1437,6 +1544,7 @@ function ConfirmStep({
   outAmount: number | null;
   outUsd: number | null;
   quote: JupiterQuoteResponse | null;
+  feeEstimateState: SwapFeeEstimateState;
   isSwapping: boolean;
   onConfirm: () => void;
   onBack: () => void;
@@ -1445,13 +1553,21 @@ function ConfirmStep({
   const fromSymbol = fromHolding?.symbol ?? "";
   const toSymbol = toHolding?.symbol ?? "";
   const fromIcon = fromHolding
-    ? getTokenIcon(fromHolding, tokenDetailsByMint?.[fromHolding.mint]?.token.logoUrl)
+    ? getTokenIcon(
+        fromHolding,
+        tokenDetailsByMint?.[fromHolding.mint]?.token.logoUrl
+      )
     : DEFAULT_TOKEN_ICON;
   const toIcon = toHolding
-    ? getTokenIcon(toHolding, tokenDetailsByMint?.[toHolding.mint]?.token.logoUrl)
+    ? getTokenIcon(
+        toHolding,
+        tokenDetailsByMint?.[toHolding.mint]?.token.logoUrl
+      )
     : DEFAULT_TOKEN_ICON;
   const rate = outAmount && outAmount > 0 ? amountNum / outAmount : null;
-  const slippagePct = quote ? Number((quote.slippageBps / 100).toFixed(2)) : null;
+  const slippagePct = quote
+    ? Number((quote.slippageBps / 100).toFixed(2))
+    : null;
   const dim = { color: "rgba(60,60,67,0.6)" } as const;
 
   return (
@@ -1556,14 +1672,20 @@ function ConfirmStep({
       {/* Rate / slippage / fee */}
       <View style={{ paddingHorizontal: 16 }}>
         <View
-          style={{ backgroundColor: "#f2f2f7", borderRadius: 20, paddingVertical: 4 }}
+          style={{
+            backgroundColor: "#f2f2f7",
+            borderRadius: 20,
+            paddingVertical: 4,
+          }}
         >
           <ConfirmRow label="Rate">
             <Text className="text-[17px] text-black" style={{ lineHeight: 22 }}>
               1 {toSymbol}
             </Text>
             <Text className="text-[17px]" style={{ ...dim, lineHeight: 22 }}>
-              {` ≈ ${rate != null ? formatTokenAmount(rate, 0) : "—"} ${fromSymbol}`}
+              {` ≈ ${
+                rate != null ? formatTokenAmount(rate, 0) : "—"
+              } ${fromSymbol}`}
             </Text>
           </ConfirmRow>
           <ConfirmRow label="Slippage">
@@ -1571,14 +1693,7 @@ function ConfirmStep({
               {slippagePct != null ? `${slippagePct}%` : "—"}
             </Text>
           </ConfirmRow>
-          <ConfirmRow label="Network Fee">
-            <Text className="text-[17px] text-black" style={{ lineHeight: 22 }}>
-              {formatSolAmount(NETWORK_FEE_SOL)} SOL
-            </Text>
-            <Text className="text-[17px]" style={{ ...dim, lineHeight: 22 }}>
-              {"  <$0.01"}
-            </Text>
-          </ConfirmRow>
+          <FeeBreakdownRows feeEstimateState={feeEstimateState} />
         </View>
       </View>
 
@@ -1617,6 +1732,85 @@ function ConfirmStep({
   );
 }
 
+function FeeValue({
+  lamports,
+  muted = false,
+}: {
+  lamports: number;
+  muted?: boolean;
+}) {
+  return (
+    <Text
+      className="text-[17px] text-black"
+      style={{
+        lineHeight: 22,
+        color: muted ? "rgba(60,60,67,0.6)" : "#000",
+      }}
+    >
+      {formatLamportsAsSol(lamports)} SOL
+    </Text>
+  );
+}
+
+function FeeSkeleton() {
+  return (
+    <View
+      style={{
+        width: 92,
+        height: 18,
+        borderRadius: 9,
+        backgroundColor: "rgba(60,60,67,0.14)",
+      }}
+    />
+  );
+}
+
+function FeeBreakdownRows({
+  feeEstimateState,
+}: {
+  feeEstimateState: SwapFeeEstimateState;
+}) {
+  if (feeEstimateState.status === "success") {
+    const { estimate } = feeEstimateState;
+    if (estimate.rentLamports > 0) {
+      return (
+        <>
+          <ConfirmRow label="Network">
+            <FeeValue lamports={estimate.transactionFeeLamports} />
+          </ConfirmRow>
+          <ConfirmRow label="ATA rent">
+            <FeeValue lamports={estimate.rentLamports} />
+          </ConfirmRow>
+          <ConfirmRow label="Total fee">
+            <FeeValue lamports={estimate.totalLamports} />
+          </ConfirmRow>
+        </>
+      );
+    }
+    return (
+      <ConfirmRow label="Network Fee">
+        <FeeValue lamports={estimate.totalLamports} />
+      </ConfirmRow>
+    );
+  }
+
+  if (feeEstimateState.status === "error") {
+    return (
+      <ConfirmRow label="Network Fee">
+        <Text className="text-[17px] text-black" style={{ lineHeight: 22 }}>
+          -
+        </Text>
+      </ConfirmRow>
+    );
+  }
+
+  return (
+    <ConfirmRow label="Network Fee">
+      <FeeSkeleton />
+    </ConfirmRow>
+  );
+}
+
 function ConfirmRow({
   label,
   children,
@@ -1646,7 +1840,7 @@ function SwappingSpinner() {
     rotation.value = withRepeat(
       withTiming(360, { duration: 900, easing: Easing.linear }),
       -1,
-      false,
+      false
     );
     return () => cancelAnimation(rotation);
   }, [rotation]);
@@ -1716,8 +1910,8 @@ function ResultStep({
         ? "Unshielding…"
         : "Swapping…"
       : status === "success"
-        ? "Swapped"
-        : "Transaction failed";
+      ? "Swapped"
+      : "Transaction failed";
 
   return (
     <View className="w-full" style={{ flex: 1 }}>
@@ -1806,7 +2000,7 @@ function ResultStep({
               >
                 {status === "swapping"
                   ? "You can close this screen and continue using the app"
-                  : (swapError ?? "Something went wrong. Please try again.")}
+                  : swapError ?? "Something went wrong. Please try again."}
               </Text>
             )}
           </View>

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -48,8 +48,10 @@ import {
 } from "@/lib/solana/constants";
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateKey,
   getJupiterQuote,
   getJupiterSwapTransaction,
+  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
   type JupiterQuoteResponse,
   type SwapFeeEstimateState,
 } from "@/lib/solana/jupiter";
@@ -301,6 +303,12 @@ export function SwapSheet({
   const [quote, setQuote] = useState<JupiterQuoteResponse | null>(null);
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
+  const feeEstimateConnection = useMemo(() => getConnection(), []);
+  const feeEstimateRequestRef = useRef<{
+    key: string;
+    quoteResponse: JupiterQuoteResponse;
+    userPublicKey: string;
+  } | null>(null);
   const [isFetchingQuote, setIsFetchingQuote] = useState(false);
   const [isSwapping, setIsSwapping] = useState(false);
   const [swapError, setSwapError] = useState<string | null>(null);
@@ -432,28 +440,55 @@ export function SwapSheet({
     };
   }, [amountNum, fromMint, toMint, fromHolding]);
 
+  const feeEstimateRequest = useMemo(() => {
+    if (!quote || !walletAddress) return null;
+    return {
+      key: getJupiterSwapFeeEstimateKey({
+        connection: feeEstimateConnection,
+        quoteResponse: quote,
+        userPublicKey: walletAddress,
+      }),
+      quoteResponse: quote,
+      userPublicKey: walletAddress,
+    };
+  }, [feeEstimateConnection, quote, walletAddress]);
+  feeEstimateRequestRef.current = feeEstimateRequest;
+  const feeEstimateKey = feeEstimateRequest?.key ?? null;
+
   useEffect(() => {
-    if (!quote || !walletAddress) {
+    if (!feeEstimateKey) {
       setFeeEstimateState({ status: "idle" });
       return;
     }
 
     let cancelled = false;
+    const abortController = new AbortController();
     setFeeEstimateState({ status: "loading" });
 
-    void (async () => {
-      const nextState = await estimateJupiterSwapFeeState({
-        connection: getConnection(),
-        quoteResponse: quote,
-        userPublicKey: walletAddress,
-      });
-      if (!cancelled) setFeeEstimateState(nextState);
-    })();
+    const timer = setTimeout(() => {
+      const request = feeEstimateRequestRef.current;
+      if (!request || request.key !== feeEstimateKey) {
+        return;
+      }
+      void (async () => {
+        const nextState = await estimateJupiterSwapFeeState({
+          connection: feeEstimateConnection,
+          quoteResponse: request.quoteResponse,
+          userPublicKey: request.userPublicKey,
+          signal: abortController.signal,
+        });
+        if (!cancelled && !abortController.signal.aborted) {
+          setFeeEstimateState(nextState);
+        }
+      })();
+    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
+      abortController.abort();
     };
-  }, [quote, walletAddress]);
+  }, [feeEstimateConnection, feeEstimateKey]);
 
   // Focus the amount input once the sheet has settled at its snap point.
   // Focusing during the present animation pushes the keyboard above the sheet.

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -48,10 +48,13 @@ import {
 } from "@/lib/solana/constants";
 import {
   estimateJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateFlowKey,
   getJupiterSwapFeeEstimateKey,
+  getSwapFeeEstimateDebounceMs,
+  getSwapFeeEstimateDisplayState,
   getJupiterQuote,
   getJupiterSwapTransaction,
-  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
+  isNonEmptySwapFeeEstimateState,
   type JupiterQuoteResponse,
   type SwapFeeEstimateState,
 } from "@/lib/solana/jupiter";
@@ -304,6 +307,9 @@ export function SwapSheet({
   const [feeEstimateState, setFeeEstimateState] =
     useState<SwapFeeEstimateState>({ status: "idle" });
   const feeEstimateConnection = useMemo(() => getConnection(), []);
+  const lastSuccessfulFeeEstimateStateRef =
+    useRef<SwapFeeEstimateState | null>(null);
+  const feeEstimateFlowKeyRef = useRef<string | null>(null);
   const feeEstimateRequestRef = useRef<{
     key: string;
     quoteResponse: JupiterQuoteResponse;
@@ -388,6 +394,9 @@ export function SwapSheet({
       setSwapStage("idle");
       setAmountStr("");
       setCurrencyMode("TOKEN");
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       setQuote(null);
       setFeeEstimateState({ status: "idle" });
       setSwapError(null);
@@ -401,9 +410,26 @@ export function SwapSheet({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  const feeEstimateFlowKey = useMemo(
+    () =>
+      getJupiterSwapFeeEstimateFlowKey({
+        inputMint: fromMint,
+        outputMint: toMint,
+        userPublicKey: walletAddress,
+      }),
+    [fromMint, toMint, walletAddress]
+  );
+  const displayFeeEstimateState = getSwapFeeEstimateDisplayState(
+    feeEstimateState,
+    lastSuccessfulFeeEstimateStateRef.current
+  );
+
   // Fetch quote when amount/tokens change
   useEffect(() => {
     if (amountNum <= 0 || fromMint === toMint || !fromHolding) {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       setQuote(null);
       setFeeEstimateState({ status: "idle" });
       return;
@@ -415,8 +441,12 @@ export function SwapSheet({
 
     let cancelled = false;
     feeEstimateRequestRef.current = null;
+    if (feeEstimateFlowKeyRef.current !== feeEstimateFlowKey) {
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+    }
     setQuote(null);
-    setFeeEstimateState({ status: "idle" });
+    setFeeEstimateState({ status: "loading" });
     setIsFetchingQuote(true);
 
     const timer = setTimeout(() => {
@@ -441,7 +471,7 @@ export function SwapSheet({
       clearTimeout(timer);
       setIsFetchingQuote(false);
     };
-  }, [amountNum, fromMint, toMint, fromHolding]);
+  }, [amountNum, feeEstimateFlowKey, fromMint, toMint, fromHolding]);
 
   const feeEstimateRequest = useMemo(() => {
     if (!quote || !walletAddress) return null;
@@ -481,17 +511,21 @@ export function SwapSheet({
           signal: abortController.signal,
         });
         if (!cancelled && !abortController.signal.aborted) {
+          if (isNonEmptySwapFeeEstimateState(nextState)) {
+            lastSuccessfulFeeEstimateStateRef.current = nextState;
+            feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          }
           setFeeEstimateState(nextState);
         }
       })();
-    }, SWAP_FEE_ESTIMATE_DEBOUNCE_MS);
+    }, getSwapFeeEstimateDebounceMs(lastSuccessfulFeeEstimateStateRef.current));
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
       abortController.abort();
     };
-  }, [feeEstimateConnection, feeEstimateKey]);
+  }, [feeEstimateConnection, feeEstimateFlowKey, feeEstimateKey]);
 
   // Focus the amount input once the sheet has settled at its snap point.
   // Focusing during the present animation pushes the keyboard above the sheet.
@@ -568,6 +602,9 @@ export function SwapSheet({
     setFromIsSecured(false);
     setAmountStr("");
     setCurrencyMode("TOKEN");
+    lastSuccessfulFeeEstimateStateRef.current = null;
+    feeEstimateFlowKeyRef.current = null;
+    feeEstimateRequestRef.current = null;
     setQuote(null);
     setFeeEstimateState({ status: "idle" });
   }, [fromMint, toMint]);
@@ -718,6 +755,9 @@ export function SwapSheet({
       setFromMint(mint);
       setFromIsSecured(isSecured);
       setShowFromPicker(false);
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       setQuote(null);
       setFeeEstimateState({ status: "idle" });
       if (mint === toMint) {
@@ -732,6 +772,9 @@ export function SwapSheet({
       setToMint(token.mint);
       setSelectedToToken(token);
       setShowToPicker(false);
+      lastSuccessfulFeeEstimateStateRef.current = null;
+      feeEstimateFlowKeyRef.current = null;
+      feeEstimateRequestRef.current = null;
       setQuote(null);
       setFeeEstimateState({ status: "idle" });
       if (token.mint === fromMint) {
@@ -842,7 +885,7 @@ export function SwapSheet({
             outAmount={outAmount}
             outUsd={outUsd}
             quote={quote}
-            feeEstimateState={feeEstimateState}
+            feeEstimateState={displayFeeEstimateState}
             feeSolPriceUsd={feeSolPriceUsd}
             isSwapping={isSwapping}
             onConfirm={handleSwap}

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -414,6 +414,9 @@ export function SwapSheet({
     ).toString();
 
     let cancelled = false;
+    feeEstimateRequestRef.current = null;
+    setQuote(null);
+    setFeeEstimateState({ status: "idle" });
     setIsFetchingQuote(true);
 
     const timer = setTimeout(() => {

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -159,10 +159,9 @@ function formatLamportsAsSol(lamports: number): string {
 }
 
 function getFeeSolPriceUsd(
-  fromHolding: TokenHolding | null,
-  toHolding: TokenHolding | null
+  holdings: (TokenHolding | null | undefined)[]
 ): number | null {
-  const solHolding = [fromHolding, toHolding].find(
+  const solHolding = holdings.find(
     (holding) =>
       holding &&
       (holding.symbol.toUpperCase() === "SOL" ||
@@ -508,6 +507,17 @@ export function SwapSheet({
     }
     return null;
   }, [outAmount, toHolding, amountNum, fromHolding]);
+  const feeSolPriceUsd = useMemo(
+    () =>
+      getFeeSolPriceUsd([
+        fromHolding,
+        toHolding,
+        selectedToToken,
+        ...tokenHoldings,
+        ...toPickerTokens,
+      ]),
+    [fromHolding, selectedToToken, toHolding, tokenHoldings, toPickerTokens]
+  );
 
   const handleFlip = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -795,6 +805,7 @@ export function SwapSheet({
             outUsd={outUsd}
             quote={quote}
             feeEstimateState={feeEstimateState}
+            feeSolPriceUsd={feeSolPriceUsd}
             isSwapping={isSwapping}
             onConfirm={handleSwap}
             onBack={() => setStep("form")}
@@ -1529,6 +1540,7 @@ function ConfirmStep({
   outUsd,
   quote,
   feeEstimateState,
+  feeSolPriceUsd,
   isSwapping,
   onConfirm,
   onBack,
@@ -1541,6 +1553,7 @@ function ConfirmStep({
   outUsd: number | null;
   quote: JupiterQuoteResponse | null;
   feeEstimateState: SwapFeeEstimateState;
+  feeSolPriceUsd: number | null;
   isSwapping: boolean;
   onConfirm: () => void;
   onBack: () => void;
@@ -1565,7 +1578,6 @@ function ConfirmStep({
     ? Number((quote.slippageBps / 100).toFixed(2))
     : null;
   const dim = { color: "rgba(60,60,67,0.6)" } as const;
-  const feeSolPriceUsd = getFeeSolPriceUsd(fromHolding, toHolding);
 
   return (
     <View style={{ flex: 1 }}>

--- a/mobile/src/components/wallet/SwapSheet.tsx
+++ b/mobile/src/components/wallet/SwapSheet.tsx
@@ -456,10 +456,21 @@ export function SwapSheet({
         amount: rawAmount,
       })
         .then((q) => {
-          if (!cancelled) setQuote(q);
+          if (cancelled) return;
+          setQuote(q);
+          if (q) return;
+          lastSuccessfulFeeEstimateStateRef.current = null;
+          feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          feeEstimateRequestRef.current = null;
+          setFeeEstimateState({ status: "idle" });
         })
         .catch(() => {
-          if (!cancelled) setQuote(null);
+          if (cancelled) return;
+          lastSuccessfulFeeEstimateStateRef.current = null;
+          feeEstimateFlowKeyRef.current = feeEstimateFlowKey;
+          feeEstimateRequestRef.current = null;
+          setQuote(null);
+          setFeeEstimateState({ status: "idle" });
         })
         .finally(() => {
           if (!cancelled) setIsFetchingQuote(false);

--- a/mobile/src/lib/solana/jupiter.ts
+++ b/mobile/src/lib/solana/jupiter.ts
@@ -1,9 +1,13 @@
 import {
   estimateJupiterSwapFeeState as estimateCoreJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateFlowKey as getCoreJupiterSwapFeeEstimateFlowKey,
   getJupiterSwapFeeEstimateKey as getCoreJupiterSwapFeeEstimateKey,
+  getSwapFeeEstimateDebounceMs,
+  getSwapFeeEstimateDisplayState,
   getJupiterQuote as getCoreJupiterQuote,
   getJupiterSwapInstructions as getCoreJupiterSwapInstructions,
   getJupiterSwapTransaction as getCoreJupiterSwapTransaction,
+  isNonEmptySwapFeeEstimateState,
   type JupiterQuoteResponse,
   type JupiterSwapInstructionsResponse,
   type JupiterSwapResponse,
@@ -23,7 +27,12 @@ export type {
   SwapFeeEstimateConnection,
   SwapFeeEstimateState,
 };
-export { SWAP_FEE_ESTIMATE_DEBOUNCE_MS };
+export {
+  getSwapFeeEstimateDebounceMs,
+  getSwapFeeEstimateDisplayState,
+  isNonEmptySwapFeeEstimateState,
+  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
+};
 
 export async function getJupiterQuote(params: {
   inputMint: string;
@@ -75,6 +84,17 @@ export function getJupiterSwapFeeEstimateKey(params: {
   userPublicKey: string;
 }): string {
   return getCoreJupiterSwapFeeEstimateKey({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
+  });
+}
+
+export function getJupiterSwapFeeEstimateFlowKey(params: {
+  inputMint: string;
+  outputMint: string;
+  userPublicKey: string | null;
+}): string | null {
+  return getCoreJupiterSwapFeeEstimateFlowKey({
     ...params,
     baseUrl: JUPITER_SWAP_API_BASE_URL,
   });

--- a/mobile/src/lib/solana/jupiter.ts
+++ b/mobile/src/lib/solana/jupiter.ts
@@ -1,5 +1,6 @@
 import {
   estimateJupiterSwapFeeState as estimateCoreJupiterSwapFeeState,
+  getJupiterSwapFeeEstimateKey as getCoreJupiterSwapFeeEstimateKey,
   getJupiterQuote as getCoreJupiterQuote,
   getJupiterSwapInstructions as getCoreJupiterSwapInstructions,
   getJupiterSwapTransaction as getCoreJupiterSwapTransaction,
@@ -9,6 +10,7 @@ import {
   type SwapFeeEstimate,
   type SwapFeeEstimateConnection,
   type SwapFeeEstimateState,
+  SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
 } from "@loyal-labs/wallet-core/lib";
 
 const JUPITER_SWAP_API_BASE_URL = "https://api.jup.ag/swap/v1";
@@ -21,6 +23,7 @@ export type {
   SwapFeeEstimateConnection,
   SwapFeeEstimateState,
 };
+export { SWAP_FEE_ESTIMATE_DEBOUNCE_MS };
 
 export async function getJupiterQuote(params: {
   inputMint: string;
@@ -58,8 +61,20 @@ export async function estimateJupiterSwapFeeState(params: {
   connection: SwapFeeEstimateConnection;
   quoteResponse: JupiterQuoteResponse;
   userPublicKey: string;
+  signal?: AbortSignal;
 }): Promise<SwapFeeEstimateState> {
   return estimateCoreJupiterSwapFeeState({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
+  });
+}
+
+export function getJupiterSwapFeeEstimateKey(params: {
+  connection?: SwapFeeEstimateConnection;
+  quoteResponse: JupiterQuoteResponse;
+  userPublicKey: string;
+}): string {
+  return getCoreJupiterSwapFeeEstimateKey({
     ...params,
     baseUrl: JUPITER_SWAP_API_BASE_URL,
   });

--- a/mobile/src/lib/solana/jupiter.ts
+++ b/mobile/src/lib/solana/jupiter.ts
@@ -1,17 +1,24 @@
-const JUPITER_QUOTE_API_URL = "https://api.jup.ag/swap/v1/quote";
-const JUPITER_SWAP_API_URL = "https://api.jup.ag/swap/v1/swap";
+import {
+  estimateSwapTransactionFee,
+  getJupiterQuote as getCoreJupiterQuote,
+  getJupiterSwapInstructions as getCoreJupiterSwapInstructions,
+  getJupiterSwapTransaction as getCoreJupiterSwapTransaction,
+  type JupiterQuoteResponse,
+  type JupiterSwapInstructionsResponse,
+  type JupiterSwapResponse,
+  type SwapFeeEstimate,
+} from "@loyal-labs/wallet-core/lib";
 
-export type JupiterQuoteResponse = {
-  inputMint: string;
-  outputMint: string;
-  inAmount: string;
-  outAmount: string;
-  otherAmountThreshold: string;
-  swapMode: string;
-  slippageBps: number;
-  priceImpactPct: string;
-  routePlan: unknown[];
+const JUPITER_SWAP_API_BASE_URL = "https://api.jup.ag/swap/v1";
+
+export type {
+  JupiterQuoteResponse,
+  JupiterSwapInstructionsResponse,
+  JupiterSwapResponse,
+  SwapFeeEstimate,
 };
+
+export { estimateSwapTransactionFee };
 
 export async function getJupiterQuote(params: {
   inputMint: string;
@@ -19,30 +26,28 @@ export async function getJupiterQuote(params: {
   amount: string;
   slippageBps?: number;
 }): Promise<JupiterQuoteResponse> {
-  const url = new URL(JUPITER_QUOTE_API_URL);
-  url.searchParams.set("inputMint", params.inputMint);
-  url.searchParams.set("outputMint", params.outputMint);
-  url.searchParams.set("amount", params.amount);
-  url.searchParams.set("slippageBps", String(params.slippageBps ?? 50));
-
-  const resp = await fetch(url.toString());
-  if (!resp.ok) throw new Error(`Jupiter quote failed: ${resp.status}`);
-  return resp.json();
+  return getCoreJupiterQuote({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
+  });
 }
 
 export async function getJupiterSwapTransaction(params: {
   quoteResponse: JupiterQuoteResponse;
   userPublicKey: string;
-}): Promise<{ swapTransaction: string }> {
-  const resp = await fetch(JUPITER_SWAP_API_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      quoteResponse: params.quoteResponse,
-      userPublicKey: params.userPublicKey,
-      wrapAndUnwrapSol: true,
-    }),
+}): Promise<JupiterSwapResponse> {
+  return getCoreJupiterSwapTransaction({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
   });
-  if (!resp.ok) throw new Error(`Jupiter swap failed: ${resp.status}`);
-  return resp.json();
+}
+
+export async function getJupiterSwapInstructions(params: {
+  quoteResponse: JupiterQuoteResponse;
+  userPublicKey: string;
+}): Promise<JupiterSwapInstructionsResponse> {
+  return getCoreJupiterSwapInstructions({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
+  });
 }

--- a/mobile/src/lib/solana/jupiter.ts
+++ b/mobile/src/lib/solana/jupiter.ts
@@ -1,5 +1,5 @@
 import {
-  estimateSwapTransactionFee,
+  estimateJupiterSwapFeeState as estimateCoreJupiterSwapFeeState,
   getJupiterQuote as getCoreJupiterQuote,
   getJupiterSwapInstructions as getCoreJupiterSwapInstructions,
   getJupiterSwapTransaction as getCoreJupiterSwapTransaction,
@@ -7,6 +7,8 @@ import {
   type JupiterSwapInstructionsResponse,
   type JupiterSwapResponse,
   type SwapFeeEstimate,
+  type SwapFeeEstimateConnection,
+  type SwapFeeEstimateState,
 } from "@loyal-labs/wallet-core/lib";
 
 const JUPITER_SWAP_API_BASE_URL = "https://api.jup.ag/swap/v1";
@@ -16,9 +18,9 @@ export type {
   JupiterSwapInstructionsResponse,
   JupiterSwapResponse,
   SwapFeeEstimate,
+  SwapFeeEstimateConnection,
+  SwapFeeEstimateState,
 };
-
-export { estimateSwapTransactionFee };
 
 export async function getJupiterQuote(params: {
   inputMint: string;
@@ -47,6 +49,17 @@ export async function getJupiterSwapInstructions(params: {
   userPublicKey: string;
 }): Promise<JupiterSwapInstructionsResponse> {
   return getCoreJupiterSwapInstructions({
+    ...params,
+    baseUrl: JUPITER_SWAP_API_BASE_URL,
+  });
+}
+
+export async function estimateJupiterSwapFeeState(params: {
+  connection: SwapFeeEstimateConnection;
+  quoteResponse: JupiterQuoteResponse;
+  userPublicKey: string;
+}): Promise<SwapFeeEstimateState> {
+  return estimateCoreJupiterSwapFeeState({
     ...params,
     baseUrl: JUPITER_SWAP_API_BASE_URL,
   });

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -12,6 +12,9 @@
       "@loyal-labs/shared": [
         "../packages/shared/src/index.ts"
       ],
+      "@loyal-labs/wallet-core/lib": [
+        "../packages/wallet-core/src/lib/index.ts"
+      ],
       "expo-seed-vault": [
         "./modules/expo-seed-vault/src/index.ts"
       ]

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@loyal-labs/solana-rpc": "workspace:*",
     "@loyal-labs/solana-wallet": "workspace:*",
-    "@loyal-labs/private-transactions": "workspace:*"
+    "@loyal-labs/private-transactions": "workspace:*",
+    "buffer": "^6.0.3"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.98.0",

--- a/packages/wallet-core/src/hooks/use-swap.ts
+++ b/packages/wallet-core/src/hooks/use-swap.ts
@@ -1,8 +1,18 @@
-import type { Connection, ParsedAccountData } from "@solana/web3.js";
-import { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import type {
+	Connection,
+	ParsedAccountData,
+	VersionedTransaction,
+} from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
 
 import { TOKEN_MINTS } from "../constants/token-mints";
+import {
+	deserializeJupiterSwapTransaction,
+	getJupiterQuote,
+	getJupiterSwapTransaction,
+} from "../lib/jupiter/client";
+import type { JupiterQuoteResponse } from "../lib/jupiter/types";
 import type { WalletSigner } from "../types/signer";
 
 // Debug logger that only emits in development
@@ -35,52 +45,8 @@ export type SwapResult = {
 };
 
 export type SwapConfig =
-	| { mode: "enabled"; apiKey: string }
+	| { mode: "enabled"; apiKey?: string; baseUrl?: string }
 	| { mode: "disabled"; reason: string };
-
-const JUPITER_QUOTE_API_URL = "https://lite-api.jup.ag/swap/v1/quote";
-const JUPITER_SWAP_API_URL = "https://lite-api.jup.ag/swap/v1/swap";
-
-const buildJupiterHeaders = (
-	apiKey: string,
-	extra?: Record<string, string>,
-): Record<string, string> => ({
-	...(extra ?? {}),
-	...(apiKey ? { "x-api-key": apiKey } : {}),
-});
-
-type JupiterQuoteResponse = {
-	inputMint: string;
-	inAmount: string;
-	outputMint: string;
-	outAmount: string;
-	otherAmountThreshold: string;
-	swapMode: string;
-	slippageBps: number;
-	platformFee: null | { amount: string; feeBps: number };
-	priceImpactPct: string;
-	routePlan: Array<{
-		swapInfo: {
-			ammKey: string;
-			label: string;
-			inputMint: string;
-			outputMint: string;
-			inAmount: string;
-			outAmount: string;
-			feeAmount: string;
-			feeMint: string;
-		};
-		percent: number;
-	}>;
-	contextSlot?: number;
-	timeTaken?: number;
-};
-
-type JupiterSwapResponse = {
-	swapTransaction: string;
-	lastValidBlockHeight: number;
-	prioritizationFeeLamports: number;
-};
 
 const getTokenMint = (symbol: string): string | undefined => {
 	return TOKEN_MINTS[symbol.toUpperCase()];
@@ -89,7 +55,7 @@ const getTokenMint = (symbol: string): string | undefined => {
 async function sendTransactionViaSigner(
 	signer: WalletSigner,
 	connection: Connection,
-	transaction: VersionedTransaction,
+	transaction: VersionedTransaction
 ): Promise<string> {
 	if (signer.sendTransaction) {
 		return signer.sendTransaction(transaction);
@@ -101,8 +67,13 @@ async function sendTransactionViaSigner(
 export function useSwap(
 	signer: WalletSigner | null,
 	connection: Connection,
-	swapConfig: SwapConfig,
+	swapConfig: SwapConfig
 ) {
+	const isSwapEnabled = swapConfig.mode === "enabled";
+	const swapApiKey = isSwapEnabled ? swapConfig.apiKey : undefined;
+	const swapBaseUrl = isSwapEnabled ? swapConfig.baseUrl : undefined;
+	const unavailableReason =
+		swapConfig.mode === "disabled" ? swapConfig.reason : null;
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [quote, setQuote] = useState<SwapQuote | null>(null);
@@ -112,8 +83,7 @@ export function useSwap(
 	const getTokenDecimals = useCallback(
 		async (mintAddress: string): Promise<number> => {
 			const mintPublicKey = new PublicKey(mintAddress);
-			const accountInfo =
-				await connection.getParsedAccountInfo(mintPublicKey);
+			const accountInfo = await connection.getParsedAccountInfo(mintPublicKey);
 			const data = accountInfo.value?.data;
 
 			if (data && typeof data === "object" && "parsed" in data) {
@@ -125,10 +95,10 @@ export function useSwap(
 			}
 
 			throw new Error(
-				`Unable to determine token decimals for mint ${mintAddress}`,
+				`Unable to determine token decimals for mint ${mintAddress}`
 			);
 		},
-		[connection],
+		[connection]
 	);
 
 	const getQuote = useCallback(
@@ -139,13 +109,13 @@ export function useSwap(
 			fromTokenMint?: string,
 			fromTokenDecimals?: number,
 			toTokenDecimals?: number,
-			toTokenMint?: string,
+			toTokenMint?: string
 		): Promise<SwapQuote | null> => {
 			try {
 				setError(null);
 
-				if (swapConfig.mode === "disabled") {
-					throw new Error(swapConfig.reason);
+				if (!isSwapEnabled) {
+					throw new Error(unavailableReason ?? "Swap unavailable");
 				}
 
 				const inputMint = fromTokenMint || getTokenMint(fromToken);
@@ -153,7 +123,7 @@ export function useSwap(
 
 				if (!inputMint) {
 					throw new Error(
-						`Unknown token: ${fromToken}. Please provide token mint address.`,
+						`Unknown token: ${fromToken}. Please provide token mint address.`
 					);
 				}
 				if (!outputMint) {
@@ -168,7 +138,7 @@ export function useSwap(
 					: getTokenDecimals(outputMint);
 				const inputDecimals = await inputDecimalsPromise;
 				const amountInSmallestUnit = Math.floor(
-					Number.parseFloat(amount) * 10 ** inputDecimals,
+					Number.parseFloat(amount) * 10 ** inputDecimals
 				).toString();
 
 				logger.debug("Token conversion:", {
@@ -181,22 +151,14 @@ export function useSwap(
 					decimals: inputDecimals,
 				});
 
-				const url = `${JUPITER_QUOTE_API_URL}?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amountInSmallestUnit}&slippageBps=50`;
-				logger.debug("Fetching quote from Jupiter API:", url);
-
-				const response = await fetch(url, {
-					headers: buildJupiterHeaders(swapConfig.apiKey),
+				const data = await getJupiterQuote({
+					inputMint,
+					outputMint,
+					amount: amountInSmallestUnit,
+					slippageBps: 50,
+					apiKey: swapApiKey,
+					baseUrl: swapBaseUrl,
 				});
-
-				if (!response.ok) {
-					const errorText = await response.text();
-					logger.debug("Quote API error:", errorText);
-					throw new Error(
-						`Failed to get quote: ${response.statusText}`,
-					);
-				}
-
-				const data: JupiterQuoteResponse = await response.json();
 				logger.debug("Jupiter Quote response:", data);
 
 				setQuoteResponse(data);
@@ -208,8 +170,7 @@ export function useSwap(
 				).toFixed(outputDecimals);
 
 				const priceImpact = `${(
-					Number.parseFloat(data.priceImpactPct) *
-					PERCENTAGE_MULTIPLIER
+					Number.parseFloat(data.priceImpactPct) * PERCENTAGE_MULTIPLIER
 				).toFixed(2)}%`;
 
 				const quoteData: SwapQuote = {
@@ -226,21 +187,26 @@ export function useSwap(
 				return quoteData;
 			} catch (err) {
 				const errorMessage =
-					err instanceof Error
-						? err.message
-						: "Failed to get quote";
+					err instanceof Error ? err.message : "Failed to get quote";
 				setError(errorMessage);
 				logger.debug("Quote error:", err);
 				return null;
 			}
 		},
-		[getTokenDecimals, swapConfig],
+		[
+			getTokenDecimals,
+			isSwapEnabled,
+			swapApiKey,
+			swapBaseUrl,
+			unavailableReason,
+		]
 	);
 
 	const executeSwap = useCallback(async (): Promise<SwapResult> => {
-		if (swapConfig.mode === "disabled") {
-			setError(swapConfig.reason);
-			return { success: false, error: swapConfig.reason };
+		if (!isSwapEnabled) {
+			const errorMsg = unavailableReason ?? "Swap unavailable";
+			setError(errorMsg);
+			return { success: false, error: errorMsg };
 		}
 
 		if (!signer) {
@@ -250,8 +216,7 @@ export function useSwap(
 		}
 
 		if (!quoteResponse) {
-			const errorMsg =
-				"No quote available. Please get a quote first.";
+			const errorMsg = "No quote available. Please get a quote first.";
 			setError(errorMsg);
 			return { success: false, error: errorMsg };
 		}
@@ -262,73 +227,43 @@ export function useSwap(
 		try {
 			logger.debug("Executing swap with quote:", quoteResponse);
 
-			const swapResponse = await fetch(JUPITER_SWAP_API_URL, {
-				method: "POST",
-				headers: buildJupiterHeaders(
-					(swapConfig as { apiKey: string }).apiKey,
-					{ "Content-Type": "application/json" },
-				),
-				body: JSON.stringify({
-					userPublicKey: signer.publicKey.toBase58(),
-					quoteResponse,
-					wrapAndUnwrapSol: true,
-					dynamicComputeUnitLimit: true,
-					prioritizationFeeLamports: {
-						priorityLevelWithMaxLamports: {
-							priorityLevel: "veryHigh",
-							maxLamports: 50_000_000,
-							global: true,
-						},
-					},
-				}),
+			const swapData = await getJupiterSwapTransaction({
+				userPublicKey: signer.publicKey.toBase58(),
+				quoteResponse,
+				apiKey: swapApiKey,
+				baseUrl: swapBaseUrl,
 			});
-
-			if (!swapResponse.ok) {
-				const errorText = await swapResponse.text();
-				logger.debug("Jupiter Swap API error:", errorText);
-				throw new Error(
-					`Jupiter Swap API failed: ${swapResponse.statusText}`,
-				);
-			}
-
-			const swapData: JupiterSwapResponse = await swapResponse.json();
 			logger.debug("Jupiter Swap transaction response:", swapData);
 
 			const { swapTransaction: serializedTx } = swapData;
 			if (!serializedTx) {
-				throw new Error(
-					"No transaction returned from Jupiter Swap API",
-				);
+				throw new Error("No transaction returned from Jupiter Swap API");
 			}
 
-			const txBuffer = Buffer.from(serializedTx, "base64");
-			const transaction =
-				VersionedTransaction.deserialize(new Uint8Array(txBuffer));
+			const transaction = deserializeJupiterSwapTransaction(serializedTx);
 
 			logger.debug("Signing and sending transaction...");
 			const signature = await sendTransactionViaSigner(
 				signer,
 				connection,
-				transaction,
+				transaction
 			);
 
 			logger.debug("Transaction sent:", signature);
 
-			const latestBlockhash =
-				await connection.getLatestBlockhash("confirmed");
+			const latestBlockhash = await connection.getLatestBlockhash("confirmed");
 			const confirmation = await connection.confirmTransaction(
 				{
 					signature,
 					blockhash: latestBlockhash.blockhash,
-					lastValidBlockHeight:
-						latestBlockhash.lastValidBlockHeight,
+					lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
 				},
-				"confirmed",
+				"confirmed"
 			);
 
 			if (confirmation.value.err) {
 				throw new Error(
-					`Transaction failed: ${JSON.stringify(confirmation.value.err)}`,
+					`Transaction failed: ${JSON.stringify(confirmation.value.err)}`
 				);
 			}
 
@@ -345,8 +280,7 @@ export function useSwap(
 					errorMessage =
 						"Transaction signing timed out. Please try again and approve the transaction in your wallet promptly.";
 				} else if (err.message.includes("User rejected")) {
-					errorMessage =
-						"Transaction was rejected in your wallet.";
+					errorMessage = "Transaction was rejected in your wallet.";
 				} else {
 					errorMessage = err.message;
 				}
@@ -356,7 +290,15 @@ export function useSwap(
 			setLoading(false);
 			return { success: false, error: errorMessage };
 		}
-	}, [connection, signer, quoteResponse, swapConfig]);
+	}, [
+		connection,
+		isSwapEnabled,
+		signer,
+		quoteResponse,
+		swapApiKey,
+		swapBaseUrl,
+		unavailableReason,
+	]);
 
 	const resetQuote = useCallback(() => {
 		setQuote(null);
@@ -371,8 +313,8 @@ export function useSwap(
 		quote,
 		loading,
 		error,
-		isAvailable: swapConfig.mode === "enabled",
-		unavailableReason:
-			swapConfig.mode === "disabled" ? swapConfig.reason : null,
+		quoteResponse,
+		isAvailable: isSwapEnabled,
+		unavailableReason,
 	};
 }

--- a/packages/wallet-core/src/lib/index.ts
+++ b/packages/wallet-core/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./jupiter/client";
+export * from "./jupiter/fee-estimator";
 export * from "./jupiter/types";
 export { getTokenIconUrl } from "./token-icon";
 export * from "./solana/wsol-adapter";

--- a/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
+++ b/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
@@ -13,7 +13,11 @@ import {
 } from "@solana/web3.js";
 import { describe, expect, test } from "bun:test";
 
-import { estimateSwapTransactionFee } from "../fee-estimator";
+import {
+	estimateSwapTransactionFee,
+	getSwapFeeEstimateErrorState,
+	getSwapFeeEstimateState,
+} from "../fee-estimator";
 import type { JupiterInstruction } from "../types";
 
 const RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS = 2_039_280;
@@ -195,5 +199,56 @@ describe("estimateSwapTransactionFee", () => {
 		expect(estimate.createdAtaAccounts).toHaveLength(0);
 		expect(estimate.rentLamports).toBe(0);
 		expect(estimate.totalLamports).toBe(MESSAGE_FEE_LAMPORTS);
+	});
+});
+
+describe("swap fee estimate state helpers", () => {
+	const baseEstimate = {
+		totalLamports: 5_000,
+		transactionFeeLamports: 5_000,
+		prioritizationFeeLamports: null,
+		prioritizationFeeIncludedInTransactionFee: false,
+		rentLamports: 0,
+		createdAtaAccounts: [],
+		simulation: {
+			status: "passed" as const,
+			error: null,
+			unitsConsumed: 10_000,
+			logs: [],
+		},
+	};
+
+	test("maps a passing simulation to a success state", () => {
+		expect(getSwapFeeEstimateState(baseEstimate)).toEqual({
+			status: "success",
+			estimate: baseEstimate,
+		});
+	});
+
+	test("maps a failed simulation to an error state", () => {
+		expect(
+			getSwapFeeEstimateState({
+				...baseEstimate,
+				simulation: {
+					...baseEstimate.simulation,
+					status: "failed",
+					error: { InstructionError: [0, "Custom"] },
+				},
+			})
+		).toEqual({
+			status: "error",
+			error: "Swap fee simulation failed",
+		});
+	});
+
+	test("normalizes thrown errors for fee-estimate state", () => {
+		expect(getSwapFeeEstimateErrorState(new Error("quote expired"))).toEqual({
+			status: "error",
+			error: "quote expired",
+		});
+		expect(getSwapFeeEstimateErrorState("nope")).toEqual({
+			status: "error",
+			error: "Swap fee unavailable",
+		});
 	});
 });

--- a/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
+++ b/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
@@ -13,11 +13,7 @@ import {
 } from "@solana/web3.js";
 import { describe, expect, test } from "bun:test";
 
-import {
-	estimateSwapTransactionFee,
-	getSwapFeeEstimateErrorState,
-	getSwapFeeEstimateState,
-} from "../fee-estimator";
+import { estimateSwapTransactionFee } from "../fee-estimator";
 import type { JupiterInstruction } from "../types";
 
 const RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS = 2_039_280;
@@ -199,56 +195,5 @@ describe("estimateSwapTransactionFee", () => {
 		expect(estimate.createdAtaAccounts).toHaveLength(0);
 		expect(estimate.rentLamports).toBe(0);
 		expect(estimate.totalLamports).toBe(MESSAGE_FEE_LAMPORTS);
-	});
-});
-
-describe("swap fee estimate state helpers", () => {
-	const baseEstimate = {
-		totalLamports: 5_000,
-		transactionFeeLamports: 5_000,
-		prioritizationFeeLamports: null,
-		prioritizationFeeIncludedInTransactionFee: false,
-		rentLamports: 0,
-		createdAtaAccounts: [],
-		simulation: {
-			status: "passed" as const,
-			error: null,
-			unitsConsumed: 10_000,
-			logs: [],
-		},
-	};
-
-	test("maps a passing simulation to a success state", () => {
-		expect(getSwapFeeEstimateState(baseEstimate)).toEqual({
-			status: "success",
-			estimate: baseEstimate,
-		});
-	});
-
-	test("maps a failed simulation to an error state", () => {
-		expect(
-			getSwapFeeEstimateState({
-				...baseEstimate,
-				simulation: {
-					...baseEstimate.simulation,
-					status: "failed",
-					error: { InstructionError: [0, "Custom"] },
-				},
-			})
-		).toEqual({
-			status: "error",
-			error: "Swap fee simulation failed",
-		});
-	});
-
-	test("normalizes thrown errors for fee-estimate state", () => {
-		expect(getSwapFeeEstimateErrorState(new Error("quote expired"))).toEqual({
-			status: "error",
-			error: "quote expired",
-		});
-		expect(getSwapFeeEstimateErrorState("nope")).toEqual({
-			status: "error",
-			error: "Swap fee unavailable",
-		});
 	});
 });

--- a/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
+++ b/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
@@ -1,0 +1,199 @@
+import {
+	ACCOUNT_SIZE,
+	createAssociatedTokenAccountIdempotentInstruction,
+	getAssociatedTokenAddressSync,
+	TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+	ComputeBudgetProgram,
+	Keypair,
+	PublicKey,
+	TransactionMessage,
+	VersionedTransaction,
+} from "@solana/web3.js";
+import { describe, expect, test } from "bun:test";
+
+import { estimateSwapTransactionFee } from "../fee-estimator";
+import type { JupiterInstruction } from "../types";
+
+const RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS = 2_039_280;
+const MESSAGE_FEE_LAMPORTS = 7_000;
+type EstimateFeeConnection = Parameters<
+	typeof estimateSwapTransactionFee
+>[0]["connection"];
+type MultipleAccountInfos = Awaited<
+	ReturnType<EstimateFeeConnection["getMultipleAccountsInfo"]>
+>;
+const EXISTING_ACCOUNT = {} as NonNullable<MultipleAccountInfos[number]>;
+
+const toJupiterInstruction = (
+	instruction: ReturnType<
+		typeof createAssociatedTokenAccountIdempotentInstruction
+	>
+): JupiterInstruction => ({
+	programId: instruction.programId.toBase58(),
+	accounts: instruction.keys.map((account) => ({
+		pubkey: account.pubkey.toBase58(),
+		isSigner: account.isSigner,
+		isWritable: account.isWritable,
+	})),
+	data: Buffer.from(instruction.data).toString("base64"),
+});
+
+const createSwapTransaction = (params: {
+	payer: PublicKey;
+	instructions: ReturnType<
+		typeof createAssociatedTokenAccountIdempotentInstruction
+	>[];
+}): VersionedTransaction => {
+	const message = new TransactionMessage({
+		payerKey: params.payer,
+		recentBlockhash: Keypair.generate().publicKey.toBase58(),
+		instructions: [
+			ComputeBudgetProgram.setComputeUnitLimit({ units: 100_000 }),
+			ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 2_000 }),
+			...params.instructions,
+		],
+	}).compileToV0Message();
+	return new VersionedTransaction(message);
+};
+
+const createMockConnection = (
+	existingAccounts: MultipleAccountInfos = []
+): EstimateFeeConnection => ({
+	getFeeForMessage: async () => ({
+		context: { slot: 1 },
+		value: MESSAGE_FEE_LAMPORTS,
+	}),
+	getMinimumBalanceForRentExemption: async (size: number) => {
+		expect(size).toBe(ACCOUNT_SIZE);
+		return RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS;
+	},
+	getMultipleAccountsInfo: async () => existingAccounts,
+	simulateTransaction: async () => ({
+		context: { slot: 1 },
+		value: {
+			err: null,
+			logs: ["ok"],
+			unitsConsumed: 42_000,
+		},
+	}),
+});
+
+describe("estimateSwapTransactionFee", () => {
+	test("adds missing user-paid ATA rent to the simulated network fee", async () => {
+		const payer = Keypair.generate().publicKey;
+		const owner = payer;
+		const mint = Keypair.generate().publicKey;
+		const ata = getAssociatedTokenAddressSync(mint, owner);
+		const createAtaInstruction =
+			createAssociatedTokenAccountIdempotentInstruction(
+				payer,
+				ata,
+				owner,
+				mint,
+				TOKEN_PROGRAM_ID
+			);
+		const transaction = createSwapTransaction({
+			payer,
+			instructions: [createAtaInstruction],
+		});
+
+		const estimate = await estimateSwapTransactionFee({
+			connection: createMockConnection([null]),
+			transaction,
+			swapResponse: {
+				swapTransaction: Buffer.from(transaction.serialize()).toString(
+					"base64"
+				),
+				prioritizationFeeLamports: 123,
+			},
+			swapInstructions: {
+				setupInstructions: [toJupiterInstruction(createAtaInstruction)],
+			},
+			userPublicKey: payer,
+		});
+
+		expect(estimate.simulation.status).toBe("passed");
+		expect(estimate.transactionFeeLamports).toBe(MESSAGE_FEE_LAMPORTS);
+		expect(estimate.prioritizationFeeLamports).toBe(123);
+		expect(estimate.rentLamports).toBe(RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS);
+		expect(estimate.totalLamports).toBe(
+			MESSAGE_FEE_LAMPORTS + RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS
+		);
+		expect(estimate.createdAtaAccounts).toHaveLength(1);
+		expect(estimate.createdAtaAccounts[0]).toMatchObject({
+			address: ata.toBase58(),
+			mint: mint.toBase58(),
+			owner: owner.toBase58(),
+			paidByUser: true,
+			alreadyExisted: false,
+			rentLamports: RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS,
+		});
+	});
+
+	test("does not charge ATA rent for accounts that already exist", async () => {
+		const payer = Keypair.generate().publicKey;
+		const owner = payer;
+		const mint = Keypair.generate().publicKey;
+		const ata = getAssociatedTokenAddressSync(mint, owner);
+		const createAtaInstruction =
+			createAssociatedTokenAccountIdempotentInstruction(
+				payer,
+				ata,
+				owner,
+				mint,
+				TOKEN_PROGRAM_ID
+			);
+		const transaction = createSwapTransaction({
+			payer,
+			instructions: [createAtaInstruction],
+		});
+
+		const estimate = await estimateSwapTransactionFee({
+			connection: createMockConnection([EXISTING_ACCOUNT]),
+			transaction,
+			swapInstructions: {
+				setupInstructions: [toJupiterInstruction(createAtaInstruction)],
+			},
+			userPublicKey: payer,
+		});
+
+		expect(estimate.rentLamports).toBe(0);
+		expect(estimate.totalLamports).toBe(MESSAGE_FEE_LAMPORTS);
+		expect(estimate.createdAtaAccounts[0]?.alreadyExisted).toBe(true);
+	});
+
+	test("does not include ATA rent paid by a different payer", async () => {
+		const payer = Keypair.generate().publicKey;
+		const user = Keypair.generate().publicKey;
+		const owner = user;
+		const mint = Keypair.generate().publicKey;
+		const ata = getAssociatedTokenAddressSync(mint, owner);
+		const createAtaInstruction =
+			createAssociatedTokenAccountIdempotentInstruction(
+				payer,
+				ata,
+				owner,
+				mint,
+				TOKEN_PROGRAM_ID
+			);
+		const transaction = createSwapTransaction({
+			payer,
+			instructions: [createAtaInstruction],
+		});
+
+		const estimate = await estimateSwapTransactionFee({
+			connection: createMockConnection([null]),
+			transaction,
+			swapInstructions: {
+				setupInstructions: [toJupiterInstruction(createAtaInstruction)],
+			},
+			userPublicKey: user,
+		});
+
+		expect(estimate.createdAtaAccounts).toHaveLength(0);
+		expect(estimate.rentLamports).toBe(0);
+		expect(estimate.totalLamports).toBe(MESSAGE_FEE_LAMPORTS);
+	});
+});

--- a/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
+++ b/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
@@ -16,8 +16,15 @@ import { describe, expect, test } from "bun:test";
 import {
 	estimateJupiterSwapFeeState,
 	estimateSwapTransactionFee,
+	getJupiterSwapFeeEstimateFlowKey,
 	getJupiterSwapFeeEstimateKey,
+	getSwapFeeEstimateDebounceMs,
+	getSwapFeeEstimateDisplayState,
+	isNonEmptySwapFeeEstimateState,
+	SWAP_FEE_ESTIMATE_DEBOUNCE_MS,
+	SWAP_FEE_ESTIMATE_RECOMPUTE_DEBOUNCE_MS,
 } from "../fee-estimator";
+import type { SwapFeeEstimateState } from "../types";
 import type { JupiterInstruction } from "../types";
 
 const RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS = 2_039_280;
@@ -133,6 +140,26 @@ const jsonResponse = (body: unknown) =>
 		headers: { "Content-Type": "application/json" },
 		status: 200,
 	});
+
+const createFeeEstimateState = (
+	totalLamports: number
+): Extract<SwapFeeEstimateState, { status: "success" }> => ({
+	status: "success",
+	estimate: {
+		totalLamports,
+		transactionFeeLamports: totalLamports,
+		prioritizationFeeLamports: null,
+		prioritizationFeeIncludedInTransactionFee: false,
+		rentLamports: 0,
+		createdAtaAccounts: [],
+		simulation: {
+			status: "passed",
+			error: null,
+			unitsConsumed: 1,
+			logs: [],
+		},
+	},
+});
 
 describe("estimateSwapTransactionFee", () => {
 	test("adds missing user-paid ATA rent to the simulated network fee", async () => {
@@ -362,5 +389,71 @@ describe("estimateJupiterSwapFeeState", () => {
 
 		expect(state).toEqual({ status: "idle" });
 		expect(fetchCalls).toBe(0);
+	});
+});
+
+describe("swap fee estimate display policy", () => {
+	test("uses the longer recompute debounce after a non-empty fee estimate", () => {
+		expect(getSwapFeeEstimateDebounceMs()).toBe(
+			SWAP_FEE_ESTIMATE_DEBOUNCE_MS
+		);
+		expect(getSwapFeeEstimateDebounceMs(createFeeEstimateState(0))).toBe(
+			SWAP_FEE_ESTIMATE_DEBOUNCE_MS
+		);
+		expect(getSwapFeeEstimateDebounceMs(createFeeEstimateState(5_000))).toBe(
+			SWAP_FEE_ESTIMATE_RECOMPUTE_DEBOUNCE_MS
+		);
+	});
+
+	test("retains the last non-empty fee while recomputing or after errors", () => {
+		const lastSuccessfulState = createFeeEstimateState(5_000);
+
+		expect(isNonEmptySwapFeeEstimateState(lastSuccessfulState)).toBe(true);
+		expect(
+			getSwapFeeEstimateDisplayState(
+				{ status: "loading" },
+				lastSuccessfulState
+			)
+		).toBe(lastSuccessfulState);
+		expect(
+			getSwapFeeEstimateDisplayState(
+				{ status: "error", error: "rate limited" },
+				lastSuccessfulState
+			)
+		).toBe(lastSuccessfulState);
+		expect(
+			getSwapFeeEstimateDisplayState({ status: "idle" }, lastSuccessfulState)
+		).toBe(lastSuccessfulState);
+		expect(
+			getSwapFeeEstimateDisplayState({ status: "loading" }, null)
+		).toEqual({ status: "loading" });
+	});
+
+	test("keys retained display state by token pair and user, not amount", () => {
+		const userPublicKey = Keypair.generate().publicKey;
+		const inputMint = Keypair.generate().publicKey.toBase58();
+		const outputMint = Keypair.generate().publicKey.toBase58();
+		const baseParams = {
+			inputMint,
+			outputMint,
+			userPublicKey,
+			baseUrl: "https://api.jup.ag/swap/v1",
+		};
+
+		expect(getJupiterSwapFeeEstimateFlowKey(baseParams)).toBe(
+			getJupiterSwapFeeEstimateFlowKey(baseParams)
+		);
+		expect(getJupiterSwapFeeEstimateFlowKey(baseParams)).not.toBe(
+			getJupiterSwapFeeEstimateFlowKey({
+				...baseParams,
+				outputMint: Keypair.generate().publicKey.toBase58(),
+			})
+		);
+		expect(
+			getJupiterSwapFeeEstimateFlowKey({
+				...baseParams,
+				userPublicKey: null,
+			})
+		).toBeNull();
 	});
 });

--- a/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
+++ b/packages/wallet-core/src/lib/jupiter/__tests__/fee-estimator.test.ts
@@ -13,7 +13,11 @@ import {
 } from "@solana/web3.js";
 import { describe, expect, test } from "bun:test";
 
-import { estimateSwapTransactionFee } from "../fee-estimator";
+import {
+	estimateJupiterSwapFeeState,
+	estimateSwapTransactionFee,
+	getJupiterSwapFeeEstimateKey,
+} from "../fee-estimator";
 import type { JupiterInstruction } from "../types";
 
 const RENT_EXEMPT_TOKEN_ACCOUNT_LAMPORTS = 2_039_280;
@@ -79,6 +83,56 @@ const createMockConnection = (
 		},
 	}),
 });
+
+const createQuoteResponse = (params?: {
+	inputMint?: string;
+	outputMint?: string;
+	inAmount?: string;
+	outAmount?: string;
+	contextSlot?: number;
+	timeTaken?: number;
+}) => {
+	const inputMint = params?.inputMint ?? Keypair.generate().publicKey.toBase58();
+	const outputMint =
+		params?.outputMint ?? Keypair.generate().publicKey.toBase58();
+	const inAmount = params?.inAmount ?? "1000000";
+	const outAmount = params?.outAmount ?? "990000";
+
+	return {
+		inputMint,
+		inAmount,
+		outputMint,
+		outAmount,
+		otherAmountThreshold: "980000",
+		swapMode: "ExactIn",
+		slippageBps: 50,
+		platformFee: null,
+		priceImpactPct: "0",
+		routePlan: [
+			{
+				swapInfo: {
+					ammKey: Keypair.generate().publicKey.toBase58(),
+					label: "Test AMM",
+					inputMint,
+					outputMint,
+					inAmount,
+					outAmount,
+					feeAmount: "0",
+					feeMint: inputMint,
+				},
+				percent: 100,
+			},
+		],
+		contextSlot: params?.contextSlot,
+		timeTaken: params?.timeTaken,
+	};
+};
+
+const jsonResponse = (body: unknown) =>
+	new Response(JSON.stringify(body), {
+		headers: { "Content-Type": "application/json" },
+		status: 200,
+	});
 
 describe("estimateSwapTransactionFee", () => {
 	test("adds missing user-paid ATA rent to the simulated network fee", async () => {
@@ -195,5 +249,118 @@ describe("estimateSwapTransactionFee", () => {
 		expect(estimate.createdAtaAccounts).toHaveLength(0);
 		expect(estimate.rentLamports).toBe(0);
 		expect(estimate.totalLamports).toBe(MESSAGE_FEE_LAMPORTS);
+	});
+});
+
+describe("estimateJupiterSwapFeeState", () => {
+	test("uses a stable key for materially identical quote responses", () => {
+		const userPublicKey = Keypair.generate().publicKey;
+		const quoteResponse = createQuoteResponse({
+			contextSlot: 1,
+			timeTaken: 0.1,
+		});
+
+		const firstKey = getJupiterSwapFeeEstimateKey({
+			connection: createMockConnection(),
+			quoteResponse,
+			userPublicKey,
+			baseUrl: "https://api.jup.ag/swap/v1",
+		});
+		const secondKey = getJupiterSwapFeeEstimateKey({
+			connection: createMockConnection(),
+			quoteResponse: {
+				...quoteResponse,
+				contextSlot: 2,
+				timeTaken: 0.2,
+			},
+			userPublicKey,
+			baseUrl: "https://api.jup.ag/swap/v1",
+		});
+
+		expect(secondKey).toBe(firstKey);
+	});
+
+	test("dedupes inflight swap builds and caches the completed estimate", async () => {
+		const userPublicKey = Keypair.generate().publicKey;
+		const quoteResponse = createQuoteResponse();
+		const transaction = createSwapTransaction({
+			payer: userPublicKey,
+			instructions: [],
+		});
+		const swapTransaction = Buffer.from(transaction.serialize()).toString(
+			"base64"
+		);
+		let swapCalls = 0;
+		let instructionCalls = 0;
+		const fetchFn = (async (input: Parameters<typeof fetch>[0]) => {
+			const url = String(input);
+			if (url.endsWith("/swap")) {
+				swapCalls += 1;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return jsonResponse({
+					swapTransaction,
+					lastValidBlockHeight: 1,
+					prioritizationFeeLamports: 123,
+				});
+			}
+			if (url.endsWith("/swap-instructions")) {
+				instructionCalls += 1;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return jsonResponse({
+					setupInstructions: [],
+					swapInstruction: {
+						programId: Keypair.generate().publicKey.toBase58(),
+						accounts: [],
+						data: "",
+					},
+				});
+			}
+			return jsonResponse({});
+		}) as typeof fetch;
+		const params = {
+			connection: createMockConnection(),
+			quoteResponse,
+			userPublicKey,
+			baseUrl: "https://api.jup.ag/swap/v1",
+			fetchFn,
+		};
+
+		const [firstState, secondState] = await Promise.all([
+			estimateJupiterSwapFeeState(params),
+			estimateJupiterSwapFeeState(params),
+		]);
+
+		expect(firstState.status).toBe("success");
+		expect(secondState.status).toBe("success");
+		expect(swapCalls).toBe(1);
+		expect(instructionCalls).toBe(1);
+
+		const cachedState = await estimateJupiterSwapFeeState(params);
+
+		expect(cachedState.status).toBe("success");
+		expect(swapCalls).toBe(1);
+		expect(instructionCalls).toBe(1);
+	});
+
+	test("does not fetch when fee estimation is already aborted", async () => {
+		const abortController = new AbortController();
+		abortController.abort();
+		let fetchCalls = 0;
+		const fetchFn = (async (_input: Parameters<typeof fetch>[0]) => {
+			fetchCalls += 1;
+			return jsonResponse({});
+		}) as typeof fetch;
+
+		const state = await estimateJupiterSwapFeeState({
+			connection: createMockConnection(),
+			quoteResponse: createQuoteResponse(),
+			userPublicKey: Keypair.generate().publicKey,
+			baseUrl: "https://api.jup.ag/swap/v1",
+			fetchFn,
+			signal: abortController.signal,
+		});
+
+		expect(state).toEqual({ status: "idle" });
+		expect(fetchCalls).toBe(0);
 	});
 });

--- a/packages/wallet-core/src/lib/jupiter/client.ts
+++ b/packages/wallet-core/src/lib/jupiter/client.ts
@@ -1,94 +1,166 @@
-import type { JupiterQuoteResponse, JupiterSwapResponse } from "./types";
+import { VersionedTransaction } from "@solana/web3.js";
+import { Buffer } from "buffer";
 
-const JUPITER_QUOTE_API_URL = "https://lite-api.jup.ag/swap/v1/quote";
-const JUPITER_SWAP_API_URL = "https://lite-api.jup.ag/swap/v1/swap";
+import type {
+	JupiterQuoteResponse,
+	JupiterSwapInstructionsResponse,
+	JupiterSwapResponse,
+} from "./types";
+
+const DEFAULT_JUPITER_SWAP_API_BASE_URL = "https://lite-api.jup.ag/swap/v1";
 
 const buildJupiterHeaders = (
-	apiKey: string,
-	extra?: Record<string, string>,
+	apiKey?: string,
+	extra?: Record<string, string>
 ): Record<string, string> => ({
 	...(extra ?? {}),
 	...(apiKey ? { "x-api-key": apiKey } : {}),
 });
+
+const normalizeBaseUrl = (baseUrl?: string): string =>
+	(baseUrl || DEFAULT_JUPITER_SWAP_API_BASE_URL).replace(/\/+$/, "");
+
+const buildJupiterUrl = (baseUrl: string | undefined, path: string): string =>
+	`${normalizeBaseUrl(baseUrl)}/${path.replace(/^\/+/, "")}`;
+
+const fetchJson = async <T>(
+	url: string,
+	init?: RequestInit,
+	fetchFn: typeof fetch = fetch
+): Promise<T> => {
+	const response = await fetchFn(url, init);
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(
+			`Jupiter API failed: ${response.statusText} - ${errorText}`
+		);
+	}
+
+	return response.json() as Promise<T>;
+};
+
+const decodeBase64 = (value: string): Uint8Array => {
+	return new Uint8Array(Buffer.from(value, "base64"));
+};
+
+export { DEFAULT_JUPITER_SWAP_API_BASE_URL };
 
 export interface JupiterQuoteParams {
 	inputMint: string;
 	outputMint: string;
 	amount: string; // in smallest unit (lamports etc.)
 	slippageBps?: number;
-	apiKey: string;
+	apiKey?: string;
+	baseUrl?: string;
+	fetchFn?: typeof fetch;
 }
 
 export async function getJupiterQuote(
-	params: JupiterQuoteParams,
+	params: JupiterQuoteParams
 ): Promise<JupiterQuoteResponse> {
-	const { inputMint, outputMint, amount, slippageBps = 50, apiKey } = params;
+	const {
+		inputMint,
+		outputMint,
+		amount,
+		slippageBps = 50,
+		apiKey,
+		baseUrl,
+		fetchFn,
+	} = params;
 
-	const url = `${JUPITER_QUOTE_API_URL}?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amount}&slippageBps=${slippageBps}`;
+	const url = new URL(buildJupiterUrl(baseUrl, "quote"));
+	url.searchParams.set("inputMint", inputMint);
+	url.searchParams.set("outputMint", outputMint);
+	url.searchParams.set("amount", amount);
+	url.searchParams.set("slippageBps", String(slippageBps));
 
-	const response = await fetch(url, {
-		headers: buildJupiterHeaders(apiKey),
-	});
-
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(
-			`Failed to get Jupiter quote: ${response.statusText} - ${errorText}`,
-		);
-	}
-
-	return response.json();
+	return fetchJson<JupiterQuoteResponse>(
+		url.toString(),
+		{
+			headers: buildJupiterHeaders(apiKey),
+		},
+		fetchFn
+	);
 }
 
 export interface JupiterSwapParams {
 	userPublicKey: string;
 	quoteResponse: JupiterQuoteResponse;
-	apiKey: string;
+	apiKey?: string;
+	baseUrl?: string;
+	fetchFn?: typeof fetch;
 	wrapAndUnwrapSol?: boolean;
 	dynamicComputeUnitLimit?: boolean;
 	priorityLevel?: string;
 	maxPriorityFeeLamports?: number;
 }
 
-export async function executeJupiterSwap(
-	params: JupiterSwapParams,
-): Promise<JupiterSwapResponse> {
+const buildSwapRequestBody = (params: JupiterSwapParams) => {
 	const {
 		userPublicKey,
 		quoteResponse,
-		apiKey,
 		wrapAndUnwrapSol = true,
 		dynamicComputeUnitLimit = true,
 		priorityLevel = "veryHigh",
 		maxPriorityFeeLamports = 50_000_000,
 	} = params;
 
-	const response = await fetch(JUPITER_SWAP_API_URL, {
-		method: "POST",
-		headers: buildJupiterHeaders(apiKey, {
-			"Content-Type": "application/json",
-		}),
-		body: JSON.stringify({
-			userPublicKey,
-			quoteResponse,
-			wrapAndUnwrapSol,
-			dynamicComputeUnitLimit,
-			prioritizationFeeLamports: {
-				priorityLevelWithMaxLamports: {
-					priorityLevel,
-					maxLamports: maxPriorityFeeLamports,
-					global: true,
-				},
+	return {
+		userPublicKey,
+		quoteResponse,
+		wrapAndUnwrapSol,
+		dynamicComputeUnitLimit,
+		prioritizationFeeLamports: {
+			priorityLevelWithMaxLamports: {
+				priorityLevel,
+				maxLamports: maxPriorityFeeLamports,
+				global: true,
 			},
-		}),
-	});
+		},
+	};
+};
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(
-			`Jupiter Swap API failed: ${response.statusText} - ${errorText}`,
-		);
-	}
+export async function getJupiterSwapTransaction(
+	params: JupiterSwapParams
+): Promise<JupiterSwapResponse> {
+	return fetchJson<JupiterSwapResponse>(
+		buildJupiterUrl(params.baseUrl, "swap"),
+		{
+			method: "POST",
+			headers: buildJupiterHeaders(params.apiKey, {
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify(buildSwapRequestBody(params)),
+		},
+		params.fetchFn
+	);
+}
 
-	return response.json();
+export async function executeJupiterSwap(
+	params: JupiterSwapParams
+): Promise<JupiterSwapResponse> {
+	return getJupiterSwapTransaction(params);
+}
+
+export async function getJupiterSwapInstructions(
+	params: JupiterSwapParams
+): Promise<JupiterSwapInstructionsResponse> {
+	return fetchJson<JupiterSwapInstructionsResponse>(
+		buildJupiterUrl(params.baseUrl, "swap-instructions"),
+		{
+			method: "POST",
+			headers: buildJupiterHeaders(params.apiKey, {
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify(buildSwapRequestBody(params)),
+		},
+		params.fetchFn
+	);
+}
+
+export function deserializeJupiterSwapTransaction(
+	swapTransaction: string
+): VersionedTransaction {
+	return VersionedTransaction.deserialize(decodeBase64(swapTransaction));
 }

--- a/packages/wallet-core/src/lib/jupiter/client.ts
+++ b/packages/wallet-core/src/lib/jupiter/client.ts
@@ -54,6 +54,7 @@ export interface JupiterQuoteParams {
 	apiKey?: string;
 	baseUrl?: string;
 	fetchFn?: typeof fetch;
+	signal?: AbortSignal;
 }
 
 export async function getJupiterQuote(
@@ -67,6 +68,7 @@ export async function getJupiterQuote(
 		apiKey,
 		baseUrl,
 		fetchFn,
+		signal,
 	} = params;
 
 	const url = new URL(buildJupiterUrl(baseUrl, "quote"));
@@ -79,6 +81,7 @@ export async function getJupiterQuote(
 		url.toString(),
 		{
 			headers: buildJupiterHeaders(apiKey),
+			signal,
 		},
 		fetchFn
 	);
@@ -90,6 +93,7 @@ export interface JupiterSwapParams {
 	apiKey?: string;
 	baseUrl?: string;
 	fetchFn?: typeof fetch;
+	signal?: AbortSignal;
 	wrapAndUnwrapSol?: boolean;
 	dynamicComputeUnitLimit?: boolean;
 	priorityLevel?: string;
@@ -132,6 +136,7 @@ export async function getJupiterSwapTransaction(
 				"Content-Type": "application/json",
 			}),
 			body: JSON.stringify(buildSwapRequestBody(params)),
+			signal: params.signal,
 		},
 		params.fetchFn
 	);
@@ -154,6 +159,7 @@ export async function getJupiterSwapInstructions(
 				"Content-Type": "application/json",
 			}),
 			body: JSON.stringify(buildSwapRequestBody(params)),
+			signal: params.signal,
 		},
 		params.fetchFn
 	);

--- a/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
+++ b/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
@@ -7,17 +7,23 @@ import {
 } from "@solana/web3.js";
 import { Buffer } from "buffer";
 
-import { deserializeJupiterSwapTransaction } from "./client";
+import {
+	deserializeJupiterSwapTransaction,
+	getJupiterSwapInstructions,
+	getJupiterSwapTransaction,
+} from "./client";
 import type {
 	JupiterInstruction,
+	JupiterQuoteResponse,
 	JupiterSwapInstructionsResponse,
 	JupiterSwapResponse,
 	SwapCreatedAtaRentEntry,
 	SwapFeeEstimate,
+	SwapFeeEstimateState,
 	SwapFeeSimulationResult,
 } from "./types";
 
-type FeeEstimateConnection = Pick<
+export type SwapFeeEstimateConnection = Pick<
 	Connection,
 	| "getFeeForMessage"
 	| "getMinimumBalanceForRentExemption"
@@ -26,7 +32,7 @@ type FeeEstimateConnection = Pick<
 >;
 
 type EstimateSwapTransactionFeeParams = {
-	connection: FeeEstimateConnection;
+	connection: SwapFeeEstimateConnection;
 	transaction?: VersionedTransaction | string;
 	swapResponse?: Pick<
 		JupiterSwapResponse,
@@ -34,6 +40,16 @@ type EstimateSwapTransactionFeeParams = {
 	>;
 	swapInstructions?: Pick<JupiterSwapInstructionsResponse, "setupInstructions">;
 	userPublicKey?: PublicKey | string | { toBase58(): string };
+	commitment?: "processed" | "confirmed" | "finalized";
+};
+
+type EstimateJupiterSwapFeeStateParams = {
+	connection: SwapFeeEstimateConnection;
+	quoteResponse: JupiterQuoteResponse;
+	userPublicKey: PublicKey | string | { toBase58(): string };
+	apiKey?: string;
+	baseUrl?: string;
+	fetchFn?: typeof fetch;
 	commitment?: "processed" | "confirmed" | "finalized";
 };
 
@@ -201,7 +217,7 @@ const dedupeCreatedAtas = (entries: ParsedAtaCreate[]): ParsedAtaCreate[] => {
 };
 
 const getRentEntries = async (params: {
-	connection: FeeEstimateConnection;
+	connection: SwapFeeEstimateConnection;
 	transaction: VersionedTransaction;
 	swapInstructions?: Pick<JupiterSwapInstructionsResponse, "setupInstructions">;
 	userPublicKey: string | null;
@@ -287,7 +303,7 @@ const estimatePrioritizationFeeFromMessage = (
 };
 
 const simulateSwapTransaction = async (params: {
-	connection: FeeEstimateConnection;
+	connection: SwapFeeEstimateConnection;
 	transaction: VersionedTransaction;
 	commitment: "processed" | "confirmed" | "finalized";
 }): Promise<SwapFeeSimulationResult> => {
@@ -315,6 +331,26 @@ const simulateSwapTransaction = async (params: {
 		};
 	}
 };
+
+export const getSwapFeeEstimateState = (
+	estimate: SwapFeeEstimate
+): SwapFeeEstimateState => {
+	if (estimate.simulation.status === "passed") {
+		return { status: "success", estimate };
+	}
+
+	return {
+		status: "error",
+		error: "Swap fee simulation failed",
+	};
+};
+
+export const getSwapFeeEstimateErrorState = (
+	error: unknown
+): SwapFeeEstimateState => ({
+	status: "error",
+	error: error instanceof Error ? error.message : "Swap fee unavailable",
+});
 
 export async function estimateSwapTransactionFee(
 	params: EstimateSwapTransactionFeeParams
@@ -351,4 +387,43 @@ export async function estimateSwapTransactionFee(
 		createdAtaAccounts: rent.createdAtaAccounts,
 		simulation,
 	};
+}
+
+export async function estimateJupiterSwapFeeState(
+	params: EstimateJupiterSwapFeeStateParams
+): Promise<SwapFeeEstimateState> {
+	try {
+		const userPublicKey = getPublicKeyString(params.userPublicKey);
+		if (!userPublicKey) {
+			throw new Error("User public key is required for swap fee estimation");
+		}
+
+		const [swapResponse, swapInstructions] = await Promise.all([
+			getJupiterSwapTransaction({
+				quoteResponse: params.quoteResponse,
+				userPublicKey,
+				apiKey: params.apiKey,
+				baseUrl: params.baseUrl,
+				fetchFn: params.fetchFn,
+			}),
+			getJupiterSwapInstructions({
+				quoteResponse: params.quoteResponse,
+				userPublicKey,
+				apiKey: params.apiKey,
+				baseUrl: params.baseUrl,
+				fetchFn: params.fetchFn,
+			}).catch(() => undefined),
+		]);
+		const estimate = await estimateSwapTransactionFee({
+			connection: params.connection,
+			swapResponse,
+			swapInstructions,
+			userPublicKey,
+			commitment: params.commitment,
+		});
+
+		return getSwapFeeEstimateState(estimate);
+	} catch (error) {
+		return getSwapFeeEstimateErrorState(error);
+	}
 }

--- a/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
+++ b/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
@@ -1,0 +1,354 @@
+import { ACCOUNT_SIZE, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import {
+	ComputeBudgetProgram,
+	type Connection,
+	PublicKey,
+	VersionedTransaction,
+} from "@solana/web3.js";
+import { Buffer } from "buffer";
+
+import { deserializeJupiterSwapTransaction } from "./client";
+import type {
+	JupiterInstruction,
+	JupiterSwapInstructionsResponse,
+	JupiterSwapResponse,
+	SwapCreatedAtaRentEntry,
+	SwapFeeEstimate,
+	SwapFeeSimulationResult,
+} from "./types";
+
+type FeeEstimateConnection = Pick<
+	Connection,
+	| "getFeeForMessage"
+	| "getMinimumBalanceForRentExemption"
+	| "getMultipleAccountsInfo"
+	| "simulateTransaction"
+>;
+
+type EstimateSwapTransactionFeeParams = {
+	connection: FeeEstimateConnection;
+	transaction?: VersionedTransaction | string;
+	swapResponse?: Pick<
+		JupiterSwapResponse,
+		"prioritizationFeeLamports" | "swapTransaction"
+	>;
+	swapInstructions?: Pick<JupiterSwapInstructionsResponse, "setupInstructions">;
+	userPublicKey?: PublicKey | string | { toBase58(): string };
+	commitment?: "processed" | "confirmed" | "finalized";
+};
+
+const SOLANA_SIGNATURE_FEE_LAMPORTS = 5_000;
+const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000n;
+
+const getPublicKeyString = (
+	value?: PublicKey | string | { toBase58(): string }
+): string | null => {
+	if (!value) return null;
+	if (typeof value === "string") return value;
+	return value.toBase58();
+};
+
+const decodeBase64 = (value: string): Uint8Array => {
+	return new Uint8Array(Buffer.from(value, "base64"));
+};
+
+const readLittleEndianU32 = (data: Uint8Array, offset: number): number => {
+	let value = 0;
+	for (let index = 0; index < 4; index += 1) {
+		value += (data[offset + index] ?? 0) * 2 ** (8 * index);
+	}
+	return value;
+};
+
+const readLittleEndianU64 = (data: Uint8Array, offset: number): bigint => {
+	let value = 0n;
+	for (let index = 0; index < 8; index += 1) {
+		value += BigInt(data[offset + index] ?? 0) << BigInt(8 * index);
+	}
+	return value;
+};
+
+const toTransaction = (
+	transaction?: VersionedTransaction | string,
+	swapResponse?: Pick<JupiterSwapResponse, "swapTransaction">
+): VersionedTransaction => {
+	if (transaction instanceof VersionedTransaction) {
+		return transaction;
+	}
+	if (typeof transaction === "string") {
+		return deserializeJupiterSwapTransaction(transaction);
+	}
+	if (swapResponse?.swapTransaction) {
+		return deserializeJupiterSwapTransaction(swapResponse.swapTransaction);
+	}
+	throw new Error("Swap transaction is required for fee estimation");
+};
+
+type ParsedAtaCreate = Omit<
+	SwapCreatedAtaRentEntry,
+	"alreadyExisted" | "paidByUser" | "rentLamports"
+>;
+
+const parseAssociatedTokenCreate = (params: {
+	programId: string;
+	accounts: string[];
+	data: Uint8Array;
+	instructionSource: "swap-instructions" | "transaction";
+}): ParsedAtaCreate | null => {
+	if (params.programId !== ASSOCIATED_TOKEN_PROGRAM_ID.toBase58()) {
+		return null;
+	}
+
+	const tag = params.data[0] ?? 0;
+	const isCreate =
+		params.data.length === 0 ||
+		tag === 0 ||
+		(tag === 1 && params.data.length === 1);
+	if (!isCreate || params.accounts.length < 6) {
+		return null;
+	}
+
+	return {
+		payer: params.accounts[0],
+		address: params.accounts[1],
+		owner: params.accounts[2],
+		mint: params.accounts[3],
+		tokenProgramId: params.accounts[5],
+		instructionSource: params.instructionSource,
+	};
+};
+
+const getStaticAccountKeys = (transaction: VersionedTransaction): string[] => {
+	const message = transaction.message as typeof transaction.message & {
+		accountKeys?: PublicKey[];
+		staticAccountKeys?: PublicKey[];
+	};
+	const keys = message.staticAccountKeys ?? message.accountKeys ?? [];
+	return keys.map((key) => key.toBase58());
+};
+
+const getCompiledInstructions = (transaction: VersionedTransaction) => {
+	const message = transaction.message as typeof transaction.message & {
+		compiledInstructions?: Array<{
+			programIdIndex: number;
+			accountKeyIndexes?: number[];
+			accounts?: number[];
+			data: Uint8Array;
+		}>;
+		instructions?: Array<{
+			programIdIndex: number;
+			accountKeyIndexes?: number[];
+			accounts?: number[];
+			data: Uint8Array;
+		}>;
+	};
+	return message.compiledInstructions ?? message.instructions ?? [];
+};
+
+const getCreatedAtasFromTransaction = (
+	transaction: VersionedTransaction
+): ParsedAtaCreate[] => {
+	const accountKeys = getStaticAccountKeys(transaction);
+	const instructions = getCompiledInstructions(transaction);
+	const entries: ParsedAtaCreate[] = [];
+
+	for (const instruction of instructions) {
+		const programId = accountKeys[instruction.programIdIndex];
+		if (!programId) continue;
+		const accountIndexes =
+			instruction.accountKeyIndexes ?? instruction.accounts ?? [];
+		const accounts = accountIndexes
+			.map((index) => accountKeys[index])
+			.filter((account): account is string => Boolean(account));
+		const parsed = parseAssociatedTokenCreate({
+			programId,
+			accounts,
+			data: instruction.data,
+			instructionSource: "transaction",
+		});
+		if (parsed) entries.push(parsed);
+	}
+
+	return entries;
+};
+
+const getCreatedAtasFromSetupInstructions = (
+	swapInstructions?: Pick<JupiterSwapInstructionsResponse, "setupInstructions">
+): ParsedAtaCreate[] => {
+	const instructions = swapInstructions?.setupInstructions ?? [];
+	return instructions
+		.map((instruction: JupiterInstruction) =>
+			parseAssociatedTokenCreate({
+				programId: instruction.programId,
+				accounts: instruction.accounts.map((account) => account.pubkey),
+				data: instruction.data
+					? decodeBase64(instruction.data)
+					: new Uint8Array(),
+				instructionSource: "swap-instructions",
+			})
+		)
+		.filter((entry): entry is ParsedAtaCreate => Boolean(entry));
+};
+
+const dedupeCreatedAtas = (entries: ParsedAtaCreate[]): ParsedAtaCreate[] => {
+	const byAddress = new Map<string, ParsedAtaCreate>();
+	for (const entry of entries) {
+		if (!byAddress.has(entry.address)) {
+			byAddress.set(entry.address, entry);
+		}
+	}
+	return [...byAddress.values()];
+};
+
+const getRentEntries = async (params: {
+	connection: FeeEstimateConnection;
+	transaction: VersionedTransaction;
+	swapInstructions?: Pick<JupiterSwapInstructionsResponse, "setupInstructions">;
+	userPublicKey: string | null;
+}): Promise<{
+	rentLamports: number;
+	createdAtaAccounts: SwapCreatedAtaRentEntry[];
+}> => {
+	const parsedEntries = dedupeCreatedAtas([
+		...getCreatedAtasFromSetupInstructions(params.swapInstructions),
+		...getCreatedAtasFromTransaction(params.transaction),
+	]).filter(
+		(entry) => !params.userPublicKey || entry.payer === params.userPublicKey
+	);
+
+	if (parsedEntries.length === 0) {
+		return { rentLamports: 0, createdAtaAccounts: [] };
+	}
+
+	const rentExemptionLamports =
+		await params.connection.getMinimumBalanceForRentExemption(ACCOUNT_SIZE);
+	const existingAccounts = await params.connection.getMultipleAccountsInfo(
+		parsedEntries.map((entry) => new PublicKey(entry.address))
+	);
+
+	let rentLamports = 0;
+	const createdAtaAccounts = parsedEntries.map((entry, index) => {
+		const alreadyExisted = existingAccounts[index] !== null;
+		const entryRentLamports = alreadyExisted ? 0 : rentExemptionLamports;
+		rentLamports += entryRentLamports;
+		return {
+			...entry,
+			rentLamports: entryRentLamports,
+			alreadyExisted,
+			paidByUser: !params.userPublicKey || entry.payer === params.userPublicKey,
+		};
+	});
+
+	return { rentLamports, createdAtaAccounts };
+};
+
+const getSignatureFeeFallback = (transaction: VersionedTransaction): number => {
+	const message = transaction.message as typeof transaction.message & {
+		header?: { numRequiredSignatures: number };
+	};
+	return (
+		(message.header?.numRequiredSignatures ?? transaction.signatures.length) *
+		SOLANA_SIGNATURE_FEE_LAMPORTS
+	);
+};
+
+const estimatePrioritizationFeeFromMessage = (
+	transaction: VersionedTransaction
+): number | null => {
+	const accountKeys = getStaticAccountKeys(transaction);
+	const instructions = getCompiledInstructions(transaction);
+	let computeUnitLimit: number | null = null;
+	let microLamportsPerUnit: bigint | null = null;
+
+	for (const instruction of instructions) {
+		const programId = accountKeys[instruction.programIdIndex];
+		if (programId !== ComputeBudgetProgram.programId.toBase58()) {
+			continue;
+		}
+		const data = instruction.data;
+		if (data[0] === 2 && data.length >= 5) {
+			computeUnitLimit = readLittleEndianU32(data, 1);
+		}
+		if (data[0] === 3 && data.length >= 9) {
+			microLamportsPerUnit = readLittleEndianU64(data, 1);
+		}
+	}
+
+	if (computeUnitLimit === null || microLamportsPerUnit === null) {
+		return null;
+	}
+
+	const lamports =
+		(BigInt(computeUnitLimit) * microLamportsPerUnit +
+			MICRO_LAMPORTS_PER_LAMPORT -
+			1n) /
+		MICRO_LAMPORTS_PER_LAMPORT;
+	return Number(lamports);
+};
+
+const simulateSwapTransaction = async (params: {
+	connection: FeeEstimateConnection;
+	transaction: VersionedTransaction;
+	commitment: "processed" | "confirmed" | "finalized";
+}): Promise<SwapFeeSimulationResult> => {
+	try {
+		const simulation = await params.connection.simulateTransaction(
+			params.transaction,
+			{
+				commitment: params.commitment,
+				replaceRecentBlockhash: true,
+				sigVerify: false,
+			}
+		);
+		return {
+			status: simulation.value.err ? "failed" : "passed",
+			error: simulation.value.err ?? null,
+			unitsConsumed: simulation.value.unitsConsumed ?? null,
+			logs: simulation.value.logs ?? null,
+		};
+	} catch (error) {
+		return {
+			status: "failed",
+			error,
+			unitsConsumed: null,
+			logs: null,
+		};
+	}
+};
+
+export async function estimateSwapTransactionFee(
+	params: EstimateSwapTransactionFeeParams
+): Promise<SwapFeeEstimate> {
+	const transaction = toTransaction(params.transaction, params.swapResponse);
+	const commitment = params.commitment ?? "confirmed";
+	const [feeForMessage, rent, simulation] = await Promise.all([
+		params.connection.getFeeForMessage(transaction.message, commitment),
+		getRentEntries({
+			connection: params.connection,
+			transaction,
+			swapInstructions: params.swapInstructions,
+			userPublicKey: getPublicKeyString(params.userPublicKey),
+		}),
+		simulateSwapTransaction({
+			connection: params.connection,
+			transaction,
+			commitment,
+		}),
+	]);
+	const transactionFeeLamports =
+		feeForMessage.value ?? getSignatureFeeFallback(transaction);
+	const prioritizationFeeLamports =
+		params.swapResponse?.prioritizationFeeLamports ??
+		estimatePrioritizationFeeFromMessage(transaction);
+
+	return {
+		totalLamports: transactionFeeLamports + rent.rentLamports,
+		transactionFeeLamports,
+		prioritizationFeeLamports,
+		prioritizationFeeIncludedInTransactionFee:
+			prioritizationFeeLamports !== null,
+		rentLamports: rent.rentLamports,
+		createdAtaAccounts: rent.createdAtaAccounts,
+		simulation,
+	};
+}

--- a/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
+++ b/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
@@ -57,6 +57,7 @@ type EstimateJupiterSwapFeeStateParams = {
 const SOLANA_SIGNATURE_FEE_LAMPORTS = 5_000;
 const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000n;
 export const SWAP_FEE_ESTIMATE_DEBOUNCE_MS = 700;
+export const SWAP_FEE_ESTIMATE_RECOMPUTE_DEBOUNCE_MS = 10_000;
 const SWAP_FEE_ESTIMATE_SUCCESS_CACHE_MS = 20_000;
 const SWAP_FEE_ESTIMATE_ERROR_CACHE_MS = 3_000;
 
@@ -127,6 +128,24 @@ export const getJupiterSwapFeeEstimateKey = (params: {
 			priceImpactPct: quoteResponse.priceImpactPct,
 			routePlan,
 		},
+	});
+};
+
+export const getJupiterSwapFeeEstimateFlowKey = (params: {
+	inputMint?: string | null;
+	outputMint?: string | null;
+	userPublicKey: PublicKey | string | { toBase58(): string } | null;
+	baseUrl?: string;
+	slippageBps?: number;
+}): string | null => {
+	const userPublicKey = getPublicKeyString(params.userPublicKey ?? undefined);
+	if (!(params.inputMint && params.outputMint && userPublicKey)) return null;
+	return JSON.stringify({
+		baseUrl: params.baseUrl ?? null,
+		inputMint: params.inputMint,
+		outputMint: params.outputMint,
+		slippageBps: params.slippageBps ?? 50,
+		userPublicKey,
 	});
 };
 
@@ -417,6 +436,28 @@ export const getSwapFeeEstimateErrorState = (
 	status: "error",
 	error: error instanceof Error ? error.message : "Swap fee unavailable",
 });
+
+export const isNonEmptySwapFeeEstimateState = (
+	state: SwapFeeEstimateState | null | undefined
+): state is Extract<SwapFeeEstimateState, { status: "success" }> =>
+	state?.status === "success" && state.estimate.totalLamports > 0;
+
+export const getSwapFeeEstimateDebounceMs = (
+	lastSuccessfulState?: SwapFeeEstimateState | null
+): number =>
+	isNonEmptySwapFeeEstimateState(lastSuccessfulState)
+		? SWAP_FEE_ESTIMATE_RECOMPUTE_DEBOUNCE_MS
+		: SWAP_FEE_ESTIMATE_DEBOUNCE_MS;
+
+export const getSwapFeeEstimateDisplayState = (
+	state: SwapFeeEstimateState,
+	lastSuccessfulState?: SwapFeeEstimateState | null
+): SwapFeeEstimateState =>
+	state.status === "success"
+		? state
+		: isNonEmptySwapFeeEstimateState(lastSuccessfulState)
+			? lastSuccessfulState
+			: state;
 
 const getCachedFeeEstimateState = (
 	key: string,

--- a/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
+++ b/packages/wallet-core/src/lib/jupiter/fee-estimator.ts
@@ -50,11 +50,26 @@ type EstimateJupiterSwapFeeStateParams = {
 	apiKey?: string;
 	baseUrl?: string;
 	fetchFn?: typeof fetch;
+	signal?: AbortSignal;
 	commitment?: "processed" | "confirmed" | "finalized";
 };
 
 const SOLANA_SIGNATURE_FEE_LAMPORTS = 5_000;
 const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000n;
+export const SWAP_FEE_ESTIMATE_DEBOUNCE_MS = 700;
+const SWAP_FEE_ESTIMATE_SUCCESS_CACHE_MS = 20_000;
+const SWAP_FEE_ESTIMATE_ERROR_CACHE_MS = 3_000;
+
+type SwapFeeEstimateCacheEntry = {
+	state: SwapFeeEstimateState;
+	expiresAt: number;
+};
+
+const feeEstimateStateCache = new Map<string, SwapFeeEstimateCacheEntry>();
+const feeEstimateStateInflight = new Map<
+	string,
+	Promise<SwapFeeEstimateState>
+>();
 
 const getPublicKeyString = (
 	value?: PublicKey | string | { toBase58(): string }
@@ -62,6 +77,57 @@ const getPublicKeyString = (
 	if (!value) return null;
 	if (typeof value === "string") return value;
 	return value.toBase58();
+};
+
+const getConnectionCacheKey = (connection: SwapFeeEstimateConnection): string => {
+	const maybeConnection = connection as SwapFeeEstimateConnection & {
+		rpcEndpoint?: string;
+	};
+	return maybeConnection.rpcEndpoint ?? "connection";
+};
+
+export const getJupiterSwapFeeEstimateKey = (params: {
+	connection?: SwapFeeEstimateConnection;
+	quoteResponse: JupiterQuoteResponse;
+	userPublicKey: PublicKey | string | { toBase58(): string };
+	baseUrl?: string;
+	commitment?: "processed" | "confirmed" | "finalized";
+}): string => {
+	const { quoteResponse } = params;
+	const routePlan = quoteResponse.routePlan.map((route) => ({
+		percent: route.percent,
+		swapInfo: {
+			ammKey: route.swapInfo.ammKey,
+			label: route.swapInfo.label,
+			inputMint: route.swapInfo.inputMint,
+			outputMint: route.swapInfo.outputMint,
+			inAmount: route.swapInfo.inAmount,
+			outAmount: route.swapInfo.outAmount,
+			feeAmount: route.swapInfo.feeAmount,
+			feeMint: route.swapInfo.feeMint,
+		},
+	}));
+
+	return JSON.stringify({
+		baseUrl: params.baseUrl ?? null,
+		commitment: params.commitment ?? "confirmed",
+		connection: params.connection
+			? getConnectionCacheKey(params.connection)
+			: null,
+		userPublicKey: getPublicKeyString(params.userPublicKey),
+		quote: {
+			inputMint: quoteResponse.inputMint,
+			inAmount: quoteResponse.inAmount,
+			outputMint: quoteResponse.outputMint,
+			outAmount: quoteResponse.outAmount,
+			otherAmountThreshold: quoteResponse.otherAmountThreshold,
+			swapMode: quoteResponse.swapMode,
+			slippageBps: quoteResponse.slippageBps,
+			platformFee: quoteResponse.platformFee,
+			priceImpactPct: quoteResponse.priceImpactPct,
+			routePlan,
+		},
+	});
 };
 
 const decodeBase64 = (value: string): Uint8Array => {
@@ -352,6 +418,44 @@ export const getSwapFeeEstimateErrorState = (
 	error: error instanceof Error ? error.message : "Swap fee unavailable",
 });
 
+const getCachedFeeEstimateState = (
+	key: string,
+	now = Date.now()
+): SwapFeeEstimateState | null => {
+	const entry = feeEstimateStateCache.get(key);
+	if (!entry) return null;
+	if (entry.expiresAt < now) {
+		feeEstimateStateCache.delete(key);
+		return null;
+	}
+	return entry.state;
+};
+
+const getCachedSuccessfulFeeEstimateState = (
+	key: string
+): SwapFeeEstimateState | null => {
+	const entry = feeEstimateStateCache.get(key);
+	return entry?.state.status === "success" ? entry.state : null;
+};
+
+const isAbortError = (error: unknown): boolean =>
+	error instanceof Error && error.name === "AbortError";
+
+const setCachedFeeEstimateState = (
+	key: string,
+	state: SwapFeeEstimateState,
+	now = Date.now()
+) => {
+	feeEstimateStateCache.set(key, {
+		state,
+		expiresAt:
+			now +
+			(state.status === "success"
+				? SWAP_FEE_ESTIMATE_SUCCESS_CACHE_MS
+				: SWAP_FEE_ESTIMATE_ERROR_CACHE_MS),
+	});
+};
+
 export async function estimateSwapTransactionFee(
 	params: EstimateSwapTransactionFeeParams
 ): Promise<SwapFeeEstimate> {
@@ -392,6 +496,33 @@ export async function estimateSwapTransactionFee(
 export async function estimateJupiterSwapFeeState(
 	params: EstimateJupiterSwapFeeStateParams
 ): Promise<SwapFeeEstimateState> {
+	const cacheKey = getJupiterSwapFeeEstimateKey(params);
+	const cachedState = getCachedFeeEstimateState(cacheKey);
+	if (cachedState) {
+		return cachedState;
+	}
+
+	const inflight = feeEstimateStateInflight.get(cacheKey);
+	if (inflight) {
+		return inflight;
+	}
+
+	if (params.signal?.aborted) {
+		return { status: "idle" };
+	}
+
+	const request = estimateUncachedJupiterSwapFeeState(params, cacheKey);
+	feeEstimateStateInflight.set(cacheKey, request);
+	request.finally(() => {
+		feeEstimateStateInflight.delete(cacheKey);
+	});
+	return request;
+}
+
+async function estimateUncachedJupiterSwapFeeState(
+	params: EstimateJupiterSwapFeeStateParams,
+	cacheKey: string
+): Promise<SwapFeeEstimateState> {
 	try {
 		const userPublicKey = getPublicKeyString(params.userPublicKey);
 		if (!userPublicKey) {
@@ -405,6 +536,7 @@ export async function estimateJupiterSwapFeeState(
 				apiKey: params.apiKey,
 				baseUrl: params.baseUrl,
 				fetchFn: params.fetchFn,
+				signal: params.signal,
 			}),
 			getJupiterSwapInstructions({
 				quoteResponse: params.quoteResponse,
@@ -412,8 +544,12 @@ export async function estimateJupiterSwapFeeState(
 				apiKey: params.apiKey,
 				baseUrl: params.baseUrl,
 				fetchFn: params.fetchFn,
+				signal: params.signal,
 			}).catch(() => undefined),
 		]);
+		if (params.signal?.aborted) {
+			return { status: "idle" };
+		}
 		const estimate = await estimateSwapTransactionFee({
 			connection: params.connection,
 			swapResponse,
@@ -422,8 +558,19 @@ export async function estimateJupiterSwapFeeState(
 			commitment: params.commitment,
 		});
 
-		return getSwapFeeEstimateState(estimate);
+		const state = getSwapFeeEstimateState(estimate);
+		setCachedFeeEstimateState(cacheKey, state);
+		return state;
 	} catch (error) {
-		return getSwapFeeEstimateErrorState(error);
+		if (params.signal?.aborted || isAbortError(error)) {
+			return { status: "idle" };
+		}
+		const fallbackState = getCachedSuccessfulFeeEstimateState(cacheKey);
+		if (fallbackState) {
+			return fallbackState;
+		}
+		const state = getSwapFeeEstimateErrorState(error);
+		setCachedFeeEstimateState(cacheKey, state);
+		return state;
 	}
 }

--- a/packages/wallet-core/src/lib/jupiter/types.ts
+++ b/packages/wallet-core/src/lib/jupiter/types.ts
@@ -32,6 +32,33 @@ export type JupiterSwapResponse = {
 	swapTransaction: string;
 	lastValidBlockHeight: number;
 	prioritizationFeeLamports: number;
+	computeUnitLimit?: number;
+	prioritizationType?: unknown;
+	dynamicSlippageReport?: unknown;
+	simulationError?: unknown;
+};
+
+export type JupiterInstructionAccount = {
+	pubkey: string;
+	isSigner: boolean;
+	isWritable: boolean;
+};
+
+export type JupiterInstruction = {
+	programId: string;
+	accounts: JupiterInstructionAccount[];
+	data: string;
+};
+
+export type JupiterSwapInstructionsResponse = {
+	tokenLedgerInstruction?: JupiterInstruction | null;
+	computeBudgetInstructions?: JupiterInstruction[];
+	setupInstructions?: JupiterInstruction[];
+	swapInstruction: JupiterInstruction;
+	cleanupInstruction?: JupiterInstruction | null;
+	otherInstructions?: JupiterInstruction[];
+	addressLookupTableAddresses?: string[];
+	error?: string;
 };
 
 export type SwapQuote = {
@@ -47,4 +74,33 @@ export type SwapResult = {
 	signature?: string;
 	success: boolean;
 	error?: string;
+};
+
+export type SwapCreatedAtaRentEntry = {
+	address: string;
+	payer: string;
+	owner: string;
+	mint: string;
+	tokenProgramId: string;
+	rentLamports: number;
+	alreadyExisted: boolean;
+	paidByUser: boolean;
+	instructionSource: "swap-instructions" | "transaction";
+};
+
+export type SwapFeeSimulationResult = {
+	status: "passed" | "failed";
+	error: unknown | null;
+	unitsConsumed: number | null;
+	logs: string[] | null;
+};
+
+export type SwapFeeEstimate = {
+	totalLamports: number;
+	transactionFeeLamports: number;
+	prioritizationFeeLamports: number | null;
+	prioritizationFeeIncludedInTransactionFee: boolean;
+	rentLamports: number;
+	createdAtaAccounts: SwapCreatedAtaRentEntry[];
+	simulation: SwapFeeSimulationResult;
 };

--- a/packages/wallet-core/src/lib/jupiter/types.ts
+++ b/packages/wallet-core/src/lib/jupiter/types.ts
@@ -104,3 +104,9 @@ export type SwapFeeEstimate = {
 	createdAtaAccounts: SwapCreatedAtaRentEntry[];
 	simulation: SwapFeeSimulationResult;
 };
+
+export type SwapFeeEstimateState =
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "success"; estimate: SwapFeeEstimate }
+	| { status: "error"; error: string };


### PR DESCRIPTION
Adds shared wallet-core Jupiter Swap v1 transaction building and simulated fee/rent estimation, and wires mobile, frontend, and extension swap confirmations to show real fees after simulation. The Telegram app flow is left on its existing server-side Jupiter Ultra order/execute path because it does not share the direct Swap v1 transaction flow.