### PR TITLE
fix(earn): heal setup-stranded autodeposit targets at prepare

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/prepare/route.ts
@@ -18,6 +18,10 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
+  activateOrphanedEarnAutodepositSetup,
+  isAutodepositSetupAlreadyCompleteError,
+} from "@/lib/yield-optimization/earn-autodeposit-orphaned-setup.server";
+import {
   EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
   findCurrentEarnAutodepositState,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
@@ -246,6 +250,39 @@ export async function POST(request: Request) {
       preparedSetup: serializePreparedEarnUsdcAutodepositSetup(preparedSetup),
     });
   } catch (error) {
+    // The SDK refuses to prepare when policy + delegation + token approval
+    // all already exist on-chain. With the target row stuck in a pending
+    // lifecycle (lost stage confirms), every Create retry rethrows here —
+    // user-unrecoverable. Backfill the lost confirmations from chain and
+    // answer with the already-active contract the client knows.
+    if (isAutodepositSetupAlreadyCompleteError(error)) {
+      const activated = await activateOrphanedEarnAutodepositSetup({
+        connection: getConnection(solanaEnv),
+        settings: settingsPda,
+        vaultIndex: 1,
+        walletAddress,
+      }).catch((healError: unknown) => {
+        console.error(
+          "[mobile-earn-autodeposit-setup-prepare] orphaned setup heal failed",
+          {
+            errorMessage:
+              healError instanceof Error
+                ? healError.message
+                : "Unknown heal error.",
+            settings: settingsPda,
+            walletAddress,
+          }
+        );
+        return null;
+      });
+      if (activated) {
+        return jsonError(
+          409,
+          "autodeposit_already_active",
+          "An Autodeposit is already active for this wallet. Delete it before creating a new one."
+        );
+      }
+    }
     console.error("[mobile-earn-autodeposit-setup-prepare] prepare failed", {
       amountRaw: parsed.amountRaw.toString(),
       cluster,

--- a/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/prepare/route.ts
@@ -19,6 +19,10 @@ import {
   serializePreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
+  activateOrphanedEarnAutodepositSetup,
+  isAutodepositSetupAlreadyCompleteError,
+} from "@/lib/yield-optimization/earn-autodeposit-orphaned-setup.server";
+import {
   EARN_AUTODEPOSIT_PAUSED_MISSING_POSITION,
   findCurrentEarnAutodepositState,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
@@ -177,6 +181,41 @@ export async function POST(request: Request) {
   } catch (error) {
     if (isSmartAccountProvisioningError(error)) {
       return jsonError(error.status, error.code, error.message);
+    }
+
+    // The SDK refuses to prepare when policy + delegation + token approval
+    // all already exist on-chain. With the target row stuck in a pending
+    // lifecycle (lost stage confirms), every Create retry rethrows here —
+    // user-unrecoverable. Backfill the lost confirmations from chain and
+    // answer with the already-active contract the client knows. Keep in sync
+    // with the mobile twin route.
+    if (isAutodepositSetupAlreadyCompleteError(error)) {
+      const activated = await activateOrphanedEarnAutodepositSetup({
+        connection: getConnection(solanaEnv),
+        settings: principal.settingsPda,
+        vaultIndex: 1,
+        walletAddress: principal.walletAddress,
+      }).catch((healError: unknown) => {
+        console.error(
+          "[earn-autodeposit-setup-prepare] orphaned setup heal failed",
+          {
+            errorMessage:
+              healError instanceof Error
+                ? healError.message
+                : "Unknown heal error.",
+            settings: principal.settingsPda,
+            walletAddress: principal.walletAddress,
+          }
+        );
+        return null;
+      });
+      if (activated) {
+        return jsonError(
+          409,
+          "autodeposit_already_active",
+          "An Autodeposit is already active for this wallet. Delete it before creating a new one."
+        );
+      }
     }
 
     console.error("[earn-autodeposit-setup-prepare] prepare failed", {

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-orphaned-setup.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-orphaned-setup.server.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import {
+  activateAutodepositTargetWithBackfilledSetup,
+  findCurrentEarnAutodepositState,
+  type BalanceSweepTargetRecord,
+} from "./earn-autodeposit-repository.server";
+
+/**
+ * Heal for the orphaned-setup trap: the SDK's setup prepare throws when the
+ * policy, recurring delegation, AND token approval all already exist on-chain
+ * (nothing left to sign). That state is reachable when the on-chain setup
+ * succeeded but the stage confirms were lost in flight, leaving the target
+ * row stuck in a pending lifecycle — the app then shows the Create sheet and
+ * every retry rethrows, which is user-unrecoverable (e.g. wallet BgFJ…syuk,
+ * target 779: policy created Jul 8, confirm never landed). The heal backfills
+ * the lost confirmations from chain history and activates the row, so prepare
+ * can answer with the existing `autodeposit_already_active` contract.
+ */
+
+// Thrown by prepareEarnUsdcAutodepositSetup in @loyal-labs/smart-account-vaults
+// when every setup artifact already exists on-chain.
+const AUTODEPOSIT_SETUP_ALREADY_COMPLETE_MESSAGE =
+  "Autodeposit policy and recurring delegation already exist.";
+
+export function isAutodepositSetupAlreadyCompleteError(
+  error: unknown
+): boolean {
+  return (
+    error instanceof Error &&
+    error.message === AUTODEPOSIT_SETUP_ALREADY_COMPLETE_MESSAGE
+  );
+}
+
+// Pagination guard; setup accounts of a pending target have a handful of
+// transactions (no sweeps ever ran), so one page is the norm.
+const MAX_SIGNATURE_PAGES = 20;
+
+// Oldest successful transaction touching `address` = its creation. Pages run
+// newest -> oldest, so keep overwriting with each page's last non-failed
+// entry.
+async function findCreationSignature(
+  connection: Connection,
+  address: string
+): Promise<{ signature: string; slot: bigint } | null> {
+  let before: string | undefined;
+  let oldest: { signature: string; slot: bigint } | null = null;
+  for (let page = 0; page < MAX_SIGNATURE_PAGES; page++) {
+    const signatures = await connection.getSignaturesForAddress(
+      new PublicKey(address),
+      { before, limit: 1000 },
+      "confirmed"
+    );
+    if (signatures.length === 0) {
+      break;
+    }
+    for (const entry of signatures) {
+      if (!entry.err) {
+        oldest = { signature: entry.signature, slot: BigInt(entry.slot) };
+      }
+    }
+    before = signatures[signatures.length - 1]?.signature;
+    if (signatures.length < 1000) {
+      break;
+    }
+  }
+  return oldest;
+}
+
+/**
+ * Backfills lost setup confirmations from chain history and activates the
+ * target. Call only after the SDK reported the setup fully exists on-chain
+ * (see isAutodepositSetupAlreadyCompleteError). Returns the activated target,
+ * or null when there is nothing to heal (no pending row, or chain history
+ * could not supply the missing confirmations) — callers fall back to their
+ * existing error path.
+ */
+export async function activateOrphanedEarnAutodepositSetup(args: {
+  connection: Connection;
+  settings: string;
+  vaultIndex: 1;
+  walletAddress: string;
+}): Promise<BalanceSweepTargetRecord | null> {
+  const current = await findCurrentEarnAutodepositState({
+    settings: args.settings,
+    vaultIndex: args.vaultIndex,
+    walletAddress: args.walletAddress,
+  });
+  const target = current?.target;
+  if (
+    !target ||
+    (target.lifecycleStatus !== "pending_policy" &&
+      target.lifecycleStatus !== "pending_delegation")
+  ) {
+    return null;
+  }
+
+  const policyConfirmation =
+    target.policySignature && target.policyConfirmedSlot != null
+      ? {
+          signature: target.policySignature,
+          slot: target.policyConfirmedSlot,
+        }
+      : await findCreationSignature(args.connection, target.policyAccount);
+  if (!policyConfirmation) {
+    return null;
+  }
+
+  let delegationConfirmation: { signature: string; slot: bigint } | null =
+    target.recurringDelegationSignature &&
+    target.recurringDelegationConfirmedSlot != null
+      ? {
+          signature: target.recurringDelegationSignature,
+          slot: target.recurringDelegationConfirmedSlot,
+        }
+      : null;
+  if (!delegationConfirmation && target.recurringDelegation) {
+    delegationConfirmation = await findCreationSignature(
+      args.connection,
+      target.recurringDelegation
+    );
+  }
+  if (!delegationConfirmation) {
+    return null;
+  }
+
+  const activated = await activateAutodepositTargetWithBackfilledSetup({
+    policyAccount: target.policyAccount,
+    policyConfirmedSlot: policyConfirmation.slot,
+    policySignature: policyConfirmation.signature,
+    recurringDelegationConfirmedSlot: delegationConfirmation.slot,
+    recurringDelegationSignature: delegationConfirmation.signature,
+    settings: args.settings,
+    vaultIndex: args.vaultIndex,
+    walletAddress: args.walletAddress,
+  });
+  return activated?.lifecycleStatus === "active" && activated.active
+    ? activated
+    : null;
+}

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, gte, ne, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, ne, sql } from "drizzle-orm";
 
 import type {
   ConfirmedEarnAutodepositCloseInput,
@@ -2653,6 +2653,94 @@ export async function resumeAutodepositTargetFromMissingPosition(
   }
 
   return target;
+}
+
+// Promotes a setup-stranded target (pending_policy/pending_delegation) to
+// active by recording setup confirmations that were lost in flight. Only the
+// orphaned-setup heal calls this, after verifying on-chain that the full
+// setup (policy + delegation + token approval) exists. Conditional on the
+// row still being in a pending lifecycle so it can never race a concurrent
+// confirm or close.
+export async function activateAutodepositTargetWithBackfilledSetup(
+  input: {
+    policyAccount: string;
+    policyConfirmedSlot: bigint;
+    policySignature: string;
+    recurringDelegationConfirmedSlot: bigint | null;
+    recurringDelegationSignature: string | null;
+    settings: string;
+    vaultIndex: 1;
+    walletAddress: string;
+  },
+  dependencies: Pick<
+    EarnAutodepositRepositoryDependencies,
+    "client" | "now"
+  > = createDependencies()
+): Promise<BalanceSweepTargetRecord | null> {
+  const { client } = dependencies;
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex
+  ) {
+    throw new Error("Autodeposit target does not match the wallet.");
+  }
+  if (
+    existing.lifecycleStatus !== "pending_policy" &&
+    existing.lifecycleStatus !== "pending_delegation"
+  ) {
+    return existing.lifecycleStatus === "active" ? existing : null;
+  }
+
+  const policySignature = existing.policySignature ?? input.policySignature;
+  const policyConfirmedSlot =
+    existing.policyConfirmedSlot ?? input.policyConfirmedSlot;
+  const recurringDelegationSignature =
+    existing.recurringDelegationSignature ??
+    input.recurringDelegationSignature;
+  const recurringDelegationConfirmedSlot =
+    existing.recurringDelegationConfirmedSlot ??
+    input.recurringDelegationConfirmedSlot;
+  if (
+    !policySignature ||
+    policyConfirmedSlot === null ||
+    !recurringDelegationSignature ||
+    recurringDelegationConfirmedSlot === null
+  ) {
+    return null;
+  }
+
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({
+      active: true,
+      lastSeenAt: dependencies.now(),
+      lifecycleStatus: "active",
+      policyConfirmedSlot,
+      policySignature,
+      recurringDelegationConfirmedSlot,
+      recurringDelegationSignature,
+    })
+    .where(
+      and(
+        eq(balanceSweepTargets.policyAccount, input.policyAccount),
+        inArray(balanceSweepTargets.lifecycleStatus, [
+          "pending_policy",
+          "pending_delegation",
+        ])
+      )
+    )
+    .returning();
+
+  return target ?? null;
 }
 
 // Same shape as reconcileStaleEarnAutodepositScheduledSweeps but


### PR DESCRIPTION
When every autodeposit setup artifact already exists on-chain but the target row is stuck in a pending lifecycle (lost stage confirms), setup prepare now backfills the lost confirmations from chain history and activates the row instead of dead-ending with "Autodeposit policy and recurring delegation already exist." on every retry (wallet BgFJ…syuk, target 779).

https://claude.ai/code/session_01FhCgUGo9JDSEonGqw9S2ZU