### PR TITLE
fix(earn): keep non-final full-exit steps from claiming the final-exit label

### DIFF
--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
@@ -104,6 +104,7 @@ mock.module("@/lib/yield-optimization/earn-reserve-target.server", () => ({
       targetReserve: input.targetReserve,
     };
   },
+  findEarnReserveTargetIneligibility: async () => null,
 }));
 
 mock.module(
@@ -172,6 +173,7 @@ mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
   findActiveYieldRoutePolicy: async () => {
     throw new Error("findActiveYieldRoutePolicy was not expected.");
   },
+  findActiveYieldRoutePolicyPair: async () => null,
   findEarnCleanupVaultState: async () => ({
     routePolicy: {},
     setupPolicy: null,

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
@@ -404,7 +404,7 @@ describe("yield deposit repository idempotency", () => {
     expect(updateCalls).toHaveLength(0);
   });
 
-  test("records a zero-balance full withdrawal without closing position or policy state", async () => {
+  function createRecordedWithdrawalDependencies() {
     const position = createPosition();
     const reserveRow = {
       amountRaw: BigInt(1000),
@@ -531,30 +531,39 @@ describe("yield deposit repository idempotency", () => {
       now: () => new Date("2026-06-02T00:00:00.000Z"),
     };
 
-    const result = await recordConfirmedYieldWithdrawal(
-      createWithdrawalInput({
+    return { dependencies, insertedValues, updateSets };
+  }
+
+  const reserveWithdrawalOverrides = {
+    accountingReserve: "reserve",
+    confirmedReserveDebitAmountRaw: BigInt(1000),
+    mode: "full" as const,
+    reserveWithdrawals: [
+      {
         accountingReserve: "reserve",
-        confirmedReserveDebitAmountRaw: BigInt(1000),
-        mode: "full",
-        reserveWithdrawals: [
-          {
-            accountingReserve: "reserve",
-            collateralAta: "collateral",
-            executionMarket: "market",
-            executionReserve: "reserve",
-            kaminoWithdrawAmountRaw: "1000",
-            liquidityMint: "usdc",
-            market: "market",
-            reserve: "reserve",
-            sourceAmountRaw: "1000",
-            sourceId: "reserve",
-            vaultCollateralAta: "collateral",
-          },
-        ],
-        sourceAmountRaw: BigInt(1000),
+        collateralAta: "collateral",
+        executionMarket: "market",
+        executionReserve: "reserve",
+        kaminoWithdrawAmountRaw: "1000",
+        liquidityMint: "usdc",
+        market: "market",
+        reserve: "reserve",
+        sourceAmountRaw: "1000",
         sourceId: "reserve",
-        sourceType: "reserve",
-      }),
+        vaultCollateralAta: "collateral",
+      },
+    ],
+    sourceAmountRaw: BigInt(1000),
+    sourceId: "reserve",
+    sourceType: "reserve" as const,
+  };
+
+  test("records a zero-balance full withdrawal without closing position or policy state", async () => {
+    const { dependencies, insertedValues, updateSets } =
+      createRecordedWithdrawalDependencies();
+
+    const result = await recordConfirmedYieldWithdrawal(
+      createWithdrawalInput(reserveWithdrawalOverrides),
       dependencies as never
     );
 
@@ -582,6 +591,39 @@ describe("yield deposit repository idempotency", () => {
         expect.objectContaining({
           active: false,
         }),
+      ])
+    );
+  });
+
+  test("classifies a non-final full-exit step as a partial withdrawal even at zero remaining balance", async () => {
+    // Multi-market exit: the read-model can be blind to the other market's
+    // funds, so a step that is not the final one must never write
+    // `withdrawal_full` (ASK-1765).
+    const { dependencies, insertedValues } =
+      createRecordedWithdrawalDependencies();
+
+    const result = await recordConfirmedYieldWithdrawal(
+      createWithdrawalInput({
+        ...reserveWithdrawalOverrides,
+        isFinalStep: false,
+        stepCount: 2,
+        stepIndex: 0,
+      }),
+      dependencies as never
+    );
+
+    expect(result.principalAmountRaw).toBe(BigInt(0));
+    expect(insertedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "withdrawal_partial",
+          principalDeltaRaw: BigInt(-1000),
+        }),
+      ])
+    );
+    expect(insertedValues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "withdrawal_full" }),
       ])
     );
   });

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -1399,8 +1399,13 @@ async function resolveWithdrawalSource(
     // This is an accounting event classification only. It never authorizes
     // closing the position, vault, or policies; cleanup owns that transition
     // after a minContextSlot-safe chain-wide zero proof.
+    // A non-final step of a multi-market full exit proves funds survive in
+    // another market even when the reserve read-model has no row for it
+    // (ASK-1765), so it must never claim the final-exit label — a false
+    // `withdrawal_full` zeroes reconstructed principal for good.
     isFinalExit:
       input.mode === "full" &&
+      input.isFinalStep !== false &&
       remainingReserveAmountRaw <= BigInt(0) &&
       remainingIdleRaw < EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
     remainingIdleAmountRaw: remainingIdleRaw + reserveVaultIdleDeltaRaw,


### PR DESCRIPTION
A non-final step of a multi-step full Earn exit now records withdrawal_partial instead of withdrawal_full, since a later step is proof that funds survive in another market even when the reserve read model has no row for it — a false full-exit event permanently breaks the earnings history reconstruction (ASK-1765). Genuine final steps are unchanged, and the partial delta math already matches the position-row update exactly.

https://claude.ai/code/session_01FhCgUGo9JDSEonGqw9S2ZU