### PR TITLE
feat(observability): ingest mobile lifecycle flow events

### DIFF
--- a/frontend/src/app/api/observability/mobile/events/route.ts
+++ b/frontend/src/app/api/observability/mobile/events/route.ts
@@ -1,0 +1,108 @@
+import { deriveObservabilityActorId } from "@/features/observability/actor";
+import {
+  InvalidLifecycleEnvelopeError,
+  MAX_LIFECYCLE_REQUEST_BYTES,
+  parseMobileLifecycleEnvelope,
+} from "@/features/observability/lifecycle-contract";
+import { consumeBrowserLifecycleRateLimit } from "@/features/observability/rate-limit.server";
+import {
+  getObservabilityDeploymentEnvironment,
+  reportMobileLifecycleEnvelope,
+} from "@/features/observability/server";
+
+export const runtime = "nodejs";
+
+const NO_STORE_HEADERS = { "cache-control": "no-store" } as const;
+
+function jsonResponse(
+  body: Readonly<Record<string, boolean | string>>,
+  status: number
+): Response {
+  return Response.json(body, { headers: NO_STORE_HEADERS, status });
+}
+
+// Mirror image of the browser route's same-origin gate: native fetch never
+// sends Origin or Sec-Fetch-Site, while browsers always send them on
+// cross-site POSTs — so their presence marks traffic this route is not for.
+function isNativeAppRequest(request: Request): boolean {
+  return (
+    !request.headers.get("origin") && !request.headers.get("sec-fetch-site")
+  );
+}
+
+function isJsonRequest(request: Request): boolean {
+  return (
+    request.headers.get("content-type")?.split(";", 1)[0]?.trim() ===
+    "application/json"
+  );
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isInteger(parsedLength) || parsedLength < 0) {
+      throw new InvalidLifecycleEnvelopeError();
+    }
+    if (parsedLength > MAX_LIFECYCLE_REQUEST_BYTES) {
+      throw new RangeError("Observability request is too large.");
+    }
+  }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength === 0) throw new InvalidLifecycleEnvelopeError();
+  if (body.byteLength > MAX_LIFECYCLE_REQUEST_BYTES) {
+    throw new RangeError("Observability request is too large.");
+  }
+
+  try {
+    return JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(body)
+    ) as unknown;
+  } catch {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+}
+
+// Same HMAC derivation as the browser events route, keyed on THIS
+// deployment's environment (not the envelope's), so the same wallet resolves
+// to the same actor id whether it reports from web or mobile.
+function resolveActorId(walletAddress: string | undefined): string | undefined {
+  if (!walletAddress) return undefined;
+  try {
+    const secret = process.env.OBSERVABILITY_ACTOR_HMAC_SECRET ?? "";
+    return (
+      deriveObservabilityActorId({
+        deploymentEnvironment: getObservabilityDeploymentEnvironment(),
+        secret,
+        walletAddress,
+      }) ?? undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isNativeAppRequest(request)) {
+    return jsonResponse({ error: "forbidden" }, 403);
+  }
+  if (!isJsonRequest(request)) {
+    return jsonResponse({ error: "invalid_content_type" }, 415);
+  }
+  if (!consumeBrowserLifecycleRateLimit(request)) {
+    return jsonResponse({ error: "rate_limited" }, 429);
+  }
+
+  try {
+    const envelope = parseMobileLifecycleEnvelope(await readJsonBody(request));
+    const actorId = resolveActorId(envelope.walletAddress);
+    await reportMobileLifecycleEnvelope(envelope, actorId);
+    return jsonResponse({ accepted: true }, 202);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return jsonResponse({ error: "payload_too_large" }, 413);
+    }
+    return jsonResponse({ error: "invalid_request" }, 400);
+  }
+}

--- a/frontend/src/features/observability/error-contract.ts
+++ b/frontend/src/features/observability/error-contract.ts
@@ -234,15 +234,26 @@ function readRequiredString(
 
 // Release/environment identify the reporting build in OTLP resource
 // attributes; restrict them to a safe identifier alphabet.
+export function normalizeResourceValue(
+  value: string,
+  maxLength: number
+): string | null {
+  const normalized = value
+    .replace(RESOURCE_VALUE_PATTERN, "_")
+    .slice(0, maxLength);
+  return normalized.length > 0 ? normalized : null;
+}
+
 function readResourceValue(
   record: Record<string, unknown>,
   key: string,
   maxLength: number
 ): string {
-  const normalized = readRequiredString(record, key)
-    .replace(RESOURCE_VALUE_PATTERN, "_")
-    .slice(0, maxLength);
-  if (normalized.length === 0) {
+  const normalized = normalizeResourceValue(
+    readRequiredString(record, key),
+    maxLength
+  );
+  if (!normalized) {
     throw new InvalidObservabilityEnvelopeError();
   }
   return normalized;

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -1,4 +1,7 @@
-import { normalizeTelemetryPathname } from "./error-contract";
+import {
+  normalizeResourceValue,
+  normalizeTelemetryPathname,
+} from "./error-contract";
 
 export const OBSERVABILITY_LIFECYCLE_ENDPOINT = "/api/observability/events";
 
@@ -30,6 +33,7 @@ export const LIFECYCLE_SOURCES = [
   "next_api",
   "sse",
   "fallback",
+  "mobile_app",
 ] as const;
 export type LifecycleSource = (typeof LIFECYCLE_SOURCES)[number];
 
@@ -238,17 +242,26 @@ export type BrowserLifecycleEnvelope = LifecycleDiagnostics & {
   flowVariant: LifecycleFlowVariant;
   outcome: LifecycleOutcome;
   pathname: string;
-  runtime: "browser" | "node";
+  runtime: "browser" | "mobile" | "node";
   source: LifecycleSource;
   stage: LifecycleFlowStage;
   timestamp: string;
+};
+
+// Mobile envelopes carry their own release/environment (the app fleet mixes
+// binary versions and OTA bundles) plus an optional wallet address the ingest
+// route folds into the same HMAC-derived actor id used for web sessions.
+export type MobileLifecycleEnvelope = BrowserLifecycleEnvelope & {
+  environment: string;
+  release: string;
+  walletAddress?: string;
 };
 
 export type NormalizedLifecycleEvent = BrowserLifecycleEnvelope & {
   actorId?: string;
   deploymentEnvironment: string;
   release: string;
-  serviceName: "loyal-frontend";
+  serviceName: "loyal-frontend" | "loyal-mobile";
 };
 
 const UUID_V4_PATTERN =
@@ -368,7 +381,11 @@ export function parseBrowserLifecycleEnvelope(
   ) {
     throw new InvalidLifecycleEnvelopeError();
   }
-  if (record.runtime !== "browser" && record.runtime !== "node") {
+  if (
+    record.runtime !== "browser" &&
+    record.runtime !== "node" &&
+    record.runtime !== "mobile"
+  ) {
     throw new InvalidLifecycleEnvelopeError();
   }
   if (
@@ -520,6 +537,52 @@ export function parseBrowserLifecycleEnvelope(
   }
 
   return { ...record, pathname } as BrowserLifecycleEnvelope;
+}
+
+const WALLET_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const MAX_RELEASE_LENGTH = 80;
+const MAX_ENVIRONMENT_LENGTH = 32;
+
+export function parseMobileLifecycleEnvelope(
+  value: unknown,
+  now = Date.now()
+): MobileLifecycleEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+  const { environment, release, walletAddress, ...rest } = value as Record<
+    string,
+    unknown
+  >;
+
+  const normalizedEnvironment =
+    typeof environment === "string"
+      ? normalizeResourceValue(environment, MAX_ENVIRONMENT_LENGTH)
+      : null;
+  const normalizedRelease =
+    typeof release === "string"
+      ? normalizeResourceValue(release, MAX_RELEASE_LENGTH)
+      : null;
+  if (!normalizedEnvironment || !normalizedRelease) {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+  if (
+    walletAddress !== undefined &&
+    (typeof walletAddress !== "string" ||
+      !WALLET_ADDRESS_PATTERN.test(walletAddress))
+  ) {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+  if (rest.runtime !== "mobile") {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+
+  return {
+    ...parseBrowserLifecycleEnvelope(rest, now),
+    environment: normalizedEnvironment,
+    release: normalizedRelease,
+    ...(walletAddress ? { walletAddress } : {}),
+  };
 }
 
 export type LifecycleTracker = {

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -169,7 +169,13 @@ export function buildOtlpLifecyclePayload(
                 timeUnixNano,
               },
             ],
-            scope: { name: "loyal.frontend.lifecycle", version: "1" },
+            scope: {
+              name:
+                event.serviceName === "loyal-mobile"
+                  ? "loyal.mobile.lifecycle"
+                  : "loyal.frontend.lifecycle",
+              version: "1",
+            },
           },
         ],
       },

--- a/frontend/src/features/observability/server.ts
+++ b/frontend/src/features/observability/server.ts
@@ -10,6 +10,7 @@ import {
 } from "./error-contract";
 import type {
   BrowserLifecycleEnvelope,
+  MobileLifecycleEnvelope,
   NormalizedLifecycleEvent,
 } from "./lifecycle-contract";
 import { buildOtlpErrorPayload, buildOtlpLifecyclePayload } from "./otlp";
@@ -229,6 +230,27 @@ export async function reportBrowserLifecycleEnvelope(
       deploymentEnvironment: getObservabilityDeploymentEnvironment(),
       release: getObservabilityRelease(),
       serviceName: "loyal-frontend",
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function reportMobileLifecycleEnvelope(
+  envelope: MobileLifecycleEnvelope,
+  actorId?: string
+): Promise<boolean> {
+  try {
+    // The device reports its own release/environment; the wallet address only
+    // feeds the actor-id derivation in the route and never reaches ClickStack.
+    const { environment, release, ...event } = envelope;
+    delete event.walletAddress;
+    return await exportLifecycleEvent({
+      ...event,
+      ...(actorId ? { actorId } : {}),
+      deploymentEnvironment: environment,
+      release,
+      serviceName: "loyal-mobile",
     });
   } catch {
     return false;


### PR DESCRIPTION
Extends the ClickStack lifecycle contract to mobile: a native-app ingest twin at /api/observability/mobile/events, runtime "mobile" + source "mobile_app", device-reported release/environment, and wallet-address-to-actor-id derivation matching the web HMAC so flows correlate across surfaces. Second half of ASK-1804 — the on-device Earn flow instrumentation ships from the mobile branch and needs this deployed first.