### PR TITLE
feat(observability): add ClickStack to Telegram alert relay

### DIFF
--- a/observability/render.yaml
+++ b/observability/render.yaml
@@ -93,7 +93,9 @@ projects:
                 sync: false
               - key: COOLDOWN_SECONDS
                 value: "3600"
+              # Must match the saved search `select`, in order. Mirrors the
+              # columns the running relay is configured with today.
               - key: ALERT_COLUMNS
-                value: Timestamp,ServiceName,SeverityText,env,flow,stage,error_code,message
+                value: Timestamp,ServiceName,SeverityText,Body,env,flow,stage,error_code,exception_type,exception_message
               - key: TRACE_LOGS
                 value: "false"

--- a/observability/render.yaml
+++ b/observability/render.yaml
@@ -68,17 +68,21 @@ projects:
             buildFilter:
               paths:
                 - observability/telegram-relay/**
-            healthCheckPath: /healthz
+            # No healthCheckPath: Render supports health checks on web services
+            # only. GET /healthz still exists and can be curled from ClickStack.
+            #
             # Give the process time to drain in-flight webhooks on SIGTERM so a
             # deploy cannot drop an alert mid-delivery.
             maxShutdownDelaySeconds: 30
             envVars:
-              # Bun defaults to 127.0.0.1, which Render's health check and the
-              # ClickStack container cannot reach.
+              # Bun defaults to 127.0.0.1, which the ClickStack container cannot
+              # reach over the private network.
               - key: HOST
                 value: 0.0.0.0
+              # Render reserves 10000, 18012, 18013 and 19099 on the private
+              # network, so the relay cannot listen on any of them.
               - key: PORT
-                value: "10000"
+                value: "3000"
               # Read the generated value from the Render dashboard and paste it
               # into the ClickStack webhook's Authorization header.
               - key: CLICKSTACK_WEBHOOK_SECRET

--- a/observability/render.yaml
+++ b/observability/render.yaml
@@ -23,6 +23,7 @@ projects:
                 - observability/**
               ignoredPaths:
                 - observability/smoke-result.json
+                - observability/telegram-relay/**
             healthCheckPath: /api/health
             renderSubdomainPolicy: enabled
             envVars:
@@ -44,3 +45,51 @@ projects:
               name: clickstack-data
               mountPath: /var/lib/clickhouse
               sizeGB: 10
+
+          # Relays ClickStack alert webhooks to Telegram. Private service: it is
+          # reached only over this environment's private network, so the webhook
+          # endpoint is never exposed publicly and the Bearer token is defense in
+          # depth rather than the only control.
+          - type: pserv
+            name: loyal-clickstack-telegram-relay
+            runtime: docker
+            repo: https://github.com/loyal-labs/loyal-app.git
+            branch: main
+            region: oregon
+            plan: starter
+            # Cooldown and idempotency state is in-process. A second instance
+            # would double-post alerts, so this must stay at 1 until the state
+            # moves to a shared store.
+            numInstances: 1
+            rootDir: observability/telegram-relay
+            dockerfilePath: ./Dockerfile
+            dockerContext: .
+            autoDeployTrigger: checksPass
+            buildFilter:
+              paths:
+                - observability/telegram-relay/**
+            healthCheckPath: /healthz
+            # Give the process time to drain in-flight webhooks on SIGTERM so a
+            # deploy cannot drop an alert mid-delivery.
+            maxShutdownDelaySeconds: 30
+            envVars:
+              # Bun defaults to 127.0.0.1, which Render's health check and the
+              # ClickStack container cannot reach.
+              - key: HOST
+                value: 0.0.0.0
+              - key: PORT
+                value: "10000"
+              # Read the generated value from the Render dashboard and paste it
+              # into the ClickStack webhook's Authorization header.
+              - key: CLICKSTACK_WEBHOOK_SECRET
+                generateValue: true
+              - key: TELEGRAM_BOT_TOKEN
+                sync: false
+              - key: TELEGRAM_CHAT_ID
+                sync: false
+              - key: COOLDOWN_SECONDS
+                value: "3600"
+              - key: ALERT_COLUMNS
+                value: Timestamp,ServiceName,SeverityText,env,flow,stage,error_code,message
+              - key: TRACE_LOGS
+                value: "false"

--- a/observability/scripts/verify.sh
+++ b/observability/scripts/verify.sh
@@ -45,9 +45,21 @@ require_literal 'CLICKSTACK_INTERNAL_SMOKE_ENABLED' "$blueprint"
 require_literal 'generateValue: true' "$blueprint"
 require_literal 'value: "8081"' "$blueprint"
 require_literal 'value: 127.0.0.1' "$blueprint"
-[[ "$(rg --count '^[[:space:]]+- type: (web|pserv|worker|cron|keyvalue)$' "$blueprint")" == "1" ]] \
-  || fail "observability Blueprint must retain exactly one service"
+[[ "$(rg --count '^[[:space:]]+- type: (web|pserv|worker|cron|keyvalue)$' "$blueprint")" == "2" ]] \
+  || fail "observability Blueprint must retain exactly two services"
 pass "Blueprint pins monorepo scope, disk, health check, and generated secrets"
+
+# Telegram relay. Cooldown state is in-process, so a second instance
+# double-posts every alert. Render reserves port 10000 on the private network
+# and supports healthCheckPath on web services only.
+require_literal 'name: loyal-clickstack-telegram-relay' "$blueprint"
+require_literal 'rootDir: observability/telegram-relay' "$blueprint"
+require_literal 'value: "3000"' "$blueprint"
+rg --quiet 'healthCheckPath: /healthz' "$blueprint" \
+  && fail "private services do not support healthCheckPath"
+[[ "$(rg --after-context=20 'name: loyal-clickstack-telegram-relay' "$blueprint" | rg --count 'numInstances: 1')" == "1" ]] \
+  || fail "telegram relay must stay pinned to numInstances: 1"
+pass "Telegram relay pins single instance, non-reserved port, and no health check"
 
 require_literal '2.31.0@sha256:b01cc48cb5aaf30d630865a88217c826ab86fb9828374201f6cd7c539d5beed1' "$project_dir/Dockerfile"
 require_literal 'nginx=1.30.4-r0' "$project_dir/Dockerfile"

--- a/observability/telegram-relay/.dockerignore
+++ b/observability/telegram-relay/.dockerignore
@@ -1,0 +1,9 @@
+# Denylist rather than a `*` allowlist: an allowlist that fails to re-include
+# `src/` builds a valid image with no application code in it.
+node_modules
+.env
+.env.*
+!.env.example
+src/*.test.ts
+README.md
+bun.lock

--- a/observability/telegram-relay/.env.example
+++ b/observability/telegram-relay/.env.example
@@ -1,0 +1,11 @@
+HOST=127.0.0.1
+PORT=3000
+CLICKSTACK_WEBHOOK_SECRET=replace-with-a-long-random-secret
+TELEGRAM_BOT_TOKEN=replace-with-telegram-bot-token
+TELEGRAM_CHAT_ID=replace-with-telegram-chat-id
+COOLDOWN_SECONDS=3600
+IDEMPOTENCY_TTL_SECONDS=86400
+MAX_CACHE_ENTRIES=10000
+MAX_BODY_BYTES=65536
+ALERT_COLUMNS=Timestamp,ServiceName,SeverityText,Body
+TRACE_LOGS=false

--- a/observability/telegram-relay/.gitignore
+++ b/observability/telegram-relay/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+.env.*
+!.env.example

--- a/observability/telegram-relay/Dockerfile
+++ b/observability/telegram-relay/Dockerfile
@@ -1,0 +1,19 @@
+# Pinned to the Bun release this repo standardizes on (root `packageManager`).
+FROM oven/bun:1.3.11-debian AS runtime
+
+WORKDIR /app
+
+# The relay has no runtime dependencies, so there is no install step and no
+# lockfile in the image: the source is the artifact. `.dockerignore` keeps
+# `src/*.test.ts` out of the build context.
+COPY package.json tsconfig.json ./
+COPY src ./src
+
+USER bun
+
+ENV HOST=0.0.0.0 \
+    PORT=10000
+
+EXPOSE 10000
+
+CMD ["bun", "src/index.ts"]

--- a/observability/telegram-relay/Dockerfile
+++ b/observability/telegram-relay/Dockerfile
@@ -1,5 +1,6 @@
 # Pinned to the Bun release this repo standardizes on (root `packageManager`).
-FROM oven/bun:1.3.11-debian AS runtime
+# The 1.3.x line publishes no `-debian` variant; `-slim` is the Debian build.
+FROM oven/bun:1.3.11-slim AS runtime
 
 WORKDIR /app
 
@@ -11,9 +12,11 @@ COPY src ./src
 
 USER bun
 
+# Render reserves 10000, 18012, 18013 and 19099 on the private network, so the
+# relay has to listen somewhere else.
 ENV HOST=0.0.0.0 \
-    PORT=10000
+    PORT=3000
 
-EXPOSE 10000
+EXPOSE 3000
 
 CMD ["bun", "src/index.ts"]

--- a/observability/telegram-relay/README.md
+++ b/observability/telegram-relay/README.md
@@ -17,6 +17,10 @@ normal cooldown path.
 - Blueprint: [`../render.yaml`](../render.yaml)
 - Deployed alongside `loyal-clickstack` in the `loyal-observability` project
 
+Render supports health checks on web services only, so the Blueprint declares no
+`healthCheckPath`. `GET /healthz` still works and is the quickest liveness probe
+from a shell on the ClickStack service.
+
 ## State is in-process, so this runs one instance
 
 Cooldown and idempotency state lives in memory (`ExpiringCache` in
@@ -124,8 +128,12 @@ Configure a generic webhook destination pointing at the relay's private address
 inside the `loyal-observability` environment:
 
 ```text
-http://loyal-clickstack-telegram-relay:10000/webhooks/clickstack
+http://loyal-clickstack-telegram-relay:3000/webhooks/clickstack
 ```
+
+Port `3000` rather than Render's usual `10000`: Render reserves `10000`,
+`18012`, `18013` and `19099` on the private network, so a service listening on
+one of them is unreachable from its peers.
 
 Set these headers:
 

--- a/observability/telegram-relay/README.md
+++ b/observability/telegram-relay/README.md
@@ -1,0 +1,229 @@
+# ClickStack Telegram relay
+
+A small Bun service that sits between ClickStack and Telegram:
+
+```text
+ClickStack -> relay -> Telegram Bot API
+```
+
+It sends the first non-`OK` state immediately and suppresses repeated events
+with the same ClickStack `eventId` for 60 minutes by default. `OK` recoveries
+are acknowledged and otherwise ignored, so the chat only carries live failures
+and a flapping alert stays capped at one message per cooldown. ClickStack test
+and transitional states such as `INSUFFICIENT_DATA` are accepted and use the
+normal cooldown path.
+
+- Render service: `loyal-clickstack-telegram-relay` (private service)
+- Blueprint: [`../render.yaml`](../render.yaml)
+- Deployed alongside `loyal-clickstack` in the `loyal-observability` project
+
+## State is in-process, so this runs one instance
+
+Cooldown and idempotency state lives in memory (`ExpiringCache` in
+[`src/relay.ts`](./src/relay.ts)). There is no Redis and no database.
+
+Two consequences, both deliberate:
+
+- **`numInstances` must stay at `1`.** Two instances do not share cooldowns and
+  would double-post every alert. The Blueprint pins this.
+- **A restart clears cooldowns.** After a deploy, currently-firing alerts may be
+  posted once more. For a service whose job is to be noisy about problems this
+  is an acceptable trade, and it avoids paying for a shared store.
+
+Moving this state to a shared store is only needed to run more than one
+instance; it buys no throughput. If that day comes, the store should be owned by
+this blueprint (a dedicated database, not the App or Yield Neon product
+databases), the claim must be taken *before* sending with a short lease that is
+extended to the full cooldown only after Telegram accepts, and store errors must
+fail **open** — a duplicate message is better than a swallowed alert.
+
+## Runtime behavior
+
+- Exact `OK` returns HTTP 200 with outcome `resolved` and does nothing else.
+  Nothing is posted to Telegram, and the `eventId` cooldown is left running: a
+  flapping alert resolves and re-fires on every evaluation interval, so clearing
+  the cooldown on recovery would post that event on every cycle.
+- Every other string state is accepted and uses the alert cooldown path.
+- ClickStack's `TEST WEBHOOK` currently uses `INSUFFICIENT_DATA`; it is accepted.
+- The first event for an `eventId` is sent immediately.
+- Further non-`OK` events for that `eventId` return HTTP 200 without Telegram
+  delivery until the cooldown expires. Only elapsed time clears it.
+- An exact delivery retry with the same `Idempotency-Key` also returns HTTP 200.
+- Telegram delivery failure returns HTTP 502 and does not poison either cache.
+- A Telegram `429` with a short `retry_after` is waited out and retried once
+  in-process; a long `retry_after` returns HTTP 502 for ClickStack to retry.
+- `title` must contain non-whitespace text, so a delivered message is never
+  empty. `body` is capped at 8192 characters, comfortably inside
+  `MAX_BODY_BYTES` even for multi-byte text.
+
+## Alert formatting
+
+ClickStack renders an alert body as a short preamble plus a fenced CSV block of
+matched rows. That block has no header line: it is exactly the saved search
+`select`, in order, one quoted field per column. The relay parses it and renders
+labelled Telegram HTML instead of forwarding the raw CSV.
+
+Because the CSV carries no column names, `ALERT_COLUMNS` must list the same
+columns in the same order as the saved search `select`. For a search selecting
+
+```text
+Timestamp, ServiceName, SeverityText,
+ResourceAttributes['deployment.environment.name'] AS env,
+LogAttributes['loyal.flow.name'] AS flow,
+LogAttributes['loyal.flow.stage'] AS stage,
+LogAttributes['loyal.error.code'] AS error_code,
+LogAttributes['exception.message'] AS message
+```
+
+set:
+
+```text
+ALERT_COLUMNS=Timestamp,ServiceName,SeverityText,env,flow,stage,error_code,message
+```
+
+`Timestamp`, `ServiceName`, `SeverityText`, and `Body` are recognized by name
+and rendered as the row headline; every other column becomes a `name: value`
+line. Empty fields are dropped, so a column that is null for one event costs
+nothing. Timestamps render as `HH:MM:SS UTC`.
+
+Formatting is best-effort and never blocks delivery. The relay falls back to the
+verbatim ClickStack text when the body has no CSV block, when the CSV is
+malformed, or when the field count disagrees with `ALERT_COLUMNS`. If Telegram
+rejects the HTML with a `400`, the relay logs `telegram_formatting_rejected` and
+resends the same alert as plain text.
+
+At most 8 rows are rendered, and fewer if they would exceed Telegram's 4096
+character limit; the remainder is summarized as `and N more row(s)` above the
+search link.
+
+## Configuration
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `CLICKSTACK_WEBHOOK_SECRET` | yes | - | Bearer token accepted from ClickStack |
+| `TELEGRAM_BOT_TOKEN` | yes | - | Telegram Bot API token, stored only by this relay |
+| `TELEGRAM_CHAT_ID` | yes | - | Destination chat or channel ID |
+| `HOST` | no | `127.0.0.1` | Listen address. Must be `0.0.0.0` on Render |
+| `PORT` | no | `3000` | Listen port |
+| `COOLDOWN_SECONDS` | no | `3600` | Alert suppression interval per `eventId` |
+| `IDEMPOTENCY_TTL_SECONDS` | no | `86400` | Exact delivery deduplication interval |
+| `MAX_CACHE_ENTRIES` | no | `10000` | Per-cache memory bound |
+| `MAX_BODY_BYTES` | no | `65536` | Maximum request body accepted by Bun |
+| `ALERT_COLUMNS` | no | `Timestamp,ServiceName,SeverityText,Body` | Saved search `select` columns, in order, used to label alert rows |
+| `TRACE_LOGS` | no | `false` | Structured request and validation diagnostics |
+
+`CLICKSTACK_WEBHOOK_SECRET` uses `generateValue: true` in the Blueprint, so
+Render generates it. Read it from the Render dashboard and paste it into the
+ClickStack webhook header; it never needs to exist anywhere else.
+`TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are `sync: false` and must be set by
+an operator.
+
+## ClickStack webhook
+
+Configure a generic webhook destination pointing at the relay's private address
+inside the `loyal-observability` environment:
+
+```text
+http://loyal-clickstack-telegram-relay:10000/webhooks/clickstack
+```
+
+Set these headers:
+
+```json
+{
+  "Authorization": "Bearer YOUR_CLICKSTACK_WEBHOOK_SECRET",
+  "Content-Type": "application/json"
+}
+```
+
+ClickStack adds its own `Idempotency-Key` header. The relay requires it and uses
+it to acknowledge an exact webhook retry without posting twice.
+
+Use this body:
+
+```json
+{
+  "eventId": "{{eventId}}",
+  "state": "{{state}}",
+  "title": "{{title}}",
+  "body": "{{body}}",
+  "link": "{{link}}",
+  "startTime": {{startTime}},
+  "endTime": {{endTime}}
+}
+```
+
+The relay responds with HTTP 200 for both suppressed alerts and exact
+duplicates. A Telegram delivery failure returns HTTP 502 without recording a
+cooldown or idempotency entry, allowing ClickStack to retry safely.
+
+## Local development
+
+```sh
+bun install
+op run --env-file=/path/to/your.1password.env -- bun run dev
+curl http://127.0.0.1:3000/healthz
+```
+
+`.env.example` contains placeholders only. Do not save real secrets in the
+project. Generate a webhook secret for local use with:
+
+```sh
+python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+```
+
+To exercise the real ClickStack webhook path from a laptop, expose the local
+port with a tunnel (`ngrok http 3000`) and point a scratch webhook destination
+at `https://YOUR-TUNNEL.example/webhooks/clickstack`.
+
+## Validation
+
+```sh
+bun run check          # typecheck + tests + build
+```
+
+This package sits outside the root Bun workspace and is not covered by any CI
+workflow, so run `bun run check` here when changing the relay. Root
+`bun run lint` (prettier) does cover these files.
+
+## Trace logging
+
+Trace logs are disabled by default. Enable them temporarily when diagnosing a
+rejected ClickStack webhook by setting `TRACE_LOGS=true`. Each request then
+emits structured JSON diagnostics:
+
+```json
+{
+  "event": "clickstack_webhook_trace",
+  "traceEvent": "request_rejected",
+  "reason": "invalid_payload",
+  "issues": [
+    "startTime must be a finite number (received string)",
+    "endTime must be a finite number (received string)"
+  ]
+}
+```
+
+Trace logs never include authorization headers, Telegram tokens, idempotency key
+values, or the webhook body. Disable them again after debugging.
+
+Common HTTP 400 causes are a missing `Idempotency-Key`, invalid JSON, quoted
+numeric timestamps, or a field with the wrong JSON type. Arbitrary string values
+for `state`, including `INSUFFICIENT_DATA`, are valid.
+
+## Security notes
+
+- Never put the Telegram bot token in ClickStack; only this relay needs it.
+- Use a separate random `CLICKSTACK_WEBHOOK_SECRET` for the relay Bearer header.
+- The relay emits plain JSON logs to stdout and does not export to ClickStack.
+  Its own failures are visible only in Render logs — deliberately, so the
+  alerting path does not depend on the system it alerts about.
+- Trace logs contain field names, validation reasons, `eventId`, state, and
+  timestamps, but never request bodies or authentication values.
+
+## Routes
+
+- `POST /webhooks/clickstack` - authenticated ClickStack webhook
+- `GET /healthz` - process and in-memory cache health. Unauthenticated, so the
+  reported counts are read without sweeping the caches and may briefly include
+  expired entries that a periodic timer has not yet reclaimed.

--- a/observability/telegram-relay/README.md
+++ b/observability/telegram-relay/README.md
@@ -127,8 +127,13 @@ an operator.
 Configure a generic webhook destination pointing at the relay's private address
 inside the `loyal-observability` environment:
 
+Do not guess the hostname. Render generates a suffix for private-service
+hostnames (their own example is `elasticsearch-2j3e:9200`), so copy the real
+value from the relay service's **Connect -> Internal** panel in the Render
+dashboard. It looks like:
+
 ```text
-http://loyal-clickstack-telegram-relay:3000/webhooks/clickstack
+http://loyal-clickstack-telegram-relay-XXXX:3000/webhooks/clickstack
 ```
 
 Port `3000` rather than Render's usual `10000`: Render reserves `10000`,

--- a/observability/telegram-relay/bun.lock
+++ b/observability/telegram-relay/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "clickstack-telegram-relay",
+      "devDependencies": {
+        "@types/bun": "^1.3.13",
+        "typescript": "^5.8.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/observability/telegram-relay/package.json
+++ b/observability/telegram-relay/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "clickstack-telegram-relay",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "check": "bun run typecheck && bun test && bun build src/index.ts --target=bun --outdir=/tmp/clickstack-telegram-relay-build"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.13",
+    "typescript": "^5.8.3"
+  }
+}

--- a/observability/telegram-relay/src/app.test.ts
+++ b/observability/telegram-relay/src/app.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createRequestHandler,
+  createTelegramSender,
+  formatTelegramMessage,
+  loadConfig,
+  validatePayload,
+} from "./app.ts";
+import { AlertRelay, type ClickStackWebhookPayload } from "./relay.ts";
+
+const payload: ClickStackWebhookPayload = {
+  eventId: "alert-errors-service-loyal-mobile",
+  state: "ALERT",
+  title: "Alert for Errors",
+  body: "3 lines found",
+  link: "https://clickstack.example/search/1",
+  startTime: 1,
+  endTime: 2,
+};
+
+const defaultColumns = ["Timestamp", "ServiceName", "SeverityText", "Body"];
+
+function format(
+  item: ClickStackWebhookPayload,
+  alertColumns: string[] = defaultColumns
+) {
+  return formatTelegramMessage(item, { alertColumns });
+}
+
+function createTestHandler() {
+  const sent: ClickStackWebhookPayload[] = [];
+  const relay = new AlertRelay(
+    async (item) => {
+      sent.push(item);
+    },
+    {
+      cooldownMs: 3_600_000,
+      idempotencyTtlMs: 86_400_000,
+      maxCacheEntries: 100,
+      now: () => 1_000,
+    }
+  );
+  return {
+    sent,
+    handler: createRequestHandler(relay, {
+      clickStackWebhookSecret: "test-secret",
+    }),
+  };
+}
+
+describe("HTTP handler", () => {
+  test("rejects an invalid Bearer token", async () => {
+    const { handler } = createTestHandler();
+    const response = await handler(
+      new Request("http://localhost/webhooks/clickstack", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer wrong",
+          "Idempotency-Key": "delivery-1",
+        },
+        body: JSON.stringify(payload),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("requires Idempotency-Key", async () => {
+    const { handler } = createTestHandler();
+    const response = await handler(
+      new Request("http://localhost/webhooks/clickstack", {
+        method: "POST",
+        headers: { Authorization: "Bearer test-secret" },
+        body: JSON.stringify(payload),
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 2xx for a suppressed alert", async () => {
+    const { handler, sent } = createTestHandler();
+    const send = (idempotencyKey: string) =>
+      handler(
+        new Request("http://localhost/webhooks/clickstack", {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer test-secret",
+            "Idempotency-Key": idempotencyKey,
+          },
+          body: JSON.stringify(payload),
+        })
+      );
+
+    expect((await send("delivery-1")).status).toBe(200);
+    const suppressed = await send("delivery-2");
+    expect(suppressed.status).toBe(200);
+    expect(await suppressed.json()).toEqual({
+      ok: true,
+      outcome: "suppressed",
+    });
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe("payload and formatting", () => {
+  test("validates ClickStack payloads", () => {
+    expect(validatePayload(payload)).toEqual({ ok: true, payload });
+    expect(validatePayload({ ...payload, state: "DISABLED" })).toEqual({
+      ok: true,
+      payload: { ...payload, state: "DISABLED" },
+    });
+    expect(validatePayload({ ...payload, state: 1 }).ok).toBe(false);
+  });
+
+  test("reports field-level validation reasons without payload values", () => {
+    expect(
+      validatePayload({
+        ...payload,
+        startTime: "1",
+        endTime: "2",
+      })
+    ).toEqual({
+      ok: false,
+      issues: [
+        "startTime must be a finite number (received string)",
+        "endTime must be a finite number (received string)",
+      ],
+    });
+  });
+
+  test("rejects payloads that format into an empty Telegram message", () => {
+    expect(
+      validatePayload({
+        ...payload,
+        title: "   ",
+        body: "",
+        link: "",
+      })
+    ).toEqual({
+      ok: false,
+      issues: ["title must contain non-whitespace text"],
+    });
+  });
+
+  test("accepts arbitrary ClickStack state strings", () => {
+    expect(validatePayload({ ...payload, state: "INSUFFICIENT_DATA" })).toEqual(
+      {
+        ok: true,
+        payload: { ...payload, state: "INSUFFICIENT_DATA" },
+      }
+    );
+  });
+
+  test("keeps trace logging disabled by default", () => {
+    const env = {
+      CLICKSTACK_WEBHOOK_SECRET: "secret",
+      TELEGRAM_BOT_TOKEN: "token",
+      TELEGRAM_CHAT_ID: "chat",
+    };
+    expect(loadConfig(env).traceLogs).toBe(false);
+    expect(loadConfig({ ...env, TRACE_LOGS: "true" }).traceLogs).toBe(true);
+  });
+
+  test("keeps Telegram messages within the API limit", () => {
+    const message = format({ ...payload, body: "x".repeat(10_000) });
+    expect(message.text.length).toBeLessThanOrEqual(4096);
+    expect(message.text.endsWith(payload.link)).toBe(true);
+  });
+
+  test("never truncates a message onto a split surrogate pair", () => {
+    const message = format({ ...payload, body: "😀".repeat(5_000) });
+    expect(message.text.length).toBeLessThanOrEqual(4096);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(message.text)).toBe(false);
+  });
+
+  test("reads the default alert columns and rejects an empty override", () => {
+    const env = {
+      CLICKSTACK_WEBHOOK_SECRET: "secret",
+      TELEGRAM_BOT_TOKEN: "token",
+      TELEGRAM_CHAT_ID: "chat",
+    };
+    expect(loadConfig(env).alertColumns).toEqual([
+      "Timestamp",
+      "ServiceName",
+      "SeverityText",
+      "Body",
+    ]);
+    expect(
+      loadConfig({ ...env, ALERT_COLUMNS: "Timestamp, flow ,stage" })
+        .alertColumns
+    ).toEqual(["Timestamp", "flow", "stage"]);
+    expect(() => loadConfig({ ...env, ALERT_COLUMNS: " , ," })).toThrow(
+      "ALERT_COLUMNS"
+    );
+  });
+});
+
+describe("pretty alert formatting", () => {
+  const alertBody = [
+    'Group: "ServiceName:loyal-mobile"',
+    "2 lines found, which meets or exceeds the threshold of 1 lines",
+    "Time Range (UTC): [Jul 21 7:15:00 PM - Jul 21 7:20:00 PM)",
+    "",
+    "```",
+    '"2026-07-21T19:15:10.807000000Z","loyal-mobile","prod","earn.withdrawal","prepare",""',
+    '"2026-07-21T19:15:13.658000000Z","loyal-mobile","prod","earn.withdrawal","wallet_submit_confirm","unexpected_error"',
+    "```",
+  ].join("\n");
+  const columns = [
+    "Timestamp",
+    "ServiceName",
+    "env",
+    "flow",
+    "stage",
+    "error_code",
+  ];
+
+  test("labels CSV fields and drops empty ones", () => {
+    const message = format({ ...payload, body: alertBody }, columns);
+
+    expect(message.parseMode).toBe("HTML");
+    expect(message.text).toContain("19:15:13 UTC");
+    expect(message.text).toContain("flow: <code>earn.withdrawal</code>");
+    expect(message.text).toContain("error_code: <code>unexpected_error</code>");
+    // The first row has an empty error_code, so it must not render a label.
+    expect(message.text.match(/error_code:/g)).toHaveLength(1);
+    expect(message.text.endsWith(payload.link)).toBe(true);
+  });
+
+  test("escapes HTML so a log body cannot break the message", () => {
+    const message = format(
+      {
+        ...payload,
+        body: ["```", '"2026-07-21T19:15:10.807Z","<b>svc</b>"', "```"].join(
+          "\n"
+        ),
+      },
+      ["Timestamp", "ServiceName"]
+    );
+
+    expect(message.text).toContain("&lt;b&gt;svc&lt;/b&gt;");
+    expect(message.text).not.toContain("<b>svc</b>");
+  });
+
+  test("falls back to raw text when the columns do not match the payload", () => {
+    const message = format({ ...payload, body: alertBody }, [
+      "Timestamp",
+      "ServiceName",
+    ]);
+
+    expect(message.parseMode).toBeUndefined();
+    expect(message.text).toContain('"loyal-mobile"');
+  });
+
+  test("falls back to raw text when there is no CSV block", () => {
+    const message = format({ ...payload, body: "3 lines found" }, columns);
+
+    expect(message.parseMode).toBeUndefined();
+    expect(message.text).toBe(
+      `${payload.title}\n\n3 lines found\n\n${payload.link}`
+    );
+  });
+
+  test("keeps a formatted burst inside the Telegram limit", () => {
+    const rows = Array.from(
+      { length: 200 },
+      (_, index) =>
+        `"2026-07-21T19:15:10.807000000Z","loyal-mobile","prod","earn.withdrawal","stage-${index}","${"e".repeat(
+          200
+        )}"`
+    );
+    const message = format(
+      { ...payload, body: ["```", ...rows, "```"].join("\n") },
+      columns
+    );
+
+    expect(message.text.length).toBeLessThanOrEqual(4096);
+    expect(message.text).toContain("more row(s)");
+    expect(message.text.endsWith(payload.link)).toBe(true);
+  });
+
+  test("rejects non-integer numeric configuration", () => {
+    const env = {
+      CLICKSTACK_WEBHOOK_SECRET: "secret",
+      TELEGRAM_BOT_TOKEN: "token",
+      TELEGRAM_CHAT_ID: "chat",
+    };
+    expect(() => loadConfig({ ...env, PORT: "0x10" })).toThrow(
+      "PORT must be a positive integer"
+    );
+    expect(() => loadConfig({ ...env, PORT: "1e3" })).toThrow(
+      "PORT must be a positive integer"
+    );
+    expect(loadConfig({ ...env, PORT: "8080" }).port).toBe(8080);
+  });
+});
+
+describe("Telegram sender", () => {
+  const senderConfig = {
+    telegramBotToken: "token",
+    telegramChatId: "chat",
+    alertColumns: defaultColumns,
+  };
+  const formattedPayload: ClickStackWebhookPayload = {
+    ...payload,
+    body: [
+      "```",
+      '"2026-07-21T19:15:10.807Z","loyal-mobile","error","boom"',
+      "```",
+    ].join("\n"),
+  };
+
+  test("waits out a short retry_after and retries once", async () => {
+    const slept: number[] = [];
+    let attempts = 0;
+    const send = createTelegramSender(
+      senderConfig,
+      async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new Response(
+            JSON.stringify({ ok: false, parameters: { retry_after: 2 } }),
+            { status: 429 }
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+      async (ms) => {
+        slept.push(ms);
+      }
+    );
+
+    await send(payload);
+    expect(attempts).toBe(2);
+    expect(slept).toEqual([2000]);
+  });
+
+  test("gives the retry back to ClickStack when retry_after is long", async () => {
+    let attempts = 0;
+    const send = createTelegramSender(
+      senderConfig,
+      async () => {
+        attempts += 1;
+        return new Response(
+          JSON.stringify({ ok: false, parameters: { retry_after: 120 } }),
+          { status: 429 }
+        );
+      },
+      async () => undefined
+    );
+
+    await expect(send(payload)).rejects.toThrow("rate limited");
+    expect(attempts).toBe(1);
+  });
+
+  test("surfaces a non-rate-limit Telegram failure", async () => {
+    const send = createTelegramSender(
+      senderConfig,
+      async () =>
+        new Response(
+          JSON.stringify({ ok: false, description: "chat not found" }),
+          {
+            status: 400,
+          }
+        )
+    );
+
+    await expect(send(payload)).rejects.toThrow("HTTP 400");
+  });
+
+  test("resends unformatted text when Telegram rejects the HTML entities", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    const send = createTelegramSender(senderConfig, async (_url, init) => {
+      bodies.push(JSON.parse(String(init.body)));
+      if (bodies.length === 1) {
+        return new Response(
+          JSON.stringify({ ok: false, description: "can't parse entities" }),
+          { status: 400 }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    await send(formattedPayload);
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.parse_mode).toBe("HTML");
+    expect(bodies[1]?.parse_mode).toBeUndefined();
+    expect(bodies[1]?.text).toContain('"loyal-mobile"');
+  });
+});

--- a/observability/telegram-relay/src/app.test.ts
+++ b/observability/telegram-relay/src/app.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createRequestHandler,
   createTelegramSender,
+  formatPlainTelegramMessage,
   formatTelegramMessage,
   loadConfig,
   validatePayload,
@@ -167,6 +168,21 @@ describe("payload and formatting", () => {
     const message = format({ ...payload, body: "x".repeat(10_000) });
     expect(message.text.length).toBeLessThanOrEqual(4096);
     expect(message.text.endsWith(payload.link)).toBe(true);
+  });
+
+  test("never emits a partially truncated link", () => {
+    const link = `https://clickstack.example/search?q=${"a".repeat(4000)}`;
+    const text = formatPlainTelegramMessage({
+      ...payload,
+      title: "Errors in loyal-frontend",
+      body: "x".repeat(2000),
+      link,
+    });
+
+    expect(text.length).toBeLessThanOrEqual(4096);
+    // Either the whole link survives or none of it does; a clipped URL looks
+    // clickable and resolves nowhere.
+    expect(text.includes(link) || !text.includes("https://")).toBe(true);
   });
 
   test("never truncates a message onto a split surrogate pair", () => {
@@ -368,6 +384,21 @@ describe("Telegram sender", () => {
     );
 
     await expect(send(payload)).rejects.toThrow("HTTP 400");
+  });
+
+  test("rejects an HTTP 200 that Telegram did not acknowledge", async () => {
+    const send = createTelegramSender(
+      senderConfig,
+      async () =>
+        new Response(
+          JSON.stringify({ ok: false, description: "chat not found" }),
+          { status: 200 }
+        )
+    );
+
+    // Accepting this would record a cooldown and acknowledge ClickStack,
+    // dropping the alert for a full cooldown window.
+    await expect(send(payload)).rejects.toThrow("did not acknowledge");
   });
 
   test("resends unformatted text when Telegram rejects the HTML entities", async () => {

--- a/observability/telegram-relay/src/app.ts
+++ b/observability/telegram-relay/src/app.ts
@@ -1,0 +1,478 @@
+import { timingSafeEqual } from "node:crypto";
+
+import {
+  DEFAULT_ALERT_COLUMNS,
+  type FormattedMessage,
+  formatPlainTelegramMessage,
+  formatTelegramMessage,
+} from "./format.ts";
+import {
+  AlertRelay,
+  type ClickStackWebhookPayload,
+  type TelegramSender,
+} from "./relay.ts";
+
+export { formatPlainTelegramMessage, formatTelegramMessage } from "./format.ts";
+
+const TELEGRAM_REQUEST_TIMEOUT_MS = 10_000;
+/** Longest `retry_after` we absorb in-process before handing the retry back. */
+const TELEGRAM_MAX_RETRY_AFTER_MS = 5_000;
+/**
+ * Well under the default MAX_BODY_BYTES so that a payload this validator
+ * accepts cannot be rejected by Bun's byte-counted body cap first (multi-byte
+ * text costs 2-4 bytes per character). Anything past the Telegram limit is
+ * truncated for delivery anyway.
+ */
+const MAX_BODY_FIELD_LENGTH = 8192;
+
+export interface ServerConfig {
+  host: string;
+  port: number;
+  clickStackWebhookSecret: string;
+  telegramBotToken: string;
+  telegramChatId: string;
+  cooldownMs: number;
+  idempotencyTtlMs: number;
+  maxCacheEntries: number;
+  maxBodyBytes: number;
+  alertColumns: string[];
+  traceLogs: boolean;
+}
+
+export function loadConfig(
+  env: Record<string, string | undefined>
+): ServerConfig {
+  return {
+    host: env.HOST?.trim() || "127.0.0.1",
+    port: positiveInteger(env.PORT, 3000, "PORT"),
+    clickStackWebhookSecret: required(env, "CLICKSTACK_WEBHOOK_SECRET"),
+    telegramBotToken: required(env, "TELEGRAM_BOT_TOKEN"),
+    telegramChatId: required(env, "TELEGRAM_CHAT_ID"),
+    cooldownMs:
+      positiveInteger(env.COOLDOWN_SECONDS, 3600, "COOLDOWN_SECONDS") * 1000,
+    idempotencyTtlMs:
+      positiveInteger(
+        env.IDEMPOTENCY_TTL_SECONDS,
+        86400,
+        "IDEMPOTENCY_TTL_SECONDS"
+      ) * 1000,
+    maxCacheEntries: positiveInteger(
+      env.MAX_CACHE_ENTRIES,
+      10000,
+      "MAX_CACHE_ENTRIES"
+    ),
+    maxBodyBytes: positiveInteger(env.MAX_BODY_BYTES, 65536, "MAX_BODY_BYTES"),
+    alertColumns: alertColumns(env.ALERT_COLUMNS),
+    traceLogs: booleanValue(env.TRACE_LOGS, false, "TRACE_LOGS"),
+  };
+}
+
+/**
+ * Mirrors the saved search `select`, in the same order. ClickStack's alert body
+ * is a headerless CSV block, so these names are what turns positional fields
+ * into labelled ones.
+ */
+function alertColumns(raw: string | undefined): string[] {
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_ALERT_COLUMNS;
+  }
+
+  const columns = raw
+    .split(",")
+    .map((column) => column.trim())
+    .filter(Boolean);
+  if (columns.length === 0) {
+    throw new Error("ALERT_COLUMNS must list at least one column name");
+  }
+  return columns;
+}
+
+/** Only the call signature, so tests can inject a plain function. */
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export function createTelegramSender(
+  config: Pick<
+    ServerConfig,
+    "telegramBotToken" | "telegramChatId" | "alertColumns"
+  >,
+  fetchImpl: FetchLike = fetch,
+  sleep: (ms: number) => Promise<void> = defaultSleep
+): TelegramSender {
+  const post = (message: FormattedMessage) =>
+    fetchImpl(
+      `https://api.telegram.org/bot${config.telegramBotToken}/sendMessage`,
+      {
+        method: "POST",
+        signal: AbortSignal.timeout(TELEGRAM_REQUEST_TIMEOUT_MS),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: config.telegramChatId,
+          text: message.text,
+          ...(message.parseMode ? { parse_mode: message.parseMode } : {}),
+          disable_web_page_preview: true,
+        }),
+      }
+    );
+
+  return async (payload) => {
+    const message = formatTelegramMessage(payload, {
+      alertColumns: config.alertColumns,
+    });
+    let response = await post(message);
+
+    // All alerts land in one chat, so bursts across distinct eventIds hit
+    // Telegram's per-chat rate limit. Absorb one short backoff here rather
+    // than bouncing a 502 back and having ClickStack retry into the limit.
+    if (response.status === 429) {
+      const responseText = await response.text();
+      const retryAfterMs = parseRetryAfterMs(responseText);
+      if (
+        retryAfterMs !== null &&
+        retryAfterMs <= TELEGRAM_MAX_RETRY_AFTER_MS
+      ) {
+        await sleep(retryAfterMs);
+        response = await post(message);
+      } else {
+        throw new Error(
+          `Telegram rate limited the relay (HTTP 429): ${responseText.slice(
+            0,
+            300
+          )}`
+        );
+      }
+    }
+
+    // Telegram rejects the whole send when it dislikes an entity. Formatting is
+    // cosmetic, so resend the raw ClickStack text rather than drop the alert.
+    if (response.status === 400 && message.parseMode) {
+      console.warn(
+        JSON.stringify({
+          event: "telegram_formatting_rejected",
+          eventId: payload.eventId,
+        })
+      );
+      response = await post({ text: formatPlainTelegramMessage(payload) });
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw new Error(
+        `Telegram returned HTTP ${response.status}: ${responseText.slice(
+          0,
+          300
+        )}`
+      );
+    }
+  };
+}
+
+function parseRetryAfterMs(responseText: string): number | null {
+  try {
+    const parsed: unknown = JSON.parse(responseText);
+    if (!isRecord(parsed) || !isRecord(parsed.parameters)) {
+      return null;
+    }
+    const retryAfter = parsed.parameters.retry_after;
+    if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter)) {
+      return null;
+    }
+    return Math.max(0, retryAfter) * 1000;
+  } catch {
+    return null;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createRequestHandler(
+  relay: AlertRelay,
+  config: Pick<ServerConfig, "clickStackWebhookSecret"> & {
+    traceLogs?: boolean;
+  }
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const url = new URL(request.url);
+    const trace = (event: string, details: Record<string, unknown> = {}) => {
+      if (!config.traceLogs) {
+        return;
+      }
+      console.info(
+        JSON.stringify({
+          event: "clickstack_webhook_trace",
+          traceEvent: event,
+          method: request.method,
+          path: url.pathname,
+          ...details,
+        })
+      );
+    };
+
+    trace("request_received", {
+      contentType: request.headers.get("content-type"),
+      hasAuthorization: request.headers.has("authorization"),
+      hasIdempotencyKey: request.headers.has("idempotency-key"),
+    });
+
+    if (request.method === "GET" && url.pathname === "/healthz") {
+      trace("health_check");
+      return jsonResponse({ ok: true, cache: relay.stats() });
+    }
+
+    if (request.method !== "POST" || url.pathname !== "/webhooks/clickstack") {
+      trace("request_rejected", { reason: "not_found" });
+      return jsonResponse({ ok: false, error: "not_found" }, 404);
+    }
+
+    if (!hasValidBearerToken(request, config.clickStackWebhookSecret)) {
+      trace("request_rejected", { reason: "unauthorized" });
+      return jsonResponse({ ok: false, error: "unauthorized" }, 401, {
+        "WWW-Authenticate": "Bearer",
+      });
+    }
+
+    const idempotencyKey = request.headers.get("idempotency-key")?.trim();
+    if (!idempotencyKey || idempotencyKey.length > 512) {
+      trace("request_rejected", {
+        reason: "invalid_idempotency_key",
+        issue: !idempotencyKey ? "missing" : "too_long",
+      });
+      return jsonResponse({ ok: false, error: "invalid_idempotency_key" }, 400);
+    }
+
+    let rawPayload: unknown;
+    try {
+      rawPayload = await request.json();
+    } catch {
+      trace("request_rejected", { reason: "invalid_json" });
+      return jsonResponse({ ok: false, error: "invalid_json" }, 400);
+    }
+
+    const validation = validatePayload(rawPayload);
+    if (!validation.ok) {
+      trace("request_rejected", {
+        reason: "invalid_payload",
+        issues: validation.issues,
+      });
+      return jsonResponse({ ok: false, error: "invalid_payload" }, 400);
+    }
+    const payload = validation.payload;
+    trace("payload_accepted", {
+      eventId: payload.eventId,
+      state: payload.state,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+    });
+
+    try {
+      const result = await relay.handle(payload, idempotencyKey);
+      console.info(
+        JSON.stringify({
+          event: "clickstack_webhook",
+          eventId: payload.eventId,
+          state: payload.state,
+          outcome: result.outcome,
+        })
+      );
+      trace("request_completed", { outcome: result.outcome });
+      return jsonResponse({ ok: true, outcome: result.outcome });
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: "telegram_delivery_failed",
+          eventId: payload.eventId,
+          state: payload.state,
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        })
+      );
+      trace("request_failed", {
+        reason: "telegram_delivery_failed",
+        errorName: error instanceof Error ? error.name : "UnknownError",
+      });
+      return jsonResponse(
+        { ok: false, error: "telegram_delivery_failed" },
+        502
+      );
+    }
+  };
+}
+
+type PayloadValidationResult =
+  | { ok: true; payload: ClickStackWebhookPayload }
+  | { ok: false; issues: string[] };
+
+export function validatePayload(input: unknown): PayloadValidationResult {
+  if (!isRecord(input)) {
+    return { ok: false, issues: ["payload must be a JSON object"] };
+  }
+
+  const { eventId, state, title, body, link, startTime, endTime } = input;
+  const issues: string[] = [];
+
+  if (!isBoundedString(eventId, 1, 512)) {
+    issues.push(stringIssue("eventId", eventId, 1, 512));
+  }
+  if (!isBoundedString(state, 0, 128)) {
+    issues.push(stringIssue("state", state, 0, 128));
+  }
+  if (!isBoundedString(title, 1, 2048)) {
+    issues.push(stringIssue("title", title, 1, 2048));
+  } else if (title.trim().length === 0) {
+    issues.push("title must contain non-whitespace text");
+  }
+  if (!isBoundedString(body, 0, MAX_BODY_FIELD_LENGTH)) {
+    issues.push(stringIssue("body", body, 0, MAX_BODY_FIELD_LENGTH));
+  }
+  if (!isBoundedString(link, 0, 4096)) {
+    issues.push(stringIssue("link", link, 0, 4096));
+  }
+  if (!Number.isFinite(startTime)) {
+    issues.push(
+      `startTime must be a finite number (received ${valueType(startTime)})`
+    );
+  }
+  if (!Number.isFinite(endTime)) {
+    issues.push(
+      `endTime must be a finite number (received ${valueType(endTime)})`
+    );
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    payload: {
+      eventId: eventId as string,
+      state: state as string,
+      title: title as string,
+      body: body as string,
+      link: link as string,
+      startTime: startTime as number,
+      endTime: endTime as number,
+    },
+  };
+}
+
+function hasValidBearerToken(request: Request, expected: string): boolean {
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return false;
+  }
+
+  const actual = authorization.slice("Bearer ".length);
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+
+  return (
+    actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+}
+
+function required(
+  env: Record<string, string | undefined>,
+  name: string
+): string {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function positiveInteger(
+  raw: string | undefined,
+  fallback: number,
+  name: string
+): number {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  // Deliberately stricter than Number(): "0x10", "1e3" and " 12 " should be
+  // reported as typos rather than silently parsed into a surprising value.
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function booleanValue(
+  raw: string | undefined,
+  fallback: boolean,
+  name: string
+): boolean {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0") {
+    return false;
+  }
+  throw new Error(`${name} must be true, false, 1, or 0`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBoundedString(
+  value: unknown,
+  minLength: number,
+  maxLength: number
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= minLength &&
+    value.length <= maxLength
+  );
+}
+
+function stringIssue(
+  field: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number
+): string {
+  if (typeof value !== "string") {
+    return `${field} must be a string (received ${valueType(value)})`;
+  }
+  return `${field} length must be between ${minLength} and ${maxLength} (received ${value.length})`;
+}
+
+function valueType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
+}
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      ...extraHeaders,
+    },
+  });
+}

--- a/observability/telegram-relay/src/app.ts
+++ b/observability/telegram-relay/src/app.ts
@@ -154,8 +154,9 @@ export function createTelegramSender(
       response = await post({ text: formatPlainTelegramMessage(payload) });
     }
 
+    const responseText = await response.text();
+
     if (!response.ok) {
-      const responseText = await response.text();
       throw new Error(
         `Telegram returned HTTP ${response.status}: ${responseText.slice(
           0,
@@ -163,7 +164,41 @@ export function createTelegramSender(
         )}`
       );
     }
+
+    // The JSON `ok` field is the authoritative result, not the status code:
+    // Telegram can answer HTTP 200 with {"ok":false,...}. Accepting that as
+    // delivered would record a cooldown and acknowledge ClickStack, dropping
+    // the alert silently for a full cooldown window.
+    if (!isTelegramAcknowledgement(responseText)) {
+      throw new Error(
+        `Telegram did not acknowledge the message: ${responseText.slice(
+          0,
+          300
+        )}`
+      );
+    }
   };
+}
+
+/**
+ * Fails closed on unparseable bodies. A false negative costs a duplicate
+ * message after ClickStack retries; a false positive loses the alert.
+ */
+function isTelegramAcknowledgement(responseText: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(responseText);
+    return isRecord(parsed) && parsed.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The bot token is embedded in the request URL, so any error that quotes the
+ * URL - fetch connection errors especially - would carry it into the logs.
+ */
+export function redactBotToken(text: string): string {
+  return text.replace(/bot\d+:[\w-]+/g, "bot<redacted>");
 }
 
 function parseRetryAfterMs(responseText: string): number | null {
@@ -278,12 +313,22 @@ export function createRequestHandler(
       trace("request_completed", { outcome: result.outcome });
       return jsonResponse({ ok: true, outcome: result.outcome });
     } catch (error) {
+      // These logs are the only record of a delivery failure: the relay does
+      // not export to ClickStack. Without the message a timeout, a rate limit,
+      // and an invalid chat ID are indistinguishable here.
       console.error(
         JSON.stringify({
           event: "telegram_delivery_failed",
           eventId: payload.eventId,
           state: payload.state,
           errorName: error instanceof Error ? error.name : "UnknownError",
+          errorMessage: redactBotToken(
+            error instanceof Error ? error.message : String(error)
+          ).slice(0, 500),
+          errorStack:
+            error instanceof Error && error.stack
+              ? redactBotToken(error.stack).slice(0, 1000)
+              : undefined,
         })
       );
       trace("request_failed", {

--- a/observability/telegram-relay/src/format.ts
+++ b/observability/telegram-relay/src/format.ts
@@ -1,0 +1,342 @@
+import type { ClickStackWebhookPayload } from "./relay.ts";
+
+export const TELEGRAM_MESSAGE_LIMIT = 4096;
+
+/** Columns ClickStack projects by default when a saved search sets no `select`. */
+export const DEFAULT_ALERT_COLUMNS = [
+  "Timestamp",
+  "ServiceName",
+  "SeverityText",
+  "Body",
+];
+
+/**
+ * ClickStack renders alert rows as a CSV block with no header line, so the
+ * relay has to be told which saved-search columns it is looking at. Keep this
+ * list in the same order as the saved search `select`.
+ */
+export interface FormatOptions {
+  alertColumns: string[];
+}
+
+export interface FormattedMessage {
+  text: string;
+  parseMode?: "HTML";
+}
+
+/** Enough rows to see a pattern, few enough to stay readable in a chat. */
+const MAX_RENDERED_ROWS = 8;
+/** Headroom for the "and N more" footer while rows are being fitted. */
+const FOOTER_RESERVE = 48;
+
+export function formatTelegramMessage(
+  payload: ClickStackWebhookPayload,
+  options: FormatOptions
+): FormattedMessage {
+  return (
+    formatPrettyMessage(payload, options.alertColumns) ?? {
+      text: formatPlainTelegramMessage(payload),
+    }
+  );
+}
+
+/**
+ * Verbatim ClickStack text. Used when the payload does not carry a parseable
+ * CSV block and as the resend body when Telegram rejects HTML entities.
+ */
+export function formatPlainTelegramMessage(
+  payload: ClickStackWebhookPayload
+): string {
+  const main = [payload.title.trim(), payload.body.trim()]
+    .filter(Boolean)
+    .join("\n\n");
+  const suffix = payload.link.trim() ? `\n\n${payload.link.trim()}` : "";
+  const fullMessage = `${main}${suffix}`;
+
+  if (fullMessage.length <= TELEGRAM_MESSAGE_LIMIT) {
+    return fullMessage;
+  }
+
+  const availableMainLength = Math.max(
+    0,
+    TELEGRAM_MESSAGE_LIMIT - suffix.length - 1
+  );
+  return `${sliceWholeCodePoints(main, availableMainLength)}…${suffix}`.slice(
+    0,
+    TELEGRAM_MESSAGE_LIMIT
+  );
+}
+
+function formatPrettyMessage(
+  payload: ClickStackWebhookPayload,
+  columns: string[]
+): FormattedMessage | null {
+  if (columns.length === 0) {
+    return null;
+  }
+
+  const parsed = parseAlertBody(payload.body);
+  if (!parsed || parsed.rows.length === 0) {
+    return null;
+  }
+
+  // A column list that disagrees with what ClickStack actually sent would
+  // mislabel every field, which is worse than the raw block.
+  if (parsed.rows.some((row) => row.length !== columns.length)) {
+    return null;
+  }
+
+  const blocks = parsed.rows
+    .slice(0, MAX_RENDERED_ROWS)
+    .map((row) => renderRow(row, columns))
+    .filter((block) => block.length > 0);
+  if (blocks.length === 0) {
+    return null;
+  }
+
+  const header = [
+    `<b>${escapeHtml(payload.title.trim())}</b>`,
+    ...parsed.summaryLines.map((line) => `<i>${escapeHtml(line)}</i>`),
+  ].join("\n");
+  const link = payload.link.trim();
+  const suffix = link ? `\n\n${escapeHtml(link)}` : "";
+
+  const budget = TELEGRAM_MESSAGE_LIMIT - suffix.length - FOOTER_RESERVE;
+  const rendered: string[] = [];
+  let used = header.length;
+  for (const block of blocks) {
+    if (used + block.length + 2 > budget) {
+      break;
+    }
+    rendered.push(block);
+    used += block.length + 2;
+  }
+
+  if (rendered.length === 0) {
+    return null;
+  }
+
+  const omitted = parsed.rows.length - rendered.length;
+  const footer = omitted > 0 ? `\n\n<i>and ${omitted} more row(s)</i>` : "";
+
+  return {
+    text: `${header}\n\n${rendered.join("\n\n")}${footer}${suffix}`,
+    parseMode: "HTML",
+  };
+}
+
+interface ParsedAlertBody {
+  summaryLines: string[];
+  rows: string[][];
+}
+
+/**
+ * ClickStack sends a short preamble (group, line count, time range) followed by
+ * a fenced CSV block holding the matched rows.
+ */
+function parseAlertBody(body: string): ParsedAlertBody | null {
+  const lines = body.split("\n");
+  const fences: number[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (line.trim() === "```") {
+      fences.push(index);
+    }
+  }
+
+  const start = fences[0];
+  const end = fences.at(-1);
+  if (start === undefined || end === undefined || end <= start + 1) {
+    return null;
+  }
+
+  const rows = parseCsv(lines.slice(start + 1, end).join("\n"));
+  if (!rows) {
+    return null;
+  }
+
+  return {
+    // The threshold line repeats the count ClickStack already put in `title`.
+    summaryLines: lines
+      .slice(0, start)
+      .map((line) => line.trim())
+      .filter((line) => line && !/^\d+ lines found/.test(line)),
+    rows,
+  };
+}
+
+/**
+ * RFC 4180 parsing rather than `split(",")`: a log body can legitimately
+ * contain commas, quotes, and newlines inside one quoted field.
+ */
+function parseCsv(input: string): string[][] | null {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let dirty = false;
+
+  const endField = () => {
+    row.push(field);
+    field = "";
+  };
+  const endRow = () => {
+    endField();
+    if (dirty) {
+      rows.push(row);
+    }
+    row = [];
+    dirty = false;
+  };
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+
+    if (inQuotes) {
+      if (char !== '"') {
+        field += char;
+      } else if (input[index + 1] === '"') {
+        field += '"';
+        index += 1;
+      } else {
+        inQuotes = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      dirty = true;
+    } else if (char === ",") {
+      endField();
+      dirty = true;
+    } else if (char === "\n") {
+      endRow();
+    } else if (char !== "\r") {
+      field += char;
+      dirty = true;
+    }
+  }
+
+  if (inQuotes) {
+    return null;
+  }
+  endRow();
+
+  return rows;
+}
+
+type ColumnRole = "time" | "service" | "severity" | "headline" | "detail";
+
+function roleOf(column: string): ColumnRole {
+  switch (column.trim().toLowerCase()) {
+    case "timestamp":
+    case "time":
+      return "time";
+    case "servicename":
+    case "service":
+      return "service";
+    case "severitytext":
+    case "severity":
+    case "level":
+      return "severity";
+    case "body":
+      return "headline";
+    default:
+      return "detail";
+  }
+}
+
+function renderRow(row: string[], columns: string[]): string {
+  const fields = columns.map((column, index) => ({
+    label: column.trim(),
+    role: roleOf(column),
+    value: (row[index] ?? "").trim(),
+  }));
+  const valueOf = (role: ColumnRole) =>
+    fields.find((field) => field.role === role && field.value)?.value ?? "";
+
+  const severity = valueOf("severity");
+  const head = [
+    severity ? `${severityIcon(severity)} <b>${escapeHtml(severity)}</b>` : "",
+    formatTimestamp(valueOf("time")),
+    valueOf("service"),
+  ]
+    .filter(Boolean)
+    .map((part, index) => (index === 0 && severity ? part : escapeHtml(part)))
+    .join(" · ");
+
+  const lines: string[] = [];
+  if (head) {
+    lines.push(head);
+  }
+
+  const headline = valueOf("headline");
+  if (headline) {
+    lines.push(`<b>${escapeHtml(headline)}</b>`);
+  }
+
+  for (const field of fields) {
+    if (field.role === "detail" && field.value) {
+      lines.push(
+        `${escapeHtml(field.label)}: <code>${escapeHtml(field.value)}</code>`
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function severityIcon(severity: string): string {
+  switch (severity.toLowerCase()) {
+    case "error":
+    case "fatal":
+    case "critical":
+      return "🔴";
+    case "warn":
+    case "warning":
+      return "🟡";
+    case "info":
+      return "🔵";
+    default:
+      return "⚪";
+  }
+}
+
+/**
+ * ClickStack timestamps carry nanosecond precision, which `Date` does not
+ * accept, so trim to milliseconds before parsing and keep the raw value when
+ * the column turns out not to be a timestamp at all.
+ */
+function formatTimestamp(value: string): string {
+  if (!value) {
+    return "";
+  }
+
+  const trimmed = value.replace(/(\.\d{3})\d+(Z|$)/, "$1$2");
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return `${parsed.toISOString().slice(11, 19)} UTC`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/**
+ * `String.prototype.slice` cuts on UTF-16 units and can leave a dangling high
+ * surrogate, which renders as a replacement character. Drop the split pair.
+ */
+function sliceWholeCodePoints(value: string, maxLength: number): string {
+  const sliced = value.slice(0, maxLength);
+  const lastCode = sliced.charCodeAt(sliced.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    return sliced.slice(0, -1);
+  }
+  return sliced;
+}

--- a/observability/telegram-relay/src/format.ts
+++ b/observability/telegram-relay/src/format.ts
@@ -57,14 +57,15 @@ export function formatPlainTelegramMessage(
     return fullMessage;
   }
 
-  const availableMainLength = Math.max(
-    0,
-    TELEGRAM_MESSAGE_LIMIT - suffix.length - 1
-  );
-  return `${sliceWholeCodePoints(main, availableMainLength)}…${suffix}`.slice(
-    0,
-    TELEGRAM_MESSAGE_LIMIT
-  );
+  // A partial URL is worse than none: it looks clickable, resolves nowhere, and
+  // hides the alert title behind it. When the link cannot fit whole, drop it and
+  // keep the text; otherwise reserve it in full and truncate only the text.
+  if (suffix.length + 1 > TELEGRAM_MESSAGE_LIMIT) {
+    return `${sliceWholeCodePoints(main, TELEGRAM_MESSAGE_LIMIT - 1)}…`;
+  }
+
+  const availableMainLength = TELEGRAM_MESSAGE_LIMIT - suffix.length - 1;
+  return `${sliceWholeCodePoints(main, availableMainLength)}…${suffix}`;
 }
 
 function formatPrettyMessage(

--- a/observability/telegram-relay/src/index.ts
+++ b/observability/telegram-relay/src/index.ts
@@ -1,0 +1,70 @@
+import {
+  createRequestHandler,
+  createTelegramSender,
+  loadConfig,
+} from "./app.ts";
+import { AlertRelay } from "./relay.ts";
+
+function readConfig() {
+  try {
+    return loadConfig(process.env);
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "server_start_failed",
+        error: error instanceof Error ? error.message : "unknown config error",
+      })
+    );
+    process.exit(1);
+  }
+}
+
+const config = readConfig();
+const relay = new AlertRelay(createTelegramSender(config), {
+  cooldownMs: config.cooldownMs,
+  idempotencyTtlMs: config.idempotencyTtlMs,
+  maxCacheEntries: config.maxCacheEntries,
+});
+
+const cleanupTimer = setInterval(() => relay.cleanup(), 60_000);
+cleanupTimer.unref();
+
+const server = Bun.serve({
+  hostname: config.host,
+  port: config.port,
+  maxRequestBodySize: config.maxBodyBytes,
+  fetch: createRequestHandler(relay, config),
+});
+
+console.info(
+  JSON.stringify({
+    event: "server_started",
+    url: server.url.toString(),
+    webhookPath: "/webhooks/clickstack",
+    cooldownSeconds: config.cooldownMs / 1000,
+  })
+);
+
+// Render sends SIGTERM on every deploy and restart. Without this, an in-flight
+// webhook is cut mid-delivery: ClickStack sees a connection reset rather than a
+// status code, and that alert is lost unless it happens to re-fire. Draining
+// lets the request finish and return 200, or 502 so ClickStack retries.
+let shuttingDown = false;
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  clearInterval(cleanupTimer);
+  console.info(JSON.stringify({ event: "server_stopping", signal }));
+
+  // `false` keeps active connections alive until their handler resolves.
+  await server.stop(false);
+
+  console.info(JSON.stringify({ event: "server_stopped", signal }));
+  process.exit(0);
+}
+
+process.on("SIGTERM", (signal) => void shutdown(signal));
+process.on("SIGINT", (signal) => void shutdown(signal));

--- a/observability/telegram-relay/src/relay.test.ts
+++ b/observability/telegram-relay/src/relay.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+
+import { AlertRelay, type ClickStackWebhookPayload } from "./relay.ts";
+
+const alertPayload: ClickStackWebhookPayload = {
+  eventId: "alert-errors-service-loyal-mobile",
+  state: "ALERT",
+  title: "Alert for Errors",
+  body: "3 lines found",
+  link: "https://clickstack.example/search/1",
+  startTime: 1,
+  endTime: 2,
+};
+
+function createRelay(
+  sender: (payload: ClickStackWebhookPayload) => Promise<void>,
+  now: () => number
+) {
+  return new AlertRelay(sender, {
+    cooldownMs: 60 * 60 * 1000,
+    idempotencyTtlMs: 24 * 60 * 60 * 1000,
+    maxCacheEntries: 100,
+    now,
+  });
+}
+
+describe("AlertRelay", () => {
+  test("sends the first alert and suppresses the same event during cooldown", async () => {
+    let now = 1_000;
+    const sent: ClickStackWebhookPayload[] = [];
+    const relay = createRelay(
+      async (payload) => {
+        sent.push(payload);
+      },
+      () => now
+    );
+
+    expect(await relay.handle(alertPayload, "delivery-1")).toEqual({
+      outcome: "sent",
+    });
+    now += 10_000;
+    expect(await relay.handle(alertPayload, "delivery-2")).toEqual({
+      outcome: "suppressed",
+    });
+    expect(sent).toHaveLength(1);
+  });
+
+  test("recognizes an exact delivery retry by Idempotency-Key", async () => {
+    const sent: ClickStackWebhookPayload[] = [];
+    const relay = createRelay(
+      async (payload) => {
+        sent.push(payload);
+      },
+      () => 1_000
+    );
+
+    await relay.handle(alertPayload, "same-delivery");
+    expect(await relay.handle(alertPayload, "same-delivery")).toEqual({
+      outcome: "duplicate",
+    });
+    expect(sent).toHaveLength(1);
+  });
+
+  test("serializes the same Idempotency-Key across different events", async () => {
+    let releaseFirstSend: () => void = () => undefined;
+    const firstSendGate = new Promise<void>((resolve) => {
+      releaseFirstSend = resolve;
+    });
+    let markFirstSendStarted: () => void = () => undefined;
+    const firstSendStarted = new Promise<void>((resolve) => {
+      markFirstSendStarted = resolve;
+    });
+    const sent: ClickStackWebhookPayload[] = [];
+    const relay = createRelay(
+      async (payload) => {
+        sent.push(payload);
+        markFirstSendStarted();
+        await firstSendGate;
+      },
+      () => 1_000
+    );
+
+    const first = relay.handle(alertPayload, "same-delivery");
+    const second = relay.handle(
+      { ...alertPayload, eventId: "another-event" },
+      "same-delivery"
+    );
+    await firstSendStarted;
+
+    expect(sent).toHaveLength(1);
+    releaseFirstSend();
+    expect(await first).toEqual({ outcome: "sent" });
+    expect(await second).toEqual({ outcome: "duplicate" });
+    expect(sent).toHaveLength(1);
+  });
+
+  test("keeps a flapping alert suppressed across OK recoveries", async () => {
+    let now = 1_000;
+    const sent: ClickStackWebhookPayload[] = [];
+    const relay = createRelay(
+      async (payload) => {
+        sent.push(payload);
+      },
+      () => now
+    );
+    const okPayload = { ...alertPayload, state: "OK" as const };
+
+    expect(await relay.handle(alertPayload, "alert-1")).toEqual({
+      outcome: "sent",
+    });
+    // Two full flap cycles inside the cooldown must stay silent.
+    for (const cycle of [1, 2]) {
+      now += 60_000;
+      expect(await relay.handle(okPayload, `ok-${cycle}`)).toEqual({
+        outcome: "resolved",
+      });
+      now += 60_000;
+      expect(await relay.handle(alertPayload, `alert-flap-${cycle}`)).toEqual({
+        outcome: "suppressed",
+      });
+    }
+    expect(sent).toHaveLength(1);
+
+    // Once the cooldown expires the event is allowed through again.
+    now += 60 * 60 * 1000;
+    expect(await relay.handle(alertPayload, "alert-after-cooldown")).toEqual({
+      outcome: "sent",
+    });
+    expect(sent.map((payload) => payload.state)).toEqual(["ALERT", "ALERT"]);
+  });
+
+  test("sends again after cooldown expiration", async () => {
+    let now = 1_000;
+    let sendCount = 0;
+    const relay = createRelay(
+      async () => {
+        sendCount += 1;
+      },
+      () => now
+    );
+
+    await relay.handle(alertPayload, "delivery-1");
+    now += 60 * 60 * 1000 + 1;
+    expect(await relay.handle(alertPayload, "delivery-2")).toEqual({
+      outcome: "sent",
+    });
+    expect(sendCount).toBe(2);
+  });
+
+  test("does not poison caches when Telegram delivery fails", async () => {
+    let attempt = 0;
+    const relay = createRelay(
+      async () => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error("Telegram unavailable");
+        }
+      },
+      () => 1_000
+    );
+
+    await expect(relay.handle(alertPayload, "delivery-1")).rejects.toThrow(
+      "Telegram unavailable"
+    );
+    expect(await relay.handle(alertPayload, "delivery-1")).toEqual({
+      outcome: "sent",
+    });
+    expect(attempt).toBe(2);
+  });
+
+  test("serializes concurrent alerts for the same event", async () => {
+    let releaseFirstSend: () => void = () => undefined;
+    const firstSendGate = new Promise<void>((resolve) => {
+      releaseFirstSend = resolve;
+    });
+    let sendCount = 0;
+    const relay = createRelay(
+      async () => {
+        sendCount += 1;
+        await firstSendGate;
+      },
+      () => 1_000
+    );
+
+    const first = relay.handle(alertPayload, "delivery-1");
+    const second = relay.handle(alertPayload, "delivery-2");
+    await Promise.resolve();
+    releaseFirstSend();
+
+    expect(await first).toEqual({ outcome: "sent" });
+    expect(await second).toEqual({ outcome: "suppressed" });
+    expect(sendCount).toBe(1);
+  });
+});

--- a/observability/telegram-relay/src/relay.ts
+++ b/observability/telegram-relay/src/relay.ts
@@ -1,0 +1,180 @@
+export interface ClickStackWebhookPayload {
+  eventId: string;
+  state: string;
+  title: string;
+  body: string;
+  link: string;
+  startTime: number;
+  endTime: number;
+}
+
+export type RelayOutcome = "sent" | "suppressed" | "duplicate" | "resolved";
+
+export interface RelayResult {
+  outcome: RelayOutcome;
+}
+
+export type TelegramSender = (
+  payload: ClickStackWebhookPayload
+) => Promise<void>;
+
+export interface AlertRelayOptions {
+  cooldownMs: number;
+  idempotencyTtlMs: number;
+  maxCacheEntries: number;
+  now?: () => number;
+}
+
+class ExpiringCache {
+  private readonly entries = new Map<string, number>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  has(key: string, now: number): boolean {
+    const expiresAt = this.entries.get(key);
+    if (expiresAt === undefined) {
+      return false;
+    }
+
+    if (expiresAt <= now) {
+      this.entries.delete(key);
+      return false;
+    }
+
+    return true;
+  }
+
+  set(key: string, expiresAt: number, now: number): void {
+    if (!this.entries.has(key) && this.entries.size >= this.maxEntries) {
+      this.evictExpired(now);
+    }
+
+    if (!this.entries.has(key) && this.entries.size >= this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.entries.delete(oldestKey);
+      }
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, expiresAt);
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+
+  /**
+   * Full O(n) sweep. Kept off the request path: `has` expires entries lazily,
+   * and the periodic timer reclaims whatever is never read again.
+   */
+  evictExpired(now: number): void {
+    for (const [key, expiresAt] of this.entries) {
+      if (expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+export class AlertRelay {
+  private readonly cooldowns: ExpiringCache;
+  private readonly idempotencyKeys: ExpiringCache;
+  private readonly eventLocks = new Map<string, Promise<void>>();
+  private readonly idempotencyLocks = new Map<string, Promise<void>>();
+  private readonly now: () => number;
+
+  constructor(
+    private readonly sender: TelegramSender,
+    private readonly options: AlertRelayOptions
+  ) {
+    this.cooldowns = new ExpiringCache(options.maxCacheEntries);
+    this.idempotencyKeys = new ExpiringCache(options.maxCacheEntries);
+    this.now = options.now ?? Date.now;
+  }
+
+  async handle(
+    payload: ClickStackWebhookPayload,
+    idempotencyKey: string
+  ): Promise<RelayResult> {
+    return this.withLock(this.idempotencyLocks, idempotencyKey, () =>
+      this.withLock(this.eventLocks, payload.eventId, async () => {
+        const now = this.now();
+
+        if (this.idempotencyKeys.has(idempotencyKey, now)) {
+          return { outcome: "duplicate" };
+        }
+
+        // Recoveries are not actionable in chat and must not shorten the
+        // cooldown either: a flapping alert resolves and re-fires every
+        // evaluation interval, so clearing it here would post that event on
+        // every cycle instead of once per cooldown.
+        if (payload.state === "OK") {
+          this.rememberIdempotencyKey(idempotencyKey, now);
+          return { outcome: "resolved" };
+        }
+
+        if (this.cooldowns.has(payload.eventId, now)) {
+          this.rememberIdempotencyKey(idempotencyKey, now);
+          return { outcome: "suppressed" };
+        }
+
+        await this.sender(payload);
+        this.cooldowns.set(payload.eventId, now + this.options.cooldownMs, now);
+        this.rememberIdempotencyKey(idempotencyKey, now);
+        return { outcome: "sent" };
+      })
+    );
+  }
+
+  cleanup(now = this.now()): void {
+    this.cooldowns.evictExpired(now);
+    this.idempotencyKeys.evictExpired(now);
+  }
+
+  /**
+   * O(1) and non-mutating, so the unauthenticated health route cannot be used
+   * to force repeated full-cache sweeps. Counts may briefly include entries
+   * that have expired but not yet been reclaimed.
+   */
+  stats(): { cooldowns: number; idempotencyKeys: number } {
+    return {
+      cooldowns: this.cooldowns.size,
+      idempotencyKeys: this.idempotencyKeys.size,
+    };
+  }
+
+  private rememberIdempotencyKey(key: string, now: number): void {
+    this.idempotencyKeys.set(key, now + this.options.idempotencyTtlMs, now);
+  }
+
+  private async withLock<T>(
+    locks: Map<string, Promise<void>>,
+    key: string,
+    action: () => Promise<T>
+  ): Promise<T> {
+    const previous = locks.get(key) ?? Promise.resolve();
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    locks.set(key, tail);
+
+    // `await previous` sits inside the try so that a rejection can never skip
+    // `release()` and strand every later waiter on this key.
+    try {
+      await previous;
+      return await action();
+    } finally {
+      release();
+      if (locks.get(key) === tail) {
+        locks.delete(key);
+      }
+    }
+  }
+}

--- a/observability/telegram-relay/tsconfig.json
+++ b/observability/telegram-relay/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a small Bun relay that forwards ClickStack alert webhooks to Telegram, deployed as a private Render service alongside `loyal-clickstack` in the `loyal-observability` project.

Cooldown and idempotency state is in-process, so the service is pinned to one instance and drains in-flight webhooks on SIGTERM; moving that state to a shared store is deferred.

Closes ASK-1849.