### PR TITLE
fix(earn): pause autodeposits that lost their Earn position and resume on redeposit

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -17,7 +17,10 @@ import {
   parseEarnAutodepositSetupPrepareRequestBody,
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
-import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import {
+  EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
+  findCurrentEarnAutodepositState,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import {
   EARN_POSITION_REQUIRED_ERROR,
   hasActiveEarnRoutePolicyPair,
@@ -184,7 +187,13 @@ export async function POST(request: Request) {
       // fresh prepare mints a second policy seed and stands up a duplicate
       // on-chain policy that delete/withdraw flows then trip over. A stale
       // "active" row heals through the `/state` reconcile before retry.
-      if (target?.lifecycleStatus === "active") {
+      // A position-paused row is the same fully-built autodeposit (it
+      // auto-resumes on the next state read after a deposit), so it guards
+      // identically.
+      if (
+        target?.lifecycleStatus === "active" ||
+        target?.lifecycleStatus === EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION
+      ) {
         return jsonError(
           409,
           "autodeposit_already_active",

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/state/route.ts
@@ -18,6 +18,7 @@ import {
   probeEarnAutodepositArtifacts,
 } from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
 import { readEarnAutodepositBootstrapWalletBalanceSnapshot } from "@/lib/yield-optimization/earn-autodeposit-bootstrap.server";
+import { reconcileEarnAutodepositPositionPause } from "@/lib/yield-optimization/earn-autodeposit-position-pause.server";
 import { getDisplayableEarnAutodepositScheduledSweeps } from "@/lib/yield-optimization/earn-autodeposit-loaded-state.shared";
 import {
   findCurrentEarnAutodepositState,
@@ -319,7 +320,7 @@ export async function GET(request: Request) {
     }
     const serverEnv = getServerEnv();
     const connection = getConnection(getConfiguredSolanaEnv());
-    const reconciledState = await reconcileAutodepositArtifacts({
+    let reconciledState = await reconcileAutodepositArtifacts({
       connection,
       settings: account.settingsPda,
       smartAccountsProgramId: new PublicKey(
@@ -338,8 +339,21 @@ export async function GET(request: Request) {
         smartAccountAddress: account.smartAccountAddress,
       });
     }
+    // Pause the autodeposit while the wallet has no Earn position to sweep
+    // into (and auto-resume once a deposit recreates the policy pair) —
+    // otherwise the worker perma-fails and the app shows an eternal
+    // "Execute now".
+    const positionPause = await reconcileEarnAutodepositPositionPause({
+      cluster: resolveLoyalClusterForSolanaEnv(getConfiguredSolanaEnv()),
+      settingsPda: account.settingsPda,
+      state: reconciledState,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress,
+    });
+    reconciledState = positionPause.state;
     const activatedFromPending =
-      state.status === "pending" && reconciledState.status === "active";
+      (state.status === "pending" && reconciledState.status === "active") ||
+      positionPause.resumed;
     if (activatedFromPending) {
       try {
         const snapshotResult =

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
@@ -18,7 +18,10 @@ import {
   parseEarnAutodepositSetupPrepareRequestBody,
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
-import { findCurrentEarnAutodepositState } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import {
+  EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
+  findCurrentEarnAutodepositState,
+} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import {
   EARN_POSITION_REQUIRED_ERROR,
   hasActiveEarnRoutePolicyPair,
@@ -93,7 +96,14 @@ export async function POST(request: Request) {
         vaultIndex: 1,
         walletAddress: principal.walletAddress,
       });
-      if (current?.target.lifecycleStatus === "active") {
+      // A position-paused row is the same fully-built autodeposit (it
+      // auto-resumes on the next state read after a deposit), so it guards
+      // identically.
+      if (
+        current?.target.lifecycleStatus === "active" ||
+        current?.target.lifecycleStatus ===
+          EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION
+      ) {
         return jsonError(
           409,
           "autodeposit_already_active",

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -15,6 +15,7 @@ import {
   probeEarnAutodepositArtifacts,
 } from "@/lib/yield-optimization/earn-autodeposit-artifacts.server";
 import { readEarnAutodepositBootstrapWalletBalanceSnapshot } from "@/lib/yield-optimization/earn-autodeposit-bootstrap.server";
+import { reconcileEarnAutodepositPositionPause } from "@/lib/yield-optimization/earn-autodeposit-position-pause.server";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
 import {
   findCurrentEarnAutodepositState,
@@ -365,7 +366,7 @@ export async function GET(request: Request) {
           if (!state) {
             return null;
           }
-          const reconciledState = await reconcileAutodepositArtifacts({
+          let reconciledState = await reconcileAutodepositArtifacts({
             connection,
             settings: principal.settingsPda,
             smartAccountsProgramId: programId,
@@ -377,8 +378,22 @@ export async function GET(request: Request) {
           if (reconciledState.target.lifecycleStatus === "closed") {
             return null;
           }
+          // Pause the autodeposit while the wallet has no Earn position to
+          // sweep into (and auto-resume once a deposit recreates the policy
+          // pair) — otherwise the worker perma-fails and the pane shows an
+          // eternal "Execute now".
+          const positionPause = await reconcileEarnAutodepositPositionPause({
+            cluster,
+            settingsPda: principal.settingsPda,
+            state: reconciledState,
+            vaultIndex: EARN_VAULT_INDEX,
+            walletAddress: principal.walletAddress,
+          });
+          reconciledState = positionPause.state;
           const activatedFromPending =
-            state.status === "pending" && reconciledState.status === "active";
+            (state.status === "pending" &&
+              reconciledState.status === "active") ||
+            positionPause.resumed;
           if (activatedFromPending) {
             try {
               const snapshotResult =

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-position-pause.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-position-pause.server.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const PAUSED = "paused_missing_position";
+
+function makeTarget(overrides: Record<string, unknown> = {}) {
+  return {
+    active: true,
+    lifecycleStatus: "active",
+    policyAccount: "policy-account",
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    policy: null,
+    status: "active",
+    target: makeTarget(),
+    ...overrides,
+  };
+}
+
+const hasActiveEarnRoutePolicyPair = mock(async () => true);
+const markAutodepositTargetPausedMissingPosition = mock(async () =>
+  makeTarget({ active: false, lifecycleStatus: PAUSED })
+);
+const resumeAutodepositTargetFromMissingPosition = mock(async () =>
+  makeTarget()
+);
+const suppressEarnAutodepositScheduledSweepsForMissingPosition = mock(
+  async () => ({ canceledSlotCount: 0, suppressedLotCount: 0 })
+);
+
+mock.module("@/lib/yield-optimization/earn-position-gate.server", () => ({
+  hasActiveEarnRoutePolicyPair,
+}));
+
+// The real resolver's logic is duplicated here because mock.module replaces
+// the whole repository module; keep in sync with resolveEarnAutodepositStatus.
+mock.module(
+  "@/lib/yield-optimization/earn-autodeposit-repository.server",
+  () => ({
+    EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION: PAUSED,
+    markAutodepositTargetPausedMissingPosition,
+    resolveEarnAutodepositStatus: (target: {
+      active: boolean;
+      lifecycleStatus: string;
+    }) => {
+      if (target.lifecycleStatus === "active") {
+        return target.active ? "active" : "paused";
+      }
+      return target.lifecycleStatus === PAUSED ? "paused" : "pending";
+    },
+    resumeAutodepositTargetFromMissingPosition,
+    suppressEarnAutodepositScheduledSweepsForMissingPosition,
+  })
+);
+
+const { reconcileEarnAutodepositPositionPause } = await import(
+  "@/lib/yield-optimization/earn-autodeposit-position-pause.server"
+);
+
+const baseArgs = {
+  cluster: "mainnet-beta",
+  settingsPda: "settings",
+  vaultIndex: 1 as const,
+  walletAddress: "wallet",
+};
+
+describe("reconcileEarnAutodepositPositionPause", () => {
+  beforeEach(() => {
+    hasActiveEarnRoutePolicyPair.mockClear();
+    hasActiveEarnRoutePolicyPair.mockResolvedValue(true);
+    markAutodepositTargetPausedMissingPosition.mockClear();
+    markAutodepositTargetPausedMissingPosition.mockResolvedValue(
+      makeTarget({ active: false, lifecycleStatus: PAUSED })
+    );
+    resumeAutodepositTargetFromMissingPosition.mockClear();
+    resumeAutodepositTargetFromMissingPosition.mockResolvedValue(makeTarget());
+    suppressEarnAutodepositScheduledSweepsForMissingPosition.mockClear();
+  });
+
+  test("pauses an active target when the policy pair is gone", async () => {
+    hasActiveEarnRoutePolicyPair.mockResolvedValue(false);
+
+    const result = await reconcileEarnAutodepositPositionPause({
+      ...baseArgs,
+      state: makeState() as never,
+    });
+
+    expect(markAutodepositTargetPausedMissingPosition).toHaveBeenCalledTimes(
+      1
+    );
+    expect(
+      suppressEarnAutodepositScheduledSweepsForMissingPosition
+    ).toHaveBeenCalledTimes(1);
+    expect(result.resumed).toBe(false);
+    expect(result.state.status).toBe("paused");
+    expect(result.state.target.lifecycleStatus).toBe(PAUSED);
+  });
+
+  test("leaves an active target alone while the policy pair exists", async () => {
+    const state = makeState();
+
+    const result = await reconcileEarnAutodepositPositionPause({
+      ...baseArgs,
+      state: state as never,
+    });
+
+    expect(markAutodepositTargetPausedMissingPosition).not.toHaveBeenCalled();
+    expect(result.state).toEqual(state as never);
+  });
+
+  test("resumes a paused target once the policy pair is back", async () => {
+    const result = await reconcileEarnAutodepositPositionPause({
+      ...baseArgs,
+      state: makeState({
+        status: "paused",
+        target: makeTarget({ active: false, lifecycleStatus: PAUSED }),
+      }) as never,
+    });
+
+    expect(resumeAutodepositTargetFromMissingPosition).toHaveBeenCalledTimes(
+      1
+    );
+    expect(result.resumed).toBe(true);
+    expect(result.state.status).toBe("active");
+  });
+
+  test("keeps a paused target paused while the pair is missing", async () => {
+    hasActiveEarnRoutePolicyPair.mockResolvedValue(false);
+
+    const result = await reconcileEarnAutodepositPositionPause({
+      ...baseArgs,
+      state: makeState({
+        status: "paused",
+        target: makeTarget({ active: false, lifecycleStatus: PAUSED }),
+      }) as never,
+    });
+
+    expect(resumeAutodepositTargetFromMissingPosition).not.toHaveBeenCalled();
+    expect(result.resumed).toBe(false);
+    expect(result.state.status).toBe("paused");
+  });
+
+  test("skips pending and user-toggled-off targets entirely", async () => {
+    for (const state of [
+      makeState({
+        status: "pending",
+        target: makeTarget({ lifecycleStatus: "pending_delegation" }),
+      }),
+      makeState({ status: "paused", target: makeTarget({ active: false }) }),
+    ]) {
+      const result = await reconcileEarnAutodepositPositionPause({
+        ...baseArgs,
+        state: state as never,
+      });
+      expect(result.state).toEqual(state as never);
+    }
+    expect(hasActiveEarnRoutePolicyPair).not.toHaveBeenCalled();
+    expect(markAutodepositTargetPausedMissingPosition).not.toHaveBeenCalled();
+  });
+
+  test("does not cancel sweeps when the pause write lost a race", async () => {
+    hasActiveEarnRoutePolicyPair.mockResolvedValue(false);
+    markAutodepositTargetPausedMissingPosition.mockResolvedValue(
+      makeTarget({ active: false, lifecycleStatus: "closed" })
+    );
+
+    const result = await reconcileEarnAutodepositPositionPause({
+      ...baseArgs,
+      state: makeState() as never,
+    });
+
+    expect(
+      suppressEarnAutodepositScheduledSweepsForMissingPosition
+    ).not.toHaveBeenCalled();
+    expect(result.state.status).toBe("pending");
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-position-pause.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-position-pause.server.ts
@@ -1,0 +1,79 @@
+import {
+  EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
+  markAutodepositTargetPausedMissingPosition,
+  resolveEarnAutodepositStatus,
+  resumeAutodepositTargetFromMissingPosition,
+  suppressEarnAutodepositScheduledSweepsForMissingPosition,
+  type CurrentEarnAutodepositState,
+} from "./earn-autodeposit-repository.server";
+import { hasActiveEarnRoutePolicyPair } from "./earn-position-gate.server";
+
+// An Autodeposit sweep can only route into an ACTIVE Earn position (see
+// earn-position-gate.server). When a full withdrawal closes the position
+// while the Autodeposit stays on, the worker perma-fails every slot ("no
+// active Earn route policy") and the app renders an eternal "Execute now" —
+// this reconcile pauses the target instead, and auto-resumes it the moment a
+// new deposit recreates the policy pair. Both Earn state reads run it, so a
+// wrong pause (or a missed resume) heals on the next read in either
+// direction.
+export async function reconcileEarnAutodepositPositionPause(args: {
+  cluster: string;
+  settingsPda: string;
+  state: CurrentEarnAutodepositState;
+  vaultIndex: 1;
+  walletAddress: string;
+}): Promise<{ resumed: boolean; state: CurrentEarnAutodepositState }> {
+  const targetInput = {
+    policyAccount: args.state.target.policyAccount,
+    settings: args.settingsPda,
+    vaultIndex: args.vaultIndex,
+    walletAddress: args.walletAddress,
+  };
+
+  if (
+    args.state.target.lifecycleStatus ===
+    EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION
+  ) {
+    if (
+      !(await hasActiveEarnRoutePolicyPair({
+        cluster: args.cluster,
+        settingsPda: args.settingsPda,
+        walletAddress: args.walletAddress,
+      }))
+    ) {
+      return { resumed: false, state: args.state };
+    }
+    const target = await resumeAutodepositTargetFromMissingPosition(
+      targetInput
+    );
+    const status = resolveEarnAutodepositStatus(target);
+    return {
+      resumed: status === "active",
+      state: { ...args.state, status, target },
+    };
+  }
+
+  // Only a fully-active target can strand sweeps; pending/paused/closed rows
+  // aren't scheduling anything.
+  if (args.state.status !== "active") {
+    return { resumed: false, state: args.state };
+  }
+  if (
+    await hasActiveEarnRoutePolicyPair({
+      cluster: args.cluster,
+      settingsPda: args.settingsPda,
+      walletAddress: args.walletAddress,
+    })
+  ) {
+    return { resumed: false, state: args.state };
+  }
+
+  const target = await markAutodepositTargetPausedMissingPosition(targetInput);
+  if (target.lifecycleStatus === EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION) {
+    await suppressEarnAutodepositScheduledSweepsForMissingPosition({ target });
+  }
+  return {
+    resumed: false,
+    state: { ...args.state, status: resolveEarnAutodepositStatus(target), target },
+  };
+}

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -194,11 +194,22 @@ function assertSetupHasPolicy(input: ConfirmedEarnAutodepositSetupInput) {
   }
 }
 
-function resolveEarnAutodepositStatus(
+// System pause distinct from the user toggle: the wallet's Earn route policy
+// pair is gone (a full withdrawal closed the position), so the sweep worker
+// can never execute for this target. The dedicated lifecycle value lets the
+// state reconcile auto-resume it once a deposit recreates the policy pair —
+// a plain toggle-off (active=false, lifecycle "active") stays user-owned.
+export const EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION =
+  "paused_missing_position" as const;
+
+export function resolveEarnAutodepositStatus(
   target: Pick<BalanceSweepTargetRecord, "active" | "lifecycleStatus">
 ): CurrentEarnAutodepositState["status"] {
   if (target.lifecycleStatus === "active") {
     return target.active ? "active" : "paused";
+  }
+  if (target.lifecycleStatus === EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION) {
+    return "paused";
   }
   return "pending";
 }
@@ -2512,6 +2523,173 @@ export async function markAutodepositTargetActiveFromArtifacts(
   }
 
   return target;
+}
+
+// System-pauses a fully-active target whose Earn route policy pair is gone
+// (see EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION). active=false is the same
+// switch the user toggle uses, so the sweep worker stops scheduling. Only an
+// active+lifecycle-"active" row is eligible — closed/pending rows aren't
+// sweeping, and a user toggle-off must stay user-owned. The write is
+// conditional on that same shape so a concurrent close or demote wins.
+export async function markAutodepositTargetPausedMissingPosition(
+  input: {
+    policyAccount: string;
+    settings: string;
+    vaultIndex: 1;
+    walletAddress: string;
+  },
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client" | "now"
+  > = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  const { client } = dependencies;
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex
+  ) {
+    throw new Error("Autodeposit target does not match the wallet.");
+  }
+  if (existing.lifecycleStatus !== "active" || !existing.active) {
+    return existing;
+  }
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      active: false,
+      lastSeenAt: dependencies.now(),
+      lifecycleStatus: EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
+    })
+    .where(
+      and(
+        eq(balanceSweepTargets.policyAccount, input.policyAccount),
+        eq(balanceSweepTargets.lifecycleStatus, "active"),
+        eq(balanceSweepTargets.active, true)
+      )
+    )
+    .returning();
+
+  if (!target) {
+    const fresh = await findTargetByPolicy({
+      client,
+      policyAccount: input.policyAccount,
+    });
+    return fresh ?? existing;
+  }
+
+  return target;
+}
+
+// Reverses markAutodepositTargetPausedMissingPosition once a deposit has
+// recreated the route policy pair. Conditional on the row still being
+// system-paused so it can never resurrect a row a concurrent close confirm
+// or artifacts demote has moved elsewhere.
+export async function resumeAutodepositTargetFromMissingPosition(
+  input: {
+    policyAccount: string;
+    settings: string;
+    vaultIndex: 1;
+    walletAddress: string;
+  },
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client" | "now"
+  > = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  const { client } = dependencies;
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex
+  ) {
+    throw new Error("Autodeposit target does not match the wallet.");
+  }
+  if (existing.lifecycleStatus !== EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION) {
+    return existing;
+  }
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      active: true,
+      lastSeenAt: dependencies.now(),
+      lifecycleStatus: "active",
+    })
+    .where(
+      and(
+        eq(balanceSweepTargets.policyAccount, input.policyAccount),
+        eq(
+          balanceSweepTargets.lifecycleStatus,
+          EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION
+        )
+      )
+    )
+    .returning();
+
+  if (!target) {
+    const fresh = await findTargetByPolicy({
+      client,
+      policyAccount: input.policyAccount,
+    });
+    return fresh ?? existing;
+  }
+
+  return target;
+}
+
+// Same shape as reconcileStaleEarnAutodepositScheduledSweeps but
+// unconditional on surplus: a paused target's sweeps can never execute, so
+// open lots are suppressed (their 'scheduled' slots empty out and stay
+// reusable after a resume) and finished 'failed'/'released' slots stop
+// rendering as an eternal "Execute now".
+export async function suppressEarnAutodepositScheduledSweepsForMissingPosition(
+  args: { target: Pick<BalanceSweepTargetRecord, "id"> },
+  dependencies: EarnAutodepositRepositoryDependencies = createDependencies()
+): Promise<{ canceledSlotCount: number; suppressedLotCount: number }> {
+  const { client } = dependencies;
+  const now = dependencies.now();
+
+  const suppressed = await client.db.execute(sql`
+    UPDATE ${balanceSweepSurplusLots}
+    SET status = 'suppressed', updated_at = ${now}
+    WHERE ${balanceSweepSurplusLots.targetId} = ${args.target.id}
+      AND ${balanceSweepSurplusLots.status} = 'open'
+      AND ${balanceSweepSurplusLots.remainingAmountRaw} > 0
+    RETURNING ${balanceSweepSurplusLots.id}
+  `);
+
+  const canceled = await client.db.execute(sql`
+    UPDATE ${balanceSweepScheduledSlots}
+    SET status = 'canceled',
+        last_error = 'reconciled: autodeposit paused, Earn position closed',
+        updated_at = ${now}
+    WHERE ${balanceSweepScheduledSlots.targetId} = ${args.target.id}
+      AND ${balanceSweepScheduledSlots.status} IN ('failed', 'released')
+    RETURNING ${balanceSweepScheduledSlots.id}
+  `);
+
+  return {
+    canceledSlotCount: getExecuteRows(canceled).length,
+    suppressedLotCount: getExecuteRows(suppressed).length,
+  };
 }
 
 // Records a close observed on-chain rather than through the close confirm:


### PR DESCRIPTION
Both Earn state reads now system-pause an active autodeposit whose route policy pair is gone (full withdrawal closed the position) — cancels its stranded slots so the eternal "Execute now" row disappears — and auto-resume it the moment a deposit recreates the pair, with a bootstrap sweep so pending surplus deposits immediately. Heals the 37 existing zombie targets on their next state read.