### PR TITLE
fix(earn): reconcile chain-closed autodeposits to closed instead of pending

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -22,6 +22,7 @@ import {
   findCurrentEarnAutodepositState,
   findPendingEarnAutodepositScheduledSweeps,
   markAutodepositTargetActiveFromArtifacts,
+  markAutodepositTargetClosedFromChain,
   markAutodepositTargetPendingDelegation,
   reconcileStaleEarnAutodepositScheduledSweeps,
   scheduleBootstrapEarnAutodepositSweep,
@@ -141,6 +142,26 @@ async function reconcileAutodepositArtifacts(args: {
     args.state.target.recurringDelegationSignature !== null &&
     args.state.target.recurringDelegationConfirmedSlot !== null;
 
+  // Both stage transactions were recorded and both accounts are gone from
+  // chain: the autodeposit was closed on-chain but the close confirm never
+  // reached the DB (or lost a write race against this reconciler). Record the
+  // close — demoting to pending would strand the row as a live autodeposit
+  // the close flow can no longer tear down.
+  if (
+    hasRecordedPolicy &&
+    hasRecordedDelegation &&
+    !policyReady &&
+    !delegationReady
+  ) {
+    const target = await markAutodepositTargetClosedFromChain({
+      policyAccount: args.state.target.policyAccount,
+      settings: args.settings,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress: args.walletAddress,
+    });
+    return { ...args.state, target };
+  }
+
   if (args.state.status !== "pending" && (!policyReady || !delegationReady)) {
     const target = await markAutodepositTargetPendingDelegation({
       lifecycleStatus: policyReady
@@ -253,6 +274,16 @@ export async function GET(request: Request) {
       state,
       walletAddress,
     });
+    // Reconcile (or a concurrent close confirm surfaced by its write guards)
+    // concluded the autodeposit is closed — render it exactly like no row.
+    if (reconciledState.target.lifecycleStatus === "closed") {
+      return NextResponse.json({
+        autodeposit: null,
+        prepareContext: buildPrepareContext(),
+        settingsPda: account.settingsPda,
+        smartAccountAddress: account.smartAccountAddress,
+      });
+    }
     const activatedFromPending =
       state.status === "pending" && reconciledState.status === "active";
     if (activatedFromPending) {

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -19,6 +19,7 @@ import {
   findCurrentEarnAutodepositState,
   findPendingEarnAutodepositScheduledSweeps,
   markAutodepositTargetActiveFromArtifacts,
+  markAutodepositTargetClosedFromChain,
   markAutodepositTargetPendingDelegation,
   reconcileStaleEarnAutodepositScheduledSweeps,
   scheduleBootstrapEarnAutodepositSweep,
@@ -98,6 +99,26 @@ async function reconcileAutodepositArtifacts(args: {
   const hasRecordedDelegation =
     args.state.target.recurringDelegationSignature !== null &&
     args.state.target.recurringDelegationConfirmedSlot !== null;
+
+  // Both stage transactions were recorded and both accounts are gone from
+  // chain: the autodeposit was closed on-chain but the close confirm never
+  // reached the DB (or lost a write race against this reconciler). Record the
+  // close — demoting to pending would strand the row as a live autodeposit
+  // the close flow can no longer tear down.
+  if (
+    hasRecordedPolicy &&
+    hasRecordedDelegation &&
+    !policyReady &&
+    !delegationReady
+  ) {
+    const target = await markAutodepositTargetClosedFromChain({
+      policyAccount: args.state.target.policyAccount,
+      settings: args.settings,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress: args.walletAddress,
+    });
+    return { ...args.state, target };
+  }
 
   if (args.state.status !== "pending" && (!policyReady || !delegationReady)) {
     const target = await markAutodepositTargetPendingDelegation({
@@ -302,6 +323,11 @@ export async function GET(request: Request) {
             state,
             walletAddress: principal.walletAddress,
           });
+          // Reconcile (or a concurrent close confirm surfaced by its write
+          // guards) concluded the autodeposit is closed — same as no row.
+          if (reconciledState.target.lifecycleStatus === "closed") {
+            return null;
+          }
           const activatedFromPending =
             state.status === "pending" && reconciledState.status === "active";
           if (activatedFromPending) {

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -2312,6 +2312,10 @@ export async function markAutodepositTargetPendingDelegation(
     return existing;
   }
 
+  // The closed guard above is read-then-write (Neon HTTP has no
+  // transactions), and the caller runs RPC probes between its read and this
+  // write — a close confirm landing in that window must win, so the demote
+  // is conditional on the row still not being closed.
   const [target] = await client.db
     .update(balanceSweepTargets)
     .set({
@@ -2319,10 +2323,22 @@ export async function markAutodepositTargetPendingDelegation(
         lastSeenAt: dependencies.now(),
         lifecycleStatus: input.lifecycleStatus ?? "pending_delegation",
       })
-    .where(eq(balanceSweepTargets.policyAccount, input.policyAccount))
+    .where(
+      and(
+        eq(balanceSweepTargets.policyAccount, input.policyAccount),
+        ne(balanceSweepTargets.lifecycleStatus, "closed")
+      )
+    )
     .returning();
 
   if (!target) {
+    const closed = await findTargetByPolicy({
+      client,
+      policyAccount: input.policyAccount,
+    });
+    if (closed?.lifecycleStatus === "closed") {
+      return closed;
+    }
     throw new Error("Failed to mark autodeposit target pending.");
   }
 
@@ -2364,6 +2380,9 @@ export async function markAutodepositTargetActiveFromArtifacts(
     throw new Error("Autodeposit recurring delegation is missing.");
   }
 
+  // Same concurrent-close guard as markAutodepositTargetPendingDelegation:
+  // a close recorded between the read above and this write must not be
+  // resurrected to active.
   const [target] = await client.db
     .update(balanceSweepTargets)
     .set({
@@ -2371,11 +2390,97 @@ export async function markAutodepositTargetActiveFromArtifacts(
       lastSeenAt: dependencies.now(),
       lifecycleStatus: "active",
     })
+    .where(
+      and(
+        eq(balanceSweepTargets.policyAccount, input.policyAccount),
+        ne(balanceSweepTargets.lifecycleStatus, "closed")
+      )
+    )
+    .returning();
+
+  if (!target) {
+    const closed = await findTargetByPolicy({
+      client,
+      policyAccount: input.policyAccount,
+    });
+    if (closed?.lifecycleStatus === "closed") {
+      return closed;
+    }
+    throw new Error("Failed to mark autodeposit target active.");
+  }
+
+  return target;
+}
+
+// Records a close observed on-chain rather than through the close confirm:
+// both stage transactions were recorded for this row, yet the policy AND
+// recurring delegation accounts are gone from chain — the close transaction
+// landed but its confirm never reached the DB (or lost a write race). Without
+// this the reconciler demotes the row to pending_delegation and it lingers as
+// a live autodeposit forever. No close signature is available here, so the
+// close proof columns stay untouched for a later confirm retry to fill.
+export async function markAutodepositTargetClosedFromChain(
+  input: {
+    policyAccount: string;
+    settings: string;
+    vaultIndex: 1;
+    walletAddress: string;
+  },
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client" | "now"
+  > = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  const { client } = dependencies;
+  const now = dependencies.now();
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex
+  ) {
+    throw new Error("Autodeposit target does not match the wallet.");
+  }
+
+  await cancelScheduledAutodepositTransactionsForClose({
+    client,
+    now,
+    targetId: existing.id,
+  });
+
+  if (existing.lifecycleStatus === "closed") {
+    return existing;
+  }
+
+  await client.db
+    .update(balanceSweepPolicies)
+    .set({
+      active: false,
+      closedAt: sql`COALESCE(${balanceSweepPolicies.closedAt}, ${now})`,
+      lastSeenAt: now,
+    })
+    .where(eq(balanceSweepPolicies.policyAccount, input.policyAccount));
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      active: false,
+      closedAt: sql`COALESCE(${balanceSweepTargets.closedAt}, ${now})`,
+      lastSeenAt: now,
+      lifecycleStatus: "closed",
+    })
     .where(eq(balanceSweepTargets.policyAccount, input.policyAccount))
     .returning();
 
   if (!target) {
-    throw new Error("Failed to mark autodeposit target active.");
+    throw new Error("Failed to close autodeposit target from chain state.");
   }
 
   return target;


### PR DESCRIPTION
A close confirm racing the /state reconciler could be clobbered back to pending_delegation (read-then-write demote, no transactions on Neon HTTP), leaving a deleted autodeposit rendered as live forever. Demote/promote updates are now conditional on the row not being closed, and when both stage signatures are recorded but the policy + delegation accounts are gone from chain, both state reconcilers record the close (rendering it as no autodeposit) instead of stranding the row.