### PR TITLE
fix(earn): source full Earn exits from live snapshot when DB rows are empty

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -72,8 +72,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -161,11 +160,9 @@ function sourceMatchesStableMint(
     return false;
   }
 
-  const identifiers = [
-    request.id,
-    request.liquidityMint,
-    request.mint,
-  ].filter(isNonEmptyString);
+  const identifiers = [request.id, request.liquidityMint, request.mint].filter(
+    isNonEmptyString
+  );
 
   return source.type === "reserve"
     ? identifiers.includes(source.liquidityMint)
@@ -278,14 +275,70 @@ function snapshotReserveTarget(
   };
 }
 
-function selectEarnWithdrawSource(args: {
+// Full-withdrawal targets from the live snapshot (fallback when the DB rows
+// are empty). Collateral metadata comes from the holding provenance when
+// present; the SDK resolves anything omitted on-chain.
+function snapshotFullWithdrawalTargets(
+  holdings: EarnRpcHolding[],
+  reserve: string
+): {
   amountRaw: bigint;
+  liquidityMint: PublicKey;
+  market: PublicKey;
+  reserve: PublicKey;
+  reserveCollateralMint?: PublicKey;
+  supplyApyBps: bigint | null;
+}[] {
+  const targets = [];
+  for (const holding of holdings) {
+    if (
+      holding.kind !== "kamino" ||
+      holding.reserve !== reserve ||
+      !holding.market
+    ) {
+      continue;
+    }
+    let amountRaw: bigint;
+    try {
+      amountRaw = BigInt(holding.amountRaw);
+    } catch {
+      continue;
+    }
+    if (amountRaw <= BigInt(0)) {
+      continue;
+    }
+    let supplyApyBps: bigint | null = null;
+    if (holding.supplyApyBps) {
+      try {
+        supplyApyBps = BigInt(holding.supplyApyBps);
+      } catch {
+        supplyApyBps = null;
+      }
+    }
+    const reserveCollateralMint = publicKeyFromMetadata(holding.provenance, [
+      "reserveCollateralMint",
+    ]);
+    targets.push({
+      amountRaw,
+      liquidityMint: new PublicKey(holding.liquidityMint),
+      market: new PublicKey(holding.market),
+      reserve: new PublicKey(holding.reserve),
+      ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
+      supplyApyBps,
+    });
+  }
+  return targets;
+}
+
+// Withdraw sources from the reconciled DB rows (full exits) — the row
+// planning metadata carries the collateral accounts the full-withdrawal
+// instruction prefers. Empty after a cross-market rebalance the reconcile
+// couldn't follow; the caller then falls back to the live snapshot.
+function buildDbEarnWithdrawSources(args: {
   idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
-  mode: "partial" | "full";
   position: UserYieldPositionRecord;
-  request: EarnWithdrawSourceRequest;
   reserveRows: CurrentYieldVaultReservePositionRecord[];
-}): SelectedEarnWithdrawSource {
+}): SelectedEarnWithdrawSource[] {
   const reserveSources = args.reserveRows
     .filter((row) => row.amountRaw > BigInt(0))
     .map((row) => {
@@ -326,11 +379,22 @@ function selectEarnWithdrawSource(args: {
           },
         ]
       : [];
-  const sources = [
-    ...reserveSources,
-    ...idleSources,
-    ...positionFallbackSources,
-  ];
+  return [...reserveSources, ...idleSources, ...positionFallbackSources];
+}
+
+function selectEarnWithdrawSource(args: {
+  amountRaw: bigint;
+  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
+  mode: "partial" | "full";
+  position: UserYieldPositionRecord;
+  request: EarnWithdrawSourceRequest;
+  reserveRows: CurrentYieldVaultReservePositionRecord[];
+}): SelectedEarnWithdrawSource {
+  const sources = buildDbEarnWithdrawSources({
+    idleRows: args.idleRows,
+    position: args.position,
+    reserveRows: args.reserveRows,
+  });
 
   if (sources.length === 0) {
     throw new Error("No active Earn withdrawal source was found.");
@@ -483,12 +547,15 @@ export async function POST(request: Request) {
       ]);
     policy = policyResult?.routePolicy ?? null;
     if (!policy) {
-      console.warn("[mobile-earn-withdraw-prepare] missing active Earn policy", {
-        cluster,
-        settings: settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        walletAddress,
-      });
+      console.warn(
+        "[mobile-earn-withdraw-prepare] missing active Earn policy",
+        {
+          cluster,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        }
+      );
       return jsonError(
         409,
         "missing_earn_policy",
@@ -522,6 +589,9 @@ export async function POST(request: Request) {
     let selectedSource: SelectedEarnWithdrawSource;
     let isFinalExit: boolean;
     let withdrawTarget: EarnUsdcReserveTarget;
+    // Set when a full exit had to source from the live snapshot (DB rows
+    // empty); the full-withdrawal targets are then built from it too.
+    let snapshotFullExitHoldings: EarnRpcHolding[] | null = null;
     if (mode === "partial") {
       const snapshot = await fetchEarnRpcHoldingsSnapshot({
         cluster,
@@ -564,8 +634,75 @@ export async function POST(request: Request) {
               reserve: new PublicKey(selected.reserve),
               supplyApyBps: null,
             }
-          : (snapshotReserveTarget(snapshot.holdings) ??
-            earnReserveTargetFromActivePosition(position));
+          : snapshotReserveTarget(snapshot.holdings) ??
+            earnReserveTargetFromActivePosition(position);
+    } else if (
+      buildDbEarnWithdrawSources({
+        idleRows: currentIdleRows,
+        position,
+        reserveRows: currentReserveRows,
+      }).length === 0
+    ) {
+      // Full-exit snapshot fallback: after a cross-market rebalance the
+      // reconciled DB rows (and the position row) can read zero while the
+      // funds live on-chain in another market's obligation. Source the full
+      // exit from the same live snapshot partial withdrawals use — its
+      // provenance carries the collateral metadata the full path needs.
+      const snapshot = await fetchEarnRpcHoldingsSnapshot({
+        cluster,
+        connection,
+        policy: policyResult
+          ? serializeRoutePolicyState(
+              policyResult.routePolicy,
+              policyResult.setupPolicy ?? null
+            )
+          : null,
+        programId,
+        settingsPda: settingsPdaKey,
+      });
+      const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
+      if (snapshotSources.length === 0) {
+        throw new Error("No active Earn withdrawal source was found.");
+      }
+      const selected = selectRequestedEarnWithdrawSource(
+        snapshotSources,
+        selectedSourceRequest
+      );
+      if (!selected) {
+        throw new Error("Select an Earn source before withdrawing.");
+      }
+      selectedSource = selected;
+      effectiveAmountRaw = selected.amountRaw;
+      const remainingReserveAmountRaw = snapshotSources.reduce(
+        (total, source) =>
+          total +
+          (source.type === "reserve" && source.id !== selected.id
+            ? source.amountRaw
+            : BigInt(0)),
+        BigInt(0)
+      );
+      const remainingIdleAmountRaw = snapshotSources.reduce(
+        (total, source) =>
+          total +
+          (source.type === "idle" && source.id !== selected.id
+            ? source.amountRaw
+            : BigInt(0)),
+        BigInt(0)
+      );
+      isFinalExit =
+        remainingReserveAmountRaw <= BigInt(0) &&
+        remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
+      withdrawTarget =
+        selected.type === "reserve"
+          ? {
+              liquidityMint: new PublicKey(selected.liquidityMint),
+              market: new PublicKey(selected.market),
+              reserve: new PublicKey(selected.reserve),
+              supplyApyBps: null,
+            }
+          : snapshotReserveTarget(snapshot.holdings) ??
+            earnReserveTargetFromActivePosition(position);
+      snapshotFullExitHoldings = snapshot.holdings;
     } else {
       selectedSource = selectEarnWithdrawSource({
         amountRaw,
@@ -711,53 +848,62 @@ export async function POST(request: Request) {
       target: withdrawTarget,
       ...(mode === "full" && selectedSource.type === "reserve"
         ? {
-            fullWithdrawalTargets: currentReserveRows
-              .filter((row) => row.reserve === selectedSource.reserve)
-              .map((row) => {
-                if (!row.market) {
-                  throw new Error(
-                    "Reconciled Earn reserve row is missing a Kamino market."
-                  );
-                }
-                const reserveCollateralMint = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "reserveCollateralMint",
-                    "reserve_collateral_mint",
-                    "collateralMint",
-                    "collateral_mint",
-                  ]
-                );
-                const reserveLiquiditySupply = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "reserveLiquiditySupply",
-                    "reserve_liquidity_supply",
-                    "liquiditySupply",
-                    "liquidity_supply",
-                  ]
-                );
-                const vaultCollateralAta = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "vaultCollateralAta",
-                    "vault_collateral_ata",
-                    "collateralAta",
-                    "collateral_ata",
-                  ]
-                );
+            fullWithdrawalTargets: snapshotFullExitHoldings
+              ? snapshotFullWithdrawalTargets(
+                  snapshotFullExitHoldings,
+                  selectedSource.reserve
+                )
+              : currentReserveRows
+                  .filter((row) => row.reserve === selectedSource.reserve)
+                  .map((row) => {
+                    if (!row.market) {
+                      throw new Error(
+                        "Reconciled Earn reserve row is missing a Kamino market."
+                      );
+                    }
+                    const reserveCollateralMint = publicKeyFromMetadata(
+                      row.planningMetadata,
+                      [
+                        "reserveCollateralMint",
+                        "reserve_collateral_mint",
+                        "collateralMint",
+                        "collateral_mint",
+                      ]
+                    );
+                    const reserveLiquiditySupply = publicKeyFromMetadata(
+                      row.planningMetadata,
+                      [
+                        "reserveLiquiditySupply",
+                        "reserve_liquidity_supply",
+                        "liquiditySupply",
+                        "liquidity_supply",
+                      ]
+                    );
+                    const vaultCollateralAta = publicKeyFromMetadata(
+                      row.planningMetadata,
+                      [
+                        "vaultCollateralAta",
+                        "vault_collateral_ata",
+                        "collateralAta",
+                        "collateral_ata",
+                      ]
+                    );
 
-                return {
-                  amountRaw: row.amountRaw,
-                  liquidityMint: new PublicKey(row.liquidityMint),
-                  market: new PublicKey(row.market),
-                  reserve: new PublicKey(row.reserve),
-                  ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
-                  ...(reserveLiquiditySupply ? { reserveLiquiditySupply } : {}),
-                  supplyApyBps: row.supplyApyBps ?? null,
-                  ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
-                };
-              }),
+                    return {
+                      amountRaw: row.amountRaw,
+                      liquidityMint: new PublicKey(row.liquidityMint),
+                      market: new PublicKey(row.market),
+                      reserve: new PublicKey(row.reserve),
+                      ...(reserveCollateralMint
+                        ? { reserveCollateralMint }
+                        : {}),
+                      ...(reserveLiquiditySupply
+                        ? { reserveLiquiditySupply }
+                        : {}),
+                      supplyApyBps: row.supplyApyBps ?? null,
+                      ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
+                    };
+                  }),
           }
         : {}),
       closePoliciesOnFullWithdrawal: isFinalExit,


### PR DESCRIPTION
Full (MAX) Earn withdrawals on mobile failed with "No active Earn withdrawal source was found" when a cross-market rebalance left the reconciled DB rows at zero while the funds live on-chain in another market's obligation. Falls back to the same live RPC holdings snapshot partial withdrawals already use, building the full-withdrawal targets from the snapshot provenance.