### PR TITLE
fix(earn): adopt on-chain policy creation signature when confirm has no DB row

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -18,6 +18,7 @@ import {
 import {
   EarnDepositConfirmError,
   recordConfirmedEarnDeposit,
+  resolvePolicyCreationSignatureFromChain,
 } from "@/lib/yield-optimization/earn-deposit-confirm.server";
 import {
   resolveEarnDepositConfirmPolicySignature,
@@ -190,7 +191,7 @@ export async function POST(request: Request) {
       vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
       vaultPubkey: earnVaultPda.toBase58(),
     });
-    const activePolicy: EarnDepositPolicySignatureSource = policyPair?.routePolicy
+    let activePolicy: EarnDepositPolicySignatureSource = policyPair?.routePolicy
       ? {
           account: policyPair.routePolicy.policyAccount,
           seed: policyPair.routePolicy.policySeed.toString(),
@@ -198,6 +199,32 @@ export async function POST(request: Request) {
           lastSeenSlot: policyPair.routePolicy.lastSeenSlot?.toString() ?? null,
         }
       : null;
+    // Recovery path: prepare can reuse a policy pair it discovered on-chain
+    // when a prior confirm failure left no DB rows — then there is no recorded
+    // creation signature for the reuse resolution to cite. Resolve it from the
+    // chain so this confirm can adopt the policy instead of failing.
+    const reusedPolicyAccount = preparedDeposit.policy.account.toBase58();
+    if (
+      !preparedDeposit.policySetupPrepared &&
+      !preparedDeposit.policyFinalizePrepared &&
+      preparedDeposit.persistence.policyInitialization !== "create" &&
+      (!activePolicy ||
+        activePolicy.account !== reusedPolicyAccount ||
+        !activePolicy.lastSeenSignature)
+    ) {
+      const creation = await resolvePolicyCreationSignatureFromChain({
+        cluster: solanaEnv,
+        policyAccount: reusedPolicyAccount,
+      });
+      if (creation) {
+        activePolicy = {
+          account: reusedPolicyAccount,
+          seed: preparedDeposit.policy.seed.toString(),
+          lastSeenSignature: creation.signature,
+          lastSeenSlot: creation.slot,
+        };
+      }
+    }
 
     const resolution = resolveEarnDepositConfirmPolicySignature({
       activePolicy,

--- a/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
@@ -329,6 +329,34 @@ function getConnection(cluster: SolanaEnv): Connection {
   return connection;
 }
 
+// A route policy can exist on-chain without DB rows (the deposit that created
+// it landed but its confirm failed), so a reuse confirm has no recorded
+// creation signature to cite. Recover it from the chain: the policy account's
+// oldest successful transaction is the one that created it.
+export async function resolvePolicyCreationSignatureFromChain(args: {
+  cluster: SolanaEnv;
+  policyAccount: string;
+}): Promise<{ signature: string; slot: string } | null> {
+  try {
+    const connection = getConnection(args.cluster);
+    const signatures = await connection.getSignaturesForAddress(
+      new PublicKey(args.policyAccount),
+      { limit: 1000 },
+      "confirmed"
+    );
+    const creation = [...signatures]
+      .reverse()
+      .find((entry) => entry.err === null);
+    if (!creation) {
+      return null;
+    }
+    return { signature: creation.signature, slot: creation.slot.toString() };
+  } catch {
+    // Best-effort recovery; the caller falls back to the original error.
+    return null;
+  }
+}
+
 async function resolveConfirmedSignatureSlot(args: {
   cluster: SolanaEnv;
   operation: "deposit" | "route policy setup" | "setup policy setup";


### PR DESCRIPTION
Third follow-up in the first-deposit recovery chain (#428, #429): when prepare reuses a policy pair discovered on-chain, the mobile confirm's reuse resolution still failed with "Confirming this Earn top-up requires the active policy signature" because the DB has no active-policy row to cite a creation signature from (the confirm that would have written it is the one that failed). The mobile confirm route now resolves the policy account's creation signature from the chain (its oldest successful transaction) and adopts the pair. The web sidebar hook resolves client-side and still has this gap for the same rare state.