### PR TITLE
feat(observability): accept OTLP metrics and traces

### DIFF
--- a/observability/FRONTEND-ERRORS-VERIFIER.md
+++ b/observability/FRONTEND-ERRORS-VERIFIER.md
@@ -14,9 +14,9 @@ Run this verifier cold from `/Users/taequn/loyal/loyal-apps`. Treat this file as
 ### 2. Public ingestion boundary
 
 - Render still publishes only `0.0.0.0:$PORT` on the existing ClickStack service. HyperDX runs on a loopback-only internal port; ClickHouse, MongoDB, and collector ports remain non-public.
-- Normal HyperDX UI/API/WebSocket traffic and `/api/health` still work through the proxy. Only exact `POST /v1/logs` is proxied to the local collector; other `/v1/*` paths and non-POST methods are rejected.
-- The public log path fails closed until the collector demonstrably rejects an unauthenticated request. Missing and wrong credentials receive `401` or `403`; the configured credential is accepted. The proxy removes collector CORS response headers, applies a request-body limit no greater than 64 KiB, and uses bounded connect/read/send timeouts.
-- A local Docker smoke proves UI health, missing/wrong/correct credential behavior, method/path rejection, oversized-body rejection, absence of permissive CORS, a unique OTLP log queryable in `default.otel_logs`, and persistence of that same log after container recreation against the same volume.
+- Normal HyperDX UI/API/WebSocket traffic and `/api/health` still work through the proxy. Only exact `POST /v1/logs`, `POST /v1/metrics`, and `POST /v1/traces` are proxied to the local collector. `/v1/workflows`, every other `/v1/*` path, query-bearing requests, and non-POST methods are rejected.
+- All three public OTLP paths fail closed until the collector demonstrably rejects unauthenticated requests on all three. Missing and wrong credentials receive `401` or `403`; the configured credential is accepted. The proxy removes collector CORS response headers, applies a request-body limit no greater than 64 KiB per endpoint, and uses bounded connect/read/send timeouts.
+- A local Docker smoke proves UI health; missing/wrong/correct credential behavior; method, query, unsupported-path, and oversized-body rejection; absence of permissive CORS; valid OTLP metrics and traces canaries; a unique OTLP log queryable in `default.otel_logs`; and persistence of that same log after container recreation against the same volume.
 
 ### 3. Frontend error contract and privacy
 
@@ -38,7 +38,7 @@ Run this verifier cold from `/Users/taequn/loyal/loyal-apps`. Treat this file as
 
 - The latest Render deploy and Loyal frontend Vercel production deploy are live from the tested commit. Unrelated projects are not deployed by an observability-only change.
 - `https://loyal-clickstack.onrender.com/api/health` is healthy through the proxy; HyperDX signup/login redirects remain on the hosted origin; recent logs show no proxy or ClickStack crash loop.
-- Live missing/wrong credential, method/path, oversized-body, and CORS probes have the same safe results as local probes. Direct public connections to `4318`, ClickHouse, and MongoDB remain unavailable.
+- Live missing/wrong credential, method/query/unsupported-path, oversized-body, and CORS probes have the same safe results as local probes for logs, metrics, and traces. Valid authenticated canaries are accepted on exactly those three paths. Direct public connections to `4318`, ClickHouse, and MongoDB remain unavailable.
 - A unique synthetic event sent through the deployed same-origin frontend route returns the documented non-blocking success status and becomes queryable in ClickHouse/HyperDX within 60 seconds with the required service/release/environment/runtime/operation/exception fields. A planted forbidden marker does not appear in stored attributes or body.
 - A second unique server-format event sent through the authenticated hosted OTLP path is queryable within 60 seconds. After one controlled ClickStack restart, an existing marker remains queryable and the frontend error route resumes without configuration changes.
 - No secret value appears in Git diff, built client references, HTTP responses, verification artifacts, Render/Vercel logs captured for evidence, or the final report.

--- a/observability/README.md
+++ b/observability/README.md
@@ -16,13 +16,17 @@ The Loyal web frontend sends:
 - deposit, top-up, and withdrawal progress;
 - Autodeposit setup, update, pause, resume, close, and Execute Now progress.
 
-We do not yet collect mobile, extension, metrics, traces, service maps, session
-replay, or general console logs.
+The public gateway also accepts authenticated OTLP metrics and traces from
+trusted service exporters. This does not by itself instrument a service or
+enable browser-direct telemetry. We do not yet collect mobile, extension,
+service maps, session replay, or general console logs.
 
 ```text
 Browser or Next.js
   -> frontend same-origin observability route
-  -> authenticated /v1/logs
+  -> authenticated exact POST /v1/logs
+Trusted service exporter
+  -> authenticated exact POST /v1/metrics or /v1/traces
   -> nginx
   -> OpenTelemetry Collector
   -> ClickHouse
@@ -31,6 +35,26 @@ Browser or Next.js
 
 ClickHouse, MongoDB, and collector ports are private. The browser never receives
 the ingestion key. Telemetry failure must not change product behavior.
+
+## Public OTLP gateway
+
+The nginx edge exposes exactly three OTLP/HTTP ingestion paths:
+
+- `POST /v1/logs`
+- `POST /v1/metrics`
+- `POST /v1/traces`
+
+All three use the collector's same `INGESTION_API_KEY` authentication, reject
+query strings and non-`POST` methods, and limit each request body to 64 KiB.
+They remain unavailable until the startup supervisor proves that the collector
+rejects missing credentials on all three paths. `/v1/workflows` does not exist,
+and every other `/v1/*` path returns `404`.
+
+The collector remains on loopback and nginx strips collector CORS response
+headers, so these endpoints are not browser APIs. Access logs include only the
+method, path, protocol, status, and response size; they omit query strings,
+authorization, referrers, and user agents. ClickHouse, MongoDB, and collector
+ports remain private.
 
 ## Investigating a report
 
@@ -144,7 +168,8 @@ Static checks and Render Blueprint validation:
 ./observability/scripts/verify.sh
 ```
 
-Full disposable Docker persistence smoke:
+Full disposable Docker security, logs/metrics/traces canary, and log-persistence
+smoke:
 
 ```sh
 ./observability/scripts/verify.sh --local

--- a/observability/VERIFIER.md
+++ b/observability/VERIFIER.md
@@ -5,34 +5,41 @@ Run this verifier cold from `/Users/taequn/loyal/loyal-apps`. Report PASS or FAI
 ## Required
 
 1. Repository state and scope
+
 - `git status --short` contains only the intended observability/deploy-isolation changes before commit, and is clean after the deployment commit.
 - A standalone `observability/` project contains the ClickStack Render Blueprint, pinned Docker definition, startup/configuration, a repeatable verifier, and a README with deploy, rollback, persistence, cost/limitations, and test commands.
 - It is not added to the root Bun workspaces and no frontend/app/admin/dashboard/mobile/extension runtime code or lockfile changed.
 - No plaintext secret or credential exists in the diff or tracked observability files.
 
 2. Deploy isolation
+
 - Every observability Render service has `rootDir: observability` and a complete `buildFilter` whose positive paths are only `observability/**` and whose `ignoredPaths` is explicitly present.
 - `observability/**`-only changes do not match existing Vercel, extension, mobile, package-release, or mirror deployment triggers; unrelated-path-only changes do not match the observability build filter. A checked-in script proves these cases and exits nonzero on a negative fixture.
 - Existing Vercel deployment configuration is unchanged unless evidence proves an edit is required.
 
 3. Static and local validation
+
 - `render blueprints validate observability/render.yaml` exits 0.
 - The Docker image is pinned by immutable digest, binds the ClickStack UI to `0.0.0.0:$PORT`, exposes no database port publicly, persists MongoDB and ClickHouse state beneath the one Render disk mount, disables upstream usage telemetry, and has a readiness check that fails when the UI is unavailable.
-- `docker build` succeeds. A local container returns HTTP 200 for the UI, accepts a uniquely named OTLP smoke event, ClickHouse contains that event, and the same event remains after recreating the container against the same volume.
+- `docker build` succeeds. A local container returns HTTP 200 for the UI; accepts valid authenticated OTLP logs, metrics, and traces canaries only on the exact bounded endpoints; keeps `/v1/workflows` and every other `/v1/*` path closed; stores the uniquely named log in ClickHouse; and retains that same log after recreating the container against the same volume.
 
 4. Live Render end-state
+
 - A separate Render project/environment for Loyal observability contains exactly the intended initial ClickStack test service; it is not placed in either yield-worker project.
-- The service is sourced from the deployed repository commit, has one paid persistent disk, one instance, path-filtered auto-deploy, and only the UI HTTP port is public. ClickHouse, MongoDB, and OTLP ports are not publicly reachable in this milestone.
+- The service is sourced from the deployed repository commit, has one paid persistent disk, one instance, path-filtered auto-deploy, and only the nginx UI/gateway HTTP port is public. ClickHouse, MongoDB, and the collector's OTLP ports are not publicly reachable.
 - The latest deploy status is `live`; its public HTTPS URL and configured health path return 2xx/3xx.
-- From inside the live service, a uniquely named OTLP smoke event is accepted and queryable in ClickHouse. After one controlled service restart, the same event is still queryable.
+- From inside the live service, valid authenticated OTLP logs, metrics, and traces canaries are accepted through nginx, unsupported paths remain rejected, and a uniquely named log is queryable in ClickHouse. After one controlled service restart, the same log is still queryable.
 - Recent deploy/runtime logs show ClickHouse, MongoDB, the OTel collector, and HyperDX running with no crash loop, fatal startup error, or repeated readiness failure.
 
 5. Handoff quality
-- The implementation plan clearly separates this milestone from later app instrumentation/public ingestion work.
+
+- The implementation plan clearly separates the gateway paths from later service instrumentation and higher-volume ingestion work.
 - The final report gives the project/service identity, public UI URL, deployed commit, disk/instance choice, exact verification results, current non-production limitations, and any unavoidable manual account/bootstrap step. It does not print secrets.
 
 ## Nice to have
+
 - A machine-readable smoke-test result artifact is produced without storing credentials.
 
 ## Verdict
+
 Overall PASS only if all five Required sections pass. Otherwise overall FAIL, list each false condition, preserve this verifier unchanged, and continue the plan-do-verify loop unless blocked by user-only authentication or billing approval.

--- a/observability/nginx.conf
+++ b/observability/nginx.conf
@@ -68,6 +68,66 @@ http {
       proxy_hide_header Access-Control-Max-Age;
     }
 
+    location = /v1/metrics {
+      client_max_body_size 64k;
+
+      if ($request_method != POST) {
+        return 405;
+      }
+      if ($args != '') {
+        return 404;
+      }
+      if (!-f /tmp/loyal-clickstack-collector-auth-ready) {
+        return 503;
+      }
+
+      proxy_pass http://127.0.0.1:4318/v1/metrics;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1:4318;
+      proxy_set_header Connection '';
+      proxy_request_buffering on;
+      proxy_connect_timeout 1s;
+      proxy_send_timeout 5s;
+      proxy_read_timeout 5s;
+
+      proxy_hide_header Access-Control-Allow-Origin;
+      proxy_hide_header Access-Control-Allow-Credentials;
+      proxy_hide_header Access-Control-Allow-Headers;
+      proxy_hide_header Access-Control-Allow-Methods;
+      proxy_hide_header Access-Control-Expose-Headers;
+      proxy_hide_header Access-Control-Max-Age;
+    }
+
+    location = /v1/traces {
+      client_max_body_size 64k;
+
+      if ($request_method != POST) {
+        return 405;
+      }
+      if ($args != '') {
+        return 404;
+      }
+      if (!-f /tmp/loyal-clickstack-collector-auth-ready) {
+        return 503;
+      }
+
+      proxy_pass http://127.0.0.1:4318/v1/traces;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1:4318;
+      proxy_set_header Connection '';
+      proxy_request_buffering on;
+      proxy_connect_timeout 1s;
+      proxy_send_timeout 5s;
+      proxy_read_timeout 5s;
+
+      proxy_hide_header Access-Control-Allow-Origin;
+      proxy_hide_header Access-Control-Allow-Credentials;
+      proxy_hide_header Access-Control-Allow-Headers;
+      proxy_hide_header Access-Control-Allow-Methods;
+      proxy_hide_header Access-Control-Expose-Headers;
+      proxy_hide_header Access-Control-Max-Age;
+    }
+
     location ^~ /v1/ {
       return 404;
     }

--- a/observability/scripts/entrypoint.sh
+++ b/observability/scripts/entrypoint.sh
@@ -135,13 +135,24 @@ stack_pid=$!
 nginx -g 'daemon off;' &
 nginx_pid=$!
 
+collector_auth_is_active() {
+  case "$1" in
+    401|403) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 wait_for_collector_authentication() {
   # Keep only ingestion closed until the collector proves that its own key
   # enforcement is active. HyperDX remains reachable so a fresh installation
   # can create its first user/team without an authentication bootstrap deadlock.
   auth_probe='{"resourceLogs":[]}'
-  last_status="unreachable"
+  log_status="unreachable"
+  metrics_status="unreachable"
+  traces_status="unreachable"
   attempt=0
+  metrics_auth_probe='{"resourceMetrics":[]}'
+  traces_auth_probe='{"resourceSpans":[]}'
 
   while true; do
     if ! kill -0 "$stack_pid" 2>/dev/null; then
@@ -149,17 +160,26 @@ wait_for_collector_authentication() {
       return 1
     fi
 
-    last_status="$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
+    log_status="$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
       -X POST 'http://127.0.0.1:4318/v1/logs' \
       -H 'Content-Type: application/json' \
       --data "$auth_probe" || true)"
-    case "$last_status" in
-      401|403)
-        : > "$collector_auth_ready_file"
-        echo "Collector authentication is active; public log ingestion is enabled"
-        return 0
-        ;;
-    esac
+    metrics_status="$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
+      -X POST 'http://127.0.0.1:4318/v1/metrics' \
+      -H 'Content-Type: application/json' \
+      --data "$metrics_auth_probe" || true)"
+    traces_status="$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
+      -X POST 'http://127.0.0.1:4318/v1/traces' \
+      -H 'Content-Type: application/json' \
+      --data "$traces_auth_probe" || true)"
+
+    if collector_auth_is_active "$log_status" \
+      && collector_auth_is_active "$metrics_status" \
+      && collector_auth_is_active "$traces_status"; then
+      : > "$collector_auth_ready_file"
+      echo "Collector authentication is active; public OTLP ingestion is enabled"
+      return 0
+    fi
 
     attempt=$((attempt + 1))
     if [ $((attempt % 60)) -eq 0 ]; then

--- a/observability/scripts/smoke-live.sh
+++ b/observability/scripts/smoke-live.sh
@@ -5,6 +5,8 @@ state_root="/var/lib/clickhouse/.clickstack"
 marker_file="$state_root/render-smoke-marker"
 health_url="http://127.0.0.1:${PORT:-8080}/api/health"
 otlp_url="http://127.0.0.1:${PORT:-8080}/v1/logs"
+metrics_url="http://127.0.0.1:${PORT:-8080}/v1/metrics"
+traces_url="http://127.0.0.1:${PORT:-8080}/v1/traces"
 headers_file="/tmp/loyal-clickstack-smoke-headers-$$"
 oversized_file="/tmp/loyal-clickstack-smoke-oversized-$$"
 
@@ -29,6 +31,10 @@ fi
 case "$marker" in
   *[!A-Za-z0-9._:-]*) fail "invalid persisted marker" ;;
 esac
+
+seconds="$(date +%s)"
+metrics_payload="$(printf '{\"resourceMetrics\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"loyal-clickstack-render-smoke\"}}]},\"scopeMetrics\":[{\"scope\":{\"name\":\"loyal-clickstack-render-verifier\"},\"metrics\":[{\"name\":\"loyal.clickstack.smoke\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%s000000000\",\"asInt\":\"1\",\"attributes\":[{\"key\":\"loyal.smoke.marker\",\"value\":{\"stringValue\":\"%s\"}}]}]}}]}]}]}' "$seconds" "$marker")"
+traces_payload="$(printf '{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"loyal-clickstack-render-smoke\"}}]},\"scopeSpans\":[{\"scope\":{\"name\":\"loyal-clickstack-render-verifier\"},\"spans\":[{\"traceId\":\"11111111111111111111111111111111\",\"spanId\":\"2222222222222222\",\"name\":\"%s\",\"kind\":1,\"startTimeUnixNano\":\"%s000000000\",\"endTimeUnixNano\":\"%s001000000\",\"attributes\":[{\"key\":\"loyal.smoke.marker\",\"value\":{\"stringValue\":\"%s\"}}],\"status\":{\"code\":1}}]}]}]}' "$marker" "$seconds" "$seconds" "$marker")"
 
 health_status=""
 for _ in $(seq 1 300); do
@@ -64,17 +70,57 @@ case "$wrong_status" in
   *) fail "wrong ingestion credential was not rejected" ;;
 esac
 
+for signal in metrics traces; do
+  case "$signal" in
+    metrics) signal_url="$metrics_url"; signal_payload="$metrics_payload" ;;
+    traces) signal_url="$traces_url"; signal_payload="$traces_payload" ;;
+  esac
+
+  signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$signal_url" \
+    -H 'Content-Type: application/json' \
+    --data "$signal_payload" || true)"
+  case "$signal_status" in
+    401|403) ;;
+    *) fail "missing $signal ingestion credential was not rejected" ;;
+  esac
+
+  signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$signal_url" \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: deliberately-wrong-ingestion-key' \
+    --data "$signal_payload" || true)"
+  case "$signal_status" in
+    401|403) ;;
+    *) fail "wrong $signal ingestion credential was not rejected" ;;
+  esac
+done
+
 method_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   "$otlp_url" \
   -H "Authorization: $INGESTION_API_KEY" || true)"
 [ "$method_status" = "405" ] || fail "non-POST log request was not rejected"
 
+for signal_url in "$metrics_url" "$traces_url"; do
+  signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    "$signal_url" \
+    -H "Authorization: $INGESTION_API_KEY" || true)"
+  [ "$signal_status" = "405" ] || fail "non-POST metrics or traces request was not rejected"
+done
+
 path_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-  -X POST "http://127.0.0.1:${PORT:-8080}/v1/traces" \
+  -X POST "http://127.0.0.1:${PORT:-8080}/v1/workflows" \
   -H 'Content-Type: application/json' \
   -H "Authorization: $INGESTION_API_KEY" \
   --data "$probe_payload" || true)"
-[ "$path_status" = "404" ] || fail "non-log OTLP path was not rejected"
+[ "$path_status" = "404" ] || fail "nonexistent workflows path was not rejected"
+
+other_path_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+  -X POST "http://127.0.0.1:${PORT:-8080}/v1/not-supported" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: $INGESTION_API_KEY" \
+  --data "$probe_payload" || true)"
+[ "$other_path_status" = "404" ] || fail "other unsupported OTLP path was not rejected"
 
 query_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   -X POST "${otlp_url}?unexpected=true" \
@@ -83,6 +129,19 @@ query_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   --data "$probe_payload" || true)"
 [ "$query_status" = "404" ] || fail "query-bearing log path was not rejected"
 
+for signal in metrics traces; do
+  case "$signal" in
+    metrics) signal_url="$metrics_url"; signal_payload="$metrics_payload" ;;
+    traces) signal_url="$traces_url"; signal_payload="$traces_payload" ;;
+  esac
+  signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "${signal_url}?unexpected=true" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $INGESTION_API_KEY" \
+    --data "$signal_payload" || true)"
+  [ "$signal_status" = "404" ] || fail "query-bearing $signal path was not rejected"
+done
+
 dd if=/dev/zero bs=1024 count=65 2>/dev/null | tr '\0' 'x' > "$oversized_file"
 oversized_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   -X POST "$otlp_url" \
@@ -90,6 +149,15 @@ oversized_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   -H "Authorization: $INGESTION_API_KEY" \
   --data-binary "@$oversized_file" || true)"
 [ "$oversized_status" = "413" ] || fail "oversized log request was not rejected"
+
+for signal_url in "$metrics_url" "$traces_url"; do
+  signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$signal_url" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $INGESTION_API_KEY" \
+    --data-binary "@$oversized_file" || true)"
+  [ "$signal_status" = "413" ] || fail "oversized metrics or traces request was not rejected"
+done
 
 correct_status=""
 for _ in $(seq 1 120); do
@@ -111,6 +179,40 @@ esac
 if grep -Eiq '^Access-Control-Allow-' "$headers_file"; then
   fail "public log response exposed a permissive CORS header"
 fi
+
+metrics_status=""
+traces_status=""
+for signal in metrics traces; do
+  case "$signal" in
+    metrics) signal_url="$metrics_url"; signal_payload="$metrics_payload" ;;
+    traces) signal_url="$traces_url"; signal_payload="$traces_payload" ;;
+  esac
+
+  signal_status=""
+  for _ in $(seq 1 120); do
+    signal_status="$(curl -sS -o /dev/null -D "$headers_file" -w '%{http_code}' \
+      -X POST "$signal_url" \
+      -H 'Content-Type: application/json' \
+      -H 'Origin: https://untrusted.example.test' \
+      -H "Authorization: $INGESTION_API_KEY" \
+      --data "$signal_payload" || true)"
+    case "$signal_status" in
+      2*) break ;;
+    esac
+    sleep 1
+  done
+  case "$signal_status" in
+    2*) ;;
+    *) fail "configured $signal ingestion credential was not accepted" ;;
+  esac
+  if grep -Eiq '^Access-Control-Allow-' "$headers_file"; then
+    fail "public $signal response exposed a permissive CORS header"
+  fi
+  case "$signal" in
+    metrics) metrics_status="$signal_status" ;;
+    traces) traces_status="$signal_status" ;;
+  esac
+done
 
 query_count() {
   clickhouse-client \
@@ -163,6 +265,7 @@ if [ "$stage" = "initial" ]; then
   mv "$marker_tmp" "$marker_file"
 fi
 
-printf 'CLICKSTACK_SMOKE_RESULT {"status":"pass","stage":"%s","marker":"%s","health_status":%s,"auth":{"missing":%s,"wrong":%s,"correct":%s},"rejections":{"method":%s,"path":%s,"query":%s,"oversized":%s},"cors":false,"count":%s}\n' \
+printf 'CLICKSTACK_SMOKE_RESULT {"status":"pass","stage":"%s","marker":"%s","health_status":%s,"auth":{"missing":%s,"wrong":%s,"correct":%s},"accepted":{"logs":%s,"metrics":%s,"traces":%s},"rejections":{"method":%s,"workflows":%s,"other_v1":%s,"query":%s,"oversized":%s},"cors":false,"count":%s}\n' \
   "$stage" "$marker" "$health_status" "$missing_status" "$wrong_status" "$correct_status" \
-  "$method_status" "$path_status" "$query_status" "$oversized_status" "$count"
+  "$correct_status" "$metrics_status" "$traces_status" "$method_status" "$path_status" \
+  "$other_path_status" "$query_status" "$oversized_status" "$count"

--- a/observability/scripts/smoke-local.sh
+++ b/observability/scripts/smoke-local.sh
@@ -13,11 +13,16 @@ ingestion_key="local-${marker}"
 result_file="${CLICKSTACK_SMOKE_RESULT:-$project_dir/smoke-result.json}"
 tmp_dir="$(mktemp -d)"
 payload=""
+metrics_payload=""
+traces_payload=""
 missing_status=""
 wrong_status=""
 correct_status=""
+metrics_status=""
+traces_status=""
 method_status=""
 path_status=""
+other_path_status=""
 query_status=""
 oversized_status=""
 
@@ -75,9 +80,20 @@ bootstrap_local_team() {
   assert_status "local HyperDX team bootstrap" "$status" 200
 }
 
-build_payload() {
+build_payloads() {
   seconds="$(date +%s)"
   payload="{\"resourceLogs\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"loyal-clickstack-smoke\"}}]},\"scopeLogs\":[{\"scope\":{\"name\":\"loyal-clickstack-verifier\"},\"logRecords\":[{\"timeUnixNano\":\"${seconds}000000000\",\"severityText\":\"INFO\",\"body\":{\"stringValue\":\"$marker\"}}]}]}]}"
+  metrics_payload="{\"resourceMetrics\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"loyal-clickstack-smoke\"}}]},\"scopeMetrics\":[{\"scope\":{\"name\":\"loyal-clickstack-verifier\"},\"metrics\":[{\"name\":\"loyal.clickstack.smoke\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"${seconds}000000000\",\"asInt\":\"1\",\"attributes\":[{\"key\":\"loyal.smoke.marker\",\"value\":{\"stringValue\":\"$marker\"}}]}]}}]}]}]}"
+  traces_payload="{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"loyal-clickstack-smoke\"}}]},\"scopeSpans\":[{\"scope\":{\"name\":\"loyal-clickstack-verifier\"},\"spans\":[{\"traceId\":\"11111111111111111111111111111111\",\"spanId\":\"2222222222222222\",\"name\":\"$marker\",\"kind\":1,\"startTimeUnixNano\":\"${seconds}000000000\",\"endTimeUnixNano\":\"${seconds}001000000\",\"attributes\":[{\"key\":\"loyal.smoke.marker\",\"value\":{\"stringValue\":\"$marker\"}}],\"status\":{\"code\":1}}]}]}]}"
+}
+
+payload_for_signal() {
+  case "$1" in
+    logs) printf '%s' "$payload" ;;
+    metrics) printf '%s' "$metrics_payload" ;;
+    traces) printf '%s' "$traces_payload" ;;
+    *) fail_with_logs "unknown OTLP signal: $1" ;;
+  esac
 }
 
 assert_status() {
@@ -95,6 +111,10 @@ assert_status() {
 }
 
 assert_public_boundary() {
+  local signal
+  local signal_payload
+  local signal_status
+
   for _ in $(seq 1 180); do
     missing_status="$(curl -sS -o /dev/null -w '%{http_code}' \
       -X POST "http://127.0.0.1:${ui_port}/v1/logs" \
@@ -117,17 +137,47 @@ assert_public_boundary() {
     --data "$payload" || true)"
   assert_status "wrong ingestion credential" "$wrong_status" 401 403
 
+  for signal in metrics traces; do
+    signal_payload="$(payload_for_signal "$signal")"
+    signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "http://127.0.0.1:${ui_port}/v1/$signal" \
+      -H 'Content-Type: application/json' \
+      --data "$signal_payload" || true)"
+    assert_status "missing $signal ingestion credential" "$signal_status" 401 403
+
+    signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "http://127.0.0.1:${ui_port}/v1/$signal" \
+      -H 'Content-Type: application/json' \
+      -H 'Authorization: deliberately-wrong-ingestion-key' \
+      --data "$signal_payload" || true)"
+    assert_status "wrong $signal ingestion credential" "$signal_status" 401 403
+  done
+
   method_status="$(curl -sS -o /dev/null -w '%{http_code}' \
     "http://127.0.0.1:${ui_port}/v1/logs" \
     -H "Authorization: $ingestion_key" || true)"
   assert_status "non-POST log request" "$method_status" 405
 
+  for signal in metrics traces; do
+    signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      "http://127.0.0.1:${ui_port}/v1/$signal" \
+      -H "Authorization: $ingestion_key" || true)"
+    assert_status "non-POST $signal request" "$signal_status" 405
+  done
+
   path_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-    -X POST "http://127.0.0.1:${ui_port}/v1/traces" \
+    -X POST "http://127.0.0.1:${ui_port}/v1/workflows" \
     -H 'Content-Type: application/json' \
     -H "Authorization: $ingestion_key" \
     --data "$payload" || true)"
-  assert_status "non-log OTLP path" "$path_status" 404
+  assert_status "nonexistent workflows path" "$path_status" 404
+
+  other_path_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "http://127.0.0.1:${ui_port}/v1/not-supported" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $ingestion_key" \
+    --data "$payload" || true)"
+  assert_status "other unsupported OTLP path" "$other_path_status" 404
 
   query_status="$(curl -sS -o /dev/null -w '%{http_code}' \
     -X POST "http://127.0.0.1:${ui_port}/v1/logs?unexpected=true" \
@@ -136,6 +186,16 @@ assert_public_boundary() {
     --data "$payload" || true)"
   assert_status "query-bearing log path" "$query_status" 404
 
+  for signal in metrics traces; do
+    signal_payload="$(payload_for_signal "$signal")"
+    signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "http://127.0.0.1:${ui_port}/v1/$signal?unexpected=true" \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: $ingestion_key" \
+      --data "$signal_payload" || true)"
+    assert_status "query-bearing $signal path" "$signal_status" 404
+  done
+
   dd if=/dev/zero bs=1024 count=65 2>/dev/null | tr '\0' 'x' > "$tmp_dir/oversized-body"
   oversized_status="$(curl -sS -o /dev/null -w '%{http_code}' \
     -X POST "http://127.0.0.1:${ui_port}/v1/logs" \
@@ -143,6 +203,15 @@ assert_public_boundary() {
     -H "Authorization: $ingestion_key" \
     --data-binary "@$tmp_dir/oversized-body" || true)"
   assert_status "oversized log request" "$oversized_status" 413
+
+  for signal in metrics traces; do
+    signal_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "http://127.0.0.1:${ui_port}/v1/$signal" \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: $ingestion_key" \
+      --data-binary "@$tmp_dir/oversized-body" || true)"
+    assert_status "oversized $signal request" "$signal_status" 413
+  done
 
   cors_status=""
   for _ in $(seq 1 60); do
@@ -163,6 +232,33 @@ assert_public_boundary() {
   if rg --quiet --ignore-case '^Access-Control-Allow-' "$tmp_dir/cors-headers"; then
     fail_with_logs "public log response exposed a permissive CORS header"
   fi
+
+  for signal in metrics traces; do
+    signal_payload="$(payload_for_signal "$signal")"
+    signal_status=""
+    for _ in $(seq 1 60); do
+      signal_status="$(curl -sS -o /dev/null -D "$tmp_dir/cors-headers" -w '%{http_code}' \
+        -X POST "http://127.0.0.1:${ui_port}/v1/$signal" \
+        -H 'Content-Type: application/json' \
+        -H 'Origin: https://untrusted.example.test' \
+        -H "Authorization: $ingestion_key" \
+        --data "$signal_payload" || true)"
+      if [[ "$signal_status" =~ ^2 ]]; then
+        break
+      fi
+      sleep 1
+    done
+    if [[ ! "$signal_status" =~ ^2 ]]; then
+      fail_with_logs "$signal canary never reached an accepted authenticated response"
+    fi
+    if rg --quiet --ignore-case '^Access-Control-Allow-' "$tmp_dir/cors-headers"; then
+      fail_with_logs "public $signal response exposed a permissive CORS header"
+    fi
+    case "$signal" in
+      metrics) metrics_status="$signal_status" ;;
+      traces) traces_status="$signal_status" ;;
+    esac
+  done
 
   published_ports="$(docker inspect "$container" --format '{{json .HostConfig.PortBindings}}')"
   if rg --quiet '4318|8123|9000|27017' <<<"$published_ports"; then
@@ -217,7 +313,7 @@ docker volume create "$volume" >/dev/null
 run_container
 wait_for_ui
 bootstrap_local_team
-build_payload
+build_payloads
 assert_public_boundary
 send_marker
 wait_for_marker true
@@ -231,6 +327,7 @@ wait_for_ui
 wait_for_marker false
 after_restart="$(query_marker_count)"
 
-printf '{"status":"pass","marker":"%s","health_status":200,"auth":{"missing":%s,"wrong":%s,"correct":%s},"rejections":{"method":%s,"path":%s,"query":%s,"oversized":%s},"cors":false,"private_ports":true,"count_before_restart":%s,"count_after_restart":%s}\n' \
-  "$marker" "$missing_status" "$wrong_status" "$correct_status" "$method_status" "$path_status" \
-  "$query_status" "$oversized_status" "$before_restart" "$after_restart" | tee "$result_file"
+printf '{"status":"pass","marker":"%s","health_status":200,"auth":{"missing":%s,"wrong":%s,"correct":%s},"accepted":{"logs":%s,"metrics":%s,"traces":%s},"rejections":{"method":%s,"workflows":%s,"other_v1":%s,"query":%s,"oversized":%s},"cors":false,"private_ports":true,"count_before_restart":%s,"count_after_restart":%s}\n' \
+  "$marker" "$missing_status" "$wrong_status" "$correct_status" "$correct_status" "$metrics_status" \
+  "$traces_status" "$method_status" "$path_status" "$other_path_status" "$query_status" \
+  "$oversized_status" "$before_restart" "$after_restart" | tee "$result_file"

--- a/observability/scripts/verify.sh
+++ b/observability/scripts/verify.sh
@@ -76,6 +76,10 @@ require_literal 'listen 0.0.0.0:8080' "$project_dir/nginx.conf"
 require_literal 'proxy_pass http://127.0.0.1:8081' "$project_dir/nginx.conf"
 require_literal 'location = /v1/logs' "$project_dir/nginx.conf"
 require_literal 'proxy_pass http://127.0.0.1:4318/v1/logs' "$project_dir/nginx.conf"
+require_literal 'location = /v1/metrics' "$project_dir/nginx.conf"
+require_literal 'proxy_pass http://127.0.0.1:4318/v1/metrics' "$project_dir/nginx.conf"
+require_literal 'location = /v1/traces' "$project_dir/nginx.conf"
+require_literal 'proxy_pass http://127.0.0.1:4318/v1/traces' "$project_dir/nginx.conf"
 require_literal 'location ^~ /v1/' "$project_dir/nginx.conf"
 require_literal 'client_max_body_size 64k' "$project_dir/nginx.conf"
 require_literal 'proxy_connect_timeout 1s' "$project_dir/nginx.conf"
@@ -84,14 +88,53 @@ require_literal 'proxy_read_timeout 5s' "$project_dir/nginx.conf"
 require_literal 'proxy_hide_header Access-Control-Allow-Origin' "$project_dir/nginx.conf"
 require_literal '!-f /tmp/loyal-clickstack-collector-auth-ready' "$project_dir/nginx.conf"
 require_literal ': > "$collector_auth_ready_file"' "$project_dir/scripts/entrypoint.sh"
-[[ "$(rg --count 'client_max_body_size 64k' "$project_dir/nginx.conf")" == "1" ]] \
-  || fail "public proxy must define exactly one 64 KiB body limit"
-exact_log_line="$(rg -n --no-heading 'location = /v1/logs' "$project_dir/nginx.conf" | cut -d: -f1)"
-body_limit_line="$(rg -n --no-heading 'client_max_body_size 64k' "$project_dir/nginx.conf" | cut -d: -f1)"
-fallback_line="$(rg -n --no-heading 'location / \{' "$project_dir/nginx.conf" | cut -d: -f1)"
-if (( body_limit_line <= exact_log_line || body_limit_line >= fallback_line )); then
-  fail "64 KiB body limit must apply only to the exact log-ingestion location"
+for signal in logs metrics traces; do
+  require_literal "/v1/$signal" "$project_dir/scripts/entrypoint.sh"
+done
+[[ "$(rg --count 'client_max_body_size 64k' "$project_dir/nginx.conf")" == "3" ]] \
+  || fail "public proxy must define one 64 KiB body limit per OTLP endpoint"
+[[ "$(rg --count 'location = /v1/' "$project_dir/nginx.conf")" == "3" ]] \
+  || fail "public proxy must define exactly three exact OTLP endpoint locations"
+if rg --quiet 'location = /v1/workflows' "$project_dir/nginx.conf"; then
+  fail "the nonexistent /v1/workflows path must not be proxied"
 fi
+for signal in logs metrics traces; do
+  location_block="$(awk -v signal="$signal" '
+    $0 ~ "location = /v1/" signal " \\{" { capture = 1 }
+    capture { print }
+    capture && /^    }$/ { exit }
+  ' "$project_dir/nginx.conf")"
+  for directive in \
+    'client_max_body_size 64k' \
+    'if ($request_method != POST)' \
+    "if (\$args != '')" \
+    '!-f /tmp/loyal-clickstack-collector-auth-ready' \
+    "proxy_pass http://127.0.0.1:4318/v1/$signal" \
+    'proxy_hide_header Access-Control-Allow-Origin'; do
+    rg --quiet --fixed-strings -- "$directive" <<<"$location_block" \
+      || fail "exact /v1/$signal location is missing '$directive'"
+  done
+done
+for directive in \
+  'if ($request_method != POST)' \
+  "if (\$args != '')" \
+  'proxy_connect_timeout 1s' \
+  'proxy_send_timeout 5s' \
+  'proxy_read_timeout 5s' \
+  'proxy_hide_header Access-Control-Allow-Origin' \
+  '!-f /tmp/loyal-clickstack-collector-auth-ready'; do
+  [[ "$(rg --count --fixed-strings -- "$directive" "$project_dir/nginx.conf")" == "3" ]] \
+    || fail "public proxy must apply '$directive' to exactly three OTLP endpoints"
+done
+for smoke_script in "$project_dir/scripts/smoke-local.sh" "$project_dir/scripts/smoke-live.sh"; do
+  require_literal '/v1/workflows' "$smoke_script"
+  require_literal 'resourceMetrics' "$smoke_script"
+  require_literal 'resourceSpans' "$smoke_script"
+  require_literal 'for signal in metrics traces' "$smoke_script"
+done
+require_literal '/v1/$signal' "$project_dir/scripts/smoke-local.sh"
+require_literal '/v1/metrics' "$project_dir/scripts/smoke-live.sh"
+require_literal '/v1/traces' "$project_dir/scripts/smoke-live.sh"
 nginx_log_format="$(awk '/log_format loyal/{capture=1} capture{print} capture && /;/{exit}' "$project_dir/nginx.conf")"
 if rg --quiet '\$request\b|\$args\b|\$http_referer|\$http_user_agent|\$http_authorization' <<<"$nginx_log_format"; then
   fail "proxy access logs or config reference sensitive request metadata"
@@ -102,7 +145,7 @@ fi
 if rg --quiet -- '--publish[^[:cntrl:]]*(4318|8123|9000|27017)' "$project_dir/scripts/smoke-local.sh"; then
   fail "local smoke must not publish collector or database ports"
 fi
-pass "single public proxy exposes only the bounded authenticated log endpoint"
+pass "single public proxy exposes only bounded authenticated logs, metrics, and traces endpoints"
 
 sh -n "$project_dir/scripts/entrypoint.sh" "$project_dir/scripts/smoke-live.sh"
 bash -n "$project_dir/scripts/smoke-local.sh" "$project_dir/scripts/smoke-auth-redirect.sh"


### PR DESCRIPTION
Expose authenticated exact OTLP/HTTP metrics and traces endpoints through the loyal-clickstack nginx gateway, preserving the existing auth-readiness, 64 KiB, loopback, CORS, logging, and negative-path boundaries while extending the smoke and verifier documentation. This is draft because Docker is unavailable here and the repository verifier hits a pre-existing frontend `walletAddress` assertion on `main`.