### PR TITLE
feat(api): add chart timeframe support to mobile token detail endpoint

### DIFF
--- a/app/src/app/api/mobile/tokens/[mint]/route.test.ts
+++ b/app/src/app/api/mobile/tokens/[mint]/route.test.ts
@@ -1,0 +1,134 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const fetchTokenDetailByMint = mock(async () => ({
+  chart: [{ priceUsd: 0.12, timestamp: 1_712_534_400 }],
+  info: {
+    description: "Loyal token",
+    freezeAuthority: "no",
+    gtScore: 84.5,
+    gtVerified: true,
+    holderDistribution: { rest: "57.9", top10: "42.1" },
+    mintAuthority: "no",
+  },
+  links: {
+    discord: "https://discord.gg/loyal",
+    explorer: "https://solscan.io/token/target-mint",
+    telegram: "https://t.me/loyal_chat",
+    twitter: "https://x.com/loyal",
+    website: "https://loyal.example.com",
+  },
+  market: {
+    fdvUsd: 3_350_000.12,
+    holderCount: 1_572,
+    liquidityUsd: 410_250.55,
+    marketCapUsd: 2_040_111.99,
+    priceChange24hPercent: 6.25,
+    priceUsd: 0.16312,
+    updatedAt: "2026-04-13T10:15:00.000Z",
+    volume24hUsd: 120_034.55,
+  },
+  mint: "target-mint",
+  token: {
+    decimals: 6,
+    logoUrl: "https://cdn.example.com/loyal.png",
+    name: "Loyal",
+    symbol: "LOYAL",
+  },
+}));
+
+mock.module("@/lib/market/token-detail.server", () => ({
+  fetchTokenDetailByMint,
+  parseMobileTokenDetailTimeframe: (value: string | null) =>
+    ["1d", "1w", "1m", "1y"].includes(value ?? "") ? value : "1d",
+}));
+
+let GET: typeof import("./route").GET;
+let OPTIONS: typeof import("./route").OPTIONS;
+
+describe("mobile token detail route", () => {
+  beforeAll(async () => {
+    ({ GET, OPTIONS } = await import("./route"));
+  });
+
+  beforeEach(() => {
+    fetchTokenDetailByMint.mockClear();
+  });
+
+  test("returns CORS preflight headers", async () => {
+    const response = await OPTIONS();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      "GET, OPTIONS"
+    );
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
+      "Content-Type"
+    );
+  });
+
+  test("returns the token detail payload with mobile CORS headers", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/mobile/tokens/target-mint"),
+      { params: Promise.resolve({ mint: "target-mint" }) }
+    );
+
+    expect(fetchTokenDetailByMint).toHaveBeenCalledWith("target-mint", "1d");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await response.json()).toEqual({
+      chart: [{ priceUsd: 0.12, timestamp: 1_712_534_400 }],
+      info: {
+        description: "Loyal token",
+        freezeAuthority: "no",
+        gtScore: 84.5,
+        gtVerified: true,
+        holderDistribution: { rest: "57.9", top10: "42.1" },
+        mintAuthority: "no",
+      },
+      links: {
+        discord: "https://discord.gg/loyal",
+        explorer: "https://solscan.io/token/target-mint",
+        telegram: "https://t.me/loyal_chat",
+        twitter: "https://x.com/loyal",
+        website: "https://loyal.example.com",
+      },
+      market: {
+        fdvUsd: 3_350_000.12,
+        holderCount: 1_572,
+        liquidityUsd: 410_250.55,
+        marketCapUsd: 2_040_111.99,
+        priceChange24hPercent: 6.25,
+        priceUsd: 0.16312,
+        updatedAt: "2026-04-13T10:15:00.000Z",
+        volume24hUsd: 120_034.55,
+      },
+      mint: "target-mint",
+      token: {
+        decimals: 6,
+        logoUrl: "https://cdn.example.com/loyal.png",
+        name: "Loyal",
+        symbol: "LOYAL",
+      },
+    });
+  });
+
+  test("returns 500 when token detail fetch fails", async () => {
+    fetchTokenDetailByMint.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/mobile/tokens/target-mint"),
+      { params: Promise.resolve({ mint: "target-mint" }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await response.json()).toEqual({
+      error: "Failed to fetch token detail",
+    });
+  });
+});

--- a/app/src/app/api/mobile/tokens/[mint]/route.ts
+++ b/app/src/app/api/mobile/tokens/[mint]/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { fetchTokenDetailByMint } from "@/lib/market/token-detail.server";
+import {
+  fetchTokenDetailByMint,
+  parseMobileTokenDetailTimeframe,
+} from "@/lib/market/token-detail.server";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -13,19 +16,19 @@ export async function OPTIONS() {
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ mint: string }> }
 ): Promise<NextResponse> {
   try {
     const { mint } = await context.params;
-    const detail = await fetchTokenDetailByMint(mint);
+    const timeframe = parseMobileTokenDetailTimeframe(
+      new URL(request.url).searchParams.get("timeframe")
+    );
+    const detail = await fetchTokenDetailByMint(mint, timeframe);
 
     return NextResponse.json(detail, { headers: corsHeaders });
   } catch (error) {
-    console.error(
-      "[api/mobile/tokens/[mint]] Failed to fetch token detail",
-      error
-    );
+    console.error("[api/mobile/tokens/[mint]] Failed to fetch token detail", error);
 
     return NextResponse.json(
       { error: "Failed to fetch token detail" },

--- a/app/src/lib/market/coingecko.server.ts
+++ b/app/src/lib/market/coingecko.server.ts
@@ -48,6 +48,26 @@ export type CoinGeckoChartResult = {
   volumeUsd24h: number | null;
 };
 
+export type CoinGeckoChartTimeframe = "1d" | "1w" | "1m" | "1y";
+
+const COIN_CHART_DAYS: Record<CoinGeckoChartTimeframe, string> = {
+  "1d": "1",
+  "1w": "7",
+  "1m": "30",
+  "1y": "365",
+};
+
+// GeckoTerminal OHLCV granularity per window (limit caps at 1000 candles).
+const POOL_OHLCV_PARAMS: Record<
+  CoinGeckoChartTimeframe,
+  { granularity: "hour" | "day"; limit: number }
+> = {
+  "1d": { granularity: "hour", limit: 24 },
+  "1w": { granularity: "hour", limit: 168 },
+  "1m": { granularity: "day", limit: 30 },
+  "1y": { granularity: "day", limit: 365 },
+};
+
 type OnchainTokenResponse = {
   data?: {
     attributes?: {
@@ -182,10 +202,11 @@ export async function fetchCoinGeckoTokenInfo(
 }
 
 export async function fetchCoinGeckoCoinChart(
-  coingeckoCoinId: string
+  coingeckoCoinId: string,
+  timeframe: CoinGeckoChartTimeframe = "1d"
 ): Promise<CoinGeckoChartResult> {
   const response = await fetchJson<CoinMarketChartResponse>(
-    `${COINGECKO_BASE_URL}/coins/${coingeckoCoinId}/market_chart?vs_currency=usd&days=1`,
+    `${COINGECKO_BASE_URL}/coins/${coingeckoCoinId}/market_chart?vs_currency=usd&days=${COIN_CHART_DAYS[timeframe]}`,
     { method: "GET", headers: getHeaders() }
   );
 
@@ -201,20 +222,21 @@ export async function fetchCoinGeckoCoinChart(
 }
 
 export async function fetchCoinGeckoPoolOhlcv(
-  poolId: string
+  poolId: string,
+  timeframe: CoinGeckoChartTimeframe = "1d"
 ): Promise<CoinGeckoChartPoint[]> {
+  const { granularity, limit } = POOL_OHLCV_PARAMS[timeframe];
   const response = await fetchJson<PoolOhlcvResponse>(
-    `${COINGECKO_BASE_URL}/onchain/networks/${SOLANA_NETWORK}/pools/${poolId}/ohlcv/hour`,
+    `${COINGECKO_BASE_URL}/onchain/networks/${SOLANA_NETWORK}/pools/${poolId}/ohlcv/${granularity}?limit=${limit}`,
     { method: "GET", headers: getHeaders() }
   );
 
   const ohlcvList = response.data?.attributes?.ohlcv_list ?? [];
 
-  // OHLCV tuples: [timestamp, open, high, low, close, volume].
+  // OHLCV tuples: [timestamp, open, high, low, close, volume]. GeckoTerminal
+  // returns candles newest-first; sort ascending so charts read left-to-right.
   return ohlcvList
-    .filter(
-      (candle): candle is number[] =>
-        Array.isArray(candle) && candle.length >= 5
-    )
-    .map((candle) => ({ timestamp: candle[0], priceUsd: candle[4] }));
+    .filter((candle): candle is number[] => Array.isArray(candle) && candle.length >= 5)
+    .map((candle) => ({ timestamp: candle[0], priceUsd: candle[4] }))
+    .sort((a, b) => a.timestamp - b.timestamp);
 }

--- a/app/src/lib/market/token-detail.server.ts
+++ b/app/src/lib/market/token-detail.server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import {
   type CoinGeckoChartPoint,
+  type CoinGeckoChartTimeframe,
   type CoinGeckoTokenData,
   type CoinGeckoTokenInfo,
   fetchCoinGeckoCoinChart,
@@ -13,6 +14,25 @@ import {
 const TOKEN_DETAIL_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export type MobileTokenDetailChartPoint = CoinGeckoChartPoint;
+
+export type MobileTokenDetailTimeframe = CoinGeckoChartTimeframe;
+
+const MOBILE_TOKEN_DETAIL_TIMEFRAMES: readonly MobileTokenDetailTimeframe[] = [
+  "1d",
+  "1w",
+  "1m",
+  "1y",
+];
+
+export function parseMobileTokenDetailTimeframe(
+  value: string | null
+): MobileTokenDetailTimeframe {
+  return (MOBILE_TOKEN_DETAIL_TIMEFRAMES as readonly string[]).includes(
+    value ?? ""
+  )
+    ? (value as MobileTokenDetailTimeframe)
+    : "1d";
+}
 
 export type MobileTokenDetailLinks = {
   website: string | null;
@@ -65,10 +85,7 @@ type TokenDetailCacheEntry = {
 };
 
 const tokenDetailCache = new Map<string, TokenDetailCacheEntry>();
-const tokenDetailInflight = new Map<
-  string,
-  Promise<MobileTokenDetailResponse>
->();
+const tokenDetailInflight = new Map<string, Promise<MobileTokenDetailResponse>>();
 
 async function getSettledValue<T>(promise: Promise<T>): Promise<T | null> {
   try {
@@ -78,15 +95,15 @@ async function getSettledValue<T>(promise: Promise<T>): Promise<T | null> {
   }
 }
 
-function getCachedTokenDetail(mint: string): MobileTokenDetailResponse | null {
-  const cached = tokenDetailCache.get(mint);
+function getCachedTokenDetail(key: string): MobileTokenDetailResponse | null {
+  const cached = tokenDetailCache.get(key);
 
   if (!cached) {
     return null;
   }
 
   if (cached.expiresAt <= Date.now()) {
-    tokenDetailCache.delete(mint);
+    tokenDetailCache.delete(key);
     return null;
   }
 
@@ -102,13 +119,14 @@ function canCacheTokenDetail(detail: MobileTokenDetailResponse): boolean {
 }
 
 function setCachedTokenDetail(
+  key: string,
   detail: MobileTokenDetailResponse
 ): MobileTokenDetailResponse {
   if (!canCacheTokenDetail(detail)) {
     return detail;
   }
 
-  tokenDetailCache.set(detail.mint, {
+  tokenDetailCache.set(key, {
     expiresAt: Date.now() + TOKEN_DETAIL_CACHE_TTL_MS,
     value: detail,
   });
@@ -133,13 +151,13 @@ function derivePriceChange24hPercent(
   return ((last - first) / first) * 100;
 }
 
-async function loadChartFor(token: CoinGeckoTokenData): Promise<{
-  chart: MobileTokenDetailChartPoint[];
-  volumeOverride: number | null;
-}> {
+async function loadChartFor(
+  token: CoinGeckoTokenData,
+  timeframe: MobileTokenDetailTimeframe
+): Promise<{ chart: MobileTokenDetailChartPoint[]; volumeOverride: number | null }> {
   if (token.coingeckoCoinId) {
     const result = await getSettledValue(
-      fetchCoinGeckoCoinChart(token.coingeckoCoinId)
+      fetchCoinGeckoCoinChart(token.coingeckoCoinId, timeframe)
     );
 
     if (result && result.points.length > 0) {
@@ -149,7 +167,7 @@ async function loadChartFor(token: CoinGeckoTokenData): Promise<{
 
   if (token.topPoolIds.length > 0) {
     const points = await getSettledValue(
-      fetchCoinGeckoPoolOhlcv(token.topPoolIds[0])
+      fetchCoinGeckoPoolOhlcv(token.topPoolIds[0], timeframe)
     );
 
     if (points && points.length > 0) {
@@ -211,14 +229,16 @@ function buildResponse(
 }
 
 export async function fetchTokenDetailByMint(
-  mint: string
+  mint: string,
+  timeframe: MobileTokenDetailTimeframe = "1d"
 ): Promise<MobileTokenDetailResponse> {
-  const cached = getCachedTokenDetail(mint);
+  const cacheKey = `${mint}:${timeframe}`;
+  const cached = getCachedTokenDetail(cacheKey);
   if (cached) {
     return cached;
   }
 
-  const inflight = tokenDetailInflight.get(mint);
+  const inflight = tokenDetailInflight.get(cacheKey);
   if (inflight) {
     return inflight;
   }
@@ -230,16 +250,17 @@ export async function fetchTokenDetailByMint(
     ]);
 
     const { chart, volumeOverride } = token
-      ? await loadChartFor(token)
+      ? await loadChartFor(token, timeframe)
       : { chart: [] as MobileTokenDetailChartPoint[], volumeOverride: null };
 
     return setCachedTokenDetail(
+      cacheKey,
       buildResponse(mint, token, info, chart, volumeOverride)
     );
   })().finally(() => {
-    tokenDetailInflight.delete(mint);
+    tokenDetailInflight.delete(cacheKey);
   });
 
-  tokenDetailInflight.set(mint, request);
+  tokenDetailInflight.set(cacheKey, request);
   return request;
 }


### PR DESCRIPTION
Adds a validated `?timeframe=1d|1w|1m|1y` param to `/api/mobile/tokens/[mint]` (CoinGecko `days` mapping + GeckoTerminal OHLCV granularity, cache keyed per mint+timeframe) so the redesigned mobile token page chart pills return real data. Also sorts pool-OHLCV fallback candles ascending — they arrive newest-first and previously drew backwards.