### PR TITLE
fix(earn): tolerate already-closed policies on final exit and release stale DB pair at confirm

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -35,6 +35,7 @@ import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-s
 import {
   findActiveYieldRoutePolicyPair,
   findCurrentNonzeroYieldVaultReservePositions,
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
   findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type CurrentYieldVaultIdleTokenBalanceRecord,
@@ -50,16 +51,6 @@ import {
 // account, so (unlike deposit) it never provisions. Keep the prepare body below
 // in sync with the session route.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
-
-// Sub-cent idle USDC must not block a final exit. The final-exit prepare path
-// sweeps the vault USDC ATA's live balance into the wallet transfer, so
-// tolerated idle dust is paid out, the ATA closes, and the policies close (SOL
-// rent refund). Without the tolerance, the 1-2 raw units that Kamino redemption
-// rounding strands in the idle account keep the position open at $0.00 forever
-// — the cent-precision withdraw UIs can't express an amount below $0.01 to
-// clear it. Reserve remainders stay strict: the sweep does not touch other
-// reserves' collateral. Keep in sync with the session withdrawals/prepare route.
-const EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW = BigInt(10_000); // $0.01
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -133,6 +133,7 @@ mock.module(
 );
 
 mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW: BigInt(10_000),
   findActiveManagedYieldVaultWithPolicy: async () => null,
   findActiveYieldRoutePolicyPair: async (input: unknown) => {
     findPolicyCalls.push(input);

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -24,6 +24,7 @@ import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/ea
 import {
   findActiveYieldRoutePolicyPair,
   findCurrentNonzeroYieldVaultReservePositions,
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
   findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type CurrentYieldVaultIdleTokenBalanceRecord,
@@ -33,16 +34,6 @@ import {
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
-
-// Sub-cent idle USDC must not block a final exit. The final-exit prepare path
-// sweeps the vault USDC ATA's live balance into the wallet transfer, so
-// tolerated idle dust is paid out, the ATA closes, and the policies close (SOL
-// rent refund). Without the tolerance, the 1-2 raw units that Kamino redemption
-// rounding strands in the idle account keep the position open at $0.00 forever
-// — the cent-precision withdraw UIs can't express an amount below $0.01 to
-// clear it. Reserve remainders stay strict: the sweep does not touch other
-// reserves' collateral.
-const EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW = BigInt(10_000); // $0.01
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -272,6 +272,14 @@ export type SnapshotReconciliationInput = {
   sourceSnapshotId: bigint;
 };
 
+// Sub-cent idle USDC must not block a final exit. Shared by the withdraw
+// prepare routes (which close the on-chain policies on this basis) and the
+// confirm-side resolveWithdrawalSource (which releases the DB policy rows).
+// Prepare and confirm MUST agree: when prepare closes the policies but confirm
+// keeps the DB pair active, the next deposit adopts dead policy accounts and
+// every subsequent withdraw prepare fails with "Unable to find Policy account".
+export const EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW = BigInt(10_000); // $0.01
+
 const REDEEMABLE_LIQUIDITY_AMOUNT_SEMANTICS = new Set([
   "kamino_redeemable_liquidity",
 ]);
@@ -1521,10 +1529,13 @@ async function resolveWithdrawalSource(
 
   return {
     idleRows: currentIdleRows,
+    // Mirrors the prepare routes' final-exit derivation (same dust tolerance):
+    // a full-mode exit sweeps idle dust and closes the on-chain policies, so
+    // the DB pair must be released here on the same basis.
     isFinalExit:
       input.mode === "full" &&
       remainingReserveAmountRaw <= BigInt(0) &&
-      remainingIdleRaw <= BigInt(0),
+      remainingIdleRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
     remainingIdleAmountRaw: remainingIdleRaw + reserveVaultIdleDeltaRaw,
     remainingReserveAmountRaw,
     selectedIdleRow,

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -6732,7 +6732,7 @@ export function createSmartAccountVaultsClient(
           } as never
         );
       const policyCloseOperation = isFinalExit
-        ? await prepareCloseYieldRoutingPoliciesSync({
+        ? await prepareCloseLiveYieldRoutingPoliciesSync({
             settingsPda: args.settingsPda,
             feePayer: args.feePayer,
             signers: [args.walletAddress],
@@ -7483,7 +7483,7 @@ export function createSmartAccountVaultsClient(
         );
       const policyCloseOperation =
         isFinalExit && isFinalBatch
-          ? await prepareCloseYieldRoutingPoliciesSync({
+          ? await prepareCloseLiveYieldRoutingPoliciesSync({
               settingsPda: args.settingsPda,
               feePayer: args.feePayer,
               signers: [args.walletAddress],
@@ -7814,13 +7814,15 @@ export function createSmartAccountVaultsClient(
         ? [args.yieldRoutingPolicy.setupPolicy.account]
         : []),
     ];
-    const policyCloseOperation = await prepareCloseYieldRoutingPoliciesSync({
-      settingsPda: args.settingsPda,
-      feePayer: args.feePayer,
-      signers: [args.walletAddress],
-      policies: policyAccounts,
-      memo: args.memo,
-    });
+    const policyCloseOperation = await prepareCloseLiveYieldRoutingPoliciesSync(
+      {
+        settingsPda: args.settingsPda,
+        feePayer: args.feePayer,
+        signers: [args.walletAddress],
+        policies: policyAccounts,
+        memo: args.memo,
+      }
+    );
     const autodepositClosePrepared = args.autodepositClose
       ? await prepareEarnUsdcAutodepositClose({
           cluster,
@@ -7836,8 +7838,13 @@ export function createSmartAccountVaultsClient(
       : null;
     const operations = [
       ...(tokenOperation ? [tokenOperation] : []),
-      policyCloseOperation,
+      ...(policyCloseOperation ? [policyCloseOperation] : []),
     ];
+    if (operations.length === 0) {
+      throw new Error(
+        "Nothing to clean up: yield routing policies are already closed."
+      );
+    }
     const prepared = freezePreparedOperation({
       operation: "earnUsdcCleanup",
       payer: args.feePayer,
@@ -8666,6 +8673,28 @@ export function createSmartAccountVaultsClient(
         remainingAccounts: toWritableAccountMetas(policies),
       } as never
     );
+  }
+
+  // Earn final-exit cleanup must tolerate policies a prior exit already closed
+  // on-chain (a stale DB pair can hand out dead accounts): closing nothing is
+  // success, not an error. Returns null when no listed policy exists anymore.
+  async function prepareCloseLiveYieldRoutingPoliciesSync(
+    args: SmartAccountClosePoliciesSyncInput
+  ): Promise<PreparedLoyalSmartAccountsOperation<string> | null> {
+    const existing = await getExistingAccountSet({
+      accounts: args.policies,
+      connection: config.connection,
+    });
+    const livePolicies = args.policies.filter((policy) =>
+      existing.has(policy.toBase58())
+    );
+    if (livePolicies.length === 0) {
+      return null;
+    }
+    return prepareCloseYieldRoutingPoliciesSync({
+      ...args,
+      policies: livePolicies,
+    });
   }
 
   async function prepareUseSolSpendingLimitPolicy(


### PR DESCRIPTION
MAX withdrawals after #438 close the on-chain route/setup policies, but confirm re-derived isFinalExit without the dust tolerance and never released the DB pair — the next deposit adopted dead policy accounts and every withdraw prepare failed with "Unable to find Policy account". Final-exit close now skips policies already gone on-chain (mobile + web share the client), and confirm releases the DB pair with the same dust tolerance prepare uses.