### PR TITLE
fix(earn): refuse autodeposit setup adoption and close of non-sweep policies

### DIFF
--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -362,6 +362,50 @@ function createSerializedEarnPolicyAccount(seed = new BN(1)) {
   };
 }
 
+// Sweep policies carry subscriptions-program instruction constraints — the
+// on-chain fingerprint the autodeposit setup/close guards verify (ASK-1802).
+function createSerializedSweepPolicyAccount(seed = new BN(3)) {
+  const [data] = Policy.fromArgs({
+    bump: 255,
+    expiration: null,
+    policyState: {
+      __kind: "ProgramInteraction",
+      fields: [
+        {
+          accountIndex: 1,
+          instructionsConstraints: [
+            {
+              programId: SUBSCRIPTIONS_PROGRAM_ID,
+              accountConstraints: [],
+              dataConstraints: [],
+            },
+          ],
+          postHook: null,
+          preHook: null,
+          spendingLimits: [],
+        },
+      ],
+    },
+    rentCollector: walletAddress,
+    seed,
+    settings: settingsPda,
+    signers: [],
+    staleTransactionIndex: new BN(0),
+    start: new BN(0),
+    threshold: 1,
+    timeLock: 0,
+    transactionIndex: new BN(0),
+  }).serialize();
+
+  return {
+    data,
+    executable: false,
+    lamports: 1,
+    owner: programId,
+    rentEpoch: 0,
+  };
+}
+
 function createSerializedSettingsAccount(policySeed: BN | null = null) {
   const [data] = Settings.fromArgs({
     accountUtilization: 0,
@@ -1482,6 +1526,9 @@ describe("prepareEarnUsdcWithdraw", () => {
           rentEpoch: 0,
         };
       }
+      if (account.equals(autodepositPolicyAccount)) {
+        return createSerializedSweepPolicyAccount();
+      }
       return createSerializedEarnPolicyAccount();
     });
     const client = createSmartAccountVaultsClient({
@@ -1581,6 +1628,9 @@ describe("prepareEarnUsdcWithdraw", () => {
           owner: TOKEN_PROGRAM_ID,
           rentEpoch: 0,
         };
+      }
+      if (account.equals(autodepositPolicyAccount)) {
+        return createSerializedSweepPolicyAccount();
       }
       return createSerializedEarnPolicyAccount();
     });
@@ -1863,6 +1913,9 @@ describe("prepareEarnUsdcWithdraw", () => {
           rentEpoch: 0,
         };
       }
+      if (account.equals(autodepositPolicyAccount)) {
+        return createSerializedSweepPolicyAccount();
+      }
       return createSerializedEarnPolicyAccount();
     });
     const simulateTransaction = mock(async () => ({
@@ -1973,7 +2026,11 @@ describe("prepareEarnUsdcWithdraw", () => {
   test("splits autodeposit teardown from idle full withdraw cleanup", async () => {
     const client = createSmartAccountVaultsClient({
       connection: {
-        getAccountInfo: mock(async () => createSerializedEarnPolicyAccount()),
+        getAccountInfo: mock(async (account: PublicKey) =>
+          account.equals(autodepositPolicyAccount)
+            ? createSerializedSweepPolicyAccount()
+            : createSerializedEarnPolicyAccount()
+        ),
         getLatestBlockhash: mock(async () => ({
           blockhash: "11111111111111111111111111111111",
           lastValidBlockHeight: 1,
@@ -2522,7 +2579,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
       if (nonSettingsLookupCount === 2) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       return null;
     });
@@ -2645,7 +2702,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
     });
     const getMultipleAccountsInfo = mock(async (addresses: PublicKey[]) =>
       addresses.map((_, index) =>
-        index === 0 ? createSerializedEarnPolicyAccount() : null
+        index === 0 ? createSerializedSweepPolicyAccount() : null
       )
     );
     const client = createSmartAccountVaultsClient({
@@ -2694,7 +2751,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
       if (nonSettingsLookupCount === 2) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (nonSettingsLookupCount === 3) {
         return createSerializedRecurringDelegationAccount();
@@ -2733,7 +2790,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
       if (nonSettingsLookupCount === 2) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (nonSettingsLookupCount === 3) {
         return createSerializedRecurringDelegationAccount();
@@ -2789,7 +2846,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
       if (nonSettingsLookupCount === 2) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (nonSettingsLookupCount === 3) {
         return createSerializedRecurringDelegationAccount();
@@ -2845,7 +2902,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
         return createSerializedSubscriptionAuthorityAccount(BigInt(7));
       }
       if (nonSettingsLookupCount === 2) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (nonSettingsLookupCount === 3) {
         return createSerializedRecurringDelegationAccount();
@@ -2896,7 +2953,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
     );
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(policyAccount)) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (address.equals(recurringDelegation)) {
         return createSerializedRecurringDelegationAccount();
@@ -2954,7 +3011,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
     const foreignDelegate = new PublicKey("1111111111111111111111111111111C");
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(policyAccount)) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       if (address.equals(recurringDelegation)) {
         return createSerializedRecurringDelegationAccount();
@@ -2997,7 +3054,7 @@ describe("prepareEarnUsdcAutodeposit", () => {
   test("omits the delegation revoke when the delegation was never created", async () => {
     const getAccountInfo = mock(async (address: PublicKey) => {
       if (address.equals(policyAccount)) {
-        return createSerializedEarnPolicyAccount();
+        return createSerializedSweepPolicyAccount();
       }
       return null;
     });
@@ -3021,6 +3078,36 @@ describe("prepareEarnUsdcAutodeposit", () => {
     // policy-close instruction remains.
     expect(result.prepared.instructions).toHaveLength(1);
     expectSyncExecutionUsesSettingsConsensus(result.prepared.instructions[0]);
+  });
+
+  // ASK-1802 regression: a seed collision can leave the autodeposit row
+  // pointing at the wallet's live Earn ROUTE policy; closing it stranded a
+  // user's Earn funds behind `missing_earn_policy`.
+  test("refuses to close a policy that is not an Autodeposit sweep policy", async () => {
+    const getAccountInfo = mock(async (address: PublicKey) => {
+      if (address.equals(policyAccount)) {
+        return createSerializedEarnPolicyAccount();
+      }
+      return null;
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: { getAccountInfo } as never,
+      programId,
+    });
+
+    await expect(
+      client.prepareEarnUsdcAutodepositClose({
+        settingsPda,
+        walletAddress,
+        feePayer,
+        signer: walletAddress,
+        policySigner: backendSigner,
+        policy: policyAccount,
+        recurringDelegation: new PublicKey("11111111111111111111111111111116"),
+      })
+    ).rejects.toThrow(
+      "Refusing to close a policy that is not an Autodeposit sweep policy."
+    );
   });
 
   test("builds pull execution with the backend policy signer", async () => {

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -3807,6 +3807,27 @@ function compareProposalSnapshotsByRecency(
   return left.proposalAddress.localeCompare(right.proposalAddress);
 }
 
+// An account sitting at a derived autodeposit policy PDA is only safe to
+// adopt (setup) or close when it really is a subscription-sweep policy. A
+// stale Settings read can resolve a policy seed that collides with the
+// wallet's live Earn ROUTE policy — closing that one strands the wallet's
+// Earn funds behind `missing_earn_policy` (ASK-1802). Sweep policies are
+// ProgramInteraction policies whose every instruction constraint targets the
+// subscriptions program; route policies never do.
+function isSubscriptionSweepPolicy(policy: Policy): boolean {
+  if (policy.policyState.__kind !== "ProgramInteraction") {
+    return false;
+  }
+  const interaction = policy.policyState.fields[0];
+  return (
+    interaction.accountIndex === EARN_DEPOSIT_VAULT_INDEX &&
+    interaction.instructionsConstraints.length > 0 &&
+    interaction.instructionsConstraints.every((constraint) =>
+      constraint.programId.equals(SUBSCRIPTIONS_PROGRAM_ID)
+    )
+  );
+}
+
 function resolveNextPolicySeed(settings: {
   policySeed: Parameters<typeof toBigInt>[0] | null;
 }) {
@@ -8767,6 +8788,11 @@ export function createSmartAccountVaultsClient(
   type EarnAutodepositSetupAccountState = {
     delegationAccount: AccountInfo<Buffer> | null;
     policyAccountExists: boolean;
+    // The raw policy account when this run actually read it from RPC —
+    // undefined on the account-evidence fast path (the policy was created by
+    // an earlier stage of this same flow). Lets the collision guard validate
+    // without an extra fetch.
+    policyAccountInfo?: AccountInfo<Buffer> | null;
     walletUsdcAtaAccount: AccountInfo<Buffer> | null;
     vaultUsdcAtaExists: boolean | undefined;
   };
@@ -9079,6 +9105,7 @@ export function createSmartAccountVaultsClient(
           delegationAccount:
             accountInfos.get(recurringDelegationAddress) ?? null,
           policyAccountExists: Boolean(accountInfos.get(policyAccountAddress)),
+          policyAccountInfo: accountInfos.get(policyAccountAddress) ?? null,
           walletUsdcAtaAccount:
             accountInfos.get(walletUsdcAta.toBase58()) ?? null,
           vaultUsdcAtaExists: Boolean(accountInfos.get(vaultUsdcAtaAddress)),
@@ -9113,6 +9140,24 @@ export function createSmartAccountVaultsClient(
         : readSubscriptionAuthorityInitId(authorityAccount);
     if (expectedSubscriptionAuthorityInitId === null) {
       throw new Error("Subscription authority init id is unavailable.");
+    }
+    // The stage machine treats an existing account at the derived policy PDA
+    // as "policy stage done". When a stale Settings read resolves a colliding
+    // seed, that account is the wallet's live Earn ROUTE policy — adopting it
+    // half-lands the setup and later feeds the route policy to the close
+    // flow, which destroys the wallet's Earn access (ASK-1802). Only adopt an
+    // account that verifies as a sweep policy. (Skipped on the
+    // account-evidence fast path — an earlier stage of this flow created the
+    // policy, so there is nothing foreign to adopt.)
+    if (accountState.policyAccountInfo) {
+      const [existingPolicy] = Policy.fromAccountInfo(
+        accountState.policyAccountInfo
+      );
+      if (!isSubscriptionSweepPolicy(existingPolicy)) {
+        throw new Error(
+          `Autodeposit policy seed ${policySeed} collides with an existing non-Autodeposit policy — the settings read is stale. Retry the setup.`
+        );
+      }
     }
     const policyExistsForPlanning =
       options.assumePolicyExists || accountState.policyAccountExists;
@@ -9509,6 +9554,23 @@ export function createSmartAccountVaultsClient(
       settingsPda: args.settingsPda,
       accountIndex: EARN_DEPOSIT_VAULT_INDEX,
     })[0];
+    // The close input's `policy` travels through DB/state rows that a seed
+    // collision can leave pointing at the wallet's live Earn ROUTE policy
+    // (see the setup-stage guard). Closing that policy strands the wallet's
+    // Earn funds behind `missing_earn_policy` (ASK-1802), so verify the
+    // on-chain shape first. A missing account passes through — the close
+    // then only revokes the delegation and the token approval.
+    const policyAccountInfo = await config.connection.getAccountInfo(
+      args.policy
+    );
+    if (policyAccountInfo) {
+      const [policyToClose] = Policy.fromAccountInfo(policyAccountInfo);
+      if (!isSubscriptionSweepPolicy(policyToClose)) {
+        throw new Error(
+          "Refusing to close a policy that is not an Autodeposit sweep policy."
+        );
+      }
+    }
     const closePolicy = await prepareClosePoliciesSync({
       settingsPda: args.settingsPda,
       feePayer: args.feePayer,


### PR DESCRIPTION
Guards the autodeposit SDK flows against the ASK-1802 seed-collision shape: setup no longer silently adopts a foreign account sitting at the derived policy PDA, and close refuses to destroy a policy that isn't a subscription-sweep policy (the ASK-1801 incident closed a user's live Earn route policy). Includes a regression test reproducing the incident.

Linear: ASK-1802