### PR TITLE
fix(earn): backfill lost autodeposit stage proofs from chain history

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -12,7 +12,10 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { probeEarnAutodepositArtifacts } from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
+import {
+  healPendingEarnAutodepositArtifactProofs,
+  probeEarnAutodepositArtifacts,
+} from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
 import { readEarnAutodepositBootstrapWalletBalanceSnapshot } from "@/lib/yield-optimization/earn-autodeposit-bootstrap.server";
 import { getDisplayableEarnAutodepositScheduledSweeps } from "@/lib/yield-optimization/earn-autodeposit-loaded-state.shared";
 import {
@@ -153,20 +156,36 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, status: "pending", target };
   }
 
-  if (
-    args.state.status === "pending" &&
-    policyReady &&
-    delegationReady &&
-    hasRecordedPolicy &&
-    hasRecordedDelegation
-  ) {
-    const target = await markAutodepositTargetActiveFromArtifacts({
-      policyAccount: args.state.target.policyAccount,
+  if (args.state.status === "pending" && policyReady && delegationReady) {
+    let target = args.state.target;
+    if (!hasRecordedPolicy || !hasRecordedDelegation) {
+      // A stage transaction can land while its confirm never reaches the DB;
+      // retry flows skip already-existing stages, so the missing proof would
+      // strand the row in pending forever. Backfill it from chain history
+      // once the artifacts verify as canonical.
+      const healed = await healPendingEarnAutodepositArtifactProofs({
+        connection: args.connection,
+        smartAccountsProgramId: args.smartAccountsProgramId,
+        target,
+      });
+      const proofsComplete =
+        healed != null &&
+        healed.policySignature != null &&
+        healed.policyConfirmedSlot != null &&
+        healed.recurringDelegationSignature != null &&
+        healed.recurringDelegationConfirmedSlot != null;
+      if (!proofsComplete) {
+        return healed ? { ...args.state, target: healed } : args.state;
+      }
+      target = healed;
+    }
+    const activeTarget = await markAutodepositTargetActiveFromArtifacts({
+      policyAccount: target.policyAccount,
       settings: args.settings,
       vaultIndex: EARN_VAULT_INDEX,
       walletAddress: args.walletAddress,
     });
-    return { ...args.state, status: "active", target };
+    return { ...args.state, status: "active", target: activeTarget };
   }
 
   return args.state;

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -9,7 +9,10 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { probeEarnAutodepositArtifacts } from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
+import {
+  healPendingEarnAutodepositArtifactProofs,
+  probeEarnAutodepositArtifacts,
+} from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
 import { readEarnAutodepositBootstrapWalletBalanceSnapshot } from "@/lib/yield-optimization/earn-autodeposit-bootstrap.server";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
 import {
@@ -111,20 +114,36 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, status: "pending", target };
   }
 
-  if (
-    args.state.status === "pending" &&
-    policyReady &&
-    delegationReady &&
-    hasRecordedPolicy &&
-    hasRecordedDelegation
-  ) {
-    const target = await markAutodepositTargetActiveFromArtifacts({
-      policyAccount: args.state.target.policyAccount,
+  if (args.state.status === "pending" && policyReady && delegationReady) {
+    let target = args.state.target;
+    if (!hasRecordedPolicy || !hasRecordedDelegation) {
+      // A stage transaction can land while its confirm never reaches the DB;
+      // retry flows skip already-existing stages, so the missing proof would
+      // strand the row in pending forever. Backfill it from chain history
+      // once the artifacts verify as canonical.
+      const healed = await healPendingEarnAutodepositArtifactProofs({
+        connection: args.connection,
+        smartAccountsProgramId: args.smartAccountsProgramId,
+        target,
+      });
+      const proofsComplete =
+        healed != null &&
+        healed.policySignature != null &&
+        healed.policyConfirmedSlot != null &&
+        healed.recurringDelegationSignature != null &&
+        healed.recurringDelegationConfirmedSlot != null;
+      if (!proofsComplete) {
+        return healed ? { ...args.state, target: healed } : args.state;
+      }
+      target = healed;
+    }
+    const activeTarget = await markAutodepositTargetActiveFromArtifacts({
+      policyAccount: target.policyAccount,
       settings: args.settings,
       vaultIndex: EARN_VAULT_INDEX,
       walletAddress: args.walletAddress,
     });
-    return { ...args.state, status: "active", target };
+    return { ...args.state, status: "active", target: activeTarget };
   }
 
   return args.state;

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-artifacts.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-artifacts.server.ts
@@ -1,7 +1,20 @@
 import "server-only";
 
-import { SUBSCRIPTIONS_PROGRAM_ID } from "@loyal-labs/actions";
+import {
+  resolveLoyalClusterForSolanaEnv,
+  SUBSCRIPTIONS_PROGRAM_ID,
+} from "@loyal-labs/actions";
+import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import { Connection, PublicKey } from "@solana/web3.js";
+
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+
+import { getDeploymentPolicySignerPublicKey } from "./deployment-policy-signer.server";
+import {
+  backfillAutodepositTargetStageProofs,
+  type AutodepositStageProof,
+  type BalanceSweepTargetRecord,
+} from "./earn-autodeposit-repository.server";
 
 type AutodepositArtifactProbeAccount = {
   exists: boolean;
@@ -101,6 +114,122 @@ export async function probeEarnAutodepositArtifacts(args: {
       SUBSCRIPTIONS_PROGRAM_ID
     ),
   };
+}
+
+// One RPC page is far beyond any fresh artifact's transaction history at heal
+// time — these accounts are read right after (attempted) setup.
+const AUTODEPOSIT_PROOF_SIGNATURE_PAGE_LIMIT = 1000;
+
+// Oldest successful transaction that touched the account. For an autodeposit
+// artifact that is its creating transaction — exactly the signature/slot the
+// lost confirm would have recorded.
+async function resolveArtifactCreationProof(
+  connection: Connection,
+  account: string
+): Promise<AutodepositStageProof | null> {
+  const signatures = await connection.getSignaturesForAddress(
+    new PublicKey(account),
+    { limit: AUTODEPOSIT_PROOF_SIGNATURE_PAGE_LIMIT },
+    "confirmed"
+  );
+
+  for (let index = signatures.length - 1; index >= 0; index -= 1) {
+    const entry = signatures[index];
+    if (entry.err === null) {
+      return {
+        confirmedSlot: BigInt(entry.slot),
+        signature: entry.signature,
+      };
+    }
+  }
+
+  return null;
+}
+
+// Heals a pending target whose stage transaction landed on-chain while its
+// confirm never reached the DB: the flow died in between, and retries skip
+// already-existing stages, so the proof is never re-posted — leaving the row
+// permanently unable to satisfy the recorded-proof promotion guard. When BOTH
+// artifacts verify against the canonical derivation (same check the session
+// confirm route runs), the missing signature/slot is backfilled from chain
+// history so promotion can proceed on the same read.
+//
+// Best-effort by design: any verification or lookup failure returns null and
+// must never break the state read. Returns the updated target, or null when
+// nothing was (or could be) healed.
+export async function healPendingEarnAutodepositArtifactProofs(args: {
+  connection: Connection;
+  smartAccountsProgramId: PublicKey;
+  target: BalanceSweepTargetRecord;
+}): Promise<BalanceSweepTargetRecord | null> {
+  const { target } = args;
+  const missingPolicyProof =
+    target.policySignature == null || target.policyConfirmedSlot == null;
+  const missingDelegationProof =
+    target.recurringDelegationSignature == null ||
+    target.recurringDelegationConfirmedSlot == null;
+
+  if (!missingPolicyProof && !missingDelegationProof) {
+    return null;
+  }
+  const nonce = target.recurringDelegationNonce;
+  if (!target.recurringDelegation || nonce == null) {
+    // Without the recorded nonce the delegation PDA cannot be re-derived, so
+    // the artifacts cannot be verified as this target's — do not backfill.
+    return null;
+  }
+
+  try {
+    const vaultsClient = createSmartAccountVaultsClient({
+      connection: args.connection,
+      programId: args.smartAccountsProgramId,
+    });
+    await vaultsClient.assertEarnUsdcAutodepositCanonicalArtifacts({
+      amountRaw: target.maxAmountPerPeriod,
+      cluster: resolveLoyalClusterForSolanaEnv(
+        resolveLoyalWebSolanaEnvFromEnv(process.env)
+      ),
+      nonce,
+      policy: new PublicKey(target.policyAccount),
+      policySeed: target.policySeed,
+      policySigner: getDeploymentPolicySignerPublicKey(),
+      recurringDelegation: new PublicKey(target.recurringDelegation),
+      settingsPda: new PublicKey(target.settings),
+      walletAddress: new PublicKey(target.wallet),
+    });
+
+    const [policyProof, recurringDelegationProof] = await Promise.all([
+      missingPolicyProof
+        ? resolveArtifactCreationProof(args.connection, target.policyAccount)
+        : Promise.resolve(null),
+      missingDelegationProof
+        ? resolveArtifactCreationProof(
+            args.connection,
+            target.recurringDelegation
+          )
+        : Promise.resolve(null),
+    ]);
+    if (!policyProof && !recurringDelegationProof) {
+      return null;
+    }
+
+    return await backfillAutodepositTargetStageProofs({
+      policyAccount: target.policyAccount,
+      policyProof,
+      recurringDelegationProof,
+      settings: target.settings,
+      vaultIndex: target.vaultIndex,
+      walletAddress: target.wallet,
+    });
+  } catch (error) {
+    console.warn("[earn-autodeposit] artifact proof heal skipped", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown heal error.",
+      policyAccount: target.policyAccount,
+      wallet: target.wallet,
+    });
+    return null;
+  }
 }
 
 export async function assertEarnAutodepositArtifactsExist(args: {

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -2381,6 +2381,80 @@ export async function markAutodepositTargetActiveFromArtifacts(
   return target;
 }
 
+export type AutodepositStageProof = {
+  confirmedSlot: bigint;
+  signature: string;
+};
+
+// Fills stage proof columns that a lost confirm left NULL (the stage's
+// transaction landed on-chain but its confirm never reached the DB, so the
+// row can never satisfy the recorded-proof promotion guard). COALESCE keeps
+// any recorded proof authoritative — the backfill only ever completes a row,
+// never rewrites it. Lifecycle promotion stays with the reconciler.
+export async function backfillAutodepositTargetStageProofs(
+  input: {
+    policyAccount: string;
+    policyProof: AutodepositStageProof | null;
+    recurringDelegationProof: AutodepositStageProof | null;
+    settings: string;
+    vaultIndex: number;
+    walletAddress: string;
+  },
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client" | "now"
+  > = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  const { client } = dependencies;
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex
+  ) {
+    throw new Error("Autodeposit target does not match the wallet.");
+  }
+  if (existing.lifecycleStatus === "closed") {
+    return existing;
+  }
+  if (!input.policyProof && !input.recurringDelegationProof) {
+    return existing;
+  }
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      lastSeenAt: dependencies.now(),
+      ...(input.policyProof
+        ? {
+            policySignature: sql`COALESCE(${balanceSweepTargets.policySignature}, ${input.policyProof.signature})`,
+            policyConfirmedSlot: sql`COALESCE(${balanceSweepTargets.policyConfirmedSlot}, ${input.policyProof.confirmedSlot.toString()}::bigint)`,
+          }
+        : {}),
+      ...(input.recurringDelegationProof
+        ? {
+            recurringDelegationSignature: sql`COALESCE(${balanceSweepTargets.recurringDelegationSignature}, ${input.recurringDelegationProof.signature})`,
+            recurringDelegationConfirmedSlot: sql`COALESCE(${balanceSweepTargets.recurringDelegationConfirmedSlot}, ${input.recurringDelegationProof.confirmedSlot.toString()}::bigint)`,
+          }
+        : {}),
+    })
+    .where(eq(balanceSweepTargets.policyAccount, input.policyAccount))
+    .returning();
+
+  if (!target) {
+    throw new Error("Failed to backfill autodeposit target proofs.");
+  }
+
+  return target;
+}
+
 export async function upsertBalanceSweepWalletBalanceCurrent(
   input: BalanceSweepWalletBalanceCurrentInput,
   dependencies: EarnAutodepositRepositoryDependencies = createDependencies()


### PR DESCRIPTION
A setup stage whose transaction lands on-chain but whose confirm never reaches the DB strands the target in pending forever: retry flows skip already-existing stages so the proof is never re-posted, and the reconciler's promotion guard requires both recorded signatures. Both state-route reconcilers now verify the on-chain artifacts against the canonical derivation (assertEarnUsdcAutodepositCanonicalArtifacts) and backfill the missing signature/slot from the account's oldest successful transaction, letting promotion (and the bootstrap sweep) proceed on the same read.