### PR TITLE
fix(smart-accounts): retry provisioning index races and reconcile failed records on a cron

### DIFF
--- a/frontend/src/app/api/cron/smart-account-reconcile/route.ts
+++ b/frontend/src/app/api/cron/smart-account-reconcile/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+import { reconcileRecoverableSmartAccounts } from "@/features/smart-accounts/server/reconciler";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+// Repairs smart accounts stuck in `failed`/stale `provisioning` states
+// (sponsor outages, concurrent-signup index races) before the user retries.
+// The same repair already runs inline on a user's next attempt — this cron
+// just gets there first, so returning users never see a second error.
+async function handleCronRequest(request: Request) {
+  const authError = validateCronAuthHeader(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const summary = await reconcileRecoverableSmartAccounts();
+    return NextResponse.json(summary);
+  } catch (error) {
+    console.error("[cron/smart-account-reconcile] failed", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "smart_account_reconcile_failed",
+          message: "Failed to reconcile recoverable smart accounts.",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = handleCronRequest;
+export const POST = handleCronRequest;

--- a/frontend/src/features/smart-accounts/service.test.ts
+++ b/frontend/src/features/smart-accounts/service.test.ts
@@ -283,3 +283,61 @@ describe("ensureUserSmartAccount delegated root signer onboarding", () => {
     expect(dependencies.createSmartAccount).toHaveBeenCalled();
   });
 });
+
+describe("ensureUserSmartAccount concurrent-signup index race", () => {
+  test("re-reserves and retries once when a racing signup takes the reserved settings PDA", async () => {
+    const firstPda = deriveSettingsPdaAddress({
+      programId,
+      accountIndex: BigInt(11),
+    });
+    const secondPda = deriveSettingsPdaAddress({
+      programId,
+      accountIndex: BigInt(12),
+    });
+    let reservations = 0;
+    let creates = 0;
+    const markFailed = mock(async () => createReadyRecord({ state: "failed" }));
+    const dependencies = createDependencies({
+      reserveProvisioning: mock(async () => {
+        reservations += 1;
+        return createReadyRecord({
+          creationSignature: null,
+          id: `reserved-${reservations}`,
+          settingsPda: reservations === 1 ? firstPda : secondPda,
+          state: "provisioning",
+        });
+      }),
+      createSmartAccount: mock(async (input) => {
+        creates += 1;
+        if (creates === 1) {
+          throw new Error("Missing account");
+        }
+        expect(input.settingsPda).toBe(secondPda);
+        return "sponsor-signature-2";
+      }),
+      // After the failed create, the first PDA holds the RACING user's
+      // settings — our wallet is not among its signers (owner_mismatch).
+      findSignerAddressesForSettings: mock(async () => [
+        "SomeOtherWa11etAddre55111111111111111111111",
+      ]),
+      markFailed,
+      markReady: mock(async (input) =>
+        createReadyRecord({
+          creationSignature: input.creationSignature ?? null,
+          settingsPda: secondPda,
+        })
+      ),
+    });
+
+    const result = await ensureUserSmartAccount(
+      { userId, walletAddress },
+      dependencies
+    );
+
+    expect(result.provisioningOutcome).toBe("sponsored_new_record");
+    expect(result.smartAccount.settingsPda).toBe(secondPda);
+    expect(reservations).toBe(2);
+    expect(creates).toBe(2);
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/smart-accounts/service.ts
+++ b/frontend/src/features/smart-accounts/service.ts
@@ -299,43 +299,64 @@ async function sponsorRecord(args: {
   treasury: PublicKey;
   dependencies: SmartAccountServiceDependencies;
 }): Promise<ServiceRecord> {
-  let signature: string | null = null;
+  let record = args.record;
+  let treasury = args.treasury;
 
-  try {
-    signature = await args.dependencies.createSmartAccount({
-      solanaEnv: args.record.solanaEnv,
-      programId: args.programId,
-      settingsPda: args.record.settingsPda,
-      treasury: args.treasury,
-      walletAddress: args.walletAddress,
-    });
+  for (let attempt = 0; ; attempt += 1) {
+    let signature: string | null = null;
 
-    return await args.dependencies.markReady({
-      userId: args.record.userId,
-      solanaEnv: args.record.solanaEnv,
-      creationSignature: signature,
-    });
-  } catch (error) {
-    const reconciledRecord = await maybePromoteRecord({
-      record: args.record,
-      programId: args.programId,
-      walletAddress: args.walletAddress,
-      dependencies: args.dependencies,
-    });
+    try {
+      signature = await args.dependencies.createSmartAccount({
+        solanaEnv: record.solanaEnv,
+        programId: args.programId,
+        settingsPda: record.settingsPda,
+        treasury,
+        walletAddress: args.walletAddress,
+      });
 
-    if (reconciledRecord.kind === "ready") {
-      return reconciledRecord.record;
+      return await args.dependencies.markReady({
+        userId: record.userId,
+        solanaEnv: record.solanaEnv,
+        creationSignature: signature,
+      });
+    } catch (error) {
+      const reconciledRecord = await maybePromoteRecord({
+        record,
+        programId: args.programId,
+        walletAddress: args.walletAddress,
+        dependencies: args.dependencies,
+      });
+
+      if (reconciledRecord.kind === "ready") {
+        return reconciledRecord.record;
+      }
+
+      // Concurrent-signup index race: another user's create landed on the
+      // settings PDA this record had reserved, so our create failed and the
+      // PDA now belongs to them. Reserve the next index and retry once
+      // instead of surfacing a transient error to the user.
+      if (reconciledRecord.kind === "owner_mismatch" && attempt === 0) {
+        const reservation = await reserveProvisioningRecord({
+          userId: record.userId,
+          solanaEnv: record.solanaEnv,
+          programId: args.programId,
+          dependencies: args.dependencies,
+        });
+        record = reservation.record;
+        treasury = reservation.treasury;
+        continue;
+      }
+
+      const failure = toFailure({ error });
+      await args.dependencies.markFailed({
+        userId: record.userId,
+        solanaEnv: record.solanaEnv,
+        errorCode: failure.code,
+        errorMessage: failure.message,
+        ...(signature ? { creationSignature: signature } : {}),
+      });
+      throw failure;
     }
-
-    const failure = toFailure({ error });
-    await args.dependencies.markFailed({
-      userId: args.record.userId,
-      solanaEnv: args.record.solanaEnv,
-      errorCode: failure.code,
-      errorMessage: failure.message,
-      ...(signature ? { creationSignature: signature } : {}),
-    });
-    throw failure;
   }
 }
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/solana-week-quest-completions",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/smart-account-reconcile",
+      "schedule": "*/15 * * * *"
     }
   ],
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ] || ! git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null; then exit 1; fi; git diff \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD --quiet -- . ../packages ../sdk",


### PR DESCRIPTION
Launch-load hardening for new-user smart-account provisioning: sponsorRecord re-reserves a fresh settings PDA and retries once when a concurrent signup wins the reserved index (the "Missing account" failures), and a new */15 cron route runs the existing recoverable-records reconciler so failed rows heal proactively. Covered by a new race test in service.test.ts.