### PR TITLE
fix(earn): discover policy markets the Earn read-model never recorded

### DIFF
--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.test.ts
@@ -11,6 +11,10 @@ const reserve = new PublicKey("11111111111111111111111111111116");
 const market = new PublicKey("11111111111111111111111111111117");
 const usdcAta = new PublicKey("11111111111111111111111111111118");
 const programId = new PublicKey("11111111111111111111111111111119");
+// A Safe market the policy allows but the read-model has never recorded — the
+// shape a rebalance leaves behind.
+const secondMarket = new PublicKey("1111111111111111111111111111111A");
+const secondReserve = new PublicKey("1111111111111111111111111111111B");
 const tokenProgramId = new PublicKey(
   "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 );
@@ -49,7 +53,7 @@ mock.module("@loyal-labs/actions", () => ({
     market,
     reserve,
   }),
-  getRiskBasketMarketsForCluster: () => [market],
+  getRiskBasketMarketsForCluster: () => [market, secondMarket],
   getStablecoinMintForCluster: () => usdcMint,
   normalizeLoyalCluster: (cluster: string) => cluster,
   resolveLoyalClusterForSolanaEnv: () => "mainnet-beta",
@@ -71,11 +75,30 @@ mock.module("@loyal-labs/smart-account-vaults", () => ({
   },
   parseKaminoObligationDepositedCollateralAmountRaw: ({
     data,
+    reserve,
   }: {
     data: Buffer;
-  }) => (data[0] === 1 ? BigInt(5) : BigInt(0)),
+    reserve: PublicKey;
+  }) => {
+    if (data[0] === 3) {
+      return reserve.equals(secondReserve) ? BigInt(9) : BigInt(0);
+    }
+
+    return data[0] === 1 ? BigInt(5) : BigInt(0);
+  },
+  // A `3` obligation belongs to the second market and deposits into a reserve
+  // the read-model has never recorded; anything else deposits nothing new.
+  parseKaminoObligationAccount: (data: Buffer) => ({
+    deposits:
+      data[0] === 3
+        ? [{ depositedAmountRaw: BigInt(9), reserve: secondReserve, slotIndex: 0 }]
+        : [],
+    lendingMarket: data[0] === 3 ? secondMarket : market,
+    owner: vault,
+  }),
   parseKaminoReserveTokenAccounts: () => ({
     reserveCollateralMint: collateralMint,
+    reserveLiquidityMint: usdcMint,
   }),
   parseKaminoReserveSnapshot: () => ({
     collateralSupplyRaw: BigInt(100),
@@ -173,6 +196,33 @@ function createConnection(accounts: Array<{ data: Buffer } | null>) {
         };
       }
     ),
+  };
+}
+
+function obligationFor(lendingMarket: PublicKey) {
+  return PublicKey.findProgramAddressSync(
+    [
+      Uint8Array.of(0),
+      Uint8Array.of(0),
+      vault.toBytes(),
+      lendingMarket.toBytes(),
+      PublicKey.default.toBytes(),
+      PublicKey.default.toBytes(),
+    ],
+    programId
+  )[0];
+}
+
+// Answers by pubkey rather than position, so the second market's obligation and
+// its reserve resolve wherever they land in the batch.
+function createKeyedConnection(
+  accounts: Map<string, { data: Buffer; owner: PublicKey }>
+) {
+  return {
+    getMultipleAccountsInfoAndContext: mock(async (keys: PublicKey[]) => ({
+      context: { slot: 321 },
+      value: keys.map((key) => accounts.get(key.toBase58()) ?? null),
+    })),
   };
 }
 
@@ -338,6 +388,79 @@ describe("earn position reconciliation", () => {
     expect(
       connection.getMultipleAccountsInfoAndContext.mock.calls[0]?.[1]
     ).toEqual({ commitment: "confirmed", minContextSlot: 500 });
+  });
+
+  test("discovers a policy market the read-model never recorded", async () => {
+    // The rebalance shape: the recorded market's obligation is empty and the
+    // funds sit in a Safe market that has no reserve row, so the old candidate
+    // list (canonical + position + rows) could never see them.
+    const now = new Date("2026-06-17T00:50:00.000Z");
+    const connection = createKeyedConnection(
+      new Map([
+        [reserve.toBase58(), { data: Buffer.from([0]), owner: programId }],
+        [
+          obligationFor(market).toBase58(),
+          { data: Buffer.from([0]), owner: programId },
+        ],
+        [
+          obligationFor(secondMarket).toBase58(),
+          { data: Buffer.from([3]), owner: programId },
+        ],
+        [
+          secondReserve.toBase58(),
+          { data: Buffer.from([0]), owner: programId },
+        ],
+        [usdcAta.toBase58(), { data: Buffer.from([2]), owner: tokenProgramId }],
+      ])
+    );
+    findActiveManagedYieldVaultWithPolicy.mockImplementation(async () => ({
+      ...createManagedVault(null),
+      routePolicy: {
+        kaminoMarkets: [market.toBase58(), secondMarket.toBase58()],
+      },
+    }));
+    findReconciledActiveYieldPositionForVault.mockImplementation(async () =>
+      createPosition()
+    );
+    findCurrentNonzeroYieldVaultReservePositions.mockImplementation(
+      async () => []
+    );
+
+    const result = await reconcileEarnVaultPosition(
+      {
+        authority: "wallet",
+        cluster: "mainnet-beta" as never,
+        connection: connection as never,
+        force: true,
+        settings: "settings",
+        vaultPubkey: vault.toBase58(),
+      },
+      { now: () => now }
+    );
+
+    expect(result.status).toBe("refreshed");
+    const [snapshotInput] = (recordReconciledYieldVaultSnapshot.mock.calls.at(
+      -1
+    ) ?? []) as unknown as [
+      { positions: Array<{ amountRaw: bigint; market: string; reserve: string }> },
+    ];
+    const discovered = snapshotInput.positions.find(
+      (row) => row.reserve === secondReserve.toBase58()
+    );
+    // 9 collateral units valued through the discovered reserve (mock rate 2x).
+    expect(discovered?.amountRaw).toBe(BigInt(18));
+    expect(discovered?.market).toBe(secondMarket.toBase58());
+
+    // The position row follows the money, so every read-model consumer stops
+    // pointing at the empty market.
+    const [holdingInput] = (recordSnapshotReconciledYieldHolding.mock.calls.at(
+      -1
+    ) ?? []) as unknown as [
+      { amountRaw: bigint; market: string; reserve: string },
+    ];
+    expect(holdingInput.reserve).toBe(secondReserve.toBase58());
+    expect(holdingInput.market).toBe(secondMarket.toBase58());
+    expect(holdingInput.amountRaw).toBe(BigInt(25));
   });
 
   test("rejects an unreadable reserve before mutating a positive obligation snapshot", async () => {

--- a/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-position-reconciliation.server.ts
@@ -4,10 +4,13 @@ import {
   KAMINO_VANILLA_OBLIGATION_ID,
   KAMINO_VANILLA_OBLIGATION_TAG,
   LoyalCluster,
+  RiskBasket,
   getKaminoUsdcEarnTargetForCluster,
+  getRiskBasketMarketsForCluster,
 } from "@loyal-labs/actions";
 import {
   calculateKaminoRedeemableLiquidityAmountRaw,
+  parseKaminoObligationAccount,
   parseKaminoObligationDepositedCollateralAmountRaw,
   parseKaminoReserveTokenAccounts,
   parseKaminoReserveSnapshot,
@@ -17,7 +20,12 @@ import {
   AccountLayout,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import type { AccountInfo, Connection } from "@solana/web3.js";
+import type {
+  AccountInfo,
+  Commitment,
+  Connection,
+  GetMultipleAccountsConfig,
+} from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
 
 import {
@@ -83,12 +91,6 @@ type ReconciledReserveCandidate = {
   obligationAccount: AccountInfo<Buffer> | null;
   reserveAccount: AccountInfo<Buffer> | null;
   reserveCollateralMint: PublicKey | null;
-};
-
-type CandidateAccountRole = {
-  candidateIndex: number;
-  kind: "obligation" | "reserve";
-  pubkey: PublicKey;
 };
 
 function isFresh(lastReconciledAt: Date | null, now: Date): boolean {
@@ -195,6 +197,30 @@ function buildReserveCandidates(args: {
   return [...candidates.values()];
 }
 
+// The Safe markets this policy may route into. The candidate list above only
+// covers reserves we have ALREADY recorded, so a market the optimizer
+// rebalanced into is invisible to it — and its funds then read as zero. Deriving
+// an obligation for every allowed market lets the chain tell us where the money
+// actually is, the same universe `fetchEarnRpcHoldingsSnapshot` scans.
+function resolvePolicySafeMarkets(args: {
+  cluster: Parameters<typeof getRiskBasketMarketsForCluster>[0];
+  policy: { kaminoMarkets?: string[] | null };
+}): PublicKey[] {
+  const safeMarkets = new Set(
+    getRiskBasketMarketsForCluster(args.cluster, RiskBasket.Safe).map((market) =>
+      market.toBase58()
+    )
+  );
+
+  return (args.policy.kaminoMarkets ?? []).flatMap((market) => {
+    if (!safeMarkets.has(market)) {
+      return [];
+    }
+    const key = publicKeyOrNull(market);
+    return key ? [key] : [];
+  });
+}
+
 function fallbackRowsAsPositions(
   currentRows: CurrentYieldVaultReservePositionRecord[]
 ): ReconciledYieldVaultReservePositionInput[] {
@@ -276,77 +302,156 @@ export async function reconcileEarnVaultPosition(
     vaultPda,
   });
   const lendProgramId = EARN_MAINNET_TARGET.lendProgramId;
-  const candidateAccountRoles: CandidateAccountRole[] = candidates.flatMap(
-    (candidate, candidateIndex) => {
-      const reserve = publicKeyOrNull(candidate.reserve);
-      const market = publicKeyOrNull(candidate.market);
-      if (!reserve || !market) {
-        return [];
-      }
+  const readConfig: Commitment | GetMultipleAccountsConfig =
+    input.minContextSlot !== undefined
+      ? { commitment: SOURCE_COMMITMENT, minContextSlot: input.minContextSlot }
+      : SOURCE_COMMITMENT;
+  const obligationForMarket = (market: PublicKey) =>
+    deriveKaminoVanillaObligation({ lendProgramId, market, vaultPda });
 
-      return [
-        { candidateIndex, kind: "reserve" as const, pubkey: reserve },
-        {
-          candidateIndex,
-          kind: "obligation" as const,
-          pubkey: deriveKaminoVanillaObligation({
-            lendProgramId,
-            market,
-            vaultPda,
-          }),
-        },
-      ];
+  const accountKeys: PublicKey[] = [];
+  const requestedKeys = new Set<string>();
+  const requestKey = (key: PublicKey) => {
+    const text = key.toBase58();
+    if (requestedKeys.has(text)) {
+      return;
     }
-  );
-  const accountKeys = [
-    ...candidateAccountRoles.map((role) => role.pubkey),
-    canonicalAccounts.usdcAta,
-  ];
+    requestedKeys.add(text);
+    accountKeys.push(key);
+  };
+
+  for (const candidate of candidates) {
+    const reserve = publicKeyOrNull(candidate.reserve);
+    const market = publicKeyOrNull(candidate.market);
+    if (!reserve || !market) {
+      continue;
+    }
+    requestKey(reserve);
+    requestKey(obligationForMarket(market));
+  }
+  // Discovery rides along in the SAME batch: an allowed market whose obligation
+  // a candidate already covers dedupes away, so the common single-market vault
+  // reads exactly the accounts it read before.
+  const policySafeMarkets = resolvePolicySafeMarkets({
+    cluster: input.cluster,
+    policy: managed.routePolicy,
+  });
+  for (const market of policySafeMarkets) {
+    requestKey(obligationForMarket(market));
+  }
+  requestKey(canonicalAccounts.usdcAta);
+
   const { context: reserveContext, value: reserveValues } =
     await input.connection.getMultipleAccountsInfoAndContext(
       accountKeys,
-      input.minContextSlot !== undefined
-        ? { commitment: SOURCE_COMMITMENT, minContextSlot: input.minContextSlot }
-        : SOURCE_COMMITMENT
+      readConfig
     );
-  const idleAccount = reserveValues[reserveValues.length - 1] ?? null;
-  const accountForRole = (role: CandidateAccountRole) =>
-    reserveValues[candidateAccountRoles.indexOf(role)] ?? null;
+  const accountByKey = new Map<string, AccountInfo<Buffer> | null>();
+  accountKeys.forEach((key, index) => {
+    accountByKey.set(key.toBase58(), reserveValues[index] ?? null);
+  });
+  const accountFor = (key: PublicKey | null) =>
+    key ? accountByKey.get(key.toBase58()) ?? null : null;
   const idleAmountRaw = decodeTokenAccountAmount({
-    account: idleAccount,
+    account: accountFor(canonicalAccounts.usdcAta),
     expectedMint: canonicalAccounts.targetReserve.liquidityMint,
     expectedOwner: vaultPda,
   });
 
-  const reconciledCandidates: ReconciledReserveCandidate[] = candidates.map(
-    (candidate, candidateIndex) => {
-      const reserveRole = candidateAccountRoles.find(
-        (role) =>
-          role.kind === "reserve" && role.candidateIndex === candidateIndex
-      );
-      const obligationRole = candidateAccountRoles.find(
-        (role) =>
-          role.kind === "obligation" && role.candidateIndex === candidateIndex
-      );
-      const reserveAccount = reserveRole ? accountForRole(reserveRole) : null;
-      const obligationAccount = obligationRole
-        ? accountForRole(obligationRole)
-        : null;
-      const reserveTokenAccounts = reserveAccount
-        ? parseKaminoReserveTokenAccounts(reserveAccount.data)
-        : null;
-
-      return {
-        candidate,
-        obligation: obligationRole?.pubkey ?? null,
-        obligationAccount,
-        reserveAccount,
-        reserveCollateralMint:
-          reserveTokenAccounts?.reserveCollateralMint ?? null,
-      };
+  // Reserves the vault holds in a policy market we have never recorded. Their
+  // exchange rate needs a second read, so this only costs an extra round trip
+  // when a market actually went missing from the read-model.
+  const knownReserves = new Set(candidates.map((candidate) => candidate.reserve));
+  const discoveredCandidates: ReserveCandidate[] = [];
+  for (const market of policySafeMarkets) {
+    const obligationAccount = accountFor(obligationForMarket(market));
+    if (!obligationAccount || !obligationAccount.owner.equals(lendProgramId)) {
+      continue;
     }
-  );
 
+    const parsedObligation = parseKaminoObligationAccount(
+      obligationAccount.data
+    );
+    if (
+      !parsedObligation.owner.equals(vaultPda) ||
+      !parsedObligation.lendingMarket.equals(market)
+    ) {
+      continue;
+    }
+
+    for (const deposit of parsedObligation.deposits) {
+      const reserve = deposit.reserve.toBase58();
+      if (
+        knownReserves.has(reserve) ||
+        deposit.depositedAmountRaw <= BigInt(0)
+      ) {
+        continue;
+      }
+
+      knownReserves.add(reserve);
+      discoveredCandidates.push({
+        borrowApyBps: null,
+        liquidityMint: canonicalAccounts.targetReserve.liquidityMint.toBase58(),
+        market: market.toBase58(),
+        planningMetadata: { source: "policy_market_discovery" },
+        reserve,
+        supplyApyBps: null,
+      });
+    }
+  }
+
+  if (discoveredCandidates.length > 0) {
+    const discoveredReserveKeys = discoveredCandidates.map(
+      (candidate) => new PublicKey(candidate.reserve)
+    );
+    const { value: discoveredReserveValues } =
+      await input.connection.getMultipleAccountsInfoAndContext(
+        discoveredReserveKeys,
+        readConfig
+      );
+    discoveredReserveKeys.forEach((key, index) => {
+      accountByKey.set(key.toBase58(), discoveredReserveValues[index] ?? null);
+    });
+  }
+
+  // An unreadable reserve keeps its candidate: dropping it here would hide a
+  // positive obligation from the post-withdrawal zero proof's fail-closed check
+  // below. A readable reserve for some other liquidity is not ours — drop it.
+  const usdcCandidates = discoveredCandidates.filter((candidate) => {
+    const reserveAccount = accountFor(new PublicKey(candidate.reserve));
+    if (!reserveAccount) {
+      return true;
+    }
+
+    return parseKaminoReserveTokenAccounts(
+      reserveAccount.data
+    ).reserveLiquidityMint?.equals(canonicalAccounts.targetReserve.liquidityMint);
+  });
+  const reconciledCandidates: ReconciledReserveCandidate[] = [
+    ...candidates,
+    ...usdcCandidates,
+  ].map((candidate) => {
+    const market = publicKeyOrNull(candidate.market);
+    const obligation = market ? obligationForMarket(market) : null;
+    const reserveAccount = accountFor(publicKeyOrNull(candidate.reserve));
+    const obligationAccount = accountFor(obligation);
+    const reserveTokenAccounts = reserveAccount
+      ? parseKaminoReserveTokenAccounts(reserveAccount.data)
+      : null;
+
+    return {
+      candidate,
+      obligation,
+      obligationAccount,
+      reserveAccount,
+      reserveCollateralMint:
+        reserveTokenAccounts?.reserveCollateralMint ?? null,
+    };
+  });
+
+  // The obligations and the idle ATA — everything that defines a balance — come
+  // from the first read; a discovered reserve only contributes its exchange
+  // rate, so this slot stays the honest observation point.
   const observedSlot = BigInt(reserveContext.slot);
 
   const positions = reconciledCandidates.map((reconciled) => {
@@ -430,7 +535,7 @@ export async function reconcileEarnVaultPosition(
       source: "frontend_position_reconcile",
       purpose: input.purpose ?? "routine",
       sourceCommitment: SOURCE_COMMITMENT,
-      skippedReserveCount: candidates.length - reconciledCandidates.length,
+      discoveredReserveCount: reconciledCandidates.length - candidates.length,
     },
     idleTokenBalance: {
       amountRaw: idleAmountRaw,


### PR DESCRIPTION
`reconcileEarnVaultPosition` built its candidate reserves from the canonical target, the position row, and the reserve rows it had already written — so a market the optimizer rebalanced into was invisible to it, and funds sitting in that market's obligation reconciled as zero. The read-model then drifted from the chain for as long as the position stayed open, and the yield worker reads those rows too. #482 let users withdraw their way out of that state; this stops the state from being recorded wrong in the first place.

Reconcile now derives an obligation for every Safe market the route policy allows (the same universe the live holdings snapshot scans) and takes the reserves from what the chain reports. Discovery rides along in the existing batch — an allowed market a candidate already covers dedupes away, so a single-market vault reads exactly the accounts it read before, and only a vault that actually drifted pays for the second round trip that values the new reserve. An unreadable reserve keeps its candidate so the post-withdrawal zero proof's fail-closed check still fires on a positive obligation, and the last-known-positive fallbacks are untouched.