### PR TITLE
feat(earn): serve mobile deposit and withdraw prepare contexts for on-device builds

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
@@ -1,0 +1,286 @@
+import { NextResponse } from "next/server";
+import {
+  getStablecoinMintForCluster,
+  resolveLoyalClusterForSolanaEnv,
+  Stablecoin,
+} from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import {
+  ensureWalletUserSmartAccount,
+  findReadyCurrentUserSmartAccount,
+  isSmartAccountProvisioningError,
+} from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { hasLiveBalanceSweepTargetForWallet } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { parseEarnDepositPrepareRequestBody } from "@/lib/yield-optimization/earn-deposit-prepare-contracts.shared";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  findActiveYieldRoutePolicyPair,
+  findReconciledActiveYieldPositionForVault,
+  type RoutePolicyRecord,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Context twin of `../prepare` for ON-DEVICE deposit prepare: same auth,
+// provisioning gate, and DB reads, but instead of building the deposit here
+// (a ~16-RPC-call SDK prepare that contends for this server's shared,
+// per-IP-rate-limited Solana RPC pipe) it returns the inputs so the device
+// runs `prepareEarnUsdcDeposit` on its own RPC/IP allowance — mirroring the
+// on-device autodeposit setup/close flows. `../prepare` stays for app
+// versions that predate on-device prepare; keep the auth/provisioning gate
+// below in sync with it.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getServerSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+// Sum the wallet's USDC across its token accounts (parsed RPC; no spl-token
+// dependency, mirroring the frontend asset provider).
+async function getWalletUsdcBalanceRaw(
+  connection: Connection,
+  owner: PublicKey,
+  usdcMint: PublicKey
+): Promise<bigint> {
+  const { value } = await connection.getParsedTokenAccountsByOwner(owner, {
+    mint: usdcMint,
+  });
+  let total = BigInt(0);
+  for (const entry of value) {
+    const parsed = entry.account.data.parsed as
+      | { info?: { tokenAmount?: { amount?: unknown } } }
+      | undefined;
+    const amount = parsed?.info?.tokenAmount?.amount;
+    if (typeof amount === "string") {
+      total += BigInt(amount);
+    }
+  }
+  return total;
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-deposit-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let amountRaw: bigint;
+  try {
+    ({ amountRaw } = parseEarnDepositPrepareRequestBody(body));
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  // Resolve (provisioning if needed) the canonical smart account for this
+  // wallet — same gate as `../prepare`: the first-ever provisioning is
+  // sponsored, so require the wallet to already hold the USDC it is
+  // depositing before minting an account for it.
+  let settingsPda: string;
+  let smartAccountAddress: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+      walletAddress,
+    });
+    if (existing) {
+      settingsPda = existing.settingsPda;
+      smartAccountAddress = existing.smartAccountAddress;
+    } else {
+      const usdcMint = getStablecoinMintForCluster(cluster, Stablecoin.USDC);
+      const usdcBalanceRaw = await getWalletUsdcBalanceRaw(
+        getConnection(solanaEnv),
+        new PublicKey(walletAddress),
+        usdcMint
+      );
+      if (usdcBalanceRaw < amountRaw) {
+        return jsonError(
+          402,
+          "insufficient_usdc",
+          "Wallet must hold the USDC it is depositing before its Earn account can be created."
+        );
+      }
+      const ensured = await ensureWalletUserSmartAccount({
+        userId: user.id,
+        walletAddress,
+      });
+      settingsPda = ensured.smartAccount.settingsPda;
+      smartAccountAddress = ensured.smartAccount.smartAccountAddress;
+    }
+  } catch (error) {
+    if (isSmartAccountProvisioningError(error)) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    console.error("[mobile-earn-deposit-prepare-context] provisioning failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown provisioning error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "provisioning_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  let policy: RoutePolicyRecord | null = null;
+
+  try {
+    const serverEnv = getServerEnv();
+    const programId = new PublicKey(serverEnv.loyalSmartAccounts.programId);
+    const settings = new PublicKey(settingsPda);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+      programId,
+      settingsPda: settings,
+    });
+    const [policyResult, activePosition] = await Promise.all([
+      findActiveYieldRoutePolicyPair({
+        authority: walletAddress,
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+      }),
+      findReconciledActiveYieldPositionForVault({
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        walletAddress,
+      }),
+    ]);
+    policy = policyResult?.routePolicy ?? null;
+    const policySigner = getDeploymentPolicySignerPublicKey();
+    // A top-up deposits into the reserve the position is already in (always a
+    // safe USDC reserve) — same rule as `../prepare`.
+    const target =
+      policy && activePosition
+        ? earnReserveTargetFromActivePosition(activePosition)
+        : null;
+    // Stray-approval heal, fail-closed: the SPL delegate is load-bearing for
+    // sweeps, so the revoke rider is requested only when the wallet provably
+    // has NO live autodeposit target (any settings, duplicates included). The
+    // SDK re-checks on chain that the delegate is our subscription authority.
+    let revokeStrayUsdcDelegate = false;
+    try {
+      revokeStrayUsdcDelegate =
+        !(await hasLiveBalanceSweepTargetForWallet(walletAddress));
+    } catch {
+      revokeStrayUsdcDelegate = false;
+    }
+    return NextResponse.json({
+      cluster,
+      programId: serverEnv.loyalSmartAccounts.programId,
+      settingsPda,
+      smartAccountAddress,
+      policySigner: policySigner.toBase58(),
+      revokeStrayUsdcDelegate,
+      yieldRoutingPolicy: policy
+        ? {
+            account: policy.policyAccount,
+            seed: policy.policySeed.toString(),
+            setupPolicy: policyResult?.setupPolicy
+              ? {
+                  account: policyResult.setupPolicy.policyAccount,
+                  seed: policyResult.setupPolicy.policySeed.toString(),
+                }
+              : null,
+          }
+        : null,
+      target: target
+        ? {
+            reserve: target.reserve.toBase58(),
+            market: target.market.toBase58(),
+            liquidityMint: target.liquidityMint.toBase58(),
+            supplyApyBps: target.supplyApyBps?.toString() ?? null,
+          }
+        : null,
+    });
+  } catch (error) {
+    console.error("[mobile-earn-deposit-prepare-context] context failed", {
+      amountRaw: amountRaw.toString(),
+      cluster,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown context error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      policyAccount: policy?.policyAccount ?? null,
+      settings: settingsPda,
+      solanaEnv,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "context_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to resolve Earn deposit context."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
-import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
 
@@ -13,24 +12,21 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import {
-  parseEarnWithdrawPrepareRequestBody,
-  serializePreparedEarnUsdcWithdraw,
-} from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+import { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
 import {
   EarnWithdrawResolveError,
   resolveEarnUsdcWithdrawInput,
+  serializeEarnUsdcWithdrawInput,
 } from "@/lib/yield-optimization/earn-withdraw-input-resolution.server";
 
-// Mobile twin of `yield-optimization/withdrawals/prepare`. Identical source
-// selection + prepare logic, but authenticated by a wallet signature (no
-// Turnstile/session) and it resolves the caller's smart account itself instead
-// of reading it from a session principal. Withdrawing requires an existing
-// account, so (unlike deposit) it never provisions. Source selection lives in
-// `earn-withdraw-input-resolution.server.ts`, shared with `../prepare-context`
-// (the on-device build twin) — this route remains for app versions that
-// predate on-device prepare.
+// Context twin of `../prepare` for ON-DEVICE withdraw prepare: same auth and
+// source-selection/reconcile logic (shared via
+// `earn-withdraw-input-resolution.server.ts`), but instead of building the
+// withdrawal here it returns the resolved SDK input so the device runs
+// `prepareEarnUsdcWithdraw` on its own RPC/IP allowance — mirroring the
+// deposit `prepare-context` and the on-device autodeposit flows. `../prepare`
+// stays for app versions that predate on-device prepare.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
 const connectionCache = new Map<SolanaEnv, Connection>();
@@ -129,7 +125,7 @@ export async function POST(request: Request) {
     settingsPda = existing.settingsPda;
     smartAccountAddress = existing.smartAccountAddress;
   } catch (error) {
-    console.error("[mobile-earn-withdraw-prepare] resolve failed", {
+    console.error("[mobile-earn-withdraw-prepare-context] resolve failed", {
       errorMessage:
         error instanceof Error ? error.message : "Unknown resolve error.",
       errorName: error instanceof Error ? error.name : typeof error,
@@ -154,13 +150,12 @@ export async function POST(request: Request) {
       programId,
       settingsPda: new PublicKey(settingsPda),
     });
-    const connection = getConnection(solanaEnv);
     const resolved = await resolveEarnUsdcWithdrawInput({
       amountRaw,
       cluster,
-      connection,
+      connection: getConnection(solanaEnv),
       earnVaultPda,
-      logTag: "mobile-earn-withdraw-prepare",
+      logTag: "mobile-earn-withdraw-prepare-context",
       mode,
       policySigner: getDeploymentPolicySignerPublicKey(),
       programId,
@@ -168,30 +163,23 @@ export async function POST(request: Request) {
       sourceRequest: selectedSourceRequest,
       walletAddress,
     });
-    const client = createSmartAccountVaultsClient({
-      connection,
-      programId,
-    });
-    const preparedWithdraw = await client.prepareEarnUsdcWithdraw(
-      resolved.input
-    );
 
     return NextResponse.json({
       cluster,
       programId: serverEnv.loyalSmartAccounts.programId,
       settingsPda,
       smartAccountAddress,
-      preparedWithdraw: serializePreparedEarnUsdcWithdraw(preparedWithdraw),
+      withdrawInput: serializeEarnUsdcWithdrawInput(resolved.input),
     });
   } catch (error) {
     if (error instanceof EarnWithdrawResolveError) {
       return jsonError(error.status, error.code, error.message);
     }
-    console.error("[mobile-earn-withdraw-prepare] prepare failed", {
+    console.error("[mobile-earn-withdraw-prepare-context] context failed", {
       amountRaw: amountRaw.toString(),
       cluster,
       errorMessage:
-        error instanceof Error ? error.message : "Unknown prepare error.",
+        error instanceof Error ? error.message : "Unknown context error.",
       errorName: error instanceof Error ? error.name : typeof error,
       mode,
       settings: settingsPda,
@@ -201,10 +189,10 @@ export async function POST(request: Request) {
     });
     return jsonError(
       500,
-      "prepare_failed",
+      "context_failed",
       error instanceof Error
         ? error.message
-        : "Failed to prepare Earn withdrawal."
+        : "Failed to resolve Earn withdrawal context."
     );
   }
 }

--- a/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -1,0 +1,908 @@
+import "server-only";
+
+import type { LoyalCluster } from "@loyal-labs/actions";
+import type { SmartAccountEarnUsdcWithdrawInput } from "@loyal-labs/smart-account-vaults";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import {
+  findCurrentEarnAutodepositState,
+  reconcileMissingOnChainEarnAutodepositPolicy,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
+import {
+  earnReserveTargetFromActivePosition,
+  type EarnUsdcReserveTarget,
+} from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  fetchEarnRpcHoldingsSnapshot,
+  type EarnRpcHolding,
+} from "@/lib/yield-optimization/earn-rpc-holdings.client";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
+import type { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+import {
+  findActiveYieldRoutePolicyPair,
+  findCurrentNonzeroYieldVaultReservePositions,
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
+  findCurrentYieldVaultIdleTokenBalances,
+  findReconciledActiveYieldPositionForVault,
+  type CurrentYieldVaultIdleTokenBalanceRecord,
+  type CurrentYieldVaultReservePositionRecord,
+  type RoutePolicyRecord,
+  type UserYieldPositionRecord,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Source selection + SDK-input assembly for a mobile Earn USDC withdrawal,
+// extracted VERBATIM from `mobile/earn/withdraw/prepare` so the route (server
+// build) and `mobile/earn/withdraw/prepare-context` (on-device build) resolve
+// the exact same input. Everything here is the decision "WHAT to withdraw";
+// the caller decides where the instruction build ("HOW") runs.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+// Resolution failures the routes surface as specific HTTP responses rather
+// than a generic 500 (`missing_earn_policy` / `missing_earn_position`).
+export class EarnWithdrawResolveError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "EarnWithdrawResolveError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+type EarnWithdrawSourceRequest = ReturnType<
+  typeof parseEarnWithdrawPrepareRequestBody
+>["source"];
+
+type SelectedEarnWithdrawSource =
+  | {
+      amountRaw: bigint;
+      id: string;
+      liquidityMint: string;
+      market: string;
+      reserve: string;
+      type: "reserve";
+    }
+  | {
+      amountRaw: bigint;
+      id: string;
+      mint: string;
+      tokenAccount: string;
+      type: "idle";
+    };
+
+function publicKeyFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  keys: string[]
+): PublicKey | null {
+  if (!metadata) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      continue;
+    }
+    try {
+      return new PublicKey(value);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function isNonEmptyString(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function sourceMatchesDirectIdentifier(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawSourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [
+    request.id,
+    request.reserve,
+    request.tokenAccount,
+  ].filter(isNonEmptyString);
+
+  if (identifiers.includes(source.id)) {
+    return true;
+  }
+
+  return source.type === "reserve" && identifiers.includes(source.reserve);
+}
+
+function sourceMatchesStableMint(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawSourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [request.id, request.liquidityMint, request.mint].filter(
+    isNonEmptyString
+  );
+
+  return source.type === "reserve"
+    ? identifiers.includes(source.liquidityMint)
+    : identifiers.includes(source.mint);
+}
+
+function selectRequestedEarnWithdrawSource(
+  sources: SelectedEarnWithdrawSource[],
+  request: EarnWithdrawSourceRequest
+): SelectedEarnWithdrawSource | null {
+  if (!request) {
+    return sources.length === 1 ? sources[0] ?? null : null;
+  }
+
+  const directMatch = sources.find((source) =>
+    sourceMatchesDirectIdentifier(source, request)
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const stableMintMatches = sources.filter((source) =>
+    sourceMatchesStableMint(source, request)
+  );
+  if (stableMintMatches.length === 1) {
+    return stableMintMatches[0] ?? null;
+  }
+
+  const amountMatchedStableMintMatches = stableMintMatches.filter(
+    (source) => request.amountRaw === source.amountRaw.toString()
+  );
+
+  return amountMatchedStableMintMatches.length === 1
+    ? amountMatchedStableMintMatches[0] ?? null
+    : null;
+}
+
+// Build withdraw sources from the LIVE on-chain holdings snapshot (partial
+// withdrawals). The DB read-model + reconcile can't follow a cross-market
+// rebalance; this scans the policy's markets and reflects reality. Drops entries
+// missing the identifiers a withdrawal needs to match/build.
+function buildSnapshotWithdrawSources(
+  holdings: EarnRpcHolding[]
+): SelectedEarnWithdrawSource[] {
+  const sources: SelectedEarnWithdrawSource[] = [];
+  for (const holding of holdings) {
+    let amountRaw: bigint;
+    try {
+      amountRaw = BigInt(holding.amountRaw);
+    } catch {
+      continue;
+    }
+    if (amountRaw <= BigInt(0)) {
+      continue;
+    }
+    if (holding.kind === "idle") {
+      const tokenAccount = holding.provenance.tokenAccount;
+      if (!tokenAccount) {
+        continue;
+      }
+      sources.push({
+        amountRaw,
+        id: tokenAccount,
+        mint: holding.liquidityMint,
+        tokenAccount,
+        type: "idle",
+      });
+      continue;
+    }
+    if (!holding.reserve || !holding.market) {
+      continue;
+    }
+    sources.push({
+      amountRaw,
+      id: holding.reserve,
+      liquidityMint: holding.liquidityMint,
+      market: holding.market,
+      reserve: holding.reserve,
+      type: "reserve",
+    });
+  }
+  return sources;
+}
+
+// The deployed Kamino reserve target for a snapshot-sourced withdrawal — used
+// when withdrawing idle USDC (a reserve withdrawal targets its own reserve).
+// Null when the vault holds no Kamino reserve (fully idle).
+function snapshotReserveTarget(
+  holdings: EarnRpcHolding[]
+): EarnUsdcReserveTarget | null {
+  const kamino = holdings.find(
+    (holding) => holding.kind === "kamino" && holding.reserve && holding.market
+  );
+  if (!kamino || !kamino.reserve || !kamino.market) {
+    return null;
+  }
+  let supplyApyBps: bigint | null = null;
+  if (kamino.supplyApyBps) {
+    try {
+      supplyApyBps = BigInt(kamino.supplyApyBps);
+    } catch {
+      supplyApyBps = null;
+    }
+  }
+  return {
+    liquidityMint: new PublicKey(kamino.liquidityMint),
+    market: new PublicKey(kamino.market),
+    reserve: new PublicKey(kamino.reserve),
+    supplyApyBps,
+  };
+}
+
+// Full-withdrawal targets from the live snapshot (fallback when the DB rows
+// are empty). Collateral metadata comes from the holding provenance when
+// present; the SDK resolves anything omitted on-chain.
+function snapshotFullWithdrawalTargets(
+  holdings: EarnRpcHolding[],
+  reserve: string
+): {
+  amountRaw: bigint;
+  liquidityMint: PublicKey;
+  market: PublicKey;
+  reserve: PublicKey;
+  reserveCollateralMint?: PublicKey;
+  supplyApyBps: bigint | null;
+}[] {
+  const targets = [];
+  for (const holding of holdings) {
+    if (
+      holding.kind !== "kamino" ||
+      holding.reserve !== reserve ||
+      !holding.market
+    ) {
+      continue;
+    }
+    let amountRaw: bigint;
+    try {
+      amountRaw = BigInt(holding.amountRaw);
+    } catch {
+      continue;
+    }
+    if (amountRaw <= BigInt(0)) {
+      continue;
+    }
+    let supplyApyBps: bigint | null = null;
+    if (holding.supplyApyBps) {
+      try {
+        supplyApyBps = BigInt(holding.supplyApyBps);
+      } catch {
+        supplyApyBps = null;
+      }
+    }
+    const reserveCollateralMint = publicKeyFromMetadata(holding.provenance, [
+      "reserveCollateralMint",
+    ]);
+    targets.push({
+      amountRaw,
+      liquidityMint: new PublicKey(holding.liquidityMint),
+      market: new PublicKey(holding.market),
+      reserve: new PublicKey(holding.reserve),
+      ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
+      supplyApyBps,
+    });
+  }
+  return targets;
+}
+
+// Withdraw sources from the reconciled DB rows (full exits) — the row
+// planning metadata carries the collateral accounts the full-withdrawal
+// instruction prefers. Empty after a cross-market rebalance the reconcile
+// couldn't follow; the caller then falls back to the live snapshot.
+function buildDbEarnWithdrawSources(args: {
+  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
+  position: UserYieldPositionRecord;
+  reserveRows: CurrentYieldVaultReservePositionRecord[];
+}): SelectedEarnWithdrawSource[] {
+  const reserveSources = args.reserveRows
+    .filter((row) => row.amountRaw > BigInt(0))
+    .map((row) => {
+      if (!row.market) {
+        throw new Error("Reconciled Earn reserve row is missing a market.");
+      }
+      return {
+        amountRaw: row.amountRaw,
+        id: row.reserve,
+        liquidityMint: row.liquidityMint,
+        market: row.market,
+        reserve: row.reserve,
+        type: "reserve" as const,
+      };
+    });
+  const idleSources = args.idleRows
+    .filter((row) => row.amountRaw > BigInt(0))
+    .map((row) => ({
+      amountRaw: row.amountRaw,
+      id: row.tokenAccount,
+      mint: row.mint,
+      tokenAccount: row.tokenAccount,
+      type: "idle" as const,
+    }));
+  const positionFallbackSources =
+    reserveSources.length === 0 &&
+    idleSources.length === 0 &&
+    isNonEmptyString(args.position.currentMarket) &&
+    args.position.currentAmountRaw > BigInt(0)
+      ? [
+          {
+            amountRaw: args.position.currentAmountRaw,
+            id: args.position.currentReserve,
+            liquidityMint: args.position.currentLiquidityMint,
+            market: args.position.currentMarket,
+            reserve: args.position.currentReserve,
+            type: "reserve" as const,
+          },
+        ]
+      : [];
+  return [...reserveSources, ...idleSources, ...positionFallbackSources];
+}
+
+function selectEarnWithdrawSource(args: {
+  amountRaw: bigint;
+  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
+  mode: "partial" | "full";
+  position: UserYieldPositionRecord;
+  request: EarnWithdrawSourceRequest;
+  reserveRows: CurrentYieldVaultReservePositionRecord[];
+}): SelectedEarnWithdrawSource {
+  const sources = buildDbEarnWithdrawSources({
+    idleRows: args.idleRows,
+    position: args.position,
+    reserveRows: args.reserveRows,
+  });
+
+  if (sources.length === 0) {
+    throw new Error("No active Earn withdrawal source was found.");
+  }
+
+  const selected = selectRequestedEarnWithdrawSource(sources, args.request);
+
+  if (!selected) {
+    throw new Error("Select an Earn source before withdrawing.");
+  }
+  if (args.mode === "partial" && args.amountRaw > selected.amountRaw) {
+    throw new Error("Withdrawal exceeds the selected Earn source amount.");
+  }
+
+  return selected;
+}
+
+export type ResolvedEarnUsdcWithdraw = {
+  // Complete SDK input, ready for `client.prepareEarnUsdcWithdraw(input)`.
+  input: SmartAccountEarnUsdcWithdrawInput;
+  policy: RoutePolicyRecord;
+  effectiveAmountRaw: bigint;
+};
+
+export async function resolveEarnUsdcWithdrawInput(args: {
+  connection: Connection;
+  cluster: LoyalCluster;
+  programId: PublicKey;
+  policySigner: PublicKey;
+  walletAddress: string;
+  settingsPda: string;
+  earnVaultPda: PublicKey;
+  amountRaw: bigint;
+  mode: "partial" | "full";
+  sourceRequest: EarnWithdrawSourceRequest;
+  // Route-specific log prefix so on-call greps keep working per endpoint.
+  logTag: string;
+}): Promise<ResolvedEarnUsdcWithdraw> {
+  const {
+    connection,
+    cluster,
+    walletAddress,
+    settingsPda,
+    earnVaultPda,
+    amountRaw,
+    mode,
+    logTag,
+  } = args;
+  const settingsPdaKey = new PublicKey(settingsPda);
+  // Reconcile the DB position against the live on-chain Kamino obligation
+  // before deriving the withdrawal target — otherwise a stale snapshot points
+  // the withdraw at a reserve/market whose vanilla obligation doesn't exist
+  // (KLEND_OBLIGATION_NOT_FOUND). Mirrors the web `withdrawals/prepare` route.
+  await reconcileEarnVaultPosition({
+    authority: walletAddress,
+    cluster,
+    connection,
+    force: true,
+    settings: settingsPda,
+    vaultPubkey: earnVaultPda.toBase58(),
+  });
+  const [policyResult, position, currentReserveRows, currentIdleRows] =
+    await Promise.all([
+      findActiveYieldRoutePolicyPair({
+        authority: walletAddress,
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+      }),
+      findReconciledActiveYieldPositionForVault({
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        walletAddress,
+      }),
+      findCurrentNonzeroYieldVaultReservePositions({
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+        walletAddress,
+      }),
+      findCurrentYieldVaultIdleTokenBalances({
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+        walletAddress,
+      }),
+    ]);
+  const policy = policyResult?.routePolicy ?? null;
+  if (!policy) {
+    console.warn(`[${logTag}] missing active Earn policy`, {
+      cluster,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      walletAddress,
+    });
+    throw new EarnWithdrawResolveError(
+      409,
+      "missing_earn_policy",
+      "Set up the Earn policy before withdrawing USDC."
+    );
+  }
+
+  if (!position) {
+    console.warn(`[${logTag}] missing active Earn position`, {
+      cluster,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      walletAddress,
+    });
+    throw new EarnWithdrawResolveError(
+      409,
+      "missing_earn_position",
+      "No active Earn position was found for this withdrawal."
+    );
+  }
+
+  // Partial withdrawals source from the LIVE on-chain holdings snapshot — the
+  // same read `/holdings`, the withdraw picker, and the positions sheet use.
+  // The DB read-model + reconcile can't follow a cross-market rebalance, so it
+  // reports a stale reserve that the picker showed and this route would reject
+  // ("Select an Earn source"). Full exits keep the DB path (its reconciled
+  // rows carry the collateral metadata the full-withdrawal instruction needs).
+  let selectedSource: SelectedEarnWithdrawSource;
+  let isFinalExit: boolean;
+  let withdrawTarget: EarnUsdcReserveTarget;
+  let effectiveAmountRaw: bigint;
+  // Set when a full exit had to source from the live snapshot (DB rows
+  // empty); the full-withdrawal targets are then built from it too.
+  let snapshotFullExitHoldings: EarnRpcHolding[] | null = null;
+  if (mode === "partial") {
+    const snapshot = await fetchEarnRpcHoldingsSnapshot({
+      cluster,
+      connection,
+      policy: policyResult
+        ? serializeRoutePolicyState(
+            policyResult.routePolicy,
+            policyResult.setupPolicy ?? null
+          )
+        : null,
+      programId: args.programId,
+      settingsPda: settingsPdaKey,
+    });
+    const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
+    if (snapshotSources.length === 0) {
+      throw new Error("No active Earn withdrawal source was found.");
+    }
+    const selected = selectRequestedEarnWithdrawSource(
+      snapshotSources,
+      args.sourceRequest
+    );
+    if (!selected) {
+      throw new Error("Select an Earn source before withdrawing.");
+    }
+    if (amountRaw > selected.amountRaw) {
+      throw new Error("Withdrawal exceeds the selected Earn source amount.");
+    }
+    selectedSource = selected;
+    effectiveAmountRaw = amountRaw;
+    const snapshotTotal = snapshotSources.reduce(
+      (total, source) => total + source.amountRaw,
+      BigInt(0)
+    );
+    isFinalExit = snapshotTotal - effectiveAmountRaw <= BigInt(0);
+    withdrawTarget =
+      selected.type === "reserve"
+        ? {
+            liquidityMint: new PublicKey(selected.liquidityMint),
+            market: new PublicKey(selected.market),
+            reserve: new PublicKey(selected.reserve),
+            supplyApyBps: null,
+          }
+        : snapshotReserveTarget(snapshot.holdings) ??
+          earnReserveTargetFromActivePosition(position);
+  } else if (
+    buildDbEarnWithdrawSources({
+      idleRows: currentIdleRows,
+      position,
+      reserveRows: currentReserveRows,
+    }).length === 0
+  ) {
+    // Full-exit snapshot fallback: after a cross-market rebalance the
+    // reconciled DB rows (and the position row) can read zero while the
+    // funds live on-chain in another market's obligation. Source the full
+    // exit from the same live snapshot partial withdrawals use — its
+    // provenance carries the collateral metadata the full path needs.
+    const snapshot = await fetchEarnRpcHoldingsSnapshot({
+      cluster,
+      connection,
+      policy: policyResult
+        ? serializeRoutePolicyState(
+            policyResult.routePolicy,
+            policyResult.setupPolicy ?? null
+          )
+        : null,
+      programId: args.programId,
+      settingsPda: settingsPdaKey,
+    });
+    const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
+    if (snapshotSources.length === 0) {
+      throw new Error("No active Earn withdrawal source was found.");
+    }
+    const selected = selectRequestedEarnWithdrawSource(
+      snapshotSources,
+      args.sourceRequest
+    );
+    if (!selected) {
+      throw new Error("Select an Earn source before withdrawing.");
+    }
+    selectedSource = selected;
+    effectiveAmountRaw = selected.amountRaw;
+    const remainingReserveAmountRaw = snapshotSources.reduce(
+      (total, source) =>
+        total +
+        (source.type === "reserve" && source.id !== selected.id
+          ? source.amountRaw
+          : BigInt(0)),
+      BigInt(0)
+    );
+    const remainingIdleAmountRaw = snapshotSources.reduce(
+      (total, source) =>
+        total +
+        (source.type === "idle" && source.id !== selected.id
+          ? source.amountRaw
+          : BigInt(0)),
+      BigInt(0)
+    );
+    isFinalExit =
+      remainingReserveAmountRaw <= BigInt(0) &&
+      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
+    withdrawTarget =
+      selected.type === "reserve"
+        ? {
+            liquidityMint: new PublicKey(selected.liquidityMint),
+            market: new PublicKey(selected.market),
+            reserve: new PublicKey(selected.reserve),
+            supplyApyBps: null,
+          }
+        : snapshotReserveTarget(snapshot.holdings) ??
+          earnReserveTargetFromActivePosition(position);
+    snapshotFullExitHoldings = snapshot.holdings;
+  } else {
+    selectedSource = selectEarnWithdrawSource({
+      amountRaw,
+      idleRows: currentIdleRows,
+      mode,
+      position,
+      request: args.sourceRequest,
+      reserveRows: currentReserveRows,
+    });
+    effectiveAmountRaw = selectedSource.amountRaw;
+    const remainingReserveAmountRaw = currentReserveRows.reduce(
+      (total, row) =>
+        total +
+        (selectedSource.type === "reserve" &&
+        row.reserve === selectedSource.reserve
+          ? row.amountRaw > effectiveAmountRaw
+            ? row.amountRaw - effectiveAmountRaw
+            : BigInt(0)
+          : row.amountRaw),
+      BigInt(0)
+    );
+    const remainingIdleAmountRaw = currentIdleRows.reduce(
+      (total, row) =>
+        total +
+        (selectedSource.type === "idle" &&
+        row.tokenAccount === selectedSource.tokenAccount
+          ? row.amountRaw > effectiveAmountRaw
+            ? row.amountRaw - effectiveAmountRaw
+            : BigInt(0)
+          : row.amountRaw),
+      BigInt(0)
+    );
+    isFinalExit =
+      remainingReserveAmountRaw <= BigInt(0) &&
+      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
+    withdrawTarget = earnReserveTargetFromActivePosition(position);
+  }
+
+  const yieldRoutingPolicy = {
+    account: new PublicKey(policy.policyAccount),
+    seed: policy.policySeed,
+    ...(policyResult?.setupPolicy
+      ? {
+          setupPolicy: {
+            account: new PublicKey(policyResult.setupPolicy.policyAccount),
+            seed: policyResult.setupPolicy.policySeed,
+          },
+        }
+      : {}),
+  };
+  const autodepositState =
+    mode === "full" && isFinalExit
+      ? await findCurrentEarnAutodepositState({
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        })
+      : null;
+  let autodepositClose:
+    | {
+        policy: PublicKey;
+        recurringDelegation: PublicKey;
+      }
+    | undefined;
+  let reconciledMissingAutodepositPolicy = false;
+
+  if (
+    autodepositState?.target.policyAccount &&
+    autodepositState.target.recurringDelegation
+  ) {
+    const autodepositPolicyAccount = new PublicKey(
+      autodepositState.target.policyAccount
+    );
+    const autodepositPolicyInfo = await connection.getAccountInfo(
+      autodepositPolicyAccount,
+      "confirmed"
+    );
+
+    if (autodepositPolicyInfo) {
+      autodepositClose = {
+        policy: autodepositPolicyAccount,
+        recurringDelegation: new PublicKey(
+          autodepositState.target.recurringDelegation
+        ),
+      };
+    } else {
+      reconciledMissingAutodepositPolicy = true;
+      const reconciledTarget =
+        await reconcileMissingOnChainEarnAutodepositPolicy({
+          policyAccount: autodepositState.target.policyAccount,
+          settings: settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          walletAddress,
+        });
+      console.warn(`[${logTag}] reconciled missing autodeposit policy account`, {
+        cluster,
+        lifecycleStatus: reconciledTarget.lifecycleStatus,
+        policyAccount: autodepositState.target.policyAccount,
+        reconciliationSource: "reconciled_missing_policy",
+        settings: settingsPda,
+        targetId: reconciledTarget.id.toString(),
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        walletAddress,
+      });
+    }
+  }
+
+  if (
+    mode === "full" &&
+    isFinalExit &&
+    autodepositState &&
+    !autodepositClose &&
+    !reconciledMissingAutodepositPolicy
+  ) {
+    console.warn(`[${logTag}] active autodeposit state is missing close metadata`, {
+      cluster,
+      policyAccount: autodepositState.target.policyAccount,
+      recurringDelegation: autodepositState.target.recurringDelegation,
+      settings: settingsPda,
+      targetId: autodepositState.target.id.toString(),
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      walletAddress,
+    });
+  }
+
+  const withdrawInput = {
+    amountRaw: effectiveAmountRaw,
+    cluster,
+    feePayer: new PublicKey(walletAddress),
+    policySigner: args.policySigner,
+    settingsPda: settingsPdaKey,
+    target: withdrawTarget,
+    ...(mode === "full" && selectedSource.type === "reserve"
+      ? {
+          fullWithdrawalTargets: snapshotFullExitHoldings
+            ? snapshotFullWithdrawalTargets(
+                snapshotFullExitHoldings,
+                selectedSource.reserve
+              )
+            : currentReserveRows
+                .filter((row) => row.reserve === selectedSource.reserve)
+                .map((row) => {
+                  if (!row.market) {
+                    throw new Error(
+                      "Reconciled Earn reserve row is missing a Kamino market."
+                    );
+                  }
+                  const reserveCollateralMint = publicKeyFromMetadata(
+                    row.planningMetadata,
+                    [
+                      "reserveCollateralMint",
+                      "reserve_collateral_mint",
+                      "collateralMint",
+                      "collateral_mint",
+                    ]
+                  );
+                  const reserveLiquiditySupply = publicKeyFromMetadata(
+                    row.planningMetadata,
+                    [
+                      "reserveLiquiditySupply",
+                      "reserve_liquidity_supply",
+                      "liquiditySupply",
+                      "liquidity_supply",
+                    ]
+                  );
+                  const vaultCollateralAta = publicKeyFromMetadata(
+                    row.planningMetadata,
+                    [
+                      "vaultCollateralAta",
+                      "vault_collateral_ata",
+                      "collateralAta",
+                      "collateral_ata",
+                    ]
+                  );
+
+                  return {
+                    amountRaw: row.amountRaw,
+                    liquidityMint: new PublicKey(row.liquidityMint),
+                    market: new PublicKey(row.market),
+                    reserve: new PublicKey(row.reserve),
+                    ...(reserveCollateralMint
+                      ? { reserveCollateralMint }
+                      : {}),
+                    ...(reserveLiquiditySupply
+                      ? { reserveLiquiditySupply }
+                      : {}),
+                    supplyApyBps: row.supplyApyBps ?? null,
+                    ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
+                  };
+                }),
+        }
+      : {}),
+    closePoliciesOnFullWithdrawal: isFinalExit,
+    source:
+      selectedSource.type === "idle"
+        ? {
+            amountRaw: selectedSource.amountRaw,
+            id: selectedSource.id,
+            mint: new PublicKey(selectedSource.mint),
+            tokenAccount: new PublicKey(selectedSource.tokenAccount),
+            type: "idle" as const,
+          }
+        : {
+            amountRaw: selectedSource.amountRaw,
+            id: selectedSource.id,
+            liquidityMint: new PublicKey(selectedSource.liquidityMint),
+            market: new PublicKey(selectedSource.market),
+            reserve: new PublicKey(selectedSource.reserve),
+            type: "reserve" as const,
+          },
+    walletAddress: new PublicKey(walletAddress),
+    yieldRoutingPolicy,
+  };
+
+  const input: SmartAccountEarnUsdcWithdrawInput =
+    mode === "full"
+      ? {
+          ...withdrawInput,
+          ...(autodepositClose ? { autodepositClose } : {}),
+          mode,
+        }
+      : {
+          ...withdrawInput,
+          mode,
+        };
+
+  return { input, policy, effectiveAmountRaw };
+}
+
+// Wire form of the resolved SDK input, served by `withdraw/prepare-context`
+// so the device can hydrate it and run `prepareEarnUsdcWithdraw` locally.
+// Keep in sync with the mobile hydrator (`mobile/src/lib/solana/earn/wire.ts`).
+export function serializeEarnUsdcWithdrawInput(
+  input: SmartAccountEarnUsdcWithdrawInput
+) {
+  return {
+    amountRaw: input.amountRaw.toString(),
+    mode: input.mode,
+    closePoliciesOnFullWithdrawal: input.closePoliciesOnFullWithdrawal ?? false,
+    policySigner: input.policySigner.toBase58(),
+    source: input.source
+      ? input.source.type === "idle"
+        ? {
+            amountRaw: input.source.amountRaw.toString(),
+            id: input.source.id,
+            mint: input.source.mint.toBase58(),
+            tokenAccount: input.source.tokenAccount.toBase58(),
+            type: "idle" as const,
+          }
+        : {
+            amountRaw: input.source.amountRaw.toString(),
+            id: input.source.id,
+            liquidityMint: input.source.liquidityMint.toBase58(),
+            market: input.source.market.toBase58(),
+            reserve: input.source.reserve.toBase58(),
+            type: "reserve" as const,
+          }
+      : null,
+    target: input.target
+      ? {
+          liquidityMint: input.target.liquidityMint.toBase58(),
+          market: input.target.market.toBase58(),
+          reserve: input.target.reserve.toBase58(),
+          supplyApyBps: input.target.supplyApyBps?.toString() ?? null,
+        }
+      : null,
+    fullWithdrawalTargets:
+      input.fullWithdrawalTargets?.map((target) => ({
+        amountRaw: target.amountRaw?.toString() ?? null,
+        liquidityMint: target.liquidityMint.toBase58(),
+        market: target.market.toBase58(),
+        reserve: target.reserve.toBase58(),
+        reserveCollateralMint: target.reserveCollateralMint?.toBase58() ?? null,
+        reserveLiquiditySupply:
+          target.reserveLiquiditySupply?.toBase58() ?? null,
+        supplyApyBps: target.supplyApyBps?.toString() ?? null,
+        vaultCollateralAta: target.vaultCollateralAta?.toBase58() ?? null,
+      })) ?? null,
+    yieldRoutingPolicy: {
+      account: input.yieldRoutingPolicy!.account.toBase58(),
+      seed: input.yieldRoutingPolicy!.seed.toString(),
+      setupPolicy: input.yieldRoutingPolicy!.setupPolicy
+        ? {
+            account: input.yieldRoutingPolicy!.setupPolicy.account.toBase58(),
+            seed: input.yieldRoutingPolicy!.setupPolicy.seed.toString(),
+          }
+        : null,
+    },
+    autodepositClose:
+      input.mode === "full" && input.autodepositClose
+        ? {
+            policy: input.autodepositClose.policy.toBase58(),
+            recurringDelegation:
+              input.autodepositClose.recurringDelegation.toBase58(),
+          }
+        : null,
+  };
+}


### PR DESCRIPTION
Adds `mobile/earn/deposit/prepare-context` and `mobile/earn/withdraw/prepare-context` — same auth/provisioning/source-selection as the existing prepare routes (withdraw resolution extracted verbatim into a shared `earn-withdraw-input-resolution.server.ts`), but returning the SDK inputs so the device builds the transactions locally, mirroring the on-device autodeposit flows. Moves the RPC-heavy prepares off the server's shared rate-limited RPC pipe, which was stretching first deposits to 1–2 minutes under launch traffic.