### PR TITLE
fix(earn): refuse untracked Earn deposit reserves and serve backfilled APY history

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
@@ -23,7 +23,7 @@ import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { hasLiveBalanceSweepTargetForWallet } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import { parseEarnDepositPrepareRequestBody } from "@/lib/yield-optimization/earn-deposit-prepare-contracts.shared";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import { resolveEligibleEarnDepositTarget } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   findActiveYieldRoutePolicyPair,
   findReconciledActiveYieldPositionForVault,
@@ -218,10 +218,16 @@ export async function POST(request: Request) {
     policy = policyResult?.routePolicy ?? null;
     const policySigner = getDeploymentPolicySignerPublicKey();
     // A top-up deposits into the reserve the position is already in (always a
-    // safe USDC reserve) — same rule as `../prepare`.
+    // safe USDC reserve) — same rule as `../prepare` — unless that reserve is
+    // ineligible (hidden/unsampled or drained); then fall back to the default
+    // reserve instead of feeding it (ASK-1764).
     const target =
       policy && activePosition
-        ? earnReserveTargetFromActivePosition(activePosition)
+        ? await resolveEligibleEarnDepositTarget({
+            cluster,
+            logTag: "mobile-earn-deposit-prepare-context",
+            position: activePosition,
+          })
         : null;
     // Stray-approval heal, fail-closed: the SPL delegate is load-bearing for
     // sweeps, so the revoke rider is requested only when the wallet provably

--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
@@ -27,7 +27,7 @@ import {
   serializePreparedEarnUsdcDeposit,
 } from "@/lib/yield-optimization/earn-deposit-prepare-contracts.shared";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import { resolveEligibleEarnDepositTarget } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   findActiveYieldRoutePolicyPair,
   findReconciledActiveYieldPositionForVault,
@@ -249,9 +249,15 @@ export async function POST(request: Request) {
     // findBestSafeUsdcEarnReserveTarget re-picked the best fresh candidate and
     // hard-failed ~1-in-5 attempts whenever every safe USDC reserve was
     // momentarily flagged reserveLastUpdateStale in the Timescale feed.
+    // Exception (ASK-1764): an ineligible current reserve (hidden/unsampled
+    // or drained) is never followed — fall back to the default reserve.
     const target =
       policy && activePosition
-        ? earnReserveTargetFromActivePosition(activePosition)
+        ? await resolveEligibleEarnDepositTarget({
+            cluster,
+            logTag: "mobile-earn-deposit-prepare",
+            position: activePosition,
+          })
         : null;
     // Stray-approval heal, fail-closed: the SPL delegate is load-bearing for
     // sweeps, so the revoke rider is requested only when the wallet provably

--- a/frontend/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
@@ -19,7 +19,7 @@ import {
   serializePreparedEarnUsdcDeposit,
 } from "@/lib/yield-optimization/earn-deposit-prepare-contracts.shared";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
-import { earnReserveTargetFromActivePosition } from "@/lib/yield-optimization/earn-reserve-target.server";
+import { resolveEligibleEarnDepositTarget } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   findCurrentEarnDepositOnboardingAttempt,
   findActiveYieldRoutePolicyPair,
@@ -198,7 +198,11 @@ export async function POST(request: Request) {
       : undefined;
     const target =
       policy && activePosition
-        ? earnReserveTargetFromActivePosition(activePosition)
+        ? await resolveEligibleEarnDepositTarget({
+            cluster,
+            logTag: "earn-deposit-prepare",
+            position: activePosition,
+          })
         : null;
     const preparedDeposit = await client.prepareEarnUsdcDeposit({
       amountRaw,

--- a/frontend/src/lib/kamino/timescale-reserve-client.server.ts
+++ b/frontend/src/lib/kamino/timescale-reserve-client.server.ts
@@ -90,6 +90,11 @@ export type TimescaleReserveUpdateRow =
   typeof timescaleReserveUpdates.$inferSelect;
 export type TimescaleSupportedReserveRow =
   typeof timescaleSupportedReserves.$inferSelect;
+export type TimescaleReservePresenceRow = Pick<
+  TimescaleReserveUpdateRow,
+  "observedAt" | "reserve" | "totalSupplyUsdEstimate"
+>;
+
 export type TimescaleReserveApySample = Pick<
   TimescaleReserveUpdateRow,
   "observedAt" | "supplyApy"
@@ -162,6 +167,25 @@ export async function getCurrentReserveUpdatesByReserve(args: {
   const client = new TimescaleReserveClient({ databaseUrl, maxConnections: 1 });
   try {
     return await client.getCurrentReserveUpdatesByReserve(args);
+  } finally {
+    await client.close();
+  }
+}
+
+// Returns null (not []) when the Timescale feed is not configured so
+// eligibility callers can tell "feed unavailable" from "reserve was never
+// sampled" — the latter is what marks hidden/untracked reserves ineligible.
+export async function getLatestReserveObservationsByReserve(args: {
+  reserves: readonly string[];
+}): Promise<TimescaleReservePresenceRow[] | null> {
+  const databaseUrl = getTimescaleReserveDatabaseUrl();
+  if (!databaseUrl) {
+    return null;
+  }
+
+  const client = new TimescaleReserveClient({ databaseUrl, maxConnections: 1 });
+  try {
+    return await client.getLatestReserveObservationsByReserve(args);
   } finally {
     await client.close();
   }
@@ -439,13 +463,37 @@ export class TimescaleReserveClient {
         SELECT r.reserve, sample.observed_at, sample.supply_apy
         FROM requested_reserves r
         CROSS JOIN LATERAL (
+          -- Union the indexer stream with the curated API backfill
+          -- (kamino.reserve_apy_backfill) per branch so each side keeps its
+          -- own index-backed ORDER BY ... LIMIT 1 instead of materializing
+          -- the full sample set. Backfill covers reserves the indexer never
+          -- sampled (e.g. hidden reserves a position historically held);
+          -- earnings coverage is the only path that reads it.
           SELECT observed_at, supply_apy
-          FROM kamino.reserve_updates
-          WHERE reserve = r.reserve
-            AND reserve_last_update_stale = false
-            AND supply_apy >= 0
-            AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
-            AND observed_at < ${startIso}::timestamptz
+          FROM (
+            (
+              SELECT observed_at, supply_apy
+              FROM kamino.reserve_updates
+              WHERE reserve = r.reserve
+                AND reserve_last_update_stale = false
+                AND supply_apy >= 0
+                AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+                AND observed_at < ${startIso}::timestamptz
+              ORDER BY observed_at DESC
+              LIMIT 1
+            )
+            UNION ALL
+            (
+              SELECT observed_at, supply_apy
+              FROM kamino.reserve_apy_backfill
+              WHERE reserve = r.reserve
+                AND supply_apy >= 0
+                AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+                AND observed_at < ${startIso}::timestamptz
+              ORDER BY observed_at DESC
+              LIMIT 1
+            )
+          ) candidates
           ORDER BY observed_at DESC
           LIMIT 1
         ) sample
@@ -455,12 +503,30 @@ export class TimescaleReserveClient {
         FROM requested_reserves r
         CROSS JOIN LATERAL (
           SELECT observed_at, supply_apy
-          FROM kamino.reserve_updates
-          WHERE reserve = r.reserve
-            AND reserve_last_update_stale = false
-            AND supply_apy >= 0
-            AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
-            AND observed_at <= ${endIso}::timestamptz
+          FROM (
+            (
+              SELECT observed_at, supply_apy
+              FROM kamino.reserve_updates
+              WHERE reserve = r.reserve
+                AND reserve_last_update_stale = false
+                AND supply_apy >= 0
+                AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+                AND observed_at <= ${endIso}::timestamptz
+              ORDER BY observed_at DESC
+              LIMIT 1
+            )
+            UNION ALL
+            (
+              SELECT observed_at, supply_apy
+              FROM kamino.reserve_apy_backfill
+              WHERE reserve = r.reserve
+                AND supply_apy >= 0
+                AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+                AND observed_at <= ${endIso}::timestamptz
+              ORDER BY observed_at DESC
+              LIMIT 1
+            )
+          ) candidates
           ORDER BY observed_at DESC
           LIMIT 1
         ) sample
@@ -475,13 +541,24 @@ export class TimescaleReserveClient {
           ) AS sample_bucket,
           observed_at,
           supply_apy
-        FROM kamino.reserve_updates
-        WHERE reserve = ANY(${reserves}::text[])
-          AND reserve_last_update_stale = false
-          AND supply_apy >= 0
-          AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
-          AND observed_at >= ${startIso}::timestamptz
-          AND observed_at <= ${endIso}::timestamptz
+        FROM (
+          SELECT reserve, observed_at, supply_apy
+          FROM kamino.reserve_updates
+          WHERE reserve = ANY(${reserves}::text[])
+            AND reserve_last_update_stale = false
+            AND supply_apy >= 0
+            AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+            AND observed_at >= ${startIso}::timestamptz
+            AND observed_at <= ${endIso}::timestamptz
+          UNION ALL
+          SELECT reserve, observed_at, supply_apy
+          FROM kamino.reserve_apy_backfill
+          WHERE reserve = ANY(${reserves}::text[])
+            AND supply_apy >= 0
+            AND supply_apy < ${DEFAULT_MAX_SUPPLY_APY}
+            AND observed_at >= ${startIso}::timestamptz
+            AND observed_at <= ${endIso}::timestamptz
+        ) sources
       ),
       range_samples AS (
         SELECT DISTINCT ON (reserve, sample_bucket)
@@ -544,6 +621,42 @@ export class TimescaleReserveClient {
       .orderBy(asc(reserveUpdates.reserve));
 
     return rows.map((row) => row.reserve_updates);
+  }
+
+  async getLatestReserveObservationsByReserve(args: {
+    reserves: readonly string[];
+  }): Promise<TimescaleReservePresenceRow[]> {
+    if (args.reserves.length === 0) {
+      return [];
+    }
+
+    const reserveUpdates = this.tables.reserveUpdates;
+    const latestReserveUpdates = this.tables.latestReserveUpdates;
+
+    // Deliberately no stale-flag or APY-bounds filters: presence in the
+    // indexer's latest view is the eligibility signal (a hidden reserve is
+    // never sampled at all), and a transiently stale row must not fail
+    // deposits — that flakiness is why #381 removed the old APY-ranked
+    // picker.
+    const rows = await this.db
+      .select({
+        observedAt: reserveUpdates.observedAt,
+        reserve: reserveUpdates.reserve,
+        totalSupplyUsdEstimate: reserveUpdates.totalSupplyUsdEstimate,
+      })
+      .from(reserveUpdates)
+      .innerJoin(
+        latestReserveUpdates,
+        and(
+          eq(reserveUpdates.reserve, latestReserveUpdates.reserve),
+          eq(reserveUpdates.slot, latestReserveUpdates.slot),
+          eq(reserveUpdates.observedAt, latestReserveUpdates.observedAt)
+        )
+      )
+      .where(inArray(reserveUpdates.reserve, [...new Set(args.reserves)]))
+      .orderBy(asc(reserveUpdates.reserve));
+
+    return rows;
   }
 
   async getCurrentBestApyReserveByStablecoin(args: {

--- a/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
@@ -16,7 +16,10 @@ import {
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { assertSafeUsdcEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  assertSafeUsdcEarnReserveMetadata,
+  findEarnReserveTargetIneligibility,
+} from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   markEarnDepositOnboardingAccountingFailed,
   markEarnDepositOnboardingComplete,
@@ -208,6 +211,28 @@ function createCanonicalDepositInput(
     market: requestInput.market,
     targetReserve: requestInput.targetReserve,
   });
+  // Best-effort alarm, never a gate: the deposit already landed on-chain, so
+  // rejecting the confirm would only make it invisible. Prepare-time routing
+  // refuses ineligible reserves; a confirm that still names one means a
+  // client bypassed prepare or the guard has a hole (ASK-1764).
+  void findEarnReserveTargetIneligibility({
+    cluster,
+    reserve: target.targetReserve,
+  })
+    .then((reason) => {
+      if (reason) {
+        console.error(
+          "[earn-deposit-confirm] confirmed deposit targets an ineligible reserve",
+          {
+            cluster,
+            market: target.market,
+            reason,
+            reserve: target.targetReserve,
+          }
+        );
+      }
+    })
+    .catch(() => undefined);
   if (
     requestInput.targetSupplyApyBps !== null &&
     requestInput.targetSupplyApyBps < BigInt(0)

--- a/frontend/src/lib/yield-optimization/earn-reserve-target.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-reserve-target.server.ts
@@ -12,9 +12,20 @@ import { PublicKey } from "@solana/web3.js";
 
 import {
   getCurrentBestApyReserveByStablecoin,
+  getLatestReserveObservationsByReserve,
   type CurrentBestApyReserveByStablecoin,
 } from "@/lib/kamino/timescale-reserve-client.server";
 import type { UserYieldPositionRecord } from "./yield-deposit-repository.server";
+
+// A reserve this small cannot be a deliberate Earn venue — the hidden OnRe
+// USDC reserve that swallowed a user's top-ups (ASK-1764) held ~$17k and
+// later ~$37. Matches DEFAULT_MIN_TOTAL_SUPPLY_USD_ESTIMATE used for
+// APY-ranked selection.
+const MIN_ELIGIBLE_RESERVE_TOTAL_SUPPLY_USD = 100_000;
+
+export type EarnReserveIneligibilityReason =
+  | "below_liquidity_floor"
+  | "unsampled_reserve";
 
 export type EarnUsdcReserveTarget = {
   reserve: PublicKey;
@@ -138,4 +149,76 @@ export function earnReserveTargetFromActivePosition(
     reserve: new PublicKey(position.currentReserve),
     supplyApyBps: null,
   };
+}
+
+// ASK-1764: an external rebalance execution seeded a $3 line in a HIDDEN
+// Kamino reserve; the read model adopted it as current_reserve and deposit
+// top-ups then routed $7.3k into a ~0%-APY venue. Deposit targets must be
+// reserves our indexer actually tracks (hidden reserves are never sampled)
+// with real liquidity behind them. Returns null when eligible.
+export async function findEarnReserveTargetIneligibility(args: {
+  cluster: LoyalCluster;
+  reserve: string;
+}): Promise<EarnReserveIneligibilityReason | null> {
+  if (args.cluster !== LoyalCluster.MainnetBeta) {
+    // The Timescale reserve feed only tracks mainnet reserves.
+    return null;
+  }
+
+  const observations = await getLatestReserveObservationsByReserve({
+    reserves: [args.reserve],
+  });
+  if (observations === null) {
+    // Feed not configured in this environment — never brick deposits over a
+    // config gap; the confirm-side alert still surfaces bad targets.
+    return null;
+  }
+
+  const observation = observations.find(
+    (candidate) => candidate.reserve === args.reserve
+  );
+  if (!observation) {
+    return "unsampled_reserve";
+  }
+  if (
+    observation.totalSupplyUsdEstimate <= MIN_ELIGIBLE_RESERVE_TOTAL_SUPPLY_USD
+  ) {
+    return "below_liquidity_floor";
+  }
+  return null;
+}
+
+// Deposit-routing wrapper around earnReserveTargetFromActivePosition:
+// refuses to follow a position into an ineligible reserve and lets the
+// caller fall through to the default main-market target instead.
+// ponytail: fallback is the hardcoded MAIN target, not the best eligible
+// same-market sibling — nobody currently holds an ineligible reserve, and
+// full exits unwind every market since #482.
+export async function resolveEligibleEarnDepositTarget(args: {
+  cluster: LoyalCluster;
+  logTag: string;
+  position: Pick<
+    UserYieldPositionRecord,
+    "currentLiquidityMint" | "currentMarket" | "currentReserve"
+  >;
+}): Promise<EarnUsdcReserveTarget | null> {
+  const target = earnReserveTargetFromActivePosition(args.position);
+  const ineligibility = await findEarnReserveTargetIneligibility({
+    cluster: args.cluster,
+    reserve: target.reserve.toBase58(),
+  });
+  if (!ineligibility) {
+    return target;
+  }
+
+  console.error(
+    `[${args.logTag}] refusing ineligible Earn deposit target; falling back to the default reserve`,
+    {
+      cluster: args.cluster,
+      market: target.market.toBase58(),
+      reason: ineligibility,
+      reserve: target.reserve.toBase58(),
+    }
+  );
+  return null;
 }

--- a/scripts/backfill-reserve-apy-from-kamino-api.ts
+++ b/scripts/backfill-reserve-apy-from-kamino-api.ts
@@ -1,0 +1,245 @@
+import { neon } from "@neondatabase/serverless";
+
+// Backfills kamino.reserve_apy_backfill (sidecar to the worker-owned
+// kamino.reserve_updates ingestion stream — we never write to that table)
+// from Kamino's public reserve metrics/history REST API. Used for reserves
+// the indexer never sampled (e.g. hidden reserves a position historically
+// held), so the earnings coverage gate can compute instead of returning
+// apy_coverage_incomplete forever. Read-path union lives in
+// frontend/src/lib/kamino/timescale-reserve-client.server.ts
+// (getReserveApyHistorySamplesForReserves).
+
+const TIMESCALE_URL_ENV_NAME = "TIMESCALEDB_URL";
+// Mirrors DEFAULT_MAX_SUPPLY_APY in timescale-reserve-client.server.ts —
+// rows at/above this are ignored by the read path, so refuse to store them.
+const MAX_SUPPLY_APY = 0.5;
+const MAX_GAP_HOURS_TOLERATED = 36;
+
+const CREATE_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS kamino.reserve_apy_backfill (
+  reserve text NOT NULL,
+  observed_at timestamptz NOT NULL,
+  supply_apy double precision NOT NULL,
+  market text,
+  source text NOT NULL DEFAULT 'kamino_api_backfill',
+  inserted_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (reserve, observed_at)
+)`;
+
+type ParsedArgs = {
+  end: Date;
+  execute: boolean;
+  market: string;
+  reserve: string;
+  start: Date;
+};
+
+type HistoryPoint = {
+  observedAt: Date;
+  status: string;
+  supplyApy: number;
+};
+
+function printHelpAndExit(): never {
+  console.log(`Usage:
+  op run --env-file=.env.1password -- sh -c 'bun run scripts/backfill-reserve-apy-from-kamino-api.ts \\
+      --market <MARKET_PUBKEY> --reserve <RESERVE_PUBKEY> \\
+      --start 2026-06-25T00:00:00Z --end 2026-07-10T00:00:00Z [--execute]'
+
+Required:
+  --market <PUBKEY>    Kamino lending market of the reserve.
+  --reserve <PUBKEY>   Reserve to backfill.
+  --start <ISO>        Window start (inclusive).
+  --end <ISO>          Window end (inclusive).
+
+Options:
+  --execute            Create the sidecar table if missing and upsert rows.
+                       Omit for a dry-run report.
+
+Environment:
+  ${TIMESCALE_URL_ENV_NAME}   kamino_timescale database URL (required only with --execute).
+`);
+  process.exit(0);
+}
+
+function readFlagValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function parseDateArg(value: string, flag: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${flag} is not a valid ISO timestamp: ${value}`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv = process.argv.slice(2)): ParsedArgs {
+  let execute = false;
+  let market: string | null = null;
+  let reserve: string | null = null;
+  let start: Date | null = null;
+  let end: Date | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        printHelpAndExit();
+        break;
+      case "--execute":
+        execute = true;
+        break;
+      case "--market":
+        market = readFlagValue(argv, index, arg);
+        index += 1;
+        break;
+      case "--reserve":
+        reserve = readFlagValue(argv, index, arg);
+        index += 1;
+        break;
+      case "--start":
+        start = parseDateArg(readFlagValue(argv, index, arg), arg);
+        index += 1;
+        break;
+      case "--end":
+        end = parseDateArg(readFlagValue(argv, index, arg), arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!market || !reserve || !start || !end) {
+    throw new Error(
+      "--market, --reserve, --start and --end are all required. See --help."
+    );
+  }
+  if (end.getTime() <= start.getTime()) {
+    throw new Error("--end must be after --start.");
+  }
+  return { end, execute, market, reserve, start };
+}
+
+async function fetchHistory(args: ParsedArgs): Promise<HistoryPoint[]> {
+  const url =
+    `https://api.kamino.finance/kamino-market/${args.market}` +
+    `/reserves/${args.reserve}/metrics/history` +
+    `?env=mainnet-beta&start=${args.start.toISOString()}&end=${args.end.toISOString()}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Kamino history API responded ${response.status} for ${url}`
+    );
+  }
+  const body = (await response.json()) as {
+    history?: {
+      metrics?: { status?: unknown; supplyInterestAPY?: unknown };
+      timestamp?: unknown;
+    }[];
+    reserve?: unknown;
+  };
+  if (body.reserve !== args.reserve || !Array.isArray(body.history)) {
+    throw new Error("Kamino history API returned an unexpected shape.");
+  }
+
+  const points: HistoryPoint[] = [];
+  for (const entry of body.history) {
+    const observedAt = new Date(String(entry.timestamp));
+    const supplyApy = Number(entry.metrics?.supplyInterestAPY);
+    if (Number.isNaN(observedAt.getTime()) || !Number.isFinite(supplyApy)) {
+      throw new Error(
+        `Malformed history point: ${JSON.stringify(entry).slice(0, 200)}`
+      );
+    }
+    if (supplyApy < 0 || supplyApy >= MAX_SUPPLY_APY) {
+      throw new Error(
+        `supplyInterestAPY ${supplyApy} at ${observedAt.toISOString()} is outside [0, ${MAX_SUPPLY_APY}) — refusing to store a row the read path would ignore.`
+      );
+    }
+    points.push({
+      observedAt,
+      status: String(entry.metrics?.status ?? "unknown"),
+      supplyApy,
+    });
+  }
+  points.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+  return points;
+}
+
+function reportGaps(points: HistoryPoint[]): number {
+  let maxGapMs = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    const gap =
+      points[index]!.observedAt.getTime() -
+      points[index - 1]!.observedAt.getTime();
+    maxGapMs = Math.max(maxGapMs, gap);
+  }
+  return maxGapMs;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const points = await fetchHistory(args);
+  if (points.length === 0) {
+    throw new Error("Kamino history API returned zero points for the window.");
+  }
+
+  const maxGapHours = reportGaps(points) / (60 * 60 * 1000);
+  const statuses = [...new Set(points.map((point) => point.status))];
+  console.log(`reserve:   ${args.reserve}`);
+  console.log(`market:    ${args.market}`);
+  console.log(`points:    ${points.length}`);
+  console.log(
+    `range:     ${points[0]!.observedAt.toISOString()} → ${points.at(-1)!.observedAt.toISOString()}`
+  );
+  console.log(`max gap:   ${maxGapHours.toFixed(2)}h`);
+  console.log(`statuses:  ${statuses.join(", ")}`);
+  console.log(
+    `apy range: ${Math.min(...points.map((p) => p.supplyApy))} → ${Math.max(...points.map((p) => p.supplyApy))}`
+  );
+  if (maxGapHours > MAX_GAP_HOURS_TOLERATED) {
+    throw new Error(
+      `Max gap ${maxGapHours.toFixed(2)}h exceeds the ${MAX_GAP_HOURS_TOLERATED}h coverage tolerance — the backfill would not heal the earnings gate.`
+    );
+  }
+
+  if (!args.execute) {
+    console.log("\nDry-run only. Re-run with --execute to write.");
+    return;
+  }
+
+  const databaseUrl = process.env[TIMESCALE_URL_ENV_NAME];
+  if (!databaseUrl) {
+    throw new Error(`${TIMESCALE_URL_ENV_NAME} is required with --execute.`);
+  }
+  const sql = neon(databaseUrl);
+  await sql.query(CREATE_TABLE_SQL);
+  const inserted = await sql.query(
+    `INSERT INTO kamino.reserve_apy_backfill (reserve, observed_at, supply_apy, market)
+     SELECT $1, observed_at, supply_apy, $2
+     FROM unnest($3::timestamptz[], $4::double precision[]) AS t(observed_at, supply_apy)
+     ON CONFLICT (reserve, observed_at) DO NOTHING
+     RETURNING observed_at`,
+    [
+      args.reserve,
+      args.market,
+      points.map((point) => point.observedAt.toISOString()),
+      points.map((point) => point.supplyApy),
+    ]
+  );
+  console.log(
+    `\nInserted ${inserted.length} new rows (${points.length - inserted.length} already present).`
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
Earn deposit routing now refuses reserve targets the indexer has never sampled or that sit below the liquidity floor, falling back to the default reserve, with a confirm-side alert instead of a gate (ASK-1764). The earnings read path additionally unions the kamino.reserve_apy_backfill sidecar table so positions that historically held an untracked reserve can compute their history.

https://claude.ai/code/session_01FhCgUGo9JDSEonGqw9S2ZU