### PR TITLE
fix(earn): repair autodeposit token approval

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
@@ -44,6 +44,7 @@ import {
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
   recordConfirmedAutodepositDelegation,
+  recordConfirmedAutodepositTokenApproval,
   recordPendingAutodepositSetup,
   scheduleBootstrapEarnAutodepositSweep,
   type BalanceSweepTargetRecord,
@@ -318,8 +319,7 @@ function serializeScheduledSweep(
     classification: sweep.classification,
     confidence: sweep.confidence,
     eligibleAfter: sweep.eligibleAfter.toISOString(),
-    executeNowAvailableAt:
-      sweep.executeNowAvailableAt?.toISOString() ?? null,
+    executeNowAvailableAt: sweep.executeNowAvailableAt?.toISOString() ?? null,
     id: sweep.id.toString(),
     lotCount: sweep.lotCount,
     originalAmountRaw: sweep.originalAmountRaw.toString(),
@@ -402,6 +402,31 @@ async function readBootstrapWalletBalanceSnapshot(args: {
     },
     status: "ok",
   };
+}
+
+async function assertWalletTokenApproval(args: {
+  connection: Connection;
+  input: ConfirmedEarnAutodepositSetupInput;
+}) {
+  const walletUsdcAta = new PublicKey(args.input.walletUsdcAta);
+  const account = await args.connection.getAccountInfo(
+    walletUsdcAta,
+    "confirmed"
+  );
+  if (!account) {
+    throw new Error("Wallet USDC ATA does not exist.");
+  }
+
+  const tokenAccount = unpackAccount(walletUsdcAta, account, TOKEN_PROGRAM_ID);
+  const expectedDelegate = new PublicKey(args.input.subscriptionAuthority);
+  if (!tokenAccount.delegate?.equals(expectedDelegate)) {
+    throw new Error("Wallet USDC ATA delegate does not match autodeposit.");
+  }
+  if (tokenAccount.delegatedAmount < args.input.amountPerPeriodRaw) {
+    throw new Error(
+      "Wallet USDC ATA delegated amount is below autodeposit period amount."
+    );
+  }
 }
 
 function parseMobileSetupConfirmFields(
@@ -591,7 +616,8 @@ export async function POST(request: Request) {
 
   if (
     input.setupStage === "create_policy" ||
-    input.setupStage === "create_recurring_delegation"
+    input.setupStage === "create_recurring_delegation" ||
+    input.setupStage === "approve_token_delegate"
   ) {
     try {
       await withEarnAutodepositArtifactRetry(async () => {
@@ -599,9 +625,12 @@ export async function POST(request: Request) {
           connection,
           policyAccount: input.policyAccount,
           recurringDelegation: input.recurringDelegation,
-          requirePolicy: input.setupStage === "create_policy",
+          requirePolicy:
+            input.setupStage === "create_policy" ||
+            input.setupStage === "approve_token_delegate",
           requireRecurringDelegation:
-            input.setupStage === "create_recurring_delegation",
+            input.setupStage === "create_recurring_delegation" ||
+            input.setupStage === "approve_token_delegate",
           smartAccountsProgramId: new PublicKey(
             serverEnv.loyalSmartAccounts.programId
           ),
@@ -618,6 +647,25 @@ export async function POST(request: Request) {
     }
   }
 
+  if (
+    input.setupStage === "create_recurring_delegation" ||
+    input.setupStage === "approve_token_delegate"
+  ) {
+    try {
+      await withEarnAutodepositArtifactRetry(async () => {
+        await assertWalletTokenApproval({ connection, input });
+      });
+    } catch (error) {
+      return jsonError(
+        409,
+        "token_approval_missing",
+        error instanceof Error
+          ? error.message
+          : "Confirmed Autodeposit token approval is missing."
+      );
+    }
+  }
+
   if (input.setupStage === "initialize_subscription_authority") {
     return NextResponse.json({
       confirmedSlot: confirmedSlot.toString(),
@@ -627,6 +675,8 @@ export async function POST(request: Request) {
   const target =
     input.setupStage === "create_recurring_delegation"
       ? await recordConfirmedAutodepositDelegation(input)
+      : input.setupStage === "approve_token_delegate"
+      ? await recordConfirmedAutodepositTokenApproval(input)
       : await recordPendingAutodepositSetup(input);
   let bootstrapSweep: EarnAutodepositSetupConfirmResponse["bootstrapSweep"];
   if (target.active && target.lifecycleStatus === "active") {
@@ -669,7 +719,10 @@ export async function POST(request: Request) {
     }
   }
 
-  if (input.setupStage === "create_recurring_delegation") {
+  if (
+    input.setupStage === "create_recurring_delegation" ||
+    input.setupStage === "approve_token_delegate"
+  ) {
     // Transactional push (ASK-1651). When the bootstrap sweep already found
     // idle USDC, the "about to move" push implies auto-deposit is on — send
     // one push, not two.

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -22,9 +22,9 @@ import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-a
 // Mobile twin of `yield-optimization/autodeposit/setup/prepare`. Wallet-sig auth
 // + self-resolved smart account; the SDK returns the next setup stage's prepared
 // op (initialize_subscription_authority -> create_policy ->
-// create_recurring_delegation) for the device to sign. The orchestrator threads
-// the returned nonce/policySeed back into subsequent stages. Keep in sync with
-// the session route.
+// create_recurring_delegation, or approve_token_delegate repair) for the device
+// to sign. The orchestrator threads the returned nonce/policySeed back into
+// subsequent stages. Keep in sync with the session route.
 const connectionCache = new Map<SolanaEnv, Connection>();
 
 function jsonError(
@@ -166,8 +166,7 @@ export async function POST(request: Request) {
       ) {
         policySeed = target.policySeed;
         nonce = target.recurringDelegationNonce;
-        periodLengthSeconds =
-          target.periodLengthSeconds ?? periodLengthSeconds;
+        periodLengthSeconds = target.periodLengthSeconds ?? periodLengthSeconds;
         startTimestamp = target.startTimestamp ?? startTimestamp;
         expiryTimestamp =
           target.recurringDelegationExpiryTimestamp ?? expiryTimestamp;

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { AccountLayout, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Connection, PublicKey } from "@solana/web3.js";
 
 import { findCurrentUser } from "@/features/chat/server/app-user";
@@ -57,8 +58,7 @@ function serializeScheduledSweep(
     classification: sweep.classification,
     confidence: sweep.confidence,
     eligibleAfter: sweep.eligibleAfter.toISOString(),
-    executeNowAvailableAt:
-      sweep.executeNowAvailableAt?.toISOString() ?? null,
+    executeNowAvailableAt: sweep.executeNowAvailableAt?.toISOString() ?? null,
     id: sweep.id.toString(),
     lotCount: sweep.lotCount,
     originalAmountRaw: sweep.originalAmountRaw.toString(),
@@ -89,10 +89,13 @@ function buildPrepareContext(): {
       programId: getServerEnv().loyalSmartAccounts.programId,
     };
   } catch (error) {
-    console.warn("[mobile-earn-autodeposit-state] prepare context unavailable", {
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown context error.",
-    });
+    console.warn(
+      "[mobile-earn-autodeposit-state] prepare context unavailable",
+      {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown context error.",
+      }
+    );
     return null;
   }
 }
@@ -112,6 +115,41 @@ function getConnection(cluster: SolanaEnv): Connection {
   });
   connectionCache.set(cluster, connection);
   return connection;
+}
+
+async function hasExpectedWalletTokenDelegate(args: {
+  connection: Connection;
+  minimumDelegatedAmount: bigint;
+  subscriptionAuthority: string | null | undefined;
+  walletUsdcAta: string | null | undefined;
+}): Promise<boolean> {
+  if (!args.subscriptionAuthority || !args.walletUsdcAta) {
+    return false;
+  }
+
+  try {
+    const expectedDelegate = new PublicKey(args.subscriptionAuthority);
+    const account = await args.connection.getAccountInfo(
+      new PublicKey(args.walletUsdcAta),
+      "confirmed"
+    );
+    if (
+      !account ||
+      !account.owner.equals(TOKEN_PROGRAM_ID) ||
+      account.data.length < AccountLayout.span
+    ) {
+      return false;
+    }
+
+    const decoded = AccountLayout.decode(account.data);
+    return (
+      decoded.delegateOption === 1 &&
+      new PublicKey(decoded.delegate).equals(expectedDelegate) &&
+      decoded.delegatedAmount >= args.minimumDelegatedAmount
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function reconcileAutodepositArtifacts(args: {
@@ -135,6 +173,12 @@ async function reconcileAutodepositArtifacts(args: {
   const policyReady = probe.policy.exists && !probe.policy.invalidOwner;
   const delegationReady =
     probe.recurringDelegation.exists && !probe.recurringDelegation.invalidOwner;
+  const tokenApprovalReady = await hasExpectedWalletTokenDelegate({
+    connection: args.connection,
+    minimumDelegatedAmount: args.state.target.maxAmountPerPeriod,
+    subscriptionAuthority: args.state.target.subscriptionAuthority,
+    walletUsdcAta: args.state.target.walletUsdcAta,
+  });
   const hasRecordedPolicy =
     args.state.target.policySignature !== null &&
     args.state.target.policyConfirmedSlot !== null;
@@ -162,13 +206,14 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, target };
   }
 
-  if (args.state.status !== "pending" && (!policyReady || !delegationReady)) {
+  if (
+    args.state.status !== "pending" &&
+    (!policyReady || !delegationReady || !tokenApprovalReady)
+  ) {
+    const lifecycleStatus =
+      !policyReady && delegationReady ? "pending_policy" : "pending_delegation";
     const target = await markAutodepositTargetPendingDelegation({
-      lifecycleStatus: policyReady
-        ? "pending_delegation"
-        : delegationReady
-        ? "pending_policy"
-        : "pending_delegation",
+      lifecycleStatus,
       policyAccount: args.state.target.policyAccount,
       settings: args.settings,
       vaultIndex: EARN_VAULT_INDEX,
@@ -177,7 +222,12 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, status: "pending", target };
   }
 
-  if (args.state.status === "pending" && policyReady && delegationReady) {
+  if (
+    args.state.status === "pending" &&
+    policyReady &&
+    delegationReady &&
+    tokenApprovalReady
+  ) {
     let target = args.state.target;
     if (!hasRecordedPolicy || !hasRecordedDelegation) {
       // A stage transaction can land while its confirm never reaches the DB;

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -127,29 +127,30 @@ async function hasExpectedWalletTokenDelegate(args: {
     return false;
   }
 
-  try {
-    const expectedDelegate = new PublicKey(args.subscriptionAuthority);
-    const account = await args.connection.getAccountInfo(
-      new PublicKey(args.walletUsdcAta),
-      "confirmed"
-    );
-    if (
-      !account ||
-      !account.owner.equals(TOKEN_PROGRAM_ID) ||
-      account.data.length < AccountLayout.span
-    ) {
-      return false;
-    }
-
-    const decoded = AccountLayout.decode(account.data);
-    return (
-      decoded.delegateOption === 1 &&
-      new PublicKey(decoded.delegate).equals(expectedDelegate) &&
-      decoded.delegatedAmount >= args.minimumDelegatedAmount
-    );
-  } catch {
+  // Deliberately no catch: a failed RPC read must throw (failing the whole
+  // reconcile, which is served unreconciled — same contract as
+  // probeEarnAutodepositArtifacts), NOT read as "approval missing". Mapping a
+  // transient read error to false would demote a healthy ACTIVE autodeposit
+  // and silently stop its sweeps until a later state read re-promotes it.
+  const expectedDelegate = new PublicKey(args.subscriptionAuthority);
+  const account = await args.connection.getAccountInfo(
+    new PublicKey(args.walletUsdcAta),
+    "confirmed"
+  );
+  if (
+    !account ||
+    !account.owner.equals(TOKEN_PROGRAM_ID) ||
+    account.data.length < AccountLayout.span
+  ) {
     return false;
   }
+
+  const decoded = AccountLayout.decode(account.data);
+  return (
+    decoded.delegateOption === 1 &&
+    new PublicKey(decoded.delegate).equals(expectedDelegate) &&
+    decoded.delegatedAmount >= args.minimumDelegatedAmount
+  );
 }
 
 async function reconcileAutodepositArtifacts(args: {

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
   recordConfirmedAutodepositDelegation,
+  recordConfirmedAutodepositTokenApproval,
   recordPendingAutodepositSetup,
   scheduleBootstrapEarnAutodepositSweep,
   type BalanceSweepTargetRecord,
@@ -381,6 +382,31 @@ async function readBootstrapWalletBalanceSnapshot(args: {
   };
 }
 
+async function assertWalletTokenApproval(args: {
+  connection: Connection;
+  input: ConfirmedEarnAutodepositSetupInput;
+}) {
+  const walletUsdcAta = new PublicKey(args.input.walletUsdcAta);
+  const account = await args.connection.getAccountInfo(
+    walletUsdcAta,
+    "confirmed"
+  );
+  if (!account) {
+    throw new Error("Wallet USDC ATA does not exist.");
+  }
+
+  const tokenAccount = unpackAccount(walletUsdcAta, account, TOKEN_PROGRAM_ID);
+  const expectedDelegate = new PublicKey(args.input.subscriptionAuthority);
+  if (!tokenAccount.delegate?.equals(expectedDelegate)) {
+    throw new Error("Wallet USDC ATA delegate does not match autodeposit.");
+  }
+  if (tokenAccount.delegatedAmount < args.input.amountPerPeriodRaw) {
+    throw new Error(
+      "Wallet USDC ATA delegated amount is below autodeposit period amount."
+    );
+  }
+}
+
 export async function POST(request: Request) {
   const principal = await resolveAuthenticatedPrincipalFromRequest(request);
 
@@ -464,7 +490,8 @@ export async function POST(request: Request) {
 
   if (
     input.setupStage === "create_policy" ||
-    input.setupStage === "create_recurring_delegation"
+    input.setupStage === "create_recurring_delegation" ||
+    input.setupStage === "approve_token_delegate"
   ) {
     try {
       const smartAccountsProgramId = new PublicKey(
@@ -475,9 +502,12 @@ export async function POST(request: Request) {
           connection,
           policyAccount: input.policyAccount,
           recurringDelegation: input.recurringDelegation,
-          requirePolicy: input.setupStage === "create_policy",
+          requirePolicy:
+            input.setupStage === "create_policy" ||
+            input.setupStage === "approve_token_delegate",
           requireRecurringDelegation:
-            input.setupStage === "create_recurring_delegation",
+            input.setupStage === "create_recurring_delegation" ||
+            input.setupStage === "approve_token_delegate",
           smartAccountsProgramId,
         });
         await createSmartAccountVaultsClient({
@@ -491,9 +521,12 @@ export async function POST(request: Request) {
           policySeed: input.policySeed,
           policySigner: getDeploymentPolicySignerPublicKey(),
           recurringDelegation: new PublicKey(input.recurringDelegation),
-          requirePolicy: input.setupStage === "create_policy",
+          requirePolicy:
+            input.setupStage === "create_policy" ||
+            input.setupStage === "approve_token_delegate",
           requireRecurringDelegation:
-            input.setupStage === "create_recurring_delegation",
+            input.setupStage === "create_recurring_delegation" ||
+            input.setupStage === "approve_token_delegate",
           settingsPda: new PublicKey(input.settings),
           walletAddress: new PublicKey(input.walletAddress),
         });
@@ -509,6 +542,25 @@ export async function POST(request: Request) {
     }
   }
 
+  if (
+    input.setupStage === "create_recurring_delegation" ||
+    input.setupStage === "approve_token_delegate"
+  ) {
+    try {
+      await withEarnAutodepositArtifactRetry(async () => {
+        await assertWalletTokenApproval({ connection, input });
+      });
+    } catch (error) {
+      return jsonError(
+        409,
+        "token_approval_missing",
+        error instanceof Error
+          ? error.message
+          : "Confirmed Autodeposit token approval is missing."
+      );
+    }
+  }
+
   if (input.setupStage === "initialize_subscription_authority") {
     return NextResponse.json({
       confirmedSlot: confirmedSlot.toString(),
@@ -520,6 +572,8 @@ export async function POST(request: Request) {
     target =
       input.setupStage === "create_recurring_delegation"
         ? await recordConfirmedAutodepositDelegation(input)
+        : input.setupStage === "approve_token_delegate"
+        ? await recordConfirmedAutodepositTokenApproval(input)
         : await recordPendingAutodepositSetup(input);
   } catch (error) {
     const message =

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { AccountLayout, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Connection, PublicKey } from "@solana/web3.js";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
@@ -72,6 +73,41 @@ function getConnection(cluster: SolanaEnv): Connection {
   return connection;
 }
 
+async function hasExpectedWalletTokenDelegate(args: {
+  connection: Connection;
+  minimumDelegatedAmount: bigint;
+  subscriptionAuthority: string | null | undefined;
+  walletUsdcAta: string | null | undefined;
+}): Promise<boolean> {
+  if (!args.subscriptionAuthority || !args.walletUsdcAta) {
+    return false;
+  }
+
+  try {
+    const expectedDelegate = new PublicKey(args.subscriptionAuthority);
+    const account = await args.connection.getAccountInfo(
+      new PublicKey(args.walletUsdcAta),
+      "confirmed"
+    );
+    if (
+      !account ||
+      !account.owner.equals(TOKEN_PROGRAM_ID) ||
+      account.data.length < AccountLayout.span
+    ) {
+      return false;
+    }
+
+    const decoded = AccountLayout.decode(account.data);
+    return (
+      decoded.delegateOption === 1 &&
+      new PublicKey(decoded.delegate).equals(expectedDelegate) &&
+      decoded.delegatedAmount >= args.minimumDelegatedAmount
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function reconcileAutodepositArtifacts(args: {
   connection: Connection;
   settings: string;
@@ -93,6 +129,12 @@ async function reconcileAutodepositArtifacts(args: {
   const policyReady = probe.policy.exists && !probe.policy.invalidOwner;
   const delegationReady =
     probe.recurringDelegation.exists && !probe.recurringDelegation.invalidOwner;
+  const tokenApprovalReady = await hasExpectedWalletTokenDelegate({
+    connection: args.connection,
+    minimumDelegatedAmount: args.state.target.maxAmountPerPeriod,
+    subscriptionAuthority: args.state.target.subscriptionAuthority,
+    walletUsdcAta: args.state.target.walletUsdcAta,
+  });
   const hasRecordedPolicy =
     args.state.target.policySignature !== null &&
     args.state.target.policyConfirmedSlot !== null;
@@ -120,13 +162,14 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, target };
   }
 
-  if (args.state.status !== "pending" && (!policyReady || !delegationReady)) {
+  if (
+    args.state.status !== "pending" &&
+    (!policyReady || !delegationReady || !tokenApprovalReady)
+  ) {
+    const lifecycleStatus =
+      !policyReady && delegationReady ? "pending_policy" : "pending_delegation";
     const target = await markAutodepositTargetPendingDelegation({
-      lifecycleStatus: policyReady
-        ? "pending_delegation"
-        : delegationReady
-        ? "pending_policy"
-        : "pending_delegation",
+      lifecycleStatus,
       policyAccount: args.state.target.policyAccount,
       settings: args.settings,
       vaultIndex: EARN_VAULT_INDEX,
@@ -135,7 +178,12 @@ async function reconcileAutodepositArtifacts(args: {
     return { ...args.state, status: "pending", target };
   }
 
-  if (args.state.status === "pending" && policyReady && delegationReady) {
+  if (
+    args.state.status === "pending" &&
+    policyReady &&
+    delegationReady &&
+    tokenApprovalReady
+  ) {
     let target = args.state.target;
     if (!hasRecordedPolicy || !hasRecordedDelegation) {
       // A stage transaction can land while its confirm never reaches the DB;

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -83,29 +83,30 @@ async function hasExpectedWalletTokenDelegate(args: {
     return false;
   }
 
-  try {
-    const expectedDelegate = new PublicKey(args.subscriptionAuthority);
-    const account = await args.connection.getAccountInfo(
-      new PublicKey(args.walletUsdcAta),
-      "confirmed"
-    );
-    if (
-      !account ||
-      !account.owner.equals(TOKEN_PROGRAM_ID) ||
-      account.data.length < AccountLayout.span
-    ) {
-      return false;
-    }
-
-    const decoded = AccountLayout.decode(account.data);
-    return (
-      decoded.delegateOption === 1 &&
-      new PublicKey(decoded.delegate).equals(expectedDelegate) &&
-      decoded.delegatedAmount >= args.minimumDelegatedAmount
-    );
-  } catch {
+  // Deliberately no catch: a failed RPC read must throw (failing the whole
+  // reconcile, which is served unreconciled — same contract as
+  // probeEarnAutodepositArtifacts), NOT read as "approval missing". Mapping a
+  // transient read error to false would demote a healthy ACTIVE autodeposit
+  // and silently stop its sweeps until a later state read re-promotes it.
+  const expectedDelegate = new PublicKey(args.subscriptionAuthority);
+  const account = await args.connection.getAccountInfo(
+    new PublicKey(args.walletUsdcAta),
+    "confirmed"
+  );
+  if (
+    !account ||
+    !account.owner.equals(TOKEN_PROGRAM_ID) ||
+    account.data.length < AccountLayout.span
+  ) {
     return false;
   }
+
+  const decoded = AccountLayout.decode(account.data);
+  return (
+    decoded.delegateOption === 1 &&
+    new PublicKey(decoded.delegate).equals(expectedDelegate) &&
+    decoded.delegatedAmount >= args.minimumDelegatedAmount
+  );
 }
 
 async function reconcileAutodepositArtifacts(args: {

--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -6417,31 +6417,14 @@ export function useSmartAccountSidebarData(
                 : "Failed to record confirmed Autodeposit setup.",
           };
         }
-        const nextPreparedSetup =
-          preparedSetup.stage === "create_recurring_delegation"
-            ? null
-            : preparedSetup.stage === "create_policy"
-            ? (
-                await prepareEarnAutodepositSetupBatch({
-                  amountRaw: request.amountRaw,
-                  expiryTimestamp:
-                    request.expiryTimestamp ??
-                    preparedSetup.subscription.expiryTimestamp,
-                  nonce: preparedSetup.subscription.nonce,
-                  periodLengthSeconds:
-                    request.periodLengthSeconds ??
-                    preparedSetup.subscription.periodLengthSeconds,
-                  policySeed: preparedSetup.policy.seed ?? undefined,
-                  preparedSetup,
-                  refreshImmediateStartTimestamp:
-                    requestedStartTimestamp === undefined,
-                  // Undefined means "immediate"; let the builder resolve it
-                  // after policy confirmation so the delegation start is not stale.
-                  startTimestamp: requestedStartTimestamp,
-                  walletBalanceFloorRaw: request.walletBalanceFloorRaw,
-                })
-              ).nextPreparedSetup
-            : await prepareEarnAutodepositSetup({
+        const completedAutodepositSetup =
+          preparedSetup.stage === "create_recurring_delegation" ||
+          preparedSetup.stage === "approve_token_delegate";
+        const nextPreparedSetup = completedAutodepositSetup
+          ? null
+          : preparedSetup.stage === "create_policy"
+          ? (
+              await prepareEarnAutodepositSetupBatch({
                 amountRaw: request.amountRaw,
                 expiryTimestamp:
                   request.expiryTimestamp ??
@@ -6451,19 +6434,37 @@ export function useSmartAccountSidebarData(
                   request.periodLengthSeconds ??
                   preparedSetup.subscription.periodLengthSeconds,
                 policySeed: preparedSetup.policy.seed ?? undefined,
+                preparedSetup,
+                refreshImmediateStartTimestamp:
+                  requestedStartTimestamp === undefined,
+                // Undefined means "immediate"; let the builder resolve it
+                // after policy confirmation so the delegation start is not stale.
                 startTimestamp: requestedStartTimestamp,
                 walletBalanceFloorRaw: request.walletBalanceFloorRaw,
-              });
+              })
+            ).nextPreparedSetup
+          : await prepareEarnAutodepositSetup({
+              amountRaw: request.amountRaw,
+              expiryTimestamp:
+                request.expiryTimestamp ??
+                preparedSetup.subscription.expiryTimestamp,
+              nonce: preparedSetup.subscription.nonce,
+              periodLengthSeconds:
+                request.periodLengthSeconds ??
+                preparedSetup.subscription.periodLengthSeconds,
+              policySeed: preparedSetup.policy.seed ?? undefined,
+              startTimestamp: requestedStartTimestamp,
+              walletBalanceFloorRaw: request.walletBalanceFloorRaw,
+            });
 
         const nextEarnState = await fetchEarnState();
         if (nextEarnState) {
           setEarnState(nextEarnState);
         }
         const scheduledSweeps =
-          confirmResponse.bootstrapSweep?.sweep &&
-          preparedSetup.stage === "create_recurring_delegation"
+          confirmResponse.bootstrapSweep?.sweep && completedAutodepositSetup
             ? [confirmResponse.bootstrapSweep.sweep]
-            : preparedSetup.stage === "create_recurring_delegation"
+            : completedAutodepositSetup
             ? nextEarnState?.autodeposit?.scheduledSweeps ?? []
             : undefined;
 

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared.ts
@@ -26,6 +26,7 @@ export type EarnAutodepositSetupPrepareRequestBody = {
 
 export type EarnAutodepositSetupStage =
   | "initialize_subscription_authority"
+  | "approve_token_delegate"
   | "create_policy"
   | "create_recurring_delegation";
 
@@ -312,6 +313,7 @@ function readSetupStage(
   const value = readRequiredString(body, "setupStage");
   if (
     value !== "initialize_subscription_authority" &&
+    value !== "approve_token_delegate" &&
     value !== "create_policy" &&
     value !== "create_recurring_delegation"
   ) {

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -204,7 +204,10 @@ function resolveEarnAutodepositStatus(
 }
 
 function hasRecordedAutodepositPolicy(
-  target: Pick<BalanceSweepTargetRecord, "policyConfirmedSlot" | "policySignature">
+  target: Pick<
+    BalanceSweepTargetRecord,
+    "policyConfirmedSlot" | "policySignature"
+  >
 ): boolean {
   return Boolean(
     target.policySignature &&
@@ -867,8 +870,7 @@ export async function findPendingEarnAutodepositScheduledSweeps(
     ORDER BY aggregated.eligible_after ASC, aggregated.first_lot_created_at ASC NULLS LAST, aggregated.slot_id ASC
   `);
 
-  const executeNowAvailableAt =
-    resolveEarnAutodepositDelegationReadyAt(target);
+  const executeNowAvailableAt = resolveEarnAutodepositDelegationReadyAt(target);
 
   return getExecuteRows(queryResult).map((row) => ({
     classification: String(row.classification),
@@ -1541,7 +1543,10 @@ function resolveMergedLastSeen(args: {
   existing: BalanceSweepTargetRecord | null;
   input: ConfirmedEarnAutodepositSetupInput;
 }): { lastSeenSignature: string; lastSeenSlot: bigint } {
-  if (!args.existing || args.input.confirmedSlot >= args.existing.lastSeenSlot) {
+  if (
+    !args.existing ||
+    args.input.confirmedSlot >= args.existing.lastSeenSlot
+  ) {
     return {
       lastSeenSignature: args.input.setupSignature,
       lastSeenSlot: args.input.confirmedSlot,
@@ -1564,8 +1569,12 @@ function mergedTargetActiveSql() {
 function mergedTargetLifecycleStatusSql() {
   return sql`CASE
     WHEN ${mergedTargetActiveSql()} THEN 'active'
-    WHEN COALESCE(${balanceSweepTargets.policySignature}, excluded.policy_signature) IS NOT NULL
-      AND COALESCE(${balanceSweepTargets.policyConfirmedSlot}, excluded.policy_confirmed_slot) IS NOT NULL
+    WHEN COALESCE(${
+      balanceSweepTargets.policySignature
+    }, excluded.policy_signature) IS NOT NULL
+      AND COALESCE(${
+        balanceSweepTargets.policyConfirmedSlot
+      }, excluded.policy_confirmed_slot) IS NOT NULL
       THEN 'pending_delegation'
     ELSE 'pending_policy'
   END`;
@@ -1772,6 +1781,73 @@ export async function recordConfirmedAutodepositDelegation(
   }
 
   return recordAutodepositSetupConfirmation(input, dependencies);
+}
+
+export async function recordConfirmedAutodepositTokenApproval(
+  input: ConfirmedEarnAutodepositSetupInput,
+  dependencies: EarnAutodepositRepositoryDependencies = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  if (input.setupStage !== "approve_token_delegate") {
+    throw new Error(
+      "Autodeposit token approval repair requires approval stage."
+    );
+  }
+
+  const { client } = dependencies;
+  const now = dependencies.now();
+  const existing = await findTargetForAutodepositSetup({
+    client,
+    policyAccount: input.policyAccount,
+    recurringDelegation: input.recurringDelegation,
+  });
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist for approval repair.");
+  }
+  assertTargetCanResumeAutodepositSetup(existing, input);
+  if (!hasRecordedAutodepositPolicy(existing)) {
+    throw new Error("Autodeposit approval repair requires a recorded policy.");
+  }
+  if (!hasRecordedAutodepositDelegation(existing)) {
+    throw new Error(
+      "Autodeposit approval repair requires a recorded recurring delegation."
+    );
+  }
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      active: true,
+      cluster: input.cluster,
+      closeSignature: null,
+      closeSlot: null,
+      closedAt: null,
+      delegatedSigners: [input.delegatedSigner],
+      lastSeenAt: now,
+      lastSeenSignature: input.setupSignature,
+      lastSeenSlot: input.confirmedSlot,
+      lifecycleStatus: "active",
+      maxAmountPerPeriod: input.amountPerPeriodRaw,
+      periodLengthSeconds: input.periodLengthSeconds,
+      recurringDelegationExpiryTimestamp: input.expiryTimestamp,
+      recurringDelegationNonce: input.nonce,
+      startTimestamp: input.startTimestamp,
+      subscriptionAuthority: input.subscriptionAuthority,
+      tokenMint: input.liquidityMint,
+      vaultPubkey: input.vaultPubkey,
+      vaultTokenAta: input.vaultUsdcAta,
+      vaultUsdcAta: input.vaultUsdcAta,
+      walletBalanceFloorRaw: input.walletBalanceFloorRaw,
+      walletTokenAta: input.walletUsdcAta,
+      walletUsdcAta: input.walletUsdcAta,
+    })
+    .where(eq(balanceSweepTargets.id, existing.id))
+    .returning();
+
+  if (!target) {
+    throw new Error("Failed to record autodeposit approval repair.");
+  }
+
+  return target;
 }
 
 export async function recordClosedAutodepositTarget(
@@ -2345,10 +2421,10 @@ export async function markAutodepositTargetPendingDelegation(
   const [target] = await client.db
     .update(balanceSweepTargets)
     .set({
-        active: false,
-        lastSeenAt: dependencies.now(),
-        lifecycleStatus: input.lifecycleStatus ?? "pending_delegation",
-      })
+      active: false,
+      lastSeenAt: dependencies.now(),
+      lifecycleStatus: input.lifecycleStatus ?? "pending_delegation",
+    })
     .where(
       and(
         eq(balanceSweepTargets.policyAccount, input.policyAccount),
@@ -2566,13 +2642,17 @@ export async function backfillAutodepositTargetStageProofs(
       ...(input.policyProof
         ? {
             policySignature: sql`COALESCE(${balanceSweepTargets.policySignature}, ${input.policyProof.signature})`,
-            policyConfirmedSlot: sql`COALESCE(${balanceSweepTargets.policyConfirmedSlot}, ${input.policyProof.confirmedSlot.toString()}::bigint)`,
+            policyConfirmedSlot: sql`COALESCE(${
+              balanceSweepTargets.policyConfirmedSlot
+            }, ${input.policyProof.confirmedSlot.toString()}::bigint)`,
           }
         : {}),
       ...(input.recurringDelegationProof
         ? {
             recurringDelegationSignature: sql`COALESCE(${balanceSweepTargets.recurringDelegationSignature}, ${input.recurringDelegationProof.signature})`,
-            recurringDelegationConfirmedSlot: sql`COALESCE(${balanceSweepTargets.recurringDelegationConfirmedSlot}, ${input.recurringDelegationProof.confirmedSlot.toString()}::bigint)`,
+            recurringDelegationConfirmedSlot: sql`COALESCE(${
+              balanceSweepTargets.recurringDelegationConfirmedSlot
+            }, ${input.recurringDelegationProof.confirmedSlot.toString()}::bigint)`,
           }
         : {}),
     })

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -20,6 +20,8 @@ import {
 import {
   AccountLayout,
   ASSOCIATED_TOKEN_PROGRAM_ID,
+  decodeApproveCheckedInstruction,
+  decodeRevokeInstruction,
   decodeTransferCheckedInstruction,
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,
@@ -315,6 +317,15 @@ function deriveVaultUsdcAta() {
   );
 }
 
+function deriveWalletUsdcAta() {
+  return getAssociatedTokenAddressSync(
+    STABLECOIN_MINTS[Stablecoin.USDC],
+    walletAddress,
+    false,
+    TOKEN_PROGRAM_ID
+  );
+}
+
 function createSerializedEarnPolicyAccount(seed = new BN(1)) {
   const [data] = Policy.fromArgs({
     bump: 255,
@@ -475,13 +486,28 @@ function createSerializedKaminoObligationData(args: {
 
 function createTokenAccountData(args: {
   amountRaw: bigint;
+  delegatedAmountRaw?: bigint;
+  delegate?: PublicKey;
   mint?: PublicKey;
   owner?: PublicKey;
 }): Buffer {
   const data = Buffer.alloc(AccountLayout.span);
-  (args.mint ?? STABLECOIN_MINTS[Stablecoin.USDC]).toBuffer().copy(data, 0);
-  (args.owner ?? deriveVault()).toBuffer().copy(data, 32);
-  data.writeBigUInt64LE(args.amountRaw, 64);
+  AccountLayout.encode(
+    {
+      amount: args.amountRaw,
+      closeAuthority: PublicKey.default,
+      closeAuthorityOption: 0,
+      delegatedAmount: args.delegatedAmountRaw ?? BigInt(0),
+      delegate: args.delegate ?? PublicKey.default,
+      delegateOption: args.delegate ? 1 : 0,
+      isNative: BigInt(0),
+      isNativeOption: 0,
+      mint: args.mint ?? STABLECOIN_MINTS[Stablecoin.USDC],
+      owner: args.owner ?? deriveVault(),
+      state: 1,
+    },
+    data
+  );
   return data;
 }
 
@@ -496,6 +522,29 @@ function expectSyncExecutionUsesSettingsConsensus(
 ) {
   expect(instruction?.programId.toBase58()).toBe(programId.toBase58());
   expect(instruction?.keys[0]?.pubkey.toBase58()).toBe(settingsPda.toBase58());
+}
+
+function expectAutodepositApproveCheckedInstruction(
+  instruction: TransactionInstruction | undefined
+) {
+  expect(instruction?.programId.toBase58()).toBe(TOKEN_PROGRAM_ID.toBase58());
+  const decoded = decodeApproveCheckedInstruction(instruction!);
+  expect(decoded.keys.account.pubkey.toBase58()).toBe(
+    deriveWalletUsdcAta().toBase58()
+  );
+  expect(decoded.keys.mint.pubkey.toBase58()).toBe(
+    STABLECOIN_MINTS[Stablecoin.USDC].toBase58()
+  );
+  expect(decoded.keys.delegate.pubkey.toBase58()).toBe(
+    deriveSubscriptionAuthority(
+      walletAddress,
+      STABLECOIN_MINTS[Stablecoin.USDC]
+    ).toBase58()
+  );
+  expect(decoded.keys.owner.pubkey.toBase58()).toBe(walletAddress.toBase58());
+  expect(decoded.keys.owner.isSigner).toBe(true);
+  expect(decoded.data.amount).toBe((BigInt(1) << BigInt(64)) - BigInt(1));
+  expect(decoded.data.decimals).toBe(6);
 }
 
 function expectIncludesKaminoSetupAccount(
@@ -2349,14 +2398,11 @@ describe("prepareEarnUsdcAutodeposit", () => {
       "create_policy",
       "create_recurring_delegation",
     ]);
-    expect(setups[0]!.subscription.startTimestamp).toBe(
-      BigInt(1_780_000_000)
-    );
-    expect(setups[1]!.subscription.startTimestamp).toBe(
-      BigInt(1_780_000_030)
-    );
-    // Settings + subscription authority + wallet USDC ATA delegate probe.
-    expect(getAccountInfo).toHaveBeenCalledTimes(3);
+    expect(setups[0]!.subscription.startTimestamp).toBe(BigInt(1_780_000_000));
+    expect(setups[1]!.subscription.startTimestamp).toBe(BigInt(1_780_000_030));
+    // Settings + subscription authority. Policy/delegation/vault/wallet ATA
+    // state is batched below.
+    expect(getAccountInfo).toHaveBeenCalledTimes(2);
     expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
     const firstProbe = getMultipleAccountsInfo.mock.calls[0]?.[0] as
       | PublicKey[]
@@ -2365,6 +2411,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
       setups[0]!.policy.account!.toBase58(),
       setups[0]!.subscription.recurringDelegation.toBase58(),
       deriveVaultUsdcAta().toBase58(),
+      deriveWalletUsdcAta().toBase58(),
     ]);
   });
 
@@ -2444,8 +2491,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
       if (nonSettingsLookupCount === 1) {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
-      // Lookup 2 is the wallet USDC ATA delegate probe (null = no re-init).
-      if (nonSettingsLookupCount === 3) {
+      if (nonSettingsLookupCount === 2) {
         return createSerializedEarnPolicyAccount();
       }
       return null;
@@ -2472,11 +2518,12 @@ describe("prepareEarnUsdcAutodeposit", () => {
     });
 
     expect(result.stage).toBe("create_recurring_delegation");
-    expect(result.prepared.instructions).toHaveLength(2);
+    expect(result.prepared.instructions).toHaveLength(3);
     expect(result.prepared.instructions[0]?.programId.toBase58()).toBe(
       ASSOCIATED_TOKEN_PROGRAM_ID.toBase58()
     );
-    expect(result.prepared.instructions[1]?.programId.toBase58()).toBe(
+    expectAutodepositApproveCheckedInstruction(result.prepared.instructions[1]);
+    expect(result.prepared.instructions[2]?.programId.toBase58()).toBe(
       SUBSCRIPTIONS_PROGRAM_ID.toBase58()
     );
     expect(() =>
@@ -2602,10 +2649,11 @@ describe("prepareEarnUsdcAutodeposit", () => {
       result.policy.account!.toBase58(),
       result.subscription.recurringDelegation.toBase58(),
       deriveVaultUsdcAta().toBase58(),
+      deriveWalletUsdcAta().toBase58(),
     ]);
   });
 
-  test("rejects setup when policy and recurring delegation already exist", async () => {
+  test("repairs setup when policy and recurring delegation exist without token approval", async () => {
     let nonSettingsLookupCount = 0;
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(settingsPda)) {
@@ -2618,7 +2666,119 @@ describe("prepareEarnUsdcAutodeposit", () => {
       if (nonSettingsLookupCount === 2) {
         return createSerializedEarnPolicyAccount();
       }
-      return createSerializedRecurringDelegationAccount();
+      if (nonSettingsLookupCount === 3) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcAutodepositSetup({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      signer: walletAddress,
+      policySigner: backendSigner,
+      amountRaw: BigInt(1_000_000),
+      nonce: BigInt(42),
+    });
+
+    expect(result.stage).toBe("approve_token_delegate");
+    expect(result.prepared.instructions).toHaveLength(1);
+    expectAutodepositApproveCheckedInstruction(result.prepared.instructions[0]);
+  });
+
+  test("repairs setup when policy and recurring delegation exist with a foreign token approval", async () => {
+    const foreignDelegate = new PublicKey("1111111111111111111111111111111C");
+    let nonSettingsLookupCount = 0;
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(settingsPda)) {
+        return createSerializedSettingsAccount();
+      }
+      nonSettingsLookupCount += 1;
+      if (nonSettingsLookupCount === 1) {
+        return createSerializedSubscriptionAuthorityAccount(BigInt(7));
+      }
+      if (nonSettingsLookupCount === 2) {
+        return createSerializedEarnPolicyAccount();
+      }
+      if (nonSettingsLookupCount === 3) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      if (nonSettingsLookupCount === 5) {
+        return {
+          data: createTokenAccountData({
+            amountRaw: BigInt(1_000_000),
+            delegatedAmountRaw: BigInt(1),
+            delegate: foreignDelegate,
+            owner: walletAddress,
+          }),
+          executable: false,
+          lamports: 1,
+          owner: TOKEN_PROGRAM_ID,
+          rentEpoch: 0,
+        };
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcAutodepositSetup({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      signer: walletAddress,
+      policySigner: backendSigner,
+      amountRaw: BigInt(1_000_000),
+      nonce: BigInt(42),
+    });
+
+    expect(result.stage).toBe("approve_token_delegate");
+    expect(result.prepared.instructions).toHaveLength(1);
+    expectAutodepositApproveCheckedInstruction(result.prepared.instructions[0]);
+  });
+
+  test("rejects setup when policy, recurring delegation, and token approval already exist", async () => {
+    const subscriptionAuthority = deriveSubscriptionAuthority(
+      walletAddress,
+      STABLECOIN_MINTS[Stablecoin.USDC]
+    );
+    let nonSettingsLookupCount = 0;
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(settingsPda)) {
+        return createSerializedSettingsAccount();
+      }
+      nonSettingsLookupCount += 1;
+      if (nonSettingsLookupCount === 1) {
+        return createSerializedSubscriptionAuthorityAccount(BigInt(7));
+      }
+      if (nonSettingsLookupCount === 2) {
+        return createSerializedEarnPolicyAccount();
+      }
+      if (nonSettingsLookupCount === 3) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      if (nonSettingsLookupCount === 5) {
+        return {
+          data: createTokenAccountData({
+            amountRaw: BigInt(1_000_000),
+            delegatedAmountRaw: BigInt(1_000_000),
+            delegate: subscriptionAuthority,
+            owner: walletAddress,
+          }),
+          executable: false,
+          lamports: 1,
+          owner: TOKEN_PROGRAM_ID,
+          rentEpoch: 0,
+        };
+      }
+      return null;
     });
     const client = createSmartAccountVaultsClient({
       connection: { getAccountInfo } as never,
@@ -2640,9 +2800,69 @@ describe("prepareEarnUsdcAutodeposit", () => {
     );
   });
 
+  test("repairs setup when expected token approval is below the period amount", async () => {
+    const subscriptionAuthority = deriveSubscriptionAuthority(
+      walletAddress,
+      STABLECOIN_MINTS[Stablecoin.USDC]
+    );
+    let nonSettingsLookupCount = 0;
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(settingsPda)) {
+        return createSerializedSettingsAccount();
+      }
+      nonSettingsLookupCount += 1;
+      if (nonSettingsLookupCount === 1) {
+        return createSerializedSubscriptionAuthorityAccount(BigInt(7));
+      }
+      if (nonSettingsLookupCount === 2) {
+        return createSerializedEarnPolicyAccount();
+      }
+      if (nonSettingsLookupCount === 3) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      if (nonSettingsLookupCount === 5) {
+        return {
+          data: createTokenAccountData({
+            amountRaw: BigInt(1_000_000),
+            delegatedAmountRaw: BigInt(1),
+            delegate: subscriptionAuthority,
+            owner: walletAddress,
+          }),
+          executable: false,
+          lamports: 1,
+          owner: TOKEN_PROGRAM_ID,
+          rentEpoch: 0,
+        };
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcAutodepositSetup({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      signer: walletAddress,
+      policySigner: backendSigner,
+      amountRaw: BigInt(1_000_000),
+      nonce: BigInt(42),
+    });
+
+    expect(result.stage).toBe("approve_token_delegate");
+    expect(result.prepared.instructions).toHaveLength(1);
+    expectAutodepositApproveCheckedInstruction(result.prepared.instructions[0]);
+  });
+
   test("builds close policy removal with backend signer metadata", async () => {
     const recurringDelegation = new PublicKey(
       "11111111111111111111111111111116"
+    );
+    const subscriptionAuthority = deriveSubscriptionAuthority(
+      walletAddress,
+      STABLECOIN_MINTS[Stablecoin.USDC]
     );
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(policyAccount)) {
@@ -2650,6 +2870,78 @@ describe("prepareEarnUsdcAutodeposit", () => {
       }
       if (address.equals(recurringDelegation)) {
         return createSerializedRecurringDelegationAccount();
+      }
+      if (address.equals(deriveWalletUsdcAta())) {
+        return {
+          data: createTokenAccountData({
+            amountRaw: BigInt(1_000_000),
+            delegatedAmountRaw: BigInt(1),
+            delegate: subscriptionAuthority,
+            owner: walletAddress,
+          }),
+          executable: false,
+          lamports: 1,
+          owner: TOKEN_PROGRAM_ID,
+          rentEpoch: 0,
+        };
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcAutodepositClose({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      signer: walletAddress,
+      policySigner: backendSigner,
+      policy: policyAccount,
+      recurringDelegation,
+    });
+
+    expect(result.prepared.instructions).toHaveLength(3);
+    expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[1]);
+    const revoke = decodeRevokeInstruction(result.prepared.instructions[2]!);
+    expect(revoke.keys.account.pubkey.toBase58()).toBe(
+      deriveWalletUsdcAta().toBase58()
+    );
+    expect(revoke.keys.owner.pubkey.toBase58()).toBe(walletAddress.toBase58());
+    expect(revoke.keys.owner.isSigner).toBe(true);
+    expect(result.persistence).toMatchObject({
+      delegatedSigner: backendSigner.toBase58(),
+      policyAccount: policyAccount.toBase58(),
+      walletAddress: walletAddress.toBase58(),
+    });
+  });
+
+  test("preserves a foreign wallet token delegate during autodeposit close", async () => {
+    const recurringDelegation = new PublicKey(
+      "11111111111111111111111111111116"
+    );
+    const foreignDelegate = new PublicKey("1111111111111111111111111111111C");
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(policyAccount)) {
+        return createSerializedEarnPolicyAccount();
+      }
+      if (address.equals(recurringDelegation)) {
+        return createSerializedRecurringDelegationAccount();
+      }
+      if (address.equals(deriveWalletUsdcAta())) {
+        return {
+          data: createTokenAccountData({
+            amountRaw: BigInt(1_000_000),
+            delegatedAmountRaw: BigInt(1),
+            delegate: foreignDelegate,
+            owner: walletAddress,
+          }),
+          executable: false,
+          lamports: 1,
+          owner: TOKEN_PROGRAM_ID,
+          rentEpoch: 0,
+        };
       }
       return null;
     });
@@ -2670,11 +2962,6 @@ describe("prepareEarnUsdcAutodeposit", () => {
 
     expect(result.prepared.instructions).toHaveLength(2);
     expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[1]);
-    expect(result.persistence).toMatchObject({
-      delegatedSigner: backendSigner.toBase58(),
-      policyAccount: policyAccount.toBase58(),
-      walletAddress: walletAddress.toBase58(),
-    });
   });
 
   test("omits the delegation revoke when the delegation was never created", async () => {

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -71,6 +71,7 @@ import {
 import { decodeSolanaInstruction } from "@loyal-labs/solana-instruction-decoder";
 import {
   AccountLayout,
+  createApproveCheckedInstruction,
   createAssociatedTokenAccountIdempotentInstruction,
   createCloseAccountInstruction,
   createRevokeInstruction,
@@ -209,6 +210,8 @@ const EARN_DEPOSIT_VAULT_INDEX = 1 as const;
 const EARN_SAME_MINT_INSTRUCTION_CONSTRAINT_INDEXES = [0, 1] as const;
 const EARN_POLICY_PACKET_DATA_SIZE = 1232;
 const EARN_DEPOSIT_USDC_DECIMALS = 6;
+const EARN_AUTODEPOSIT_TOKEN_APPROVAL_ALLOWANCE_RAW =
+  (BigInt(1) << BigInt(64)) - BigInt(1);
 const EARN_RISK_PROFILE = RiskBasket.Safe;
 const EARN_ROUTE_MODES = ["same_mint_kamino"] as const;
 const EARN_UNIVERSE_PRESET = "canonical_stable_kamino";
@@ -3601,6 +3604,45 @@ function readSubscriptionAuthorityInitId(
   ).getBigInt64(0, true);
 }
 
+function readSplTokenDelegate(
+  account: AccountInfo<Buffer> | null | undefined
+): { delegate: PublicKey | null; delegatedAmount: bigint } {
+  if (
+    !account ||
+    !account.owner.equals(TOKEN_PROGRAM_ID) ||
+    account.data.length < AccountLayout.span
+  ) {
+    return { delegate: null, delegatedAmount: BigInt(0) };
+  }
+
+  const decoded = AccountLayout.decode(account.data);
+  return {
+    delegate:
+      decoded.delegateOption === 1 ? new PublicKey(decoded.delegate) : null,
+    delegatedAmount: decoded.delegatedAmount,
+  };
+}
+
+function hasExpectedSplTokenDelegateAuthority(args: {
+  account: AccountInfo<Buffer> | null | undefined;
+  expectedDelegate: PublicKey;
+}): boolean {
+  const delegate = readSplTokenDelegate(args.account);
+  return delegate.delegate?.equals(args.expectedDelegate) === true;
+}
+
+function hasSufficientExpectedSplTokenDelegate(args: {
+  account: AccountInfo<Buffer> | null | undefined;
+  expectedDelegate: PublicKey;
+  minimumDelegatedAmount: bigint;
+}): boolean {
+  const delegate = readSplTokenDelegate(args.account);
+  return (
+    delegate.delegate?.equals(args.expectedDelegate) === true &&
+    delegate.delegatedAmount >= args.minimumDelegatedAmount
+  );
+}
+
 function normalizeAutodepositU64(value: bigint, name: string): bigint {
   const max = (BigInt(1) << BigInt(64)) - BigInt(1);
   if (value < BigInt(0) || value > max) {
@@ -6671,8 +6713,7 @@ export function createSmartAccountVaultsClient(
     let preparedLength = preparedPacketLength(prepared);
     if (
       strayDelegateRevokeInstruction &&
-      (preparedLength === null ||
-        preparedLength > EARN_POLICY_PACKET_DATA_SIZE)
+      (preparedLength === null || preparedLength > EARN_POLICY_PACKET_DATA_SIZE)
     ) {
       // The heal rider must never sink a deposit: drop it when the tx is at
       // the packet ceiling — a later deposit or delete re-heals the wallet.
@@ -8677,6 +8718,7 @@ export function createSmartAccountVaultsClient(
   type EarnAutodepositSetupAccountState = {
     delegationAccount: AccountInfo<Buffer> | null;
     policyAccountExists: boolean;
+    walletUsdcAtaAccount: AccountInfo<Buffer> | null;
     vaultUsdcAtaExists: boolean | undefined;
   };
 
@@ -8860,30 +8902,7 @@ export function createSmartAccountVaultsClient(
         "confirmed"
       );
     }
-    // A close revokes the wallet USDC ATA's SPL delegate; an authority account
-    // that survives with a missing/foreign delegate can't sweep, so re-run
-    // InitAuthority — the program re-approves the delegate and bumps its init
-    // id (delegations pin the previous id, so stale ones stay dead).
-    let authorityDelegateMissing = false;
-    if (authorityAccount && expectedSubscriptionAuthorityInitId === null) {
-      const walletUsdcAtaInfo = await config.connection.getAccountInfo(
-        walletUsdcAta,
-        "confirmed"
-      );
-      if (
-        walletUsdcAtaInfo &&
-        walletUsdcAtaInfo.data.length >= AccountLayout.span
-      ) {
-        const decoded = AccountLayout.decode(walletUsdcAtaInfo.data);
-        authorityDelegateMissing =
-          decoded.delegateOption !== 1 ||
-          !new PublicKey(decoded.delegate).equals(subscriptionAuthority);
-      }
-    }
-    if (
-      (!authorityAccount || authorityDelegateMissing) &&
-      expectedSubscriptionAuthorityInitId === null
-    ) {
+    if (!authorityAccount && expectedSubscriptionAuthorityInitId === null) {
       const prepared = freezePreparedOperation({
         operation: "earnUsdcAutodepositInitializeSubscriptionAuthority",
         payer: args.feePayer,
@@ -8910,9 +8929,7 @@ export function createSmartAccountVaultsClient(
         rentCandidates: [
           {
             account: subscriptionAuthority,
-            // Re-init on an existing authority (delegate re-approve) pays no
-            // rent; only a first-time init creates the account.
-            exists: authorityAccount !== null,
+            exists: false,
             kind: "subscription_authority_rent",
             label: "Autodeposit subscription authority rent",
             space: SUBSCRIPTION_AUTHORITY_DATA_LEN,
@@ -8994,21 +9011,27 @@ export function createSmartAccountVaultsClient(
             policyAccountExists:
               options.assumePolicyExists ||
               accountEvidence.policyExists === true,
+            walletUsdcAtaAccount: null,
             vaultUsdcAtaExists: accountEvidence.vaultUsdcAtaExists,
           };
         }
 
         const accountInfos = await getAccountInfoMap({
-          accounts: [policyAccount, recurringDelegation, vaultUsdcAta],
+          accounts: [
+            policyAccount,
+            recurringDelegation,
+            vaultUsdcAta,
+            walletUsdcAta,
+          ],
           connection: config.connection,
         });
 
         return {
           delegationAccount:
             accountInfos.get(recurringDelegationAddress) ?? null,
-          policyAccountExists: Boolean(
-            accountInfos.get(policyAccountAddress)
-          ),
+          policyAccountExists: Boolean(accountInfos.get(policyAccountAddress)),
+          walletUsdcAtaAccount:
+            accountInfos.get(walletUsdcAta.toBase58()) ?? null,
           vaultUsdcAtaExists: Boolean(accountInfos.get(vaultUsdcAtaAddress)),
         };
       };
@@ -9044,6 +9067,17 @@ export function createSmartAccountVaultsClient(
     }
     const policyExistsForPlanning =
       options.assumePolicyExists || accountState.policyAccountExists;
+    const createTokenDelegateApprovalInstruction = () =>
+      createApproveCheckedInstruction(
+        walletUsdcAta,
+        usdcMint,
+        subscriptionAuthority,
+        args.walletAddress,
+        EARN_AUTODEPOSIT_TOKEN_APPROVAL_ALLOWANCE_RAW,
+        EARN_DEPOSIT_USDC_DECIMALS,
+        [],
+        TOKEN_PROGRAM_ID
+      );
 
     if (accountState.delegationAccount) {
       if (
@@ -9054,6 +9088,75 @@ export function createSmartAccountVaultsClient(
         );
       }
       if (policyExistsForPlanning) {
+        if (
+          !hasSufficientExpectedSplTokenDelegate({
+            account: accountState.walletUsdcAtaAccount,
+            expectedDelegate: subscriptionAuthority,
+            minimumDelegatedAmount: amountPerPeriodRaw,
+          })
+        ) {
+          const prepared = freezePreparedOperation({
+            operation: "earnUsdcAutodepositApproveTokenDelegate",
+            payer: args.feePayer,
+            programId: TOKEN_PROGRAM_ID,
+            requiresConfirmation: true,
+            instructions: [createTokenDelegateApprovalInstruction()],
+            lookupTableAccounts: [],
+          });
+          const nativeSolRequirement = await estimateNativeSolRequirement({
+            checkBalance: false,
+            cluster,
+            connection: config.connection,
+            estimateFees: false,
+            payer: args.feePayer,
+            preferStaticMainnetRent: true,
+            prepared: [prepared],
+            rentCandidates: [],
+          });
+
+          return {
+            prepared,
+            nativeSolRequirement,
+            stage: "approve_token_delegate",
+            accountEvidence: createAccountEvidence({
+              policyAccount,
+              policyExists: true,
+              policySeed,
+              recurringDelegationExists: true,
+              subscriptionAuthorityExists: true,
+              subscriptionAuthorityInitId: expectedSubscriptionAuthorityInitId,
+              subscriptionAuthorityOwnerVerified: true,
+              vaultUsdcAtaExists: accountState.vaultUsdcAtaExists,
+            }),
+            authorityInitializationRequired: false,
+            policy: {
+              account: policyAccount,
+              id: policySeed,
+              seed: policySeed,
+            },
+            vault: {
+              accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+              pubkey: vaultPda,
+              usdcAta: vaultUsdcAta,
+            },
+            subscription: {
+              authority: subscriptionAuthority,
+              recurringDelegation,
+              amountPerPeriodRaw,
+              periodLengthSeconds,
+              nonce,
+              startTimestamp,
+              expiryTimestamp,
+            },
+            persistence: {
+              ...basePersistence,
+              policyId: policySeed.toString(),
+              policyAccount: policyAccount.toBase58(),
+              policySeed: policySeed.toString(),
+              subscriptionAuthorityInitialization: "exists",
+            },
+          };
+        }
         throw new Error(
           "Autodeposit policy and recurring delegation already exist."
         );
@@ -9223,6 +9326,7 @@ export function createSmartAccountVaultsClient(
           usdcMint,
           TOKEN_PROGRAM_ID
         ),
+        createTokenDelegateApprovalInstruction(),
         createDelegationInstruction,
       ],
       lookupTableAccounts: [],
@@ -9371,12 +9475,12 @@ export function createSmartAccountVaultsClient(
       args.recurringDelegation
     );
     // The subscription program's RevokeDelegation only closes the delegation
-    // account — the unlimited SPL delegate that InitAuthority approved on the
-    // wallet's USDC ATA stays behind and shows up as a lingering token
-    // approval in wallet UIs. Revoke it in the same tx (the wallet signs the
-    // close anyway), but only when the delegate is still our subscription
-    // authority so a foreign approval is never clobbered. Setup re-approves
-    // via InitAuthority re-init when the delegate is missing.
+    // account — the SPL delegate approval on the wallet's USDC ATA stays
+    // behind and shows up as a lingering token approval in wallet UIs. Revoke
+    // it in the same tx (the wallet signs the close anyway), but only when the
+    // delegate is still our subscription authority so a foreign approval is
+    // never clobbered. Setup repairs missing/insufficient approval through the
+    // explicit approve_token_delegate stage.
     const usdcMint = getStablecoinMintForCluster(cluster, Stablecoin.USDC);
     const walletUsdcAta = getAssociatedTokenAddressSync(
       usdcMint,
@@ -9391,16 +9495,10 @@ export function createSmartAccountVaultsClient(
     const walletUsdcAtaInfo = await config.connection.getAccountInfo(
       walletUsdcAta
     );
-    let revokeTokenDelegate = false;
-    if (
-      walletUsdcAtaInfo &&
-      walletUsdcAtaInfo.data.length >= AccountLayout.span
-    ) {
-      const decoded = AccountLayout.decode(walletUsdcAtaInfo.data);
-      revokeTokenDelegate =
-        decoded.delegateOption === 1 &&
-        new PublicKey(decoded.delegate).equals(subscriptionAuthority);
-    }
+    const revokeTokenDelegate = hasExpectedSplTokenDelegateAuthority({
+      account: walletUsdcAtaInfo,
+      expectedDelegate: subscriptionAuthority,
+    });
     const prepared = freezePreparedOperation({
       operation: "earnUsdcAutodepositClose",
       payer: args.feePayer,

--- a/packages/smart-account-vaults/src/types.ts
+++ b/packages/smart-account-vaults/src/types.ts
@@ -929,6 +929,7 @@ export type SmartAccountPreparedEarnUsdcAutodepositSetup = {
   nativeSolRequirement: SmartAccountNativeSolRequirement;
   stage:
     | "initialize_subscription_authority"
+    | "approve_token_delegate"
     | "create_policy"
     | "create_recurring_delegation";
   authorityInitializationRequired: boolean;


### PR DESCRIPTION
Supersedes #471 (ASK-1726, zotho's approve_token_delegate repair stage, carried as-is) plus one fix: the state-route reconcile no longer treats a failed wallet-ATA RPC read as a missing approval — a read error now fails the reconcile loudly instead of demoting a healthy active Autodeposit and silently stopping its sweeps.