### PR TITLE
feat(frontend): add env-tinted favicons for preview and local dev

### DIFF
--- a/frontend/public/icon-dev.svg
+++ b/frontend/public/icon-dev.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="320" viewBox="0 0 400 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M60 280L0 140H180V0L260 140L280 0L400 320L60 280Z" fill="#9CA3AF"/>
+<path d="M221.359 173.036C254.451 174.77 280.059 199.425 278.555 228.105L158.72 221.824C160.223 193.145 188.268 171.302 221.359 173.036Z" fill="white"/>
+<mask id="mask0_5_1302" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="158" y="172" width="121" height="57">
+<path d="M221.36 173.036C254.452 174.77 280.059 199.425 278.556 228.105L158.721 221.824C160.224 193.145 188.268 171.302 221.36 173.036Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_5_1302)">
+<circle cx="219.998" cy="199" r="27" transform="rotate(3 219.998 199)" fill="black"/>
+</g>
+</svg>

--- a/frontend/public/icon-preview.svg
+++ b/frontend/public/icon-preview.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="320" viewBox="0 0 400 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M60 280L0 140H180V0L260 140L280 0L400 320L60 280Z" fill="#EAB308"/>
+<path d="M221.359 173.036C254.451 174.77 280.059 199.425 278.555 228.105L158.72 221.824C160.223 193.145 188.268 171.302 221.359 173.036Z" fill="white"/>
+<mask id="mask0_5_1302" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="158" y="172" width="121" height="57">
+<path d="M221.36 173.036C254.452 174.77 280.059 199.425 278.556 228.105L158.721 221.824C160.224 193.145 188.268 171.302 221.36 173.036Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_5_1302)">
+<circle cx="219.998" cy="199" r="27" transform="rotate(3 219.998 199)" fill="black"/>
+</g>
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -74,6 +74,14 @@ const siteJsonLd = {
   ],
 };
 
+// Env-tinted favicon: red in prod, yellow on Vercel previews, gray in local dev.
+const faviconPath =
+  process.env.VERCEL_ENV === "production"
+    ? "/icon.svg"
+    : process.env.VERCEL_ENV === "preview"
+      ? "/icon-preview.svg"
+      : "/icon-dev.svg";
+
 export const metadata: Metadata = {
   title: "Loyal: Solana Wallet That Earns Yield Automatically",
   description:
@@ -83,8 +91,8 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   icons: {
-    icon: "/icon.svg",
-    shortcut: "/icon.svg",
+    icon: faviconPath,
+    shortcut: faviconPath,
     apple: "/apple-touch-icon.png",
   },
   openGraph: {


### PR DESCRIPTION
Favicon now signals the environment: current red icon in production, yellow tint on Vercel previews, gray in local dev. Picked at build time from VERCEL_ENV in the root layout metadata.