### PR TITLE
fix(earn): refuse autodeposit setup while one is already active

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -147,6 +147,17 @@ export async function POST(request: Request) {
         walletAddress,
       });
       const target = current?.target;
+      // An already-active Autodeposit must be deleted, not set up over: a
+      // fresh prepare mints a second policy seed and stands up a duplicate
+      // on-chain policy that delete/withdraw flows then trip over. A stale
+      // "active" row heals through the `/state` reconcile before retry.
+      if (target?.lifecycleStatus === "active") {
+        return jsonError(
+          409,
+          "autodeposit_already_active",
+          "An Autodeposit is already active for this wallet. Delete it before creating a new one."
+        );
+      }
       if (
         (target?.lifecycleStatus === "pending_delegation" ||
           target?.lifecycleStatus === "pending_policy") &&

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
@@ -14,6 +14,7 @@ import {
   parseEarnAutodepositSetupPrepareRequestBody,
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
+import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 
@@ -68,6 +69,25 @@ export async function POST(request: Request) {
   const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
 
   try {
+    // A fresh setup (no resume seed) while an Autodeposit is already active
+    // would mint a second policy seed and stand up a duplicate on-chain
+    // policy that delete/withdraw flows then trip over. Resumes pass the
+    // recorded seed and skip this. Keep in sync with the mobile twin route.
+    if (parsed.policySeed === undefined) {
+      const current = await findCurrentEarnAutodepositState({
+        settings: principal.settingsPda,
+        vaultIndex: 1,
+        walletAddress: principal.walletAddress,
+      });
+      if (current?.target.lifecycleStatus === "active") {
+        return jsonError(
+          409,
+          "autodeposit_already_active",
+          "An Autodeposit is already active for this wallet. Delete it before creating a new one."
+        );
+      }
+    }
+
     const serverEnv = getServerEnv();
     const policySigner = getDeploymentPolicySignerPublicKey();
     const client = createSmartAccountVaultsClient({


### PR DESCRIPTION
Both autodeposit setup/prepare routes (web session + mobile twin) now return 409 when a live active autodeposit row already exists and no resume seed is passed — a fresh prepare in that state mints a second policy seed and stands up a duplicate on-chain policy that delete/withdraw flows then trip over (17 wallets currently carry duplicate live rows). Companion mobile fix on ask-1355-mobile-earn-tab closes the surfaced autodeposit during full withdraw and sweeps duplicate rows on delete.