### PR TITLE
fix(earn): verify zero balances before closing positions

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts
@@ -1,0 +1,254 @@
+import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import {
+  assertEarnFullExitProven,
+  EarnCleanupConfirmError,
+  resolveConfirmedSignatureSlot,
+} from "@/lib/yield-optimization/earn-cleanup-confirm.server";
+import {
+  findEarnCleanupVaultState,
+  recordConfirmedEarnCleanup,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
+
+const EARN_DEPOSIT_VAULT_INDEX = 1;
+
+const connectionCache = new Map<SolanaEnv, Connection>();
+
+type MobileEarnCleanupConfirmFields = {
+  cleanupSignature: string;
+  confirmedSlot: string;
+};
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function getConfiguredSolanaEnv(): SolanaEnv {
+  return resolveLoyalWebSolanaEnvFromEnv(process.env);
+}
+
+function getConnection(cluster: SolanaEnv): Connection {
+  const cached = connectionCache.get(cluster);
+  if (cached) {
+    return cached;
+  }
+
+  const { rpcEndpoint, websocketEndpoint } =
+    getServerSolanaEndpoints(cluster);
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  connectionCache.set(cluster, connection);
+  return connection;
+}
+
+function parseMobileEarnCleanupConfirmFields(
+  body: unknown
+): MobileEarnCleanupConfirmFields {
+  if (!body || typeof body !== "object") {
+    throw new Error("Invalid request body.");
+  }
+  const record = body as Record<string, unknown>;
+  if (
+    typeof record.cleanupSignature !== "string" ||
+    !record.cleanupSignature
+  ) {
+    throw new Error("cleanupSignature is required.");
+  }
+  if (
+    typeof record.confirmedSlot !== "string" ||
+    !/^\d+$/.test(record.confirmedSlot)
+  ) {
+    throw new Error("confirmedSlot must be a non-negative integer string.");
+  }
+  if (!Number.isSafeInteger(Number(record.confirmedSlot))) {
+    throw new Error("confirmedSlot is outside the supported range.");
+  }
+  return {
+    cleanupSignature: record.cleanupSignature,
+    confirmedSlot: record.confirmedSlot,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: "earn-withdraw-confirm",
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  let fields: MobileEarnCleanupConfirmFields;
+  try {
+    fields = parseMobileEarnCleanupConfirmFields(body);
+  } catch (error) {
+    return jsonError(
+      400,
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid request body."
+    );
+  }
+
+  let settingsPda: string;
+  try {
+    const user = await getOrCreateCurrentUser({
+      provider: "solana",
+      authMethod: "wallet",
+      subjectAddress: walletAddress,
+      walletAddress,
+    });
+    const existing = await findReadyCurrentUserSmartAccount({
+      userId: user.id,
+      walletAddress,
+    });
+    if (!existing) {
+      return jsonError(
+        409,
+        "smart_account_not_ready",
+        "No provisioned smart account for this wallet."
+      );
+    }
+    settingsPda = existing.settingsPda;
+  } catch (error) {
+    console.error("[mobile-earn-withdraw-cleanup-confirm] resolve failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown resolve error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      502,
+      "resolve_failed",
+      "Failed to resolve the smart account for this wallet."
+    );
+  }
+
+  const solanaEnv = getConfiguredSolanaEnv();
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  try {
+    const serverEnv = getServerEnv();
+    const programId = new PublicKey(serverEnv.loyalSmartAccounts.programId);
+    const settingsPdaKey = new PublicKey(settingsPda);
+    const [earnVaultPda] = pda.getSmartAccountPda({
+      accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+      programId,
+      settingsPda: settingsPdaKey,
+    });
+    const cleanupState = await findEarnCleanupVaultState({
+      authority: walletAddress,
+      includeInactive: true,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+    });
+    if (!cleanupState) {
+      return jsonError(
+        409,
+        "missing_earn_policy",
+        "Earn policy state is unavailable for cleanup confirmation."
+      );
+    }
+
+    const connection = getConnection(solanaEnv);
+    const confirmedSlot = await resolveConfirmedSignatureSlot({
+      connection,
+      signature: fields.cleanupSignature,
+    });
+    if (confirmedSlot !== BigInt(fields.confirmedSlot)) {
+      return jsonError(
+        400,
+        "slot_mismatch",
+        "Confirmed Earn cleanup slot does not match the transaction status."
+      );
+    }
+
+    await assertEarnFullExitProven({
+      cleanupState,
+      cluster,
+      connection,
+      minContextSlot: Number(fields.confirmedSlot),
+      policyAccounts: [
+        cleanupState.routePolicy.policyAccount,
+        ...(cleanupState.setupPolicy
+          ? [cleanupState.setupPolicy.policyAccount]
+          : []),
+      ],
+      programId,
+      settingsPda: settingsPdaKey,
+    });
+
+    await recordConfirmedEarnCleanup({
+      cleanupSignature: fields.cleanupSignature,
+      cluster,
+      confirmedSlot: BigInt(fields.confirmedSlot),
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+      walletAddress,
+    });
+
+    console.info("[mobile-earn-withdraw-cleanup-confirm] full exit closed", {
+      cleanupSignature: fields.cleanupSignature,
+      confirmedSlot: fields.confirmedSlot,
+      settings: settingsPda,
+      status: "full_exit_closed",
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      walletAddress,
+    });
+    return NextResponse.json({ ok: true, status: "full_exit_closed" });
+  } catch (error) {
+    if (error instanceof EarnCleanupConfirmError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    console.error("[mobile-earn-withdraw-cleanup-confirm] failed", {
+      cleanupSignature: fields.cleanupSignature,
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown cleanup error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      settings: settingsPda,
+      stack: error instanceof Error ? error.stack : undefined,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "confirm_failed",
+      error instanceof Error
+        ? error.message
+        : "Earn cleanup confirmation failed."
+    );
+  }
+}

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
-import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
 
@@ -14,9 +13,12 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { fetchEarnRpcHoldingsSnapshot } from "@/lib/yield-optimization/earn-rpc-holdings.client";
+import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
 import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
-import { findEarnCleanupVaultState } from "@/lib/yield-optimization/yield-deposit-repository.server";
+import {
+  findEarnCleanupVaultState,
+  findLatestFullYieldWithdrawalForVault,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Phase two of a full mobile withdrawal. The backend only resolves a fresh,
 // post-withdraw chain context; the device builds and signs the cleanup with
@@ -69,57 +71,6 @@ function parseMinContextSlot(body: unknown): number {
   return slot;
 }
 
-function hasPositiveAmount(amountRaw: string): boolean {
-  try {
-    return BigInt(amountRaw) > BigInt(0);
-  } catch {
-    return true;
-  }
-}
-
-// The device pins these reads to its withdrawal confirmation slot; this
-// route's RPC node can be a beat behind right after confirmation, which
-// surfaces as JSON-RPC -32016 rather than stale data. That lag clears within
-// a slot or two, so retry briefly instead of failing the cleanup phase of an
-// already-landed withdrawal (the invisible-deposits incident came from
-// unretried post-confirm reads like this).
-const SLOT_LAG_ATTEMPTS = 3;
-const SLOT_LAG_RETRY_DELAY_MS = 500;
-
-function isMinContextSlotError(error: unknown): boolean {
-  if (
-    error !== null &&
-    typeof error === "object" &&
-    (error as { code?: unknown }).code === -32016
-  ) {
-    return true;
-  }
-  return (
-    error instanceof Error &&
-    /minimum context slot has not been reached/i.test(error.message)
-  );
-}
-
-async function readWithSlotLagRetry<T>(read: () => Promise<T>): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < SLOT_LAG_ATTEMPTS; attempt++) {
-    if (attempt > 0) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, SLOT_LAG_RETRY_DELAY_MS)
-      );
-    }
-    try {
-      return await read();
-    } catch (error) {
-      if (!isMinContextSlotError(error)) {
-        throw error;
-      }
-      lastError = error;
-    }
-  }
-  throw lastError;
-}
-
 export async function POST(request: Request) {
   let body: unknown;
   try {
@@ -141,9 +92,9 @@ export async function POST(request: Request) {
     return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
   }
 
-  let minContextSlot: number;
+  let requestedMinContextSlot: number;
   try {
-    minContextSlot = parseMinContextSlot(body);
+    requestedMinContextSlot = parseMinContextSlot(body);
   } catch (error) {
     return jsonError(
       400,
@@ -201,7 +152,6 @@ export async function POST(request: Request) {
     });
     const cleanupState = await findEarnCleanupVaultState({
       authority: walletAddress,
-      includeInactive: true,
       settings: settingsPda,
       vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
       vaultPubkey: earnVaultPda.toBase58(),
@@ -215,71 +165,78 @@ export async function POST(request: Request) {
     }
 
     const connection = getConnection(solanaEnv);
-    const client = createSmartAccountVaultsClient({ connection, programId });
-    const [holdingsSnapshot, vaultSnapshot] = await readWithSlotLagRetry(() =>
-      Promise.all([
-        fetchEarnRpcHoldingsSnapshot({
-          cluster,
-          connection,
-          minContextSlot,
-          policy: serializeRoutePolicyState(
-            cleanupState.routePolicy,
-            cleanupState.setupPolicy
-          ),
-          programId,
-          settingsPda: settingsPdaKey,
-        }),
-        client.fetchEarnVaultRefundSnapshot({
-          cluster,
-          minContextSlot,
-          settingsPda: settingsPdaKey,
-        }),
-      ])
+    const latestFullWithdrawal = await findLatestFullYieldWithdrawalForVault({
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+      walletAddress,
+    });
+    if (!latestFullWithdrawal) {
+      return jsonError(
+        409,
+        "missing_full_withdrawal",
+        "A confirmed full withdrawal is required before closing Earn accounts."
+      );
+    }
+    const serverMinContextSlot = Number(latestFullWithdrawal.confirmedSlot);
+    if (!Number.isSafeInteger(serverMinContextSlot) || serverMinContextSlot < 0) {
+      return jsonError(
+        409,
+        "missing_full_exit_verification_anchor",
+        "The confirmed full withdrawal slot is outside the supported range."
+      );
+    }
+    const minContextSlot = Math.max(
+      requestedMinContextSlot,
+      serverMinContextSlot
     );
-    if (
-      holdingsSnapshot.holdings.some(
-        (holding) =>
-          holding.kind === "kamino" && hasPositiveAmount(holding.amountRaw)
-      )
-    ) {
+
+    let proof: Awaited<ReturnType<typeof verifyEarnFullExitZeroBalances>>;
+    try {
+      proof = await verifyEarnFullExitZeroBalances({
+        cluster,
+        connection,
+        minContextSlot,
+        policy: serializeRoutePolicyState(
+          cleanupState.routePolicy,
+          cleanupState.setupPolicy
+        ),
+        programId,
+        settingsPda: settingsPdaKey,
+      });
+    } catch (error) {
+      console.error(
+        "[mobile-earn-withdraw-cleanup-context] zero proof retryable",
+        {
+          errorMessage:
+            error instanceof Error ? error.message : "Unknown proof error.",
+          errorName: error instanceof Error ? error.name : typeof error,
+          minContextSlot,
+          settings: settingsPda,
+          stack: error instanceof Error ? error.stack : undefined,
+          walletAddress,
+        }
+      );
       return jsonError(
-        409,
-        "active_earn_sources_remaining",
-        "The full Earn withdrawal must confirm before cleanup."
+        503,
+        "full_exit_verification_retryable",
+        error instanceof Error
+          ? error.message
+          : "Earn balances could not be verified. Retry cleanup."
       );
     }
-
-    const vaultUsdcAta = vaultSnapshot.vaultUsdcAta;
-    if (
-      vaultSnapshot.tokenAccounts.some(
-        (tokenAccount) =>
-          !tokenAccount.address.equals(vaultUsdcAta) &&
-          tokenAccount.amountRaw > BigInt(0)
-      )
-    ) {
+    if (proof.status !== "policy_close_required") {
       return jsonError(
         409,
-        "active_earn_sources_remaining",
-        "The Earn vault still holds a non-cleanup token balance."
+        "full_exit_incomplete",
+        "Earn balances remain above the full-exit dust tolerance."
       );
     }
-
-    const idleAmountRaw =
-      vaultSnapshot.tokenAccounts.find((tokenAccount) =>
-        tokenAccount.address.equals(vaultUsdcAta)
-      )?.amountRaw ?? BigInt(0);
-    const closeVaultCollateralAtas = vaultSnapshot.tokenAccounts
-      .filter(
-        (tokenAccount) =>
-          !tokenAccount.address.equals(vaultUsdcAta) &&
-          tokenAccount.amountRaw === BigInt(0)
-      )
-      .map((tokenAccount) => tokenAccount.address.toBase58());
 
     return NextResponse.json({
       cleanupInput: {
-        closeVaultCollateralAtas,
-        idleAmountRaw: idleAmountRaw.toString(),
+        closeVaultCollateralAtas: proof.closeableTokenAccounts,
+        idleAmountRaw: proof.idleAmountRaw,
         policySigner: getDeploymentPolicySignerPublicKey().toBase58(),
         yieldRoutingPolicy: {
           account: cleanupState.routePolicy.policyAccount,
@@ -302,7 +259,7 @@ export async function POST(request: Request) {
       errorMessage:
         error instanceof Error ? error.message : "Unknown context error.",
       errorName: error instanceof Error ? error.name : typeof error,
-      minContextSlot,
+      requestedMinContextSlot,
       settings: settingsPda,
       solanaEnv,
       stack: error instanceof Error ? error.stack : undefined,

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
@@ -216,12 +216,12 @@ export async function POST(request: Request) {
     });
     const input = parseEarnWithdrawalConfirmRequestBody(confirmBody);
 
-    const position = await recordConfirmedEarnWithdrawal({
+    const result = await recordConfirmedEarnWithdrawal({
       principal: { walletAddress, smartAccountAddress, settingsPda },
       input,
       solanaEnv: getConfiguredSolanaEnv(),
     });
-    return NextResponse.json({ position });
+    return NextResponse.json(result);
   } catch (error) {
     if (error instanceof EarnWithdrawConfirmError) {
       return jsonError(error.status, error.code, error.message);

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Connection, Keypair } from "@solana/web3.js";
+
+mock.module("server-only", () => ({}));
+
+const principal = {
+  settingsPda: "11111111111111111111111111111112",
+  walletAddress: Keypair.fromSeed(
+    new Uint8Array(32).fill(3)
+  ).publicKey.toBase58(),
+};
+const policyAccount = "11111111111111111111111111111114";
+const persistence = {
+  autodepositClose: null,
+  cluster: "mainnet-beta",
+  policyAccount,
+  policySeed: "7",
+  settings: principal.settingsPda,
+  setupPolicyAccount: null,
+  setupPolicySeed: null,
+  vaultIndex: 1,
+  vaultPubkey: "11111111111111111111111111111115",
+  walletAddress: principal.walletAddress,
+};
+
+let proofStatus: "full_exit_incomplete" | "policy_close_required";
+let proofError: Error | null;
+let policyAccountStillOpen: boolean;
+let callOrder: string[];
+let cleanupRecordCount: number;
+let preparedWalletAddress: string;
+
+mock.module("@/features/identity/server/auth-session", () => ({
+  resolveAuthenticatedPrincipalFromRequest: async () => principal,
+}));
+
+mock.module("@/lib/core/config/server", () => ({
+  getServerEnv: () => ({
+    loyalSmartAccounts: {
+      programId: "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG",
+    },
+  }),
+}));
+
+mock.module("@/lib/core/config/solana-env-override", () => ({
+  resolveLoyalWebSolanaEnvFromEnv: () => "mainnet",
+}));
+
+mock.module("@/lib/solana/rpc-endpoints.server", () => ({
+  getServerSolanaEndpoints: () => ({
+    rpcEndpoint: "http://127.0.0.1:8899",
+    websocketEndpoint: "ws://127.0.0.1:8900",
+  }),
+}));
+
+mock.module("@/lib/solana/rpc-rate-limit", () => ({
+  getFrontendSolanaRpcFetch: (fetchImpl: typeof fetch) => fetchImpl,
+}));
+
+mock.module(
+  "@/lib/yield-optimization/earn-autodeposit-repository.server",
+  () => ({
+    recordClosedAutodepositTarget: async () => {
+      throw new Error("Autodeposit closure was not expected.");
+    },
+  })
+);
+
+mock.module(
+  "@/lib/yield-optimization/earn-full-exit-zero-proof.server",
+  () => ({
+    verifyEarnFullExitZeroBalances: async () => {
+      callOrder.push("verify-zero");
+      if (proofError) {
+        throw proofError;
+      }
+      return {
+        status: proofStatus,
+      };
+    },
+  })
+);
+
+mock.module("@/lib/yield-optimization/earn-state-serializers.server", () => ({
+  serializeRoutePolicyState: () => ({ vaultIndex: 1 }),
+}));
+
+mock.module(
+  "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared",
+  () => ({
+    parseEarnWithdrawCleanupConfirmRequestBody: () => ({
+      cleanupSignature: "cleanup-signature",
+      confirmedSlot: "600",
+      preparedCleanup: {
+        persistence: { ...persistence, walletAddress: preparedWalletAddress },
+      },
+    }),
+  })
+);
+
+mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
+  findEarnCleanupVaultState: async () => ({
+    routePolicy: {
+      policyAccount,
+      policySeed: BigInt(7),
+    },
+    setupPolicy: null,
+  }),
+  recordConfirmedEarnCleanup: async () => {
+    callOrder.push("record-cleanup");
+    cleanupRecordCount += 1;
+  },
+}));
+
+function createRequest() {
+  return new Request("http://localhost/api/withdrawals/cleanup/confirm", {
+    body: JSON.stringify({}),
+    method: "POST",
+  });
+}
+
+describe("Earn cleanup confirm route", () => {
+  beforeEach(() => {
+    proofStatus = "policy_close_required";
+    proofError = null;
+    policyAccountStillOpen = false;
+    callOrder = [];
+    cleanupRecordCount = 0;
+    preparedWalletAddress = principal.walletAddress;
+    Connection.prototype.getSignatureStatuses = mock(async () => ({
+      value: [
+        {
+          confirmationStatus: "confirmed",
+          err: null,
+          slot: 600,
+        },
+      ],
+    })) as never;
+    Connection.prototype.getMultipleAccountsInfoAndContext = mock(async () => {
+      callOrder.push("verify-policy-accounts");
+      return {
+        context: { slot: 600 },
+        value: [policyAccountStillOpen ? { lamports: 1 } : null],
+      };
+    }) as never;
+  });
+
+  test("rejects cleanup prepared for another wallet before chain reads", async () => {
+    const { POST } = await import("./route");
+    preparedWalletAddress = Keypair.fromSeed(new Uint8Array(32).fill(4))
+      .publicKey.toBase58();
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(403);
+    expect(cleanupRecordCount).toBe(0);
+    expect(callOrder).toEqual([]);
+  });
+
+  test("does not close database state when post-cleanup balance proof fails", async () => {
+    const { POST } = await import("./route");
+    proofError = new Error("minimum context slot has not been reached");
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "full_exit_verification_retryable" },
+    });
+    expect(cleanupRecordCount).toBe(0);
+    expect(callOrder).toEqual(["verify-zero"]);
+  });
+
+  test("does not close database state while any balance remains", async () => {
+    const { POST } = await import("./route");
+    proofStatus = "full_exit_incomplete";
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(409);
+    expect(cleanupRecordCount).toBe(0);
+    expect(callOrder).toEqual(["verify-zero"]);
+  });
+
+  test("does not close database state until policy accounts are closed on-chain", async () => {
+    const { POST } = await import("./route");
+    policyAccountStillOpen = true;
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(503);
+    expect(cleanupRecordCount).toBe(0);
+    expect(callOrder).toEqual(["verify-zero", "verify-policy-accounts"]);
+  });
+
+  test("closes database state only after balances and policy accounts verify", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      status: "full_exit_closed",
+    });
+    expect(cleanupRecordCount).toBe(1);
+    expect(callOrder).toEqual([
+      "verify-zero",
+      "verify-policy-accounts",
+      "record-cleanup",
+    ]);
+  });
+});

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
@@ -1,14 +1,21 @@
 import { NextResponse } from "next/server";
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
-import { Connection } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
+import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import { parseEarnWithdrawCleanupConfirmRequestBody } from "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared";
-import { recordConfirmedEarnCleanup } from "@/lib/yield-optimization/yield-deposit-repository.server";
+import {
+  findEarnCleanupVaultState,
+  recordConfirmedEarnCleanup,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
@@ -49,7 +56,14 @@ async function resolveConfirmedSignatureSlot(args: {
     { searchTransactionHistory: true }
   );
   const status = value[0] ?? null;
-  if (typeof status?.slot === "number") {
+  if (status?.err) {
+    throw new Error("Earn cleanup transaction failed on-chain.");
+  }
+  if (
+    typeof status?.slot === "number" &&
+    (status.confirmationStatus === "confirmed" ||
+      status.confirmationStatus === "finalized")
+  ) {
     return BigInt(status.slot);
   }
 
@@ -57,11 +71,55 @@ async function resolveConfirmedSignatureSlot(args: {
     commitment: "confirmed",
     maxSupportedTransactionVersion: 0,
   });
+  if (transaction?.meta?.err) {
+    throw new Error("Earn cleanup transaction failed on-chain.");
+  }
   if (typeof transaction?.slot === "number") {
     return BigInt(transaction.slot);
   }
 
   throw new Error("Confirmed transaction slot is unavailable.");
+}
+
+function cleanupPolicyMetadataMatches(args: {
+  cleanupState: NonNullable<
+    Awaited<ReturnType<typeof findEarnCleanupVaultState>>
+  >;
+  persistence: ReturnType<
+    typeof parseEarnWithdrawCleanupConfirmRequestBody
+  >["preparedCleanup"]["persistence"];
+}): boolean {
+  const { cleanupState, persistence } = args;
+  const setupPolicy = cleanupState.setupPolicy;
+
+  return (
+    cleanupState.routePolicy.policyAccount === persistence.policyAccount &&
+    cleanupState.routePolicy.policySeed.toString() === persistence.policySeed &&
+    (setupPolicy?.policyAccount ?? null) ===
+      (persistence.setupPolicyAccount ?? null) &&
+    (setupPolicy?.policySeed.toString() ?? null) ===
+      (persistence.setupPolicySeed ?? null)
+  );
+}
+
+async function verifyPolicyAccountsClosed(args: {
+  accounts: string[];
+  connection: Connection;
+  minContextSlot: number;
+}): Promise<void> {
+  const { context, value } =
+    await args.connection.getMultipleAccountsInfoAndContext(
+      args.accounts.map((account) => new PublicKey(account)),
+      { commitment: "confirmed", minContextSlot: args.minContextSlot }
+    );
+  if (context.slot < args.minContextSlot) {
+    throw new Error(
+      "Earn policy close proof was observed before the cleanup confirmation slot."
+    );
+  }
+  if (value.some((account) => account !== null)) {
+    throw new Error("One or more Earn policy accounts remain open on-chain.");
+  }
 }
 
 export async function POST(request: Request) {
@@ -96,6 +154,15 @@ export async function POST(request: Request) {
   }
 
   const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
+  if (
+    persistence.cluster !== resolveLoyalClusterForSolanaEnv(solanaEnv)
+  ) {
+    return jsonError(
+      400,
+      "cluster_mismatch",
+      "Prepared cleanup cluster does not match the configured Solana environment."
+    );
+  }
   const connection = getConnection(solanaEnv);
 
   try {
@@ -108,6 +175,28 @@ export async function POST(request: Request) {
         400,
         "slot_mismatch",
         "Confirmed Earn cleanup slot does not match the transaction status."
+      );
+    }
+
+    const cleanupState = await findEarnCleanupVaultState({
+      authority: persistence.walletAddress,
+      includeInactive: true,
+      settings: persistence.settings,
+      vaultIndex: persistence.vaultIndex,
+      vaultPubkey: persistence.vaultPubkey,
+    });
+    if (!cleanupState) {
+      return jsonError(
+        409,
+        "missing_earn_policy",
+        "Earn policy state is unavailable for cleanup confirmation."
+      );
+    }
+    if (!cleanupPolicyMetadataMatches({ cleanupState, persistence })) {
+      return jsonError(
+        409,
+        "cleanup_policy_mismatch",
+        "Prepared cleanup policy metadata does not match the persisted Earn policy."
       );
     }
 
@@ -138,7 +227,76 @@ export async function POST(request: Request) {
           "Confirmed Autodeposit close slot does not match the transaction status."
         );
       }
+    }
 
+    const minContextSlot = Number(confirmedSlot);
+    if (!Number.isSafeInteger(minContextSlot) || minContextSlot < 0) {
+      return jsonError(
+        400,
+        "invalid_confirmed_slot",
+        "Confirmed Earn cleanup slot is outside the supported range."
+      );
+    }
+
+    try {
+      const serverEnv = getServerEnv();
+      const proof = await verifyEarnFullExitZeroBalances({
+        cluster: persistence.cluster,
+        connection,
+        minContextSlot,
+        policy: serializeRoutePolicyState(
+          cleanupState.routePolicy,
+          cleanupState.setupPolicy
+        ),
+        programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
+        settingsPda: new PublicKey(persistence.settings),
+      });
+      if (proof.status !== "policy_close_required") {
+        return jsonError(
+          409,
+          "full_exit_incomplete",
+          "Earn balances remain after cleanup; the position stays active."
+        );
+      }
+
+      await verifyPolicyAccountsClosed({
+        accounts: [
+          persistence.policyAccount,
+          ...(persistence.setupPolicyAccount
+            ? [persistence.setupPolicyAccount]
+            : []),
+          ...(persistence.autodepositClose?.policyAccount
+            ? [persistence.autodepositClose.policyAccount]
+            : []),
+        ],
+        connection,
+        minContextSlot,
+      });
+    } catch (error) {
+      console.error("[earn-withdraw-cleanup-confirm] proof retryable", {
+        cleanupSignature: body.cleanupSignature,
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown proof error.",
+        errorName: error instanceof Error ? error.name : typeof error,
+        minContextSlot,
+        settings: principal.settingsPda,
+        stack: error instanceof Error ? error.stack : undefined,
+        walletAddress: principal.walletAddress,
+      });
+      return jsonError(
+        503,
+        "full_exit_verification_retryable",
+        error instanceof Error
+          ? error.message
+          : "Earn cleanup could not be verified. Retry confirmation."
+      );
+    }
+
+    if (
+      persistence.autodepositClose &&
+      body.autodepositCloseSignature &&
+      body.autodepositCloseConfirmedSlot
+    ) {
       await recordClosedAutodepositTarget({
         cluster: persistence.cluster,
         closeSignature: body.autodepositCloseSignature,
@@ -163,7 +321,15 @@ export async function POST(request: Request) {
       walletAddress: persistence.walletAddress,
     });
 
-    return NextResponse.json({ ok: true });
+    console.info("[earn-withdraw-cleanup-confirm] full exit closed", {
+      cleanupSignature: body.cleanupSignature,
+      confirmedSlot: confirmedSlot.toString(),
+      settings: persistence.settings,
+      status: "full_exit_closed",
+      vaultIndex: persistence.vaultIndex,
+      walletAddress: persistence.walletAddress,
+    });
+    return NextResponse.json({ ok: true, status: "full_exit_closed" });
   } catch (error) {
     console.error("[earn-withdraw-cleanup-confirm] failed", {
       cleanupSignature: body.cleanupSignature,
@@ -175,11 +341,11 @@ export async function POST(request: Request) {
       walletAddress: principal.walletAddress,
     });
     return jsonError(
-      500,
-      "confirm_failed",
+      503,
+      "full_exit_verification_retryable",
       error instanceof Error
         ? error.message
-        : "Failed to record confirmed Earn cleanup."
+        : "Earn cleanup confirmation could not be verified. Retry confirmation."
     );
   }
 }

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
@@ -9,8 +9,11 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
-import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
-import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
+import {
+  assertEarnFullExitProven,
+  EarnCleanupConfirmError,
+  resolveConfirmedSignatureSlot,
+} from "@/lib/yield-optimization/earn-cleanup-confirm.server";
 import { parseEarnWithdrawCleanupConfirmRequestBody } from "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared";
 import {
   findEarnCleanupVaultState,
@@ -47,40 +50,6 @@ function getConnection(cluster: SolanaEnv): Connection {
   return connection;
 }
 
-async function resolveConfirmedSignatureSlot(args: {
-  connection: Connection;
-  signature: string;
-}): Promise<bigint> {
-  const { value } = await args.connection.getSignatureStatuses(
-    [args.signature],
-    { searchTransactionHistory: true }
-  );
-  const status = value[0] ?? null;
-  if (status?.err) {
-    throw new Error("Earn cleanup transaction failed on-chain.");
-  }
-  if (
-    typeof status?.slot === "number" &&
-    (status.confirmationStatus === "confirmed" ||
-      status.confirmationStatus === "finalized")
-  ) {
-    return BigInt(status.slot);
-  }
-
-  const transaction = await args.connection.getTransaction(args.signature, {
-    commitment: "confirmed",
-    maxSupportedTransactionVersion: 0,
-  });
-  if (transaction?.meta?.err) {
-    throw new Error("Earn cleanup transaction failed on-chain.");
-  }
-  if (typeof transaction?.slot === "number") {
-    return BigInt(transaction.slot);
-  }
-
-  throw new Error("Confirmed transaction slot is unavailable.");
-}
-
 function cleanupPolicyMetadataMatches(args: {
   cleanupState: NonNullable<
     Awaited<ReturnType<typeof findEarnCleanupVaultState>>
@@ -100,26 +69,6 @@ function cleanupPolicyMetadataMatches(args: {
     (setupPolicy?.policySeed.toString() ?? null) ===
       (persistence.setupPolicySeed ?? null)
   );
-}
-
-async function verifyPolicyAccountsClosed(args: {
-  accounts: string[];
-  connection: Connection;
-  minContextSlot: number;
-}): Promise<void> {
-  const { context, value } =
-    await args.connection.getMultipleAccountsInfoAndContext(
-      args.accounts.map((account) => new PublicKey(account)),
-      { commitment: "confirmed", minContextSlot: args.minContextSlot }
-    );
-  if (context.slot < args.minContextSlot) {
-    throw new Error(
-      "Earn policy close proof was observed before the cleanup confirmation slot."
-    );
-  }
-  if (value.some((account) => account !== null)) {
-    throw new Error("One or more Earn policy accounts remain open on-chain.");
-  }
 }
 
 export async function POST(request: Request) {
@@ -240,27 +189,12 @@ export async function POST(request: Request) {
 
     try {
       const serverEnv = getServerEnv();
-      const proof = await verifyEarnFullExitZeroBalances({
+      await assertEarnFullExitProven({
+        cleanupState,
         cluster: persistence.cluster,
         connection,
         minContextSlot,
-        policy: serializeRoutePolicyState(
-          cleanupState.routePolicy,
-          cleanupState.setupPolicy
-        ),
-        programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
-        settingsPda: new PublicKey(persistence.settings),
-      });
-      if (proof.status !== "policy_close_required") {
-        return jsonError(
-          409,
-          "full_exit_incomplete",
-          "Earn balances remain after cleanup; the position stays active."
-        );
-      }
-
-      await verifyPolicyAccountsClosed({
-        accounts: [
+        policyAccounts: [
           persistence.policyAccount,
           ...(persistence.setupPolicyAccount
             ? [persistence.setupPolicyAccount]
@@ -269,10 +203,13 @@ export async function POST(request: Request) {
             ? [persistence.autodepositClose.policyAccount]
             : []),
         ],
-        connection,
-        minContextSlot,
+        programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
+        settingsPda: new PublicKey(persistence.settings),
       });
     } catch (error) {
+      if (!(error instanceof EarnCleanupConfirmError)) {
+        throw error;
+      }
       console.error("[earn-withdraw-cleanup-confirm] proof retryable", {
         cleanupSignature: body.cleanupSignature,
         errorMessage:
@@ -283,13 +220,7 @@ export async function POST(request: Request) {
         stack: error instanceof Error ? error.stack : undefined,
         walletAddress: principal.walletAddress,
       });
-      return jsonError(
-        503,
-        "full_exit_verification_retryable",
-        error instanceof Error
-          ? error.message
-          : "Earn cleanup could not be verified. Retry confirmation."
-      );
+      return jsonError(error.status, error.code, error.message);
     }
 
     if (
@@ -331,6 +262,9 @@ export async function POST(request: Request) {
     });
     return NextResponse.json({ ok: true, status: "full_exit_closed" });
   } catch (error) {
+    if (error instanceof EarnCleanupConfirmError) {
+      return jsonError(error.status, error.code, error.message);
+    }
     console.error("[earn-withdraw-cleanup-confirm] failed", {
       cleanupSignature: body.cleanupSignature,
       errorMessage:
@@ -341,11 +275,11 @@ export async function POST(request: Request) {
       walletAddress: principal.walletAddress,
     });
     return jsonError(
-      503,
-      "full_exit_verification_retryable",
+      500,
+      "confirm_failed",
       error instanceof Error
         ? error.message
-        : "Earn cleanup confirmation could not be verified. Retry confirmation."
+        : "Earn cleanup confirmation failed."
     );
   }
 }

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+
+mock.module("server-only", () => ({}));
+
+const principal = {
+  settingsPda: "11111111111111111111111111111112",
+  smartAccountAddress: "11111111111111111111111111111113",
+  walletAddress: Keypair.fromSeed(
+    new Uint8Array(32).fill(2)
+  ).publicKey.toBase58(),
+};
+const policyAccount = "11111111111111111111111111111114";
+const closeableTokenAccount = "11111111111111111111111111111115";
+
+let latestFullWithdrawal: { confirmedSlot: bigint } | null;
+let proofStatus: "full_exit_incomplete" | "policy_close_required";
+let proofError: Error | null;
+let proofCalls: Array<Record<string, unknown>>;
+let prepareCalls: Array<Record<string, unknown>>;
+let autodepositReadCount: number;
+
+mock.module("@/features/identity/server/auth-session", () => ({
+  resolveAuthenticatedPrincipalFromRequest: async () => principal,
+}));
+
+mock.module("@/features/smart-accounts/server/service", () => ({
+  assertAuthenticatedWalletControlsSettings: async () => {},
+  isSmartAccountProvisioningError: () => false,
+}));
+
+mock.module("@/lib/core/config/server", () => ({
+  getServerEnv: () => ({
+    loyalSmartAccounts: {
+      programId: "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG",
+    },
+  }),
+}));
+
+mock.module("@/lib/core/config/solana-env-override", () => ({
+  resolveLoyalWebSolanaEnvFromEnv: () => "mainnet",
+}));
+
+mock.module("@/lib/solana/rpc-endpoints.server", () => ({
+  getServerSolanaEndpoints: () => ({
+    rpcEndpoint: "http://127.0.0.1:8899",
+    websocketEndpoint: "ws://127.0.0.1:8900",
+  }),
+}));
+
+mock.module("@/lib/solana/rpc-rate-limit", () => ({
+  getFrontendSolanaRpcFetch: (fetchImpl: typeof fetch) => fetchImpl,
+}));
+
+mock.module("@/lib/yield-optimization/deployment-policy-signer.server", () => ({
+  getDeploymentPolicySignerPublicKey: () => PublicKey.default,
+}));
+
+mock.module(
+  "@/lib/yield-optimization/earn-autodeposit-repository.server",
+  () => ({
+    findCurrentEarnAutodepositState: async () => {
+      autodepositReadCount += 1;
+      return null;
+    },
+    reconcileMissingOnChainEarnAutodepositPolicy: async () => {},
+  })
+);
+
+mock.module(
+  "@/lib/yield-optimization/earn-full-exit-zero-proof.server",
+  () => ({
+    verifyEarnFullExitZeroBalances: async (input: Record<string, unknown>) => {
+      proofCalls.push(input);
+      if (proofError) {
+        throw proofError;
+      }
+      return {
+        blockingTokenAccounts: [],
+        closeableTokenAccounts: [closeableTokenAccount],
+        idleAmountRaw: "9999",
+        idleReadsAgree: true,
+        observedSlot: "500",
+        remainingHoldings:
+          proofStatus === "full_exit_incomplete"
+            ? [{ amountRaw: "1", kind: "kamino" }]
+            : [],
+        status: proofStatus,
+      };
+    },
+  })
+);
+
+mock.module("@/lib/yield-optimization/earn-state-serializers.server", () => ({
+  serializeRoutePolicyState: () => ({ vaultIndex: 1 }),
+}));
+
+mock.module(
+  "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared",
+  () => ({
+    serializePreparedEarnUsdcCleanup: () => ({ prepared: true }),
+  })
+);
+
+mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
+  findEarnCleanupVaultState: async () => ({
+    routePolicy: {
+      policyAccount,
+      policySeed: BigInt(7),
+    },
+    setupPolicy: null,
+    vault: { id: BigInt(1) },
+  }),
+  findLatestFullYieldWithdrawalForVault: async () => latestFullWithdrawal,
+}));
+
+mock.module("@loyal-labs/smart-account-vaults", () => ({
+  createSmartAccountVaultsClient: () => ({
+    prepareEarnUsdcCleanup: async (input: Record<string, unknown>) => {
+      prepareCalls.push(input);
+      return {};
+    },
+  }),
+}));
+
+describe("Earn cleanup prepare route", () => {
+  beforeEach(() => {
+    latestFullWithdrawal = { confirmedSlot: BigInt(500) };
+    proofStatus = "full_exit_incomplete";
+    proofError = null;
+    proofCalls = [];
+    prepareCalls = [];
+    autodepositReadCount = 0;
+    Connection.prototype.getAccountInfo = mock(async () => null) as never;
+    Connection.prototype.getMultipleAccountsInfo = mock(
+      async () => []
+    ) as never;
+  });
+
+  test("requires a confirmed full withdrawal before any close preparation", async () => {
+    const { POST } = await import("./route");
+    latestFullWithdrawal = null;
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: "missing_full_withdrawal" },
+    });
+    expect(proofCalls).toHaveLength(0);
+    expect(prepareCalls).toHaveLength(0);
+  });
+
+  test("keeps every close operation unprepared while a reserve remains positive", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: "full_exit_incomplete" },
+    });
+    expect(prepareCalls).toHaveLength(0);
+    expect(autodepositReadCount).toBe(0);
+  });
+
+  test("returns a retryable state without preparing closure when RPC fails", async () => {
+    const { POST } = await import("./route");
+    proofError = new Error("minimum context slot has not been reached");
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "full_exit_verification_retryable" },
+    });
+    expect(prepareCalls).toHaveLength(0);
+  });
+
+  test("prepares the separate close phase only after zero proof", async () => {
+    const { POST } = await import("./route");
+    proofStatus = "policy_close_required";
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(proofCalls[0]?.minContextSlot).toBe(500);
+    expect(prepareCalls).toHaveLength(1);
+    expect(prepareCalls[0]?.idleAmountRaw).toBe(BigInt(9999));
+    expect(
+      (prepareCalls[0]?.closeVaultCollateralAtas as PublicKey[])[0]?.toBase58()
+    ).toBe(closeableTokenAccount);
+  });
+});

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts
@@ -19,10 +19,12 @@ import {
   findCurrentEarnAutodepositState,
   reconcileMissingOnChainEarnAutodepositPolicy,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import { serializePreparedEarnUsdcCleanup } from "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared";
 import {
   findEarnCleanupVaultState,
-  type CurrentYieldVaultReservePositionRecord,
+  findLatestFullYieldWithdrawalForVault,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
@@ -57,55 +59,6 @@ function getConnection(cluster: SolanaEnv): Connection {
   });
   connectionCache.set(cluster, connection);
   return connection;
-}
-
-function publicKeyFromMetadata(
-  metadata: Record<string, unknown> | null | undefined,
-  keys: string[]
-): PublicKey | null {
-  if (!metadata) {
-    return null;
-  }
-
-  for (const key of keys) {
-    const value = metadata[key];
-    if (typeof value !== "string" || value.trim().length === 0) {
-      continue;
-    }
-    try {
-      return new PublicKey(value);
-    } catch {
-      continue;
-    }
-  }
-
-  return null;
-}
-
-function resolveVaultCollateralAtas(
-  rows: CurrentYieldVaultReservePositionRecord[]
-): PublicKey[] {
-  const seen = new Set<string>();
-  const atas: PublicKey[] = [];
-
-  for (const row of rows) {
-    const vaultCollateralAta = publicKeyFromMetadata(row.planningMetadata, [
-      "vaultCollateralAta",
-      "vault_collateral_ata",
-      "collateralAta",
-      "collateral_ata",
-    ]);
-    if (!vaultCollateralAta) {
-      continue;
-    }
-    const key = vaultCollateralAta.toBase58();
-    if (!seen.has(key)) {
-      seen.add(key);
-      atas.push(vaultCollateralAta);
-    }
-  }
-
-  return atas;
 }
 
 export async function POST(request: Request) {
@@ -146,22 +99,70 @@ export async function POST(request: Request) {
       );
     }
 
-    const activeReserveRows = cleanupState.reserveRows.filter(
-      (row) => row.amountRaw > BigInt(0)
-    );
-    if (activeReserveRows.length > 0) {
+    const connection = getConnection(solanaEnv);
+    const latestFullWithdrawal =
+      await findLatestFullYieldWithdrawalForVault({
+        settings: principal.settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+        walletAddress: principal.walletAddress,
+      });
+    if (!latestFullWithdrawal) {
       return jsonError(
         409,
-        "active_earn_sources_remaining",
-        "Withdraw active Earn sources before closing Earn accounts."
+        "missing_full_withdrawal",
+        "A confirmed full withdrawal is required before closing Earn accounts."
+      );
+    }
+    const minContextSlot = Number(latestFullWithdrawal.confirmedSlot);
+    if (!Number.isSafeInteger(minContextSlot) || minContextSlot < 0) {
+      return jsonError(
+        409,
+        "missing_full_exit_verification_anchor",
+        "A confirmed full withdrawal is required before closing Earn accounts."
       );
     }
 
-    const idleAmountRaw = cleanupState.idleRows.reduce(
-      (total, row) => total + row.amountRaw,
-      BigInt(0)
-    );
-    const connection = getConnection(solanaEnv);
+    let zeroProof: Awaited<ReturnType<typeof verifyEarnFullExitZeroBalances>>;
+    try {
+      zeroProof = await verifyEarnFullExitZeroBalances({
+        cluster,
+        connection,
+        minContextSlot,
+        policy: serializeRoutePolicyState(
+          cleanupState.routePolicy,
+          cleanupState.setupPolicy
+        ),
+        programId,
+        settingsPda,
+      });
+    } catch (error) {
+      console.error("[earn-withdraw-cleanup-prepare] zero proof retryable", {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown proof error.",
+        errorName: error instanceof Error ? error.name : typeof error,
+        minContextSlot,
+        settings: principal.settingsPda,
+        stack: error instanceof Error ? error.stack : undefined,
+        walletAddress: principal.walletAddress,
+      });
+      return jsonError(
+        503,
+        "full_exit_verification_retryable",
+        error instanceof Error
+          ? error.message
+          : "Earn balances could not be verified. Retry cleanup."
+      );
+    }
+    if (zeroProof.status !== "policy_close_required") {
+      return jsonError(
+        409,
+        "full_exit_incomplete",
+        "Earn balances remain above the full-exit dust tolerance. Resume withdrawal before closing policies."
+      );
+    }
+
+    const idleAmountRaw = BigInt(zeroProof.idleAmountRaw);
     const client = createSmartAccountVaultsClient({ connection, programId });
     const autodepositState = await findCurrentEarnAutodepositState({
       settings: principal.settingsPda,
@@ -219,8 +220,8 @@ export async function POST(request: Request) {
           );
     const preparedCleanup = await client.prepareEarnUsdcCleanup({
       cluster,
-      closeVaultCollateralAtas: resolveVaultCollateralAtas(
-        cleanupState.reserveRows
+      closeVaultCollateralAtas: zeroProof.closeableTokenAccounts.map(
+        (account) => new PublicKey(account)
       ),
       feePayer: new PublicKey(principal.walletAddress),
       idleAmountRaw,

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
@@ -22,6 +22,7 @@ let parsedInput: Record<string, unknown>;
 let resolvedPrincipal: typeof principal | null = principal;
 let callOrder: string[] = [];
 let depositCalls: unknown[] = [];
+let reconcileCalls: unknown[] = [];
 let withdrawalCalls: unknown[] = [];
 let fullExitProofStatus: "full_exit_incomplete" | "policy_close_required" =
   "full_exit_incomplete";
@@ -120,8 +121,9 @@ mock.module(
 mock.module(
   "@/lib/yield-optimization/earn-position-reconciliation.server",
   () => ({
-    reconcileEarnVaultPosition: async () => {
+    reconcileEarnVaultPosition: async (input: unknown) => {
       callOrder.push("reconcile");
+      reconcileCalls.push(input);
       return { status: "refreshed" };
     },
   })
@@ -298,6 +300,7 @@ describe("Earn withdrawal confirm route", () => {
     resolvedPrincipal = principal;
     callOrder = [];
     depositCalls = [];
+    reconcileCalls = [];
     withdrawalCalls = [];
     fullExitProofError = null;
     fullExitProofStatus = "full_exit_incomplete";
@@ -368,7 +371,7 @@ describe("Earn withdrawal confirm route", () => {
     })) as never;
   });
 
-  test("records withdrawal before zero verification and keeps positive holdings active", async () => {
+  test("does not reconcile holdings until zero verification succeeds", async () => {
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -383,11 +386,8 @@ describe("Earn withdrawal confirm route", () => {
       position: { status: "active" },
       status: "full_exit_incomplete",
     });
-    expect(callOrder).toEqual([
-      "record-withdrawal",
-      "reconcile",
-      "verify-zero",
-    ]);
+    expect(callOrder).toEqual(["record-withdrawal", "verify-zero"]);
+    expect(reconcileCalls).toEqual([]);
     expect(withdrawalCalls[0]).toMatchObject({
       mode: "full",
       withdrawalSignature: "withdrawal-signature",
@@ -432,11 +432,8 @@ describe("Earn withdrawal confirm route", () => {
     expect(await response.json()).toMatchObject({
       error: { code: "full_exit_verification_retryable" },
     });
-    expect(callOrder).toEqual([
-      "record-withdrawal",
-      "reconcile",
-      "verify-zero",
-    ]);
+    expect(callOrder).toEqual(["record-withdrawal", "verify-zero"]);
+    expect(reconcileCalls).toEqual([]);
   });
 
   test("reports policy close required without closing the active position", async () => {
@@ -457,9 +454,13 @@ describe("Earn withdrawal confirm route", () => {
     });
     expect(callOrder).toEqual([
       "record-withdrawal",
-      "reconcile",
       "verify-zero",
+      "reconcile",
     ]);
+    expect(reconcileCalls[0]).toMatchObject({
+      minContextSlot: 300,
+      purpose: "post_withdrawal_zero_proof",
+    });
   });
 });
 
@@ -469,6 +470,7 @@ describe("Earn deposit confirm route", () => {
     resolvedPrincipal = principal;
     callOrder = [];
     depositCalls = [];
+    reconcileCalls = [];
     withdrawalCalls = [];
     Connection.prototype.getSignatureStatuses = mock(async () => ({
       value: [

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { Connection, PublicKey } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 
 mock.module("server-only", () => ({}));
 
 const principal = {
   settingsPda: "11111111111111111111111111111112",
   smartAccountAddress: "11111111111111111111111111111113",
-  walletAddress: "11111111111111111111111111111114",
+  walletAddress: Keypair.fromSeed(new Uint8Array(32).fill(1))
+    .publicKey.toBase58(),
 };
 const canonical = {
   liquidityMint: "11111111111111111111111111111115",
@@ -20,9 +21,11 @@ const canonical = {
 let parsedInput: Record<string, unknown>;
 let resolvedPrincipal: typeof principal | null = principal;
 let callOrder: string[] = [];
-let closeCalls: unknown[] = [];
 let depositCalls: unknown[] = [];
 let withdrawalCalls: unknown[] = [];
+let fullExitProofStatus: "full_exit_incomplete" | "policy_close_required" =
+  "full_exit_incomplete";
+let fullExitProofError: Error | null = null;
 
 mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => resolvedPrincipal,
@@ -30,6 +33,14 @@ mock.module("@/features/identity/server/auth-session", () => ({
 
 mock.module("@/lib/core/config/solana-env-override", () => ({
   resolveLoyalWebSolanaEnvFromEnv: () => "mainnet",
+}));
+
+mock.module("@/lib/core/config/server", () => ({
+  getServerEnv: () => ({
+    loyalSmartAccounts: {
+      programId: "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG",
+    },
+  }),
 }));
 
 mock.module("@/lib/solana/rpc-endpoints", () => ({
@@ -54,6 +65,7 @@ mock.module("@loyal-labs/actions", () => ({
 }));
 
 mock.module("@loyal-labs/loyal-smart-accounts", () => ({
+  PROGRAM_ADDRESS: "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG",
   pda: {
     getPolicyPda: (input: { policySeed: number }) => [
       new PublicKey(
@@ -99,11 +111,58 @@ mock.module(
     findCurrentEarnAutodepositState: async () => {
       throw new Error("findCurrentEarnAutodepositState was not expected.");
     },
-    recordClosedAutodepositTarget: async (input: unknown) => {
-      callOrder.push("close-autodeposit");
-      closeCalls.push(input);
-      return {};
+    recordClosedAutodepositTarget: async () => {
+      throw new Error("recordClosedAutodepositTarget was not expected.");
     },
+  })
+);
+
+mock.module(
+  "@/lib/yield-optimization/earn-position-reconciliation.server",
+  () => ({
+    reconcileEarnVaultPosition: async () => {
+      callOrder.push("reconcile");
+      return { status: "refreshed" };
+    },
+  })
+);
+
+mock.module(
+  "@/lib/yield-optimization/earn-full-exit-zero-proof.server",
+  () => ({
+    verifyEarnFullExitZeroBalances: async () => {
+      callOrder.push("verify-zero");
+      if (fullExitProofError) {
+        throw fullExitProofError;
+      }
+      return {
+        blockingTokenAccounts: [],
+        closeableTokenAccounts: [],
+        idleAmountRaw: "0",
+        idleReadsAgree: true,
+        observedSlot: "300",
+        remainingHoldings:
+          fullExitProofStatus === "full_exit_incomplete"
+            ? [
+                {
+                  amountRaw: "1",
+                  kind: "kamino",
+                  liquidityMint: canonical.liquidityMint,
+                  market: canonical.market,
+                  reserve: canonical.reserve,
+                },
+              ]
+            : [],
+        status: fullExitProofStatus,
+      };
+    },
+  })
+);
+
+mock.module(
+  "@/lib/yield-optimization/earn-state-serializers.server",
+  () => ({
+    serializeRoutePolicyState: () => ({ vaultIndex: 1 }),
   })
 );
 
@@ -111,11 +170,30 @@ mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
   findActiveYieldRoutePolicy: async () => {
     throw new Error("findActiveYieldRoutePolicy was not expected.");
   },
-  findReconciledActiveYieldPositionForVault: async () => {
-    throw new Error(
-      "findReconciledActiveYieldPositionForVault was not expected."
-    );
-  },
+  findEarnCleanupVaultState: async () => ({
+    routePolicy: {},
+    setupPolicy: null,
+  }),
+  findReconciledActiveYieldPositionForVault: async () => ({
+    currentAmountRaw: BigInt(0),
+    currentLiquidityMint: canonical.liquidityMint,
+    currentMarket: canonical.market,
+    currentObservedAt: new Date("2026-06-02T00:00:00.000Z"),
+    currentObservedSlot: BigInt(300),
+    currentReserve: canonical.reserve,
+    id: BigInt(1),
+    initialLiquidityMint: canonical.liquidityMint,
+    initialMarket: canonical.market,
+    initialReserve: canonical.reserve,
+    initialSupplyApyBps: null,
+    lastHoldingEventId: BigInt(2),
+    lastRebalanceDecisionId: null,
+    principalAmountRaw: BigInt(0),
+    status: "active",
+  }),
+  markEarnDepositOnboardingAccountingFailed: async () => {},
+  markEarnDepositOnboardingComplete: async () => {},
+  recordEarnDepositOnboardingDepositSignature: async () => ({}),
   recordConfirmedYieldDeposit: async (input: unknown) => {
     depositCalls.push(input);
     return {
@@ -154,7 +232,7 @@ mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
       lastHoldingEventId: BigInt(2),
       lastRebalanceDecisionId: null,
       principalAmountRaw: BigInt(0),
-      status: "closed",
+      status: "active",
     };
   },
 }));
@@ -181,7 +259,7 @@ function createDepositInput(overrides: Record<string, unknown> = {}) {
     setupPolicyId: BigInt(8),
     setupPolicySeed: BigInt(8),
     setupPolicySignature: "setup-policy-signature",
-    smartAccountAddress: principal.smartAccountAddress,
+    smartAccountAddress: canonical.vaultPubkey,
     targetReserve: canonical.reserve,
     targetSupplyApyBps: BigInt(123),
     vaultIndex: 1,
@@ -193,13 +271,6 @@ function createDepositInput(overrides: Record<string, unknown> = {}) {
 
 function createFullWithdrawalInput(overrides: Record<string, unknown> = {}) {
   return {
-    autodepositClose: {
-      closeSignature: "autodeposit-close-signature",
-      confirmedSlot: BigInt(299),
-      delegatedSigner: "autodeposit-delegate",
-      policyAccount: "1111111111111111111111111111111A",
-      recurringDelegation: "1111111111111111111111111111111B",
-    },
     cluster: "mainnet-beta",
     confirmedSlot: BigInt(300),
     delegatedSigner: "yield-delegate",
@@ -210,7 +281,7 @@ function createFullWithdrawalInput(overrides: Record<string, unknown> = {}) {
     policyId: BigInt(7),
     policySeed: BigInt(7),
     settings: principal.settingsPda,
-    smartAccountAddress: principal.smartAccountAddress,
+    smartAccountAddress: canonical.vaultPubkey,
     targetReserve: canonical.reserve,
     vaultIndex: 1,
     vaultPubkey: canonical.vaultPubkey,
@@ -226,25 +297,78 @@ describe("Earn withdrawal confirm route", () => {
     parsedInput = createFullWithdrawalInput();
     resolvedPrincipal = principal;
     callOrder = [];
-    closeCalls = [];
     depositCalls = [];
     withdrawalCalls = [];
-    Connection.prototype.getSignatureStatuses = mock(async (signatures) => ({
+    fullExitProofError = null;
+    fullExitProofStatus = "full_exit_incomplete";
+    Connection.prototype.getSignatureStatuses = mock(async () => ({
       value: [
         {
           confirmationStatus: "confirmed",
           err: null,
-          slot:
-            Array.isArray(signatures) &&
-            signatures[0] === "autodeposit-close-signature"
-              ? 299
-              : 300,
+          slot: 300,
         },
       ],
     })) as never;
+    Connection.prototype.getParsedTransaction = mock(async () => ({
+      blockTime: 1,
+      meta: {
+        err: null,
+        fee: 5000,
+        innerInstructions: null,
+        logMessages: [],
+        postBalances: [1],
+        postTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: canonical.liquidityMint,
+            owner: principal.walletAddress,
+            uiTokenAmount: {
+              amount: "1000000",
+              decimals: 6,
+              uiAmount: 1,
+              uiAmountString: "1",
+            },
+          },
+        ],
+        preBalances: [1],
+        preTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: canonical.liquidityMint,
+            owner: principal.walletAddress,
+            uiTokenAmount: {
+              amount: "0",
+              decimals: 6,
+              uiAmount: 0,
+              uiAmountString: "0",
+            },
+          },
+        ],
+        rewards: [],
+        status: { Ok: null },
+      },
+      slot: 300,
+      transaction: {
+        message: {
+          accountKeys: [
+            {
+              pubkey: new PublicKey("1111111111111111111111111111111B"),
+              signer: false,
+              source: "transaction",
+              writable: true,
+            },
+          ],
+          addressTableLookups: null,
+          instructions: [],
+          recentBlockhash: "11111111111111111111111111111111",
+        },
+        signatures: ["withdrawal-signature"],
+      },
+    })) as never;
   });
 
-  test("verifies and closes split autodeposit target before recording full withdrawal", async () => {
+  test("records withdrawal before zero verification and keeps positive holdings active", async () => {
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -255,55 +379,27 @@ describe("Earn withdrawal confirm route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(callOrder).toEqual(["close-autodeposit", "record-withdrawal"]);
-    expect(closeCalls).toEqual([
-      {
-        cluster: "mainnet-beta",
-        closeSignature: "autodeposit-close-signature",
-        confirmedSlot: BigInt(299),
-        delegatedSigner: "autodeposit-delegate",
-        policyAccount: "1111111111111111111111111111111A",
-        recurringDelegation: "1111111111111111111111111111111B",
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        vaultPubkey: canonical.vaultPubkey,
-        walletAddress: principal.walletAddress,
-      },
+    expect(await response.json()).toMatchObject({
+      position: { status: "active" },
+      status: "full_exit_incomplete",
+    });
+    expect(callOrder).toEqual([
+      "record-withdrawal",
+      "reconcile",
+      "verify-zero",
     ]);
     expect(withdrawalCalls[0]).toMatchObject({
-      autodepositClose: {
-        closeSignature: "autodeposit-close-signature",
-        confirmedSlot: BigInt(299),
-        delegatedSigner: "autodeposit-delegate",
-        policyAccount: "1111111111111111111111111111111A",
-        recurringDelegation: "1111111111111111111111111111111B",
-      },
       mode: "full",
       withdrawalSignature: "withdrawal-signature",
     });
   });
 
-  test("rejects autodeposit close metadata on partial confirmations", async () => {
-    const { POST } = await import("./route");
-    parsedInput = createFullWithdrawalInput({ mode: "partial" });
-
-    const response = await POST(
-      new Request("http://localhost/api/withdrawals/confirm", {
-        body: JSON.stringify({}),
-        method: "POST",
-      })
-    );
-
-    expect(response.status).toBe(400);
-    expect(callOrder).toEqual([]);
-  });
-
-  test("rejects mismatched split autodeposit close slots", async () => {
+  test("rejects policy close metadata on every withdrawal confirmation", async () => {
     const { POST } = await import("./route");
     parsedInput = createFullWithdrawalInput({
       autodepositClose: {
         closeSignature: "autodeposit-close-signature",
-        confirmedSlot: BigInt(301),
+        confirmedSlot: BigInt(299),
         delegatedSigner: "autodeposit-delegate",
         policyAccount: "1111111111111111111111111111111A",
         recurringDelegation: "1111111111111111111111111111111B",
@@ -319,6 +415,51 @@ describe("Earn withdrawal confirm route", () => {
 
     expect(response.status).toBe(400);
     expect(callOrder).toEqual([]);
+  });
+
+  test("returns retryable after recording when post-withdraw RPC verification fails", async () => {
+    const { POST } = await import("./route");
+    fullExitProofError = new Error("minimum context slot has not been reached");
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/confirm", {
+        body: JSON.stringify({}),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "full_exit_verification_retryable" },
+    });
+    expect(callOrder).toEqual([
+      "record-withdrawal",
+      "reconcile",
+      "verify-zero",
+    ]);
+  });
+
+  test("reports policy close required without closing the active position", async () => {
+    const { POST } = await import("./route");
+    fullExitProofStatus = "policy_close_required";
+
+    const response = await POST(
+      new Request("http://localhost/api/withdrawals/confirm", {
+        body: JSON.stringify({}),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      position: { status: "active" },
+      status: "policy_close_required",
+    });
+    expect(callOrder).toEqual([
+      "record-withdrawal",
+      "reconcile",
+      "verify-zero",
+    ]);
   });
 });
 
@@ -327,7 +468,6 @@ describe("Earn deposit confirm route", () => {
     parsedInput = createDepositInput();
     resolvedPrincipal = principal;
     callOrder = [];
-    closeCalls = [];
     depositCalls = [];
     withdrawalCalls = [];
     Connection.prototype.getSignatureStatuses = mock(async () => ({
@@ -338,6 +478,62 @@ describe("Earn deposit confirm route", () => {
           slot: 300,
         },
       ],
+    })) as never;
+    Connection.prototype.getParsedTransaction = mock(async () => ({
+      blockTime: 1,
+      meta: {
+        err: null,
+        fee: 5000,
+        innerInstructions: null,
+        logMessages: [],
+        postBalances: [1],
+        postTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: canonical.liquidityMint,
+            owner: principal.walletAddress,
+            uiTokenAmount: {
+              amount: "0",
+              decimals: 6,
+              uiAmount: 0,
+              uiAmountString: "0",
+            },
+          },
+        ],
+        preBalances: [1],
+        preTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: canonical.liquidityMint,
+            owner: principal.walletAddress,
+            uiTokenAmount: {
+              amount: "1000000",
+              decimals: 6,
+              uiAmount: 1,
+              uiAmountString: "1",
+            },
+          },
+        ],
+        rewards: [],
+        status: { Ok: null },
+      },
+      slot: 300,
+      transaction: {
+        message: {
+          accountKeys: [
+            {
+              pubkey: new PublicKey("1111111111111111111111111111111B"),
+              signer: false,
+              source: "transaction",
+              writable: true,
+            },
+          ],
+          addressTableLookups: null,
+          instructions: [],
+          recentBlockhash: "11111111111111111111111111111111",
+        },
+        signatures: ["deposit-signature"],
+      },
     })) as never;
   });
 
@@ -413,7 +609,7 @@ describe("Earn deposit confirm route", () => {
     expect(depositCalls).toEqual([]);
   });
 
-  test("rejects mismatched confirmed slots before recording", async () => {
+  test("uses the server-resolved slot when the client context slot differs", async () => {
     const { POST } = await import("../../deposits/confirm/route");
     parsedInput = createDepositInput({ confirmedSlot: BigInt(301) });
 
@@ -424,8 +620,8 @@ describe("Earn deposit confirm route", () => {
       })
     );
 
-    expect(response.status).toBe(400);
-    expect(depositCalls).toEqual([]);
+    expect(response.status).toBe(200);
+    expect(depositCalls[0]).toMatchObject({ confirmedSlot: BigInt(300) });
   });
 
   test("rejects missing sessions before recording", async () => {

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const position = await recordConfirmedEarnWithdrawal({
+    const result = await recordConfirmedEarnWithdrawal({
       principal: {
         walletAddress: principal.walletAddress,
         smartAccountAddress: principal.smartAccountAddress,
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
       input,
       solanaEnv: getConfiguredSolanaEnv(),
     });
-    return NextResponse.json({ position });
+    return NextResponse.json(result);
   } catch (error) {
     if (error instanceof EarnWithdrawConfirmError) {
       return jsonError(error.status, error.code, error.message);

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -68,6 +68,11 @@ mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => currentPrincipal,
 }));
 
+mock.module("@/features/smart-accounts/server/service", () => ({
+  assertAuthenticatedWalletControlsSettings: async () => {},
+  isSmartAccountProvisioningError: () => false,
+}));
+
 mock.module("@/lib/core/config/server", () => ({
   getServerEnv: () => ({
     loyalSmartAccounts: {
@@ -95,6 +100,13 @@ mock.module("@/lib/yield-optimization/deployment-policy-signer.server", () => ({
   getDeploymentPolicySignerPublicKey: () =>
     new PublicKey("11111111111111111111111111111115"),
 }));
+
+mock.module(
+  "@/lib/yield-optimization/earn-position-reconciliation.server",
+  () => ({
+    reconcileEarnVaultPosition: async () => ({ status: "refreshed" }),
+  })
+);
 
 mock.module(
   "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared",
@@ -206,6 +218,16 @@ function createRequest(body: Record<string, unknown>): Request {
 describe("Earn withdrawal prepare route", () => {
   beforeEach(() => {
     (
+      globalThis as unknown as {
+        __createEarnTestVaultsClient?: () => unknown;
+      }
+    ).__createEarnTestVaultsClient = () => ({
+      prepareEarnUsdcWithdraw: async (input: Record<string, unknown>) => {
+        prepareCalls.push(input);
+        return { prepared: true, input };
+      },
+    });
+    (
       Connection.prototype as unknown as {
         getAccountInfo: (key: PublicKey) => Promise<unknown | null>;
       }
@@ -283,7 +305,7 @@ describe("Earn withdrawal prepare route", () => {
     ).toBe(activeSetupPolicy.policySeed);
   });
 
-  test("passes complete active autodeposit close metadata for full withdrawals", async () => {
+  test("never combines policy closure with a full withdrawal", async () => {
     const { POST } = await import("./route");
     currentAutodepositState = completeAutodepositState;
 
@@ -302,85 +324,11 @@ describe("Earn withdrawal prepare route", () => {
     ]);
     expect(findReserveRowsCalls).toHaveLength(1);
     expect(prepareCalls[0]?.amountRaw).toBe(activePosition.principalAmountRaw);
-    expect(findAutodepositCalls).toEqual([
-      {
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        walletAddress: principal.walletAddress,
-      },
-    ]);
-    expect(getAccountInfoCalls).toEqual([
-      completeAutodepositState.policy.policyAccount,
-    ]);
+    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
+    expect(prepareCalls[0]?.autodepositClose).toBeUndefined();
+    expect(findAutodepositCalls).toHaveLength(0);
+    expect(getAccountInfoCalls).toHaveLength(0);
     expect(reconcileMissingAutodepositCalls).toHaveLength(0);
-    expect(
-      (
-        prepareCalls[0]?.autodepositClose as {
-          policy: PublicKey;
-          recurringDelegation: PublicKey;
-        }
-      ).policy.toBase58()
-    ).toBe(completeAutodepositState.policy.policyAccount);
-    expect(
-      (
-        prepareCalls[0]?.autodepositClose as {
-          policy: PublicKey;
-          recurringDelegation: PublicKey;
-        }
-      ).recurringDelegation.toBase58()
-    ).toBe(completeAutodepositState.target.recurringDelegation);
-  });
-
-  test("reconciles and skips autodeposit close when the policy account is already missing", async () => {
-    const { POST } = await import("./route");
-    currentAutodepositState = completeAutodepositState;
-    currentAutodepositPolicyAccountExists = false;
-
-    const response = await POST(
-      createRequest({ amountRaw: "1000000", mode: "full" })
-    );
-
-    expect(response.status).toBe(200);
-    expect(getAccountInfoCalls).toEqual([
-      completeAutodepositState.policy.policyAccount,
-    ]);
-    expect(reconcileMissingAutodepositCalls).toEqual([
-      {
-        policyAccount: completeAutodepositState.policy.policyAccount,
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        walletAddress: principal.walletAddress,
-      },
-    ]);
-    expect(prepareCalls[0]?.autodepositClose).toBeUndefined();
-  });
-
-  test("omits autodeposit close metadata when full withdrawal state is incomplete", async () => {
-    const { POST } = await import("./route");
-    currentAutodepositState = {
-      ...completeAutodepositState,
-      target: {
-        ...completeAutodepositState.target,
-        recurringDelegation: null,
-      },
-    } as never;
-
-    const response = await POST(
-      createRequest({
-        amountRaw: "1000000",
-        mode: "full",
-        source: {
-          id: activePosition.currentReserve,
-          reserve: activePosition.currentReserve,
-          type: "reserve",
-        },
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(findAutodepositCalls).toHaveLength(1);
-    expect(findPositionCalls).toHaveLength(1);
-    expect(prepareCalls[0]?.autodepositClose).toBeUndefined();
   });
 
   test("passes reconciled nonzero reserve rows as full withdrawal targets", async () => {
@@ -426,7 +374,7 @@ describe("Earn withdrawal prepare route", () => {
     expect(targets[0]?.reserve.toBase58()).toBe(activePosition.currentReserve);
   });
 
-  test("treats sub-cent idle dust as a final exit on full reserve withdrawals", async () => {
+  test("keeps policy closure out of withdrawal even with only sub-cent idle dust", async () => {
     const { POST } = await import("./route");
     currentIdleRows = [
       {
@@ -449,7 +397,7 @@ describe("Earn withdrawal prepare route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(true);
+    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
   });
 
   test("keeps full reserve withdrawals non-final while a withdrawable idle balance remains", async () => {

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -19,16 +19,11 @@ import {
   serializePreparedEarnUsdcWithdraw,
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import {
-  findCurrentEarnAutodepositState,
-  reconcileMissingOnChainEarnAutodepositPolicy,
-} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
 import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   findActiveYieldRoutePolicyPair,
   findCurrentNonzeroYieldVaultReservePositions,
-  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
   findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type CurrentYieldVaultIdleTokenBalanceRecord,
@@ -379,32 +374,6 @@ export async function POST(request: Request) {
       reserveRows: currentReserveRows,
     });
     effectiveAmountRaw = mode === "full" ? selectedSource.amountRaw : amountRaw;
-    const remainingReserveAmountRaw = currentReserveRows.reduce(
-      (total, row) =>
-        total +
-        (selectedSource.type === "reserve" &&
-        row.reserve === selectedSource.reserve
-          ? row.amountRaw > effectiveAmountRaw!
-            ? row.amountRaw - effectiveAmountRaw!
-            : BigInt(0)
-          : row.amountRaw),
-      BigInt(0)
-    );
-    const remainingIdleAmountRaw = currentIdleRows.reduce(
-      (total, row) =>
-        total +
-        (selectedSource.type === "idle" &&
-        row.tokenAccount === selectedSource.tokenAccount
-          ? row.amountRaw > effectiveAmountRaw!
-            ? row.amountRaw - effectiveAmountRaw!
-            : BigInt(0)
-          : row.amountRaw),
-      BigInt(0)
-    );
-    const isFinalExit =
-      remainingReserveAmountRaw <= BigInt(0) &&
-      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
-
     const policySigner = getDeploymentPolicySignerPublicKey();
     const client = createSmartAccountVaultsClient({
       connection,
@@ -422,87 +391,6 @@ export async function POST(request: Request) {
           }
         : {}),
     };
-    const autodepositState =
-      mode === "full" && isFinalExit
-        ? await findCurrentEarnAutodepositState({
-            settings: principal.settingsPda,
-            vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-            walletAddress: principal.walletAddress,
-          })
-        : null;
-    let autodepositClose:
-      | {
-          policy: PublicKey;
-          recurringDelegation: PublicKey;
-        }
-      | undefined;
-    let reconciledMissingAutodepositPolicy = false;
-
-    if (
-      autodepositState?.target.policyAccount &&
-      autodepositState.target.recurringDelegation
-    ) {
-      const autodepositPolicyAccount = new PublicKey(
-        autodepositState.target.policyAccount
-      );
-      const autodepositPolicyInfo = await connection.getAccountInfo(
-        autodepositPolicyAccount,
-        "confirmed"
-      );
-
-      if (autodepositPolicyInfo) {
-        autodepositClose = {
-          policy: autodepositPolicyAccount,
-          recurringDelegation: new PublicKey(
-            autodepositState.target.recurringDelegation
-          ),
-        };
-      } else {
-        reconciledMissingAutodepositPolicy = true;
-        const reconciledTarget =
-          await reconcileMissingOnChainEarnAutodepositPolicy({
-            policyAccount: autodepositState.target.policyAccount,
-            settings: principal.settingsPda,
-            vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-            walletAddress: principal.walletAddress,
-          });
-        console.warn(
-          "[earn-withdraw-prepare] reconciled missing autodeposit policy account",
-          {
-            cluster,
-            lifecycleStatus: reconciledTarget.lifecycleStatus,
-            policyAccount: autodepositState.target.policyAccount,
-            reconciliationSource: "reconciled_missing_policy",
-            settings: principal.settingsPda,
-            targetId: reconciledTarget.id.toString(),
-            vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-            walletAddress: principal.walletAddress,
-          }
-        );
-      }
-    }
-
-    if (
-      mode === "full" &&
-      isFinalExit &&
-      autodepositState &&
-      !autodepositClose &&
-      !reconciledMissingAutodepositPolicy
-    ) {
-      console.warn(
-        "[earn-withdraw-prepare] active autodeposit state is missing close metadata",
-        {
-          cluster,
-          policyAccount: autodepositState.target.policyAccount,
-          recurringDelegation: autodepositState.target.recurringDelegation,
-          settings: principal.settingsPda,
-          targetId: autodepositState.target.id.toString(),
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          walletAddress: principal.walletAddress,
-        }
-      );
-    }
-
     const withdrawInput = {
       amountRaw: effectiveAmountRaw,
       cluster,
@@ -561,7 +449,9 @@ export async function POST(request: Request) {
               }),
           }
         : {}),
-      closePoliciesOnFullWithdrawal: isFinalExit,
+      // Full withdrawal and policy close are intentionally separate phases.
+      // Cleanup is prepared only after a minContextSlot-safe zero proof.
+      closePoliciesOnFullWithdrawal: false,
       source:
         selectedSource.type === "idle"
           ? {
@@ -582,17 +472,10 @@ export async function POST(request: Request) {
       walletAddress: new PublicKey(principal.walletAddress),
       yieldRoutingPolicy,
     };
-    const preparedWithdraw =
-      mode === "full"
-        ? await client.prepareEarnUsdcWithdraw({
-            ...withdrawInput,
-            ...(autodepositClose ? { autodepositClose } : {}),
-            mode,
-          })
-        : await client.prepareEarnUsdcWithdraw({
-            ...withdrawInput,
-            mode,
-          });
+    const preparedWithdraw = await client.prepareEarnUsdcWithdraw({
+      ...withdrawInput,
+      mode,
+    });
 
     return NextResponse.json({
       preparedWithdraw: serializePreparedEarnUsdcWithdraw(preparedWithdraw),

--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -1515,27 +1515,6 @@ function resolveActiveEarnDepositTarget(
     : null;
 }
 
-function getEarnPositionTotalAmountRaw(
-  position: ActiveEarnPosition | null
-): bigint {
-  const holdings = position?.holdings ?? [];
-  if (holdings.length > 0) {
-    return holdings.reduce((total, holding) => {
-      try {
-        return total + BigInt(holding.amountRaw);
-      } catch {
-        return total;
-      }
-    }, BigInt(0));
-  }
-
-  try {
-    return BigInt(position?.currentTotalAmountRaw ?? "0");
-  } catch {
-    return BigInt(0);
-  }
-}
-
 function earnHoldingMatchesWithdrawSource(
   holding: ActiveEarnPositionHolding,
   source: EarnWithdrawSourceOption
@@ -4402,8 +4381,7 @@ export function AppWalletWorkspace({
 
   const prepareEarnWithdrawInBrowser = useCallback(
     async (
-      draft: EarnWithdrawDraft,
-      options: { autodepositCloseAlreadyCompleted?: boolean } = {}
+      draft: EarnWithdrawDraft
     ): Promise<SmartAccountPreparedEarnUsdcWithdraw> => {
       const overview = smartAccountData.overview;
       const policy = smartAccountData.earnPolicy;
@@ -4434,27 +4412,6 @@ export function AppWalletWorkspace({
         draft.source.type === "reserve"
           ? toEarnWithdrawReserveTarget(draft.source)
           : null;
-      const totalLiveAmountRaw =
-        getEarnPositionTotalAmountRaw(activeEarnPosition);
-      const isFinalExit =
-        draft.mode === "full" &&
-        totalLiveAmountRaw > BigInt(0) &&
-        effectiveAmountRaw >= totalLiveAmountRaw;
-      const autodepositClose =
-        draft.mode === "full" &&
-        isFinalExit &&
-        !options.autodepositCloseAlreadyCompleted &&
-        smartAccountData.earnAutodeposit?.policyAccount &&
-        smartAccountData.earnAutodeposit.recurringDelegation
-          ? {
-              policy: new PublicKey(
-                smartAccountData.earnAutodeposit.policyAccount
-              ),
-              recurringDelegation: new PublicKey(
-                smartAccountData.earnAutodeposit.recurringDelegation
-              ),
-            }
-          : undefined;
       const client = createSmartAccountVaultsClient({
         connection,
         programId: new PublicKey(overview.programId),
@@ -4471,7 +4428,9 @@ export function AppWalletWorkspace({
       };
       const withdrawInput = {
         amountRaw: effectiveAmountRaw,
-        closePoliciesOnFullWithdrawal: isFinalExit,
+        // Policy teardown is prepared only after the server proves the
+        // post-withdraw balances at or after the confirmed withdrawal slot.
+        closePoliciesOnFullWithdrawal: false,
         cluster,
         feePayer: userWallet,
         policySigner: new PublicKey(policySigner),
@@ -4488,7 +4447,6 @@ export function AppWalletWorkspace({
       return draft.mode === "full"
         ? client.prepareEarnUsdcWithdraw({
             ...withdrawInput,
-            ...(autodepositClose ? { autodepositClose } : {}),
             mode: "full",
           })
         : client.prepareEarnUsdcWithdraw({
@@ -4497,11 +4455,9 @@ export function AppWalletWorkspace({
           });
     },
     [
-      activeEarnPosition,
       connection,
       getEarnWithdrawDraftAmountRaw,
       publicEnv.solanaEnv,
-      smartAccountData.earnAutodeposit,
       smartAccountData.earnPolicy,
       smartAccountData.overview,
       personalWalletAddress,
@@ -5078,8 +5034,7 @@ export function AppWalletWorkspace({
           setAutodepositConfig(null);
           setIsEarnWithdrawPreparePending(true);
           const nextPreparedWithdraw = await prepareEarnWithdrawInBrowser(
-            pendingEarnWithdrawDraft,
-            { autodepositCloseAlreadyCompleted: true }
+            pendingEarnWithdrawDraft
           );
           setIsEarnWithdrawPreparePending(false);
           if (nextPreparedWithdraw.autodepositClosePrepared) {

--- a/frontend/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import type { LoyalCluster } from "@loyal-labs/actions";
+import { PublicKey, type Connection } from "@solana/web3.js";
+
+import { verifyEarnFullExitZeroBalances } from "./earn-full-exit-zero-proof.server";
+import { serializeRoutePolicyState } from "./earn-state-serializers.server";
+import type { EarnCleanupVaultState } from "./yield-deposit-repository.server";
+
+export class EarnCleanupConfirmError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "EarnCleanupConfirmError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function retryableVerificationError(error: unknown): EarnCleanupConfirmError {
+  return new EarnCleanupConfirmError(
+    503,
+    "full_exit_verification_retryable",
+    error instanceof Error
+      ? error.message
+      : "Earn cleanup could not be verified. Retry confirmation."
+  );
+}
+
+export async function resolveConfirmedSignatureSlot(args: {
+  connection: Connection;
+  signature: string;
+}): Promise<bigint> {
+  try {
+    const { value } = await args.connection.getSignatureStatuses(
+      [args.signature],
+      { searchTransactionHistory: true }
+    );
+    const status = value[0] ?? null;
+    if (status?.err) {
+      throw new EarnCleanupConfirmError(
+        400,
+        "cleanup_transaction_failed",
+        "Earn cleanup transaction failed on-chain."
+      );
+    }
+    if (
+      typeof status?.slot === "number" &&
+      (status.confirmationStatus === "confirmed" ||
+        status.confirmationStatus === "finalized")
+    ) {
+      return BigInt(status.slot);
+    }
+
+    const transaction = await args.connection.getTransaction(args.signature, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+    if (transaction?.meta?.err) {
+      throw new EarnCleanupConfirmError(
+        400,
+        "cleanup_transaction_failed",
+        "Earn cleanup transaction failed on-chain."
+      );
+    }
+    if (typeof transaction?.slot === "number") {
+      return BigInt(transaction.slot);
+    }
+
+    throw new EarnCleanupConfirmError(
+      503,
+      "full_exit_verification_retryable",
+      "Confirmed transaction slot is unavailable."
+    );
+  } catch (error) {
+    if (error instanceof EarnCleanupConfirmError) {
+      throw error;
+    }
+    throw retryableVerificationError(error);
+  }
+}
+
+export async function verifyPolicyAccountsClosed(args: {
+  accounts: string[];
+  connection: Connection;
+  minContextSlot: number;
+}): Promise<void> {
+  try {
+    const { context, value } =
+      await args.connection.getMultipleAccountsInfoAndContext(
+        args.accounts.map((account) => new PublicKey(account)),
+        { commitment: "confirmed", minContextSlot: args.minContextSlot }
+      );
+    if (context.slot < args.minContextSlot) {
+      throw new EarnCleanupConfirmError(
+        503,
+        "full_exit_verification_retryable",
+        "Earn policy close proof was observed before the cleanup confirmation slot."
+      );
+    }
+    if (value.some((account) => account !== null)) {
+      throw new EarnCleanupConfirmError(
+        503,
+        "full_exit_verification_retryable",
+        "One or more Earn policy accounts remain open on-chain."
+      );
+    }
+  } catch (error) {
+    if (error instanceof EarnCleanupConfirmError) {
+      throw error;
+    }
+    throw retryableVerificationError(error);
+  }
+}
+
+export async function assertEarnFullExitProven(args: {
+  cleanupState: Pick<EarnCleanupVaultState, "routePolicy" | "setupPolicy">;
+  cluster: LoyalCluster;
+  connection: Connection;
+  minContextSlot: number;
+  policyAccounts: string[];
+  programId: PublicKey;
+  settingsPda: PublicKey;
+}): Promise<void> {
+  try {
+    const proof = await verifyEarnFullExitZeroBalances({
+      cluster: args.cluster,
+      connection: args.connection,
+      minContextSlot: args.minContextSlot,
+      policy: serializeRoutePolicyState(
+        args.cleanupState.routePolicy,
+        args.cleanupState.setupPolicy
+      ),
+      programId: args.programId,
+      settingsPda: args.settingsPda,
+    });
+    if (proof.status !== "policy_close_required") {
+      throw new EarnCleanupConfirmError(
+        409,
+        "full_exit_incomplete",
+        "Earn balances remain after cleanup; the position stays active."
+      );
+    }
+
+    await verifyPolicyAccountsClosed({
+      accounts: args.policyAccounts,
+      connection: args.connection,
+      minContextSlot: args.minContextSlot,
+    });
+  } catch (error) {
+    if (error instanceof EarnCleanupConfirmError) {
+      throw error;
+    }
+    throw retryableVerificationError(error);
+  }
+}

--- a/frontend/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, mock, test } from "bun:test";
+import { PublicKey } from "@solana/web3.js";
+
+mock.module("server-only", () => ({}));
+
+mock.module("./yield-deposit-repository.server", () => ({
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW: BigInt(10_000),
+}));
+
+const { verifyEarnFullExitZeroBalances } = await import(
+  "./earn-full-exit-zero-proof.server"
+);
+
+const programId = new PublicKey("11111111111111111111111111111112");
+const settingsPda = new PublicKey("11111111111111111111111111111113");
+const vaultPda = new PublicKey("11111111111111111111111111111114");
+const vaultUsdcAta = new PublicKey("11111111111111111111111111111115");
+const collateralAta = new PublicKey("11111111111111111111111111111116");
+const usdcMint = new PublicKey("11111111111111111111111111111117");
+const collateralMint = new PublicKey("11111111111111111111111111111118");
+
+const connection = {
+  getTokenAccountsByOwner: async () => ({ context: { slot: 500 }, value: [] }),
+};
+
+function createHolding(args: {
+  amountRaw: string;
+  kind: "idle" | "kamino";
+  reserve?: string | null;
+}) {
+  return {
+    amountRaw: args.amountRaw,
+    kind: args.kind,
+    label: args.kind === "idle" ? "Idle Balance" : "Kamino",
+    liquidityMint: usdcMint.toBase58(),
+    market: args.kind === "idle" ? null : programId.toBase58(),
+    marketName: "USDC",
+    observedAt: "2026-07-13T00:00:00.000Z",
+    observedSlot: "500",
+    provenance: {},
+    reserve: args.reserve ?? null,
+    supplyApyBps: null,
+  };
+}
+
+function createHoldingsSnapshot(
+  holdings: ReturnType<typeof createHolding>[],
+  observedSlot = "500"
+) {
+  return {
+    currentTotalAmountRaw: holdings
+      .reduce((total, holding) => total + BigInt(holding.amountRaw), BigInt(0))
+      .toString(),
+    holdings,
+    observedAt: "2026-07-13T00:00:00.000Z",
+    observedSlot,
+    provenance: {
+      accountCount: 1,
+      chunkCount: 1,
+      commitment: "confirmed" as const,
+      source: "rpc_getMultipleAccounts" as const,
+      watchedAccounts: [],
+    },
+  };
+}
+
+function createVaultSnapshot(args: {
+  collateralAmountRaw?: bigint;
+  idleAmountRaw?: bigint;
+}) {
+  return {
+    lamports: BigInt(0),
+    tokenAccounts: [
+      {
+        address: vaultUsdcAta,
+        amountRaw: args.idleAmountRaw ?? BigInt(0),
+        isUsdc: true,
+        lamports: 1,
+        mint: usdcMint,
+      },
+      {
+        address: collateralAta,
+        amountRaw: args.collateralAmountRaw ?? BigInt(0),
+        isUsdc: false,
+        lamports: 1,
+        mint: collateralMint,
+      },
+    ],
+    vaultPda,
+    vaultUsdcAta,
+  };
+}
+
+function createInput() {
+  return {
+    cluster: "mainnet-beta" as never,
+    connection: connection as never,
+    minContextSlot: 500,
+    policy: {
+      account: programId.toBase58(),
+      seed: "7",
+      vaultIndex: 1,
+      vaultPubkey: vaultPda.toBase58(),
+    },
+    programId,
+    settingsPda,
+  };
+}
+
+describe("Earn full-exit zero proof", () => {
+  test("keeps closure blocked when a second policy reserve is still positive", async () => {
+    const secondReserve = new PublicKey(
+      "11111111111111111111111111111119"
+    ).toBase58();
+    const fetchHoldingsSnapshot = mock(
+      async (input: Record<string, unknown>) => {
+        expect(input.minContextSlot).toBe(500);
+        expect(input.requireCompleteReserveReads).toBe(true);
+        return createHoldingsSnapshot([
+          createHolding({
+            amountRaw: "25",
+            kind: "kamino",
+            reserve: secondReserve,
+          }),
+        ]);
+      }
+    );
+
+    const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+      fetchHoldingsSnapshot: fetchHoldingsSnapshot as never,
+      fetchVaultSnapshot: async () => createVaultSnapshot({}),
+    });
+
+    expect(proof.status).toBe("full_exit_incomplete");
+    expect(proof.remainingHoldings).toEqual([
+      expect.objectContaining({ amountRaw: "25", reserve: secondReserve }),
+    ]);
+  });
+
+  test("rejects a stale RPC context instead of authorizing closure", async () => {
+    await expect(
+      verifyEarnFullExitZeroBalances(createInput(), {
+        fetchHoldingsSnapshot: async () =>
+          createHoldingsSnapshot([], "499") as never,
+        fetchVaultSnapshot: async () => createVaultSnapshot({}),
+      })
+    ).rejects.toThrow(
+      "Earn full-exit proof was observed before the withdrawal confirmation slot."
+    );
+  });
+
+  test("retries minimum-context RPC lag and remains retryable on failure", async () => {
+    const slotLagError = Object.assign(
+      new Error("Minimum context slot has not been reached"),
+      { code: -32_016 }
+    );
+    const fetchHoldingsSnapshot = mock(async () => {
+      throw slotLagError;
+    });
+    const sleep = mock(async () => {});
+
+    await expect(
+      verifyEarnFullExitZeroBalances(createInput(), {
+        fetchHoldingsSnapshot: fetchHoldingsSnapshot as never,
+        fetchVaultSnapshot: async () => createVaultSnapshot({}),
+        sleep,
+      })
+    ).rejects.toBe(slotLagError);
+    expect(fetchHoldingsSnapshot).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  test("allows the separate close phase only when reserves are zero and idle is dust", async () => {
+    const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+      fetchHoldingsSnapshot: async () =>
+        createHoldingsSnapshot([
+          createHolding({ amountRaw: "9999", kind: "idle" }),
+        ]) as never,
+      fetchVaultSnapshot: async () =>
+        createVaultSnapshot({ idleAmountRaw: BigInt(9999) }),
+    });
+
+    expect(proof).toMatchObject({
+      closeableTokenAccounts: [collateralAta.toBase58()],
+      idleAmountRaw: "9999",
+      idleReadsAgree: true,
+      status: "policy_close_required",
+    });
+  });
+
+  test("blocks closure when independent idle-account reads disagree", async () => {
+    const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+      fetchHoldingsSnapshot: async () => createHoldingsSnapshot([]) as never,
+      fetchVaultSnapshot: async () =>
+        createVaultSnapshot({ idleAmountRaw: BigInt(1) }),
+    });
+
+    expect(proof).toMatchObject({
+      idleAmountRaw: "1",
+      idleReadsAgree: false,
+      status: "full_exit_incomplete",
+    });
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
@@ -1,0 +1,243 @@
+import "server-only";
+
+import type { LoyalCluster } from "@loyal-labs/actions";
+import {
+  createSmartAccountVaultsClient,
+  type SmartAccountEarnVaultRefundSnapshot,
+} from "@loyal-labs/smart-account-vaults";
+import type { Connection, PublicKey } from "@solana/web3.js";
+
+import {
+  fetchEarnRpcHoldingsSnapshot,
+  type EarnRpcHolding,
+  type EarnRpcHoldingsSnapshot,
+  type EarnRpcPolicyMetadata,
+} from "./earn-rpc-holdings.client";
+import { EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW } from "./yield-deposit-repository.server";
+
+const SLOT_LAG_ATTEMPTS = 3;
+const SLOT_LAG_RETRY_DELAY_MS = 500;
+
+export type EarnFullExitZeroProof = {
+  blockingTokenAccounts: Array<{
+    address: string;
+    amountRaw: string;
+    mint: string;
+  }>;
+  closeableTokenAccounts: string[];
+  idleAmountRaw: string;
+  idleReadsAgree: boolean;
+  observedSlot: string;
+  remainingHoldings: EarnRpcHolding[];
+  status: "full_exit_incomplete" | "policy_close_required";
+};
+
+type EarnFullExitZeroProofDependencies = {
+  fetchHoldingsSnapshot?: typeof fetchEarnRpcHoldingsSnapshot;
+  fetchVaultSnapshot?: (args: {
+    cluster: LoyalCluster;
+    connection: Connection;
+    minContextSlot: number;
+    programId: PublicKey;
+    settingsPda: PublicKey;
+  }) => Promise<SmartAccountEarnVaultRefundSnapshot>;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+function isMinContextSlotError(error: unknown): boolean {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    (error as { code?: unknown }).code === -32016
+  ) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    /minimum context slot has not been reached/i.test(error.message)
+  );
+}
+
+async function readWithSlotLagRetry<T>(args: {
+  read: () => Promise<T>;
+  sleep: (milliseconds: number) => Promise<void>;
+}): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < SLOT_LAG_ATTEMPTS; attempt += 1) {
+    if (attempt > 0) {
+      await args.sleep(SLOT_LAG_RETRY_DELAY_MS);
+    }
+
+    try {
+      return await args.read();
+    } catch (error) {
+      if (!isMinContextSlotError(error)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+function positiveAmountRaw(amountRaw: string): bigint {
+  if (!/^\d+$/.test(amountRaw)) {
+    throw new Error("Earn full-exit proof received an invalid balance.");
+  }
+
+  return BigInt(amountRaw);
+}
+
+function classifyZeroProof(args: {
+  holdingsSnapshot: EarnRpcHoldingsSnapshot;
+  minContextSlot: number;
+  vaultSnapshot: SmartAccountEarnVaultRefundSnapshot;
+}): EarnFullExitZeroProof {
+  const observedSlot = Number(args.holdingsSnapshot.observedSlot);
+  if (
+    !Number.isSafeInteger(observedSlot) ||
+    observedSlot < args.minContextSlot
+  ) {
+    throw new Error(
+      "Earn full-exit proof was observed before the withdrawal confirmation slot."
+    );
+  }
+
+  const remainingReserveHoldings = args.holdingsSnapshot.holdings.filter(
+    (holding) =>
+      holding.kind === "kamino" &&
+      positiveAmountRaw(holding.amountRaw) > BigInt(0)
+  );
+  const holdingsIdleAmountRaw = args.holdingsSnapshot.holdings.reduce(
+    (total, holding) =>
+      holding.kind === "idle"
+        ? total + positiveAmountRaw(holding.amountRaw)
+        : total,
+    BigInt(0)
+  );
+  const vaultIdleAmountRaw =
+    args.vaultSnapshot.tokenAccounts.find((account) =>
+      account.address.equals(args.vaultSnapshot.vaultUsdcAta)
+    )?.amountRaw ?? BigInt(0);
+  const idleReadsAgree = holdingsIdleAmountRaw === vaultIdleAmountRaw;
+  const idleAmountRaw =
+    holdingsIdleAmountRaw > vaultIdleAmountRaw
+      ? holdingsIdleAmountRaw
+      : vaultIdleAmountRaw;
+  const blockingTokenAccounts = args.vaultSnapshot.tokenAccounts
+    .filter(
+      (account) =>
+        !account.address.equals(args.vaultSnapshot.vaultUsdcAta) &&
+        account.amountRaw > BigInt(0)
+    )
+    .map((account) => ({
+      address: account.address.toBase58(),
+      amountRaw: account.amountRaw.toString(),
+      mint: account.mint.toBase58(),
+    }));
+  const closeableTokenAccounts = args.vaultSnapshot.tokenAccounts
+    .filter(
+      (account) =>
+        !account.address.equals(args.vaultSnapshot.vaultUsdcAta) &&
+        account.amountRaw === BigInt(0)
+    )
+    .map((account) => account.address.toBase58());
+  const idleWithinDustTolerance =
+    idleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
+  const status =
+    remainingReserveHoldings.length === 0 &&
+    blockingTokenAccounts.length === 0 &&
+    idleReadsAgree &&
+    idleWithinDustTolerance
+      ? "policy_close_required"
+      : "full_exit_incomplete";
+
+  return {
+    blockingTokenAccounts,
+    closeableTokenAccounts,
+    idleAmountRaw: idleAmountRaw.toString(),
+    idleReadsAgree,
+    observedSlot: String(observedSlot),
+    remainingHoldings: args.holdingsSnapshot.holdings.filter(
+      (holding) => positiveAmountRaw(holding.amountRaw) > BigInt(0)
+    ),
+    status,
+  };
+}
+
+export async function verifyEarnFullExitZeroBalances(
+  args: {
+    cluster: LoyalCluster;
+    connection: Connection;
+    minContextSlot: number;
+    policy: EarnRpcPolicyMetadata;
+    programId: PublicKey;
+    settingsPda: PublicKey;
+  },
+  dependencies: EarnFullExitZeroProofDependencies = {}
+): Promise<EarnFullExitZeroProof> {
+  if (!Number.isSafeInteger(args.minContextSlot) || args.minContextSlot < 0) {
+    throw new Error("Earn full-exit minContextSlot is outside the safe range.");
+  }
+  if (
+    typeof (args.connection as Pick<Connection, "getTokenAccountsByOwner">)
+      .getTokenAccountsByOwner !== "function" &&
+    !dependencies.fetchVaultSnapshot
+  ) {
+    throw new Error(
+      "Earn full-exit proof cannot read all vault token accounts."
+    );
+  }
+
+  const fetchHoldingsSnapshot =
+    dependencies.fetchHoldingsSnapshot ?? fetchEarnRpcHoldingsSnapshot;
+  const fetchVaultSnapshot =
+    dependencies.fetchVaultSnapshot ??
+    (async (input) =>
+      createSmartAccountVaultsClient({
+        connection: input.connection,
+        programId: input.programId,
+      }).fetchEarnVaultRefundSnapshot({
+        cluster: input.cluster,
+        minContextSlot: input.minContextSlot,
+        settingsPda: input.settingsPda,
+      }));
+  const sleep =
+    dependencies.sleep ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, milliseconds);
+      }));
+
+  const [holdingsSnapshot, vaultSnapshot] = await readWithSlotLagRetry({
+    read: () =>
+      Promise.all([
+        fetchHoldingsSnapshot({
+          cluster: args.cluster,
+          connection: args.connection,
+          minContextSlot: args.minContextSlot,
+          policy: args.policy,
+          programId: args.programId,
+          requireCompleteReserveReads: true,
+          settingsPda: args.settingsPda,
+        }),
+        fetchVaultSnapshot({
+          cluster: args.cluster,
+          connection: args.connection,
+          minContextSlot: args.minContextSlot,
+          programId: args.programId,
+          settingsPda: args.settingsPda,
+        }),
+      ]),
+    sleep,
+  });
+
+  return classifyZeroProof({
+    holdingsSnapshot,
+    minContextSlot: args.minContextSlot,
+    vaultSnapshot,
+  });
+}

--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
@@ -10,6 +10,7 @@ const collateralAta = new PublicKey("11111111111111111111111111111115");
 const reserve = new PublicKey("11111111111111111111111111111116");
 const market = new PublicKey("11111111111111111111111111111117");
 const usdcAta = new PublicKey("11111111111111111111111111111118");
+const programId = new PublicKey("11111111111111111111111111111119");
 const tokenProgramId = new PublicKey(
   "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 );
@@ -26,20 +27,32 @@ const findReconciledActiveYieldPositionForVault = mock(
 const recordReconciledYieldVaultSnapshot = mock(async () => ({
   snapshotId: BigInt(55),
 }));
+const recordSnapshotReconciledYieldHolding = mock(async () => ({}));
 
 mock.module("./yield-deposit-repository.server", () => ({
   findActiveManagedYieldVaultWithPolicy,
   findCurrentNonzeroYieldVaultReservePositions,
   findReconciledActiveYieldPositionForVault,
+  recordSnapshotReconciledYieldHolding,
   recordReconciledYieldVaultSnapshot,
 }));
 
 mock.module("@loyal-labs/actions", () => ({
+  KAMINO_VANILLA_OBLIGATION_ID: 0,
+  KAMINO_VANILLA_OBLIGATION_TAG: 0,
+  LoyalCluster: { MainnetBeta: "mainnet-beta" },
+  RiskBasket: { Safe: "safe" },
+  Stablecoin: { USDC: "usdc" },
   getKaminoUsdcEarnTargetForCluster: () => ({
+    lendProgramId: programId,
     liquidityMint: usdcMint,
     market,
     reserve,
   }),
+  getRiskBasketMarketsForCluster: () => [market],
+  getStablecoinMintForCluster: () => usdcMint,
+  normalizeLoyalCluster: (cluster: string) => cluster,
+  resolveLoyalClusterForSolanaEnv: () => "mainnet-beta",
 }));
 
 mock.module("@loyal-labs/smart-account-vaults", () => ({
@@ -48,6 +61,22 @@ mock.module("@loyal-labs/smart-account-vaults", () => ({
   }: {
     collateralAmountRaw: bigint;
   }) => collateralAmountRaw * BigInt(2),
+  createSmartAccountVaultsClient: (input: unknown) => {
+    const hook = (
+      globalThis as unknown as {
+        __createEarnTestVaultsClient?: (config: unknown) => unknown;
+      }
+    ).__createEarnTestVaultsClient;
+    return hook?.(input) ?? {};
+  },
+  parseKaminoObligationDepositedCollateralAmountRaw: ({
+    data,
+  }: {
+    data: Buffer;
+  }) => (data[0] === 1 ? BigInt(5) : BigInt(0)),
+  parseKaminoReserveTokenAccounts: () => ({
+    reserveCollateralMint: collateralMint,
+  }),
   parseKaminoReserveSnapshot: () => ({
     collateralSupplyRaw: BigInt(100),
     totalLiquiditySupplyScaled: BigInt(200),
@@ -69,6 +98,9 @@ mock.module("@loyal-labs/smart-account-vaults", () => ({
 }));
 
 mock.module("@solana/spl-token", () => ({
+  ASSOCIATED_TOKEN_PROGRAM_ID: new PublicKey(
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+  ),
   AccountLayout: {
     decode: (data: Buffer) => {
       if (data[0] === 1) {
@@ -87,6 +119,7 @@ mock.module("@solana/spl-token", () => ({
     },
   },
   TOKEN_PROGRAM_ID: tokenProgramId,
+  getAssociatedTokenAddressSync: () => usdcAta,
 }));
 
 const { reconcileEarnVaultPosition } = await import(
@@ -123,17 +156,23 @@ function createPosition() {
 
 function createConnection(accounts: Array<{ data: Buffer } | null>) {
   return {
-    getMultipleAccountsInfoAndContext: mock(async () => ({
-      context: { slot: 123 },
-      value: accounts.map((account) =>
-        account
-          ? {
-              data: account.data,
-              owner: tokenProgramId,
-            }
-          : null
-      ),
-    })),
+    getMultipleAccountsInfoAndContext: mock(
+      async (_keys: PublicKey[], _config?: unknown) => {
+        void _keys;
+        void _config;
+        return {
+          context: { slot: 123 },
+          value: accounts.map((account) =>
+            account
+              ? {
+                  data: account.data,
+                  owner: tokenProgramId,
+                }
+              : null
+          ),
+        };
+      }
+    ),
   };
 }
 
@@ -245,5 +284,59 @@ describe("earn position reconciliation", () => {
     const [input] = (recordReconciledYieldVaultSnapshot.mock.calls.at(-1) ??
       []) as unknown as [RecordedSnapshotInput];
     expect(input.idleTokenBalance.amountRaw).toBe(BigInt(0));
+  });
+
+  test("does not reuse a positive fallback for a post-withdraw zero proof", async () => {
+    const now = new Date("2026-06-17T00:30:00.000Z");
+    const connection = createConnection([
+      { data: Buffer.from([0]) },
+      { data: Buffer.from([0]) },
+      null,
+    ]);
+    findActiveManagedYieldVaultWithPolicy.mockImplementation(async () =>
+      createManagedVault(null)
+    );
+    findReconciledActiveYieldPositionForVault.mockImplementation(async () =>
+      createPosition()
+    );
+    findCurrentNonzeroYieldVaultReservePositions.mockImplementation(
+      async () => [
+        {
+          amountRaw: BigInt(99),
+          borrowApyBps: null,
+          hasValue: true,
+          liquidityMint: usdcMint.toBase58(),
+          market: market.toBase58(),
+          observedAt: now,
+          observedSlot: BigInt(400),
+          planningMetadata: {},
+          reserve: reserve.toBase58(),
+          snapshotId: BigInt(1),
+          supplyApyBps: null,
+          vaultId: BigInt(22),
+        },
+      ]
+    );
+
+    await reconcileEarnVaultPosition(
+      {
+        authority: "wallet",
+        cluster: "mainnet-beta" as never,
+        connection: connection as never,
+        force: true,
+        minContextSlot: 500,
+        purpose: "post_withdrawal_zero_proof",
+        settings: "settings",
+        vaultPubkey: vault.toBase58(),
+      },
+      { now: () => now }
+    );
+
+    const [input] = (recordReconciledYieldVaultSnapshot.mock.calls.at(-1) ??
+      []) as unknown as [RecordedSnapshotInput];
+    expect(input.positions[0]?.amountRaw).toBe(BigInt(0));
+    expect(
+      connection.getMultipleAccountsInfoAndContext.mock.calls[0]?.[1]
+    ).toEqual({ commitment: "confirmed", minContextSlot: 500 });
   });
 });

--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
@@ -339,4 +339,45 @@ describe("earn position reconciliation", () => {
       connection.getMultipleAccountsInfoAndContext.mock.calls[0]?.[1]
     ).toEqual({ commitment: "confirmed", minContextSlot: 500 });
   });
+
+  test("rejects an unreadable reserve before mutating a positive obligation snapshot", async () => {
+    const now = new Date("2026-06-17T00:40:00.000Z");
+    const connection = createConnection([
+      null,
+      { data: Buffer.from([1]) },
+      null,
+    ]);
+    findActiveManagedYieldVaultWithPolicy.mockImplementation(async () =>
+      createManagedVault(null)
+    );
+    findReconciledActiveYieldPositionForVault.mockImplementation(async () =>
+      createPosition()
+    );
+    findCurrentNonzeroYieldVaultReservePositions.mockImplementation(
+      async () => []
+    );
+    const snapshotWriteCount =
+      recordReconciledYieldVaultSnapshot.mock.calls.length;
+
+    await expect(
+      reconcileEarnVaultPosition(
+        {
+          authority: "wallet",
+          cluster: "mainnet-beta" as never,
+          connection: connection as never,
+          force: true,
+          minContextSlot: 500,
+          purpose: "post_withdrawal_zero_proof",
+          settings: "settings",
+          vaultPubkey: vault.toBase58(),
+        },
+        { now: () => now }
+      )
+    ).rejects.toThrow(
+      "Kamino reserve account is unavailable for a positive Earn obligation."
+    );
+    expect(recordReconciledYieldVaultSnapshot.mock.calls.length).toBe(
+      snapshotWriteCount
+    );
+  });
 });

--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
@@ -59,6 +59,10 @@ type ReconcileEarnVaultPositionInput = {
   // When set, the chain read demands a node at or past this slot so a lagging
   // node cannot feed pre-confirmation account state into the reconciled write.
   minContextSlot?: number;
+  // Routine reads preserve a last-known-positive fallback when an RPC account
+  // is temporarily unavailable. A post-withdraw proof must instead accept
+  // confirmed zeroes as authoritative and fail closed in the caller.
+  purpose?: "routine" | "post_withdrawal_zero_proof";
   settings: string;
   vaultPubkey: string;
 };
@@ -377,6 +381,8 @@ export async function reconcileEarnVaultPosition(
     const amountRaw =
       measuredAmountRaw > BigInt(0)
         ? measuredAmountRaw
+        : input.purpose === "post_withdrawal_zero_proof"
+        ? BigInt(0)
         : fallbackRow?.amountRaw ?? positionFallbackRaw;
     const reconciliationFallback =
       measuredAmountRaw <= BigInt(0) && amountRaw > BigInt(0)
@@ -413,6 +419,7 @@ export async function reconcileEarnVaultPosition(
     chainSlot: observedSlot,
     context: {
       source: "frontend_position_reconcile",
+      purpose: input.purpose ?? "routine",
       sourceCommitment: SOURCE_COMMITMENT,
       skippedReserveCount: candidates.length - reconciledCandidates.length,
     },

--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
@@ -60,8 +60,9 @@ type ReconcileEarnVaultPositionInput = {
   // node cannot feed pre-confirmation account state into the reconciled write.
   minContextSlot?: number;
   // Routine reads preserve a last-known-positive fallback when an RPC account
-  // is temporarily unavailable. A post-withdraw proof must instead accept
-  // confirmed zeroes as authoritative and fail closed in the caller.
+  // is temporarily unavailable. Post-withdraw reconciliation runs only after
+  // an independent zero proof and must fail before writing if a positive
+  // obligation cannot be valued from its reserve account.
   purpose?: "routine" | "post_withdrawal_zero_proof";
   settings: string;
   vaultPubkey: string;
@@ -364,13 +365,21 @@ export async function reconcileEarnVaultPosition(
           ? position.currentAmountRaw - idleAmountRaw
           : BigInt(0)
         : BigInt(0);
-    const obligationCollateralAmountRaw =
-      reserveAccount && obligationAccount
-        ? parseKaminoObligationDepositedCollateralAmountRaw({
-            data: obligationAccount.data,
-            reserve: new PublicKey(candidate.reserve),
-          })
-        : BigInt(0);
+    const obligationCollateralAmountRaw = obligationAccount
+      ? parseKaminoObligationDepositedCollateralAmountRaw({
+          data: obligationAccount.data,
+          reserve: new PublicKey(candidate.reserve),
+        })
+      : BigInt(0);
+    if (
+      input.purpose === "post_withdrawal_zero_proof" &&
+      obligationCollateralAmountRaw > BigInt(0) &&
+      !reserveAccount
+    ) {
+      throw new Error(
+        "Kamino reserve account is unavailable for a positive Earn obligation."
+      );
+    }
     const measuredAmountRaw =
       reserveAccount && obligationAccount
         ? calculateKaminoRedeemableLiquidityAmountRaw({

--- a/frontend/src/lib/yield-optimization/earn-rpc-holdings.client.ts
+++ b/frontend/src/lib/yield-optimization/earn-rpc-holdings.client.ts
@@ -417,6 +417,10 @@ export async function fetchEarnRpcHoldingsSnapshot(args: {
   minContextSlot?: number;
   policy: EarnRpcPolicyMetadata | null | undefined;
   programId: PublicKey;
+  // Closure verification cannot treat an unreadable reserve backing a
+  // discovered obligation deposit as zero. Ordinary display reads retain the
+  // historical best-effort behavior; full-exit proof opts into fail-closed.
+  requireCompleteReserveReads?: boolean;
   settingsPda: PublicKey;
   now?: () => Date;
 }): Promise<EarnRpcHoldingsSnapshot> {
@@ -536,6 +540,14 @@ export async function fetchEarnRpcHoldingsSnapshot(args: {
       lendProgramId,
     });
     if (!reserveAccount) {
+      if (
+        args.requireCompleteReserveReads &&
+        discovered.collateralAmountRaw > BigInt(0)
+      ) {
+        throw new Error(
+          "Kamino reserve account is unavailable for a positive Earn obligation."
+        );
+      }
       continue;
     }
 

--- a/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
@@ -708,16 +708,6 @@ export async function recordConfirmedEarnWithdrawal(args: {
 
   try {
     const minContextSlot = toSafeContextSlot(input.confirmedSlot);
-    await reconcileEarnVaultPosition({
-      authority: input.walletAddress,
-      cluster,
-      connection,
-      force: true,
-      minContextSlot,
-      purpose: "post_withdrawal_zero_proof",
-      settings: input.settings,
-      vaultPubkey: input.vaultPubkey,
-    });
     const cleanupState = await findEarnCleanupVaultState({
       authority: input.walletAddress,
       settings: input.settings,
@@ -742,13 +732,26 @@ export async function recordConfirmedEarnWithdrawal(args: {
       programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
       settingsPda: new PublicKey(input.settings),
     });
-    const reconciledPosition =
-      (await findReconciledActiveYieldPositionForVault({
+    let reconciledPosition = position;
+    if (proof.status === "policy_close_required") {
+      await reconcileEarnVaultPosition({
+        authority: input.walletAddress,
         cluster,
+        connection,
+        force: true,
+        minContextSlot: toSafeContextSlot(BigInt(proof.observedSlot)),
+        purpose: "post_withdrawal_zero_proof",
         settings: input.settings,
-        vaultIndex: input.vaultIndex,
-        walletAddress: input.walletAddress,
-      })) ?? position;
+        vaultPubkey: input.vaultPubkey,
+      });
+      reconciledPosition =
+        (await findReconciledActiveYieldPositionForVault({
+          cluster,
+          settings: input.settings,
+          vaultIndex: input.vaultIndex,
+          walletAddress: input.walletAddress,
+        })) ?? position;
+    }
 
     console.info("[earn-withdraw-confirm] full exit verification", {
       blockingTokenAccountCount: proof.blockingTokenAccounts.length,

--- a/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
@@ -17,12 +17,16 @@ import {
   type TokenBalance,
 } from "@solana/web3.js";
 
+import { getServerEnv } from "@/lib/core/config/server";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import { pollRpcRead } from "@/lib/yield-optimization/earn-deposit-confirm.server";
+import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
 import { assertSafeUsdcEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
+import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import {
+  findEarnCleanupVaultState,
+  findReconciledActiveYieldPositionForVault,
   recordConfirmedYieldWithdrawal,
   type ConfirmedYieldWithdrawalInput,
   type UserYieldPositionRecord,
@@ -413,9 +417,9 @@ export function createCanonicalWithdrawalInput(
     canonicalInput.vaultPubkey,
     "vaultPubkey"
   );
-  if (requestInput.mode !== "full" && requestInput.autodepositClose) {
+  if (requestInput.autodepositClose) {
     throw new Error(
-      "autodepositClose can only be confirmed with full withdrawals."
+      "Withdrawal confirmation cannot include policy close metadata; close policies only after zero-balance verification."
     );
   }
 
@@ -487,6 +491,36 @@ export function serializeWithdrawPosition(position: UserYieldPositionRecord) {
   };
 }
 
+export type EarnWithdrawConfirmationStatus =
+  | "withdrawal_recorded"
+  | "full_exit_incomplete"
+  | "policy_close_required";
+
+export type EarnWithdrawConfirmationResult = {
+  blockingTokenAccounts: Array<{
+    address: string;
+    amountRaw: string;
+    mint: string;
+  }>;
+  position: ReturnType<typeof serializeWithdrawPosition>;
+  remainingHoldings: Array<{
+    amountRaw: string;
+    kind: "idle" | "kamino";
+    liquidityMint: string;
+    market: string | null;
+    reserve: string | null;
+  }>;
+  status: EarnWithdrawConfirmationStatus;
+};
+
+function toSafeContextSlot(slot: bigint): number {
+  const value = Number(slot);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Confirmed withdrawal slot is outside the safe RPC range.");
+  }
+  return value;
+}
+
 // Validates + records a confirmed Earn withdrawal against the authenticated
 // principal. Throws `EarnWithdrawConfirmError` (with an HTTP status) on any
 // validation failure; returns the serialized post-withdrawal position.
@@ -494,7 +528,7 @@ export async function recordConfirmedEarnWithdrawal(args: {
   principal: EarnWithdrawConfirmPrincipal;
   input: ConfirmedYieldWithdrawalInput;
   solanaEnv: SolanaEnv;
-}): Promise<ReturnType<typeof serializeWithdrawPosition>> {
+}): Promise<EarnWithdrawConfirmationResult> {
   const { principal, solanaEnv } = args;
 
   const rejectionContext = {
@@ -592,82 +626,9 @@ export async function recordConfirmedEarnWithdrawal(args: {
     });
   }
 
-  if (input.mode === "full" && input.autodepositClose) {
-    let autodepositClose = input.autodepositClose;
-    let autodepositCloseConfirmedSlot: bigint;
-    try {
-      autodepositCloseConfirmedSlot = await resolveConfirmedSignatureSlot({
-        cluster: solanaEnv,
-        operation: "autodeposit close",
-        signature: autodepositClose.closeSignature,
-      });
-    } catch (error) {
-      rejectWithdrawConfirm({
-        status: 400,
-        code: "unconfirmed_autodeposit_close_signature",
-        message:
-          error instanceof Error
-            ? error.message
-            : "Autodeposit close transaction is not confirmed.",
-        context: {
-          ...rejectionContext,
-          closeSignature: autodepositClose.closeSignature,
-        },
-      });
-    }
-
-    if (autodepositClose.confirmedSlot !== autodepositCloseConfirmedSlot) {
-      console.warn(
-        "[earn-withdraw-confirm] corrected autodeposit close slot",
-        {
-          ...rejectionContext,
-          clientSlot: autodepositClose.confirmedSlot.toString(),
-          resolvedSlot: autodepositCloseConfirmedSlot.toString(),
-        }
-      );
-      autodepositClose = {
-        ...autodepositClose,
-        confirmedSlot: autodepositCloseConfirmedSlot,
-      };
-      input = { ...input, autodepositClose };
-    }
-
-    await recordClosedAutodepositTarget({
-      cluster: input.cluster,
-      closeSignature: autodepositClose.closeSignature,
-      confirmedSlot: autodepositClose.confirmedSlot,
-      delegatedSigner: autodepositClose.delegatedSigner,
-      policyAccount: autodepositClose.policyAccount,
-      recurringDelegation: autodepositClose.recurringDelegation,
-      settings: input.settings,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      vaultPubkey: input.vaultPubkey,
-      walletAddress: input.walletAddress,
-    });
-  }
-
   let position: UserYieldPositionRecord;
   try {
     position = await recordConfirmedYieldWithdrawal(input);
-    await reconcileEarnVaultPosition({
-      authority: input.walletAddress,
-      cluster: normalizeLoyalCluster(input.cluster),
-      connection: getConnection(solanaEnv),
-      force: true,
-      settings: input.settings,
-      vaultPubkey: input.vaultPubkey,
-    }).catch((error) => {
-      console.warn("[earn-withdraw-confirm] post-record reconcile failed", {
-        cluster: input.cluster,
-        errorMessage:
-          error instanceof Error ? error.message : "Unknown reconcile error.",
-        errorName: error instanceof Error ? error.name : typeof error,
-        settings: input.settings,
-        signature: input.withdrawalSignature,
-        vaultIndex: input.vaultIndex,
-        walletAddress: input.walletAddress,
-      });
-    });
   } catch (error) {
     const message =
       error instanceof Error
@@ -704,5 +665,138 @@ export async function recordConfirmedEarnWithdrawal(args: {
     throw new EarnWithdrawConfirmError(500, "record_failed", message);
   }
 
-  return serializeWithdrawPosition(position);
+  const connection = getConnection(solanaEnv);
+  const cluster = normalizeLoyalCluster(input.cluster);
+
+  if (input.mode !== "full") {
+    await reconcileEarnVaultPosition({
+      authority: input.walletAddress,
+      cluster,
+      connection,
+      force: true,
+      settings: input.settings,
+      vaultPubkey: input.vaultPubkey,
+    }).catch((error) => {
+      console.warn("[earn-withdraw-confirm] partial reconcile failed", {
+        cluster: input.cluster,
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown reconcile error.",
+        errorName: error instanceof Error ? error.name : typeof error,
+        settings: input.settings,
+        signature: input.withdrawalSignature,
+        vaultIndex: input.vaultIndex,
+        walletAddress: input.walletAddress,
+      });
+    });
+
+    return {
+      blockingTokenAccounts: [],
+      position: serializeWithdrawPosition(position),
+      remainingHoldings: [],
+      status: "withdrawal_recorded",
+    };
+  }
+
+  if (input.isFinalStep === false) {
+    return {
+      blockingTokenAccounts: [],
+      position: serializeWithdrawPosition(position),
+      remainingHoldings: [],
+      status: "full_exit_incomplete",
+    };
+  }
+
+  try {
+    const minContextSlot = toSafeContextSlot(input.confirmedSlot);
+    await reconcileEarnVaultPosition({
+      authority: input.walletAddress,
+      cluster,
+      connection,
+      force: true,
+      minContextSlot,
+      purpose: "post_withdrawal_zero_proof",
+      settings: input.settings,
+      vaultPubkey: input.vaultPubkey,
+    });
+    const cleanupState = await findEarnCleanupVaultState({
+      authority: input.walletAddress,
+      settings: input.settings,
+      vaultIndex: input.vaultIndex,
+      vaultPubkey: input.vaultPubkey,
+    });
+    if (!cleanupState) {
+      throw new Error(
+        "Active Earn policy state is unavailable for full-exit verification."
+      );
+    }
+
+    const serverEnv = getServerEnv();
+    const proof = await verifyEarnFullExitZeroBalances({
+      cluster,
+      connection,
+      minContextSlot,
+      policy: serializeRoutePolicyState(
+        cleanupState.routePolicy,
+        cleanupState.setupPolicy
+      ),
+      programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
+      settingsPda: new PublicKey(input.settings),
+    });
+    const reconciledPosition =
+      (await findReconciledActiveYieldPositionForVault({
+        cluster,
+        settings: input.settings,
+        vaultIndex: input.vaultIndex,
+        walletAddress: input.walletAddress,
+      })) ?? position;
+
+    console.info("[earn-withdraw-confirm] full exit verification", {
+      blockingTokenAccountCount: proof.blockingTokenAccounts.length,
+      cluster: input.cluster,
+      idleAmountRaw: proof.idleAmountRaw,
+      idleReadsAgree: proof.idleReadsAgree,
+      observedSlot: proof.observedSlot,
+      remainingHoldingCount: proof.remainingHoldings.length,
+      settings: input.settings,
+      signature: input.withdrawalSignature,
+      status: proof.status,
+      vaultIndex: input.vaultIndex,
+      walletAddress: input.walletAddress,
+    });
+
+    return {
+      blockingTokenAccounts: proof.blockingTokenAccounts,
+      position: serializeWithdrawPosition(reconciledPosition),
+      remainingHoldings: proof.remainingHoldings.map((holding) => ({
+        amountRaw: holding.amountRaw,
+        kind: holding.kind,
+        liquidityMint: holding.liquidityMint,
+        market: holding.market,
+        reserve: holding.reserve,
+      })),
+      status: proof.status,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Post-withdraw balance verification failed.";
+    console.error("[earn-withdraw-confirm] full exit verification retryable", {
+      cluster: input.cluster,
+      errorMessage: message,
+      errorName: error instanceof Error ? error.name : typeof error,
+      minContextSlot: input.confirmedSlot.toString(),
+      settings: input.settings,
+      signature: input.withdrawalSignature,
+      stack: error instanceof Error ? error.stack : undefined,
+      status: "full_exit_verification_retryable",
+      vaultIndex: input.vaultIndex,
+      walletAddress: input.walletAddress,
+    });
+    throw new EarnWithdrawConfirmError(
+      503,
+      "full_exit_verification_retryable",
+      message
+    );
+  }
 }

--- a/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -4,10 +4,6 @@ import type { LoyalCluster } from "@loyal-labs/actions";
 import type { SmartAccountEarnUsdcWithdrawInput } from "@loyal-labs/smart-account-vaults";
 import { Connection, PublicKey } from "@solana/web3.js";
 
-import {
-  findCurrentEarnAutodepositState,
-  reconcileMissingOnChainEarnAutodepositPolicy,
-} from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
 import {
   earnReserveTargetFromActivePosition,
@@ -22,7 +18,6 @@ import type { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimizati
 import {
   findActiveYieldRoutePolicyPair,
   findCurrentNonzeroYieldVaultReservePositions,
-  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
   findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type CurrentYieldVaultIdleTokenBalanceRecord,
@@ -491,7 +486,6 @@ export async function resolveEarnUsdcWithdrawInput(args: {
   // ("Select an Earn source"). Full exits keep the DB path (its reconciled
   // rows carry the collateral metadata the full-withdrawal instruction needs).
   let selectedSource: SelectedEarnWithdrawSource;
-  let isFinalExit: boolean;
   let withdrawTarget: EarnUsdcReserveTarget;
   let effectiveAmountRaw: bigint;
   // Set when a full exit had to source from the live snapshot (DB rows
@@ -526,11 +520,6 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     }
     selectedSource = selected;
     effectiveAmountRaw = amountRaw;
-    const snapshotTotal = snapshotSources.reduce(
-      (total, source) => total + source.amountRaw,
-      BigInt(0)
-    );
-    isFinalExit = snapshotTotal - effectiveAmountRaw <= BigInt(0);
     withdrawTarget =
       selected.type === "reserve"
         ? {
@@ -578,25 +567,6 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     }
     selectedSource = selected;
     effectiveAmountRaw = selected.amountRaw;
-    const remainingReserveAmountRaw = snapshotSources.reduce(
-      (total, source) =>
-        total +
-        (source.type === "reserve" && source.id !== selected.id
-          ? source.amountRaw
-          : BigInt(0)),
-      BigInt(0)
-    );
-    const remainingIdleAmountRaw = snapshotSources.reduce(
-      (total, source) =>
-        total +
-        (source.type === "idle" && source.id !== selected.id
-          ? source.amountRaw
-          : BigInt(0)),
-      BigInt(0)
-    );
-    isFinalExit =
-      remainingReserveAmountRaw <= BigInt(0) &&
-      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
     withdrawTarget =
       selected.type === "reserve"
         ? {
@@ -618,31 +588,6 @@ export async function resolveEarnUsdcWithdrawInput(args: {
       reserveRows: currentReserveRows,
     });
     effectiveAmountRaw = selectedSource.amountRaw;
-    const remainingReserveAmountRaw = currentReserveRows.reduce(
-      (total, row) =>
-        total +
-        (selectedSource.type === "reserve" &&
-        row.reserve === selectedSource.reserve
-          ? row.amountRaw > effectiveAmountRaw
-            ? row.amountRaw - effectiveAmountRaw
-            : BigInt(0)
-          : row.amountRaw),
-      BigInt(0)
-    );
-    const remainingIdleAmountRaw = currentIdleRows.reduce(
-      (total, row) =>
-        total +
-        (selectedSource.type === "idle" &&
-        row.tokenAccount === selectedSource.tokenAccount
-          ? row.amountRaw > effectiveAmountRaw
-            ? row.amountRaw - effectiveAmountRaw
-            : BigInt(0)
-          : row.amountRaw),
-      BigInt(0)
-    );
-    isFinalExit =
-      remainingReserveAmountRaw <= BigInt(0) &&
-      remainingIdleAmountRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW;
     withdrawTarget = earnReserveTargetFromActivePosition(position);
   }
 
@@ -658,81 +603,6 @@ export async function resolveEarnUsdcWithdrawInput(args: {
         }
       : {}),
   };
-  const autodepositState =
-    mode === "full" && isFinalExit
-      ? await findCurrentEarnAutodepositState({
-          settings: settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          walletAddress,
-        })
-      : null;
-  let autodepositClose:
-    | {
-        policy: PublicKey;
-        recurringDelegation: PublicKey;
-      }
-    | undefined;
-  let reconciledMissingAutodepositPolicy = false;
-
-  if (
-    autodepositState?.target.policyAccount &&
-    autodepositState.target.recurringDelegation
-  ) {
-    const autodepositPolicyAccount = new PublicKey(
-      autodepositState.target.policyAccount
-    );
-    const autodepositPolicyInfo = await connection.getAccountInfo(
-      autodepositPolicyAccount,
-      "confirmed"
-    );
-
-    if (autodepositPolicyInfo) {
-      autodepositClose = {
-        policy: autodepositPolicyAccount,
-        recurringDelegation: new PublicKey(
-          autodepositState.target.recurringDelegation
-        ),
-      };
-    } else {
-      reconciledMissingAutodepositPolicy = true;
-      const reconciledTarget =
-        await reconcileMissingOnChainEarnAutodepositPolicy({
-          policyAccount: autodepositState.target.policyAccount,
-          settings: settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          walletAddress,
-        });
-      console.warn(`[${logTag}] reconciled missing autodeposit policy account`, {
-        cluster,
-        lifecycleStatus: reconciledTarget.lifecycleStatus,
-        policyAccount: autodepositState.target.policyAccount,
-        reconciliationSource: "reconciled_missing_policy",
-        settings: settingsPda,
-        targetId: reconciledTarget.id.toString(),
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        walletAddress,
-      });
-    }
-  }
-
-  if (
-    mode === "full" &&
-    isFinalExit &&
-    autodepositState &&
-    !autodepositClose &&
-    !reconciledMissingAutodepositPolicy
-  ) {
-    console.warn(`[${logTag}] active autodeposit state is missing close metadata`, {
-      cluster,
-      policyAccount: autodepositState.target.policyAccount,
-      recurringDelegation: autodepositState.target.recurringDelegation,
-      settings: settingsPda,
-      targetId: autodepositState.target.id.toString(),
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      walletAddress,
-    });
-  }
-
   const withdrawInput = {
     amountRaw: effectiveAmountRaw,
     cluster,
@@ -800,7 +670,8 @@ export async function resolveEarnUsdcWithdrawInput(args: {
                 }),
         }
       : {}),
-    closePoliciesOnFullWithdrawal: isFinalExit,
+    // Full withdrawal and policy close are intentionally separate phases.
+    closePoliciesOnFullWithdrawal: false,
     source:
       selectedSource.type === "idle"
         ? {
@@ -822,17 +693,10 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     yieldRoutingPolicy,
   };
 
-  const input: SmartAccountEarnUsdcWithdrawInput =
-    mode === "full"
-      ? {
-          ...withdrawInput,
-          ...(autodepositClose ? { autodepositClose } : {}),
-          mode,
-        }
-      : {
-          ...withdrawInput,
-          mode,
-        };
+  const input: SmartAccountEarnUsdcWithdrawInput = {
+    ...withdrawInput,
+    mode,
+  };
 
   return { input, policy, effectiveAmountRaw };
 }

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
@@ -5,6 +5,9 @@ mock.module("server-only", () => ({}));
 const { recordConfirmedYieldDeposit } = await import(
   "./yield-deposit-repository.server"
 );
+const { recordConfirmedEarnCleanup } = await import(
+  "./yield-deposit-repository.server"
+);
 const { recordConfirmedYieldWithdrawal } = await import(
   "./yield-deposit-repository.server"
 );
@@ -285,12 +288,12 @@ describe("yield deposit repository idempotency", () => {
     expect(dependencies.update).not.toHaveBeenCalled();
   });
 
-  test("completes zero-current cleanup and deactivation for duplicate full withdrawals", async () => {
+  test("keeps policies active when a full withdrawal confirmation is replayed", async () => {
     const position = createPosition();
     Object.assign(position, {
       currentAmountRaw: BigInt(0),
       principalAmountRaw: BigInt(0),
-      status: "closed",
+      status: "active",
     });
     const insertCalls: Array<{ index: number; values: unknown }> = [];
     const updateCalls: Array<{ index: number; set: unknown }> = [];
@@ -392,24 +395,12 @@ describe("yield deposit repository idempotency", () => {
     );
 
     expect(result).toBe(position);
-    expect(batchCalls).toHaveLength(2);
-    expect(insertCalls).toHaveLength(2);
-    expect(updateCalls.map((call) => call.set)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          amountRaw: BigInt(0),
-          hasValue: false,
-        }),
-        expect.objectContaining({
-          active: false,
-          lastSeenSignature: "withdrawal-signature",
-          lastSeenSlot: BigInt(500),
-        }),
-      ])
-    );
+    expect(batchCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+    expect(updateCalls).toHaveLength(0);
   });
 
-  test("closes reserve-source full withdrawals when no holdings remain", async () => {
+  test("records a zero-balance full withdrawal without closing position or policy state", async () => {
     const position = createPosition();
     const reserveRow = {
       amountRaw: BigInt(1000),
@@ -563,7 +554,7 @@ describe("yield deposit repository idempotency", () => {
       dependencies as never
     );
 
-    expect(result.status).toBe("closed");
+    expect(result.status).toBe("active");
     expect(result.principalAmountRaw).toBe(BigInt(0));
     expect(insertedValues).toEqual(
       expect.arrayContaining([
@@ -578,13 +569,50 @@ describe("yield deposit repository idempotency", () => {
       expect.arrayContaining([
         expect.objectContaining({
           principalAmountRaw: BigInt(0),
-          status: "closed",
+          status: "active",
         }),
+      ])
+    );
+    expect(updateSets).not.toEqual(
+      expect.arrayContaining([
         expect.objectContaining({
           active: false,
         }),
       ])
     );
+  });
+});
+
+describe("Earn cleanup idempotency", () => {
+  test("treats an already inactive vault as a completed cleanup", async () => {
+    const batch = mock(async () => []);
+    const dependencies = {
+      client: {
+        db: {
+          batch,
+          query: {
+            managedVaults: {
+              findFirst: mock(async () => null),
+            },
+          },
+        },
+      },
+      now: () => new Date("2026-06-02T00:00:00.000Z"),
+    };
+    const input = {
+      cleanupSignature: "cleanup-signature",
+      cluster: "mainnet-beta",
+      confirmedSlot: BigInt(600),
+      settings: "settings",
+      vaultIndex: 1,
+      vaultPubkey: "vault",
+      walletAddress: "wallet",
+    };
+
+    await recordConfirmedEarnCleanup(input, dependencies as never);
+    await recordConfirmedEarnCleanup(input, dependencies as never);
+
+    expect(batch).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -84,7 +84,7 @@ export type ConfirmedYieldRoutePolicyInput = {
 export type UserYieldPositionRecord = typeof userYieldPositions.$inferSelect;
 export type UserYieldPositionHoldingEventRecord =
   typeof userYieldPositionHoldingEvents.$inferSelect;
-type UserYieldPositionWithdrawalRecord =
+export type UserYieldPositionWithdrawalRecord =
   typeof userYieldPositionWithdrawals.$inferSelect;
 export type RoutePolicyRecord = typeof routePolicies.$inferSelect;
 export type UserYieldPositionEventRecord = {
@@ -577,140 +577,6 @@ async function projectPositionForUserFacingRead(
   ))
     ? principalBackedPositionProjection(position, latestEvent)
     : position;
-}
-
-async function recordZeroCurrentVaultPositionsAfterFullWithdrawal(
-  input: ConfirmedYieldWithdrawalInput,
-  dependencies: Pick<YieldDepositRepositoryDependencies, "client" | "now">
-): Promise<void> {
-  const vault = await dependencies.client.db.query.managedVaults.findFirst({
-    where: and(
-      eq(managedVaults.settings, input.settings),
-      eq(managedVaults.vaultIndex, input.vaultIndex),
-      eq(managedVaults.vaultPubkey, input.vaultPubkey)
-    ),
-  });
-  if (!vault) {
-    return;
-  }
-
-  const currentRows = await dependencies.client.db
-    .select()
-    .from(vaultReservePositionsCurrent)
-    .where(eq(vaultReservePositionsCurrent.vaultId, vault.id));
-  if (currentRows.length === 0) {
-    return;
-  }
-  const alreadyZeroCurrent = currentRows.every(
-    (row) => row.amountRaw === BigInt(0) && !row.hasValue
-  );
-  if (alreadyZeroCurrent) {
-    return;
-  }
-
-  const observedAt = dependencies.now();
-  const [snapshot] = await dependencies.client.db
-    .insert(vaultPositionSnapshots)
-    .values({
-      chainSlot: input.confirmedSlot,
-      context: {
-        source: "frontend_full_withdraw",
-        withdrawalSignature: input.withdrawalSignature,
-      },
-      isCurrent: false,
-      observedAt,
-      observedSlot: input.confirmedSlot,
-      policyId: vault.activePolicyId,
-      vaultId: vault.id,
-    })
-    .returning({ id: vaultPositionSnapshots.id });
-  if (!snapshot) {
-    return;
-  }
-
-  await dependencies.client.db.batch([
-    dependencies.client.db.insert(vaultPositionSnapshotPositions).values(
-      currentRows.map((row) => ({
-        amountRaw: BigInt(0),
-        borrowApyBps: row.borrowApyBps,
-        hasValue: false,
-        liquidityMint: row.liquidityMint,
-        market: row.market,
-        planningMetadata: {
-          ...row.planningMetadata,
-          source: "frontend_full_withdraw",
-        },
-        reserve: row.reserve,
-        snapshotId: snapshot.id,
-        supplyApyBps: row.supplyApyBps,
-      }))
-    ) as never,
-    dependencies.client.db
-      .update(vaultPositionSnapshots)
-      .set({ isCurrent: false })
-      .where(eq(vaultPositionSnapshots.vaultId, vault.id)) as never,
-    dependencies.client.db
-      .update(vaultReservePositionsCurrent)
-      .set({
-        amountRaw: BigInt(0),
-        hasValue: false,
-        observedAt,
-        observedSlot: input.confirmedSlot,
-        snapshotId: snapshot.id,
-      })
-      .where(eq(vaultReservePositionsCurrent.vaultId, vault.id)) as never,
-    dependencies.client.db
-      .update(vaultPositionSnapshots)
-      .set({ isCurrent: true })
-      .where(eq(vaultPositionSnapshots.id, snapshot.id)) as never,
-  ]);
-}
-
-async function deactivateVaultAfterFullWithdrawal(
-  input: ConfirmedYieldWithdrawalInput,
-  dependencies: Pick<YieldDepositRepositoryDependencies, "client">,
-  now: Date
-): Promise<void> {
-  const vault = await dependencies.client.db.query.managedVaults.findFirst({
-    where: and(
-      eq(managedVaults.settings, input.settings),
-      eq(managedVaults.vaultIndex, input.vaultIndex),
-      eq(managedVaults.vaultPubkey, input.vaultPubkey)
-    ),
-  });
-  if (!vault) {
-    return;
-  }
-
-  const policyIds = [vault.activePolicyId, vault.setupPolicyId].filter(
-    (policyId): policyId is bigint => typeof policyId === "bigint"
-  );
-
-  if (policyIds.length === 0) {
-    const deactivateVault = dependencies.client.db
-      .update(managedVaults)
-      .set({ active: false, lastSeenAt: now })
-      .where(eq(managedVaults.id, vault.id)) as never;
-
-    await dependencies.client.db.batch([deactivateVault]);
-    return;
-  }
-
-  const deactivatePolicies = dependencies.client.db
-    .update(routePolicies)
-    .set({
-      active: false,
-      lastSeenAt: now,
-      lastSeenSignature: input.withdrawalSignature,
-      lastSeenSlot: input.confirmedSlot,
-    })
-    .where(inArray(routePolicies.id, policyIds)) as never;
-  const deactivateVault = dependencies.client.db
-    .update(managedVaults)
-    .set({ active: false, lastSeenAt: now })
-    .where(eq(managedVaults.id, vault.id)) as never;
-
-  await dependencies.client.db.batch([deactivatePolicies, deactivateVault]);
 }
 
 export async function recordConfirmedEarnCleanup(
@@ -1529,9 +1395,9 @@ async function resolveWithdrawalSource(
 
   return {
     idleRows: currentIdleRows,
-    // Mirrors the prepare routes' final-exit derivation (same dust tolerance):
-    // a full-mode exit sweeps idle dust and closes the on-chain policies, so
-    // the DB pair must be released here on the same basis.
+    // This is an accounting event classification only. It never authorizes
+    // closing the position, vault, or policies; cleanup owns that transition
+    // after a minContextSlot-safe chain-wide zero proof.
     isFinalExit:
       input.mode === "full" &&
       remainingReserveAmountRaw <= BigInt(0) &&
@@ -3298,6 +3164,35 @@ export async function findEarnCleanupVaultState(
   };
 }
 
+export async function findLatestFullYieldWithdrawalForVault(
+  input: {
+    settings: string;
+    vaultIndex: number;
+    vaultPubkey: string;
+    walletAddress: string;
+  },
+  dependencies: Pick<YieldDepositRepositoryDependencies, "client"> = {
+    client: getYieldOptimizationClient(),
+  }
+): Promise<UserYieldPositionWithdrawalRecord | null> {
+  const withdrawal =
+    await dependencies.client.db.query.userYieldPositionWithdrawals.findFirst({
+      where: and(
+        eq(userYieldPositionWithdrawals.mode, "full"),
+        eq(userYieldPositionWithdrawals.settings, input.settings),
+        eq(userYieldPositionWithdrawals.vaultIndex, input.vaultIndex),
+        eq(userYieldPositionWithdrawals.vaultPubkey, input.vaultPubkey),
+        eq(userYieldPositionWithdrawals.walletAddress, input.walletAddress)
+      ),
+      orderBy: [
+        desc(userYieldPositionWithdrawals.confirmedSlot),
+        desc(userYieldPositionWithdrawals.id),
+      ],
+    });
+
+  return withdrawal ?? null;
+}
+
 export async function findActiveManagedYieldVaultWithPolicy(
   input: {
     authority: string;
@@ -3872,13 +3767,6 @@ export async function recordConfirmedYieldWithdrawal(
       input,
       withdrawal: idempotentWithdrawal.withdrawal,
     });
-    if (idempotentWithdrawal.position.status === "closed") {
-      await recordZeroCurrentVaultPositionsAfterFullWithdrawal(
-        input,
-        dependencies
-      );
-      await deactivateVaultAfterFullWithdrawal(input, dependencies, now);
-    }
     return idempotentWithdrawal.position;
   }
 
@@ -3961,9 +3849,8 @@ export async function recordConfirmedYieldWithdrawal(
     withdrawalSignature: input.withdrawalSignature,
     withdrawnAmountRaw: input.withdrawnAmountRaw,
   };
-  const nextPrincipal = withdrawalSource.isFinalExit
-    ? BigInt(0)
-    : withdrawalSource.sourceType === "idle"
+  const nextPrincipal =
+    withdrawalSource.sourceType === "idle"
     ? existingPosition.principalAmountRaw
     : existingPosition.principalAmountRaw > input.withdrawnAmountRaw
     ? existingPosition.principalAmountRaw - input.withdrawnAmountRaw
@@ -3993,13 +3880,11 @@ export async function recordConfirmedYieldWithdrawal(
   }
 
   const [insertedWithdrawal] = insertedWithdrawals;
-  const nextHoldingAmountRaw = withdrawalSource.isFinalExit
-    ? BigInt(0)
-    : withdrawalSource.remainingReserveAmountRaw +
-      withdrawalSource.remainingIdleAmountRaw;
-  const principalDeltaRaw = withdrawalSource.isFinalExit
-    ? -existingPosition.principalAmountRaw
-    : withdrawalSource.sourceType === "idle"
+  const nextHoldingAmountRaw =
+    withdrawalSource.remainingReserveAmountRaw +
+    withdrawalSource.remainingIdleAmountRaw;
+  const principalDeltaRaw =
+    withdrawalSource.sourceType === "idle"
     ? BigInt(0)
     : -(existingPosition.principalAmountRaw > input.withdrawnAmountRaw
         ? input.withdrawnAmountRaw
@@ -4034,12 +3919,11 @@ export async function recordConfirmedYieldWithdrawal(
     event,
     lastConfirmedSlot: input.confirmedSlot,
     now,
-    principalAmountRaw: withdrawalSource.isFinalExit
-      ? BigInt(0)
-      : withdrawalSource.sourceType === "idle"
+    principalAmountRaw:
+      withdrawalSource.sourceType === "idle"
       ? existingPosition.principalAmountRaw
       : nextPrincipal,
-    status: withdrawalSource.isFinalExit ? "closed" : "active",
+    status: "active",
   });
 
   await recordCurrentVaultSourceWithdrawal({
@@ -4047,10 +3931,6 @@ export async function recordConfirmedYieldWithdrawal(
     input,
     resolution: withdrawalSource,
   });
-
-  if (withdrawalSource.isFinalExit) {
-    await deactivateVaultAfterFullWithdrawal(input, dependencies, now);
-  }
 
   if (position.principalAmountRaw !== nextPrincipal) {
     return position;


### PR DESCRIPTION
Adds a two-phase Earn full-exit safety brake: withdrawals keep position and policy state active until a minContextSlot-safe all-market and idle-account proof succeeds, then separate cleanup confirms on-chain policy closure before database finalization. Base: main; no dependency.