### PR TITLE
docs: add Q2 2026 transparency report

### DIFF
--- a/user-docs/docs.json
+++ b/user-docs/docs.json
@@ -75,7 +75,7 @@
           },
           {
             "group": "Reports",
-            "pages": ["transparency/q1-2026", "transparency/q4-2025"]
+            "pages": ["transparency/q2-2026", "transparency/q1-2026", "transparency/q4-2025"]
           },
           {
             "group": "Launch",

--- a/user-docs/transparency/q2-2026.mdx
+++ b/user-docs/transparency/q2-2026.mdx
@@ -1,0 +1,131 @@
+---
+title: "Q2 2026 Transparency Report"
+description: "Loyal Public Transparency Report covering April 1 – June 30, 2026"
+---
+
+<Info>
+**Period:** Apr 1, 2026 → Jun 30, 2026
+**Currency:** USDC
+**Accounting view:** Cash basis (expenses recognized when paid)
+</Info>
+
+## What Happened This Quarter
+
+During the Apr 1–Jun 30 reporting period, Loyal shipped across every product surface:
+
+- **Shipped:** Chrome extension public launch — the Loyal side-panel wallet went live on the Chrome Web Store. It connects to any Solana dApp via wallet adapters, with agent controls and privacy built in.
+- **Shipped:** Loyal EARN — Smart Account autodeposit into yield (via Kamino) on shielded USDC. Assets keep earning while they stay private. Roughly $390K in assets under management as of mid-July.
+- **Android app in testing:** the Android build is available through Google Play's testing track.
+- **Shipped:** Solana Seeker — Loyal listed in the Seeker dApp store for the device launch.
+- **Governance:** No new MetaDAO proposals this quarter (see Governance Actions below).
+
+## Organizational Status
+
+| Item | Status |
+|------|--------|
+| **Scope** | Consolidated reporting for Loyal (no separate "company ops" vs "DAO ops" separation at this stage) |
+| **Incorporation** | Marshall Islands entity completed in Q1 (certificate issued). US (Delaware) structuring is in progress — the Delaware Corp & Tax and Qe.tax fees reflect preparatory work; the US entity is not yet established |
+| **Legal / tax providers** | MiDAO (Marshall Islands); Qe.tax (US corporate tax) |
+
+## Expense Details
+
+**Total operating expenses paid (Apr 1–Jun 30): 172,839.34 USDC**
+
+<Note>
+This operating expense summary excludes governance-directed capital actions (e.g., buybacks and liquidity changes), which are disclosed separately and are inherently dynamic.
+</Note>
+
+### Monthly Breakdown
+
+| Category | Apr | May | Jun | Total |
+|----------|-----|-----|-----|-------|
+| Salaries | 51,550.00 | 53,398.00 | 46,726.00 | 151,674.00 |
+| Marketing | 5,545.22 | 5,612.37 | 2,968.32 | 14,125.91 |
+| Administrative | 439.19 | 0.00 | 0.00 | 439.19 |
+| Software | 883.18 | 1,952.33 | 1,596.73 | 4,432.24 |
+| Legal | 2,168.00 | 0.00 | 0.00 | 2,168.00 |
+| Travel | 0.00 | 0.00 | 0.00 | 0.00 |
+| **Total** | **60,585.59** | **60,962.70** | **51,291.05** | **172,839.34** |
+
+<Note>
+The Salaries row is shown by the month of service it compensates, not the payment date. Several May salaries were disbursed in early-to-mid June; placing them in their service month gives a truer month-to-month picture and reflects a team paid steadily at roughly 50,000/month. This reallocates the same Q2 cash total (151,674.00 USDC) across months and does not tie to individual on-chain payment dates. All other categories remain on a cash basis.
+</Note>
+
+## Statement of Operations
+
+### Spending Analysis
+
+- **Salaries (87.75%)** edged up from 86.00% in Q1. Headcount is stable and this was a full-team payroll quarter; the ratio moves mostly because non-salary lines stayed flat while total spend grew ~6%.
+- **Marketing (8.17%)** held essentially flat in absolute terms (14,125.91 vs 14,028.35 in Q1). Community growth (Sector 0 payouts) and platform spend (X Premium Business, X paid features, Discord boosts) make up the bulk.
+- **Legal (1.25%)** landed as forecast in the Q1 report: the Delaware Corp & Tax (668.00) and Qe.tax (1,500.00) fees hit this quarter as US structuring got underway.
+- **Software (2.56%)** roughly tripled versus Q1 (4,432.24 vs 1,598.21) as products went live — Helius RPC, Vercel, Neon, Streamingfast, Dune and the rest of the production stack now carry recurring monthly cost.
+- **Administrative (0.25%)** and **Travel (0.00%)** stayed near zero. No hardware purchase this quarter (Q1 had the Seeker unit); no travel.
+- **Salary presentation (by service month):** salaries are shown by the month they compensate rather than the payment date. Most May payroll cleared in early-to-mid June, so a strict payment-date view would show May at ~10,500 and June at ~89,624; by service month the team's compensation is level at roughly 50,000/month. June reads slightly lighter than May because one salary was paid after quarter-end (Jul 16). The quarterly total (151,674.00) is unchanged.
+- **Totals reconcile:** the sum of monthly totals equals the sum of category totals (172,839.34 USDC).
+
+### Income Statement
+
+| Line Item | Amount (USDC) | % of Operating Expenses |
+|-----------|---------------|------------------------|
+| **Revenue** | 0.00 | — |
+| **Total revenue** | 0.00 | — |
+| **Operating expenses** | | |
+| Salaries (including R&D) | 151,674.00 | 87.75% |
+| Marketing | 14,125.91 | 8.17% |
+| Administrative | 439.19 | 0.25% |
+| Software | 4,432.24 | 2.56% |
+| Legal | 2,168.00 | 1.25% |
+| Travel | 0.00 | 0.00% |
+| **Total operating expenses** | **172,839.34** | 100.00% |
+| **Operating income (loss)** | (172,839.34) | — |
+| Other income (expenses) | 0.00 | — |
+| **Net income (loss)** | **(172,839.34)** | — |
+
+## Balance Sheet
+
+**As of:** Jul 20, 2026 (current snapshot; outside the Apr 1 – Jun 30 reporting window). Balances read on-chain from the published addresses below.
+
+### Published Addresses
+
+<Accordion title="View on-chain addresses">
+| Wallet | Address |
+|--------|---------|
+| Squads treasury | `AQyyTwCKemeeMu8ZPZFxrXMbVwAYTSbBhi1w4PBrhvYE` |
+| Meteora LP | `BGg7WsK98rhqtTp2uSKMa2yETqgwShFAjyf1RmYqCF7n` |
+| Operating | `92yGiPxBVG3E6voo1XyaKXaBR4Uvd7cntMsj3pL1fAYa` |
+| LOYAL mint / CA | `LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta` |
+| Futarchy AMM LP | `GxpJkPEsPmuRCCTNnfZaDKg4X3gf4ZPgmqgFqtibaPtK` |
+</Accordion>
+
+### USDC Assets
+
+| Asset | Amount (USDC) |
+|-------|---------------|
+| USDC — Squads treasury | 0.04 |
+| USDC — operating wallet | 2.00 |
+| USDC — in Futarchy AMM LP | 364,164.25 |
+| **Total USDC assets** | **364,166.29** |
+
+<Note>
+Down from 581,848.69 at the April 1 snapshot. The decrease reflects Q2 operating expenses funded from treasury and operating USDC. The DAO's liquid USDC now sits in the Futarchy AMM LP; the Squads treasury operating balance is drawn down to near zero.
+</Note>
+
+### Token Balances
+
+| Asset | Amount (LOYAL) |
+|-------|----------------|
+| LOYAL — held in treasury | 6,751,866.98 |
+| LOYAL — in Futarchy AMM LP | 2,746,015.95 |
+| LOYAL — operating wallet (fee payer) | 2,016.77 |
+| **Subtotal (on-chain verifiable)** | **9,499,899.70** |
+| LOYAL — Meteora DAMM v2 pool | Residual position; see note |
+
+<Note>
+The Meteora single-sided position was wound down by the Q4 2025 liquidity adjustment (90% withdrawn, half burned); its residual is held inside the Meteora DAMM v2 pool and is not separately valued here. Treasury LOYAL rose since Q1 (5,833,214 → 6,751,867) as the Q4 buyback program accumulated LOYAL from the AMM into the treasury; AMM LOYAL fell correspondingly.
+</Note>
+
+## Governance Actions
+
+No new MetaDAO proposals were submitted or passed during Q2 2026. The two governance actions approved in Q4 2025 — the structured LOYAL buyback program (LOYAL-001, "Buyback Loyal Up To NAV") and the single-sided liquidity adjustment (LOYAL-002) — had completed their execution schedules. Both can be verified against the published addresses above and the proposal records on [metadao.fi](https://www.metadao.fi/projects/loyal).
+
+Loyal's treasury is governed through MetaDAO proposals and executed transparently on-chain. Operational reporting follows a cash basis. All figures are denominated in USDC. Questions: [main@askloyal.com](mailto:main@askloyal.com).


### PR DESCRIPTION
Adds the **Q2 2026 Public Transparency Report** (Apr 1 – Jun 30, 2026) to the docs, alongside the existing Q1 2026 and Q4 2025 reports.

### Changes
- **New:** \`user-docs/transparency/q2-2026.mdx\` — same Mintlify format as prior reports (\`<Info>\` header, table-based Organizational Status, \`<Note>\` callouts, \`<Accordion>\` for on-chain addresses).
- **Nav:** \`docs.json\` Reports group now lists \`q2-2026\` first (newest → oldest).

### Highlights
- Total operating expenses: **172,839.34 USDC**; revenue **0.00**; net loss **(172,839.34)**.
- Salaries presented **by month of service** (May payroll largely cleared in June on a cash basis); reallocates the same cash total, does not change it.
- Balance sheet from a **Jul 20 on-chain snapshot** — treasury USDC drawn down to ~364K, verifiable against the published addresses.
- **No new MetaDAO proposals** in Q2.

Verified with \`mint validate\` (strict) and previewed locally with \`mint dev\`.