### PR TITLE
fix(earn): report reused yield policies as reuse in deposit prepare

### DIFF
--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -6080,9 +6080,6 @@ export function createSmartAccountVaultsClient(
         throw error;
       }
     }
-    const policyInitialization = shouldInitializeYieldRoutingPolicy
-      ? "create"
-      : "reuse";
     const earnPolicy = shouldInitializeYieldRoutingPolicy
       ? (await discoverEarnYieldRoutingPolicyPairOnChain({
           cluster,
@@ -6122,6 +6119,11 @@ export function createSmartAccountVaultsClient(
       : await resolveEarnYieldRoutingPolicyForExecution({
           settingsPda: args.settingsPda,
         });
+    // "create" only when route-policy creation ops are actually prepared —
+    // discovery can satisfy an initialize request by reusing an on-chain pair,
+    // and confirm requires policy-creation signatures whenever it sees
+    // "create", which reuse flows never produce.
+    const policyInitialization = earnPolicy.operation ? "create" : "reuse";
     const policyPersistence = earnPolicy.persistence ?? serializedEarnUniverse;
     const policyAccount = earnPolicy.account;
     const setupPolicyAccount = earnPolicy.setupAccount ?? null;


### PR DESCRIPTION
Follow-up to #428: policyInitialization was derived from the initialize request flag before policy discovery ran, so a deposit that reused an on-chain policy pair still reported "create" — and confirm then demanded policy-creation signatures the client never produced, failing every confirm on the discovery path (deposit lands on-chain but the read-model records nothing). Derive the flag from whether creation ops were actually prepared.