### PR TITLE
fix(earn): recover autodeposit setups stranded before the delegation stage

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -17,6 +17,7 @@ import {
   parseEarnAutodepositSetupPrepareRequestBody,
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 
 // Mobile twin of `yield-optimization/autodeposit/setup/prepare`. Wallet-sig auth
 // + self-resolved smart account; the SDK returns the next setup stage's prepared
@@ -131,19 +132,50 @@ export async function POST(request: Request) {
       connection: getConnection(solanaEnv),
       programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
     });
+    // Resume a half-finished setup: a pending_delegation target means the
+    // policy stage confirmed but the delegation tx was never signed. Reusing
+    // the recorded seed + nonce makes the SDK's chain-driven stage machine
+    // return the missing create_recurring_delegation stage for the SAME
+    // recorded delegation — a fresh seed/nonce would instead mint (and pay
+    // rent on) a duplicate policy and strand the pending row forever.
+    let policySeed = parsed.policySeed;
+    let nonce = parsed.nonce;
+    let periodLengthSeconds = parsed.periodLengthSeconds;
+    let startTimestamp = parsed.startTimestamp;
+    let expiryTimestamp = parsed.expiryTimestamp;
+    if (policySeed === undefined) {
+      const current = await findCurrentEarnAutodepositState({
+        settings: settingsPda,
+        vaultIndex: 1,
+        walletAddress,
+      });
+      const target = current?.target;
+      if (
+        target?.lifecycleStatus === "pending_delegation" &&
+        target.recurringDelegationNonce !== null
+      ) {
+        policySeed = target.policySeed;
+        nonce = target.recurringDelegationNonce;
+        periodLengthSeconds =
+          target.periodLengthSeconds ?? periodLengthSeconds;
+        startTimestamp = target.startTimestamp ?? startTimestamp;
+        expiryTimestamp =
+          target.recurringDelegationExpiryTimestamp ?? expiryTimestamp;
+      }
+    }
     const preparedSetup = await client.prepareEarnUsdcAutodepositSetup({
       amountRaw: parsed.amountRaw,
       cluster,
-      expiryTimestamp: parsed.expiryTimestamp,
+      expiryTimestamp,
       feePayer: new PublicKey(walletAddress),
       minimumDelegatorBalanceRaw: parsed.walletBalanceFloorRaw,
-      nonce: parsed.nonce,
-      periodLengthSeconds: parsed.periodLengthSeconds,
+      nonce,
+      periodLengthSeconds,
       policySigner,
-      policySeed: parsed.policySeed,
+      policySeed,
       settingsPda: new PublicKey(settingsPda),
       signer: new PublicKey(walletAddress),
-      startTimestamp: parsed.startTimestamp,
+      startTimestamp,
       walletAddress: new PublicKey(walletAddress),
     });
 

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -2395,6 +2395,43 @@ describe("prepareEarnUsdcAutodeposit", () => {
   });
 
   test("builds close policy removal with backend signer metadata", async () => {
+    const recurringDelegation = new PublicKey(
+      "11111111111111111111111111111116"
+    );
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(policyAccount)) {
+        return createSerializedEarnPolicyAccount();
+      }
+      if (address.equals(recurringDelegation)) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcAutodepositClose({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      signer: walletAddress,
+      policySigner: backendSigner,
+      policy: policyAccount,
+      recurringDelegation,
+    });
+
+    expect(result.prepared.instructions).toHaveLength(2);
+    expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[1]);
+    expect(result.persistence).toMatchObject({
+      delegatedSigner: backendSigner.toBase58(),
+      policyAccount: policyAccount.toBase58(),
+      walletAddress: walletAddress.toBase58(),
+    });
+  });
+
+  test("omits the delegation revoke when the delegation was never created", async () => {
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(policyAccount)) {
         return createSerializedEarnPolicyAccount();
@@ -2416,13 +2453,11 @@ describe("prepareEarnUsdcAutodeposit", () => {
       recurringDelegation: new PublicKey("11111111111111111111111111111116"),
     });
 
-    expect(result.prepared.instructions).toHaveLength(2);
-    expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[1]);
-    expect(result.persistence).toMatchObject({
-      delegatedSigner: backendSigner.toBase58(),
-      policyAccount: policyAccount.toBase58(),
-      walletAddress: walletAddress.toBase58(),
-    });
+    // A setup abandoned before its delegation stage: revoking the nonexistent
+    // delegation would fail simulation and strand the close, so only the
+    // policy-close instruction remains.
+    expect(result.prepared.instructions).toHaveLength(1);
+    expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[0]);
   });
 
   test("builds pull execution with the backend policy signer", async () => {

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -8394,16 +8394,27 @@ export function createSmartAccountVaultsClient(
       policies: [args.policy],
       memo: args.memo,
     });
+    // A setup abandoned before its final stage leaves the policy on-chain with
+    // the recurring delegation never created; revoking the missing delegation
+    // fails simulation ("invalid account owner") and strands the close. Only
+    // revoke a delegation that actually exists.
+    const delegationAccount = await config.connection.getAccountInfo(
+      args.recurringDelegation
+    );
     const prepared = freezePreparedOperation({
       operation: "earnUsdcAutodepositClose",
       payer: args.feePayer,
       programId: smartAccountsClient.programId,
       requiresConfirmation: true,
       instructions: [
-        createSubscriptionRevokeDelegationInstruction({
-          authority: args.walletAddress,
-          delegation: args.recurringDelegation,
-        }),
+        ...(delegationAccount
+          ? [
+              createSubscriptionRevokeDelegationInstruction({
+                authority: args.walletAddress,
+                delegation: args.recurringDelegation,
+              }),
+            ]
+          : []),
         ...closePolicy.instructions,
       ],
       lookupTableAccounts: dedupeLookupTableAccounts(


### PR DESCRIPTION
An autodeposit setup abandoned before its final stage leaves the policy on-chain with no recurring delegation and a pending DB row that can't be toggled, edited, or deleted. Close now only revokes a delegation that exists on-chain, and mobile setup prepare resumes the pending target's recorded policy seed and nonce so re-running setup signs just the missing stage instead of minting a duplicate policy.