### PR TITLE
feat(observability): trace mobile sign-in, provisioning and execute-now completion

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
@@ -12,7 +12,7 @@ import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import {
-  ensureWalletUserSmartAccount,
+  ensureWalletUserSmartAccountTraced,
   findReadyCurrentUserSmartAccount,
   isSmartAccountProvisioningError,
 } from "@/features/smart-accounts/server/service";
@@ -164,9 +164,10 @@ export async function POST(request: Request) {
           "Wallet must hold the USDC it is depositing before its Earn account can be created."
         );
       }
-      const ensured = await ensureWalletUserSmartAccount({
+      const ensured = await ensureWalletUserSmartAccountTraced({
         userId: user.id,
         walletAddress,
+        request,
       });
       settingsPda = ensured.smartAccount.settingsPda;
       smartAccountAddress = ensured.smartAccount.smartAccountAddress;

--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
@@ -13,7 +13,7 @@ import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import {
-  ensureWalletUserSmartAccount,
+  ensureWalletUserSmartAccountTraced,
   findReadyCurrentUserSmartAccount,
   isSmartAccountProvisioningError,
 } from "@/features/smart-accounts/server/service";
@@ -171,9 +171,10 @@ export async function POST(request: Request) {
           "Wallet must hold the USDC it is depositing before its Earn account can be created."
         );
       }
-      const ensured = await ensureWalletUserSmartAccount({
+      const ensured = await ensureWalletUserSmartAccountTraced({
         userId: user.id,
         walletAddress,
+        request,
       });
       settingsPda = ensured.smartAccount.settingsPda;
       smartAccountAddress = ensured.smartAccount.smartAccountAddress;

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -38,7 +38,16 @@ export const LIFECYCLE_SOURCES = [
 export type LifecycleSource = (typeof LIFECYCLE_SOURCES)[number];
 
 export const LIFECYCLE_VARIANTS = {
-  "auth.sign_in": ["interactive", "auto_reauth"],
+  // seed_vault/wallet_adapter/import_wallet/new_wallet are the mobile app's
+  // wallet-onboarding modes (Seed Vault, MWA, seed import, fresh keypair).
+  "auth.sign_in": [
+    "interactive",
+    "auto_reauth",
+    "seed_vault",
+    "wallet_adapter",
+    "import_wallet",
+    "new_wallet",
+  ],
   "auth.smart_account_provisioning": ["wallet_onboarding"],
   "earn.deposit": ["initial", "resumed", "top_up"],
   "earn.withdrawal": ["partial", "full"],

--- a/frontend/src/features/smart-accounts/server/service.ts
+++ b/frontend/src/features/smart-accounts/server/service.ts
@@ -5,6 +5,8 @@ import {
   getOrCreateCurrentUser,
 } from "@/features/chat/server/app-user";
 import type { AuthenticatedPrincipal } from "@/features/identity/server/auth-session";
+import { normalizeLifecycleErrorCode } from "@/features/observability/lifecycle-contract";
+import { createRequestLifecycle } from "@/features/observability/lifecycle.server";
 import { deriveCanonicalSmartAccountAddress } from "@/features/smart-accounts/derivation";
 import type { AppUserSmartAccountRecord } from "@/features/smart-accounts/server/repository";
 import type {
@@ -78,6 +80,43 @@ export async function ensureWalletUserSmartAccount(args: {
   walletAddress: string;
 }): Promise<EnsureUserSmartAccountResult> {
   return ensureUserSmartAccount(args, createServiceDependencies());
+}
+
+// Provisioning lifecycle twin of the web wallet-onboarding instrumentation:
+// mobile routes provision outside a browser session, so the events are
+// emitted here, joined to the caller's flow via its `x-loyal-flow-id` header
+// (no header → no lifecycle → plain ensure).
+export async function ensureWalletUserSmartAccountTraced(args: {
+  userId: string;
+  walletAddress: string;
+  request: Request;
+}): Promise<EnsureUserSmartAccountResult> {
+  const lifecycle = createRequestLifecycle({
+    flowName: "auth.smart_account_provisioning",
+    flowVariant: "wallet_onboarding",
+    request: args.request,
+  });
+  lifecycle?.setVerifiedWallet(args.walletAddress);
+  lifecycle?.tracker.start("smart_account_reserve");
+  try {
+    const ensured = await ensureWalletUserSmartAccount({
+      userId: args.userId,
+      walletAddress: args.walletAddress,
+    });
+    lifecycle?.tracker.complete("completion_persist", {
+      provisioningOutcome: ensured.provisioningOutcome,
+    });
+    return ensured;
+  } catch (error) {
+    lifecycle?.tracker.fail("sponsorship_finalize", {
+      errorCode: normalizeLifecycleErrorCode(
+        error && typeof error === "object" && "code" in error
+          ? (error as { code?: unknown }).code
+          : undefined
+      ),
+    });
+    throw error;
+  }
 }
 
 export async function ensureCurrentUserSmartAccount(args: {


### PR DESCRIPTION
Adds the mobile auth.sign_in variants (seed_vault/wallet_adapter/import_wallet/new_wallet) to the lifecycle contract and instruments mobile-triggered smart-account provisioning: a traced ensure wrapper emits auth.smart_account_provisioning events (with provisioningOutcome) from the two mobile deposit routes, joined to the device's deposit flow via its x-loyal-flow-id header. Closes the coverage gaps Chris flagged on ASK-1804; the client half ships from the mobile branch.