### PR TITLE
feat(earn): heal stray autodeposit token approvals on mobile deposit prepare

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
@@ -21,6 +21,7 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { hasLiveBalanceSweepTargetForWallet } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import {
   parseEarnDepositPrepareRequestBody,
   serializePreparedEarnUsdcDeposit,
@@ -252,12 +253,24 @@ export async function POST(request: Request) {
       policy && activePosition
         ? earnReserveTargetFromActivePosition(activePosition)
         : null;
+    // Stray-approval heal, fail-closed: the SPL delegate is load-bearing for
+    // sweeps, so the revoke rider is requested only when the wallet provably
+    // has NO live autodeposit target (any settings, duplicates included). On
+    // a gate read error the heal is skipped, never the deposit.
+    let revokeStrayUsdcDelegate = false;
+    try {
+      revokeStrayUsdcDelegate =
+        !(await hasLiveBalanceSweepTargetForWallet(walletAddress));
+    } catch {
+      revokeStrayUsdcDelegate = false;
+    }
     const preparedDeposit = await client.prepareEarnUsdcDeposit({
       amountRaw,
       cluster,
       feePayer: new PublicKey(walletAddress),
       initializeYieldRoutingPolicy: !policy,
       policySigner,
+      revokeStrayUsdcDelegate,
       settingsPda: settings,
       walletAddress: new PublicKey(walletAddress),
       ...(target ? { target } : {}),

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -717,6 +717,32 @@ export async function findCurrentEarnAutodepositState(
   };
 }
 
+/**
+ * True when the wallet has ANY non-closed autodeposit target, across all
+ * settings (duplicate/poisoned rows included). Gates the stray-approval
+ * revoke rider: the SPL delegate is load-bearing for sweeps while any target
+ * is live, so the rider must stay off unless every row is closed.
+ */
+export async function hasLiveBalanceSweepTargetForWallet(
+  walletAddress: string,
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client"
+  > = createDependencies()
+): Promise<boolean> {
+  const [row] = await dependencies.client.db
+    .select({ id: balanceSweepTargets.id })
+    .from(balanceSweepTargets)
+    .where(
+      and(
+        eq(balanceSweepTargets.wallet, walletAddress),
+        ne(balanceSweepTargets.lifecycleStatus, "closed")
+      )
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
 export function resolveEarnAutodepositCurrentPeriodStart(
   target: Pick<
     BalanceSweepTargetRecord,

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -6562,55 +6562,102 @@ export function createSmartAccountVaultsClient(
         } as never
       );
     const policyOperations = [depositExecution];
-    const prepared = freezePreparedOperation({
-      operation: "earnUsdcDeposit",
-      payer: args.feePayer,
-      programId: smartAccountsClient.programId,
-      requiresConfirmation: true,
-      instructions: [
-        createAssociatedTokenAccountIdempotentInstruction(
-          args.feePayer,
-          vaultUsdcAta,
-          vaultPda,
-          usdcMint,
-          TOKEN_PROGRAM_ID
-        ),
-        // The Kamino deposit CPI receives reserve collateral (cTokens) into the
-        // vault's collateral ATA, so it must exist and be Token-owned before the
-        // smart-account program validates the interaction. Create it idempotently.
-        ...(inferredVaultCollateralAccounts
-          ? [
-              createAssociatedTokenAccountIdempotentInstruction(
-                args.feePayer,
-                inferredVaultCollateralAccounts.vaultCollateralAta,
-                vaultPda,
-                inferredVaultCollateralAccounts.reserveCollateralMint,
-                TOKEN_PROGRAM_ID
-              ),
-            ]
-          : []),
-        ...(setupRentTopUpInstruction && !policyFinalizeOperation
-          ? [setupRentTopUpInstruction]
-          : []),
-        createTransferCheckedInstruction(
-          walletUsdcAta,
-          usdcMint,
-          vaultUsdcAta,
-          args.walletAddress,
-          args.amountRaw,
-          EARN_DEPOSIT_USDC_DECIMALS,
-          [],
-          TOKEN_PROGRAM_ID
-        ),
-        ...policyOperations.flatMap((operation) => operation.instructions),
-      ],
-      lookupTableAccounts: dedupeLookupTableAccounts(
-        policyOperations.flatMap(
-          (operation) => operation.lookupTableAccounts ?? []
-        )
+    // Stray-approval heal: a pre-fix autodeposit delete left the unlimited
+    // SPL delegate that InitAuthority approved on the wallet's USDC ATA. When
+    // the caller vouches there is no live autodeposit (DB-side gate), ride an
+    // SPL revoke in the deposit tx — but only when the delegate on chain is
+    // still our subscription authority, so a foreign approval is untouched.
+    let strayDelegateRevokeInstruction: TransactionInstruction | null = null;
+    if (args.revokeStrayUsdcDelegate === true) {
+      const subscriptionAuthority = deriveSubscriptionAuthority(
+        args.walletAddress,
+        usdcMint
+      );
+      const walletUsdcAtaInfo = await config.connection.getAccountInfo(
+        walletUsdcAta
+      );
+      if (
+        walletUsdcAtaInfo &&
+        walletUsdcAtaInfo.data.length >= AccountLayout.span
+      ) {
+        const decoded = AccountLayout.decode(walletUsdcAtaInfo.data);
+        if (
+          decoded.delegateOption === 1 &&
+          new PublicKey(decoded.delegate).equals(subscriptionAuthority)
+        ) {
+          strayDelegateRevokeInstruction = createRevokeInstruction(
+            walletUsdcAta,
+            args.walletAddress
+          );
+        }
+      }
+    }
+    const depositInstructions = [
+      createAssociatedTokenAccountIdempotentInstruction(
+        args.feePayer,
+        vaultUsdcAta,
+        vaultPda,
+        usdcMint,
+        TOKEN_PROGRAM_ID
       ),
-    });
-    const preparedLength = preparedPacketLength(prepared);
+      // The Kamino deposit CPI receives reserve collateral (cTokens) into the
+      // vault's collateral ATA, so it must exist and be Token-owned before the
+      // smart-account program validates the interaction. Create it idempotently.
+      ...(inferredVaultCollateralAccounts
+        ? [
+            createAssociatedTokenAccountIdempotentInstruction(
+              args.feePayer,
+              inferredVaultCollateralAccounts.vaultCollateralAta,
+              vaultPda,
+              inferredVaultCollateralAccounts.reserveCollateralMint,
+              TOKEN_PROGRAM_ID
+            ),
+          ]
+        : []),
+      ...(setupRentTopUpInstruction && !policyFinalizeOperation
+        ? [setupRentTopUpInstruction]
+        : []),
+      createTransferCheckedInstruction(
+        walletUsdcAta,
+        usdcMint,
+        vaultUsdcAta,
+        args.walletAddress,
+        args.amountRaw,
+        EARN_DEPOSIT_USDC_DECIMALS,
+        [],
+        TOKEN_PROGRAM_ID
+      ),
+      ...policyOperations.flatMap((operation) => operation.instructions),
+    ];
+    const freezeDeposit = (instructions: TransactionInstruction[]) =>
+      freezePreparedOperation({
+        operation: "earnUsdcDeposit",
+        payer: args.feePayer,
+        programId: smartAccountsClient.programId,
+        requiresConfirmation: true,
+        instructions,
+        lookupTableAccounts: dedupeLookupTableAccounts(
+          policyOperations.flatMap(
+            (operation) => operation.lookupTableAccounts ?? []
+          )
+        ),
+      });
+    let prepared = freezeDeposit(
+      strayDelegateRevokeInstruction
+        ? [...depositInstructions, strayDelegateRevokeInstruction]
+        : depositInstructions
+    );
+    let preparedLength = preparedPacketLength(prepared);
+    if (
+      strayDelegateRevokeInstruction &&
+      (preparedLength === null ||
+        preparedLength > EARN_POLICY_PACKET_DATA_SIZE)
+    ) {
+      // The heal rider must never sink a deposit: drop it when the tx is at
+      // the packet ceiling — a later deposit or delete re-heals the wallet.
+      prepared = freezeDeposit(depositInstructions);
+      preparedLength = preparedPacketLength(prepared);
+    }
     if (
       preparedLength === null ||
       preparedLength > EARN_POLICY_PACKET_DATA_SIZE

--- a/packages/smart-account-vaults/src/types.ts
+++ b/packages/smart-account-vaults/src/types.ts
@@ -433,6 +433,13 @@ export type SmartAccountEarnUsdcDepositInput = {
       seed: bigint;
     } | null;
   };
+  /**
+   * Heal a stray autodeposit token approval by riding an SPL revoke in the
+   * deposit tx. Callers MUST only set this when the wallet has no live
+   * autodeposit (the delegate is load-bearing for sweeps); the SDK itself only
+   * verifies on chain that the delegate is our subscription authority.
+   */
+  revokeStrayUsdcDelegate?: boolean;
   memo?: string;
 };
 


### PR DESCRIPTION
Backfill heal for the 892 wallets left with an unlimited USDC delegate by pre-#465 autodeposit deletes: the mobile deposit prepare now rides an SPL revoke in the deposit tx, double-gated — the route requires zero non-closed sweep targets for the wallet (fail-closed, all settings/duplicates included) and the SDK only revokes when the on-chain delegate is our subscription authority, so foreign approvals and live autodeposits are never touched; the rider is dropped rather than tripping the packet-size ceiling. Verified read-only on mainnet: a stray wallet's deposit simulates clean and clears the delegate; active and pending_delegation wallets suppress the rider.