### PR TITLE
fix(earn): allow paused_missing_position in the autodeposit lifecycle constraint

### DIFF
--- a/frontend/src/lib/yield-optimization/migrations/0024_allow_paused_missing_position_autodeposit_targets.sql
+++ b/frontend/src/lib/yield-optimization/migrations/0024_allow_paused_missing_position_autodeposit_targets.sql
@@ -1,0 +1,18 @@
+-- The position-pause reconcile (earn-autodeposit-position-pause.server.ts)
+-- writes lifecycle_status = 'paused_missing_position' for autodeposit targets
+-- whose Earn route policy pair is gone; without this value the CHECK
+-- constraint rejects the write and both Earn state reads 502 for every
+-- affected wallet.
+ALTER TABLE loyal_yield.balance_sweep_targets
+  DROP CONSTRAINT IF EXISTS balance_sweep_targets_lifecycle_status_chk;
+
+ALTER TABLE loyal_yield.balance_sweep_targets
+  ADD CONSTRAINT balance_sweep_targets_lifecycle_status_chk
+  CHECK (lifecycle_status IN (
+    'pending_delegation',
+    'pending_policy',
+    'active',
+    'closing',
+    'closed',
+    'paused_missing_position'
+  ));


### PR DESCRIPTION
Migration 0024: the DB CHECK constraint on balance_sweep_targets.lifecycle_status predates #475's paused_missing_position value, so the position-pause write fails and both Earn state reads 502 for every zombie-target wallet. Must be applied to the yield DB manually (like 0019/0021).