### PR TITLE
fix(solana-week): treat 202 Accepted as a completed quest report

### DIFF
--- a/frontend/src/features/solana-week/server/quest-completion-reporter.ts
+++ b/frontend/src/features/solana-week/server/quest-completion-reporter.ts
@@ -207,7 +207,11 @@ async function attemptCompletion(
     };
   }
 
-  if (response.status === 201) {
+  // 201 = recorded synchronously; 202 = accepted for asynchronous processing
+  // (the API started responding "202 Accepted" when the round opened on
+  // 2026-07-08 — previously misclassified as a permanent error, stranding
+  // rows as `failed`). Both mean Solana took the completion.
+  if (response.status === 201 || response.status === 202) {
     return { status: "completed" };
   }
   if (response.status === 200) {


### PR DESCRIPTION
Solana's quest completion endpoint now responds 202 Accepted (async processing) since the round opened on 2026-07-08; the reporter only recognized 200/201 and misclassified 202 as a permanent error, stranding completion rows as failed. Treat 202 as completed so quests report and the celebration UI fires.

https://claude.ai/code/session_01FhCgUGo9JDSEonGqw9S2ZU