### PR TITLE
feat(earn): add mobile Earn session auth for prompt-free autodeposit actions

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/floor/confirm/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
-import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { authenticateMobileEarnRequest } from "@/features/identity/server/mobile-earn-session";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import {
@@ -73,9 +73,10 @@ export async function POST(request: Request) {
 
   let walletAddress: string;
   try {
-    ({ walletAddress } = await authenticateMobileWalletRequest({
+    ({ walletAddress } = await authenticateMobileEarnRequest({
       body,
       purpose: "earn-autodeposit-floor-confirm",
+      request,
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/sweeps/execute/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/sweeps/execute/route.ts
@@ -10,7 +10,7 @@ import {
   EARN_REALTIME_SCHEMA_VERSION,
   type EarnAutodepositProgressState,
 } from "@/features/earn-realtime/types";
-import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { authenticateMobileEarnRequest } from "@/features/identity/server/mobile-earn-session";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-signature";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
@@ -252,9 +252,10 @@ export async function POST(request: Request) {
 
   let walletAddress: string;
   try {
-    ({ walletAddress } = await authenticateMobileWalletRequest({
+    ({ walletAddress } = await authenticateMobileEarnRequest({
       body,
       purpose: "earn-autodeposit-sweep-execute",
+      request,
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/autodeposit/toggle/confirm/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
-import { authenticateMobileWalletRequest } from "@/features/identity/server/mobile-wallet-auth";
+import { authenticateMobileEarnRequest } from "@/features/identity/server/mobile-earn-session";
 import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import {
@@ -53,9 +53,10 @@ export async function POST(request: Request) {
 
   let walletAddress: string;
   try {
-    ({ walletAddress } = await authenticateMobileWalletRequest({
+    ({ walletAddress } = await authenticateMobileEarnRequest({
       body,
       purpose: "earn-autodeposit-toggle-confirm",
+      request,
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {

--- a/frontend/src/app/api/smart-accounts/mobile/earn/session/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/session/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+import { issueMobileEarnSessionToken } from "@/features/identity/server/mobile-earn-session";
+import {
+  authenticateMobileWalletRequest,
+  MOBILE_WALLET_AUTH_PURPOSES,
+} from "@/features/identity/server/mobile-wallet-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+
+// Mints the mobile Earn session token (ASK-1846): trade one wallet-signed auth
+// message — scoped to ANY Earn purpose, so the app can piggyback on a
+// signature the user is already making for a real flow — for a long-lived
+// bearer token that the DB-only Autodeposit twins (sweeps/execute, floor,
+// toggle) accept without further wallet prompts. Signature-gated proof of
+// wallet control, no DB access; the token authorizes nothing a fresh signed
+// message wouldn't.
+
+function jsonError(
+  status: number,
+  code: string,
+  message: string
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, "invalid_request", "Invalid request body.");
+  }
+
+  let walletAddress: string;
+  try {
+    ({ walletAddress } = await authenticateMobileWalletRequest({
+      body,
+      purpose: MOBILE_WALLET_AUTH_PURPOSES,
+    }));
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return jsonError(error.status, error.code, error.message);
+    }
+    return jsonError(401, "unauthenticated", "Mobile wallet auth failed.");
+  }
+
+  try {
+    const session = await issueMobileEarnSessionToken(walletAddress);
+    return NextResponse.json(session, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    console.error("[mobile-earn-session] mint failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown mint error.",
+      errorName: error instanceof Error ? error.name : typeof error,
+      walletAddress,
+    });
+    return jsonError(
+      500,
+      "session_mint_failed",
+      "Failed to mint a mobile Earn session."
+    );
+  }
+}

--- a/frontend/src/features/identity/server/mobile-earn-session.ts
+++ b/frontend/src/features/identity/server/mobile-earn-session.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+import { importPKCS8, importSPKI, jwtVerify, SignJWT } from "jose";
+
+import { getServerEnv } from "@/lib/core/config/server";
+
+import {
+  authenticateMobileWalletRequest,
+  type MobileWalletAuthPurpose,
+} from "./mobile-wallet-auth";
+import { WalletAuthError } from "./wallet-auth-errors";
+import { decodeWalletAddress } from "./wallet-auth-signature";
+
+// Mobile Earn session (ASK-1846): a long-lived bearer token that lets the
+// native app call the DB-only Autodeposit endpoints (sweeps/execute, floor,
+// toggle) without signing a fresh 5-minute wallet auth message — each of those
+// signatures costs a Seed Vault/MWA approval prompt on-device, while the web
+// does the same actions on its session cookie with zero prompts.
+//
+// The token is deliberately NOT interchangeable with the web session cookie:
+// it carries only a dedicated audience + the wallet address as subject, so
+// `authSessionTokenClaimsSchema` rejects it as a web session, and this module
+// requires the audience the web tokens lack. Minting requires the same proof
+// of wallet control as every other mobile Earn request (a purpose-scoped
+// signed message within the freshness window), so it grants nothing a signed
+// message doesn't already grant — it only amortizes the prompt.
+const MOBILE_EARN_SESSION_AUDIENCE = "loyal-mobile-earn";
+const MOBILE_EARN_SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+const RS256_ALG = "RS256";
+const HS256_ALG = "HS256";
+
+// Same secret derivation as session-token.ts so AUTH_JWT_SECRET behaves
+// identically for both token kinds.
+function hs256Key(secret: string): Uint8Array {
+  return createHash("sha256").update(secret).digest();
+}
+
+export async function issueMobileEarnSessionToken(
+  walletAddress: string
+): Promise<{ token: string; expiresAt: string }> {
+  const { authJwtSecret, authSessionRs256PrivateKey } = getServerEnv();
+
+  const jwt = new SignJWT({})
+    .setAudience(MOBILE_EARN_SESSION_AUDIENCE)
+    .setSubject(walletAddress)
+    .setIssuedAt()
+    .setExpirationTime(`${MOBILE_EARN_SESSION_TTL_SECONDS}s`);
+
+  let token: string;
+  if (authSessionRs256PrivateKey) {
+    token = await jwt
+      .setProtectedHeader({ alg: RS256_ALG, typ: "JWT" })
+      .sign(await importPKCS8(authSessionRs256PrivateKey, RS256_ALG));
+  } else if (authJwtSecret) {
+    token = await jwt
+      .setProtectedHeader({ alg: HS256_ALG, typ: "JWT" })
+      .sign(hs256Key(authJwtSecret));
+  } else {
+    throw new Error(
+      "Mobile Earn session signing is not configured. Set AUTH_JWT_SECRET or AUTH_JWT_RS256_PRIVATE_KEY."
+    );
+  }
+
+  return {
+    token,
+    expiresAt: new Date(
+      Date.now() + MOBILE_EARN_SESSION_TTL_SECONDS * 1000
+    ).toISOString(),
+  };
+}
+
+async function verifyMobileEarnSessionToken(
+  token: string
+): Promise<string | null> {
+  const { authJwtSecret, authSessionRs256PublicKey } = getServerEnv();
+
+  if (authSessionRs256PublicKey) {
+    try {
+      const { payload } = await jwtVerify(
+        token,
+        await importSPKI(authSessionRs256PublicKey, RS256_ALG),
+        { algorithms: [RS256_ALG], audience: MOBILE_EARN_SESSION_AUDIENCE }
+      );
+      if (typeof payload.sub === "string") {
+        return payload.sub;
+      }
+    } catch {
+      // Fall through to HS256 verification below.
+    }
+  }
+
+  if (authJwtSecret) {
+    try {
+      const { payload } = await jwtVerify(token, hs256Key(authJwtSecret), {
+        algorithms: [HS256_ALG],
+        audience: MOBILE_EARN_SESSION_AUDIENCE,
+      });
+      if (typeof payload.sub === "string") {
+        return payload.sub;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+// Session-or-signature auth for the DB-only mobile Earn endpoints: a bearer
+// token authenticates without body auth fields; a request without the header
+// keeps the existing wallet-signed-message contract. A PRESENT-but-invalid
+// token fails with `invalid_mobile_session` (instead of falling through to a
+// confusing body-fields error) so the client knows to drop its cached token
+// and retry with a signed message.
+export async function authenticateMobileEarnRequest(args: {
+  request: Request;
+  body: unknown;
+  purpose: MobileWalletAuthPurpose | readonly MobileWalletAuthPurpose[];
+}): Promise<{ walletAddress: string }> {
+  const header = args.request.headers.get("authorization");
+  if (header?.toLowerCase().startsWith("bearer ")) {
+    const walletAddress = await verifyMobileEarnSessionToken(
+      header.slice("bearer ".length).trim()
+    );
+    if (!walletAddress) {
+      throw new WalletAuthError("Mobile Earn session is invalid or expired.", {
+        code: "invalid_mobile_session",
+        status: 401,
+      });
+    }
+    decodeWalletAddress(walletAddress);
+    return { walletAddress };
+  }
+
+  return authenticateMobileWalletRequest({
+    body: args.body,
+    purpose: args.purpose,
+  });
+}

--- a/frontend/src/features/identity/server/mobile-wallet-auth.ts
+++ b/frontend/src/features/identity/server/mobile-wallet-auth.ts
@@ -21,19 +21,26 @@ import {
 const MOBILE_AUTH_MAX_AGE_MS = 5 * 60 * 1000;
 const MOBILE_AUTH_MAX_FUTURE_SKEW_MS = 60 * 1000;
 
+// Runtime list so the session mint route can accept a signature scoped to ANY
+// Earn purpose (every purpose proves control of the same wallet key; the
+// scoping exists to stop cross-endpoint replay, not to grade trust).
+export const MOBILE_WALLET_AUTH_PURPOSES = [
+  "earn-deposit-prepare",
+  "earn-deposit-confirm",
+  "earn-withdraw-prepare",
+  "earn-withdraw-confirm",
+  "earn-autodeposit-setup-prepare",
+  "earn-autodeposit-setup-confirm",
+  "earn-autodeposit-floor-confirm",
+  "earn-autodeposit-toggle-confirm",
+  "earn-autodeposit-close-prepare",
+  "earn-autodeposit-close-confirm",
+  "earn-autodeposit-sweep-execute",
+  "earn-refund-prepare",
+] as const;
+
 export type MobileWalletAuthPurpose =
-  | "earn-deposit-prepare"
-  | "earn-deposit-confirm"
-  | "earn-withdraw-prepare"
-  | "earn-withdraw-confirm"
-  | "earn-autodeposit-setup-prepare"
-  | "earn-autodeposit-setup-confirm"
-  | "earn-autodeposit-floor-confirm"
-  | "earn-autodeposit-toggle-confirm"
-  | "earn-autodeposit-close-prepare"
-  | "earn-autodeposit-close-confirm"
-  | "earn-autodeposit-sweep-execute"
-  | "earn-refund-prepare";
+  (typeof MOBILE_WALLET_AUTH_PURPOSES)[number];
 
 export type MobileWalletAuthFields = {
   walletAddress: string;


### PR DESCRIPTION
Adds a mobile Earn session mint endpoint (POST /api/smart-accounts/mobile/earn/session) that trades one wallet-signed auth message for a 30-day mobile-scoped bearer token, and accepts it on the DB-only autodeposit twins (sweeps/execute, floor, toggle). This gives mobile web parity: execute-now, threshold changes, and pause/resume no longer cost a Seed Vault/MWA prompt (ASK-1846).