### PR TITLE
fix(earn): derive withdraw mode for reserve sources so web MAX runs the final exit

### DIFF
--- a/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
@@ -3437,13 +3437,14 @@ export function EarnWithdrawView({
   const effectiveWithdrawAmountLabel = hasWithdrawAmount
     ? withdrawAmount
     : formatDepositAmount(selectedSourceMaxAmount);
-  const effectiveWithdrawMode =
-    selectedSource?.type === "reserve"
-      ? "partial"
-      : deriveEarnWithdrawMode({
-          amount: effectiveWithdrawAmount,
-          maxWithdrawAmount: selectedSourceMaxAmount,
-        });
+  // MAX (or typing the visible floored max) must submit mode "full" for every
+  // source type. Reserve sources used to be pinned to "partial", which drained
+  // the reserve to $0 without the final-exit path — position, policies, vault
+  // ATA, and autodeposit all stayed behind.
+  const effectiveWithdrawMode = deriveEarnWithdrawMode({
+    amount: effectiveWithdrawAmount,
+    maxWithdrawAmount: selectedSourceMaxAmount,
+  });
   const withdrawAmountError = !selectedSource
     ? "No withdrawable Earn source"
     : !Number.isFinite(effectiveWithdrawAmount) || effectiveWithdrawAmount <= 0


### PR DESCRIPTION
The web withdraw pane hardcoded mode "partial" for reserve sources (since 9ae6d9b4), so MAX on a Kamino reserve drained the balance to $0 without the final-exit path — position, policies, vault ATA, and autodeposit were all left behind. Reserve sources now derive the mode like idle ones: MAX (or typing the visible max) submits "full".