### PR TITLE
fix(observability): stop forwarding Connection close to HyperDX

### DIFF
--- a/observability/Dockerfile
+++ b/observability/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/clickhouse/clickstack-all-in-one:2.30.1@sha256:bd0bde1b1f2ca0702fdafe269f3552e36b055d25e47692685b1a6018567a2d3c
+FROM docker.io/clickhouse/clickstack-all-in-one:2.31.0@sha256:b01cc48cb5aaf30d630865a88217c826ab86fb9828374201f6cd7c539d5beed1
 
 # The upstream authenticated image hardcodes a public session secret. Replace
 # that assignment with a runtime requirement and use tini to forward Render's

--- a/observability/nginx.conf
+++ b/observability/nginx.conf
@@ -16,9 +16,16 @@ http {
                    '$status $body_bytes_sent';
   access_log /dev/stdout loyal;
 
+  # Upgrade requests must carry "Connection: upgrade" upstream. Everything else
+  # must send no Connection header at all: forwarding "Connection: close" into
+  # HyperDX corrupts a socket in its internal keep-alive pool once /api/mcp has
+  # answered with an SSE stream, and the next request routed over that socket
+  # returns 400 regardless of path. Failures are intermittent, not permanent,
+  # because the pool eventually recycles the socket, which is why MCP clients
+  # see the handshake die after initialize. An empty value omits the header.
   map $http_upgrade $connection_upgrade {
     default upgrade;
-    '' close;
+    '' '';
   }
 
   map $http_x_forwarded_proto $forwarded_proto {

--- a/observability/scripts/verify.sh
+++ b/observability/scripts/verify.sh
@@ -49,7 +49,7 @@ require_literal 'value: 127.0.0.1' "$blueprint"
   || fail "observability Blueprint must retain exactly one service"
 pass "Blueprint pins monorepo scope, disk, health check, and generated secrets"
 
-require_literal '2.30.1@sha256:bd0bde1b1f2ca0702fdafe269f3552e36b055d25e47692685b1a6018567a2d3c' "$project_dir/Dockerfile"
+require_literal '2.31.0@sha256:b01cc48cb5aaf30d630865a88217c826ab86fb9828374201f6cd7c539d5beed1' "$project_dir/Dockerfile"
 require_literal 'nginx=1.30.4-r0' "$project_dir/Dockerfile"
 require_literal 'tini=0.19.0-r3' "$project_dir/Dockerfile"
 require_literal 'HYPERDX_APP_PORT=8081' "$project_dir/Dockerfile"
@@ -99,6 +99,12 @@ done
 if rg --quiet 'location = /v1/workflows' "$project_dir/nginx.conf"; then
   fail "the nonexistent /v1/workflows path must not be proxied"
 fi
+# Non-upgrade requests must resolve to an empty value so nginx omits the
+# Connection header entirely.
+require_literal "    '' '';" "$project_dir/nginx.conf"
+require_literal \
+  'proxy_set_header Connection $connection_upgrade;' \
+  "$project_dir/nginx.conf"
 require_literal 'metrics_probe_payload=' "$project_dir/scripts/smoke-live.sh"
 require_literal 'traces_probe_payload=' "$project_dir/scripts/smoke-live.sh"
 require_literal 'for signal in metrics traces' "$project_dir/scripts/smoke-live.sh"


### PR DESCRIPTION
Non-upgrade requests forwarded `Connection: close` to HyperDX, which corrupts a socket in its internal keep-alive pool once `/api/mcp` answers with an SSE stream — the next request over that socket returns 400 regardless of path, so MCP clients fail right after `initialize`. The upgrade map now resolves to an empty value so nginx omits the header, the verifier pins that value and the location's `proxy_set_header`, and the image moves to `clickstack-all-in-one` 2.31.0.

Verified locally with podman against the built image: two requests on one connection returned 200/400 before and 200/200 after, an MCP client connected on 4/4 attempts, and `smoke-local.sh` passed end to end on the new base.

Part of ASK-1815.