### PR TITLE
fix(earn): treat sub-cent idle dust as final exit in withdraw prepare

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -51,6 +51,16 @@ import {
 // in sync with the session route.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
+// Sub-cent idle USDC must not block a final exit. The final-exit prepare path
+// sweeps the vault USDC ATA's live balance into the wallet transfer, so
+// tolerated idle dust is paid out, the ATA closes, and the policies close (SOL
+// rent refund). Without the tolerance, the 1-2 raw units that Kamino redemption
+// rounding strands in the idle account keep the position open at $0.00 forever
+// — the cent-precision withdraw UIs can't express an amount below $0.01 to
+// clear it. Reserve remainders stay strict: the sweep does not touch other
+// reserves' collateral. Keep in sync with the session withdrawals/prepare route.
+const EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW = BigInt(10_000); // $0.01
+
 const connectionCache = new Map<SolanaEnv, Connection>();
 
 function jsonError(
@@ -575,30 +585,31 @@ export async function POST(request: Request) {
         reserveRows: currentReserveRows,
       });
       effectiveAmountRaw = selectedSource.amountRaw;
-      const remainingSourceAmountRaw =
-        currentReserveRows.reduce(
-          (total, row) =>
-            total +
-            (selectedSource.type === "reserve" &&
-            row.reserve === selectedSource.reserve
-              ? row.amountRaw > effectiveAmountRaw!
-                ? row.amountRaw - effectiveAmountRaw!
-                : BigInt(0)
-              : row.amountRaw),
-          BigInt(0)
-        ) +
-        currentIdleRows.reduce(
-          (total, row) =>
-            total +
-            (selectedSource.type === "idle" &&
-            row.tokenAccount === selectedSource.tokenAccount
-              ? row.amountRaw > effectiveAmountRaw!
-                ? row.amountRaw - effectiveAmountRaw!
-                : BigInt(0)
-              : row.amountRaw),
-          BigInt(0)
-        );
-      isFinalExit = remainingSourceAmountRaw <= BigInt(0);
+      const remainingReserveAmountRaw = currentReserveRows.reduce(
+        (total, row) =>
+          total +
+          (selectedSource.type === "reserve" &&
+          row.reserve === selectedSource.reserve
+            ? row.amountRaw > effectiveAmountRaw!
+              ? row.amountRaw - effectiveAmountRaw!
+              : BigInt(0)
+            : row.amountRaw),
+        BigInt(0)
+      );
+      const remainingIdleAmountRaw = currentIdleRows.reduce(
+        (total, row) =>
+          total +
+          (selectedSource.type === "idle" &&
+          row.tokenAccount === selectedSource.tokenAccount
+            ? row.amountRaw > effectiveAmountRaw!
+              ? row.amountRaw - effectiveAmountRaw!
+              : BigInt(0)
+            : row.amountRaw),
+        BigInt(0)
+      );
+      isFinalExit =
+        remainingReserveAmountRaw <= BigInt(0) &&
+        remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
       withdrawTarget = earnReserveTargetFromActivePosition(position);
     }
 

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -425,6 +425,58 @@ describe("Earn withdrawal prepare route", () => {
     expect(targets[0]?.reserve.toBase58()).toBe(activePosition.currentReserve);
   });
 
+  test("treats sub-cent idle dust as a final exit on full reserve withdrawals", async () => {
+    const { POST } = await import("./route");
+    currentIdleRows = [
+      {
+        amountRaw: BigInt(2),
+        mint: activePosition.currentLiquidityMint,
+        tokenAccount: "11111111111111111111111111111116",
+      },
+    ];
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "1000026",
+        mode: "full",
+        source: {
+          id: activePosition.currentReserve,
+          reserve: activePosition.currentReserve,
+          type: "reserve",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(true);
+  });
+
+  test("keeps full reserve withdrawals non-final while a withdrawable idle balance remains", async () => {
+    const { POST } = await import("./route");
+    currentIdleRows = [
+      {
+        amountRaw: BigInt(10_000),
+        mint: activePosition.currentLiquidityMint,
+        tokenAccount: "11111111111111111111111111111116",
+      },
+    ];
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "1000026",
+        mode: "full",
+        source: {
+          id: activePosition.currentReserve,
+          reserve: activePosition.currentReserve,
+          type: "reserve",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
+  });
+
   test("passes selected idle vault USDC as its own withdrawal source", async () => {
     const { POST } = await import("./route");
     currentIdleRows = [

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -34,6 +34,16 @@ import {
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
+// Sub-cent idle USDC must not block a final exit. The final-exit prepare path
+// sweeps the vault USDC ATA's live balance into the wallet transfer, so
+// tolerated idle dust is paid out, the ATA closes, and the policies close (SOL
+// rent refund). Without the tolerance, the 1-2 raw units that Kamino redemption
+// rounding strands in the idle account keep the position open at $0.00 forever
+// — the cent-precision withdraw UIs can't express an amount below $0.01 to
+// clear it. Reserve remainders stay strict: the sweep does not touch other
+// reserves' collateral.
+const EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW = BigInt(10_000); // $0.01
+
 const connectionCache = new Map<SolanaEnv, Connection>();
 
 function jsonError(
@@ -368,30 +378,31 @@ export async function POST(request: Request) {
       reserveRows: currentReserveRows,
     });
     effectiveAmountRaw = mode === "full" ? selectedSource.amountRaw : amountRaw;
-    const remainingSourceAmountRaw =
-      currentReserveRows.reduce(
-        (total, row) =>
-          total +
-          (selectedSource.type === "reserve" &&
-          row.reserve === selectedSource.reserve
-            ? row.amountRaw > effectiveAmountRaw!
-              ? row.amountRaw - effectiveAmountRaw!
-              : BigInt(0)
-            : row.amountRaw),
-        BigInt(0)
-      ) +
-      currentIdleRows.reduce(
-        (total, row) =>
-          total +
-          (selectedSource.type === "idle" &&
-          row.tokenAccount === selectedSource.tokenAccount
-            ? row.amountRaw > effectiveAmountRaw!
-              ? row.amountRaw - effectiveAmountRaw!
-              : BigInt(0)
-            : row.amountRaw),
-        BigInt(0)
-      );
-    const isFinalExit = remainingSourceAmountRaw <= BigInt(0);
+    const remainingReserveAmountRaw = currentReserveRows.reduce(
+      (total, row) =>
+        total +
+        (selectedSource.type === "reserve" &&
+        row.reserve === selectedSource.reserve
+          ? row.amountRaw > effectiveAmountRaw!
+            ? row.amountRaw - effectiveAmountRaw!
+            : BigInt(0)
+          : row.amountRaw),
+      BigInt(0)
+    );
+    const remainingIdleAmountRaw = currentIdleRows.reduce(
+      (total, row) =>
+        total +
+        (selectedSource.type === "idle" &&
+        row.tokenAccount === selectedSource.tokenAccount
+          ? row.amountRaw > effectiveAmountRaw!
+            ? row.amountRaw - effectiveAmountRaw!
+            : BigInt(0)
+          : row.amountRaw),
+      BigInt(0)
+    );
+    const isFinalExit =
+      remainingReserveAmountRaw <= BigInt(0) &&
+      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
 
     const policySigner = getDeploymentPolicySignerPublicKey();
     const client = createSmartAccountVaultsClient({


### PR DESCRIPTION
A full withdrawal's final exit was blocked by 1-2 raw units of idle USDC that Kamino redemption rounding strands in the vault — the position stayed open at $0.00 with policies never closed (no SOL rent refund) and the cent-precision UIs can't express an amount below $0.01 to clear it. Both withdraw prepare routes (session + mobile twin) now tolerate a sub-cent idle remainder when deciding the final exit; the final-exit path already sweeps the vault USDC ATA's live balance into the wallet transfer, so the dust is paid out and the ATA + policies close. Reserve remainders stay strict since the sweep doesn't touch other reserves' collateral.