### PR TITLE
fix(auth): report sign-in failures at the stage they occur

### DIFF
--- a/frontend/src/components/auth/use-wallet-proof-auth.ts
+++ b/frontend/src/components/auth/use-wallet-proof-auth.ts
@@ -516,7 +516,8 @@ export function useWalletProofAuth({
             new WalletProofSignerError(
               "This wallet does not support transaction signing.",
               "wallet_signing_unsupported"
-            )
+            ),
+            { stage: "wallet_connect" }
           );
           return;
         }
@@ -537,7 +538,8 @@ export function useWalletProofAuth({
           new WalletProofSignerError(
             "This wallet does not support message signing.",
             "wallet_signing_unsupported"
-          )
+          ),
+          { stage: "wallet_connect" }
         );
         return;
       }

--- a/frontend/src/components/auth/use-wallet-proof-auth.ts
+++ b/frontend/src/components/auth/use-wallet-proof-auth.ts
@@ -1,6 +1,20 @@
 "use client";
 
 import type { WalletName } from "@solana/wallet-adapter-base";
+import {
+  WalletConnectionError,
+  WalletDisconnectedError,
+  WalletError,
+  WalletLoadError,
+  WalletNotConnectedError,
+  WalletNotReadyError,
+  WalletSignInError,
+  WalletSignMessageError,
+  WalletSignTransactionError,
+  WalletTimeoutError,
+  WalletWindowBlockedError,
+  WalletWindowClosedError,
+} from "@solana/wallet-adapter-base";
 import { useWallet } from "@solana/wallet-adapter-react";
 import {
   useCallback,
@@ -30,6 +44,8 @@ import { WalletProofSignerError } from "@/lib/auth/wallet-proof-signer";
 import { useExplicitWalletConnectIntent } from "@/components/solana/wallet-provider";
 import { createBrowserLifecycleTracker } from "@/features/observability/client";
 import {
+  type LifecycleErrorCode,
+  type LifecycleFlowStage,
   type LifecycleTracker,
   normalizeLifecycleErrorCode,
 } from "@/features/observability/lifecycle-contract";
@@ -37,11 +53,11 @@ import {
 const WALLET_CONNECTION_SETTLE_MS = 2500;
 const WALLET_SELECTION_SETTLE_MS = 7000;
 
-function isRejectedWalletRequest(error: unknown): boolean {
+function hasRejectionWording(value: unknown): boolean {
   const message =
-    error instanceof Error
-      ? error.message.toLowerCase()
-      : String(error).toLowerCase();
+    value instanceof Error
+      ? value.message.toLowerCase()
+      : String(value ?? "").toLowerCase();
 
   return (
     message.includes("rejected") ||
@@ -50,6 +66,68 @@ function isRejectedWalletRequest(error: unknown): boolean {
     message.includes("canceled") ||
     message.includes("user denied")
   );
+}
+
+// Wallet adapters disagree on how a dismissed prompt surfaces: some throw
+// `WalletWindowClosedError`, others a generic `WalletConnectionError` whose
+// wording is the only signal, and several nest the provider's own error under
+// `WalletError.error`. Check the class first and fall back to wording on both
+// the wrapper and the nested cause — matching wording alone used to classify a
+// closed popup as a hard failure (ASK-1857).
+function isRejectedWalletRequest(error: unknown): boolean {
+  if (error instanceof WalletWindowClosedError) {
+    return true;
+  }
+
+  if (error instanceof WalletError) {
+    return hasRejectionWording(error) || hasRejectionWording(error.error);
+  }
+
+  return hasRejectionWording(error);
+}
+
+// Maps a wallet-adapter failure onto the lifecycle vocabulary so connect-time
+// problems stop collapsing into `unexpected_error`. Returns undefined for
+// anything that is not a wallet-adapter error, leaving the caller's own
+// normalization in charge.
+function classifyWalletAdapterError(
+  error: unknown
+): LifecycleErrorCode | undefined {
+  if (!(error instanceof WalletError)) {
+    return undefined;
+  }
+
+  if (error instanceof WalletTimeoutError) {
+    return "wallet_connection_timeout";
+  }
+
+  // Not installed, disabled, or still injecting; and a blocked popup is the
+  // same dead end from the user's side — the browser suppressed the prompt.
+  if (
+    error instanceof WalletNotReadyError ||
+    error instanceof WalletLoadError ||
+    error instanceof WalletWindowBlockedError
+  ) {
+    return "wallet_unavailable";
+  }
+
+  if (
+    error instanceof WalletConnectionError ||
+    error instanceof WalletNotConnectedError ||
+    error instanceof WalletDisconnectedError
+  ) {
+    return "wallet_connection_timeout";
+  }
+
+  if (
+    error instanceof WalletSignInError ||
+    error instanceof WalletSignMessageError ||
+    error instanceof WalletSignTransactionError
+  ) {
+    return "invalid_wallet_signature";
+  }
+
+  return "wallet_unavailable";
 }
 
 function mapWalletProofError(error: unknown): {
@@ -149,23 +227,36 @@ export function useWalletProofAuth({
     [wallets]
   );
 
+  // `stage` is where the flow actually died. It defaults to `completion` only
+  // for the proof-flow callers, which have already emitted `challenge` and
+  // `wallet_approval` themselves; every pre-proof caller passes its own stage
+  // so a connect failure is not reported as a completion failure (ASK-1857).
   const handleFailure = useCallback(
-    (error: unknown) => {
+    (
+      error: unknown,
+      options?: { stage?: LifecycleFlowStage; errorCode?: LifecycleErrorCode }
+    ) => {
       endExplicitWalletConnect(selectedWalletNameRef.current);
       const nextError = mapWalletProofError(error);
-      const errorCode = normalizeLifecycleErrorCode(
-        error instanceof AuthApiClientError
-          ? error.code
-          : error instanceof WalletProofSignerError
-          ? error.code
-          : undefined
-      );
+      const errorCode =
+        options?.errorCode ??
+        normalizeLifecycleErrorCode(
+          error instanceof AuthApiClientError
+            ? error.code
+            : error instanceof WalletProofSignerError
+            ? error.code
+            : classifyWalletAdapterError(error)
+        );
       if (nextError.status === "rejected") {
-        lifecycleRef.current?.cancel("wallet_approval", {
+        // Without an explicit stage this is a proof-flow caller, where a
+        // rejection is always the signature prompt.
+        lifecycleRef.current?.cancel(options?.stage ?? "wallet_approval", {
           errorCode: "wallet_rejected",
         });
       } else {
-        lifecycleRef.current?.fail("completion", { errorCode });
+        lifecycleRef.current?.fail(options?.stage ?? "completion", {
+          errorCode,
+        });
       }
       dispatch({
         type: "failed",
@@ -193,7 +284,10 @@ export function useWalletProofAuth({
 
   const verifySelectedWalletWithSiws = useCallback(async () => {
     if (!wallet) {
-      handleFailure(new Error("Wallet is not selected."));
+      handleFailure(new Error("Wallet is not selected."), {
+        stage: "wallet_select",
+        errorCode: "wallet_unavailable",
+      });
       return;
     }
 
@@ -202,7 +296,8 @@ export function useWalletProofAuth({
         new WalletProofSignerError(
           "This wallet does not support Sign In With Solana.",
           "wallet_signing_unsupported"
-        )
+        ),
+        { stage: "wallet_connect" }
       );
       return;
     }
@@ -253,7 +348,10 @@ export function useWalletProofAuth({
     }
 
     if (!connected || !publicKey) {
-      handleFailure(new Error("Wallet is not connected."));
+      handleFailure(new Error("Wallet is not connected."), {
+        stage: "wallet_connect",
+        errorCode: "wallet_unavailable",
+      });
       return;
     }
 
@@ -265,7 +363,8 @@ export function useWalletProofAuth({
           new WalletProofSignerError(
             "This wallet does not support transaction signing.",
             "wallet_signing_unsupported"
-          )
+          ),
+          { stage: "wallet_connect" }
         );
         return;
       }
@@ -307,7 +406,8 @@ export function useWalletProofAuth({
         new WalletProofSignerError(
           "This wallet does not support message signing.",
           "wallet_signing_unsupported"
-        )
+        ),
+        { stage: "wallet_connect" }
       );
       return;
     }
@@ -456,7 +556,8 @@ export function useWalletProofAuth({
       handleFailure(
         new Error(
           `Could not refresh ${selectedWalletName}. Disconnect it in the extension, then try again.`
-        )
+        ),
+        { stage: "wallet_connect", errorCode: "wallet_unavailable" }
       );
       return;
     }
@@ -465,7 +566,7 @@ export function useWalletProofAuth({
     lifecycleRef.current?.observe("wallet_connect");
     void connect().catch((error) => {
       connectAttemptedRef.current = false;
-      handleFailure(error);
+      handleFailure(error, { stage: "wallet_connect" });
     });
   }, [
     connect,
@@ -522,7 +623,8 @@ export function useWalletProofAuth({
         handleFailure(
           new Error(
             `Could not select ${selectedWalletName}. Refresh detected wallets, or choose another wallet.`
-          )
+          ),
+          { stage: "wallet_select", errorCode: "wallet_selection_timeout" }
         );
         return;
       }
@@ -541,7 +643,8 @@ export function useWalletProofAuth({
           staleAdapterRecoveryAttemptedRef.current
             ? `Could not refresh ${selectedWalletName}. Disconnect it in the extension, then try again.`
             : `Could not start ${selectedWalletName}. Unlock the extension, refresh detected wallets, or choose another wallet.`
-        )
+        ),
+        { stage: "wallet_connect", errorCode: "wallet_connection_timeout" }
       );
     }, settleDelay);
 
@@ -602,7 +705,7 @@ export function useWalletProofAuth({
         lifecycleRef.current?.observe("wallet_connect");
         void connect().catch((error) => {
           connectAttemptedRef.current = false;
-          handleFailure(error);
+          handleFailure(error, { stage: "wallet_connect" });
         });
         return;
       }

--- a/frontend/src/components/auth/use-wallet-proof-auth.ts
+++ b/frontend/src/components/auth/use-wallet-proof-auth.ts
@@ -87,9 +87,14 @@ function isRejectedWalletRequest(error: unknown): boolean {
 }
 
 // Maps a wallet-adapter failure onto the lifecycle vocabulary so connect-time
-// problems stop collapsing into `unexpected_error`. Returns undefined for
-// anything that is not a wallet-adapter error, leaving the caller's own
-// normalization in charge.
+// problems stop collapsing into `unexpected_error`.
+//
+// Every branch must name what actually happened. An adapter that threw
+// immediately is not a timeout, and a wallet that could not produce a
+// signature is not an invalid signature — emitting either would make the
+// dashboard confidently wrong, which is worse than the `unexpected_error` this
+// replaces. Anything we cannot name returns undefined so the caller's
+// normalization records `unexpected_error` honestly.
 function classifyWalletAdapterError(
   error: unknown
 ): LifecycleErrorCode | undefined {
@@ -97,12 +102,14 @@ function classifyWalletAdapterError(
     return undefined;
   }
 
+  // The adapter's own timeout. Our settle watchdogs pass their code
+  // explicitly, so this is the only inferred timeout.
   if (error instanceof WalletTimeoutError) {
     return "wallet_connection_timeout";
   }
 
-  // Not installed, disabled, or still injecting; and a blocked popup is the
-  // same dead end from the user's side — the browser suppressed the prompt.
+  // Not installed, disabled, or still injecting — the wallet is genuinely not
+  // reachable. A browser-blocked popup is the same dead end.
   if (
     error instanceof WalletNotReadyError ||
     error instanceof WalletLoadError ||
@@ -111,23 +118,26 @@ function classifyWalletAdapterError(
     return "wallet_unavailable";
   }
 
+  // Resolved, but refused or dropped the connection. Not a timeout.
   if (
     error instanceof WalletConnectionError ||
     error instanceof WalletNotConnectedError ||
     error instanceof WalletDisconnectedError
   ) {
-    return "wallet_connection_timeout";
+    return "wallet_connection_failed";
   }
 
+  // The wallet failed to sign. Not `invalid_wallet_signature`, which is
+  // reserved for a signature the backend verified and rejected.
   if (
     error instanceof WalletSignInError ||
     error instanceof WalletSignMessageError ||
     error instanceof WalletSignTransactionError
   ) {
-    return "invalid_wallet_signature";
+    return "wallet_signing_failed";
   }
 
-  return "wallet_unavailable";
+  return undefined;
 }
 
 function mapWalletProofError(error: unknown): {
@@ -284,9 +294,11 @@ export function useWalletProofAuth({
 
   const verifySelectedWalletWithSiws = useCallback(async () => {
     if (!wallet) {
+      // Our own state guard — no wallet is selected yet. Says nothing about
+      // whether the wallet itself is reachable.
       handleFailure(new Error("Wallet is not selected."), {
         stage: "wallet_select",
-        errorCode: "wallet_unavailable",
+        errorCode: "state_not_ready",
       });
       return;
     }
@@ -348,9 +360,10 @@ export function useWalletProofAuth({
     }
 
     if (!connected || !publicKey) {
+      // Same: a state guard, not evidence the wallet refused or is missing.
       handleFailure(new Error("Wallet is not connected."), {
         stage: "wallet_connect",
-        errorCode: "wallet_unavailable",
+        errorCode: "state_not_ready",
       });
       return;
     }
@@ -553,11 +566,13 @@ export function useWalletProofAuth({
         return;
       }
 
+      // The adapter reports connected while the hook does not, and recovery
+      // was already attempted — a desynced adapter, not an absent wallet.
       handleFailure(
         new Error(
           `Could not refresh ${selectedWalletName}. Disconnect it in the extension, then try again.`
         ),
-        { stage: "wallet_connect", errorCode: "wallet_unavailable" }
+        { stage: "wallet_connect", errorCode: "state_not_ready" }
       );
       return;
     }

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -131,6 +131,14 @@ export const LIFECYCLE_ERROR_CODES = [
   "turnstile_verification_failed",
   "wallet_selection_timeout",
   "wallet_connection_timeout",
+  // The adapter refused or dropped the connection outright. Distinct from
+  // `wallet_connection_timeout`, which means one of our settle watchdogs
+  // elapsed while the adapter never resolved either way.
+  "wallet_connection_failed",
+  // The wallet could not produce a signature. Distinct from
+  // `invalid_wallet_signature`, which means a signature was produced and the
+  // backend rejected it during verification.
+  "wallet_signing_failed",
   "wallet_signing_unsupported",
   "wallet_rejected",
   "invalid_wallet_origin",


### PR DESCRIPTION
Sign-in failures were all reported at the `completion` stage with `unexpected_error`, even when the flow died at wallet connect and never reached `challenge` — hiding 12 connect-time failures over 7 days behind an uninformative code.

`handleFailure` now takes the real stage and an optional explicit code, emitting the `wallet_connection_timeout`, `wallet_selection_timeout` and `wallet_unavailable` codes that already existed in the lifecycle contract but were never used, and cancellation detection no longer relies solely on substring-matching the error message.

Refs ASK-1857

---

### Motivating alert

```
🚨 Alert for "Errors" - 1 lines found
Group: "ServiceName:loyal-mobile"
Time Range (UTC): [Jul 23 2:24:00 PM - Jul 23 2:25:00 PM)

🔴 error · 14:24:41 UTC · loyal-mobile
auth.sign_in.wallet_connect.failed
env: prod
flow: auth.sign_in
stage: wallet_connect
error_code: request_failed

https://loyal-clickstack.onrender.com/search/6a5fb723dcc64beb0ded6cca?from=1784816640000&to=1784816700000&isLive=false
```

**Note this alert is from `loyal-mobile`, not the web frontend this PR changes** — it is included as an illustration of the target state rather than as a failure this PR fixes.

It makes the case for the change. Mobile already attributes the stage and a specific code, so the alert names where and how the flow died and is actionable as-is. Confirmed in ClickStack (flow `1f7f532f-4612-4ac4-9761-3538b4bdef8f`, `variant: wallet_adapter`, 7203ms).

The identical failure on the web frontend would have arrived as `auth.sign_in.completion.failed` / `unexpected_error` — pointing at a stage the flow never reached, with a code that says nothing. That is what this PR corrects.
