### PR TITLE
fix(observability): drop browser-extension errors from frontend telemetry

### DIFF
--- a/frontend/src/app/api/observability/errors/route.ts
+++ b/frontend/src/app/api/observability/errors/route.ts
@@ -1,5 +1,6 @@
 import {
   InvalidObservabilityEnvelopeError,
+  isThirdPartyExtensionError,
   MAX_OBSERVABILITY_REQUEST_BYTES,
   parseBrowserErrorEnvelope,
 } from "@/features/observability/error-contract";
@@ -83,6 +84,11 @@ export async function POST(request: Request): Promise<Response> {
 
   try {
     const envelope = parseBrowserErrorEnvelope(await readJsonBody(request));
+    // Browsers running a cached bundle still post extension noise; drop it here
+    // too, and acknowledge so the client never treats telemetry as a failure.
+    if (isThirdPartyExtensionError(envelope.operation, envelope.stack)) {
+      return jsonResponse({ accepted: true }, 202);
+    }
     await reportBrowserErrorEnvelope(envelope);
     return jsonResponse({ accepted: true }, 202);
   } catch (error) {

--- a/frontend/src/features/observability/client.ts
+++ b/frontend/src/features/observability/client.ts
@@ -4,6 +4,7 @@ import {
   type BrowserErrorOperation,
   createBrowserErrorEnvelope,
   createErrorDeduplicator,
+  isThirdPartyExtensionError,
   OBSERVABILITY_ERROR_ENDPOINT,
 } from "./error-contract";
 import {
@@ -113,6 +114,9 @@ export function captureBrowserError(
 ): void {
   try {
     const envelope = createBrowserErrorEnvelope(error, operation);
+    if (isThirdPartyExtensionError(envelope.operation, envelope.stack)) {
+      return;
+    }
     if (errorDeduplicator.isDuplicate(envelope)) {
       return;
     }

--- a/frontend/src/features/observability/error-contract.test.ts
+++ b/frontend/src/features/observability/error-contract.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { isThirdPartyExtensionError } from "./error-contract";
+
+// Real stacks captured from ClickStack (ServiceName=loyal-frontend).
+const EXTENSION_ONLY_STACK = [
+  "Error: func sseError not found",
+  "    at Object.<anonymous> (chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js:252:19758)",
+  "    at Generator.next (chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js:219:38552)",
+].join("\n");
+
+const APP_STACK_WITH_EXTENSION_CALLER = [
+  "TypeError: t is not a function",
+  "    at o (chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js:2:59596)",
+  "    at p (https://app.askloyal.com/_next/static/chunks/8156-abc.js:1:2048)",
+].join("\n");
+
+describe("isThirdPartyExtensionError", () => {
+  test("drops ambient errors whose stack is only extension frames", () => {
+    expect(
+      isThirdPartyExtensionError(
+        "browser.unhandled_rejection",
+        EXTENSION_ONLY_STACK
+      )
+    ).toBe(true);
+    expect(
+      isThirdPartyExtensionError("browser.window.error", EXTENSION_ONLY_STACK)
+    ).toBe(true);
+  });
+
+  test("keeps ambient errors that touch a first-party frame", () => {
+    expect(
+      isThirdPartyExtensionError(
+        "browser.window.error",
+        APP_STACK_WITH_EXTENSION_CALLER
+      )
+    ).toBe(false);
+  });
+
+  test("keeps explicit operations even on a pure extension stack", () => {
+    expect(
+      isThirdPartyExtensionError("earn.deposit.execute", EXTENSION_ONLY_STACK)
+    ).toBe(false);
+    expect(
+      isThirdPartyExtensionError("react.error_boundary", EXTENSION_ONLY_STACK)
+    ).toBe(false);
+  });
+
+  test("keeps ambient errors that carry no stack", () => {
+    expect(
+      isThirdPartyExtensionError("browser.unhandled_rejection", undefined)
+    ).toBe(false);
+  });
+
+  test("still drops after the extension id is redacted by sanitization", () => {
+    const sanitized = EXTENSION_ONLY_STACK.replace(
+      "cadiboklkpojfamcoggejbbdjcoiljjk",
+      "[REDACTED_IDENTIFIER]"
+    );
+    expect(
+      isThirdPartyExtensionError("browser.unhandled_rejection", sanitized)
+    ).toBe(true);
+  });
+});

--- a/frontend/src/features/observability/error-contract.ts
+++ b/frontend/src/features/observability/error-contract.ts
@@ -39,6 +39,18 @@ export const BROWSER_ERROR_OPERATIONS = [
 
 export type BrowserErrorOperation = (typeof BROWSER_ERROR_OPERATIONS)[number];
 
+// The two ambient window listeners observe every script on the page, including
+// wallet extensions injected into the document. Crashes those extensions cause
+// among themselves are not Loyal failures and must not reach the error alert.
+const AMBIENT_BROWSER_ERROR_OPERATIONS: readonly BrowserErrorOperation[] = [
+  "browser.window.error",
+  "browser.unhandled_rejection",
+];
+
+const EXTENSION_FRAME_PATTERN =
+  /\b(?:chrome|moz|safari-web|safari|ms-browser)-extension:\/\//i;
+const FIRST_PARTY_FRAME_PATTERN = /\bhttps?:\/\//i;
+
 export const MOBILE_ERROR_OPERATIONS = [
   "mobile.global_error",
   "mobile.fatal_error",
@@ -197,6 +209,24 @@ export function createBrowserErrorEnvelope(
     pathname: pathname ?? "/",
     timestamp: (options.now ?? new Date()).toISOString(),
   };
+}
+
+// True when a stack is made up solely of browser-extension frames, meaning no
+// Loyal code took part in the failure. Only ambient listeners are filtered:
+// an explicit operation such as `earn.deposit.execute` reporting a wallet
+// provider error is a real signal even though the stack points at the wallet.
+export function isThirdPartyExtensionError(
+  operation: BrowserErrorOperation,
+  stack: string | undefined
+): boolean {
+  if (!stack || !AMBIENT_BROWSER_ERROR_OPERATIONS.includes(operation)) {
+    return false;
+  }
+
+  return (
+    EXTENSION_FRAME_PATTERN.test(stack) &&
+    !FIRST_PARTY_FRAME_PATTERN.test(stack)
+  );
 }
 
 function isAllowedBrowserOperation(


### PR DESCRIPTION
The ClickStack Errors alert keeps firing on wallet-extension crashes (`func sseError not found` from `chrome-extension://…/inpage.js`, `Cannot redefine property: ethereum`, and friends), which made up 65 of 95 browser error events over the last two weeks.

Ambient window `error`/`unhandledrejection` reports are now skipped when the stack has extension-scheme frames and no first-party frame — on the client and again in the ingest route so cached bundles stop writing rows. Explicit operations like `earn.deposit.execute` still report, since a wallet error surfaced through our own call site is real signal.

Closes ASK-1860.

## Originating alert

```
🚨 Alert for "Errors" - 1 lines found
Group: "ServiceName:loyal-frontend"
Time Range (UTC): [Jul 23 3:45:00 PM - Jul 23 3:46:00 PM)

🔴 error · 15:45:47 UTC · loyal-frontend
func sseError not found
env: production
exception_type: Error
exception_message: func sseError not found

🔴 error · 15:45:08 UTC · loyal-fleet-route-reconciler
fleet rebalance vault position refresh failed during the sweep
env: production
```

https://loyal-clickstack.onrender.com/search/6a5fb723dcc64beb0ded6cca?from=1784821500000&to=1784821560000&isLive=false

This PR addresses the `loyal-frontend` line only. The `loyal-fleet-route-reconciler` line is an unrelated worker issue in `loyal-yield-routing` (a vault deactivated mid-sweep is classified as `Failed` rather than `Stale`) and is tracked separately.