### PR TITLE
feat(earn): accept flow-auth reuse and batched autodeposit stages for mobile

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
@@ -207,7 +207,9 @@ export async function POST(request: Request) {
   try {
     ({ walletAddress } = await authenticateMobileWalletRequest({
       body,
-      purpose: "earn-autodeposit-close-confirm",
+      // Accepts the flow's prepare signature too — the device signs one auth
+      // message per flow (see authenticateMobileWalletRequest).
+      purpose: ["earn-autodeposit-close-confirm", "earn-autodeposit-close-prepare"],
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
@@ -446,7 +446,9 @@ export async function POST(request: Request) {
   try {
     ({ walletAddress } = await authenticateMobileWalletRequest({
       body,
-      purpose: "earn-autodeposit-setup-confirm",
+      // Accepts the flow's prepare signature too — the device signs one auth
+      // message per flow (see authenticateMobileWalletRequest).
+      purpose: ["earn-autodeposit-setup-confirm", "earn-autodeposit-setup-prepare"],
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -163,7 +163,7 @@ export async function POST(request: Request) {
           target.recurringDelegationExpiryTimestamp ?? expiryTimestamp;
       }
     }
-    const preparedSetup = await client.prepareEarnUsdcAutodepositSetup({
+    const prepareArgs = {
       amountRaw: parsed.amountRaw,
       cluster,
       expiryTimestamp,
@@ -177,9 +177,22 @@ export async function POST(request: Request) {
       signer: new PublicKey(walletAddress),
       startTimestamp,
       walletAddress: new PublicKey(walletAddress),
-    });
+    };
+    // `includeBatch` mirrors the web route: the create_policy stage also
+    // returns the create_recurring_delegation stage prepared ahead, so the
+    // device can sign both in one wallet prompt and send them in order.
+    const preparedSetups = parsed.includeBatch
+      ? await client.prepareEarnUsdcAutodepositSetupBatch(prepareArgs)
+      : [await client.prepareEarnUsdcAutodepositSetup(prepareArgs)];
+    const preparedSetup = preparedSetups[0];
+    if (!preparedSetup) {
+      throw new Error("Failed to prepare Earn autodeposit setup.");
+    }
 
     return NextResponse.json({
+      nextPreparedSetup: preparedSetups[1]
+        ? serializePreparedEarnUsdcAutodepositSetup(preparedSetups[1])
+        : null,
       preparedSetup: serializePreparedEarnUsdcAutodepositSetup(preparedSetup),
     });
   } catch (error) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -100,7 +100,9 @@ export async function POST(request: Request) {
   try {
     ({ walletAddress } = await authenticateMobileWalletRequest({
       body,
-      purpose: "earn-deposit-confirm",
+      // Accepts the flow's prepare signature too — the device signs one auth
+      // message per deposit flow (see authenticateMobileWalletRequest).
+      purpose: ["earn-deposit-confirm", "earn-deposit-prepare"],
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
@@ -127,7 +127,9 @@ export async function POST(request: Request) {
   try {
     ({ walletAddress } = await authenticateMobileWalletRequest({
       body,
-      purpose: "earn-withdraw-confirm",
+      // Accepts the flow's prepare signature too — the device signs one auth
+      // message per flow (see authenticateMobileWalletRequest).
+      purpose: ["earn-withdraw-confirm", "earn-withdraw-prepare"],
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/features/identity/server/mobile-wallet-auth.ts
+++ b/frontend/src/features/identity/server/mobile-wallet-auth.ts
@@ -82,9 +82,15 @@ function parseMobileWalletAuthFields(body: unknown): MobileWalletAuthFields {
 
 // Verifies a mobile wallet-signed request and returns the authenticated wallet
 // address. Throws `WalletAuthError` (with an HTTP status) on any failure.
+//
+// `purpose` may list several accepted purposes: confirm endpoints also accept
+// the flow's prepare-purpose signature (within the freshness window) so the
+// device signs ONE auth message per flow instead of one per request. The
+// signature is verified against each candidate message; order them
+// most-likely-first.
 export async function authenticateMobileWalletRequest(args: {
   body: unknown;
-  purpose: MobileWalletAuthPurpose;
+  purpose: MobileWalletAuthPurpose | readonly MobileWalletAuthPurpose[];
   now?: () => number;
 }): Promise<{ walletAddress: string }> {
   const { walletAddress, signature, issuedAt } = parseMobileWalletAuthFields(
@@ -115,22 +121,25 @@ export async function authenticateMobileWalletRequest(args: {
     });
   }
 
-  const message = buildMobileWalletAuthMessage({
-    purpose: args.purpose,
-    walletAddress,
-    issuedAt,
-  });
-  const verified = await verifyWalletSignature({
-    walletAddress,
-    message,
-    signature,
-  });
-  if (!verified) {
-    throw new WalletAuthError("Wallet signature could not be verified.", {
-      code: "invalid_mobile_signature",
-      status: 401,
+  const purposes = Array.isArray(args.purpose) ? args.purpose : [args.purpose];
+  for (const purpose of purposes) {
+    const message = buildMobileWalletAuthMessage({
+      purpose,
+      walletAddress,
+      issuedAt,
     });
+    const verified = await verifyWalletSignature({
+      walletAddress,
+      message,
+      signature,
+    });
+    if (verified) {
+      return { walletAddress };
+    }
   }
 
-  return { walletAddress };
+  throw new WalletAuthError("Wallet signature could not be verified.", {
+    code: "invalid_mobile_signature",
+    status: 401,
+  });
 }


### PR DESCRIPTION
Mobile Earn confirm endpoints now also accept the flow's prepare-purpose wallet signature within the existing 5-minute freshness window, so the device signs one auth message per flow instead of one per request. The mobile autodeposit setup prepare twin gains the web route's includeBatch support (create_policy + create_recurring_delegation prepared together) so the device can sign both stages in a single Seed Vault prompt.