### PR TITLE
perf(earn): fit RPC demand into the 5 rps Helius budget

### DIFF
--- a/frontend/src/app/api/cron/earn-deposit-reconcile/route.ts
+++ b/frontend/src/app/api/cron/earn-deposit-reconcile/route.ts
@@ -16,9 +16,13 @@ async function handleCronRequest(request: Request) {
     return authError;
   }
 
-  const dryRun = new URL(request.url).searchParams.get("dryRun") === "1";
+  const params = new URL(request.url).searchParams;
+  const dryRun = params.get("dryRun") === "1";
+  // Scheduled runs scan only recently-touched accounts to respect the 5 rps
+  // Helius budget; `?full=1` runs the unbounded fleet sweep on demand.
+  const fullScan = params.get("full") === "1";
   try {
-    const summary = await reconcileInvisibleEarnDeposits({ dryRun });
+    const summary = await reconcileInvisibleEarnDeposits({ dryRun, fullScan });
     return NextResponse.json(summary);
   } catch (error) {
     console.error("[cron/earn-deposit-reconcile] failed", error);

--- a/frontend/src/features/smart-accounts/server/onchain.ts
+++ b/frontend/src/features/smart-accounts/server/onchain.ts
@@ -99,11 +99,31 @@ export async function fetchProgramConfigAccount(args: {
   return client.programConfig.queries.fetchProgramConfig(programConfigPda);
 }
 
+// Settings signer sets change only through explicit settings-change flows,
+// but the wallet-pairing guard reads them on every authenticated mobile Earn
+// request (2 RPC calls per read) — far too hot for the 5 rps Helius budget.
+// Cache successful non-null reads briefly. Null results (settings not visible
+// yet) are never cached, so provisioning and promotion always see fresh
+// state. On-chain signing stays the real enforcement — a stale entry can only
+// let the read-model pairing check pass for up to the TTL.
+const SETTINGS_SIGNERS_CACHE_TTL_MS = 120_000;
+const SETTINGS_SIGNERS_CACHE_MAX_ENTRIES = 5_000;
+const settingsSignersCache = new Map<
+  string,
+  { expiresAt: number; signers: string[] }
+>();
+
 export async function findSettingsSignerAddresses(args: {
   solanaEnv: SolanaEnv;
   programId: string;
   settingsPda: string;
 }): Promise<string[] | null> {
+  const cacheKey = `${args.solanaEnv}:${args.programId}:${args.settingsPda}`;
+  const cached = settingsSignersCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return [...cached.signers];
+  }
+
   const client = getSmartAccountsClient(args);
   const settingsPda = new PublicKey(args.settingsPda);
 
@@ -121,7 +141,15 @@ export async function findSettingsSignerAddresses(args: {
     const settings =
       await client.smartAccounts.queries.fetchSettings(settingsPda);
 
-    return settings.signers.map((signer) => signer.key.toBase58());
+    const signers = settings.signers.map((signer) => signer.key.toBase58());
+    if (settingsSignersCache.size >= SETTINGS_SIGNERS_CACHE_MAX_ENTRIES) {
+      settingsSignersCache.clear();
+    }
+    settingsSignersCache.set(cacheKey, {
+      expiresAt: Date.now() + SETTINGS_SIGNERS_CACHE_TTL_MS,
+      signers,
+    });
+    return signers;
   } catch (error) {
     if (isMissingAccountError(error, "Settings")) {
       return null;

--- a/frontend/src/lib/yield-optimization/earn-deposit-reconcile.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-reconcile.server.ts
@@ -19,7 +19,7 @@ import {
   type ParsedTransactionWithMeta,
   type TokenBalance,
 } from "@solana/web3.js";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, gte } from "drizzle-orm";
 
 import { reportEarnDepositQuestCompletion } from "@/features/solana-week/server/quest-completion-service";
 import { getServerEnv } from "@/lib/core/config/server";
@@ -63,6 +63,11 @@ const DEPOSIT_TX_SCAN_CAP = 80; // max parsed txs inspected per wallet
 const MIN_ADOPT_TOTAL_RAW = BigInt(10_000); // ignore sub-$0.01 dust vaults
 const DEFAULT_TIME_BUDGET_MS = 240_000;
 const SCAN_CONCURRENCY = 5;
+// Lost confirms happen to fresh signups (every adoption so far was a new
+// account), and the Helius budget is a hard 5 rps — so each run scans only
+// recently-touched accounts (~100 RPC calls) instead of the whole fleet
+// (~1,300). `full=1` on the cron route runs the unbounded sweep on demand.
+const RECENT_CANDIDATE_WINDOW_MS = 72 * 60 * 60 * 1000;
 
 export type EarnDepositReconcileOutcome = {
   wallet: string;
@@ -122,7 +127,10 @@ function buildScanPolicyMetadata(cluster: LoyalCluster): EarnRpcPolicyMetadata {
 
 // Ready smart accounts (app DB) that have no active yield position (yield DB).
 // Newest accounts first: fresh signups are where confirms get lost.
-async function listCandidates(solanaEnv: SolanaEnv): Promise<Candidate[]> {
+async function listCandidates(
+  solanaEnv: SolanaEnv,
+  fullScan: boolean
+): Promise<Candidate[]> {
   const readyAccounts = await getDatabase()
     .select({
       settingsPda: appUserSmartAccounts.settingsPda,
@@ -133,7 +141,15 @@ async function listCandidates(solanaEnv: SolanaEnv): Promise<Candidate[]> {
     .where(
       and(
         eq(appUserSmartAccounts.state, "ready"),
-        eq(appUserSmartAccounts.solanaEnv, solanaEnv)
+        eq(appUserSmartAccounts.solanaEnv, solanaEnv),
+        ...(fullScan
+          ? []
+          : [
+              gte(
+                appUserSmartAccounts.updatedAt,
+                new Date(Date.now() - RECENT_CANDIDATE_WINDOW_MS)
+              ),
+            ])
       )
     )
     .orderBy(desc(appUserSmartAccounts.updatedAt));
@@ -591,9 +607,11 @@ async function reconcileWallet(args: {
 
 export async function reconcileInvisibleEarnDeposits(args?: {
   dryRun?: boolean;
+  fullScan?: boolean;
   timeBudgetMs?: number;
 }): Promise<EarnDepositReconcileSummary> {
   const dryRun = args?.dryRun ?? false;
+  const fullScan = args?.fullScan ?? false;
   const deadline = Date.now() + (args?.timeBudgetMs ?? DEFAULT_TIME_BUDGET_MS);
   const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
   const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
@@ -610,10 +628,7 @@ export async function reconcileInvisibleEarnDeposits(args?: {
   const scanPolicy = buildScanPolicyMetadata(cluster);
   const connection = getConnection(solanaEnv);
 
-  const candidates = await listCandidates(solanaEnv);
-  // ponytail: full scan every run — fine at hundreds of candidates (~2s per
-  // wallet, concurrency 5, 4-minute budget). If the fleet outgrows the budget,
-  // switch the work-list to prepare-time deposit intents instead of scanning.
+  const candidates = await listCandidates(solanaEnv, fullScan);
   const summary: EarnDepositReconcileSummary = {
     candidates: candidates.length,
     scanned: 0,


### PR DESCRIPTION
API responses were queueing for >1 minute: the new per-request wallet-pairing reads (2 RPC calls, uncached, on routes mobile polls every 15s) plus the reconcile cron's full-fleet scans (~1,300 RPC calls every 10 min) saturated the serialized RPC queue that keeps us under Helius's 5 rps cap. Settings signers are now cached in-process for 120s (non-null only; on-chain signing stays the real enforcement) and scheduled reconcile runs scan only accounts touched in the last 72h, with `?full=1` for on-demand full sweeps. No contract changes.