### PR TITLE
feat(observability): ingest mobile app errors into ClickStack

### DIFF
--- a/frontend/src/app/api/observability/mobile/errors/route.ts
+++ b/frontend/src/app/api/observability/mobile/errors/route.ts
@@ -1,0 +1,85 @@
+import {
+  InvalidObservabilityEnvelopeError,
+  MAX_OBSERVABILITY_REQUEST_BYTES,
+  parseMobileErrorEnvelope,
+} from "@/features/observability/error-contract";
+import { consumeBrowserErrorRateLimit } from "@/features/observability/rate-limit.server";
+import { reportMobileErrorEnvelope } from "@/features/observability/server";
+
+export const runtime = "nodejs";
+
+const NO_STORE_HEADERS = { "cache-control": "no-store" } as const;
+
+function jsonResponse(
+  body: Readonly<Record<string, boolean | string>>,
+  status: number
+): Response {
+  return Response.json(body, { headers: NO_STORE_HEADERS, status });
+}
+
+// Mirror image of the browser route's same-origin gate: native fetch never
+// sends Origin or Sec-Fetch-Site, while browsers always send them on
+// cross-site POSTs — so their presence marks traffic this route is not for.
+function isNativeAppRequest(request: Request): boolean {
+  return (
+    !request.headers.get("origin") && !request.headers.get("sec-fetch-site")
+  );
+}
+
+function isJsonRequest(request: Request): boolean {
+  return (
+    request.headers.get("content-type")?.split(";", 1)[0]?.trim() ===
+    "application/json"
+  );
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isInteger(parsedLength) || parsedLength < 0) {
+      throw new InvalidObservabilityEnvelopeError();
+    }
+    if (parsedLength > MAX_OBSERVABILITY_REQUEST_BYTES) {
+      throw new RangeError("Observability request is too large.");
+    }
+  }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength === 0) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+  if (body.byteLength > MAX_OBSERVABILITY_REQUEST_BYTES) {
+    throw new RangeError("Observability request is too large.");
+  }
+
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(body);
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isNativeAppRequest(request)) {
+    return jsonResponse({ error: "forbidden" }, 403);
+  }
+  if (!isJsonRequest(request)) {
+    return jsonResponse({ error: "invalid_content_type" }, 415);
+  }
+  if (!consumeBrowserErrorRateLimit(request)) {
+    return jsonResponse({ error: "rate_limited" }, 429);
+  }
+
+  try {
+    const envelope = parseMobileErrorEnvelope(await readJsonBody(request));
+    await reportMobileErrorEnvelope(envelope);
+    return jsonResponse({ accepted: true }, 202);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return jsonResponse({ error: "payload_too_large" }, 413);
+    }
+    return jsonResponse({ error: "invalid_request" }, 400);
+  }
+}

--- a/frontend/src/features/observability/error-contract.ts
+++ b/frontend/src/features/observability/error-contract.ts
@@ -9,6 +9,9 @@ const MAX_PATHNAME_LENGTH = 256;
 const MAX_RAW_FIELD_LENGTH = 12 * 1024;
 const MAX_EVENT_AGE_MS = 60 * 60 * 1000;
 const MAX_EVENT_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const MAX_RELEASE_LENGTH = 80;
+const MAX_ENVIRONMENT_LENGTH = 32;
+const RESOURCE_VALUE_PATTERN = /[^A-Za-z0-9._-]/g;
 
 const URL_QUERY_VALUE_PATTERN = /([?&][^=\s&#]{1,64}=)[^&#\s]*/g;
 const BEARER_VALUE_PATTERN = /\bbearer\s+[^\s,;]+/gi;
@@ -36,15 +39,37 @@ export const BROWSER_ERROR_OPERATIONS = [
 
 export type BrowserErrorOperation = (typeof BROWSER_ERROR_OPERATIONS)[number];
 
+export const MOBILE_ERROR_OPERATIONS = [
+  "mobile.global_error",
+  "mobile.fatal_error",
+  "mobile.unhandled_rejection",
+] as const;
+
+export type MobileErrorOperation = (typeof MOBILE_ERROR_OPERATIONS)[number];
+
 export type ServerErrorOperation = "next.request.error";
 
-export type ObservabilityRuntime = "browser" | "node";
+export type ObservabilityRuntime = "browser" | "mobile" | "node";
 
 export type BrowserErrorEnvelope = {
   message: string;
   name: string;
   operation: BrowserErrorOperation;
   pathname: string;
+  stack?: string;
+  timestamp: string;
+};
+
+// Mobile envelopes carry their own release/environment: the app fleet mixes
+// binary versions and OTA updates, so the server's Vercel release would be
+// meaningless for them.
+export type MobileErrorEnvelope = {
+  environment: string;
+  message: string;
+  name: string;
+  operation: MobileErrorOperation;
+  pathname: string;
+  release: string;
   stack?: string;
   timestamp: string;
 };
@@ -57,11 +82,11 @@ export type NormalizedErrorEvent = {
     stack?: string;
   };
   method?: string;
-  operation: BrowserErrorOperation | ServerErrorOperation;
+  operation: BrowserErrorOperation | MobileErrorOperation | ServerErrorOperation;
   pathname: string;
   release: string;
   runtime: ObservabilityRuntime;
-  serviceName: "loyal-frontend";
+  serviceName: "loyal-frontend" | "loyal-mobile";
   timestamp: string;
 };
 
@@ -183,6 +208,15 @@ function isAllowedBrowserOperation(
   );
 }
 
+function isAllowedMobileOperation(
+  value: unknown
+): value is MobileErrorOperation {
+  return (
+    typeof value === "string" &&
+    MOBILE_ERROR_OPERATIONS.some((operation) => operation === value)
+  );
+}
+
 function readRequiredString(
   record: Record<string, unknown>,
   key: string
@@ -198,31 +232,34 @@ function readRequiredString(
   return value;
 }
 
-export function parseBrowserErrorEnvelope(
-  value: unknown,
-  now = Date.now()
-): BrowserErrorEnvelope {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+// Release/environment identify the reporting build in OTLP resource
+// attributes; restrict them to a safe identifier alphabet.
+function readResourceValue(
+  record: Record<string, unknown>,
+  key: string,
+  maxLength: number
+): string {
+  const normalized = readRequiredString(record, key)
+    .replace(RESOURCE_VALUE_PATTERN, "_")
+    .slice(0, maxLength);
+  if (normalized.length === 0) {
     throw new InvalidObservabilityEnvelopeError();
   }
+  return normalized;
+}
 
-  const record = value as Record<string, unknown>;
-  const allowedKeys = new Set([
-    "message",
-    "name",
-    "operation",
-    "pathname",
-    "stack",
-    "timestamp",
-  ]);
-  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
-    throw new InvalidObservabilityEnvelopeError();
-  }
+type CommonErrorEnvelopeFields = {
+  message: string;
+  name: string;
+  pathname: string;
+  stack?: string;
+  timestamp: string;
+};
 
-  if (!isAllowedBrowserOperation(record.operation)) {
-    throw new InvalidObservabilityEnvelopeError();
-  }
-
+function parseCommonErrorEnvelopeFields(
+  record: Record<string, unknown>,
+  now: number
+): CommonErrorEnvelopeFields {
   const rawTimestamp = readRequiredString(record, "timestamp");
   const timestampMs = Date.parse(rawTimestamp);
   if (
@@ -264,10 +301,79 @@ export function parseBrowserErrorEnvelope(
   return {
     message,
     name,
-    operation: record.operation,
     pathname,
     ...(stack ? { stack } : {}),
     timestamp: rawTimestamp,
+  };
+}
+
+export function parseBrowserErrorEnvelope(
+  value: unknown,
+  now = Date.now()
+): BrowserErrorEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "message",
+    "name",
+    "operation",
+    "pathname",
+    "stack",
+    "timestamp",
+  ]);
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  if (!isAllowedBrowserOperation(record.operation)) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  return {
+    ...parseCommonErrorEnvelopeFields(record, now),
+    operation: record.operation,
+  };
+}
+
+export function parseMobileErrorEnvelope(
+  value: unknown,
+  now = Date.now()
+): MobileErrorEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "environment",
+    "message",
+    "name",
+    "operation",
+    "pathname",
+    "release",
+    "stack",
+    "timestamp",
+  ]);
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  if (!isAllowedMobileOperation(record.operation)) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+
+  return {
+    ...parseCommonErrorEnvelopeFields(record, now),
+    environment: readResourceValue(
+      record,
+      "environment",
+      MAX_ENVIRONMENT_LENGTH
+    ),
+    operation: record.operation,
+    release: readResourceValue(record, "release", MAX_RELEASE_LENGTH),
   };
 }
 

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -71,7 +71,10 @@ export function buildOtlpErrorPayload(event: NormalizedErrorEvent): unknown {
               },
             ],
             scope: {
-              name: "loyal.frontend.errors",
+              name:
+                event.serviceName === "loyal-mobile"
+                  ? "loyal.mobile.errors"
+                  : "loyal.frontend.errors",
               version: "1",
             },
           },

--- a/frontend/src/features/observability/server.ts
+++ b/frontend/src/features/observability/server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import {
   type BrowserErrorEnvelope,
+  type MobileErrorEnvelope,
   type NormalizedErrorEvent,
   normalizeTelemetryPathname,
   sanitizeTelemetryText,
@@ -144,6 +145,31 @@ export async function reportBrowserErrorEnvelope(
       release: getObservabilityRelease(),
       runtime: "browser",
       serviceName: "loyal-frontend",
+      timestamp: envelope.timestamp,
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function reportMobileErrorEnvelope(
+  envelope: MobileErrorEnvelope
+): Promise<boolean> {
+  try {
+    return await exportErrorEvent({
+      // The device reports its own release/environment — the app fleet mixes
+      // binary versions and OTA updates that Vercel's release can't describe.
+      deploymentEnvironment: envelope.environment,
+      exception: {
+        message: envelope.message,
+        name: envelope.name,
+        ...(envelope.stack ? { stack: envelope.stack } : {}),
+      },
+      operation: envelope.operation,
+      pathname: envelope.pathname,
+      release: envelope.release,
+      runtime: "mobile",
+      serviceName: "loyal-mobile",
       timestamp: envelope.timestamp,
     });
   } catch {


### PR DESCRIPTION
Adds a mobile ingest twin at /api/observability/mobile/errors (native-app origin gate, shared rate limiter, strict envelope parse) plus mobile error operations and a MobileErrorEnvelope carrying device release/environment, reported to ClickStack as service loyal-mobile. Server half of ASK-1804 — the RN reporter ships separately from the mobile branch and needs this deployed first.