### PR TITLE
fix(earn): source mobile withdraw from the live holdings snapshot

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -23,7 +23,15 @@ import {
   reconcileMissingOnChainEarnAutodepositPolicy,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
-import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  earnReserveTargetFromActivePosition,
+  type EarnUsdcReserveTarget,
+} from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  fetchEarnRpcHoldingsSnapshot,
+  type EarnRpcHolding,
+} from "@/lib/yield-optimization/earn-rpc-holdings.client";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import {
   findActiveYieldRoutePolicyPair,
   findCurrentNonzeroYieldVaultReservePositions,
@@ -192,6 +200,81 @@ function selectRequestedEarnWithdrawSource(
   return amountMatchedStableMintMatches.length === 1
     ? amountMatchedStableMintMatches[0] ?? null
     : null;
+}
+
+// Build withdraw sources from the LIVE on-chain holdings snapshot (partial
+// withdrawals). The DB read-model + reconcile can't follow a cross-market
+// rebalance; this scans the policy's markets and reflects reality. Drops entries
+// missing the identifiers a withdrawal needs to match/build.
+function buildSnapshotWithdrawSources(
+  holdings: EarnRpcHolding[]
+): SelectedEarnWithdrawSource[] {
+  const sources: SelectedEarnWithdrawSource[] = [];
+  for (const holding of holdings) {
+    let amountRaw: bigint;
+    try {
+      amountRaw = BigInt(holding.amountRaw);
+    } catch {
+      continue;
+    }
+    if (amountRaw <= BigInt(0)) {
+      continue;
+    }
+    if (holding.kind === "idle") {
+      const tokenAccount = holding.provenance.tokenAccount;
+      if (!tokenAccount) {
+        continue;
+      }
+      sources.push({
+        amountRaw,
+        id: tokenAccount,
+        mint: holding.liquidityMint,
+        tokenAccount,
+        type: "idle",
+      });
+      continue;
+    }
+    if (!holding.reserve || !holding.market) {
+      continue;
+    }
+    sources.push({
+      amountRaw,
+      id: holding.reserve,
+      liquidityMint: holding.liquidityMint,
+      market: holding.market,
+      reserve: holding.reserve,
+      type: "reserve",
+    });
+  }
+  return sources;
+}
+
+// The deployed Kamino reserve target for a snapshot-sourced withdrawal — used
+// when withdrawing idle USDC (a reserve withdrawal targets its own reserve).
+// Null when the vault holds no Kamino reserve (fully idle).
+function snapshotReserveTarget(
+  holdings: EarnRpcHolding[]
+): EarnUsdcReserveTarget | null {
+  const kamino = holdings.find(
+    (holding) => holding.kind === "kamino" && holding.reserve && holding.market
+  );
+  if (!kamino || !kamino.reserve || !kamino.market) {
+    return null;
+  }
+  let supplyApyBps: bigint | null = null;
+  if (kamino.supplyApyBps) {
+    try {
+      supplyApyBps = BigInt(kamino.supplyApyBps);
+    } catch {
+      supplyApyBps = null;
+    }
+  }
+  return {
+    liquidityMint: new PublicKey(kamino.liquidityMint),
+    market: new PublicKey(kamino.market),
+    reserve: new PublicKey(kamino.reserve),
+    supplyApyBps,
+  };
 }
 
 function selectEarnWithdrawSource(args: {
@@ -429,39 +512,95 @@ export async function POST(request: Request) {
       );
     }
 
-    const selectedSource = selectEarnWithdrawSource({
-      amountRaw,
-      idleRows: currentIdleRows,
-      mode,
-      position,
-      request: selectedSourceRequest,
-      reserveRows: currentReserveRows,
-    });
-    effectiveAmountRaw = mode === "full" ? selectedSource.amountRaw : amountRaw;
-    const remainingSourceAmountRaw =
-      currentReserveRows.reduce(
-        (total, row) =>
-          total +
-          (selectedSource.type === "reserve" &&
-          row.reserve === selectedSource.reserve
-            ? row.amountRaw > effectiveAmountRaw!
-              ? row.amountRaw - effectiveAmountRaw!
-              : BigInt(0)
-            : row.amountRaw),
-        BigInt(0)
-      ) +
-      currentIdleRows.reduce(
-        (total, row) =>
-          total +
-          (selectedSource.type === "idle" &&
-          row.tokenAccount === selectedSource.tokenAccount
-            ? row.amountRaw > effectiveAmountRaw!
-              ? row.amountRaw - effectiveAmountRaw!
-              : BigInt(0)
-            : row.amountRaw),
+    // Partial withdrawals source from the LIVE on-chain holdings snapshot — the
+    // same read `/holdings`, the withdraw picker, and the positions sheet use.
+    // The DB read-model + reconcile can't follow a cross-market rebalance, so it
+    // reports a stale reserve that the picker showed and this route would reject
+    // ("Select an Earn source"). Full exits keep the DB path (its reconciled
+    // rows carry the collateral metadata the full-withdrawal instruction needs).
+    let selectedSource: SelectedEarnWithdrawSource;
+    let isFinalExit: boolean;
+    let withdrawTarget: EarnUsdcReserveTarget;
+    if (mode === "partial") {
+      const snapshot = await fetchEarnRpcHoldingsSnapshot({
+        cluster,
+        connection,
+        policy: policyResult
+          ? serializeRoutePolicyState(
+              policyResult.routePolicy,
+              policyResult.setupPolicy ?? null
+            )
+          : null,
+        programId,
+        settingsPda: settingsPdaKey,
+      });
+      const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
+      if (snapshotSources.length === 0) {
+        throw new Error("No active Earn withdrawal source was found.");
+      }
+      const selected = selectRequestedEarnWithdrawSource(
+        snapshotSources,
+        selectedSourceRequest
+      );
+      if (!selected) {
+        throw new Error("Select an Earn source before withdrawing.");
+      }
+      if (amountRaw > selected.amountRaw) {
+        throw new Error("Withdrawal exceeds the selected Earn source amount.");
+      }
+      selectedSource = selected;
+      effectiveAmountRaw = amountRaw;
+      const snapshotTotal = snapshotSources.reduce(
+        (total, source) => total + source.amountRaw,
         BigInt(0)
       );
-    const isFinalExit = remainingSourceAmountRaw <= BigInt(0);
+      isFinalExit = snapshotTotal - effectiveAmountRaw <= BigInt(0);
+      withdrawTarget =
+        selected.type === "reserve"
+          ? {
+              liquidityMint: new PublicKey(selected.liquidityMint),
+              market: new PublicKey(selected.market),
+              reserve: new PublicKey(selected.reserve),
+              supplyApyBps: null,
+            }
+          : (snapshotReserveTarget(snapshot.holdings) ??
+            earnReserveTargetFromActivePosition(position));
+    } else {
+      selectedSource = selectEarnWithdrawSource({
+        amountRaw,
+        idleRows: currentIdleRows,
+        mode,
+        position,
+        request: selectedSourceRequest,
+        reserveRows: currentReserveRows,
+      });
+      effectiveAmountRaw = selectedSource.amountRaw;
+      const remainingSourceAmountRaw =
+        currentReserveRows.reduce(
+          (total, row) =>
+            total +
+            (selectedSource.type === "reserve" &&
+            row.reserve === selectedSource.reserve
+              ? row.amountRaw > effectiveAmountRaw!
+                ? row.amountRaw - effectiveAmountRaw!
+                : BigInt(0)
+              : row.amountRaw),
+          BigInt(0)
+        ) +
+        currentIdleRows.reduce(
+          (total, row) =>
+            total +
+            (selectedSource.type === "idle" &&
+            row.tokenAccount === selectedSource.tokenAccount
+              ? row.amountRaw > effectiveAmountRaw!
+                ? row.amountRaw - effectiveAmountRaw!
+                : BigInt(0)
+              : row.amountRaw),
+          BigInt(0)
+        );
+      isFinalExit = remainingSourceAmountRaw <= BigInt(0);
+      withdrawTarget = earnReserveTargetFromActivePosition(position);
+    }
 
     const policySigner = getDeploymentPolicySignerPublicKey();
     const client = createSmartAccountVaultsClient({
@@ -567,7 +706,7 @@ export async function POST(request: Request) {
       feePayer: new PublicKey(walletAddress),
       policySigner,
       settingsPda: settingsPdaKey,
-      target: earnReserveTargetFromActivePosition(position),
+      target: withdrawTarget,
       ...(mode === "full" && selectedSource.type === "reserve"
         ? {
             fullWithdrawalTargets: currentReserveRows

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/sources/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
-import { PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 
 import { findCurrentUser } from "@/features/chat/server/app-user";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
@@ -10,19 +10,29 @@ import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-sign
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import {
-  findCurrentNonzeroYieldVaultReservePositions,
-  findCurrentYieldVaultIdleTokenBalances,
-  findReconciledActiveYieldPositionForVault,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+  fetchEarnRpcHoldingsSnapshot,
+  type EarnRpcHolding,
+} from "@/lib/yield-optimization/earn-rpc-holdings.client";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
+import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Read-only list of the wallet's Earn withdrawal sources (per-reserve positions
 // + idle vault USDC), keyed by wallet address (no signature, no provisioning).
-// Mirrors the source set the withdraw/prepare route builds, so the mobile
-// source picker offers exactly the sources a `withdraw/prepare` call will
-// accept. Each item carries both display fields (amount/label) and the
-// prepare-source identifiers (type/id/reserve/tokenAccount/mint).
+//
+// Sourced from the LIVE on-chain holdings snapshot (`fetchEarnRpcHoldingsSnapshot`
+// — the same read `/holdings` and the positions sheet use), NOT the DB
+// read-model. The read-model can't follow a cross-market rebalance (its reconcile
+// only re-checks reserves it already knows), so it reported a stale
+// reserve/market/amount that the picker showed and `withdraw/prepare` then
+// rejected. The snapshot scans the policy's markets and reflects reality. Each
+// item still carries the prepare-source identifiers (type/id/reserve/
+// tokenAccount/mint) so a `withdraw/prepare` call can match it.
 const EARN_VAULT_INDEX = 1 as const;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
 
 type WithdrawSource = {
   type: "reserve" | "idle";
@@ -43,14 +53,72 @@ function jsonError(
   return NextResponse.json({ error: { code, message } }, { status });
 }
 
-function shortenAddress(address: string): string {
-  return address.length <= 8
-    ? address
-    : `${address.slice(0, 4)}…${address.slice(-4)}`;
-}
-
 function getConfiguredSolanaEnv(): SolanaEnv {
   return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(env: SolanaEnv): Connection {
+  const cached = connectionCache.get(env);
+  if (cached) {
+    return cached;
+  }
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(env);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(env, connection);
+  return connection;
+}
+
+function isPositiveAmount(amountRaw: string): boolean {
+  try {
+    return BigInt(amountRaw) > BigInt(0);
+  } catch {
+    return false;
+  }
+}
+
+// Maps a live holdings snapshot entry to a withdraw source. Drops entries we
+// can't offer as a withdrawal (zero balance, or missing the identifiers a
+// `withdraw/prepare` call needs to match/build the instruction).
+function holdingToWithdrawSource(
+  holding: EarnRpcHolding
+): WithdrawSource | null {
+  if (!isPositiveAmount(holding.amountRaw)) {
+    return null;
+  }
+  if (holding.kind === "idle") {
+    const tokenAccount = holding.provenance.tokenAccount;
+    if (!tokenAccount) {
+      return null;
+    }
+    return {
+      type: "idle",
+      id: tokenAccount,
+      label: "Idle USDC",
+      amountRaw: holding.amountRaw,
+      liquidityMint: holding.liquidityMint,
+      market: null,
+      reserve: null,
+      tokenAccount,
+    };
+  }
+  if (!holding.reserve || !holding.market) {
+    return null;
+  }
+  return {
+    type: "reserve",
+    id: holding.reserve,
+    label: "USDC reserve",
+    amountRaw: holding.amountRaw,
+    liquidityMint: holding.liquidityMint,
+    market: holding.market,
+    reserve: holding.reserve,
+    tokenAccount: null,
+  };
 }
 
 export async function GET(request: Request) {
@@ -93,98 +161,44 @@ export async function GET(request: Request) {
     const solanaEnv = getConfiguredSolanaEnv();
     const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
     const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
+    const settingsPda = new PublicKey(account.settingsPda);
     const [earnVaultPda] = pda.getSmartAccountPda({
       accountIndex: EARN_VAULT_INDEX,
       programId,
-      settingsPda: new PublicKey(account.settingsPda),
+      settingsPda,
     });
 
-    const [reserveRows, idleRows, position] = await Promise.all([
-      findCurrentNonzeroYieldVaultReservePositions({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-      findCurrentYieldVaultIdleTokenBalances({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-      findReconciledActiveYieldPositionForVault({
-        cluster,
-        settings: account.settingsPda,
-        vaultIndex: EARN_VAULT_INDEX,
-        walletAddress,
-      }),
-    ]);
+    // The live holdings read needs the active Earn route policy (the market
+    // universe to scan). No policy → nothing is deployed yet.
+    const policyPair = await findActiveYieldRoutePolicyPair({
+      authority: walletAddress,
+      cluster,
+      settings: account.settingsPda,
+      vaultIndex: EARN_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+    });
+    if (!policyPair?.routePolicy) {
+      return NextResponse.json({
+        sources: [] as WithdrawSource[],
+        settingsPda: account.settingsPda,
+        smartAccountAddress: account.smartAccountAddress,
+      });
+    }
 
-    const reserveRowsWithBalance = reserveRows.filter(
-      (row) => row.amountRaw > BigInt(0) && row.market
-    );
-    const multipleReserves = reserveRowsWithBalance.length > 1;
-    const reserveSources: WithdrawSource[] = reserveRowsWithBalance.map(
-      (row) => ({
-        type: "reserve",
-        id: row.reserve,
-        label: multipleReserves
-          ? `USDC reserve ${shortenAddress(row.reserve)}`
-          : "USDC reserve",
-        amountRaw: row.amountRaw.toString(),
-        liquidityMint: row.liquidityMint,
-        market: row.market,
-        reserve: row.reserve,
-        tokenAccount: null,
-      })
-    );
-    const idleSources: WithdrawSource[] = idleRows
-      .filter((row) => row.amountRaw > BigInt(0))
-      .map((row) => ({
-        type: "idle",
-        id: row.tokenAccount,
-        label: "Idle USDC",
-        amountRaw: row.amountRaw.toString(),
-        liquidityMint: row.mint,
-        market: null,
-        reserve: null,
-        tokenAccount: row.tokenAccount,
-      }));
+    const snapshot = await fetchEarnRpcHoldingsSnapshot({
+      cluster,
+      connection: getConnection(solanaEnv),
+      policy: serializeRoutePolicyState(
+        policyPair.routePolicy,
+        policyPair.setupPolicy ?? null
+      ),
+      programId,
+      settingsPda,
+    });
 
-    // When no user-facing RESERVE rows surfaced, fall back to the reconciled
-    // position's reserve holding. Keyed off `reserveSources.length === 0` (NOT
-    // total sources) and merged alongside idle — mirroring `withdraw/prepare`'s
-    // own fallback. The old `sources.length === 0` guard meant a dust idle
-    // balance suppressed this fallback, dropping the (filtered-out) reserve
-    // position entirely and leaving the sheet showing only idle dust. The
-    // reserve row gets filtered out when the snapshot stores the Kamino position
-    // under collateral semantics (`kamino_obligation_collateral_deposited_amount`)
-    // instead of `kamino_redeemable_liquidity`.
-    const positionFallbackSources: WithdrawSource[] =
-      reserveSources.length === 0 &&
-      position &&
-      position.currentAmountRaw > BigInt(0) &&
-      position.currentMarket
-        ? [
-            {
-              type: "reserve",
-              id: position.currentReserve,
-              label: "USDC reserve",
-              amountRaw: position.currentAmountRaw.toString(),
-              liquidityMint: position.currentLiquidityMint,
-              market: position.currentMarket,
-              reserve: position.currentReserve,
-              tokenAccount: null,
-            },
-          ]
-        : [];
-    const sources: WithdrawSource[] = [
-      ...reserveSources,
-      ...positionFallbackSources,
-      ...idleSources,
-    ];
+    const sources = snapshot.holdings
+      .map(holdingToWithdrawSource)
+      .filter((source): source is WithdrawSource => source !== null);
 
     return NextResponse.json({
       sources,


### PR DESCRIPTION
Fixes the mobile Earn withdraw being broken for positions the DB read-model can't follow (funds rebalanced to a market the reconcile never re-checks — e.g. Main Kamino → OnRe). The positions sheet + \`/holdings\` already read the live on-chain snapshot and are correct; the withdraw path still read the stale DB, so the picker showed the wrong reserve and \`withdraw/prepare\` rejected it ("Select an Earn source").

**Includes the revert of #423** (that change re-keyed the same stale DB and didn't help).

## Changes
- \`withdraw/sources\`: builds the source list from \`fetchEarnRpcHoldingsSnapshot\` (the read \`/holdings\` uses), not the DB tables. Same response shape/labels; correct reserve/market/amount + prepare identifiers.
- \`withdraw/prepare\`: **partial** withdrawals now select the source + build the target from the snapshot. **Full exits are unchanged** (still DB-sourced) because the full-withdrawal instruction needs collateral metadata (\`reserveLiquiditySupply\`/\`vaultCollateralAta\`) the snapshot doesn't carry.

## Scope / risk
- Partial path is safe-fail: \`isFinalExit\` is false unless it drains the source (no policy close), and a malformed instruction is rejected on-chain (no fund movement).
- Full-exit path is intentionally untouched here.

## Verification
- **Not locally type-checked** (off-\`main\` worktree has no deps) — the Vercel build check is the type gate; merge only when green.
- Behavioral verification: curl this PR's preview \`withdraw/sources\` for the affected wallet (expect OnRe reserve \$7 + idle \$1.98), then one real partial withdraw on a build pointed at the preview.