### PR TITLE
feat(earn): send transactional autodeposit push notifications

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -38,3 +38,8 @@ SOLANA_WEEK_QUEST_ID_FIRST_AUTODEPOSIT=
 SOLANA_WEEK_SWEEP_LOOKBACK_HOURS=
 # Bearer secret the autodeposit sweep worker uses to call /api/solana-week/sweep-notify.
 SOLANA_WEEK_NOTIFY_SECRET=
+
+# Mobile push bridge (ASK-1651): app deployment that owns the Expo push tokens.
+# MOBILE_PUSH_API_SECRET must match the app's PUSH_DEBUG_SECRET. Unset = pushes off.
+MOBILE_PUSH_API_BASE_URL=
+MOBILE_PUSH_API_SECRET=

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
@@ -5,6 +5,10 @@ import { authenticateMobileWalletRequest } from "@/features/identity/server/mobi
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import {
+  autodepositSweepScheduledPush,
+  sendWalletPush,
+} from "@/lib/push-notifications/wallet-push.server";
+import {
   parseEarnAutodepositFloorUpdateConfirmRequestBody,
   type EarnAutodepositSetupConfirmResponse,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
@@ -132,6 +136,17 @@ export async function POST(request: Request) {
       walletAddress,
       walletBalanceFloorRaw: input.walletBalanceFloorRaw,
     });
+
+    if (result.rebaselineSweep.status === "scheduled") {
+      // Transactional push (ASK-1651): lowering the floor freed up USDC and a
+      // sweep got scheduled.
+      await sendWalletPush(
+        walletAddress,
+        autodepositSweepScheduledPush(
+          result.rebaselineSweep.sweep.remainingAmountRaw
+        )
+      );
+    }
 
     return NextResponse.json({
       rebaselineSweep:

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
@@ -23,6 +23,11 @@ import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import {
+  autodepositEnabledPush,
+  autodepositSweepScheduledPush,
+  sendWalletPush,
+} from "@/lib/push-notifications/wallet-push.server";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
@@ -640,6 +645,22 @@ export async function POST(request: Request) {
         status: "failed",
       };
     }
+  }
+
+  if (input.setupStage === "create_recurring_delegation") {
+    // Transactional push (ASK-1651). When the bootstrap sweep already found
+    // idle USDC, the "about to move" push implies auto-deposit is on — send
+    // one push, not two.
+    const scheduledSweep =
+      bootstrapSweep?.status === "scheduled" ? bootstrapSweep.sweep : undefined;
+    await sendWalletPush(
+      input.walletAddress,
+      scheduledSweep
+        ? autodepositSweepScheduledPush(
+            BigInt(scheduledSweep.remainingAmountRaw)
+          )
+        : autodepositEnabledPush()
+    );
   }
 
   return NextResponse.json({

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
@@ -5,6 +5,10 @@ import { authenticateMobileWalletRequest } from "@/features/identity/server/mobi
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import {
+  autodepositEnabledPush,
+  sendWalletPush,
+} from "@/lib/push-notifications/wallet-push.server";
+import {
   parseEarnAutodepositToggleConfirmRequestBody,
   type EarnAutodepositToggleConfirmResponse,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
@@ -114,6 +118,11 @@ export async function POST(request: Request) {
       vaultIndex: input.vaultIndex,
       walletAddress,
     });
+
+    if (input.active) {
+      // Transactional push (ASK-1651).
+      await sendWalletPush(walletAddress, autodepositEnabledPush());
+    }
 
     return NextResponse.json({ target: serializeTarget(target) });
   } catch (error) {

--- a/frontend/src/app/api/solana-week/sweep-notify/route.ts
+++ b/frontend/src/app/api/solana-week/sweep-notify/route.ts
@@ -3,11 +3,21 @@ import { NextResponse } from "next/server";
 
 import { reportFirstAutodepositSweepQuestCompletion } from "@/features/solana-week/server/quest-completion-service";
 import { getOptionalEnv } from "@/lib/core/config/shared";
+import {
+  autodepositSweepExecutedPush,
+  autodepositSweepScheduledPush,
+  sendWalletPush,
+} from "@/lib/push-notifications/wallet-push.server";
+import { findLatestEarnAutodepositExecutionForWallet } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 
 // Internal backend-to-backend endpoint the autodeposit sweep worker calls the
 // moment it records a confirmed sweep, so Quest 2 ("first Earn deposit via
-// autodeposit") is reported in real time instead of waiting for the cron.
-// Authenticated with SOLANA_WEEK_NOTIFY_SECRET (Bearer). Body: { walletAddress }.
+// autodeposit") is reported in real time instead of waiting for the cron, and
+// the wallet's devices get the transactional push (ASK-1651).
+// Authenticated with SOLANA_WEEK_NOTIFY_SECRET (Bearer).
+// Body: { walletAddress, kind?: "scheduled" | "executed", amountRaw?: string }.
+// `kind` defaults to "executed" (the only event the worker sent historically);
+// "scheduled" is push-only and skips quest reporting.
 function isAuthorized(request: Request): boolean {
   const secret = getOptionalEnv(process.env, "SOLANA_WEEK_NOTIFY_SECRET");
   if (!secret) {
@@ -36,10 +46,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
   }
 
-  const walletAddress =
+  const record =
     typeof body === "object" && body !== null
-      ? (body as Record<string, unknown>).walletAddress
-      : undefined;
+      ? (body as Record<string, unknown>)
+      : {};
+  const walletAddress = record.walletAddress;
   if (typeof walletAddress !== "string" || !walletAddress.trim()) {
     return NextResponse.json(
       { error: "invalid_request", message: "walletAddress is required." },
@@ -47,10 +58,56 @@ export async function POST(request: Request) {
     );
   }
 
+  const kind = record.kind === "scheduled" ? "scheduled" : "executed";
+  let amountRaw = parseAmountRaw(record.amountRaw);
+
+  if (kind === "scheduled") {
+    await sendWalletPush(
+      walletAddress,
+      autodepositSweepScheduledPush(amountRaw)
+    );
+    return NextResponse.json({ status: "accepted" });
+  }
+
   // Best-effort + idempotent; never throws.
   await reportFirstAutodepositSweepQuestCompletion(walletAddress, {
     source: "sweep-worker-notify",
   });
 
+  if (amountRaw === null) {
+    // Worker payloads don't carry the amount yet; the execution row the
+    // worker just recorded does. Only trust it while fresh so a delayed
+    // notify can't attribute a previous sweep's amount.
+    try {
+      const execution =
+        await findLatestEarnAutodepositExecutionForWallet(walletAddress);
+      if (
+        execution &&
+        Date.now() - execution.recordedAt.getTime() <
+          EXECUTION_AMOUNT_FRESHNESS_MS
+      ) {
+        amountRaw = execution.amountRaw;
+      }
+    } catch (error) {
+      console.warn("[sweep-notify] execution amount lookup failed", {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown lookup error.",
+        walletAddress,
+      });
+    }
+  }
+
+  await sendWalletPush(walletAddress, autodepositSweepExecutedPush(amountRaw));
+
   return NextResponse.json({ status: "accepted" });
+}
+
+const EXECUTION_AMOUNT_FRESHNESS_MS = 15 * 60 * 1000;
+
+function parseAmountRaw(value: unknown): bigint | null {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return null;
+  }
+  const parsed = BigInt(value);
+  return parsed > BigInt(0) ? parsed : null;
 }

--- a/frontend/src/lib/push-notifications/wallet-push.server.ts
+++ b/frontend/src/lib/push-notifications/wallet-push.server.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { getOptionalEnv } from "@/lib/core/config/shared";
+
+export type WalletPushPayload = {
+  title: string;
+  body: string;
+};
+
+// Bridge to the app deployment's wallet push sender. Expo push tokens are
+// registered per wallet against the app backend (`push_tokens` table), so the
+// earn backend delivers pushes by calling its authenticated send endpoint
+// instead of reaching into the app database.
+// ponytail: reuses the existing `/api/push-tokens/debug-send` route as the
+// send endpoint; promote it to a non-debug path if this grows beyond earn.
+//
+// Configuration (both required, pushes are disabled when unset):
+// - MOBILE_PUSH_API_BASE_URL: app deployment origin
+// - MOBILE_PUSH_API_SECRET: must match the app's PUSH_DEBUG_SECRET
+//
+// Best-effort by design: never throws, so confirm routes and webhooks can
+// await it without wrapping.
+export async function sendWalletPush(
+  walletAddress: string,
+  payload: WalletPushPayload
+): Promise<void> {
+  const baseUrl = getOptionalEnv(process.env, "MOBILE_PUSH_API_BASE_URL");
+  const secret = getOptionalEnv(process.env, "MOBILE_PUSH_API_SECRET");
+  if (!baseUrl || !secret) {
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/+$/, "")}/api/push-tokens/debug-send`,
+      {
+        body: JSON.stringify({
+          body: payload.body,
+          title: payload.title,
+          walletPublicKey: walletAddress,
+        }),
+        headers: {
+          Authorization: `Bearer ${secret}`,
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        signal: AbortSignal.timeout(5_000),
+      }
+    );
+    // 404 = no devices registered for this wallet (web-only user); expected.
+    if (!response.ok && response.status !== 404) {
+      console.warn("[wallet-push] push send rejected", {
+        status: response.status,
+        walletAddress,
+      });
+    }
+  } catch (error) {
+    console.warn("[wallet-push] push send failed", {
+      errorMessage: error instanceof Error ? error.message : "Unknown error.",
+      walletAddress,
+    });
+  }
+}
+
+function formatUsdcAmountRaw(amountRaw: bigint): string {
+  const usd = Number(amountRaw) / 1_000_000;
+  return `$${usd.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+// Copy comes from ASK-1651 — keep in sync with the ticket.
+
+export function autodepositEnabledPush(): WalletPushPayload {
+  return {
+    body: "Your idle USDC will be moved to Earn automatically, roughly once an hour.",
+    title: "Auto-deposit is on.",
+  };
+}
+
+export function autodepositSweepScheduledPush(
+  amountRaw: bigint | null
+): WalletPushPayload {
+  const amount =
+    amountRaw !== null && amountRaw > BigInt(0)
+      ? formatUsdcAmountRaw(amountRaw)
+      : "USDC";
+  return {
+    body: "Heading to yield in ~1 hour. Adjust autodeposit limits if you need it liquid.",
+    title: `${amount} about to move to EARN.`,
+  };
+}
+
+export function autodepositSweepExecutedPush(
+  amountRaw: bigint | null
+): WalletPushPayload {
+  const amount =
+    amountRaw !== null && amountRaw > BigInt(0)
+      ? formatUsdcAmountRaw(amountRaw)
+      : "USDC";
+  return {
+    body: "Now earning USDC yield.",
+    title: `${amount} moved to EARN.`,
+  };
+}

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -1219,6 +1219,41 @@ export async function findEarnAutodepositHistoryEvents(
   });
 }
 
+// The sweep worker's notify payload only carries the wallet address; the
+// execution row it just recorded carries the amount. Callers should treat a
+// stale `recordedAt` as "no amount" rather than attribute an old sweep.
+export async function findLatestEarnAutodepositExecutionForWallet(
+  walletAddress: string,
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client"
+  > = createDependencies()
+): Promise<{ amountRaw: bigint; recordedAt: Date } | null> {
+  const rows = await dependencies.client.db
+    .select({
+      amountRaw: balanceSweepExecutions.amountRaw,
+      decodedAt: balanceSweepExecutions.decodedAt,
+      receivedAt: balanceSweepExecutions.receivedAt,
+    })
+    .from(balanceSweepExecutions)
+    .innerJoin(
+      balanceSweepTargets,
+      eq(balanceSweepExecutions.targetId, balanceSweepTargets.id)
+    )
+    .where(eq(balanceSweepTargets.wallet, walletAddress))
+    .orderBy(desc(balanceSweepExecutions.id))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+  return {
+    amountRaw: row.amountRaw,
+    recordedAt: row.decodedAt ?? row.receivedAt,
+  };
+}
+
 function targetValuesFromSetup(
   input: ConfirmedEarnAutodepositSetupInput,
   balanceSweepPolicyId: bigint,


### PR DESCRIPTION
Sends the ASK-1651 P1 transactional pushes (auto-deposit enabled, sweep scheduled, sweep executed) from the mobile earn confirm routes and the sweep worker notify endpoint, delivered through the app deployment's wallet push sender. Pushes are enabled by setting MOBILE_PUSH_API_BASE_URL + MOBILE_PUSH_API_SECRET in the frontend project.