### PR TITLE
fix(wallet): publish Digital Asset Links for the Loyal Android dApp identity

### DIFF
--- a/frontend/public/.well-known/assetlinks.json
+++ b/frontend/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.loyal.app",
+      "sha256_cert_fingerprints": [
+        "AD:69:BC:84:AA:21:71:8D:B1:2B:76:65:87:39:BA:C3:55:F9:33:5E:8D:03:59:72:E0:BF:B9:D0:10:C3:D3:7B"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Our MWA identity claims `https://askloyal.com`, but the domain served no `/.well-known/assetlinks.json` — so wallets could not verify that the calling package actually owns that domain, and rendered every signing request as an unverified dApp. The MWA spec calls this out as putting "users' funds at risk from malicious dapps".

Pins the dApp Store package (`com.loyal.app`) to its signing certificate, read from the release keystore. Static file only: no app update needed, since wallets fetch it at authorize time — already-installed builds become verifiable as soon as this deploys.

Does **not** lift the current "Scam site detected" block on Seed Vault Wallet; that is a separate domain-reputation verdict only Solana Mobile can clear. The Play Store package (`com.askloyal.app`) is re-signed by Play App Signing and still needs its fingerprint added from Play Console.