### PR TITLE
fix(observability): restore network isolation and align relay port

### DIFF
--- a/observability/render.yaml
+++ b/observability/render.yaml
@@ -5,6 +5,10 @@ projects:
   - name: loyal-observability
     environments:
       - name: test
+        # Render defaults this to `disabled` when omitted, so leaving it out
+        # silently downgrades the environment on the next Blueprint sync.
+        networking:
+          isolation: enabled
         services:
           - type: web
             name: loyal-clickstack
@@ -79,10 +83,13 @@ projects:
               # reach over the private network.
               - key: HOST
                 value: 0.0.0.0
-              # Render reserves 10000, 18012, 18013 and 19099 on the private
-              # network, so the relay cannot listen on any of them.
+              # Render's default service port. Keep it aligned with the
+              # internal address Render advertises under Connect -> Internal,
+              # or the address an operator copies from there points at a port
+              # nothing is listening on. Render reserves only 18012, 18013
+              # and 19099.
               - key: PORT
-                value: "3000"
+                value: "10000"
               # Read the generated value from the Render dashboard and paste it
               # into the ClickStack webhook's Authorization header.
               - key: CLICKSTACK_WEBHOOK_SECRET

--- a/observability/scripts/verify.sh
+++ b/observability/scripts/verify.sh
@@ -50,11 +50,14 @@ require_literal 'value: 127.0.0.1' "$blueprint"
 pass "Blueprint pins monorepo scope, disk, health check, and generated secrets"
 
 # Telegram relay. Cooldown state is in-process, so a second instance
-# double-posts every alert. Render reserves port 10000 on the private network
-# and supports healthCheckPath on web services only.
+# double-posts every alert. The listen port must match the internal address
+# Render advertises, and healthCheckPath is a web-service-only field.
+# Render treats an omitted networking.isolation as `disabled`, so a Blueprint
+# that stays silent downgrades the environment on the next sync.
+require_literal 'isolation: enabled' "$blueprint"
 require_literal 'name: loyal-clickstack-telegram-relay' "$blueprint"
 require_literal 'rootDir: observability/telegram-relay' "$blueprint"
-require_literal 'value: "3000"' "$blueprint"
+require_literal 'value: "10000"' "$blueprint"
 rg --quiet 'healthCheckPath: /healthz' "$blueprint" \
   && fail "private services do not support healthCheckPath"
 [[ "$(rg --after-context=20 'name: loyal-clickstack-telegram-relay' "$blueprint" | rg --count 'numInstances: 1')" == "1" ]] \

--- a/observability/telegram-relay/Dockerfile
+++ b/observability/telegram-relay/Dockerfile
@@ -12,11 +12,11 @@ COPY src ./src
 
 USER bun
 
-# Render reserves 10000, 18012, 18013 and 19099 on the private network, so the
-# relay has to listen somewhere else.
+# Render's default service port, and the one it advertises as this service's
+# internal address. Render reserves only 18012, 18013 and 19099.
 ENV HOST=0.0.0.0 \
-    PORT=3000
+    PORT=10000
 
-EXPOSE 3000
+EXPOSE 10000
 
 CMD ["bun", "src/index.ts"]

--- a/observability/telegram-relay/README.md
+++ b/observability/telegram-relay/README.md
@@ -133,12 +133,12 @@ value from the relay service's **Connect -> Internal** panel in the Render
 dashboard. It looks like:
 
 ```text
-http://loyal-clickstack-telegram-relay-XXXX:3000/webhooks/clickstack
+http://loyal-clickstack-telegram-relay:10000/webhooks/clickstack
 ```
 
-Port `3000` rather than Render's usual `10000`: Render reserves `10000`,
-`18012`, `18013` and `19099` on the private network, so a service listening on
-one of them is unreachable from its peers.
+The relay listens on Render's default port `10000` specifically so the address
+copied from that panel works as-is. Render reserves only `18012`, `18013` and
+`19099`.
 
 Set these headers:
 


### PR DESCRIPTION
The Telegram relay PR omitted `networking.isolation`, which Render treats as `disabled`, so the sync turned network isolation off on the `test` environment. Declares it explicitly, asserts it in the observability verifier, and moves the relay to port 10000 so it matches the internal address Render advertises under Connect -> Internal.

Follow-up to #514, part of ASK-1849.