### PR TITLE
fix(earn): read mobile withdraw sources under the position's real vault pubkey

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
-import { PublicKey } from "@solana/web3.js";
 
 import { findCurrentUser } from "@/features/chat/server/app-user";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-signature";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
-import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import {
   findCurrentNonzeroYieldVaultReservePositions,
@@ -92,35 +89,39 @@ export async function GET(request: Request) {
 
     const solanaEnv = getConfiguredSolanaEnv();
     const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
-    const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
-    const [earnVaultPda] = pda.getSmartAccountPda({
-      accountIndex: EARN_VAULT_INDEX,
-      programId,
-      settingsPda: new PublicKey(account.settingsPda),
+
+    // Resolve the reconciled position FIRST so the reserve/idle snapshot lookups
+    // key off the position's ACTUAL vault pubkey — matching the web `position`
+    // route. Deriving the vault pubkey locally (getSmartAccountPda) can resolve
+    // to a different managedVaults record than the one the reserve rows are
+    // stored under, which returns zero reserve rows and forces the stale
+    // `currentAmountRaw` fallback below — reporting the wrong reserve/market and
+    // amount (the source of the mobile↔web withdraw discrepancy).
+    const position = await findReconciledActiveYieldPositionForVault({
+      cluster,
+      settings: account.settingsPda,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress,
     });
 
-    const [reserveRows, idleRows, position] = await Promise.all([
-      findCurrentNonzeroYieldVaultReservePositions({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-      findCurrentYieldVaultIdleTokenBalances({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-      findReconciledActiveYieldPositionForVault({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        walletAddress,
-      }),
-    ]);
+    const [reserveRows, idleRows] = position
+      ? await Promise.all([
+          findCurrentNonzeroYieldVaultReservePositions({
+            cluster,
+            settings: account.settingsPda,
+            vaultIndex: EARN_VAULT_INDEX,
+            vaultPubkey: position.vaultPubkey,
+            walletAddress,
+          }),
+          findCurrentYieldVaultIdleTokenBalances({
+            cluster,
+            settings: account.settingsPda,
+            vaultIndex: EARN_VAULT_INDEX,
+            vaultPubkey: position.vaultPubkey,
+            walletAddress,
+          }),
+        ])
+      : [[], []];
 
     const reserveRowsWithBalance = reserveRows.filter(
       (row) => row.amountRaw > BigInt(0) && row.market


### PR DESCRIPTION
The mobile Earn **withdraw source picker** showed a stale/wrong reserve (e.g. $8.99 or $1.98 "USDC reserve" while web's OnRe Market position was $7), and could carry the wrong reserve/market identifiers into `withdraw/prepare`.

Root cause: `mobile/earn/withdraw/sources` derived the vault pubkey locally via `getSmartAccountPda` and passed it to the reserve/idle lookups. That can resolve to a different `managedVaults` record than the one the reserve rows are stored under, so `findCurrentNonzeroYieldVaultReservePositions` returned zero rows and the route fell back to the stale reconciled `position.currentAmountRaw` (wrong reserve, market, and amount).

Fix mirrors the web `yield-optimization/position` route: resolve the reconciled position first, then key the reserve/idle lookups off `position.vaultPubkey`. Verified against live data for wallet BAqg…qZZ (web + `/holdings` both show OnRe Market $7.00 + Idle $1.98). Read-route only; no schema/worker changes.