### PR TITLE
feat(earn): add vault-account refunds and mobile policy-refund twins

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/policy-refunds/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/policy-refunds/prepare/route.ts
@@ -2,11 +2,10 @@ import { NextResponse } from "next/server";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
 
-import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
-import {
-  assertAuthenticatedWalletControlsSettings,
-  isSmartAccountProvisioningError,
-} from "@/features/smart-accounts/server/service";
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
@@ -20,6 +19,11 @@ import {
   type EarnPolicyRefundPrepareRequestBody,
 } from "@/lib/yield-optimization/earn-policy-refund-contracts.shared";
 
+// Mobile twin of the session `policy-refunds/prepare` route: same shared core,
+// but authenticated by a wallet signature instead of a session. The prepared
+// transaction pays out to (and must be signed by) the authenticated wallet,
+// so a stolen request body cannot redirect a refund. Refunding requires an
+// existing smart account; this never provisions.
 const connectionCache = new Map<SolanaEnv, Connection>();
 
 function jsonError(
@@ -48,15 +52,29 @@ function getConnection(cluster: SolanaEnv): Connection {
 }
 
 export async function POST(request: Request) {
-  const principal = await resolveAuthenticatedPrincipalFromRequest(request);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
 
-  if (!principal) {
-    return jsonError(401, "unauthenticated", "No active auth session.");
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-refund-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
   }
 
   let parsed: EarnPolicyRefundPrepareRequestBody;
   try {
-    parsed = parseEarnPolicyRefundPrepareRequestBody(await request.json());
+    parsed = parseEarnPolicyRefundPrepareRequestBody(body);
   } catch (error) {
     return jsonError(
       400,
@@ -65,21 +83,48 @@ export async function POST(request: Request) {
     );
   }
 
+  let settingsPda: string;
   try {
-    await assertAuthenticatedWalletControlsSettings({
-      settingsPda: principal.settingsPda,
-      smartAccountAddress: principal.smartAccountAddress,
-      walletAddress: principal.walletAddress,
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
     });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+      walletAddress,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-policy-refunds-prepare] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "smart_account_resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
 
+  try {
     const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
     const response = await prepareEarnPolicyRefund(
       {
         connection: getConnection(solanaEnv),
         programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
-        settingsPda: principal.settingsPda,
+        settingsPda,
         solanaEnv,
-        walletAddress: principal.walletAddress,
+        walletAddress,
       },
       parsed
     );
@@ -89,11 +134,8 @@ export async function POST(request: Request) {
     if (error instanceof EarnPolicyRefundError) {
       return jsonError(error.status, error.code, error.message);
     }
-    if (isSmartAccountProvisioningError(error)) {
-      return jsonError(error.status, error.code, error.message);
-    }
 
-    console.error("[earn-policy-refunds-prepare] failed", {
+    console.error("[mobile-earn-policy-refunds-prepare] failed", {
       errorMessage: error instanceof Error ? error.message : String(error),
       requestedAccount:
         parsed.kind === "recurring_delegation"
@@ -101,8 +143,8 @@ export async function POST(request: Request) {
           : parsed.kind === "vault"
             ? "vault"
             : parsed.policyAccount,
-      settings: principal.settingsPda,
-      walletAddress: principal.walletAddress,
+      settings: settingsPda,
+      walletAddress,
     });
     return jsonError(
       500,

--- a/frontend/src/app/api/smart-accounts/mobile/earn/policy-refunds/scan/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/policy-refunds/scan/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { findCurrentUser } from "@/features/chat/server/app-user";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-signature";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { scanEarnPolicyRefunds } from "@/lib/yield-optimization/earn-policy-refund.server";
+
+// Mobile twin of the session `policy-refunds/scan` route. Like the mobile
+// `earn/transactions` twin this is a passive read keyed by a supplied wallet
+// address, not a signed request — the app auto-scans when the experimental
+// toggle is on, and a wallet signature here would force a Seed Vault biometric
+// prompt on every scan. Everything returned is public chain state plus
+// non-sensitive liveness flags; the prepare twin (which returns a signable
+// transaction) does require a wallet signature.
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+export async function GET(request: Request) {
+  const walletAddress =
+    new URL(request.url).searchParams.get("walletAddress")?.trim() ?? "";
+  if (!walletAddress) {
+    return jsonError(400, "invalid_request", "walletAddress is required.");
+  }
+  try {
+    // Throws a 400 WalletAuthError when the address isn't a valid 32-byte key.
+    decodeWalletAddress(walletAddress);
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(400, "invalid_request", "walletAddress is invalid.");
+  }
+
+  try {
+    const user = await findCurrentUser({
+      authMethod: "wallet",
+      provider: "solana",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    if (!user) {
+      return NextResponse.json({ scan: null });
+    }
+
+    const account = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+      walletAddress,
+    });
+    if (!account) {
+      return NextResponse.json({ scan: null });
+    }
+
+    const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
+    const scan = await scanEarnPolicyRefunds({
+      connection: getConnection(solanaEnv),
+      programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+      settingsPda: account.settingsPda,
+      solanaEnv,
+      walletAddress,
+    });
+
+    return NextResponse.json({ scan });
+  } catch (error) {
+    console.error("[mobile-earn-policy-refunds-scan] failed", {
+      errorMessage: error instanceof Error ? error.message : String(error),
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "scan_failed",
+      error instanceof Error ? error.message : "Failed to scan for refunds."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/yield-optimization/policy-refunds/scan/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/policy-refunds/scan/route.ts
@@ -1,6 +1,4 @@
 import { NextResponse } from "next/server";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
-import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
 
@@ -9,13 +7,7 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { findEarnPolicyRefundDbState } from "@/lib/yield-optimization/earn-policy-refund-state.server";
-import type {
-  EarnPolicyRefundScanPolicy,
-  EarnPolicyRefundScanResponse,
-} from "@/lib/yield-optimization/earn-policy-refund-contracts.shared";
-
-const EARN_VAULT_INDEX = 1;
+import { scanEarnPolicyRefunds } from "@/lib/yield-optimization/earn-policy-refund.server";
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 
@@ -44,23 +36,6 @@ function getConnection(cluster: SolanaEnv): Connection {
   return connection;
 }
 
-function getBlockedReason(args: {
-  activeAutodeposit: boolean;
-  activeManagedVault: boolean;
-  referencedByActivePosition: boolean;
-}): string | null {
-  if (args.referencedByActivePosition) {
-    return "Active Earn position";
-  }
-  if (args.activeAutodeposit) {
-    return "Protected recurring delegation";
-  }
-  if (args.activeManagedVault) {
-    return "Active Earn vault policy";
-  }
-  return null;
-}
-
 export async function POST(request: Request) {
   const principal = await resolveAuthenticatedPrincipalFromRequest(request);
 
@@ -70,81 +45,13 @@ export async function POST(request: Request) {
 
   try {
     const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
-    const serverEnv = getServerEnv();
-    const programId = new PublicKey(serverEnv.loyalSmartAccounts.programId);
-    const settingsPda = new PublicKey(principal.settingsPda);
-    const connection = getConnection(solanaEnv);
-    const client = createSmartAccountVaultsClient({ connection, programId });
-    const [vaultPubkey] = pda.getSmartAccountPda({
-      accountIndex: EARN_VAULT_INDEX,
-      programId,
-      settingsPda,
-    });
-
-    const overview = await client.fetchPolicyOverview({
-      settingsPda,
-      rootSigners: [],
-    });
-    const policyAddresses = overview.policies.map((policy) => policy.address);
-    const [accounts, dbState] = await Promise.all([
-      policyAddresses.length === 0
-        ? Promise.resolve([])
-        : connection.getMultipleAccountsInfo(
-            policyAddresses.map((address) => new PublicKey(address)),
-            "confirmed"
-          ),
-      findEarnPolicyRefundDbState({
-        connection,
-        policyAccounts: policyAddresses,
-        settings: principal.settingsPda,
-        vaultPubkey: vaultPubkey.toBase58(),
-        walletAddress: principal.walletAddress,
-      }),
-    ]);
-
-    const policies: EarnPolicyRefundScanPolicy[] = overview.policies.map(
-      (policy, index) => {
-        const activeManagedVault = dbState.activeManagedVaultAccounts.has(
-          policy.address
-        );
-        const activeAutodeposit = dbState.activeAutodepositAccounts.has(
-          policy.address
-        );
-        const recurringDelegations =
-          dbState.recurringDelegationsByPolicyAccount.get(policy.address) ?? [];
-        const referencedByActivePosition = dbState.activePositionAccounts.has(
-          policy.address
-        );
-        const blockedReason = getBlockedReason({
-          activeAutodeposit,
-          activeManagedVault,
-          referencedByActivePosition,
-        });
-
-        return {
-          account: policy.address,
-          accountIndex: policy.accountIndex,
-          activeAutodeposit,
-          activeManagedVault,
-          blockedReason,
-          canRefund: blockedReason === null,
-          dbPresent: dbState.routePolicyAccounts.has(policy.address),
-          lamports: accounts[index]?.lamports ?? null,
-          recurringDelegations,
-          referencedByActivePosition,
-          seed: policy.seed,
-          state: policy.state,
-        };
-      }
-    );
-
-    const response: EarnPolicyRefundScanResponse = {
-      policies,
-      recurringDelegations: dbState.recurringDelegations,
+    const response = await scanEarnPolicyRefunds({
+      connection: getConnection(solanaEnv),
+      programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
       settingsPda: principal.settingsPda,
-      vaultIndex: EARN_VAULT_INDEX,
-      vaultPubkey: vaultPubkey.toBase58(),
-    };
+      solanaEnv,
+      walletAddress: principal.walletAddress,
+    });
 
     return NextResponse.json(response);
   } catch (error) {

--- a/frontend/src/features/identity/server/mobile-wallet-auth.ts
+++ b/frontend/src/features/identity/server/mobile-wallet-auth.ts
@@ -32,7 +32,8 @@ export type MobileWalletAuthPurpose =
   | "earn-autodeposit-toggle-confirm"
   | "earn-autodeposit-close-prepare"
   | "earn-autodeposit-close-confirm"
-  | "earn-autodeposit-sweep-execute";
+  | "earn-autodeposit-sweep-execute"
+  | "earn-refund-prepare";
 
 export type MobileWalletAuthFields = {
   walletAddress: string;

--- a/frontend/src/lib/yield-optimization/earn-policy-refund-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-policy-refund-contracts.shared.ts
@@ -61,10 +61,32 @@ export type EarnPolicyRefundScanPolicy = {
   state: string;
 };
 
+export type EarnVaultRefundTokenAccount = {
+  account: string;
+  amountRaw: string;
+  isUsdc: boolean;
+  lamports: number;
+  mint: string;
+};
+
+// The Earn vault's own refundable rent: the SOL sitting on the vault PDA (the
+// unspent Kamino setup buffer) plus the rent locked in its token accounts.
+// Everything here is chain-derived, so it surfaces even when the DB rows for
+// the position are long gone.
+export type EarnPolicyRefundVaultEntry = {
+  account: string;
+  blockedReason: string | null;
+  canRefund: boolean;
+  lamports: number;
+  tokenAccounts: EarnVaultRefundTokenAccount[];
+  totalRefundableLamports: number;
+};
+
 export type EarnPolicyRefundScanResponse = {
   policies: EarnPolicyRefundScanPolicy[];
   recurringDelegations: EarnPolicyRefundRecurringDelegation[];
   settingsPda: string;
+  vault: EarnPolicyRefundVaultEntry | null;
   vaultIndex: 1;
   vaultPubkey: string;
 };
@@ -77,6 +99,9 @@ export type EarnPolicyRefundPrepareRequestBody =
   | {
       kind: "recurring_delegation";
       recurringDelegation: string;
+    }
+  | {
+      kind: "vault";
     };
 
 export type WireSmartAccountPreparedEarnPolicyRefund = {
@@ -95,9 +120,18 @@ export type WireSmartAccountPreparedEarnRecurringDelegationRefund = {
   vaultIndex: 1;
 };
 
+export type WireSmartAccountPreparedEarnVaultRefund = {
+  estimatedRefundLamports: number | null;
+  prepared: WirePreparedLoyalSmartAccountsOperation;
+  settingsPda: string;
+  vault: EarnPolicyRefundVaultEntry;
+  vaultIndex: 1;
+};
+
 export type EarnPolicyRefundPrepareResponse = {
   preparedRecurringDelegationRefund?: WireSmartAccountPreparedEarnRecurringDelegationRefund;
   preparedRefund?: WireSmartAccountPreparedEarnPolicyRefund;
+  preparedVaultRefund?: WireSmartAccountPreparedEarnVaultRefund;
 };
 
 function assertRecord(body: unknown): Record<string, unknown> {
@@ -129,8 +163,14 @@ export function parseEarnPolicyRefundPrepareRequestBody(
     };
   }
 
+  if (kind === "vault") {
+    return { kind: "vault" };
+  }
+
   if (kind !== undefined && kind !== "policy") {
-    throw new Error("kind must be either policy or recurring_delegation.");
+    throw new Error(
+      "kind must be one of policy, recurring_delegation, or vault."
+    );
   }
 
   const policyAccount = record.policyAccount;
@@ -188,6 +228,40 @@ export function hydratePreparedEarnPolicyRefund(
     policy: wire.policy,
     prepared: hydratePreparedOperation(wire.prepared),
     settingsPda: wire.settingsPda,
+    vaultIndex: wire.vaultIndex,
+  };
+}
+
+export function serializePreparedEarnVaultRefund(args: {
+  estimatedRefundLamports: number | null;
+  prepared: PreparedLoyalSmartAccountsOperation<string>;
+  settingsPda: string;
+  vault: EarnPolicyRefundVaultEntry;
+  vaultIndex: 1;
+}): WireSmartAccountPreparedEarnVaultRefund {
+  return {
+    estimatedRefundLamports: args.estimatedRefundLamports,
+    prepared: serializePreparedOperation(args.prepared),
+    settingsPda: args.settingsPda,
+    vault: args.vault,
+    vaultIndex: args.vaultIndex,
+  };
+}
+
+export function hydratePreparedEarnVaultRefund(
+  wire: WireSmartAccountPreparedEarnVaultRefund
+): {
+  estimatedRefundLamports: number | null;
+  prepared: PreparedLoyalSmartAccountsOperation<string>;
+  settingsPda: string;
+  vault: EarnPolicyRefundVaultEntry;
+  vaultIndex: 1;
+} {
+  return {
+    estimatedRefundLamports: wire.estimatedRefundLamports,
+    prepared: hydratePreparedOperation(wire.prepared),
+    settingsPda: wire.settingsPda,
+    vault: wire.vault,
     vaultIndex: wire.vaultIndex,
   };
 }

--- a/frontend/src/lib/yield-optimization/earn-policy-refund-state.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-policy-refund-state.server.ts
@@ -705,6 +705,54 @@ export async function findEarnPolicyRefundDbState(args: {
   };
 }
 
+// Vault-level (not per-policy) liveness flags gating the vault-accounts
+// refund: sweeping the vault's SOL and closing its token accounts is only
+// safe once nothing can still deposit into or hold funds in the vault. Any
+// non-closed autodeposit target counts — including pending_delegation rows
+// mid-setup.
+export async function findEarnVaultRefundDbState(args: {
+  settings: string;
+}): Promise<{
+  hasActiveAutodeposit: boolean;
+  hasActiveManagedVault: boolean;
+  hasActivePosition: boolean;
+}> {
+  const client = getYieldOptimizationClient();
+  const [activePosition, activeManagedVault, openAutodepositTarget] =
+    await Promise.all([
+      client.db.query.userYieldPositions.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(userYieldPositions.settings, args.settings),
+          eq(userYieldPositions.vaultIndex, EARN_VAULT_INDEX),
+          eq(userYieldPositions.status, "active")
+        ),
+      }),
+      client.db.query.managedVaults.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(managedVaults.active, true),
+          eq(managedVaults.settings, args.settings),
+          eq(managedVaults.vaultIndex, EARN_VAULT_INDEX)
+        ),
+      }),
+      client.db.query.balanceSweepTargets.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(balanceSweepTargets.settings, args.settings),
+          eq(balanceSweepTargets.vaultIndex, EARN_VAULT_INDEX),
+          ne(balanceSweepTargets.lifecycleStatus, "closed")
+        ),
+      }),
+    ]);
+
+  return {
+    hasActiveAutodeposit: openAutodepositTarget !== undefined,
+    hasActiveManagedVault: activeManagedVault !== undefined,
+    hasActivePosition: activePosition !== undefined,
+  };
+}
+
 export async function findSingleEarnPolicyRefundDbState(args: {
   connection: Connection;
   policyAccount: string;

--- a/frontend/src/lib/yield-optimization/earn-policy-refund.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-policy-refund.server.ts
@@ -1,0 +1,446 @@
+import {
+  resolveLoyalClusterForSolanaEnv,
+  SUBSCRIPTIONS_PROGRAM_ID,
+  subscriptionRevokeDelegationData,
+} from "@loyal-labs/actions";
+import {
+  pda,
+  type PreparedLoyalSmartAccountsOperation,
+} from "@loyal-labs/loyal-smart-accounts";
+import {
+  createSmartAccountVaultsClient,
+  type SmartAccountEarnVaultRefundSnapshot,
+} from "@loyal-labs/smart-account-vaults";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import {
+  PublicKey,
+  TransactionInstruction,
+  type Connection,
+} from "@solana/web3.js";
+
+import {
+  serializePreparedEarnPolicyRefund,
+  serializePreparedEarnRecurringDelegationRefund,
+  serializePreparedEarnVaultRefund,
+  type EarnPolicyRefundPrepareRequestBody,
+  type EarnPolicyRefundPrepareResponse,
+  type EarnPolicyRefundScanPolicy,
+  type EarnPolicyRefundScanResponse,
+  type EarnPolicyRefundVaultEntry,
+} from "./earn-policy-refund-contracts.shared";
+import {
+  findEarnPolicyRefundDbState,
+  findEarnVaultRefundDbState,
+  findSingleEarnPolicyRefundDbState,
+} from "./earn-policy-refund-state.server";
+
+// Core of the policy/account refund flow, shared by the session (web) routes
+// and the mobile wallet-signature twins. Callers own authentication and
+// connection construction; everything here is pure scan/prepare logic.
+const EARN_VAULT_INDEX = 1;
+
+export class EarnPolicyRefundError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(args: { status: number; code: string; message: string }) {
+    super(args.message);
+    this.name = "EarnPolicyRefundError";
+    this.status = args.status;
+    this.code = args.code;
+  }
+}
+
+export type EarnPolicyRefundContext = {
+  connection: Connection;
+  programId: PublicKey;
+  settingsPda: string;
+  solanaEnv: SolanaEnv;
+  walletAddress: string;
+};
+
+function getBlockedReason(args: {
+  activeAutodeposit: boolean;
+  activeManagedVault: boolean;
+  referencedByActivePosition: boolean;
+}): string | null {
+  if (args.referencedByActivePosition) {
+    return "Active Earn position";
+  }
+  if (args.activeAutodeposit) {
+    return "Protected recurring delegation";
+  }
+  if (args.activeManagedVault) {
+    return "Active Earn vault policy";
+  }
+  return null;
+}
+
+// The vault entry is refundable only when nothing on chain or in the DB can
+// still use the vault. On-chain collateral is checked first: it is the
+// strongest live-position signal and holds even when the DB rows are stale.
+function buildVaultRefundEntry(args: {
+  dbState: {
+    hasActiveAutodeposit: boolean;
+    hasActiveManagedVault: boolean;
+    hasActivePosition: boolean;
+  };
+  snapshot: SmartAccountEarnVaultRefundSnapshot;
+}): EarnPolicyRefundVaultEntry {
+  const { dbState, snapshot } = args;
+  const holdsChainFunds = snapshot.tokenAccounts.some(
+    (tokenAccount) =>
+      tokenAccount.amountRaw > BigInt(0) &&
+      !tokenAccount.address.equals(snapshot.vaultUsdcAta)
+  );
+  const blockedReason = holdsChainFunds
+    ? "Vault still holds funds on chain"
+    : dbState.hasActivePosition
+      ? "Active Earn position"
+      : dbState.hasActiveAutodeposit
+        ? "Active Autodeposit"
+        : dbState.hasActiveManagedVault
+          ? "Active Earn vault policy"
+          : null;
+  const totalRefundableLamports =
+    Number(snapshot.lamports) +
+    snapshot.tokenAccounts.reduce(
+      (total, tokenAccount) => total + tokenAccount.lamports,
+      0
+    );
+
+  return {
+    account: snapshot.vaultPda.toBase58(),
+    blockedReason,
+    canRefund: blockedReason === null && totalRefundableLamports > 0,
+    lamports: Number(snapshot.lamports),
+    tokenAccounts: snapshot.tokenAccounts.map((tokenAccount) => ({
+      account: tokenAccount.address.toBase58(),
+      amountRaw: tokenAccount.amountRaw.toString(),
+      isUsdc: tokenAccount.isUsdc,
+      lamports: tokenAccount.lamports,
+      mint: tokenAccount.mint.toBase58(),
+    })),
+    totalRefundableLamports,
+  };
+}
+
+function createSubscriptionRevokeDelegationInstruction(args: {
+  authority: PublicKey;
+  delegation: PublicKey;
+}): TransactionInstruction {
+  return new TransactionInstruction({
+    data: Buffer.from(subscriptionRevokeDelegationData()),
+    keys: [
+      { isSigner: true, isWritable: true, pubkey: args.authority },
+      { isSigner: false, isWritable: true, pubkey: args.delegation },
+    ],
+    programId: SUBSCRIPTIONS_PROGRAM_ID,
+  });
+}
+
+function prepareRecurringDelegationRefund(args: {
+  feePayer: PublicKey;
+  recurringDelegation: PublicKey;
+}): PreparedLoyalSmartAccountsOperation<string> {
+  return {
+    instructions: [
+      createSubscriptionRevokeDelegationInstruction({
+        authority: args.feePayer,
+        delegation: args.recurringDelegation,
+      }),
+    ],
+    lookupTableAccounts: [],
+    operation: "earnRecurringDelegationRentRefund",
+    payer: args.feePayer,
+    programId: SUBSCRIPTIONS_PROGRAM_ID,
+    requiresConfirmation: true,
+  };
+}
+
+function parsePublicKey(value: string, label: string): PublicKey {
+  try {
+    return new PublicKey(value);
+  } catch {
+    throw new EarnPolicyRefundError({
+      status: 400,
+      code: "invalid_request",
+      message: `${label} is not a valid public key.`,
+    });
+  }
+}
+
+export async function scanEarnPolicyRefunds(
+  context: EarnPolicyRefundContext
+): Promise<EarnPolicyRefundScanResponse> {
+  const settingsPda = new PublicKey(context.settingsPda);
+  const cluster = resolveLoyalClusterForSolanaEnv(context.solanaEnv);
+  const client = createSmartAccountVaultsClient({
+    connection: context.connection,
+    programId: context.programId,
+  });
+  const [vaultPubkey] = pda.getSmartAccountPda({
+    accountIndex: EARN_VAULT_INDEX,
+    programId: context.programId,
+    settingsPda,
+  });
+
+  const overview = await client.fetchPolicyOverview({
+    settingsPda,
+    rootSigners: [],
+  });
+  const policyAddresses = overview.policies.map((policy) => policy.address);
+  const [accounts, dbState, vaultDbState, vaultSnapshot] = await Promise.all([
+    policyAddresses.length === 0
+      ? Promise.resolve([])
+      : context.connection.getMultipleAccountsInfo(
+          policyAddresses.map((address) => new PublicKey(address)),
+          "confirmed"
+        ),
+    findEarnPolicyRefundDbState({
+      connection: context.connection,
+      policyAccounts: policyAddresses,
+      settings: context.settingsPda,
+      vaultPubkey: vaultPubkey.toBase58(),
+      walletAddress: context.walletAddress,
+    }),
+    findEarnVaultRefundDbState({ settings: context.settingsPda }),
+    client.fetchEarnVaultRefundSnapshot({ cluster, settingsPda }),
+  ]);
+
+  const policies: EarnPolicyRefundScanPolicy[] = overview.policies.map(
+    (policy, index) => {
+      const activeManagedVault = dbState.activeManagedVaultAccounts.has(
+        policy.address
+      );
+      const activeAutodeposit = dbState.activeAutodepositAccounts.has(
+        policy.address
+      );
+      const recurringDelegations =
+        dbState.recurringDelegationsByPolicyAccount.get(policy.address) ?? [];
+      const referencedByActivePosition = dbState.activePositionAccounts.has(
+        policy.address
+      );
+      const blockedReason = getBlockedReason({
+        activeAutodeposit,
+        activeManagedVault,
+        referencedByActivePosition,
+      });
+
+      return {
+        account: policy.address,
+        accountIndex: policy.accountIndex,
+        activeAutodeposit,
+        activeManagedVault,
+        blockedReason,
+        canRefund: blockedReason === null,
+        dbPresent: dbState.routePolicyAccounts.has(policy.address),
+        lamports: accounts[index]?.lamports ?? null,
+        recurringDelegations,
+        referencedByActivePosition,
+        seed: policy.seed,
+        state: policy.state,
+      };
+    }
+  );
+
+  return {
+    policies,
+    recurringDelegations: dbState.recurringDelegations,
+    settingsPda: context.settingsPda,
+    vault: buildVaultRefundEntry({
+      dbState: vaultDbState,
+      snapshot: vaultSnapshot,
+    }),
+    vaultIndex: EARN_VAULT_INDEX,
+    vaultPubkey: vaultPubkey.toBase58(),
+  };
+}
+
+export async function prepareEarnPolicyRefund(
+  context: EarnPolicyRefundContext,
+  request: EarnPolicyRefundPrepareRequestBody
+): Promise<EarnPolicyRefundPrepareResponse> {
+  const settingsPda = new PublicKey(context.settingsPda);
+  const cluster = resolveLoyalClusterForSolanaEnv(context.solanaEnv);
+  const feePayer = parsePublicKey(context.walletAddress, "walletAddress");
+  const client = createSmartAccountVaultsClient({
+    connection: context.connection,
+    programId: context.programId,
+  });
+  const [vaultPubkey] = pda.getSmartAccountPda({
+    accountIndex: EARN_VAULT_INDEX,
+    programId: context.programId,
+    settingsPda,
+  });
+
+  if (request.kind === "vault") {
+    const [vaultDbState, vaultSnapshot] = await Promise.all([
+      findEarnVaultRefundDbState({ settings: context.settingsPda }),
+      client.fetchEarnVaultRefundSnapshot({ cluster, settingsPda }),
+    ]);
+    const vault = buildVaultRefundEntry({
+      dbState: vaultDbState,
+      snapshot: vaultSnapshot,
+    });
+
+    if (vault.blockedReason) {
+      throw new EarnPolicyRefundError({
+        status: 409,
+        code: "vault_active",
+        message: vault.blockedReason,
+      });
+    }
+    if (!vault.canRefund) {
+      throw new EarnPolicyRefundError({
+        status: 409,
+        code: "vault_empty",
+        message: "Nothing to refund on the Earn vault.",
+      });
+    }
+
+    const preparedVaultRefund = await client.prepareEarnVaultAccountsRefund({
+      cluster,
+      feePayer,
+      settingsPda,
+      walletAddress: feePayer,
+    });
+
+    return {
+      preparedVaultRefund: serializePreparedEarnVaultRefund({
+        estimatedRefundLamports: vault.totalRefundableLamports,
+        prepared: preparedVaultRefund.prepared,
+        settingsPda: context.settingsPda,
+        vault,
+        vaultIndex: EARN_VAULT_INDEX,
+      }),
+    };
+  }
+
+  if (request.kind === "recurring_delegation") {
+    const recurringDelegationPubkey = parsePublicKey(
+      request.recurringDelegation,
+      "recurringDelegation"
+    );
+    const overview = await client.fetchPolicyOverview({
+      settingsPda,
+      rootSigners: [],
+    });
+    const policyAddresses = overview.policies.map((policy) => policy.address);
+    const dbState = await findEarnPolicyRefundDbState({
+      connection: context.connection,
+      policyAccounts: policyAddresses,
+      settings: context.settingsPda,
+      vaultPubkey: vaultPubkey.toBase58(),
+      walletAddress: context.walletAddress,
+    });
+    const recurringDelegation = dbState.recurringDelegations.find(
+      (delegation) => delegation.account === request.recurringDelegation
+    );
+
+    if (!recurringDelegation) {
+      throw new EarnPolicyRefundError({
+        status: 404,
+        code: "delegation_not_found",
+        message: "Recurring delegation account was not found.",
+      });
+    }
+    if (!recurringDelegation.canRefund) {
+      throw new EarnPolicyRefundError({
+        status: 409,
+        code: "delegation_protected",
+        message:
+          recurringDelegation.blockedReason ??
+          "Recurring delegation is not reclaimable.",
+      });
+    }
+
+    const prepared = prepareRecurringDelegationRefund({
+      feePayer,
+      recurringDelegation: recurringDelegationPubkey,
+    });
+
+    return {
+      preparedRecurringDelegationRefund:
+        serializePreparedEarnRecurringDelegationRefund({
+          estimatedRefundLamports: recurringDelegation.lamports,
+          prepared,
+          recurringDelegation,
+          settingsPda: context.settingsPda,
+          vaultIndex: EARN_VAULT_INDEX,
+        }),
+    };
+  }
+
+  const policyAccount = parsePublicKey(request.policyAccount, "policyAccount");
+  const [overview, accountInfo, dbState] = await Promise.all([
+    client.fetchPolicyOverview({ settingsPda, rootSigners: [] }),
+    context.connection.getAccountInfo(policyAccount, "confirmed"),
+    findSingleEarnPolicyRefundDbState({
+      connection: context.connection,
+      policyAccount: policyAccount.toBase58(),
+      settings: context.settingsPda,
+      vaultPubkey: vaultPubkey.toBase58(),
+      walletAddress: context.walletAddress,
+    }),
+  ]);
+  if (!accountInfo) {
+    throw new EarnPolicyRefundError({
+      status: 409,
+      code: "policy_closed",
+      message: "Policy account is already closed.",
+    });
+  }
+
+  const overviewPolicy = overview.policies.find(
+    (policy) => policy.address === policyAccount.toBase58()
+  );
+  if (!overviewPolicy) {
+    throw new EarnPolicyRefundError({
+      status: 403,
+      code: "policy_not_owned",
+      message: "Policy does not belong to this smart account.",
+    });
+  }
+
+  const blockedReason = getBlockedReason(dbState);
+  const policy: EarnPolicyRefundScanPolicy = {
+    account: overviewPolicy.address,
+    accountIndex: overviewPolicy.accountIndex,
+    activeAutodeposit: dbState.activeAutodeposit,
+    activeManagedVault: dbState.activeManagedVault,
+    blockedReason,
+    canRefund: blockedReason === null,
+    dbPresent: dbState.dbPresent,
+    lamports: accountInfo.lamports,
+    recurringDelegations: dbState.recurringDelegations,
+    referencedByActivePosition: dbState.referencedByActivePosition,
+    seed: overviewPolicy.seed,
+    state: overviewPolicy.state,
+  };
+
+  if (blockedReason) {
+    throw new EarnPolicyRefundError({
+      status: 409,
+      code: "policy_active",
+      message: blockedReason,
+    });
+  }
+
+  const prepared = await client.prepareClosePoliciesSync({
+    feePayer,
+    policies: [policyAccount],
+    settingsPda,
+    signers: [feePayer],
+  });
+
+  return {
+    preparedRefund: serializePreparedEarnPolicyRefund({
+      estimatedRefundLamports: accountInfo.lamports,
+      policy,
+      prepared,
+      settingsPda: context.settingsPda,
+      vaultIndex: EARN_VAULT_INDEX,
+    }),
+  };
+}

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -115,6 +115,8 @@ import type {
   SmartAccountCustomInstructionProposalInput,
   SmartAccountEarnUsdcCleanupInput,
   SmartAccountEarnUsdcDepositInput,
+  SmartAccountEarnVaultRefundInput,
+  SmartAccountEarnVaultRefundSnapshot,
   SmartAccountEarnUsdcReserveTargetInput,
   SmartAccountEarnUsdcYieldRoutingPolicyInput,
   SmartAccountNativeSolRequirement,
@@ -128,6 +130,7 @@ import type {
   SmartAccountPreparedEarnUsdcAutodepositSetup,
   SmartAccountPreparedEarnUsdcCleanup,
   SmartAccountPreparedEarnUsdcDeposit,
+  SmartAccountPreparedEarnVaultRefund,
   SmartAccountPreparedEarnUsdcWithdrawStep,
   SmartAccountPreparedEarnUsdcYieldRoutingPolicy,
   SmartAccountPreparedEarnUsdcWithdraw,
@@ -8188,6 +8191,217 @@ export function createSmartAccountVaultsClient(
     };
   }
 
+  // Chain-first inventory of everything refundable on the Earn vault itself:
+  // the vault PDA's SOL and the rent locked in its token accounts. The
+  // policy-refund scan uses this to surface "account" refunds for wallets
+  // whose Earn position is closed — route-policy DB rows may be long gone, so
+  // nothing here reads a database. Feature-checked like the other vault reads:
+  // injected connections without the RPC methods just report an empty vault.
+  async function fetchEarnVaultRefundSnapshot(args: {
+    cluster?: LoyalCluster;
+    settingsPda: PublicKey;
+  }): Promise<SmartAccountEarnVaultRefundSnapshot> {
+    const cluster = args.cluster ?? LoyalCluster.MainnetBeta;
+    const usdcMint = getStablecoinMintForCluster(cluster, Stablecoin.USDC);
+    const vaultPda = pda.getSmartAccountPda({
+      programId: smartAccountsClient.programId,
+      settingsPda: args.settingsPda,
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+    })[0];
+    const vaultUsdcAta = getAssociatedTokenAddressSync(
+      usdcMint,
+      vaultPda,
+      true,
+      TOKEN_PROGRAM_ID
+    );
+
+    const getTokenAccountsByOwner = (
+      config.connection as {
+        getTokenAccountsByOwner?: Connection["getTokenAccountsByOwner"];
+      }
+    ).getTokenAccountsByOwner;
+    const [lamports, tokenAccountsResponse] = await Promise.all([
+      getVaultSweepLamportsOrZero(config.connection, vaultPda),
+      typeof getTokenAccountsByOwner === "function"
+        ? getTokenAccountsByOwner.call(
+            config.connection,
+            vaultPda,
+            { programId: TOKEN_PROGRAM_ID },
+            "confirmed"
+          )
+        : Promise.resolve(null),
+    ]);
+
+    const tokenAccounts = (tokenAccountsResponse?.value ?? [])
+      .map(({ account, pubkey }) => {
+        const decoded = AccountLayout.decode(account.data);
+        const mint = new PublicKey(decoded.mint);
+        return {
+          address: pubkey,
+          amountRaw: BigInt(decoded.amount.toString()),
+          isUsdc: mint.equals(usdcMint),
+          lamports: account.lamports,
+          mint,
+        };
+      })
+      .sort((left, right) =>
+        left.address.toBase58().localeCompare(right.address.toBase58())
+      );
+
+    return { lamports, tokenAccounts, vaultPda, vaultUsdcAta };
+  }
+
+  // Refund the rent still parked on the Earn vault after the position is
+  // closed: withdraw any idle USDC to the wallet, close the vault's token
+  // accounts (USDC ATA + stale collateral ATAs), and sweep the vault PDA's
+  // SOL. This is the token-side of `prepareEarnUsdcCleanup` without the
+  // policy-close half, for wallets whose routing-policy rows are already
+  // closed or missing. Refuses to run while any non-USDC token account holds
+  // a balance (a live on-chain position) — unwinding that is the withdraw
+  // flow's job, never a refund's.
+  async function prepareEarnVaultAccountsRefund(
+    args: SmartAccountEarnVaultRefundInput
+  ): Promise<SmartAccountPreparedEarnVaultRefund> {
+    const cluster = args.cluster ?? LoyalCluster.MainnetBeta;
+    const usdcMint = getStablecoinMintForCluster(cluster, Stablecoin.USDC);
+    const snapshot = await fetchEarnVaultRefundSnapshot({
+      cluster,
+      settingsPda: args.settingsPda,
+    });
+    const vaultPda = snapshot.vaultPda;
+    const vaultUsdcAta = snapshot.vaultUsdcAta;
+    const walletUsdcAta = getAssociatedTokenAddressSync(
+      usdcMint,
+      args.walletAddress,
+      false,
+      TOKEN_PROGRAM_ID
+    );
+
+    const blockedTokenAccounts = snapshot.tokenAccounts.filter(
+      (tokenAccount) =>
+        tokenAccount.amountRaw > BigInt(0) &&
+        !tokenAccount.address.equals(vaultUsdcAta)
+    );
+    if (blockedTokenAccounts.length > 0) {
+      throw new Error(
+        "Earn vault still holds token balances outside its USDC account; withdraw the position before refunding vault accounts."
+      );
+    }
+
+    const idleUsdcAccount = snapshot.tokenAccounts.find((tokenAccount) =>
+      tokenAccount.address.equals(vaultUsdcAta)
+    );
+    const idleAmountRaw = idleUsdcAccount?.amountRaw ?? BigInt(0);
+    const instructions: TransactionInstruction[] = [];
+
+    if (idleAmountRaw > BigInt(0)) {
+      instructions.push(
+        makeSignerWritable(
+          createTransferCheckedInstruction(
+            vaultUsdcAta,
+            usdcMint,
+            walletUsdcAta,
+            vaultPda,
+            idleAmountRaw,
+            EARN_DEPOSIT_USDC_DECIMALS,
+            [],
+            TOKEN_PROGRAM_ID
+          ),
+          vaultPda
+        )
+      );
+    }
+
+    const closedTokenAccounts: PublicKey[] = [];
+    for (const tokenAccount of snapshot.tokenAccounts) {
+      instructions.push(
+        makeSignerWritable(
+          createCloseAccountInstruction(
+            tokenAccount.address,
+            args.walletAddress,
+            vaultPda,
+            [],
+            TOKEN_PROGRAM_ID
+          ),
+          vaultPda
+        )
+      );
+      closedTokenAccounts.push(tokenAccount.address);
+    }
+
+    const sweepLamports = snapshot.lamports;
+    if (sweepLamports > BigInt(0)) {
+      instructions.push(
+        SystemProgram.transfer({
+          fromPubkey: vaultPda,
+          toPubkey: args.walletAddress,
+          lamports: sweepLamports,
+        })
+      );
+    }
+
+    if (instructions.length === 0) {
+      throw new Error(
+        "Nothing to refund: the Earn vault holds no SOL and no token accounts."
+      );
+    }
+
+    const compiledPackedPayload = instructionsToSynchronousTransactionDetailsV2(
+      {
+        vaultPda,
+        members: [args.walletAddress],
+        transaction_instructions: instructions,
+      }
+    );
+    const operation =
+      await smartAccountsClient.features.execution.prepare.executeTransactionSyncV2(
+        {
+          feePayer: args.feePayer,
+          settingsPda: args.settingsPda,
+          accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+          numSigners: 1,
+          instructions: compiledPackedPayload.instructions,
+          instruction_accounts: compiledPackedPayload.accounts,
+          memo: args.memo,
+        } as never
+      );
+    const prepared = freezePreparedOperation({
+      operation: "earnVaultAccountsRefund",
+      payer: args.feePayer,
+      programId: smartAccountsClient.programId,
+      requiresConfirmation: true,
+      instructions: [
+        ...(idleAmountRaw > BigInt(0)
+          ? [
+              createAssociatedTokenAccountIdempotentInstruction(
+                args.feePayer,
+                walletUsdcAta,
+                args.walletAddress,
+                usdcMint,
+                TOKEN_PROGRAM_ID
+              ),
+            ]
+          : []),
+        ...operation.instructions,
+      ],
+      lookupTableAccounts: operation.lookupTableAccounts ?? [],
+    });
+
+    return {
+      prepared,
+      refund: {
+        closedTokenAccounts,
+        idleUsdcTransferRaw: idleAmountRaw,
+        sweepLamports,
+      },
+      vault: {
+        accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+        pubkey: vaultPda,
+        usdcAta: vaultUsdcAta,
+      },
+    };
+  }
+
   async function assertEarnUsdcAutodepositCanonicalArtifacts(
     args: SmartAccountEarnUsdcAutodepositCanonicalArtifactsInput
   ): Promise<void> {
@@ -9863,6 +10077,8 @@ export function createSmartAccountVaultsClient(
     prepareEarnUsdcDeposit,
     prepareEarnUsdcWithdraw,
     prepareEarnUsdcCleanup,
+    fetchEarnVaultRefundSnapshot,
+    prepareEarnVaultAccountsRefund,
     prepareEarnUsdcAutodepositSetup,
     prepareEarnUsdcAutodepositSetupBatch,
     prepareEarnUsdcAutodepositSetupBatchFromPrepared,

--- a/packages/smart-account-vaults/src/types.ts
+++ b/packages/smart-account-vaults/src/types.ts
@@ -808,6 +808,43 @@ export type SmartAccountPreparedEarnUsdcCleanup = {
   };
 };
 
+export type SmartAccountEarnVaultRefundTokenAccount = {
+  address: PublicKey;
+  amountRaw: bigint;
+  isUsdc: boolean;
+  lamports: number;
+  mint: PublicKey;
+};
+
+export type SmartAccountEarnVaultRefundSnapshot = {
+  lamports: bigint;
+  tokenAccounts: SmartAccountEarnVaultRefundTokenAccount[];
+  vaultPda: PublicKey;
+  vaultUsdcAta: PublicKey;
+};
+
+export type SmartAccountEarnVaultRefundInput = {
+  cluster?: LoyalCluster;
+  feePayer: PublicKey;
+  memo?: string;
+  settingsPda: PublicKey;
+  walletAddress: PublicKey;
+};
+
+export type SmartAccountPreparedEarnVaultRefund = {
+  prepared: PreparedLoyalSmartAccountsOperation<string>;
+  refund: {
+    closedTokenAccounts: PublicKey[];
+    idleUsdcTransferRaw: bigint;
+    sweepLamports: bigint;
+  };
+  vault: {
+    accountIndex: 1;
+    pubkey: PublicKey;
+    usdcAta: PublicKey;
+  };
+};
+
 export type SmartAccountEarnUsdcAutodepositSetupInput = {
   settingsPda: PublicKey;
   walletAddress: PublicKey;


### PR DESCRIPTION
Extends the experimental policy-refund scan with a chain-first vault entry (stranded vault SOL + token-account rents, same active-position/autodeposit gating) and adds mobile twins so the app can surface Refund rows for everything closed. Verified read-only against prod: stranded wallets scan refundable and the prepared vault refund simulates a +0.0242 SOL return; active-autodeposit wallets are correctly blocked.

https://claude.ai/code/session_01FhCgUGo9JDSEonGqw9S2ZU