### PR TITLE
fix(earn): require an active Earn position to set up autodeposit

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
 import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -18,6 +19,7 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Mobile twin of `yield-optimization/autodeposit/setup/prepare`. Wallet-sig auth
 // + self-resolved smart account; the SDK returns the next setup stage's prepared
@@ -125,6 +127,45 @@ export async function POST(request: Request) {
 
   const solanaEnv = getConfiguredSolanaEnv();
   const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  // An Autodeposit sweep can only route into an ACTIVE Earn position — the
+  // route policy is created by a user-signed deposit, and the sweep worker
+  // (delegate) can't initialize one. Without this gate a setup on an empty
+  // Earn (e.g. after a full withdrawal) strands every sweep as a perpetual
+  // worker failure ("no active Earn route policy") that the app renders as
+  // "Executing…" forever. Fail open on lookup errors: the client gates this
+  // too, and the worker's refusal remains the last line.
+  try {
+    const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: 1,
+      programId,
+      settingsPda: new PublicKey(settingsPda),
+    });
+    const policyPair = await findActiveYieldRoutePolicyPair({
+      authority: walletAddress,
+      cluster,
+      settings: settingsPda,
+      vaultIndex: 1,
+      vaultPubkey: earnVaultPda.toBase58(),
+    });
+    if (!policyPair?.routePolicy) {
+      return jsonError(
+        409,
+        "earn_position_required",
+        "Autodeposit needs an active Earn account to deposit into. Make a deposit first."
+      );
+    }
+  } catch (error) {
+    console.warn(
+      "[mobile-earn-autodeposit-setup-prepare] earn position gate skipped",
+      {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown gate error.",
+        walletAddress,
+      }
+    );
+  }
 
   try {
     const serverEnv = getServerEnv();

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
 import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -19,7 +18,10 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
-import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-deposit-repository.server";
+import {
+  EARN_POSITION_REQUIRED_ERROR,
+  hasActiveEarnRoutePolicyPair,
+} from "@/lib/yield-optimization/earn-position-gate.server";
 
 // Mobile twin of `yield-optimization/autodeposit/setup/prepare`. Wallet-sig auth
 // + self-resolved smart account; the SDK returns the next setup stage's prepared
@@ -128,32 +130,21 @@ export async function POST(request: Request) {
   const solanaEnv = getConfiguredSolanaEnv();
   const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
 
-  // An Autodeposit sweep can only route into an ACTIVE Earn position — the
-  // route policy is created by a user-signed deposit, and the sweep worker
-  // (delegate) can't initialize one. Without this gate a setup on an empty
-  // Earn (e.g. after a full withdrawal) strands every sweep as a perpetual
-  // worker failure ("no active Earn route policy") that the app renders as
-  // "Executing…" forever. Fail open on lookup errors: the client gates this
-  // too, and the worker's refusal remains the last line.
+  // Setup on an empty Earn (e.g. after a full withdrawal) strands every sweep —
+  // see earn-position-gate.server.ts. Fail open on lookup errors: the client
+  // gates this too, and the worker's refusal remains the last line.
   try {
-    const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
-    const [earnVaultPda] = pda.getSmartAccountPda({
-      accountIndex: 1,
-      programId,
-      settingsPda: new PublicKey(settingsPda),
-    });
-    const policyPair = await findActiveYieldRoutePolicyPair({
-      authority: walletAddress,
-      cluster,
-      settings: settingsPda,
-      vaultIndex: 1,
-      vaultPubkey: earnVaultPda.toBase58(),
-    });
-    if (!policyPair?.routePolicy) {
+    if (
+      !(await hasActiveEarnRoutePolicyPair({
+        cluster,
+        settingsPda,
+        walletAddress,
+      }))
+    ) {
       return jsonError(
         409,
-        "earn_position_required",
-        "Autodeposit needs an active Earn account to deposit into. Make a deposit first."
+        EARN_POSITION_REQUIRED_ERROR.code,
+        EARN_POSITION_REQUIRED_ERROR.message
       );
     }
   } catch (error) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/sweeps/execute/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/sweeps/execute/route.ts
@@ -1,15 +1,21 @@
 import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 
 import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import {
   findCurrentEarnAutodepositState,
   requestImmediateEarnAutodepositScheduledSweep,
   type BalanceSweepTargetRecord,
   type ImmediateEarnAutodepositScheduledSweepRequestResult,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import {
+  EARN_POSITION_REQUIRED_ERROR,
+  hasActiveEarnRoutePolicyPair,
+} from "@/lib/yield-optimization/earn-position-gate.server";
 
 // Mobile twin of `yield-optimization/autodeposit/sweeps/execute`. Lets the
 // native app ask the worker to run the pending scheduled Autodeposit sweep now
@@ -158,6 +164,41 @@ export async function POST(request: Request) {
         409,
         "autodeposit_not_active",
         "Earn Autodeposit must be active before a scheduled sweep can be executed now."
+      );
+    }
+
+    // A target whose Earn position was fully withdrawn has no active route
+    // policy left — the worker refuses its sweeps ("no active Earn route
+    // policy"), so accepting the request would only mint a slot stuck on
+    // "Executing…" forever. Refuse up front with the same error the setup
+    // prepare gate uses; see earn-position-gate.server.ts. Fail open on
+    // lookup errors. Keep in sync with the session route.
+    try {
+      if (
+        !(await hasActiveEarnRoutePolicyPair({
+          cluster: resolveLoyalClusterForSolanaEnv(
+            resolveLoyalWebSolanaEnvFromEnv(process.env)
+          ),
+          settingsPda,
+          walletAddress,
+        }))
+      ) {
+        return jsonError(
+          409,
+          EARN_POSITION_REQUIRED_ERROR.code,
+          EARN_POSITION_REQUIRED_ERROR.message
+        );
+      }
+    } catch (gateError) {
+      console.warn(
+        "[mobile-earn-autodeposit-sweeps-execute] earn position gate skipped",
+        {
+          errorMessage:
+            gateError instanceof Error
+              ? gateError.message
+              : "Unknown gate error.",
+          walletAddress,
+        }
       );
     }
 

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
 import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -19,6 +20,7 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 
@@ -96,6 +98,41 @@ export async function POST(request: Request) {
           "An Autodeposit is already active for this wallet. Delete it before creating a new one."
         );
       }
+    }
+
+    // An Autodeposit sweep can only route into an ACTIVE Earn position — the
+    // route policy is created by a user-signed deposit, and the sweep worker
+    // (delegate) can't initialize one. Without this gate a setup on an empty
+    // Earn (e.g. after a full withdrawal) strands every sweep as a perpetual
+    // worker failure ("no active Earn route policy"). Fail open on lookup
+    // errors: the worker's refusal remains the last line. Keep in sync with
+    // the mobile twin route.
+    try {
+      const [earnVaultPda] = pda.getSmartAccountPda({
+        accountIndex: 1,
+        programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+        settingsPda: new PublicKey(principal.settingsPda),
+      });
+      const policyPair = await findActiveYieldRoutePolicyPair({
+        authority: principal.walletAddress,
+        cluster,
+        settings: principal.settingsPda,
+        vaultIndex: 1,
+        vaultPubkey: earnVaultPda.toBase58(),
+      });
+      if (!policyPair?.routePolicy) {
+        return jsonError(
+          409,
+          "earn_position_required",
+          "Autodeposit needs an active Earn account to deposit into. Make a deposit first."
+        );
+      }
+    } catch (error) {
+      console.warn("[autodeposit-setup-prepare] earn position gate skipped", {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown gate error.",
+        walletAddress: principal.walletAddress,
+      });
     }
 
     const serverEnv = getServerEnv();

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
 import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -20,7 +19,10 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
-import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-deposit-repository.server";
+import {
+  EARN_POSITION_REQUIRED_ERROR,
+  hasActiveEarnRoutePolicyPair,
+} from "@/lib/yield-optimization/earn-position-gate.server";
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 
@@ -100,31 +102,22 @@ export async function POST(request: Request) {
       }
     }
 
-    // An Autodeposit sweep can only route into an ACTIVE Earn position — the
-    // route policy is created by a user-signed deposit, and the sweep worker
-    // (delegate) can't initialize one. Without this gate a setup on an empty
-    // Earn (e.g. after a full withdrawal) strands every sweep as a perpetual
-    // worker failure ("no active Earn route policy"). Fail open on lookup
-    // errors: the worker's refusal remains the last line. Keep in sync with
-    // the mobile twin route.
+    // Setup on an empty Earn (e.g. after a full withdrawal) strands every
+    // sweep — see earn-position-gate.server.ts. Fail open on lookup errors:
+    // the worker's refusal remains the last line. Keep in sync with the
+    // mobile twin route.
     try {
-      const [earnVaultPda] = pda.getSmartAccountPda({
-        accountIndex: 1,
-        programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
-        settingsPda: new PublicKey(principal.settingsPda),
-      });
-      const policyPair = await findActiveYieldRoutePolicyPair({
-        authority: principal.walletAddress,
-        cluster,
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        vaultPubkey: earnVaultPda.toBase58(),
-      });
-      if (!policyPair?.routePolicy) {
+      if (
+        !(await hasActiveEarnRoutePolicyPair({
+          cluster,
+          settingsPda: principal.settingsPda,
+          walletAddress: principal.walletAddress,
+        }))
+      ) {
         return jsonError(
           409,
-          "earn_position_required",
-          "Autodeposit needs an active Earn account to deposit into. Make a deposit first."
+          EARN_POSITION_REQUIRED_ERROR.code,
+          EARN_POSITION_REQUIRED_ERROR.message
         );
       }
     } catch (error) {

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/sweeps/execute/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/sweeps/execute/route.test.ts
@@ -40,6 +40,20 @@ mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest,
 }));
 
+// The earn-position gate pulls the real DB client through
+// yield-deposit-repository.server; stub it so the route stays unit-testable.
+// Defaults to an active pair — the gate is a pass-through for these cases.
+const hasActiveEarnRoutePolicyPair = mock(async () => true);
+
+mock.module("@/lib/yield-optimization/earn-position-gate.server", () => ({
+  EARN_POSITION_REQUIRED_ERROR: {
+    code: "earn_position_required",
+    message:
+      "Autodeposit needs an active Earn account to deposit into. Make a deposit first.",
+  },
+  hasActiveEarnRoutePolicyPair,
+}));
+
 mock.module(
   "@/lib/yield-optimization/earn-autodeposit-repository.server",
   () => ({
@@ -86,6 +100,8 @@ describe("Earn autodeposit sweeps execute route", () => {
     resolveAuthenticatedPrincipalFromRequest.mockClear();
     findCurrentEarnAutodepositState.mockClear();
     requestImmediateEarnAutodepositScheduledSweep.mockClear();
+    hasActiveEarnRoutePolicyPair.mockClear();
+    hasActiveEarnRoutePolicyPair.mockImplementation(async () => true);
     resolveAuthenticatedPrincipalFromRequest.mockImplementation(
       async () => principal
     );

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/sweeps/execute/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/sweeps/execute/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import {
   findCurrentEarnAutodepositState,
   requestImmediateEarnAutodepositScheduledSweep,
   type BalanceSweepTargetRecord,
   type ImmediateEarnAutodepositScheduledSweepRequestResult,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import {
+  EARN_POSITION_REQUIRED_ERROR,
+  hasActiveEarnRoutePolicyPair,
+} from "@/lib/yield-optimization/earn-position-gate.server";
 
 const EARN_AUTODEPOSIT_VAULT_INDEX = 1;
 
@@ -103,6 +109,38 @@ export async function POST(request: Request) {
         "autodeposit_not_active",
         "Earn Autodeposit must be active before a scheduled sweep can be executed now."
       );
+    }
+
+    // A target whose Earn position was fully withdrawn has no active route
+    // policy left — the worker refuses its sweeps ("no active Earn route
+    // policy"), so accepting the request would only mint a slot stuck on
+    // "Executing…" forever. Refuse up front with the same error the setup
+    // prepare gate uses; see earn-position-gate.server.ts. Fail open on
+    // lookup errors. Keep in sync with the mobile twin route.
+    try {
+      if (
+        !(await hasActiveEarnRoutePolicyPair({
+          cluster: resolveLoyalClusterForSolanaEnv(
+            resolveLoyalWebSolanaEnvFromEnv(process.env)
+          ),
+          settingsPda: principal.settingsPda,
+          walletAddress: principal.walletAddress,
+        }))
+      ) {
+        return jsonError(
+          409,
+          EARN_POSITION_REQUIRED_ERROR.code,
+          EARN_POSITION_REQUIRED_ERROR.message
+        );
+      }
+    } catch (gateError) {
+      console.warn("[autodeposit-sweeps-execute] earn position gate skipped", {
+        errorMessage:
+          gateError instanceof Error
+            ? gateError.message
+            : "Unknown gate error.",
+        walletAddress: principal.walletAddress,
+      });
     }
 
     const requestResult = await requestImmediateEarnAutodepositScheduledSweep(

--- a/frontend/src/lib/yield-optimization/earn-position-gate.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-gate.server.ts
@@ -1,0 +1,41 @@
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import { PublicKey } from "@solana/web3.js";
+
+import { getServerEnv } from "@/lib/core/config/server";
+
+import { findActiveYieldRoutePolicyPair } from "./yield-deposit-repository.server";
+
+// An Autodeposit sweep can only route into an ACTIVE Earn position — the
+// route policy is created by a user-signed deposit, and the sweep worker
+// (delegate) can't initialize one. Any Autodeposit write path (setup prepare,
+// execute-now) must hold this gate: without it the target strands every sweep
+// as a perpetual worker failure ("no active Earn route policy") that the app
+// renders as "Executing…" forever. Callers fail OPEN on thrown lookup errors —
+// the client pre-gates setup and the worker's refusal remains the last line.
+const EARN_VAULT_INDEX = 1;
+
+export const EARN_POSITION_REQUIRED_ERROR = {
+  code: "earn_position_required",
+  message:
+    "Autodeposit needs an active Earn account to deposit into. Make a deposit first.",
+} as const;
+
+export async function hasActiveEarnRoutePolicyPair(input: {
+  cluster: string;
+  settingsPda: string;
+  walletAddress: string;
+}): Promise<boolean> {
+  const [earnVaultPda] = pda.getSmartAccountPda({
+    accountIndex: EARN_VAULT_INDEX,
+    programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+    settingsPda: new PublicKey(input.settingsPda),
+  });
+  const policyPair = await findActiveYieldRoutePolicyPair({
+    authority: input.walletAddress,
+    cluster: input.cluster,
+    settings: input.settingsPda,
+    vaultIndex: EARN_VAULT_INDEX,
+    vaultPubkey: earnVaultPda.toBase58(),
+  });
+  return Boolean(policyPair?.routePolicy);
+}


### PR DESCRIPTION
Autodeposit setup prepare (web + mobile twins) now returns 409 earn_position_required when the wallet has no active Earn route policy — a sweep can only route into an active position (the policy is created by a user-signed deposit, the worker can't make one), so setups on an empty Earn stranded every sweep as a perpetual "Executing…" failure (three launch-week support reports).

The same gate (extracted to earn-position-gate.server.ts) now also refuses sweep execute-now on both twins: a full withdrawal deactivates the route policy while the autodeposit stays on, so every execute-now minted a scheduled slot the worker refuses forever (117 targets affected, 160 slots currently stuck in `requested`).