### PR TITLE
fix(earn): split max withdrawal cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,11 @@ logic lives in `mobile/src`. Keep network calls centralized in
 `mobile/src/services/api.ts`, use the `@/` alias for imports under
 `mobile/src`, and keep shared cross-app summary types in `@loyal-labs/shared`.
 
+Prepare mobile Earn deposit, withdrawal, autodeposit, and cleanup transactions
+on-device with the shared SDK. Backend mobile endpoints should return
+authenticated prepare contexts only; server-prepared transaction routes are
+legacy fallbacks for older app versions.
+
 Client-exposed mobile env vars must use the `EXPO_PUBLIC_` prefix. For cloud
 builds, `eas.json` is the source of truth; `.env` is local-only. Keep fallback
 behavior in `mobile/src/config/env.ts` aligned with production API

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
@@ -1,0 +1,274 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import { fetchEarnRpcHoldingsSnapshot } from "@/lib/yield-optimization/earn-rpc-holdings.client";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
+import { findEarnCleanupVaultState } from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+// Phase two of a full mobile withdrawal. The backend only resolves a fresh,
+// post-withdraw chain context; the device builds and signs the cleanup with
+// prepareEarnUsdcCleanup, matching the other on-device Earn prepare flows.
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+function parseMinContextSlot(body: unknown): number {
+  if (!body || typeof body !== "object") {
+    throw new Error("Invalid request body.");
+  }
+  const value = (body as { minContextSlot?: unknown }).minContextSlot;
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error("minContextSlot must be a non-negative integer string.");
+  }
+  const slot = Number(value);
+  if (!Number.isSafeInteger(slot)) {
+    throw new Error("minContextSlot is outside the supported range.");
+  }
+  return slot;
+}
+
+function hasPositiveAmount(amountRaw: string): boolean {
+  try {
+    return BigInt(amountRaw) > BigInt(0);
+  } catch {
+    return true;
+  }
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-withdraw-prepare",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let minContextSlot: number;
+  try {
+    minContextSlot = parseMinContextSlot(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+      walletAddress,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-cleanup-context] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  try {
+    const serverEnv = getServerEnv();
+    const programId = new PublicKey(serverEnv.loyalSmartAccounts.programId);
+    const settingsPdaKey = new PublicKey(settingsPda);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+      programId,
+      settingsPda: settingsPdaKey,
+    });
+    const cleanupState = await findEarnCleanupVaultState({
+      authority: walletAddress,
+      includeInactive: true,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+    });
+    if (!cleanupState) {
+      return jsonError(
+        409,
+        "missing_earn_policy",
+        "No Earn accounts were found to close."
+      );
+    }
+
+    const connection = getConnection(solanaEnv);
+    const client = createSmartAccountVaultsClient({ connection, programId });
+    const [holdingsSnapshot, vaultSnapshot] = await Promise.all([
+      fetchEarnRpcHoldingsSnapshot({
+        cluster,
+        connection,
+        minContextSlot,
+        policy: serializeRoutePolicyState(
+          cleanupState.routePolicy,
+          cleanupState.setupPolicy
+        ),
+        programId,
+        settingsPda: settingsPdaKey,
+      }),
+      client.fetchEarnVaultRefundSnapshot({
+        cluster,
+        minContextSlot,
+        settingsPda: settingsPdaKey,
+      }),
+    ]);
+    if (
+      holdingsSnapshot.holdings.some(
+        (holding) =>
+          holding.kind === "kamino" && hasPositiveAmount(holding.amountRaw)
+      )
+    ) {
+      return jsonError(
+        409,
+        "active_earn_sources_remaining",
+        "The full Earn withdrawal must confirm before cleanup."
+      );
+    }
+
+    const vaultUsdcAta = vaultSnapshot.vaultUsdcAta;
+    if (
+      vaultSnapshot.tokenAccounts.some(
+        (tokenAccount) =>
+          !tokenAccount.address.equals(vaultUsdcAta) &&
+          tokenAccount.amountRaw > BigInt(0)
+      )
+    ) {
+      return jsonError(
+        409,
+        "active_earn_sources_remaining",
+        "The Earn vault still holds a non-cleanup token balance."
+      );
+    }
+
+    const idleAmountRaw =
+      vaultSnapshot.tokenAccounts.find((tokenAccount) =>
+        tokenAccount.address.equals(vaultUsdcAta)
+      )?.amountRaw ?? BigInt(0);
+    const closeVaultCollateralAtas = vaultSnapshot.tokenAccounts
+      .filter(
+        (tokenAccount) =>
+          !tokenAccount.address.equals(vaultUsdcAta) &&
+          tokenAccount.amountRaw === BigInt(0)
+      )
+      .map((tokenAccount) => tokenAccount.address.toBase58());
+
+    return NextResponse.json({
+      cleanupInput: {
+        closeVaultCollateralAtas,
+        idleAmountRaw: idleAmountRaw.toString(),
+        policySigner: getDeploymentPolicySignerPublicKey().toBase58(),
+        yieldRoutingPolicy: {
+          account: cleanupState.routePolicy.policyAccount,
+          seed: cleanupState.routePolicy.policySeed.toString(),
+          setupPolicy: cleanupState.setupPolicy
+            ? {
+                account: cleanupState.setupPolicy.policyAccount,
+                seed: cleanupState.setupPolicy.policySeed.toString(),
+              }
+            : null,
+        },
+      },
+      cluster,
+      programId: serverEnv.loyalSmartAccounts.programId,
+      settingsPda,
+    });
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-cleanup-context] context failed", {
+      cluster,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown context error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      minContextSlot,
+      settings: settingsPda,
+      solanaEnv,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "context_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to resolve Earn cleanup context."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
@@ -77,6 +77,49 @@ function hasPositiveAmount(amountRaw: string): boolean {
   }
 }
 
+// The device pins these reads to its withdrawal confirmation slot; this
+// route's RPC node can be a beat behind right after confirmation, which
+// surfaces as JSON-RPC -32016 rather than stale data. That lag clears within
+// a slot or two, so retry briefly instead of failing the cleanup phase of an
+// already-landed withdrawal (the invisible-deposits incident came from
+// unretried post-confirm reads like this).
+const SLOT_LAG_ATTEMPTS = 3;
+const SLOT_LAG_RETRY_DELAY_MS = 500;
+
+function isMinContextSlotError(error: unknown): boolean {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    (error as { code?: unknown }).code === -32016
+  ) {
+    return true;
+  }
+  return (
+    error instanceof Error &&
+    /minimum context slot has not been reached/i.test(error.message)
+  );
+}
+
+async function readWithSlotLagRetry<T>(read: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < SLOT_LAG_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, SLOT_LAG_RETRY_DELAY_MS)
+      );
+    }
+    try {
+      return await read();
+    } catch (error) {
+      if (!isMinContextSlotError(error)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 export async function POST(request: Request) {
   let body: unknown;
   try {
@@ -173,24 +216,26 @@ export async function POST(request: Request) {
 
     const connection = getConnection(solanaEnv);
     const client = createSmartAccountVaultsClient({ connection, programId });
-    const [holdingsSnapshot, vaultSnapshot] = await Promise.all([
-      fetchEarnRpcHoldingsSnapshot({
-        cluster,
-        connection,
-        minContextSlot,
-        policy: serializeRoutePolicyState(
-          cleanupState.routePolicy,
-          cleanupState.setupPolicy
-        ),
-        programId,
-        settingsPda: settingsPdaKey,
-      }),
-      client.fetchEarnVaultRefundSnapshot({
-        cluster,
-        minContextSlot,
-        settingsPda: settingsPdaKey,
-      }),
-    ]);
+    const [holdingsSnapshot, vaultSnapshot] = await readWithSlotLagRetry(() =>
+      Promise.all([
+        fetchEarnRpcHoldingsSnapshot({
+          cluster,
+          connection,
+          minContextSlot,
+          policy: serializeRoutePolicyState(
+            cleanupState.routePolicy,
+            cleanupState.setupPolicy
+          ),
+          programId,
+          settingsPda: settingsPdaKey,
+        }),
+        client.fetchEarnVaultRefundSnapshot({
+          cluster,
+          minContextSlot,
+          settingsPda: settingsPdaKey,
+        }),
+      ])
+    );
     if (
       holdingsSnapshot.holdings.some(
         (holding) =>

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -3213,6 +3213,7 @@ export async function findActiveYieldRoutePolicyPair(
 export async function findEarnCleanupVaultState(
   input: {
     authority: string;
+    includeInactive?: boolean;
     settings: string;
     vaultIndex: number;
     vaultPubkey: string;
@@ -3224,7 +3225,7 @@ export async function findEarnCleanupVaultState(
   const client = dependencies.client;
   const vault = await client.db.query.managedVaults.findFirst({
     where: and(
-      eq(managedVaults.active, true),
+      ...(input.includeInactive ? [] : [eq(managedVaults.active, true)]),
       eq(managedVaults.settings, input.settings),
       eq(managedVaults.vaultIndex, input.vaultIndex),
       eq(managedVaults.vaultPubkey, input.vaultPubkey)
@@ -3237,7 +3238,7 @@ export async function findEarnCleanupVaultState(
 
   const routePolicy = await client.db.query.routePolicies.findFirst({
     where: and(
-      eq(routePolicies.active, true),
+      ...(input.includeInactive ? [] : [eq(routePolicies.active, true)]),
       eq(routePolicies.authority, input.authority),
       eq(routePolicies.id, vault.activePolicyId),
       eq(routePolicies.settings, input.settings),
@@ -3254,7 +3255,7 @@ export async function findEarnCleanupVaultState(
       ? Promise.resolve(null)
       : client.db.query.routePolicies.findFirst({
           where: and(
-            eq(routePolicies.active, true),
+            ...(input.includeInactive ? [] : [eq(routePolicies.active, true)]),
             eq(routePolicies.authority, input.authority),
             eq(routePolicies.id, vault.setupPolicyId),
             eq(routePolicies.settings, input.settings),

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -2039,6 +2039,33 @@ describe("prepareEarnUsdcWithdraw", () => {
     });
   });
 
+  test("pins Earn vault refund reads to the withdrawal confirmation slot", async () => {
+    const getTokenAccountsByOwner = mock(async () => ({
+      context: { slot: 101 },
+      value: [],
+    }));
+    const client = createSmartAccountVaultsClient({
+      connection: { getTokenAccountsByOwner } as never,
+      programId,
+    });
+
+    await client.fetchEarnVaultRefundSnapshot({
+      minContextSlot: 101,
+      settingsPda,
+    });
+
+    expect(getTokenAccountsByOwner).toHaveBeenCalledTimes(1);
+    const calls = getTokenAccountsByOwner.mock.calls as unknown as [
+      PublicKey,
+      unknown,
+      unknown
+    ][];
+    expect(calls[0]?.[2]).toEqual({
+      commitment: "confirmed",
+      minContextSlot: 101,
+    });
+  });
+
   test("skips collateral cleanup when the token account is not vault-owned", async () => {
     mockKaminoWithdrawInstruction();
     const vaultCollateralAta = getAssociatedTokenAddressSync(

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -8311,6 +8311,7 @@ export function createSmartAccountVaultsClient(
   // injected connections without the RPC methods just report an empty vault.
   async function fetchEarnVaultRefundSnapshot(args: {
     cluster?: LoyalCluster;
+    minContextSlot?: number;
     settingsPda: PublicKey;
   }): Promise<SmartAccountEarnVaultRefundSnapshot> {
     const cluster = args.cluster ?? LoyalCluster.MainnetBeta;
@@ -8339,7 +8340,12 @@ export function createSmartAccountVaultsClient(
             config.connection,
             vaultPda,
             { programId: TOKEN_PROGRAM_ID },
-            "confirmed"
+            {
+              commitment: "confirmed",
+              ...(args.minContextSlot !== undefined
+                ? { minContextSlot: args.minContextSlot }
+                : {}),
+            }
           )
         : Promise.resolve(null),
     ]);


### PR DESCRIPTION
Splits mobile Earn MAX withdrawal into a no-cleanup withdrawal followed by a fresh, slot-pinned cleanup context, eliminating the vault USDC close race caused by accrued Kamino yield. The device continues to prepare transactions locally; the backend only resolves confirmed cleanup inputs.