### PR TITLE
fix(sdk): don't mask errors when logs is a getter-only property

### DIFF
--- a/sdk/loyal-smart-accounts-core/src/core/errors/index.ts
+++ b/sdk/loyal-smart-accounts-core/src/core/errors/index.ts
@@ -186,7 +186,15 @@ export function translateAndThrowAnchorError(err: unknown): never {
     Error.captureStackTrace(translatedError, translateAndThrowAnchorError);
   }
 
-  (translatedError as unknown as ErrorWithLogs).logs = err.logs;
+  if (translatedError !== err) {
+    try {
+      (translatedError as unknown as ErrorWithLogs).logs = err.logs;
+    } catch {
+      // Some error types (e.g. web3.js SendTransactionError) expose `logs` as
+      // a getter-only accessor; assigning would throw a TypeError that masks
+      // the real error. Such errors already carry their own logs.
+    }
+  }
 
   throw translatedError;
 }


### PR DESCRIPTION
translateAndThrowAnchorError assigned .logs back onto the translated error; when translation falls through to the original web3.js SendTransactionError (getter-only logs), the assignment threw "Cannot set property logs ... which has only a getter", replacing the real failure message. Guard the assignment so the underlying error (e.g. the current mobile Earn deposit failure) surfaces instead.