### PR TITLE
fix(earn): resolve the reused Earn policy server-side on web deposits

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/earnings/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/earnings/route.ts
@@ -74,6 +74,9 @@ export async function GET(request: Request) {
     const payload: EarnEarningsUnavailableResponse = {
       error: {
         code,
+        ...(error instanceof EarnEarningsUnavailableError
+          ? { detailCode: error.detailCode }
+          : {}),
         message:
           code === "history_incomplete"
             ? "Earn history is still updating."

--- a/frontend/src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from "next/server";
 
 import { resolveAuthenticatedPrincipalFromRequest } from "@/features/identity/server/auth-session";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { parseEarnDepositConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
   EarnDepositConfirmError,
   recordConfirmedEarnDeposit,
+  resolvePolicyCreationSignatureFromChain,
 } from "@/lib/yield-optimization/earn-deposit-confirm.server";
-import type { ConfirmedYieldDepositInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
+import {
+  findActiveYieldRoutePolicyPair,
+  type ConfirmedYieldDepositInput,
+} from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 function jsonError(
   status: number,
@@ -14,6 +19,83 @@ function jsonError(
   message: string
 ): NextResponse {
   return NextResponse.json({ error: { code, message } }, { status });
+}
+
+// A top-up reuses a policy that already exists on-chain, so nothing in this
+// flow signs a policy transaction — the recorded "policy signature" is only a
+// citation of where we last saw that policy. The browser can only cite the DB
+// row it got from Earn state, and that row is legitimately absent: a full Earn
+// exit releases the policy pair, and a failed confirm never writes one. Left to
+// the client, such a deposit dead-ends forever ("Confirming this Earn top-up
+// requires the active policy signature"), because the state it is told to
+// refresh will always be empty.
+//
+// So the server owns the citation for a reuse, exactly as the mobile confirm
+// twin does: read the DB pair, and when it is missing, recover the policy's
+// creation signature from the chain. The setup policy is recovered alongside
+// it, because `getConfirmedSetupPolicyMetadata` only writes the managed-vault
+// row — which every Earn read keys on — when that metadata is complete.
+async function resolveReusedPolicyCitation(
+  input: ConfirmedYieldDepositInput,
+  walletAddress: string
+): Promise<ConfirmedYieldDepositInput> {
+  const pair = await findActiveYieldRoutePolicyPair({
+    authority: walletAddress,
+    cluster: input.cluster,
+    settings: input.settings,
+    vaultIndex: input.vaultIndex,
+    vaultPubkey: input.vaultPubkey,
+  });
+  if (
+    pair?.routePolicy.policyAccount === input.policyAccount &&
+    pair.routePolicy.lastSeenSignature
+  ) {
+    return {
+      ...input,
+      policyConfirmedSlot: pair.routePolicy.lastSeenSlot,
+      policySignature: pair.routePolicy.lastSeenSignature,
+    };
+  }
+
+  const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
+  const routeCreation = await resolvePolicyCreationSignatureFromChain({
+    cluster: solanaEnv,
+    policyAccount: input.policyAccount,
+  });
+  if (!routeCreation) {
+    throw new EarnDepositConfirmError({
+      code: "policy_signature_unresolved",
+      message:
+        "We couldn't verify your Earn policy on-chain. Your deposit is safe — please try again in a moment.",
+      status: 400,
+    });
+  }
+
+  const setupCreation = input.setupPolicyAccount
+    ? await resolvePolicyCreationSignatureFromChain({
+        cluster: solanaEnv,
+        policyAccount: input.setupPolicyAccount,
+      })
+    : null;
+
+  console.warn("[earn-deposit-confirm] adopted reused policy from chain", {
+    policyAccount: input.policyAccount,
+    setupPolicyAccount: input.setupPolicyAccount ?? null,
+    setupPolicyRecovered: setupCreation !== null,
+    walletAddress,
+  });
+
+  return {
+    ...input,
+    policyConfirmedSlot: BigInt(routeCreation.slot),
+    policySignature: routeCreation.signature,
+    ...(setupCreation
+      ? {
+          setupPolicyConfirmedSlot: BigInt(setupCreation.slot),
+          setupPolicySignature: setupCreation.signature,
+        }
+      : {}),
+  };
 }
 
 export async function POST(request: Request) {
@@ -35,6 +117,10 @@ export async function POST(request: Request) {
   }
 
   try {
+    if (input.policyInitialization === "reuse") {
+      input = await resolveReusedPolicyCitation(input, principal.walletAddress);
+    }
+
     const position = await recordConfirmedEarnDeposit({
       principal: {
         walletAddress: principal.walletAddress,

--- a/frontend/src/app/api/smart-accounts/yield-optimization/earnings/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/earnings/route.ts
@@ -43,6 +43,9 @@ export async function GET(request: Request) {
     const payload: EarnEarningsUnavailableResponse = {
       error: {
         code,
+        ...(error instanceof EarnEarningsUnavailableError
+          ? { detailCode: error.detailCode }
+          : {}),
         message:
           code === "history_incomplete"
             ? "Earn history is still updating."

--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -74,7 +74,10 @@ import {
   buildEarnPolicyConfirmRequestBody,
   buildEarnWithdrawalConfirmRequestBody,
 } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
-import { resolveEarnDepositConfirmPolicySignature } from "@/lib/yield-optimization/earn-deposit-flow.shared";
+import {
+  isReusedEarnDepositPolicy,
+  resolveEarnDepositConfirmPolicySignature,
+} from "@/lib/yield-optimization/earn-deposit-flow.shared";
 import {
   buildEarnAutodepositCloseConfirmRequestBody,
   buildEarnAutodepositSetupConfirmRequestBody,
@@ -5198,16 +5201,26 @@ export function useSmartAccountSidebarData(
                 return;
               }
 
-              const policySignatureResolution =
-                resolveEarnDepositConfirmPolicySignature({
-                  activePolicy: currentEarnState?.policy ?? null,
-                  policyConfirmedSlot,
-                  policySignature,
-                  preparedDeposit: request.preparedDeposit,
-                  setupPolicyConfirmedSlot,
-                  setupPolicySignature,
-                });
-              if ("error" in policySignatureResolution) {
+              // A top-up signs no policy transaction, so the confirm route
+              // resolves the reused policy's citation itself (DB row, else
+              // chain). Citing it here would dead-end every wallet whose row is
+              // gone — e.g. after a full Earn exit.
+              const policySignatureResolution = isReusedEarnDepositPolicy(
+                request.preparedDeposit
+              )
+                ? null
+                : resolveEarnDepositConfirmPolicySignature({
+                    activePolicy: currentEarnState?.policy ?? null,
+                    policyConfirmedSlot,
+                    policySignature,
+                    preparedDeposit: request.preparedDeposit,
+                    setupPolicyConfirmedSlot,
+                    setupPolicySignature,
+                  });
+              if (
+                policySignatureResolution &&
+                "error" in policySignatureResolution
+              ) {
                 throw new Error(policySignatureResolution.error);
               }
 
@@ -5217,12 +5230,12 @@ export function useSmartAccountSidebarData(
                 await postConfirmedEarnDeposit({
                   preparedDeposit: request.preparedDeposit,
                   policyConfirmedSlot:
-                    policySignatureResolution.policyConfirmedSlot,
-                  policySignature: policySignatureResolution.policySignature,
+                    policySignatureResolution?.policyConfirmedSlot,
+                  policySignature: policySignatureResolution?.policySignature,
                   setupPolicyConfirmedSlot:
-                    policySignatureResolution.setupPolicyConfirmedSlot,
+                    policySignatureResolution?.setupPolicyConfirmedSlot,
                   setupPolicySignature:
-                    policySignatureResolution.setupPolicySignature,
+                    policySignatureResolution?.setupPolicySignature,
                   signature,
                   confirmedSlot,
                   smartAccountAddress:
@@ -5413,26 +5426,34 @@ export function useSmartAccountSidebarData(
           setEarnState(currentEarnState);
         }
         const onboarding = currentEarnState?.onboarding;
-        const policySignatureResolution =
-          resolveEarnDepositConfirmPolicySignature({
-            activePolicy: currentEarnState?.policy ?? null,
-            policyConfirmedSlot:
-              request.policyConfirmedSlot ??
-              onboarding?.policy?.lastSeenSlot ??
-              currentEarnState?.policy?.lastSeenSlot,
-            policySignature:
-              request.policySignature ??
-              onboarding?.policy?.lastSeenSignature ??
-              currentEarnState?.policy?.lastSeenSignature,
-            preparedDeposit,
-            setupPolicyConfirmedSlot:
-              request.setupPolicyConfirmedSlot ??
-              onboarding?.setupPolicy?.lastSeenSlot,
-            setupPolicySignature:
-              request.setupPolicySignature ??
-              onboarding?.setupPolicy?.lastSeenSignature,
-          });
-        if ("error" in policySignatureResolution) {
+        // See the staged flow above: the confirm route owns the reused policy's
+        // citation, so a top-up must not be blocked on the browser's copy of it.
+        const policySignatureResolution = isReusedEarnDepositPolicy(
+          preparedDeposit
+        )
+          ? null
+          : resolveEarnDepositConfirmPolicySignature({
+              activePolicy: currentEarnState?.policy ?? null,
+              policyConfirmedSlot:
+                request.policyConfirmedSlot ??
+                onboarding?.policy?.lastSeenSlot ??
+                currentEarnState?.policy?.lastSeenSlot,
+              policySignature:
+                request.policySignature ??
+                onboarding?.policy?.lastSeenSignature ??
+                currentEarnState?.policy?.lastSeenSignature,
+              preparedDeposit,
+              setupPolicyConfirmedSlot:
+                request.setupPolicyConfirmedSlot ??
+                onboarding?.setupPolicy?.lastSeenSlot,
+              setupPolicySignature:
+                request.setupPolicySignature ??
+                onboarding?.setupPolicy?.lastSeenSignature,
+            });
+        if (
+          policySignatureResolution &&
+          "error" in policySignatureResolution
+        ) {
           return {
             success: false,
             error: policySignatureResolution.error,
@@ -5470,12 +5491,12 @@ export function useSmartAccountSidebarData(
         const recordDepositConfirmation = async () => {
           await postConfirmedEarnDeposit({
             preparedDeposit,
-            policyConfirmedSlot: policySignatureResolution.policyConfirmedSlot,
-            policySignature: policySignatureResolution.policySignature,
+            policyConfirmedSlot: policySignatureResolution?.policyConfirmedSlot,
+            policySignature: policySignatureResolution?.policySignature,
             setupPolicyConfirmedSlot:
-              policySignatureResolution.setupPolicyConfirmedSlot,
+              policySignatureResolution?.setupPolicyConfirmedSlot,
             setupPolicySignature:
-              policySignatureResolution.setupPolicySignature,
+              policySignatureResolution?.setupPolicySignature,
             signature,
             confirmedSlot,
             smartAccountAddress: preparedDeposit.vault.pubkey.toBase58(),

--- a/frontend/src/lib/yield-optimization/earn-deposit-flow.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-flow.shared.ts
@@ -71,6 +71,24 @@ export function getEarnDepositReviewStagePosition(args: {
   };
 }
 
+// A top-up signs no policy transaction: the policy already exists on-chain and
+// the deposit just routes through it. Its "policy signature" is therefore only
+// a citation of where we last saw that policy — a server fact, resolvable from
+// the DB row or, when there is none, from the chain. The DB row legitimately
+// goes missing (a full Earn exit releases the pair; a failed confirm never
+// wrote one), and a browser cannot read the chain, so the client must never
+// gate a top-up on being able to cite it. Callers that can reach the chain
+// (the confirm routes) resolve it themselves.
+export function isReusedEarnDepositPolicy(
+  preparedDeposit: SmartAccountPreparedEarnUsdcDeposit
+): boolean {
+  return (
+    !preparedDeposit.policySetupPrepared &&
+    !preparedDeposit.policyFinalizePrepared &&
+    preparedDeposit.persistence.policyInitialization === "reuse"
+  );
+}
+
 export function resolveEarnDepositConfirmPolicySignature(args: {
   activePolicy?: EarnDepositPolicySignatureSource;
   policyConfirmedSlot?: string | null;

--- a/frontend/src/lib/yield-optimization/earnings.shared.ts
+++ b/frontend/src/lib/yield-optimization/earnings.shared.ts
@@ -57,6 +57,12 @@ export type EarnEarningsRangeSetResponse = {
 export type EarnEarningsUnavailableResponse = {
   error: {
     code: "earnings_unavailable" | "history_incomplete";
+    // Which verification actually failed. `code` alone says only "we won't draw
+    // this", which is the same answer for a missing APY feed, a drifted
+    // principal and a drifted holding — three unrelated defects that need three
+    // unrelated fixes. Without this, triaging one report means reconstructing
+    // the wallet's whole history from the yield DB by hand.
+    detailCode?: string;
     message: string;
   };
   freshness: "unavailable";


### PR DESCRIPTION
Every wallet that fully exits Earn and comes back to deposit **on web** is permanently blocked today:

> Confirming this Earn top-up requires the active policy signature. Refresh Earn and try again.

Refreshing can never help — the Earn state it names is empty and stays empty.

## Why

A top-up signs no policy transaction. The policy already exists on-chain and the deposit just routes through it, so the "policy signature" we record is only a citation of where we last saw that policy — a server fact. The web client was asserting it from `earnState.policy`, and that row is legitimately absent: a **full Earn exit releases the policy pair**, and a failed confirm never writes one. Prepare then correctly returns `policyInitialization: "reuse"`, the client has nothing to cite, and it throws.

Mobile's confirm twin already recovers from this; web never got the same treatment.

## Change

- `deposits/confirm` now owns the citation for a reuse: read the DB pair, and when there is none, recover the policy's creation signature from the chain. The **setup policy** is recovered alongside it, because `getConfirmedSetupPolicyMetadata` only writes the `managed_vaults` row — which every Earn read keys on — when that metadata is complete.
- Both web deposit call sites stop gating a top-up on a citation the browser cannot produce. First-deposit validation is untouched.
- `isReusedEarnDepositPolicy()` so the client and the route agree on what "top-up" means.
- Earnings 503 now returns `detailCode`. "Unavailable" is currently the same answer for a missing APY feed, a drifted principal and a drifted holding — three unrelated defects — so triaging one report means rebuilding a wallet's history from the yield DB by hand.

Healthy top-ups are unaffected: the route resolves the same signature from the DB pair the client used to cite.

## Verification

- Reproduced on a real wallet that fully exited on Jul 10 (`position: null`, no policy pair, policy still on-chain). Depositing from mobile — which has this recovery — healed the DB rows and unblocked web, confirming the diagnosis.
- `bun test src/lib/yield-optimization/ src/app/api/smart-accounts/yield-optimization/` → identical to `main` (92 pass; the 15 failures are pre-existing on `main`, a `mock.module` artifact).
- `tsc --noEmit` diffed against a clean `main` baseline → 107 errors before, 107 after, byte-identical (all pre-existing unbuilt-workspace-package noise).
- `next lint` clean on every touched file.

Backend + web only. No mobile OTA needed.
