### PR TITLE
feat(quests): lower quest 1 Earn deposit threshold to $5

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -272,7 +272,7 @@ export async function POST(request: Request) {
     });
 
     // Best-effort Solana Week attribution: Quest 1 ("connect wallet and deposit
-    // $10+ in Earn"). Deposits under the threshold are a no-op. Idempotent on
+    // $5+ in Earn"). Deposits under the threshold are a no-op. Idempotent on
     // Solana's side; never blocks the deposit confirm.
     await reportEarnDepositQuestCompletion(
       walletAddress,

--- a/frontend/src/features/solana-week/server/quest-completion-service.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-service.ts
@@ -197,13 +197,13 @@ async function reportBestEffort(
 }
 
 /**
- * Minimum qualifying deposit for Quest 1: $10 USDC (6 decimals). Deposits below
+ * Minimum qualifying deposit for Quest 1: $5 USDC (6 decimals). Deposits below
  * this don't earn the badge, so we neither create a completion row nor report.
  */
-export const MIN_EARN_DEPOSIT_QUEST_USDC_RAW = BigInt(10_000_000);
+export const MIN_EARN_DEPOSIT_QUEST_USDC_RAW = BigInt(5_000_000);
 
 /**
- * Best-effort Quest 1 (connect wallet + Earn deposit of at least $10). A deposit
+ * Best-effort Quest 1 (connect wallet + Earn deposit of at least $5). A deposit
  * under the threshold is not a qualifying action and is a no-op. Never throws.
  */
 export function reportEarnDepositQuestCompletion(


### PR DESCRIPTION
Lowers the Seeker Season quest 1 qualifying Earn deposit from $10 to $5 USDC. The mobile quest card copy is updated to match on the app branch.