### PR TITLE
fix(earn): unwind every Kamino market on a full Earn exit

### DIFF
--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -1,6 +1,5 @@
+import { PublicKey } from "@solana/web3.js";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { pda } from "@loyal-labs/loyal-smart-accounts";
-import { Connection, PublicKey } from "@solana/web3.js";
 
 mock.module("server-only", () => ({}));
 
@@ -23,46 +22,85 @@ const activePosition = {
   currentReserve: "D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59",
   principalAmountRaw: BigInt(1_000_026),
 };
-const completeAutodepositState = {
-  policy: {
-    policyAccount: "11111111111111111111111111111118",
-  },
-  target: {
-    id: BigInt(11),
-    recurringDelegation: "11111111111111111111111111111119",
-  },
-};
-const [expectedEarnVaultPda] = pda.getSmartAccountPda({
-  accountIndex: 1,
-  programId: new PublicKey("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG"),
-  settingsPda: new PublicKey(principal.settingsPda),
-});
+const secondMarket = "11111111111111111111111111111119";
+const secondReserve = "6UeJYTLU1adaoHWeApWsoj1xNEDbWA2RhMbrZgYFutJk";
+const idleTokenAccount = "11111111111111111111111111111116";
+
+function kaminoHolding(args: {
+  amountRaw: string;
+  market: string;
+  reserve: string;
+}) {
+  return {
+    amountRaw: args.amountRaw,
+    kind: "kamino" as const,
+    label: "Kamino USDC",
+    liquidityMint: activePosition.currentLiquidityMint,
+    market: args.market,
+    marketName: "Kamino",
+    observedAt: "2026-07-13T00:00:00.000Z",
+    observedSlot: "1",
+    provenance: {
+      reserveCollateralMint: "11111111111111111111111111111115",
+    },
+    reserve: args.reserve,
+    supplyApyBps: "300",
+  };
+}
+
+function idleHolding(amountRaw: string) {
+  return {
+    amountRaw,
+    kind: "idle" as const,
+    label: "Idle USDC",
+    liquidityMint: activePosition.currentLiquidityMint,
+    market: null,
+    marketName: "Wallet",
+    observedAt: "2026-07-13T00:00:00.000Z",
+    observedSlot: "1",
+    provenance: { tokenAccount: idleTokenAccount },
+    reserve: null,
+    supplyApyBps: null,
+  };
+}
+
+type SnapshotHolding =
+  | ReturnType<typeof idleHolding>
+  | ReturnType<typeof kaminoHolding>;
+
+function holdingsSnapshot(holdings: SnapshotHolding[]) {
+  return {
+    currentTotalAmountRaw: "0",
+    holdings,
+    observedAt: "2026-07-13T00:00:00.000Z",
+    observedSlot: "1",
+    provenance: {
+      accountCount: 0,
+      chunkCount: 0,
+      commitment: "confirmed" as const,
+      source: "rpc_getMultipleAccounts" as const,
+      watchedAccounts: [],
+    },
+  };
+}
 
 let currentPrincipal: typeof principal | null = principal;
-let currentAutodepositState: typeof completeAutodepositState | null = null;
+let currentPolicy: typeof activePolicy | null = activePolicy;
 let currentPosition: typeof activePosition | null = activePosition;
-let findAutodepositCalls: unknown[] = [];
-let getAccountInfoCalls: string[] = [];
-let findPolicyCalls: unknown[] = [];
-let findPositionCalls: unknown[] = [];
-let findReserveRowsCalls: unknown[] = [];
-let findIdleRowsCalls: unknown[] = [];
+let currentSnapshot = holdingsSnapshot([
+  kaminoHolding({
+    amountRaw: "600000",
+    market: activePosition.currentMarket,
+    reserve: activePosition.currentReserve,
+  }),
+  kaminoHolding({
+    amountRaw: "400000",
+    market: secondMarket,
+    reserve: secondReserve,
+  }),
+  idleHolding("10000"),
+]);
 let prepareCalls: Record<string, unknown>[] = [];
-let reconcileMissingAutodepositCalls: unknown[] = [];
-let currentAutodepositPolicyAccountExists = true;
-let currentReserveRows: Array<{
-  hasValue?: boolean;
-  amountRaw: bigint;
-  liquidityMint: string;
-  market: string | null;
-  reserve: string;
-  supplyApyBps: bigint | null;
-}> = [];
-let currentIdleRows: Array<{
-  amountRaw: bigint;
-  mint: string;
-  tokenAccount: string;
-}> = [];
 
 mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => currentPrincipal,
@@ -85,8 +123,8 @@ mock.module("@/lib/core/config/solana-env-override", () => ({
   resolveLoyalWebSolanaEnvFromEnv: () => "mainnet",
 }));
 
-mock.module("@/lib/solana/rpc-endpoints", () => ({
-  getFrontendSolanaEndpoints: () => ({
+mock.module("@/lib/solana/rpc-endpoints.server", () => ({
+  getServerSolanaEndpoints: () => ({
     rpcEndpoint: "http://127.0.0.1:8899",
     websocketEndpoint: "ws://127.0.0.1:8900",
   }),
@@ -108,6 +146,17 @@ mock.module(
   })
 );
 
+mock.module("@/lib/yield-optimization/earn-rpc-holdings.client", () => ({
+  fetchEarnRpcHoldingsSnapshot: async () => currentSnapshot,
+}));
+
+mock.module(
+  "@/lib/yield-optimization/earn-state-serializers.server",
+  () => ({
+    serializeRoutePolicyState: () => ({ vaultIndex: 1 }),
+  })
+);
+
 mock.module(
   "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared",
   () => ({
@@ -124,87 +173,23 @@ mock.module(
   })
 );
 
-mock.module(
-  "@/lib/yield-optimization/earn-autodeposit-repository.server",
-  () => ({
-    findCurrentEarnAutodepositState: async (input: unknown) => {
-      findAutodepositCalls.push(input);
-      return currentAutodepositState;
-    },
-    reconcileMissingOnChainEarnAutodepositPolicy: async (input: unknown) => {
-      reconcileMissingAutodepositCalls.push(input);
-      return {
-        id: BigInt(11),
-        lifecycleStatus: "closed",
-      };
-    },
-    recordClosedAutodepositTarget: async () => {
-      throw new Error("recordClosedAutodepositTarget was not expected.");
-    },
-  })
-);
-
 mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
-  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW: BigInt(10_000),
-  findActiveManagedYieldVaultWithPolicy: async () => null,
-  findActiveYieldRoutePolicyPair: async (input: unknown) => {
-    findPolicyCalls.push(input);
-    return {
-      routePolicy: activePolicy,
-      setupPolicy: activeSetupPolicy,
-    };
-  },
-  findReconciledActiveYieldPositionForVault: async (input: unknown) => {
-    findPositionCalls.push(input);
-    return currentPosition;
-  },
-  findCurrentNonzeroYieldVaultReservePositions: async (input: unknown) => {
-    findReserveRowsCalls.push(input);
-    return currentReserveRows.map((row) => ({
-      ...row,
-      hasValue: row.hasValue ?? true,
-    }));
-  },
-  findCurrentYieldVaultIdleTokenBalances: async (input: unknown) => {
-    findIdleRowsCalls.push(input);
-    return currentIdleRows;
-  },
-  recordConfirmedYieldDeposit: async () => {
-    throw new Error("recordConfirmedYieldDeposit was not expected.");
-  },
-  recordConfirmedYieldWithdrawal: async () => {
-    throw new Error("recordConfirmedYieldWithdrawal was not expected.");
-  },
-  recordReconciledYieldVaultSnapshot: async () => {
-    throw new Error("recordReconciledYieldVaultSnapshot was not expected.");
-  },
-  recordSnapshotReconciledYieldHolding: async () => {
-    throw new Error(
-      "recordSnapshotReconciledYieldHolding was not expected."
-    );
-  },
+  findActiveYieldRoutePolicyPair: async () =>
+    currentPolicy
+      ? {
+          routePolicy: currentPolicy,
+          setupPolicy: activeSetupPolicy,
+        }
+      : null,
+  findReconciledActiveYieldPositionForVault: async () => currentPosition,
 }));
 
 mock.module("@loyal-labs/smart-account-vaults", () => ({
-  calculateKaminoRedeemableLiquidityAmountRaw: () => BigInt(0),
   createSmartAccountVaultsClient: () => ({
     prepareEarnUsdcWithdraw: async (input: Record<string, unknown>) => {
       prepareCalls.push(input);
       return { prepared: true, input };
     },
-  }),
-  parseKaminoObligationDepositedCollateralAmountRaw: () => BigInt(0),
-  parseKaminoReserveSnapshot: () => ({}),
-  parseKaminoReserveTokenAccounts: () => ({
-    collateralMint: new PublicKey("11111111111111111111111111111112"),
-    collateralSupplyVault: new PublicKey("11111111111111111111111111111113"),
-    liquidityMint: new PublicKey("11111111111111111111111111111114"),
-    liquiditySupplyVault: new PublicKey("11111111111111111111111111111115"),
-  }),
-  resolveEarnUsdcVaultTokenAccounts: () => ({
-    obligation: new PublicKey("11111111111111111111111111111116"),
-    vaultCollateralAta: new PublicKey("11111111111111111111111111111117"),
-    vaultUsdcAta: new PublicKey("11111111111111111111111111111118"),
   }),
 }));
 
@@ -217,145 +202,63 @@ function createRequest(body: Record<string, unknown>): Request {
 
 describe("Earn withdrawal prepare route", () => {
   beforeEach(() => {
-    (
-      globalThis as unknown as {
-        __createEarnTestVaultsClient?: () => unknown;
-      }
-    ).__createEarnTestVaultsClient = () => ({
-      prepareEarnUsdcWithdraw: async (input: Record<string, unknown>) => {
-        prepareCalls.push(input);
-        return { prepared: true, input };
-      },
-    });
-    (
-      Connection.prototype as unknown as {
-        getAccountInfo: (key: PublicKey) => Promise<unknown | null>;
-      }
-    ).getAccountInfo = async (key: PublicKey) => {
-      getAccountInfoCalls.push(key.toBase58());
-      return currentAutodepositPolicyAccountExists ? { lamports: 1 } : null;
-    };
     currentPrincipal = principal;
-    currentAutodepositState = null;
-    currentAutodepositPolicyAccountExists = true;
+    currentPolicy = activePolicy;
     currentPosition = activePosition;
-    findAutodepositCalls = [];
-    getAccountInfoCalls = [];
-    findPolicyCalls = [];
-    findPositionCalls = [];
-    findReserveRowsCalls = [];
-    findIdleRowsCalls = [];
-    currentReserveRows = [
-      {
-        amountRaw: activePosition.principalAmountRaw,
-        liquidityMint: activePosition.currentLiquidityMint,
+    currentSnapshot = holdingsSnapshot([
+      kaminoHolding({
+        amountRaw: "600000",
         market: activePosition.currentMarket,
         reserve: activePosition.currentReserve,
-        supplyApyBps: BigInt(300),
-      },
-    ];
-    currentIdleRows = [];
+      }),
+      kaminoHolding({
+        amountRaw: "400000",
+        market: secondMarket,
+        reserve: secondReserve,
+      }),
+      idleHolding("10000"),
+    ]);
     prepareCalls = [];
-    reconcileMissingAutodepositCalls = [];
   });
 
-  test("does not fetch autodeposit state for partial withdrawals", async () => {
+  test("unwinds every positive Kamino market in a full exit", async () => {
     const { POST } = await import("./route");
 
     const response = await POST(
-      createRequest({ amountRaw: "1000000", mode: "partial" })
+      createRequest({ amountRaw: "1", mode: "full" })
     );
 
     expect(response.status).toBe(200);
-    expect(findPolicyCalls).toEqual([
-      {
-        authority: principal.walletAddress,
-        cluster: "mainnet-beta",
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        vaultPubkey: expectedEarnVaultPda.toBase58(),
-      },
-    ]);
-    expect(findAutodepositCalls).toHaveLength(0);
-    expect(findPositionCalls).toEqual([
-      {
-        cluster: "mainnet-beta",
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        walletAddress: principal.walletAddress,
-      },
-    ]);
-    expect(findReserveRowsCalls).toHaveLength(1);
-    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(1_000_000));
-    expect(prepareCalls[0]?.mode).toBe("partial");
-    expect(prepareCalls[0]?.autodepositClose).toBeUndefined();
+    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(1_010_000));
+    const targets = prepareCalls[0]?.fullWithdrawalTargets as Array<{
+      market: PublicKey;
+      reserve: PublicKey;
+    }>;
     expect(
-      (
-        prepareCalls[0]?.yieldRoutingPolicy as {
-          setupPolicy?: { account: PublicKey; seed: bigint };
-        }
-      ).setupPolicy?.account.toBase58()
-    ).toBe(activeSetupPolicy.policyAccount);
-    expect(
-      (
-        prepareCalls[0]?.yieldRoutingPolicy as {
-          setupPolicy?: { account: PublicKey; seed: bigint };
-        }
-      ).setupPolicy?.seed
-    ).toBe(activeSetupPolicy.policySeed);
-  });
-
-  test("never combines policy closure with a full withdrawal", async () => {
-    const { POST } = await import("./route");
-    currentAutodepositState = completeAutodepositState;
-
-    const response = await POST(
-      createRequest({ amountRaw: "1000000", mode: "full" })
-    );
-
-    expect(response.status).toBe(200);
-    expect(findPositionCalls).toEqual([
+      targets.map((target) => ({
+        market: target.market.toBase58(),
+        reserve: target.reserve.toBase58(),
+      }))
+    ).toEqual([
       {
-        cluster: "mainnet-beta",
-        settings: principal.settingsPda,
-        vaultIndex: 1,
-        walletAddress: principal.walletAddress,
-      },
-    ]);
-    expect(findReserveRowsCalls).toHaveLength(1);
-    expect(prepareCalls[0]?.amountRaw).toBe(activePosition.principalAmountRaw);
-    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
-    expect(prepareCalls[0]?.autodepositClose).toBeUndefined();
-    expect(findAutodepositCalls).toHaveLength(0);
-    expect(getAccountInfoCalls).toHaveLength(0);
-    expect(reconcileMissingAutodepositCalls).toHaveLength(0);
-  });
-
-  test("passes reconciled nonzero reserve rows as full withdrawal targets", async () => {
-    const { POST } = await import("./route");
-    currentReserveRows = [
-      {
-        amountRaw: BigInt(600_000),
-        liquidityMint: activePosition.currentLiquidityMint,
         market: activePosition.currentMarket,
         reserve: activePosition.currentReserve,
-        supplyApyBps: BigInt(300),
       },
-      {
-        amountRaw: BigInt(400_000),
-        liquidityMint: activePosition.currentLiquidityMint,
-        market: activePosition.currentMarket,
-        reserve: "6UeJYTLU1adaoHWeApWsoj1xNEDbWA2RhMbrZgYFutJk",
-        supplyApyBps: BigInt(200),
-      },
-    ];
+      { market: secondMarket, reserve: secondReserve },
+    ]);
+    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
+  });
+
+  test("ignores a full-exit source request that names one market", async () => {
+    const { POST } = await import("./route");
 
     const response = await POST(
       createRequest({
-        amountRaw: "1000000",
+        amountRaw: "600000",
         mode: "full",
         source: {
           id: activePosition.currentReserve,
+          market: activePosition.currentMarket,
           reserve: activePosition.currentReserve,
           type: "reserve",
         },
@@ -364,113 +267,92 @@ describe("Earn withdrawal prepare route", () => {
 
     expect(response.status).toBe(200);
     const targets = prepareCalls[0]?.fullWithdrawalTargets as Array<{
-      amountRaw: bigint;
+      market: PublicKey;
       reserve: PublicKey;
     }>;
-    expect(targets).toHaveLength(1);
-    expect(targets.map((target) => target.amountRaw)).toEqual([
-      BigInt(600_000),
+    expect(
+      targets.map((target) => ({
+        market: target.market.toBase58(),
+        reserve: target.reserve.toBase58(),
+      }))
+    ).toEqual([
+      {
+        market: activePosition.currentMarket,
+        reserve: activePosition.currentReserve,
+      },
+      { market: secondMarket, reserve: secondReserve },
     ]);
-    expect(targets[0]?.reserve.toBase58()).toBe(activePosition.currentReserve);
   });
 
-  test("keeps policy closure out of withdrawal even with only sub-cent idle dust", async () => {
+  test("selects the requested snapshot source for a partial withdrawal", async () => {
     const { POST } = await import("./route");
-    currentIdleRows = [
-      {
-        amountRaw: BigInt(2),
-        mint: activePosition.currentLiquidityMint,
-        tokenAccount: "11111111111111111111111111111116",
-      },
-    ];
 
     const response = await POST(
       createRequest({
-        amountRaw: "1000026",
-        mode: "full",
+        amountRaw: "300000",
+        mode: "partial",
         source: {
-          id: activePosition.currentReserve,
-          reserve: activePosition.currentReserve,
+          id: secondReserve,
+          reserve: secondReserve,
           type: "reserve",
         },
       })
     );
 
     expect(response.status).toBe(200);
-    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
-  });
-
-  test("keeps full reserve withdrawals non-final while a withdrawable idle balance remains", async () => {
-    const { POST } = await import("./route");
-    currentIdleRows = [
-      {
-        amountRaw: BigInt(10_000),
-        mint: activePosition.currentLiquidityMint,
-        tokenAccount: "11111111111111111111111111111116",
-      },
-    ];
-
-    const response = await POST(
-      createRequest({
-        amountRaw: "1000026",
-        mode: "full",
-        source: {
-          id: activePosition.currentReserve,
-          reserve: activePosition.currentReserve,
-          type: "reserve",
-        },
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
-  });
-
-  test("passes selected idle vault USDC as its own withdrawal source", async () => {
-    const { POST } = await import("./route");
-    currentIdleRows = [
-      {
-        amountRaw: BigInt(250_000),
-        mint: activePosition.currentLiquidityMint,
-        tokenAccount: "11111111111111111111111111111116",
-      },
-    ];
-
-    const response = await POST(
-      createRequest({
-        amountRaw: "1",
-        mode: "full",
-        source: {
-          id: "11111111111111111111111111111116",
-          tokenAccount: "11111111111111111111111111111116",
-          type: "idle",
-        },
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(250_000));
-    expect(prepareCalls[0]?.closePoliciesOnFullWithdrawal).toBe(false);
-    expect(prepareCalls[0]?.fullWithdrawalTargets).toBeUndefined();
+    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(300_000));
     expect(prepareCalls[0]?.source).toMatchObject({
-      amountRaw: BigInt(250_000),
-      id: "11111111111111111111111111111116",
-      type: "idle",
+      id: secondReserve,
+      type: "reserve",
     });
-    expect(findAutodepositCalls).toHaveLength(0);
   });
 
-  test("rejects full withdrawals when no active position exists", async () => {
+  test("rejects a partial withdrawal larger than its requested source", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "400001",
+        mode: "partial",
+        source: {
+          id: secondReserve,
+          reserve: secondReserve,
+          type: "reserve",
+        },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.error.message).toBe(
+      "Withdrawal exceeds the selected Earn source amount."
+    );
+    expect(prepareCalls).toHaveLength(0);
+  });
+
+  test("returns missing_earn_policy when the route policy is absent", async () => {
+    const { POST } = await import("./route");
+    currentPolicy = null;
+
+    const response = await POST(
+      createRequest({ amountRaw: "1", mode: "full" })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload.error.code).toBe("missing_earn_policy");
+  });
+
+  test("returns missing_earn_position when the active position is absent", async () => {
     const { POST } = await import("./route");
     currentPosition = null;
 
     const response = await POST(
-      createRequest({ amountRaw: "1000000", mode: "full" })
+      createRequest({ amountRaw: "1", mode: "full" })
     );
     const payload = await response.json();
 
     expect(response.status).toBe(409);
     expect(payload.error.code).toBe("missing_earn_position");
-    expect(prepareCalls).toHaveLength(0);
   });
 });

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
 import { createSmartAccountVaultsClient } from "@loyal-labs/smart-account-vaults";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { NextResponse } from "next/server";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
 import {
@@ -14,23 +14,16 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
+import {
+  EarnWithdrawResolveError,
+  resolveEarnUsdcWithdrawInput,
+} from "@/lib/yield-optimization/earn-withdraw-input-resolution.server";
 import {
   parseEarnWithdrawPrepareRequestBody,
   serializePreparedEarnUsdcWithdraw,
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
-import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
-import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
-import {
-  findActiveYieldRoutePolicyPair,
-  findCurrentNonzeroYieldVaultReservePositions,
-  findCurrentYieldVaultIdleTokenBalances,
-  findReconciledActiveYieldPositionForVault,
-  type CurrentYieldVaultIdleTokenBalanceRecord,
-  type CurrentYieldVaultReservePositionRecord,
-  type RoutePolicyRecord,
-  type UserYieldPositionRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import type { RoutePolicyRecord } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
@@ -64,191 +57,6 @@ function getConnection(cluster: SolanaEnv): Connection {
   });
   connectionCache.set(cluster, connection);
   return connection;
-}
-
-type EarnWithdrawSourceRequest = ReturnType<
-  typeof parseEarnWithdrawPrepareRequestBody
->["source"];
-
-type SelectedEarnWithdrawSource =
-  | {
-      amountRaw: bigint;
-      id: string;
-      liquidityMint: string;
-      market: string;
-      reserve: string;
-      type: "reserve";
-    }
-  | {
-      amountRaw: bigint;
-      id: string;
-      mint: string;
-      tokenAccount: string;
-      type: "idle";
-    };
-
-function publicKeyFromMetadata(
-  metadata: Record<string, unknown> | null | undefined,
-  keys: string[]
-): PublicKey | null {
-  if (!metadata) {
-    return null;
-  }
-
-  for (const key of keys) {
-    const value = metadata[key];
-    if (typeof value !== "string" || value.trim().length === 0) {
-      continue;
-    }
-    try {
-      return new PublicKey(value);
-    } catch {
-      continue;
-    }
-  }
-
-  return null;
-}
-
-function isNonEmptyString(value: string | null | undefined): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function sourceMatchesDirectIdentifier(
-  source: SelectedEarnWithdrawSource,
-  request: NonNullable<EarnWithdrawSourceRequest>
-): boolean {
-  if (source.type !== request.type) {
-    return false;
-  }
-
-  const identifiers = [
-    request.id,
-    request.reserve,
-    request.tokenAccount,
-  ].filter(isNonEmptyString);
-
-  if (identifiers.includes(source.id)) {
-    return true;
-  }
-
-  return source.type === "reserve" && identifiers.includes(source.reserve);
-}
-
-function sourceMatchesStableMint(
-  source: SelectedEarnWithdrawSource,
-  request: NonNullable<EarnWithdrawSourceRequest>
-): boolean {
-  if (source.type !== request.type) {
-    return false;
-  }
-
-  const identifiers = [
-    request.id,
-    request.liquidityMint,
-    request.mint,
-  ].filter(isNonEmptyString);
-
-  return source.type === "reserve"
-    ? identifiers.includes(source.liquidityMint)
-    : identifiers.includes(source.mint);
-}
-
-function selectRequestedEarnWithdrawSource(
-  sources: SelectedEarnWithdrawSource[],
-  request: EarnWithdrawSourceRequest
-): SelectedEarnWithdrawSource | null {
-  if (!request) {
-    return sources.length === 1 ? sources[0] ?? null : null;
-  }
-
-  const directMatch = sources.find((source) =>
-    sourceMatchesDirectIdentifier(source, request)
-  );
-  if (directMatch) {
-    return directMatch;
-  }
-
-  const stableMintMatches = sources.filter((source) =>
-    sourceMatchesStableMint(source, request)
-  );
-  if (stableMintMatches.length === 1) {
-    return stableMintMatches[0] ?? null;
-  }
-
-  const amountMatchedStableMintMatches = stableMintMatches.filter(
-    (source) => request.amountRaw === source.amountRaw.toString()
-  );
-
-  return amountMatchedStableMintMatches.length === 1
-    ? amountMatchedStableMintMatches[0] ?? null
-    : null;
-}
-
-function selectEarnWithdrawSource(args: {
-  amountRaw: bigint;
-  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
-  mode: "partial" | "full";
-  position: UserYieldPositionRecord;
-  request: EarnWithdrawSourceRequest;
-  reserveRows: CurrentYieldVaultReservePositionRecord[];
-}): SelectedEarnWithdrawSource {
-  const reserveSources = args.reserveRows
-    .filter((row) => row.amountRaw > BigInt(0))
-    .map((row) => {
-      if (!row.market) {
-        throw new Error("Reconciled Earn reserve row is missing a market.");
-      }
-      return {
-        amountRaw: row.amountRaw,
-        id: row.reserve,
-        liquidityMint: row.liquidityMint,
-        market: row.market,
-        reserve: row.reserve,
-        type: "reserve" as const,
-      };
-    });
-  const idleSources = args.idleRows
-    .filter((row) => row.amountRaw > BigInt(0))
-    .map((row) => ({
-      amountRaw: row.amountRaw,
-      id: row.tokenAccount,
-      mint: row.mint,
-      tokenAccount: row.tokenAccount,
-      type: "idle" as const,
-    }));
-  const positionFallbackSources =
-    reserveSources.length === 0 &&
-    idleSources.length === 0 &&
-    isNonEmptyString(args.position.currentMarket) &&
-    args.position.currentAmountRaw > BigInt(0)
-      ? [
-          {
-            amountRaw: args.position.currentAmountRaw,
-            id: args.position.currentReserve,
-            liquidityMint: args.position.currentLiquidityMint,
-            market: args.position.currentMarket,
-            reserve: args.position.currentReserve,
-            type: "reserve" as const,
-          },
-        ]
-      : [];
-  const sources = [...reserveSources, ...idleSources, ...positionFallbackSources];
-
-  if (sources.length === 0) {
-    throw new Error("No active Earn withdrawal source was found.");
-  }
-
-  const selected = selectRequestedEarnWithdrawSource(sources, args.request);
-
-  if (!selected) {
-    throw new Error("Select an Earn source before withdrawing.");
-  }
-  if (args.mode === "partial" && args.amountRaw > selected.amountRaw) {
-    throw new Error("Withdrawal exceeds the selected Earn source amount.");
-  }
-
-  return selected;
 }
 
 export async function POST(request: Request) {
@@ -298,189 +106,35 @@ export async function POST(request: Request) {
       settingsPda,
     });
     const connection = getConnection(solanaEnv);
-    await reconcileEarnVaultPosition({
-      authority: principal.walletAddress,
+    const resolved = await resolveEarnUsdcWithdrawInput({
+      amountRaw,
       cluster,
       connection,
-      force: true,
-      settings: principal.settingsPda,
-      vaultPubkey: earnVaultPda.toBase58(),
-    });
-    const [policyResult, position, currentReserveRows, currentIdleRows] =
-      await Promise.all([
-        findActiveYieldRoutePolicyPair({
-          authority: principal.walletAddress,
-          cluster,
-          settings: principal.settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          vaultPubkey: earnVaultPda.toBase58(),
-        }),
-        findReconciledActiveYieldPositionForVault({
-          cluster,
-          settings: principal.settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          walletAddress: principal.walletAddress,
-        }),
-        findCurrentNonzeroYieldVaultReservePositions({
-          cluster,
-          settings: principal.settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          vaultPubkey: earnVaultPda.toBase58(),
-          walletAddress: principal.walletAddress,
-        }),
-        findCurrentYieldVaultIdleTokenBalances({
-          cluster,
-          settings: principal.settingsPda,
-          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-          vaultPubkey: earnVaultPda.toBase58(),
-          walletAddress: principal.walletAddress,
-        }),
-      ]);
-    policy = policyResult?.routePolicy ?? null;
-    if (!policy) {
-      console.warn("[earn-withdraw-prepare] missing active Earn policy", {
-        cluster,
-        settings: principal.settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        walletAddress: principal.walletAddress,
-      });
-      return jsonError(
-        409,
-        "missing_earn_policy",
-        "Set up the Earn policy before withdrawing USDC."
-      );
-    }
-
-    if (!position) {
-      console.warn("[earn-withdraw-prepare] missing active Earn position", {
-        cluster,
-        settings: principal.settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        walletAddress: principal.walletAddress,
-      });
-      return jsonError(
-        409,
-        "missing_earn_position",
-        "No active Earn position was found for this full withdrawal."
-      );
-    }
-
-    const selectedSource = selectEarnWithdrawSource({
-      amountRaw,
-      idleRows: currentIdleRows,
+      earnVaultPda,
+      logTag: "earn-withdraw-prepare",
       mode,
-      position,
-      request: selectedSourceRequest,
-      reserveRows: currentReserveRows,
+      policySigner: getDeploymentPolicySignerPublicKey(),
+      programId,
+      settingsPda: principal.settingsPda,
+      sourceRequest: selectedSourceRequest,
+      walletAddress: principal.walletAddress,
     });
-    effectiveAmountRaw = mode === "full" ? selectedSource.amountRaw : amountRaw;
-    const policySigner = getDeploymentPolicySignerPublicKey();
+    policy = resolved.policy;
+    effectiveAmountRaw = resolved.effectiveAmountRaw;
+
     const client = createSmartAccountVaultsClient({
       connection,
       programId,
     });
-    const yieldRoutingPolicy = {
-      account: new PublicKey(policy.policyAccount),
-      seed: policy.policySeed,
-      ...(policyResult?.setupPolicy
-        ? {
-            setupPolicy: {
-              account: new PublicKey(policyResult.setupPolicy.policyAccount),
-              seed: policyResult.setupPolicy.policySeed,
-            },
-          }
-        : {}),
-    };
-    const withdrawInput = {
-      amountRaw: effectiveAmountRaw,
-      cluster,
-      feePayer: new PublicKey(principal.walletAddress),
-      policySigner,
-      settingsPda: new PublicKey(principal.settingsPda),
-      target: earnReserveTargetFromActivePosition(position),
-      ...(mode === "full" && selectedSource.type === "reserve"
-        ? {
-            fullWithdrawalTargets: currentReserveRows
-              .filter((row) => row.reserve === selectedSource.reserve)
-              .map((row) => {
-                if (!row.market) {
-                  throw new Error(
-                    "Reconciled Earn reserve row is missing a Kamino market."
-                  );
-                }
-                const reserveCollateralMint = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "reserveCollateralMint",
-                    "reserve_collateral_mint",
-                    "collateralMint",
-                    "collateral_mint",
-                  ]
-                );
-                const reserveLiquiditySupply = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "reserveLiquiditySupply",
-                    "reserve_liquidity_supply",
-                    "liquiditySupply",
-                    "liquidity_supply",
-                  ]
-                );
-                const vaultCollateralAta = publicKeyFromMetadata(
-                  row.planningMetadata,
-                  [
-                    "vaultCollateralAta",
-                    "vault_collateral_ata",
-                    "collateralAta",
-                    "collateral_ata",
-                  ]
-                );
-
-                return {
-                  amountRaw: row.amountRaw,
-                  liquidityMint: new PublicKey(row.liquidityMint),
-                  market: new PublicKey(row.market),
-                  reserve: new PublicKey(row.reserve),
-                  ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
-                  ...(reserveLiquiditySupply ? { reserveLiquiditySupply } : {}),
-                  supplyApyBps: row.supplyApyBps ?? null,
-                  ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
-                };
-              }),
-          }
-        : {}),
-      // Full withdrawal and policy close are intentionally separate phases.
-      // Cleanup is prepared only after a minContextSlot-safe zero proof.
-      closePoliciesOnFullWithdrawal: false,
-      source:
-        selectedSource.type === "idle"
-          ? {
-              amountRaw: selectedSource.amountRaw,
-              id: selectedSource.id,
-              mint: new PublicKey(selectedSource.mint),
-              tokenAccount: new PublicKey(selectedSource.tokenAccount),
-              type: "idle" as const,
-            }
-          : {
-              amountRaw: selectedSource.amountRaw,
-              id: selectedSource.id,
-              liquidityMint: new PublicKey(selectedSource.liquidityMint),
-              market: new PublicKey(selectedSource.market),
-              reserve: new PublicKey(selectedSource.reserve),
-              type: "reserve" as const,
-            },
-      walletAddress: new PublicKey(principal.walletAddress),
-      yieldRoutingPolicy,
-    };
-    const preparedWithdraw = await client.prepareEarnUsdcWithdraw({
-      ...withdrawInput,
-      mode,
-    });
+    const preparedWithdraw = await client.prepareEarnUsdcWithdraw(resolved.input);
 
     return NextResponse.json({
       preparedWithdraw: serializePreparedEarnUsdcWithdraw(preparedWithdraw),
     });
   } catch (error) {
+    if (error instanceof EarnWithdrawResolveError) {
+      return jsonError(error.status, error.code, error.message);
+    }
     if (isSmartAccountProvisioningError(error)) {
       return jsonError(error.status, error.code, error.message);
     }

--- a/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
@@ -224,6 +224,10 @@ export type EarnWithdrawDraft = {
   amount: number;
   amountLabel: string;
   destination: EarnDepositSourceOption;
+  // Every reserve the vault still holds. A full exit must unwind all of them —
+  // a wallet can hold USDC in a second Kamino market, and leaving one behind
+  // strands it and fails the post-withdrawal zero proof.
+  fullExitSources: EarnWithdrawSourceOption[];
   mode: "partial" | "full";
   source: EarnWithdrawSourceOption;
   symbol: "USDC";
@@ -580,14 +584,44 @@ export function getEarningsRatePerSecond(
 
 export function deriveEarnWithdrawMode({
   amount,
-  maxWithdrawAmount,
+  sources,
 }: {
   amount: number;
-  maxWithdrawAmount: number;
+  sources: EarnWithdrawSourceOption[];
 }): "partial" | "full" {
+  // Compared against the WHOLE position, never the selected source: "full"
+  // closes the position, the policies and the vault, so it may only mean
+  // "everything". Maxing one of several sources is a partial withdrawal.
+  //
   // The input only accepts cents, so typing the visible (floored) max means
   // "withdraw everything" — compare at cent precision to avoid dust positions.
-  return amount >= floorToBucks(maxWithdrawAmount) ? "full" : "partial";
+  const totalWithdrawableAmount = sources.reduce(
+    (total, source) => total + source.balance,
+    0
+  );
+
+  return amount >= floorToBucks(totalWithdrawableAmount) ? "full" : "partial";
+}
+
+// The reserves a full exit must unwind, selected source first. A vault can hold
+// USDC in a second Kamino market; unwinding only the selected reserve strands
+// the rest and fails the post-withdrawal zero proof, so the position never
+// closes and its rent is never refunded. With one reserve this is [source] —
+// byte-identical to the single-target input this replaced.
+export function selectEarnFullExitSources(
+  draft: Pick<EarnWithdrawDraft, "fullExitSources" | "mode" | "source">
+): EarnWithdrawSourceOption[] {
+  if (draft.mode !== "full" || draft.source.type !== "reserve") {
+    return [];
+  }
+
+  return [
+    draft.source,
+    ...draft.fullExitSources.filter(
+      (source) =>
+        source.type === "reserve" && source.sourceId !== draft.source.sourceId
+    ),
+  ];
 }
 
 function EarnYieldIcon({ size = 64 }: { size?: number }) {
@@ -3443,7 +3477,7 @@ export function EarnWithdrawView({
   // ATA, and autodeposit all stayed behind.
   const effectiveWithdrawMode = deriveEarnWithdrawMode({
     amount: effectiveWithdrawAmount,
-    maxWithdrawAmount: selectedSourceMaxAmount,
+    sources: sourceOptions,
   });
   const withdrawAmountError = !selectedSource
     ? "No withdrawable Earn source"
@@ -3466,6 +3500,9 @@ export function EarnWithdrawView({
       amount: effectiveWithdrawAmount,
       amountLabel: effectiveWithdrawAmountLabel,
       destination: selectedDestination,
+      fullExitSources: sourceOptions.filter(
+        (source) => source.type === "reserve"
+      ),
       mode: effectiveWithdrawMode,
       source: selectedSource,
       symbol: "USDC",

--- a/frontend/src/components/wallet-sidebar/earn-withdraw-full-exit.test.ts
+++ b/frontend/src/components/wallet-sidebar/earn-withdraw-full-exit.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  deriveEarnWithdrawMode,
+  selectEarnFullExitSources,
+  type EarnWithdrawSourceOption,
+} from "./earn-detail-view";
+
+// A full exit closes the position + policies and reclaims rent, so it may only
+// mean "empty ALL of Earn". These lock down the two halves of that:
+//   1. mode "full" is derived against the WHOLE position, never one source
+//      (maxing a small source next to a large one must stay partial).
+//   2. a full exit unwinds EVERY reserve, so a second Kamino market is never
+//      stranded (which fails the zero proof: no close, no rent refund).
+// The single-source path — every ordinary wallet — must be unchanged.
+
+function reserveSource(
+  sourceId: string,
+  balance: number
+): EarnWithdrawSourceOption {
+  return {
+    amountRaw: String(Math.round(balance * 1_000_000)),
+    balance,
+    icon: "",
+    id: `reserve:${sourceId}`,
+    label: `${sourceId} reserve`,
+    liquidityMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    market: `market-${sourceId}`,
+    reserve: sourceId,
+    sourceId,
+    tokenAccount: null,
+    type: "reserve",
+  };
+}
+
+const mainReserve = reserveSource("main", 5000);
+const secondReserve = reserveSource("second", 50);
+
+describe("Earn withdraw mode derivation", () => {
+  test("maxing the only source is a full exit", () => {
+    expect(
+      deriveEarnWithdrawMode({ amount: 5000, sources: [mainReserve] })
+    ).toBe("full");
+  });
+
+  test("maxing one of several sources stays partial", () => {
+    // The user asked for the $50 source. Draining their $5,000 position too
+    // would be a catastrophe, so this must never resolve to a full exit.
+    expect(
+      deriveEarnWithdrawMode({
+        amount: 50,
+        sources: [mainReserve, secondReserve],
+      })
+    ).toBe("partial");
+  });
+
+  test("emptying the last source is a full exit", () => {
+    expect(
+      deriveEarnWithdrawMode({ amount: 50, sources: [secondReserve] })
+    ).toBe("full");
+  });
+
+  test("sub-cent dust in another reserve still allows a full exit", () => {
+    // Dust floors away at cent precision, so emptying the last real source is
+    // still a full exit — otherwise dust would trap the position open forever.
+    expect(
+      deriveEarnWithdrawMode({
+        amount: 50,
+        sources: [secondReserve, reserveSource("dust", 0.000001)],
+      })
+    ).toBe("full");
+  });
+});
+
+describe("Earn full-exit sources", () => {
+  test("a single-reserve full exit is unchanged (selected source only)", () => {
+    expect(
+      selectEarnFullExitSources({
+        fullExitSources: [mainReserve],
+        mode: "full",
+        source: mainReserve,
+      })
+    ).toEqual([mainReserve]);
+  });
+
+  test("a full exit unwinds every reserve, selected first", () => {
+    expect(
+      selectEarnFullExitSources({
+        fullExitSources: [mainReserve, secondReserve],
+        mode: "full",
+        source: secondReserve,
+      })
+    ).toEqual([secondReserve, mainReserve]);
+  });
+
+  test("a partial withdrawal never unwinds other reserves", () => {
+    expect(
+      selectEarnFullExitSources({
+        fullExitSources: [mainReserve, secondReserve],
+        mode: "partial",
+        source: secondReserve,
+      })
+    ).toEqual([]);
+  });
+
+  test("an idle-source exit adds no reserve targets", () => {
+    const idle: EarnWithdrawSourceOption = {
+      ...reserveSource("idle", 10),
+      market: null,
+      reserve: null,
+      tokenAccount: "vault-usdc-ata",
+      type: "idle",
+    };
+
+    expect(
+      selectEarnFullExitSources({
+        fullExitSources: [],
+        mode: "full",
+        source: idle,
+      })
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -84,6 +84,7 @@ import {
   EarnDepositView,
   EarnDetailView,
   EarnWithdrawView,
+  selectEarnFullExitSources,
   type EarnDepositDraft,
   type EarnAutodepositDraft,
   type EarnDepositSourceOption,
@@ -4412,6 +4413,9 @@ export function AppWalletWorkspace({
         draft.source.type === "reserve"
           ? toEarnWithdrawReserveTarget(draft.source)
           : null;
+      const fullWithdrawalTargets = selectEarnFullExitSources(draft).map(
+        toEarnWithdrawReserveTarget
+      );
       const client = createSmartAccountVaultsClient({
         connection,
         programId: new PublicKey(overview.programId),
@@ -4437,9 +4441,7 @@ export function AppWalletWorkspace({
         settingsPda,
         source,
         ...(target ? { target } : {}),
-        ...(draft.mode === "full" && target
-          ? { fullWithdrawalTargets: [target] }
-          : {}),
+        ...(fullWithdrawalTargets.length > 0 ? { fullWithdrawalTargets } : {}),
         walletAddress: userWallet,
         yieldRoutingPolicy,
       };

--- a/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -17,13 +17,8 @@ import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-s
 import type { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import {
   findActiveYieldRoutePolicyPair,
-  findCurrentNonzeroYieldVaultReservePositions,
-  findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
-  type CurrentYieldVaultIdleTokenBalanceRecord,
-  type CurrentYieldVaultReservePositionRecord,
   type RoutePolicyRecord,
-  type UserYieldPositionRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Source selection + SDK-input assembly for a mobile Earn USDC withdrawal,
@@ -164,10 +159,9 @@ function selectRequestedEarnWithdrawSource(
     : null;
 }
 
-// Build withdraw sources from the LIVE on-chain holdings snapshot (partial
-// withdrawals). The DB read-model + reconcile can't follow a cross-market
-// rebalance; this scans the policy's markets and reflects reality. Drops entries
-// missing the identifiers a withdrawal needs to match/build.
+// Build withdrawal sources from the live on-chain holdings snapshot. The DB
+// read-model cannot follow a cross-market rebalance. Drop entries missing the
+// identifiers a withdrawal needs to match or build.
 function buildSnapshotWithdrawSources(
   holdings: EarnRpcHolding[]
 ): SelectedEarnWithdrawSource[] {
@@ -239,13 +233,9 @@ function snapshotReserveTarget(
   };
 }
 
-// Full-withdrawal targets from the live snapshot (fallback when the DB rows
-// are empty). Collateral metadata comes from the holding provenance when
-// present; the SDK resolves anything omitted on-chain.
-function snapshotFullWithdrawalTargets(
-  holdings: EarnRpcHolding[],
-  reserve: string
-): {
+// Full-withdrawal targets from every live Kamino holding. Collateral metadata
+// comes from the holding provenance when present; the SDK resolves omissions.
+function snapshotFullWithdrawalTargets(holdings: EarnRpcHolding[]): {
   amountRaw: bigint;
   liquidityMint: PublicKey;
   market: PublicKey;
@@ -255,11 +245,7 @@ function snapshotFullWithdrawalTargets(
 }[] {
   const targets = [];
   for (const holding of holdings) {
-    if (
-      holding.kind !== "kamino" ||
-      holding.reserve !== reserve ||
-      !holding.market
-    ) {
+    if (holding.kind !== "kamino" || !holding.reserve || !holding.market) {
       continue;
     }
     let amountRaw: bigint;
@@ -292,88 +278,6 @@ function snapshotFullWithdrawalTargets(
     });
   }
   return targets;
-}
-
-// Withdraw sources from the reconciled DB rows (full exits) — the row
-// planning metadata carries the collateral accounts the full-withdrawal
-// instruction prefers. Empty after a cross-market rebalance the reconcile
-// couldn't follow; the caller then falls back to the live snapshot.
-function buildDbEarnWithdrawSources(args: {
-  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
-  position: UserYieldPositionRecord;
-  reserveRows: CurrentYieldVaultReservePositionRecord[];
-}): SelectedEarnWithdrawSource[] {
-  const reserveSources = args.reserveRows
-    .filter((row) => row.amountRaw > BigInt(0))
-    .map((row) => {
-      if (!row.market) {
-        throw new Error("Reconciled Earn reserve row is missing a market.");
-      }
-      return {
-        amountRaw: row.amountRaw,
-        id: row.reserve,
-        liquidityMint: row.liquidityMint,
-        market: row.market,
-        reserve: row.reserve,
-        type: "reserve" as const,
-      };
-    });
-  const idleSources = args.idleRows
-    .filter((row) => row.amountRaw > BigInt(0))
-    .map((row) => ({
-      amountRaw: row.amountRaw,
-      id: row.tokenAccount,
-      mint: row.mint,
-      tokenAccount: row.tokenAccount,
-      type: "idle" as const,
-    }));
-  const positionFallbackSources =
-    reserveSources.length === 0 &&
-    idleSources.length === 0 &&
-    isNonEmptyString(args.position.currentMarket) &&
-    args.position.currentAmountRaw > BigInt(0)
-      ? [
-          {
-            amountRaw: args.position.currentAmountRaw,
-            id: args.position.currentReserve,
-            liquidityMint: args.position.currentLiquidityMint,
-            market: args.position.currentMarket,
-            reserve: args.position.currentReserve,
-            type: "reserve" as const,
-          },
-        ]
-      : [];
-  return [...reserveSources, ...idleSources, ...positionFallbackSources];
-}
-
-function selectEarnWithdrawSource(args: {
-  amountRaw: bigint;
-  idleRows: CurrentYieldVaultIdleTokenBalanceRecord[];
-  mode: "partial" | "full";
-  position: UserYieldPositionRecord;
-  request: EarnWithdrawSourceRequest;
-  reserveRows: CurrentYieldVaultReservePositionRecord[];
-}): SelectedEarnWithdrawSource {
-  const sources = buildDbEarnWithdrawSources({
-    idleRows: args.idleRows,
-    position: args.position,
-    reserveRows: args.reserveRows,
-  });
-
-  if (sources.length === 0) {
-    throw new Error("No active Earn withdrawal source was found.");
-  }
-
-  const selected = selectRequestedEarnWithdrawSource(sources, args.request);
-
-  if (!selected) {
-    throw new Error("Select an Earn source before withdrawing.");
-  }
-  if (args.mode === "partial" && args.amountRaw > selected.amountRaw) {
-    throw new Error("Withdrawal exceeds the selected Earn source amount.");
-  }
-
-  return selected;
 }
 
 export type ResolvedEarnUsdcWithdraw = {
@@ -420,38 +324,22 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     settings: settingsPda,
     vaultPubkey: earnVaultPda.toBase58(),
   });
-  const [policyResult, position, currentReserveRows, currentIdleRows] =
-    await Promise.all([
-      findActiveYieldRoutePolicyPair({
-        authority: walletAddress,
-        cluster,
-        settings: settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-      }),
-      findReconciledActiveYieldPositionForVault({
-        cluster,
-        settings: settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        walletAddress,
-      }),
-      findCurrentNonzeroYieldVaultReservePositions({
-        cluster,
-        settings: settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-      findCurrentYieldVaultIdleTokenBalances({
-        cluster,
-        settings: settingsPda,
-        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-        vaultPubkey: earnVaultPda.toBase58(),
-        walletAddress,
-      }),
-    ]);
-  const policy = policyResult?.routePolicy ?? null;
-  if (!policy) {
+  const [policyResult, position] = await Promise.all([
+    findActiveYieldRoutePolicyPair({
+      authority: walletAddress,
+      cluster,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
+    }),
+    findReconciledActiveYieldPositionForVault({
+      cluster,
+      settings: settingsPda,
+      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+      walletAddress,
+    }),
+  ]);
+  if (!policyResult?.routePolicy) {
     console.warn(`[${logTag}] missing active Earn policy`, {
       cluster,
       settings: settingsPda,
@@ -464,6 +352,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
       "Set up the Earn policy before withdrawing USDC."
     );
   }
+  const policy = policyResult.routePolicy;
 
   if (!position) {
     console.warn(`[${logTag}] missing active Earn position`, {
@@ -479,35 +368,25 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     );
   }
 
-  // Partial withdrawals source from the LIVE on-chain holdings snapshot — the
-  // same read `/holdings`, the withdraw picker, and the positions sheet use.
-  // The DB read-model + reconcile can't follow a cross-market rebalance, so it
-  // reports a stale reserve that the picker showed and this route would reject
-  // ("Select an Earn source"). Full exits keep the DB path (its reconciled
-  // rows carry the collateral metadata the full-withdrawal instruction needs).
+  const snapshot = await fetchEarnRpcHoldingsSnapshot({
+    cluster,
+    connection,
+    policy: serializeRoutePolicyState(
+      policyResult.routePolicy,
+      policyResult.setupPolicy ?? null
+    ),
+    programId: args.programId,
+    settingsPda: settingsPdaKey,
+  });
+  const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
+  if (snapshotSources.length === 0) {
+    throw new Error("No active Earn withdrawal source was found.");
+  }
+
   let selectedSource: SelectedEarnWithdrawSource;
   let withdrawTarget: EarnUsdcReserveTarget;
   let effectiveAmountRaw: bigint;
-  // Set when a full exit had to source from the live snapshot (DB rows
-  // empty); the full-withdrawal targets are then built from it too.
-  let snapshotFullExitHoldings: EarnRpcHolding[] | null = null;
   if (mode === "partial") {
-    const snapshot = await fetchEarnRpcHoldingsSnapshot({
-      cluster,
-      connection,
-      policy: policyResult
-        ? serializeRoutePolicyState(
-            policyResult.routePolicy,
-            policyResult.setupPolicy ?? null
-          )
-        : null,
-      programId: args.programId,
-      settingsPda: settingsPdaKey,
-    });
-    const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
-    if (snapshotSources.length === 0) {
-      throw new Error("No active Earn withdrawal source was found.");
-    }
     const selected = selectRequestedEarnWithdrawSource(
       snapshotSources,
       args.sourceRequest
@@ -530,66 +409,39 @@ export async function resolveEarnUsdcWithdrawInput(args: {
           }
         : snapshotReserveTarget(snapshot.holdings) ??
           earnReserveTargetFromActivePosition(position);
-  } else if (
-    buildDbEarnWithdrawSources({
-      idleRows: currentIdleRows,
-      position,
-      reserveRows: currentReserveRows,
-    }).length === 0
-  ) {
-    // Full-exit snapshot fallback: after a cross-market rebalance the
-    // reconciled DB rows (and the position row) can read zero while the
-    // funds live on-chain in another market's obligation. Source the full
-    // exit from the same live snapshot partial withdrawals use — its
-    // provenance carries the collateral metadata the full path needs.
-    const snapshot = await fetchEarnRpcHoldingsSnapshot({
-      cluster,
-      connection,
-      policy: policyResult
-        ? serializeRoutePolicyState(
-            policyResult.routePolicy,
-            policyResult.setupPolicy ?? null
-          )
-        : null,
-      programId: args.programId,
-      settingsPda: settingsPdaKey,
-    });
-    const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
-    if (snapshotSources.length === 0) {
-      throw new Error("No active Earn withdrawal source was found.");
-    }
-    const selected = selectRequestedEarnWithdrawSource(
-      snapshotSources,
-      args.sourceRequest
+  } else {
+    const largestReserveSource = snapshotSources.reduce<Extract<
+      SelectedEarnWithdrawSource,
+      { type: "reserve" }
+    > | null>((largest, source) => {
+      if (source.type !== "reserve") {
+        return largest;
+      }
+      return !largest || source.amountRaw > largest.amountRaw
+        ? source
+        : largest;
+    }, null);
+    selectedSource =
+      largestReserveSource ??
+      snapshotSources.find((source) => source.type === "idle")!;
+    effectiveAmountRaw = snapshotSources.reduce(
+      (total, source) => total + source.amountRaw,
+      BigInt(0)
     );
-    if (!selected) {
-      throw new Error("Select an Earn source before withdrawing.");
-    }
-    selectedSource = selected;
-    effectiveAmountRaw = selected.amountRaw;
     withdrawTarget =
-      selected.type === "reserve"
+      selectedSource.type === "reserve"
         ? {
-            liquidityMint: new PublicKey(selected.liquidityMint),
-            market: new PublicKey(selected.market),
-            reserve: new PublicKey(selected.reserve),
+            liquidityMint: new PublicKey(selectedSource.liquidityMint),
+            market: new PublicKey(selectedSource.market),
+            reserve: new PublicKey(selectedSource.reserve),
             supplyApyBps: null,
           }
         : snapshotReserveTarget(snapshot.holdings) ??
           earnReserveTargetFromActivePosition(position);
-    snapshotFullExitHoldings = snapshot.holdings;
-  } else {
-    selectedSource = selectEarnWithdrawSource({
-      amountRaw,
-      idleRows: currentIdleRows,
-      mode,
-      position,
-      request: args.sourceRequest,
-      reserveRows: currentReserveRows,
-    });
-    effectiveAmountRaw = selectedSource.amountRaw;
-    withdrawTarget = earnReserveTargetFromActivePosition(position);
   }
+
+  const fullWithdrawalTargets =
+    mode === "full" ? snapshotFullWithdrawalTargets(snapshot.holdings) : [];
 
   const yieldRoutingPolicy = {
     account: new PublicKey(policy.policyAccount),
@@ -610,66 +462,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     policySigner: args.policySigner,
     settingsPda: settingsPdaKey,
     target: withdrawTarget,
-    ...(mode === "full" && selectedSource.type === "reserve"
-      ? {
-          fullWithdrawalTargets: snapshotFullExitHoldings
-            ? snapshotFullWithdrawalTargets(
-                snapshotFullExitHoldings,
-                selectedSource.reserve
-              )
-            : currentReserveRows
-                .filter((row) => row.reserve === selectedSource.reserve)
-                .map((row) => {
-                  if (!row.market) {
-                    throw new Error(
-                      "Reconciled Earn reserve row is missing a Kamino market."
-                    );
-                  }
-                  const reserveCollateralMint = publicKeyFromMetadata(
-                    row.planningMetadata,
-                    [
-                      "reserveCollateralMint",
-                      "reserve_collateral_mint",
-                      "collateralMint",
-                      "collateral_mint",
-                    ]
-                  );
-                  const reserveLiquiditySupply = publicKeyFromMetadata(
-                    row.planningMetadata,
-                    [
-                      "reserveLiquiditySupply",
-                      "reserve_liquidity_supply",
-                      "liquiditySupply",
-                      "liquidity_supply",
-                    ]
-                  );
-                  const vaultCollateralAta = publicKeyFromMetadata(
-                    row.planningMetadata,
-                    [
-                      "vaultCollateralAta",
-                      "vault_collateral_ata",
-                      "collateralAta",
-                      "collateral_ata",
-                    ]
-                  );
-
-                  return {
-                    amountRaw: row.amountRaw,
-                    liquidityMint: new PublicKey(row.liquidityMint),
-                    market: new PublicKey(row.market),
-                    reserve: new PublicKey(row.reserve),
-                    ...(reserveCollateralMint
-                      ? { reserveCollateralMint }
-                      : {}),
-                    ...(reserveLiquiditySupply
-                      ? { reserveLiquiditySupply }
-                      : {}),
-                    supplyApyBps: row.supplyApyBps ?? null,
-                    ...(vaultCollateralAta ? { vaultCollateralAta } : {}),
-                  };
-                }),
-        }
-      : {}),
+    ...(fullWithdrawalTargets.length > 0 ? { fullWithdrawalTargets } : {}),
     // Full withdrawal and policy close are intentionally separate phases.
     closePoliciesOnFullWithdrawal: false,
     source:


### PR DESCRIPTION
A vault can hold USDC in more than one Kamino market, but a full exit only unwound the market the DB read-model knew about — paying out partially, stranding the rest on-chain, and leaving the post-withdrawal zero proof failing forever, so the policies never closed and the rent was never refunded. Full exits now source from the live on-chain holdings snapshot and hand the SDK every positive Kamino holding (it already chunks multi-reserve withdrawals and re-derives each reserve's true amount on-chain).

Web prepares in the browser and never called the server route, so it carried the same defect separately — and derived `mode: "full"` from the *selected* source's balance, so maxing a small second-market source submitted a full exit. Mode is now derived from the whole position (maxing one of several sources is a partial) and a full exit unwinds every reserve; a single-source wallet produces an identical prepared transaction. The web route's duplicated resolution collapses onto the shared resolver.