### PR TITLE
fix(earn): reconcile autodeposit setup outcomes

### DIFF
--- a/frontend/scripts/verify-observability-flows.ts
+++ b/frontend/scripts/verify-observability-flows.ts
@@ -7,12 +7,14 @@ import { deriveObservabilityActorId } from "../src/features/observability/actor"
 import {
   createLifecycleTracker,
   EXECUTE_NOW_STATES,
+  LIFECYCLE_ERROR_CLASSES,
   LIFECYCLE_ERROR_CODES,
   LIFECYCLE_FLOW_NAMES,
   LIFECYCLE_OUTCOMES,
   LIFECYCLE_SAMPLING_RATIO,
   LIFECYCLE_SOURCES,
   LIFECYCLE_STAGES,
+  LIFECYCLE_HTTP_ROUTES,
   LIFECYCLE_VARIANTS,
   mapExecuteNowState,
   parseBrowserLifecycleEnvelope,
@@ -69,9 +71,20 @@ assert.deepEqual(LIFECYCLE_OUTCOMES, [
   "failed",
   "cancelled",
 ]);
-assert.deepEqual(LIFECYCLE_SOURCES, ["browser", "next_api", "sse", "fallback"]);
+assert.deepEqual(LIFECYCLE_SOURCES, [
+  "browser",
+  "next_api",
+  "sse",
+  "fallback",
+  "mobile_app",
+]);
 assert.equal(LIFECYCLE_SAMPLING_RATIO, 1);
+assert.equal(
+  new Set(LIFECYCLE_ERROR_CLASSES).size,
+  LIFECYCLE_ERROR_CLASSES.length
+);
 assert.equal(new Set(LIFECYCLE_ERROR_CODES).size, LIFECYCLE_ERROR_CODES.length);
+assert.equal(new Set(LIFECYCLE_HTTP_ROUTES).size, LIFECYCLE_HTTP_ROUTES.length);
 assert.equal(new Set(PROVISIONING_OUTCOMES).size, PROVISIONING_OUTCOMES.length);
 assert.equal(new Set(EXECUTE_NOW_STATES).size, EXECUTE_NOW_STATES.length);
 for (const flowName of LIFECYCLE_FLOW_NAMES) {
@@ -103,6 +116,8 @@ for (const invalid of [
   { ...baseEvent(), timestamp: "2026-07-16T10:59:59.999Z" },
   { ...baseEvent(), authProofKind: "siws" },
   { ...baseEvent(), executeNowState: "requested" },
+  { ...baseEvent(), errorClass: "raw_exception_name" },
+  { ...baseEvent(), httpRoute: "/api/wallets/raw-wallet-address" },
 ]) {
   assert.throws(() => parseBrowserLifecycleEnvelope(invalid, NOW));
 }
@@ -284,9 +299,12 @@ const diagnosticEvents: Array<BrowserLifecycleEnvelope & LifecycleDiagnostics> =
       durationMs: 1,
       elapsedMs: 2,
       executionMode: "batch",
+      errorClass: "http_response_error",
       flowName: "earn.deposit",
       flowVariant: "initial",
       httpStatus: 202,
+      httpRoute:
+        "/api/smart-accounts/yield-optimization/autodeposit/setup/confirm",
       instructionCount: 4,
       lookupTableUsed: true,
       outcome: "failed",
@@ -364,6 +382,7 @@ for (const key of [
   "loyal.duration_ms",
   "loyal.elapsed_ms",
   "loyal.actor.id",
+  "loyal.error.class",
   "loyal.error.code",
   "loyal.execute_now.state",
   "loyal.chain.state",
@@ -383,6 +402,7 @@ for (const key of [
   "loyal.execution.mode",
   "loyal.provisioning.outcome",
   "loyal.scheduled_slot.id",
+  "http.route",
 ])
   assert.ok(storedAttributes.has(key), `missing OTLP attribute ${key}`);
 assert.deepEqual(storedAttributes.get("loyal.duration_ms"), { intValue: "10" });

--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -161,6 +161,13 @@ import {
   type EarnRealtimeInvalidation,
 } from "@/features/earn-realtime";
 import {
+  createEarnAutodepositSetupFailure,
+  EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+  settleEarnAutodepositSetupFailure,
+  type EarnAutodepositSetupFailure,
+  type EarnAutodepositSetupFailureStage,
+} from "@/features/earn-autodeposit/setup-lifecycle";
+import {
   useRealtimeResource,
   useRealtimeSync,
   useRealtimeSyncScope,
@@ -6188,6 +6195,12 @@ export function AppWalletWorkspace({
     earnAutodepositLifecycleRef.current = tracker;
     tracker.start("intent");
     tracker.observe("prepare");
+    let failureStage: EarnAutodepositSetupFailureStage = "prepare";
+    let resultFailure: EarnAutodepositSetupFailure | null = null;
+    let confirmedSetupHttpStatus: number | undefined;
+    let confirmedSetupRecorded = false;
+    let confirmedSetupSignature: string | undefined;
+    let confirmedSetupTargetId: string | undefined;
     setProposalActionError(null);
     setAutodepositConfig((current) =>
       pendingEarnAutodepositDraft.requiresSignature === false
@@ -6234,6 +6247,7 @@ export function AppWalletWorkspace({
           throw new Error("Autodeposit account metadata is missing.");
         }
 
+        failureStage = "backend_confirm";
         tracker.observe("backend_confirm", {
           persistenceState: "not_started",
         });
@@ -6247,11 +6261,21 @@ export function AppWalletWorkspace({
         );
 
         if (!result.success) {
+          resultFailure = createEarnAutodepositSetupFailure({
+            error: new Error(
+              result.error ?? "Autodeposit wallet balance floor update failed."
+            ),
+            errorCode: "record_failed",
+            persistenceState: "failed",
+            reconcileAuthoritativeState: false,
+            stage: "backend_confirm",
+          });
           throw new Error(
             result.error ?? "Autodeposit wallet balance floor update failed."
           );
         }
 
+        failureStage = "ui_commit";
         tracker.observe("backend_confirm", { persistenceState: "recorded" });
 
         setAutodepositConfig({
@@ -6283,6 +6307,12 @@ export function AppWalletWorkspace({
       let preparedSetup = pendingEarnAutodepositSetupPrepared;
 
       for (;;) {
+        failureStage = "prepare";
+        resultFailure = null;
+        confirmedSetupHttpStatus = undefined;
+        confirmedSetupRecorded = false;
+        confirmedSetupSignature = undefined;
+        confirmedSetupTargetId = undefined;
         if (!preparedSetup) {
           preparedSetup = await smartAccountData.prepareEarnAutodepositSetup({
             amountRaw,
@@ -6311,6 +6341,7 @@ export function AppWalletWorkspace({
           chainState: "submitted",
           executionMode: "sequential",
         });
+        failureStage = "wallet_approval";
         const result = await smartAccountData.executeEarnAutodepositSetup({
           amountRaw,
           observabilityFlowId: tracker.flowId,
@@ -6324,20 +6355,37 @@ export function AppWalletWorkspace({
           startTimestamp: pendingEarnAutodepositDraft.startTimestamp,
           walletBalanceFloorRaw,
         });
+        confirmedSetupHttpStatus = result.confirmHttpStatus;
+        confirmedSetupSignature = result.signature;
+        confirmedSetupTargetId = result.targetId;
 
         if (!result.success || !result.preparedSetup) {
-          if (result.status === "confirmation_record_failed") {
-            tracker.fail("backend_confirm", {
-              chainState: "confirmed",
-              errorCode: "record_failed",
-              persistenceState: "failed",
+          resultFailure =
+            result.failure ??
+            createEarnAutodepositSetupFailure({
+              error: new Error(result.error ?? "Autodeposit setup failed."),
+              errorCode:
+                result.status === "confirmation_record_failed"
+                  ? "record_failed"
+                  : "unexpected_error",
+              reconcileAuthoritativeState:
+                result.status === "confirmation_record_failed",
+              stage:
+                result.status === "confirmation_record_failed"
+                  ? "backend_confirm"
+                  : failureStage,
             });
-          }
           throw new Error(result.error ?? "Autodeposit setup failed.");
         }
 
+        confirmedSetupRecorded = true;
+        failureStage = "ui_commit";
         tracker.observe("backend_confirm", {
           chainState: "confirmed",
+          httpRoute: EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+          ...(result.confirmHttpStatus !== undefined
+            ? { httpStatus: result.confirmHttpStatus }
+            : {}),
           persistenceState: "recorded",
         });
 
@@ -6409,19 +6457,72 @@ export function AppWalletWorkspace({
         break;
       }
     } catch (error) {
+      const resolvedFailure =
+        resultFailure ??
+        createEarnAutodepositSetupFailure({
+          ...(confirmedSetupRecorded
+            ? {
+                chainState: "confirmed" as const,
+                httpRoute: EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+                persistenceState: "recorded" as const,
+                reconcileAuthoritativeState: true,
+              }
+            : {}),
+          error,
+          errorCode:
+            failureStage === "prepare"
+              ? "instruction_fetch_failed"
+              : failureStage === "wallet_approval"
+              ? "send_failed"
+              : failureStage === "backend_confirm"
+              ? "record_failed"
+              : "unexpected_error",
+          ...(confirmedSetupHttpStatus !== undefined
+            ? { httpStatus: confirmedSetupHttpStatus }
+            : {}),
+          stage: failureStage,
+        });
+      const failure =
+        pendingEarnAutodepositDraft.requiresSignature === false
+          ? {
+              ...resolvedFailure,
+              reconcileAuthoritativeState: false,
+            }
+          : resolvedFailure;
+      const reconciled = await settleEarnAutodepositSetupFailure({
+        failure,
+        onReconciled: (config) => {
+          setAutodepositConfig(config);
+          setPendingEarnAutodepositDraft(null);
+          setPendingEarnAutodepositSetupPrepared(null);
+          setEarnAutodepositSetupReviewStage("policy");
+          setIsEarnAutodepositCloseReview(false);
+          registerExpectedEarnMutation({
+            operation: "autodeposit_setup",
+            resources: EARN_AUTODEPOSIT_MUTATION_RESOURCES,
+            signature: confirmedSetupSignature,
+            targetId: confirmedSetupTargetId,
+          });
+          markDetailPaneTransition("back");
+          setSelectedSignerId(null);
+          setDetailSelection("earn");
+          setSelectedDetail("Earn");
+          setProposalActionError(null);
+        },
+        refreshEarnAutodeposit: async () =>
+          (await smartAccountData.refreshEarnState())?.autodeposit ?? null,
+        tracker,
+      });
+      if (reconciled) {
+        return;
+      }
+
       setAutodepositConfig(previousAutodepositConfig);
       setProposalActionError(
         error instanceof Error
           ? error.message.replaceAll("autodeposit", "Autodeposit")
           : "Autodeposit setup failed."
       );
-      if (isWalletCancellation(error)) {
-        tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
-      } else {
-        tracker.fail("backend_confirm", {
-          errorCode: "unexpected_error",
-        });
-      }
     } finally {
       setIsEarnAutodepositSetupConfirming(false);
       setIsEarnAutoSigning(false);

--- a/frontend/src/features/earn-autodeposit/setup-lifecycle.test.ts
+++ b/frontend/src/features/earn-autodeposit/setup-lifecycle.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createLifecycleTracker,
+  type BrowserLifecycleEnvelope,
+} from "@/features/observability/lifecycle-contract";
+
+import {
+  createEarnAutodepositSetupFailure,
+  settleEarnAutodepositSetupFailure,
+} from "./setup-lifecycle";
+
+const NOW = Date.parse("2026-07-18T08:00:00.000Z");
+
+function createTracker(events: BrowserLifecycleEnvelope[]) {
+  return createLifecycleTracker({
+    emit: (event) => events.push(event),
+    flowId: "123e4567-e89b-42d3-a456-426614174000",
+    flowName: "earn.autodeposit.configuration",
+    flowVariant: "setup",
+    now: () => NOW,
+    pathname: "/app",
+  });
+}
+
+describe("Earn Autodeposit setup lifecycle", () => {
+  test("reports preparation failures at prepare without a backend-confirm claim", async () => {
+    const events: BrowserLifecycleEnvelope[] = [];
+    const tracker = createTracker(events);
+    tracker.start("intent");
+
+    const reconciled = await settleEarnAutodepositSetupFailure({
+      failure: createEarnAutodepositSetupFailure({
+        error: new Error(
+          "prepare failed for wallet SecretWallet and signature SecretSignature"
+        ),
+        errorCode: "instruction_fetch_failed",
+        stage: "prepare",
+      }),
+      onReconciled: () => {
+        throw new Error("preparation failures must not reconcile");
+      },
+      refreshEarnAutodeposit: () => {
+        throw new Error("preparation failures must not refetch Earn state");
+      },
+      tracker,
+    });
+
+    expect(reconciled).toBe(false);
+    expect(events.at(-1)).toMatchObject({
+      errorClass: "error",
+      errorCode: "instruction_fetch_failed",
+      outcome: "failed",
+      stage: "prepare",
+    });
+    expect(events.some((event) => event.stage === "backend_confirm")).toBe(
+      false
+    );
+    expect(JSON.stringify(events)).not.toContain("SecretWallet");
+    expect(JSON.stringify(events)).not.toContain("SecretSignature");
+  });
+
+  test("reconciles an authoritative recorded setup instead of reporting failure", async () => {
+    const events: BrowserLifecycleEnvelope[] = [];
+    const tracker = createTracker(events);
+    tracker.start("intent");
+    const reconciledStates: string[] = [];
+
+    const reconciled = await settleEarnAutodepositSetupFailure({
+      failure: createEarnAutodepositSetupFailure({
+        chainState: "confirmed",
+        error: new Error("response could not be committed"),
+        errorCode: "record_failed",
+        httpStatus: 200,
+        persistenceState: "recorded",
+        reconcileAuthoritativeState: true,
+        stage: "ui_commit",
+      }),
+      onReconciled: (config) => {
+        reconciledStates.push(config.state);
+      },
+      refreshEarnAutodeposit: async () => ({
+        amountPerPeriodRaw: "2000000",
+        policyAccount: "policy-account",
+        policySeed: "3",
+        periodLengthSeconds: "86400",
+        recurringDelegation: "recurring-delegation",
+        startTimestamp: "1784361600",
+        status: "active",
+        walletBalanceFloorRaw: "1000000",
+      }),
+      tracker,
+    });
+
+    expect(reconciled).toBe(true);
+    expect(reconciledStates).toEqual(["created"]);
+    expect(events.at(-1)).toMatchObject({
+      outcome: "completed",
+      persistenceState: "recorded",
+      stage: "ui_commit",
+    });
+    expect(events.some((event) => event.outcome === "failed")).toBe(false);
+  });
+
+  test("emits only one terminal outcome when a later handler reports again", async () => {
+    const events: BrowserLifecycleEnvelope[] = [];
+    const tracker = createTracker(events);
+    tracker.start("intent");
+    const failure = createEarnAutodepositSetupFailure({
+      error: new Error("wallet send failed"),
+      errorCode: "send_failed",
+      stage: "wallet_approval",
+    });
+
+    await settleEarnAutodepositSetupFailure({
+      failure,
+      onReconciled: () => undefined,
+      refreshEarnAutodeposit: async () => null,
+      tracker,
+    });
+    tracker.fail("backend_confirm", {
+      errorCode: "unexpected_error",
+    });
+
+    expect(
+      events.filter((event) =>
+        ["cancelled", "completed", "failed"].includes(event.outcome)
+      )
+    ).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({
+      errorCode: "send_failed",
+      outcome: "failed",
+      stage: "wallet_approval",
+    });
+  });
+});

--- a/frontend/src/features/earn-autodeposit/setup-lifecycle.ts
+++ b/frontend/src/features/earn-autodeposit/setup-lifecycle.ts
@@ -1,0 +1,205 @@
+import {
+  type LifecycleDiagnostics,
+  type LifecycleErrorClass,
+  type LifecycleErrorCode,
+  type LifecycleFlowStage,
+  type LifecycleHttpRoute,
+  type LifecycleTracker,
+  normalizeLifecycleErrorCode,
+} from "@/features/observability/lifecycle-contract";
+import {
+  earnAutodepositConfigFromLoadedState,
+  type LoadedEarnAutodepositConfig,
+  type LoadedEarnAutodepositState,
+} from "@/lib/yield-optimization/earn-autodeposit-loaded-state.shared";
+
+export const EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE =
+  "/api/smart-accounts/yield-optimization/autodeposit/setup/confirm" as const satisfies LifecycleHttpRoute;
+
+export type EarnAutodepositSetupFailureStage = Extract<
+  LifecycleFlowStage<"earn.autodeposit.configuration">,
+  "backend_confirm" | "prepare" | "ui_commit" | "wallet_approval"
+>;
+
+export type EarnAutodepositSetupFailure = {
+  chainState?: "confirmed" | "failed" | "not_submitted" | "submitted";
+  errorClass: LifecycleErrorClass;
+  errorCode: LifecycleErrorCode;
+  httpRoute?: LifecycleHttpRoute;
+  httpStatus?: number;
+  persistenceState?: "failed" | "not_started" | "recorded";
+  reconcileAuthoritativeState: boolean;
+  stage: EarnAutodepositSetupFailureStage;
+};
+
+type EarnAutodepositSetupHttpErrorArgs = {
+  errorClass: Extract<
+    LifecycleErrorClass,
+    "http_response_error" | "response_parse_error"
+  >;
+  errorCode?: unknown;
+  httpStatus: number;
+  message: string;
+};
+
+export class EarnAutodepositSetupHttpError extends Error {
+  readonly errorClass: EarnAutodepositSetupHttpErrorArgs["errorClass"];
+  readonly errorCode: LifecycleErrorCode;
+  readonly httpStatus: number;
+
+  constructor(args: EarnAutodepositSetupHttpErrorArgs) {
+    super(args.message);
+    this.name = "EarnAutodepositSetupHttpError";
+    this.errorClass = args.errorClass;
+    this.errorCode = normalizeLifecycleErrorCode(args.errorCode);
+    this.httpStatus = args.httpStatus;
+  }
+}
+
+function isWalletRejection(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String(error).toLowerCase();
+  return ["reject", "denied", "declined", "cancelled", "canceled"].some(
+    (marker) => message.includes(marker)
+  );
+}
+
+export function classifyLifecycleError(error: unknown): LifecycleErrorClass {
+  if (error instanceof EarnAutodepositSetupHttpError) {
+    return error.errorClass;
+  }
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return "dom_exception";
+  }
+  if (error instanceof TypeError) {
+    return "type_error";
+  }
+  if (error instanceof Error) {
+    return "error";
+  }
+  return "non_error";
+}
+
+export function createEarnAutodepositSetupFailure(args: {
+  chainState?: EarnAutodepositSetupFailure["chainState"];
+  error: unknown;
+  errorCode?: unknown;
+  httpRoute?: LifecycleHttpRoute;
+  httpStatus?: number;
+  persistenceState?: EarnAutodepositSetupFailure["persistenceState"];
+  reconcileAuthoritativeState?: boolean;
+  stage: EarnAutodepositSetupFailureStage;
+}): EarnAutodepositSetupFailure {
+  const httpError =
+    args.error instanceof EarnAutodepositSetupHttpError ? args.error : null;
+  const walletRejected =
+    args.stage === "wallet_approval" &&
+    !httpError &&
+    isWalletRejection(args.error);
+
+  return {
+    ...(args.chainState ? { chainState: args.chainState } : {}),
+    errorClass: walletRejected
+      ? "wallet_rejection"
+      : classifyLifecycleError(args.error),
+    errorCode: walletRejected
+      ? "wallet_rejected"
+      : normalizeLifecycleErrorCode(args.errorCode ?? httpError?.errorCode),
+    ...(args.httpRoute || httpError || args.httpStatus !== undefined
+      ? {
+          httpRoute: args.httpRoute ?? EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+        }
+      : {}),
+    ...(args.httpStatus !== undefined || httpError
+      ? { httpStatus: args.httpStatus ?? httpError?.httpStatus }
+      : {}),
+    ...(args.persistenceState
+      ? { persistenceState: args.persistenceState }
+      : {}),
+    reconcileAuthoritativeState:
+      args.reconcileAuthoritativeState ??
+      (args.stage === "backend_confirm" || args.stage === "ui_commit"),
+    stage: args.stage,
+  };
+}
+
+export function getEarnAutodepositSetupFailureDiagnostics(
+  failure: EarnAutodepositSetupFailure
+): LifecycleDiagnostics {
+  return {
+    ...(failure.chainState ? { chainState: failure.chainState } : {}),
+    errorClass: failure.errorClass,
+    errorCode: failure.errorCode,
+    ...(failure.httpRoute ? { httpRoute: failure.httpRoute } : {}),
+    ...(failure.httpStatus !== undefined
+      ? { httpStatus: failure.httpStatus }
+      : {}),
+    ...(failure.persistenceState
+      ? { persistenceState: failure.persistenceState }
+      : {}),
+  };
+}
+
+export async function reconcileRecordedEarnAutodepositSetup(args: {
+  failure: EarnAutodepositSetupFailure;
+  refreshEarnAutodeposit: () => Promise<LoadedEarnAutodepositState | null>;
+}): Promise<LoadedEarnAutodepositConfig | null> {
+  if (!args.failure.reconcileAuthoritativeState) {
+    return null;
+  }
+
+  try {
+    const autodeposit = await args.refreshEarnAutodeposit();
+    if (autodeposit?.status !== "active" || !autodeposit.recurringDelegation) {
+      return null;
+    }
+
+    const config = earnAutodepositConfigFromLoadedState(autodeposit);
+    return config?.state === "created" ? config : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function settleEarnAutodepositSetupFailure(args: {
+  failure: EarnAutodepositSetupFailure;
+  onReconciled: (config: LoadedEarnAutodepositConfig) => void;
+  refreshEarnAutodeposit: () => Promise<LoadedEarnAutodepositState | null>;
+  tracker: LifecycleTracker;
+}): Promise<boolean> {
+  const reconciled = await reconcileRecordedEarnAutodepositSetup({
+    failure: args.failure,
+    refreshEarnAutodeposit: args.refreshEarnAutodeposit,
+  });
+  if (reconciled) {
+    try {
+      args.onReconciled(reconciled);
+    } catch {
+      // The authoritative refresh already committed the setup state. A local
+      // view callback cannot turn that recorded setup back into a failure.
+    }
+    args.tracker.observe("backend_confirm", {
+      chainState: "confirmed",
+      httpRoute: EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+      ...(args.failure.httpStatus !== undefined
+        ? { httpStatus: args.failure.httpStatus }
+        : {}),
+      persistenceState: "recorded",
+    });
+    args.tracker.complete("ui_commit", {
+      chainState: "confirmed",
+      persistenceState: "recorded",
+    });
+    return true;
+  }
+
+  const diagnostics = getEarnAutodepositSetupFailureDiagnostics(args.failure);
+  if (args.failure.errorCode === "wallet_rejected") {
+    args.tracker.cancel(args.failure.stage, diagnostics);
+  } else {
+    args.tracker.fail(args.failure.stage, diagnostics);
+  }
+  return false;
+}

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -213,6 +213,22 @@ const CHAIN_STATES = [
 const PERSISTENCE_STATES = ["not_started", "recorded", "failed"] as const;
 const TRANSACTION_VERSIONS = ["legacy", "v0"] as const;
 
+export const LIFECYCLE_ERROR_CLASSES = [
+  "dom_exception",
+  "error",
+  "http_response_error",
+  "non_error",
+  "response_parse_error",
+  "type_error",
+  "wallet_rejection",
+] as const;
+export type LifecycleErrorClass = (typeof LIFECYCLE_ERROR_CLASSES)[number];
+
+export const LIFECYCLE_HTTP_ROUTES = [
+  "/api/smart-accounts/yield-optimization/autodeposit/setup/confirm",
+] as const;
+export type LifecycleHttpRoute = (typeof LIFECYCLE_HTTP_ROUTES)[number];
+
 export type LifecycleFlowVariant<
   F extends LifecycleFlowName = LifecycleFlowName
 > = (typeof LIFECYCLE_VARIANTS)[F][number];
@@ -225,9 +241,11 @@ export type LifecycleDiagnostics = {
   autodepositCloseRequired?: boolean;
   chainState?: (typeof CHAIN_STATES)[number];
   cleanupRequired?: boolean;
+  errorClass?: LifecycleErrorClass;
   errorCode?: LifecycleErrorCode;
   executeNowState?: ExecuteNowState;
   executionMode?: (typeof EXECUTION_MODES)[number];
+  httpRoute?: LifecycleHttpRoute;
   httpStatus?: number;
   instructionCount?: number;
   lookupTableUsed?: boolean;
@@ -345,12 +363,14 @@ export function parseBrowserLifecycleEnvelope(
     "cleanupRequired",
     "durationMs",
     "elapsedMs",
+    "errorClass",
     "errorCode",
     "executeNowState",
     "executionMode",
     "flowId",
     "flowName",
     "flowVariant",
+    "httpRoute",
     "httpStatus",
     "instructionCount",
     "lookupTableUsed",
@@ -425,7 +445,9 @@ export function parseBrowserLifecycleEnvelope(
     throw new InvalidLifecycleEnvelopeError();
   }
 
+  assertOptionalEnum(record.errorClass, LIFECYCLE_ERROR_CLASSES);
   assertOptionalEnum(record.errorCode, LIFECYCLE_ERROR_CODES);
+  assertOptionalEnum(record.httpRoute, LIFECYCLE_HTTP_ROUTES);
   assertOptionalEnum(record.executeNowState, EXECUTE_NOW_STATES);
   assertOptionalEnum(record.authProofKind, PROOF_KINDS);
   assertOptionalEnum(record.executionMode, EXECUTION_MODES);

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -103,6 +103,7 @@ export function buildOtlpLifecyclePayload(
 
   const strings: Array<[string, string | undefined]> = [
     ["loyal.actor.id", event.actorId],
+    ["loyal.error.class", event.errorClass],
     ["loyal.error.code", event.errorCode],
     ["loyal.execute_now.state", event.executeNowState],
     ["loyal.chain.state", event.chainState],
@@ -113,6 +114,7 @@ export function buildOtlpLifecyclePayload(
     ["loyal.execution.mode", event.executionMode],
     ["loyal.provisioning.outcome", event.provisioningOutcome],
     ["loyal.scheduled_slot.id", event.scheduledSlotId],
+    ["http.route", event.httpRoute],
   ];
   for (const [key, value] of strings) {
     if (value !== undefined) attributes.push(stringAttribute(key, value));

--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -59,6 +59,13 @@ import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { captureBrowserError } from "@/features/observability/client";
 import {
+  createEarnAutodepositSetupFailure,
+  EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+  EarnAutodepositSetupHttpError,
+  type EarnAutodepositSetupFailure,
+  type EarnAutodepositSetupFailureStage,
+} from "@/features/earn-autodeposit/setup-lifecycle";
+import {
   resolveSmartAccountRefreshError,
   resolveSmartAccountMutationRefreshPlan,
   SmartAccountPolicyFollowUp,
@@ -528,6 +535,8 @@ export type EarnAutodepositSetupResult = {
   preparedSetup?: SmartAccountPreparedEarnUsdcAutodepositSetup;
   nextPreparedSetup?: SmartAccountPreparedEarnUsdcAutodepositSetup | null;
   bootstrapSweep?: EarnAutodepositSetupConfirmResponse["bootstrapSweep"];
+  confirmHttpStatus?: number;
+  failure?: EarnAutodepositSetupFailure;
   scheduledSweeps?: LoadedEarnAutodepositScheduledSweep[];
   error?: string;
 };
@@ -907,7 +916,7 @@ export type SmartAccountSidebarData = {
   refreshGroups: (request: SmartAccountRefreshGroupsRequest) => Promise<void>;
   /** Refresh a confirmed mutation and schedule its one policy consistency read. */
   refreshMutationPlan: (plan: SmartAccountRefreshPlan) => Promise<void>;
-  refreshEarnState: () => Promise<void>;
+  refreshEarnState: () => Promise<EarnStateResponse | null>;
   /**
    * Invalidate caches and re-fetch portfolio + activity after an on-chain tx.
    * Pass the affected vault/signer addresses to make sure their balances
@@ -1545,10 +1554,13 @@ async function postConfirmedEarnAutodepositSetup(args: {
   signature: string;
   confirmedSlot: string;
   walletBalanceFloorRaw: bigint;
-}): Promise<EarnAutodepositSetupConfirmResponse> {
+}): Promise<{
+  httpStatus: number;
+  payload: EarnAutodepositSetupConfirmResponse;
+}> {
   const body = buildEarnAutodepositSetupConfirmRequestBody(args);
   const response = await fetch(
-    "/api/smart-accounts/yield-optimization/autodeposit/setup/confirm",
+    EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
     {
       method: "POST",
       credentials: "include",
@@ -1561,12 +1573,30 @@ async function postConfirmedEarnAutodepositSetup(args: {
     const payload = (await response
       .json()
       .catch(() => null)) as SmartAccountRouteErrorResponse | null;
-    throw new Error(
-      payload?.error?.message ?? "Failed to record confirmed Autodeposit setup."
-    );
+    throw new EarnAutodepositSetupHttpError({
+      errorClass: "http_response_error",
+      errorCode: payload?.error?.code,
+      httpStatus: response.status,
+      message:
+        payload?.error?.message ??
+        "Failed to record confirmed Autodeposit setup.",
+    });
   }
 
-  return (await response.json()) as EarnAutodepositSetupConfirmResponse;
+  try {
+    return {
+      httpStatus: response.status,
+      payload: (await response.json()) as EarnAutodepositSetupConfirmResponse,
+    };
+  } catch {
+    throw new EarnAutodepositSetupHttpError({
+      errorClass: "response_parse_error",
+      errorCode: "record_failed",
+      httpStatus: response.status,
+      message:
+        "Autodeposit setup was recorded, but its response could not be read.",
+    });
+  }
 }
 
 async function postConfirmedEarnAutodepositClose(args: {
@@ -3443,51 +3473,55 @@ export function useSmartAccountSidebarData(
     ]
   );
 
-  const refreshEarnState = useCallback(async () => {
-    const requestedScope = smartAccountScopeSnapshot;
-    const orderToken = refreshOrderRef.current.begin("earn");
-    if (!smartAccountScopeGeneration.isCurrent(requestedScope)) {
-      return;
-    }
-    const runId = earnStateRefreshRunIdRef.current + 1;
-    earnStateRefreshRunIdRef.current = runId;
-    const canCommit = () =>
-      smartAccountScopeGeneration.isCurrent(requestedScope) &&
-      earnStateRefreshRunIdRef.current === runId &&
-      refreshOrderRef.current.isCurrent(orderToken);
-    const requestedSettingsPda = user?.settingsPda ?? null;
-    if (!requestedSettingsPda) {
-      if (canCommit()) {
-        setEarnState(null);
-        setHasEarnStateResolved(true);
-        setIsEarnStateLoading(false);
+  const refreshEarnState =
+    useCallback(async (): Promise<EarnStateResponse | null> => {
+      const requestedScope = smartAccountScopeSnapshot;
+      const orderToken = refreshOrderRef.current.begin("earn");
+      if (!smartAccountScopeGeneration.isCurrent(requestedScope)) {
+        return null;
       }
-      return;
-    }
+      const runId = earnStateRefreshRunIdRef.current + 1;
+      earnStateRefreshRunIdRef.current = runId;
+      const canCommit = () =>
+        smartAccountScopeGeneration.isCurrent(requestedScope) &&
+        earnStateRefreshRunIdRef.current === runId &&
+        refreshOrderRef.current.isCurrent(orderToken);
+      const requestedSettingsPda = user?.settingsPda ?? null;
+      if (!requestedSettingsPda) {
+        if (canCommit()) {
+          setEarnState(null);
+          setHasEarnStateResolved(true);
+          setIsEarnStateLoading(false);
+        }
+        return null;
+      }
 
-    setIsEarnStateLoading(true);
-    try {
-      const nextEarnState = await fetchEarnState({ strict: true });
-      if (!canCommit()) {
-        return;
+      setIsEarnStateLoading(true);
+      try {
+        const nextEarnState = await fetchEarnState({ strict: true });
+        if (!canCommit()) {
+          return null;
+        }
+        setEarnState(nextEarnState);
+        if (nextEarnState) {
+          setOverview((current) =>
+            current
+              ? mergeEarnVaultIntoOverview(current, nextEarnState)
+              : current
+          );
+        }
+        return nextEarnState;
+      } finally {
+        if (canCommit()) {
+          setHasEarnStateResolved(true);
+          setIsEarnStateLoading(false);
+        }
       }
-      setEarnState(nextEarnState);
-      if (nextEarnState) {
-        setOverview((current) =>
-          current ? mergeEarnVaultIntoOverview(current, nextEarnState) : current
-        );
-      }
-    } finally {
-      if (canCommit()) {
-        setHasEarnStateResolved(true);
-        setIsEarnStateLoading(false);
-      }
-    }
-  }, [
-    smartAccountScopeGeneration,
-    smartAccountScopeSnapshot,
-    user?.settingsPda,
-  ]);
+    }, [
+      smartAccountScopeGeneration,
+      smartAccountScopeSnapshot,
+      user?.settingsPda,
+    ]);
 
   useEffect(() => {
     setHasEarnStateResolved(!user?.settingsPda);
@@ -4091,7 +4125,10 @@ export function useSmartAccountSidebarData(
         if (group === "proposals")
           return runScopedRefresh(group, loadProposals);
         if (group === "vaults") return runScopedRefresh(group, loadVaults);
-        if (group === "earn") return runScopedRefresh(group, refreshEarnState);
+        if (group === "earn")
+          return runScopedRefresh(group, async () => {
+            await refreshEarnState();
+          });
         return [];
       });
 
@@ -6744,43 +6781,96 @@ export function useSmartAccountSidebarData(
     async (
       request: EarnAutodepositSetupRequest
     ): Promise<EarnAutodepositSetupResult> => {
+      const fail = (args: {
+        chainState?: EarnAutodepositSetupFailure["chainState"];
+        error: unknown;
+        errorCode: unknown;
+        httpStatus?: number;
+        message: string;
+        persistenceState?: EarnAutodepositSetupFailure["persistenceState"];
+        reconcileAuthoritativeState?: boolean;
+        stage: EarnAutodepositSetupFailureStage;
+      }): EarnAutodepositSetupResult => ({
+        error: args.message,
+        failure: createEarnAutodepositSetupFailure({
+          ...(args.chainState ? { chainState: args.chainState } : {}),
+          error: args.error,
+          errorCode: args.errorCode,
+          ...(args.httpStatus !== undefined
+            ? { httpStatus: args.httpStatus }
+            : {}),
+          ...(args.persistenceState
+            ? { persistenceState: args.persistenceState }
+            : {}),
+          ...(args.reconcileAuthoritativeState !== undefined
+            ? {
+                reconcileAuthoritativeState: args.reconcileAuthoritativeState,
+              }
+            : {}),
+          stage: args.stage,
+        }),
+        success: false,
+      });
+
       if (!wallet.publicKey) {
-        return {
-          success: false,
-          error: "Connect the authenticated wallet to sign this action.",
-        };
+        const message = "Connect the authenticated wallet to sign this action.";
+        return fail({
+          error: new Error(message),
+          errorCode: "wallet_unavailable",
+          message,
+          stage: "prepare",
+        });
       }
 
       if (!user?.walletAddress) {
-        return {
-          success: false,
-          error: "Connect the authenticated wallet to sign this action.",
-        };
+        const message = "Connect the authenticated wallet to sign this action.";
+        return fail({
+          error: new Error(message),
+          errorCode: "wallet_unavailable",
+          message,
+          stage: "prepare",
+        });
       }
 
       if (wallet.publicKey.toBase58() !== user.walletAddress) {
-        return {
-          success: false,
-          error: "Connected wallet does not match the authenticated wallet.",
-        };
+        const message =
+          "Connected wallet does not match the authenticated wallet.";
+        return fail({
+          error: new Error(message),
+          errorCode: "wallet_mismatch",
+          message,
+          stage: "prepare",
+        });
       }
 
       if (request.amountRaw <= BigInt(0)) {
-        return { success: false, error: "Amount must be greater than 0." };
+        const message = "Amount must be greater than 0.";
+        return fail({
+          error: new Error(message),
+          errorCode: "invalid_request",
+          message,
+          stage: "prepare",
+        });
       }
       if (request.walletBalanceFloorRaw < BigInt(0)) {
-        return {
-          success: false,
-          error: "Autodeposit wallet balance floor cannot be negative.",
-        };
+        const message = "Autodeposit wallet balance floor cannot be negative.";
+        return fail({
+          error: new Error(message),
+          errorCode: "invalid_request",
+          message,
+          stage: "prepare",
+        });
       }
 
       const walletBridge = createWalletAdapterBridge(wallet);
       if (!walletBridge) {
-        return {
-          success: false,
-          error: "Connected wallet cannot sign transactions.",
-        };
+        const message = "Connected wallet cannot sign transactions.";
+        return fail({
+          error: new Error(message),
+          errorCode: "wallet_signing_unsupported",
+          message,
+          stage: "prepare",
+        });
       }
 
       const expectedEarnCluster = resolveEarnLoyalCluster(solanaEnv);
@@ -6792,6 +6882,9 @@ export function useSmartAccountSidebarData(
       );
 
       setIsActionPending(true);
+      let failureStage: EarnAutodepositSetupFailureStage = "prepare";
+      let confirmedSetupHttpStatus: number | undefined;
+      let confirmedSetupRecorded = false;
       try {
         const preparedSetup =
           request.preparedSetup ??
@@ -6809,11 +6902,14 @@ export function useSmartAccountSidebarData(
           preparedSetup.persistence.amountPerPeriodRaw !==
           request.amountRaw.toString()
         ) {
-          return {
-            success: false,
-            error:
-              "Prepared Autodeposit amount changed. Review Autodeposit again before signing.",
-          };
+          const message =
+            "Prepared Autodeposit amount changed. Review Autodeposit again before signing.";
+          return fail({
+            error: new Error(message),
+            errorCode: "invalid_request",
+            message,
+            stage: "prepare",
+          });
         }
 
         if (
@@ -6837,9 +6933,19 @@ export function useSmartAccountSidebarData(
               walletBalanceFloorRaw: request.walletBalanceFloorRaw,
             });
           } catch (error) {
+            const failure = createEarnAutodepositSetupFailure({
+              error,
+              errorCode: "instruction_fetch_failed",
+              reconcileAuthoritativeState: false,
+              stage: "prepare",
+            });
             console.warn(
               "[executeEarnAutodepositSetup] batch prepare failed; falling back to staged setup",
-              error
+              {
+                errorClass: failure.errorClass,
+                errorCode: failure.errorCode,
+                stage: failure.stage,
+              }
             );
           }
 
@@ -6854,11 +6960,14 @@ export function useSmartAccountSidebarData(
             const batchPreparedSetup = batchPrepare.preparedSetup;
             const batchNextPreparedSetup = batchPrepare.nextPreparedSetup;
             if (!batchPreparedSetup || !batchNextPreparedSetup) {
-              return {
-                success: false,
-                error:
-                  "Autodeposit setup batch did not include a recurring delegation.",
-              };
+              const message =
+                "Autodeposit setup batch did not include a recurring delegation.";
+              return fail({
+                error: new Error(message),
+                errorCode: "instruction_validation_failed",
+                message,
+                stage: "prepare",
+              });
             }
             const batchPreparedSetups: readonly SmartAccountPreparedEarnUsdcAutodepositSetup[] =
               [batchPreparedSetup, batchNextPreparedSetup];
@@ -6872,7 +6981,12 @@ export function useSmartAccountSidebarData(
               )
               .find((error): error is string => Boolean(error));
             if (clusterError) {
-              return { success: false, error: clusterError };
+              return fail({
+                error: new Error(clusterError),
+                errorCode: "cluster_mismatch",
+                message: clusterError,
+                stage: "prepare",
+              });
             }
             const nativeSolError = getNativeSolRequirementError(
               combineSmartAccountNativeSolRequirements(
@@ -6880,7 +6994,12 @@ export function useSmartAccountSidebarData(
               )
             );
             if (nativeSolError) {
-              return { success: false, error: nativeSolError };
+              return fail({
+                error: new Error(nativeSolError),
+                errorCode: "insufficient_native_sol",
+                message: nativeSolError,
+                stage: "prepare",
+              });
             }
 
             const confirmationRecordFailureRef: {
@@ -6892,10 +7011,12 @@ export function useSmartAccountSidebarData(
               } | null;
             } = { current: null };
             let policyConfirmedSlot: string | undefined;
+            let policyConfirmHttpStatus: number | undefined;
             let policySignature: string | undefined;
             let recurringDelegationConfirmedSlot: string | undefined;
             let recurringDelegationSent = false;
             let recurringDelegationSignature: string | undefined;
+            let recurringDelegationConfirmHttpStatus: number | undefined;
             let confirmResponse:
               | EarnAutodepositSetupConfirmResponse
               | undefined;
@@ -6927,24 +7048,27 @@ export function useSmartAccountSidebarData(
                     signature,
                   });
                   try {
-                    const response = await postConfirmedEarnAutodepositSetup({
-                      observabilityFlowId: request.observabilityFlowId,
-                      preparedSetup: confirmedSetup,
-                      signature,
-                      confirmedSlot,
-                      walletBalanceFloorRaw: request.walletBalanceFloorRaw,
-                    });
+                    const { httpStatus, payload } =
+                      await postConfirmedEarnAutodepositSetup({
+                        observabilityFlowId: request.observabilityFlowId,
+                        preparedSetup: confirmedSetup,
+                        signature,
+                        confirmedSlot,
+                        walletBalanceFloorRaw: request.walletBalanceFloorRaw,
+                      });
                     if (confirmedSetup.stage === "create_policy") {
                       policyConfirmedSlot = confirmedSlot;
+                      policyConfirmHttpStatus = httpStatus;
                       policySignature = signature;
                     } else {
                       recurringDelegationConfirmedSlot = confirmedSlot;
+                      recurringDelegationConfirmHttpStatus = httpStatus;
                       recurringDelegationSignature = signature;
                     }
                     if (
                       confirmedSetup.stage === "create_recurring_delegation"
                     ) {
-                      confirmResponse = response;
+                      confirmResponse = payload;
                     }
                   } catch (error) {
                     confirmationRecordFailureRef.current = {
@@ -6961,8 +7085,36 @@ export function useSmartAccountSidebarData(
               const confirmationRecordFailure =
                 confirmationRecordFailureRef.current;
               if (confirmationRecordFailure) {
+                const message =
+                  confirmationRecordFailure.error instanceof Error
+                    ? confirmationRecordFailure.error.message
+                    : "Failed to record confirmed Autodeposit setup.";
                 return {
-                  success: false,
+                  ...fail({
+                    chainState: "confirmed",
+                    error: confirmationRecordFailure.error,
+                    errorCode:
+                      confirmationRecordFailure.error instanceof
+                      EarnAutodepositSetupHttpError
+                        ? confirmationRecordFailure.error.errorCode
+                        : "record_failed",
+                    ...(confirmationRecordFailure.error instanceof
+                    EarnAutodepositSetupHttpError
+                      ? {
+                          httpStatus:
+                            confirmationRecordFailure.error.httpStatus,
+                        }
+                      : {}),
+                    message,
+                    persistenceState:
+                      confirmationRecordFailure.error instanceof
+                        EarnAutodepositSetupHttpError &&
+                      confirmationRecordFailure.error.httpStatus < 300
+                        ? "recorded"
+                        : "failed",
+                    reconcileAuthoritativeState: true,
+                    stage: "backend_confirm",
+                  }),
                   signature: confirmationRecordFailure.signature,
                   ...getEarnAutodepositSetupSignatureFields(
                     confirmationRecordFailure.preparedSetup,
@@ -6971,10 +7123,6 @@ export function useSmartAccountSidebarData(
                   confirmedSlot: confirmationRecordFailure.confirmedSlot,
                   status: "confirmation_record_failed",
                   preparedSetup: confirmationRecordFailure.preparedSetup,
-                  error:
-                    confirmationRecordFailure.error instanceof Error
-                      ? confirmationRecordFailure.error.message
-                      : "Failed to record confirmed Autodeposit setup.",
                 };
               }
 
@@ -6988,19 +7136,23 @@ export function useSmartAccountSidebarData(
                   signature: policySignature,
                   policySignature,
                   confirmedSlot: policyConfirmedSlot,
+                  confirmHttpStatus: policyConfirmHttpStatus,
                   status: "executed",
                   preparedSetup: batchPreparedSetup,
                   nextPreparedSetup: batchNextPreparedSetup,
                 };
               }
 
-              return {
-                success: false,
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Autodeposit setup failed.",
-              };
+              const message =
+                error instanceof Error
+                  ? error.message
+                  : "Autodeposit setup failed.";
+              return fail({
+                error,
+                errorCode: "send_failed",
+                message,
+                stage: "wallet_approval",
+              });
             }
 
             if (
@@ -7008,11 +7160,30 @@ export function useSmartAccountSidebarData(
               !recurringDelegationConfirmedSlot ||
               !recurringDelegationSignature
             ) {
-              return {
-                success: false,
-                error:
-                  "Autodeposit setup batch did not complete the recurring delegation.",
-              };
+              const message =
+                "Autodeposit setup batch did not complete the recurring delegation.";
+              return fail({
+                chainState: recurringDelegationConfirmedSlot
+                  ? "confirmed"
+                  : "submitted",
+                error: new Error(message),
+                errorCode: recurringDelegationConfirmedSlot
+                  ? "record_failed"
+                  : "chain_confirmation_failed",
+                ...(recurringDelegationConfirmHttpStatus !== undefined
+                  ? { httpStatus: recurringDelegationConfirmHttpStatus }
+                  : {}),
+                message,
+                persistenceState: recurringDelegationConfirmedSlot
+                  ? "recorded"
+                  : "not_started",
+                reconcileAuthoritativeState: Boolean(
+                  recurringDelegationConfirmedSlot
+                ),
+                stage: recurringDelegationConfirmedSlot
+                  ? "ui_commit"
+                  : "wallet_approval",
+              });
             }
 
             const scheduledSweeps = confirmResponse.bootstrapSweep?.sweep
@@ -7026,6 +7197,7 @@ export function useSmartAccountSidebarData(
               policySignature,
               recurringDelegationSignature,
               confirmedSlot: recurringDelegationConfirmedSlot,
+              confirmHttpStatus: recurringDelegationConfirmHttpStatus,
               status: "executed",
               preparedSetup: batchNextPreparedSetup,
               bootstrapSweep: confirmResponse.bootstrapSweep,
@@ -7038,9 +7210,15 @@ export function useSmartAccountSidebarData(
           preparedSetup.nativeSolRequirement
         );
         if (nativeSolError) {
-          return { success: false, error: nativeSolError };
+          return fail({
+            error: new Error(nativeSolError),
+            errorCode: "insufficient_native_sol",
+            message: nativeSolError,
+            stage: "prepare",
+          });
         }
 
+        failureStage = "wallet_approval";
         const setupSend = await sendPreparedEarnWithClusterPreflight({
           expectedCluster: expectedEarnCluster,
           operation: "autodeposit setup",
@@ -7054,24 +7232,55 @@ export function useSmartAccountSidebarData(
             }),
         });
         if (!setupSend.success) {
-          return setupSend;
+          return fail({
+            error: new Error(setupSend.error),
+            errorCode: "cluster_mismatch",
+            message: setupSend.error,
+            stage: "prepare",
+          });
         }
         const confirmedSlot = await resolveConfirmedSignatureSlot({
           connection,
           signature: setupSend.signature,
         });
         let confirmResponse: EarnAutodepositSetupConfirmResponse;
+        failureStage = "backend_confirm";
         try {
-          confirmResponse = await postConfirmedEarnAutodepositSetup({
+          const confirmed = await postConfirmedEarnAutodepositSetup({
             observabilityFlowId: request.observabilityFlowId,
             preparedSetup,
             signature: setupSend.signature,
             confirmedSlot,
             walletBalanceFloorRaw: request.walletBalanceFloorRaw,
           });
+          confirmResponse = confirmed.payload;
+          confirmedSetupHttpStatus = confirmed.httpStatus;
+          confirmedSetupRecorded = true;
         } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to record confirmed Autodeposit setup.";
           return {
-            success: false,
+            ...fail({
+              chainState: "confirmed",
+              error,
+              errorCode:
+                error instanceof EarnAutodepositSetupHttpError
+                  ? error.errorCode
+                  : "record_failed",
+              ...(error instanceof EarnAutodepositSetupHttpError
+                ? { httpStatus: error.httpStatus }
+                : {}),
+              message,
+              persistenceState:
+                error instanceof EarnAutodepositSetupHttpError &&
+                error.httpStatus < 300
+                  ? "recorded"
+                  : "failed",
+              reconcileAuthoritativeState: true,
+              stage: "backend_confirm",
+            }),
             signature: setupSend.signature,
             ...getEarnAutodepositSetupSignatureFields(
               preparedSetup,
@@ -7080,12 +7289,9 @@ export function useSmartAccountSidebarData(
             confirmedSlot,
             status: "confirmation_record_failed",
             preparedSetup,
-            error:
-              error instanceof Error
-                ? error.message
-                : "Failed to record confirmed Autodeposit setup.",
           };
         }
+        failureStage = "ui_commit";
         const completedAutodepositSetup =
           preparedSetup.stage === "create_recurring_delegation" ||
           preparedSetup.stage === "approve_token_delegate";
@@ -7142,6 +7348,7 @@ export function useSmartAccountSidebarData(
             setupSend.signature
           ),
           confirmedSlot,
+          confirmHttpStatus: confirmedSetupHttpStatus,
           status: "executed",
           preparedSetup,
           nextPreparedSetup,
@@ -7151,8 +7358,37 @@ export function useSmartAccountSidebarData(
       } catch (err) {
         const error =
           err instanceof Error ? err.message : "Autodeposit setup failed.";
-        console.error("[executeEarnAutodepositSetup] failed", err);
-        return { success: false, error };
+        const failure = createEarnAutodepositSetupFailure({
+          ...(confirmedSetupRecorded
+            ? {
+                chainState: "confirmed" as const,
+                httpRoute: EARN_AUTODEPOSIT_SETUP_CONFIRM_ROUTE,
+                persistenceState: "recorded" as const,
+                reconcileAuthoritativeState: true,
+              }
+            : {}),
+          error: err,
+          errorCode:
+            failureStage === "prepare"
+              ? "instruction_fetch_failed"
+              : failureStage === "wallet_approval"
+              ? "send_failed"
+              : failureStage === "backend_confirm"
+              ? "record_failed"
+              : "unexpected_error",
+          ...(confirmedSetupHttpStatus !== undefined
+            ? { httpStatus: confirmedSetupHttpStatus }
+            : {}),
+          stage: failureStage,
+        });
+        console.error("[executeEarnAutodepositSetup] failed", {
+          errorClass: failure.errorClass,
+          errorCode: failure.errorCode,
+          httpRoute: failure.httpRoute,
+          httpStatus: failure.httpStatus,
+          stage: failure.stage,
+        });
+        return { success: false, error, failure };
       } finally {
         setIsActionPending(false);
       }


### PR DESCRIPTION
Root cause: `handleCompleteEarnAutodepositSetup` collapsed every non-wallet exception into `backend_confirm/unexpected_error`, while the data hook discarded safe HTTP classification, so a recorded HTTP 200 setup could still be shown as failed. The fix tracks prepare, wallet, backend-confirm, and UI-commit stages; emits allowlisted error class, route, and status metadata; reconciles ambiguous confirmed attempts against authoritative Earn state to prevent duplicate transactions; and is validated by focused Bun tests, TypeScript, Next lint, Prettier, the observability verifier, commitlint, and `git diff --check`.