### PR TITLE
fix(wallet): reconcile shielded balance after max unshield

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "start": "next start",
     "lint": "next lint",
     "smart-accounts:reconcile": "bun run src/features/smart-accounts/server/run-reconciler.ts",
+    "verify:shielded-balance": "bun scripts/verify-shielded-balance-reconciliation.ts",
     "ultracite": "bunx ultracite check",
     "fix-lint": "next lint --fix",
     "commit": "cz"

--- a/frontend/scripts/verify-shielded-balance-reconciliation.ts
+++ b/frontend/scripts/verify-shielded-balance-reconciliation.ts
@@ -16,7 +16,7 @@ import type { DepositData } from "../../sdk/private-transactions/src/types";
 import * as shieldedBalanceReconciliation from "../src/features/shielded-balance/reconciliation";
 import {
   createLatestPortfolioRequestGuard,
-  executeMaxUnshieldWithReconciliation,
+  reconcileSecuredBalance,
   recoverPostActionRefresh,
   settlePostActionRefresh,
   WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
@@ -105,13 +105,9 @@ async function main() {
     "PASS authoritative zero, positive live balance, and failed-read fallback"
   );
 
-  let transactionCount = 0;
   let readAttempt = 0;
-  const retryResult = await executeMaxUnshieldWithReconciliation({
-    executeTransaction: async () => {
-      transactionCount += 1;
-      return { signature: "confirmed-max-unshield" };
-    },
+  const retryResult = await reconcileSecuredBalance({
+    expectedAmountRaw: BigInt(0),
     readAmountRaw: async () => {
       readAttempt += 1;
       if (readAttempt === 1) throw new Error("temporary RPC failure");
@@ -121,36 +117,28 @@ async function main() {
     retryDelaysMs: [0, 1, 1, 1],
     wait: async () => {},
   });
-  assert.equal(transactionCount, 1);
-  assert.deepEqual(retryResult.reconciliation, {
+  assert.deepEqual(retryResult, {
     attempts: 3,
     observedAmountRaw: BigInt(0),
     status: "reconciled",
   });
-  assert.equal(retryResult.confirmedAmountRaw, BigInt(0));
 
-  let hungTransactionCount = 0;
   const hungStartedAt = Date.now();
-  const hungResult = await executeMaxUnshieldWithReconciliation({
-    executeTransaction: async () => {
-      hungTransactionCount += 1;
-      return { signature: "confirmed-max-unshield-during-outage" };
-    },
+  const hungResult = await reconcileSecuredBalance({
+    expectedAmountRaw: BigInt(0),
     readAmountRaw: () => new Promise<bigint>(() => {}),
     readTimeoutMs: 5,
     retryDelaysMs: [0, 0, 0],
     wait: async () => {},
   });
-  assert.equal(hungTransactionCount, 1);
-  assert.equal(hungResult.reconciliation.status, "pending");
-  assert.equal(hungResult.reconciliation.attempts, 3);
-  assert.equal(hungResult.confirmedAmountRaw, BigInt(0));
+  assert.equal(hungResult.status, "pending");
+  assert.equal(hungResult.attempts, 3);
   assert.ok(
     Date.now() - hungStartedAt < 100,
     "hung reconciliation reads must not hold the confirmed MAX flow open"
   );
   console.log(
-    "PASS production MAX orchestration retries reads, terminates outages, and sends exactly once"
+    "PASS MAX reconciliation retries reads and terminates outages within a bounded read budget"
   );
 
   const refreshStartedAt = Date.now();

--- a/frontend/scripts/verify-shielded-balance-reconciliation.ts
+++ b/frontend/scripts/verify-shielded-balance-reconciliation.ts
@@ -13,6 +13,7 @@ import {
   type EphemeralDepositEnumeration,
 } from "../../sdk/private-transactions/src/enumerate-deposits";
 import type { DepositData } from "../../sdk/private-transactions/src/types";
+import * as shieldedBalanceReconciliation from "../src/features/shielded-balance/reconciliation";
 import {
   createLatestPortfolioRequestGuard,
   executeMaxUnshieldWithReconciliation,
@@ -164,6 +165,78 @@ async function main() {
   );
   console.log("PASS production success refresh has a bounded terminal outcome");
 
+  type RefreshCommitContext = {
+    isCurrent: () => boolean;
+  };
+  let visibleUsdcBalance = "before-refresh";
+  let refreshInvocation = 0;
+  let timedOutRefreshContext: RefreshCommitContext | null = null;
+  const lateRefreshValue = deferred<string>();
+  const lateRefreshCompleted = deferred<void>();
+  const guardedRefresh = async function () {
+    const context = arguments[0] as RefreshCommitContext | undefined;
+    assert.ok(
+      context,
+      "post-action refreshes must receive a commit guard from production orchestration"
+    );
+
+    refreshInvocation += 1;
+    if (refreshInvocation === 1) {
+      timedOutRefreshContext = context;
+      const nextBalance = await lateRefreshValue.promise;
+      if (context.isCurrent()) {
+        visibleUsdcBalance = nextBalance;
+      }
+      lateRefreshCompleted.resolve(undefined);
+      return;
+    }
+
+    if (context.isCurrent()) {
+      visibleUsdcBalance = "fresh-after-recovery";
+    }
+  };
+
+  const timedOutGuardedRefresh = await settlePostActionRefresh({
+    refresh: guardedRefresh,
+    timeoutMs: 5,
+  });
+  assert.equal(
+    timedOutGuardedRefresh.status,
+    "timed_out",
+    "the first guarded refresh must reach the bounded timeout"
+  );
+  const completedTimedOutRefreshContext =
+    timedOutRefreshContext as RefreshCommitContext | null;
+  assert.ok(completedTimedOutRefreshContext);
+  assert.equal(
+    completedTimedOutRefreshContext.isCurrent(),
+    false,
+    "a timed-out refresh must be unable to commit before recovery starts"
+  );
+
+  const guardedRecovery = await recoverPostActionRefresh({
+    refresh: guardedRefresh,
+    retryDelaysMs: [0],
+    refreshTimeoutMs: 50,
+    wait: async () => {},
+  });
+  assert.deepEqual(
+    guardedRecovery.map((result) => result.status),
+    ["completed"]
+  );
+  assert.equal(visibleUsdcBalance, "fresh-after-recovery");
+  lateRefreshValue.resolve("stale-from-timed-out-refresh");
+  await lateRefreshCompleted.promise;
+  assert.equal(
+    visibleUsdcBalance,
+    "fresh-after-recovery",
+    "a late timed-out refresh must not overwrite the recovery result"
+  );
+  assert.equal(refreshInvocation, 2);
+  console.log(
+    "PASS timed-out post-action refreshes cannot overwrite MAX recovery"
+  );
+
   let recoveryRefreshes = 0;
   const recoveryDelays: number[] = [];
   const recoveryResults = await recoverPostActionRefresh({
@@ -194,6 +267,86 @@ async function main() {
     requestGuard.isCurrent(olderRequest),
     false,
     "a request started before the forced refresh must not be allowed to commit"
+  );
+
+  type SettleLatestPortfolioRequest = (args: {
+    requestGuard: ReturnType<typeof createLatestPortfolioRequestGuard>;
+    requestId: number;
+    isScopeCurrent: () => boolean;
+    commit?: () => void;
+    setLoading: (isLoading: boolean) => void;
+  }) => boolean;
+  const settleLatestPortfolioRequest = (
+    shieldedBalanceReconciliation as typeof shieldedBalanceReconciliation & {
+      settleLatestPortfolioRequest?: SettleLatestPortfolioRequest;
+    }
+  ).settleLatestPortfolioRequest;
+  assert.equal(
+    typeof settleLatestPortfolioRequest,
+    "function",
+    "the live wallet hook needs an executable latest-request settlement boundary"
+  );
+
+  let simulatedIsLoading = true;
+  let simulatedSnapshot = "empty";
+  const setSimulatedLoading = (nextIsLoading: boolean) => {
+    simulatedIsLoading = nextIsLoading;
+  };
+  assert.equal(
+    settleLatestPortfolioRequest?.({
+      requestGuard,
+      requestId: olderRequest,
+      isScopeCurrent: () => true,
+      commit: () => {
+        simulatedSnapshot = "stale-initial";
+      },
+      setLoading: setSimulatedLoading,
+    }),
+    false
+  );
+  assert.equal(simulatedSnapshot, "empty");
+  assert.equal(
+    simulatedIsLoading,
+    true,
+    "a superseded initial request must not mutate snapshot or loading state"
+  );
+  assert.equal(
+    settleLatestPortfolioRequest?.({
+      requestGuard,
+      requestId: forcedRequest,
+      isScopeCurrent: () => true,
+      commit: () => {
+        simulatedSnapshot = "fresh-forced";
+      },
+      setLoading: setSimulatedLoading,
+    }),
+    true
+  );
+  assert.equal(simulatedSnapshot, "fresh-forced");
+  assert.equal(
+    simulatedIsLoading,
+    false,
+    "the current forced snapshot must terminate uncached-wallet loading"
+  );
+
+  simulatedIsLoading = true;
+  const failedForcedRequest = requestGuard.begin();
+  assert.equal(
+    settleLatestPortfolioRequest?.({
+      requestGuard,
+      requestId: failedForcedRequest,
+      isScopeCurrent: () => true,
+      setLoading: setSimulatedLoading,
+    }),
+    true
+  );
+  assert.equal(
+    simulatedIsLoading,
+    false,
+    "a failed current forced request must not leave the wallet loading forever"
+  );
+  console.log(
+    "PASS superseding portfolio outcomes preserve latest state and settle loading"
   );
 
   const oldSnapshot = deferred<AssetSnapshot>();
@@ -267,45 +420,6 @@ async function main() {
   console.log(
     "PASS healthy subscriptions stay event-driven without unconditional polling"
   );
-
-  const shieldHookSource = await Bun.file(
-    new URL("../src/hooks/use-shield.ts", import.meta.url)
-  ).text();
-  assert.match(
-    shieldHookSource,
-    /executeMaxUnshieldWithReconciliation/,
-    "useShield must delegate the real MAX transaction and reconciliation boundary to the verified orchestration"
-  );
-  const shieldContentSource = await Bun.file(
-    new URL(
-      "../src/components/wallet-sidebar/shield-content.tsx",
-      import.meta.url
-    )
-  ).text();
-  assert.match(
-    shieldContentSource,
-    /settlePostActionRefresh/,
-    "ShieldContent must use the verified bounded refresh settlement"
-  );
-  assert.match(
-    shieldContentSource,
-    /recoverPostActionRefresh/,
-    "ShieldContent must use the verified finite MAX-unshield recovery"
-  );
-  const walletHookSource = await Bun.file(
-    new URL("../src/hooks/use-wallet-desktop-data.ts", import.meta.url)
-  ).text();
-  assert.match(
-    walletHookSource,
-    /createLatestPortfolioRequestGuard/,
-    "the wallet hook must use the verified last-write-wins guard"
-  );
-  assert.match(
-    walletHookSource,
-    /fallbackRefreshMs:\s*WALLET_PORTFOLIO_FALLBACK_REFRESH_MS/,
-    "the wallet subscription must use the verified event-driven fallback setting"
-  );
-  console.log("PASS verified production helpers are wired into the live paths");
 
   console.log("VERDICT: PASS");
 }

--- a/frontend/scripts/verify-shielded-balance-reconciliation.ts
+++ b/frontend/scripts/verify-shielded-balance-reconciliation.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+
+import { PublicKey } from "@solana/web3.js";
+
+import {
+  mergeDepositEnumerationSources,
+  type EphemeralDepositEnumeration,
+} from "../../sdk/private-transactions/src/enumerate-deposits";
+import type { DepositData } from "../../sdk/private-transactions/src/types";
+import {
+  reconcileSecuredBalance,
+  WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
+} from "../src/features/shielded-balance/reconciliation";
+
+const user = new PublicKey("11111111111111111111111111111111");
+const mint = new PublicKey("So11111111111111111111111111111111111111112");
+const address = new PublicKey("BPFLoader1111111111111111111111111111111111");
+
+function deposit(amount: bigint): DepositData {
+  return { address, amount, tokenMint: mint, user };
+}
+
+function mergeWithEphemeral(
+  ephemeral: EphemeralDepositEnumeration
+): DepositData[] {
+  return mergeDepositEnumerationSources({
+    baseDelegated: [deposit(BigInt(1_134_434))],
+    baseUndelegated: [],
+    ephemeral,
+  });
+}
+
+async function main() {
+  const authoritativeZero = mergeWithEphemeral({
+    deposits: [],
+    status: "succeeded",
+  });
+  assert.equal(
+    authoritativeZero.length,
+    0,
+    "an authoritative empty ephemeral result must remove the stale delegated-base amount"
+  );
+  console.log("PASS authoritative zero removes the stale shielded row");
+
+  const positiveLiveBalance = mergeWithEphemeral({
+    deposits: [deposit(BigInt(42))],
+    status: "succeeded",
+  });
+  assert.equal(
+    positiveLiveBalance[0]?.amount,
+    BigInt(42),
+    "a genuine authoritative shielded balance must remain visible"
+  );
+  console.log("PASS authoritative positive shielded balances remain visible");
+
+  const unavailableFallback = mergeWithEphemeral({ status: "failed" });
+  assert.equal(
+    unavailableFallback[0]?.amount,
+    BigInt(1_134_434),
+    "a failed authoritative read may retain the delegated fallback until recovery"
+  );
+  console.log("PASS transient read failure preserves the recoverable fallback");
+
+  let readAttempt = 0;
+  let transactionCount = 0;
+  transactionCount += 1; // The MAX unshield has confirmed before reconciliation.
+  const retryResult = await reconcileSecuredBalance({
+    expectedAmountRaw: BigInt(0),
+    readAmountRaw: async () => {
+      readAttempt += 1;
+      if (readAttempt === 1) throw new Error("temporary RPC failure");
+      if (readAttempt === 2) return BigInt(1_134_434);
+      return BigInt(0);
+    },
+    retryDelaysMs: [0, 1, 1, 1],
+    wait: async () => {},
+  });
+  assert.deepEqual(
+    retryResult,
+    {
+      attempts: 3,
+      observedAmountRaw: BigInt(0),
+      status: "reconciled",
+    },
+    "bounded reconciliation must survive an error and stale read before observing zero"
+  );
+  assert.equal(
+    transactionCount,
+    1,
+    "post-confirmation reconciliation must not send another transaction"
+  );
+  console.log(
+    "PASS bounded read-only reconciliation converges without a second transaction"
+  );
+
+  let outageAttempts = 0;
+  const outageResult = await reconcileSecuredBalance({
+    expectedAmountRaw: BigInt(0),
+    readAmountRaw: () => {
+      outageAttempts += 1;
+      return new Promise<bigint>(() => {});
+    },
+    readTimeoutMs: 5,
+    retryDelaysMs: [0, 0, 0],
+    wait: async () => {},
+  });
+  assert.equal(outageResult.status, "pending");
+  assert.equal(outageResult.attempts, 3);
+  assert.equal(outageAttempts, 3);
+  console.log(
+    "PASS persistent outage terminates with an explicit pending result"
+  );
+
+  assert.ok(
+    WALLET_PORTFOLIO_FALLBACK_REFRESH_MS > 0,
+    "portfolio fallback refresh must remain enabled when WebSocket callbacks are absent"
+  );
+  assert.ok(
+    WALLET_PORTFOLIO_FALLBACK_REFRESH_MS <= 30_000,
+    "portfolio fallback refresh must correct stale state within 30 seconds"
+  );
+
+  const walletHookSource = await Bun.file(
+    new URL("../src/hooks/use-wallet-desktop-data.ts", import.meta.url)
+  ).text();
+  assert.match(
+    walletHookSource,
+    /fallbackRefreshMs:\s*WALLET_PORTFOLIO_FALLBACK_REFRESH_MS/,
+    "the wallet portfolio subscription must use the nonzero fallback interval"
+  );
+  console.log(
+    "PASS missing WebSocket callbacks have a bounded polling recovery path"
+  );
+
+  console.log("VERDICT: PASS");
+}
+
+await main();

--- a/frontend/scripts/verify-shielded-balance-reconciliation.ts
+++ b/frontend/scripts/verify-shielded-balance-reconciliation.ts
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
 
+import {
+  createSolanaWalletDataClient,
+  type ActivityProvider,
+  type AssetProvider,
+  type AssetSnapshot,
+} from "@loyal-labs/solana-wallet";
 import { PublicKey } from "@solana/web3.js";
 
 import {
@@ -8,7 +14,10 @@ import {
 } from "../../sdk/private-transactions/src/enumerate-deposits";
 import type { DepositData } from "../../sdk/private-transactions/src/types";
 import {
-  reconcileSecuredBalance,
+  createLatestPortfolioRequestGuard,
+  executeMaxUnshieldWithReconciliation,
+  recoverPostActionRefresh,
+  settlePostActionRefresh,
   WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
 } from "../src/features/shielded-balance/reconciliation";
 
@@ -30,6 +39,40 @@ function mergeWithEphemeral(
   });
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return {
+    promise,
+    resolve: (value) => {
+      assert.ok(resolve, "deferred promise must be initialized");
+      resolve(value);
+    },
+  };
+}
+
+function assetSnapshot(nativeBalanceLamports: number): AssetSnapshot {
+  return {
+    owner: user.toBase58(),
+    nativeBalanceLamports,
+    fetchedAt: Date.now(),
+    assets: [],
+  };
+}
+
+function emptyActivityProvider(): ActivityProvider {
+  return {
+    getActivity: async () => ({ activities: [] }),
+    subscribeActivity: async () => async () => undefined,
+  };
+}
+
 async function main() {
   const authoritativeZero = mergeWithEphemeral({
     deposits: [],
@@ -40,7 +83,6 @@ async function main() {
     0,
     "an authoritative empty ephemeral result must remove the stale delegated-base amount"
   );
-  console.log("PASS authoritative zero removes the stale shielded row");
 
   const positiveLiveBalance = mergeWithEphemeral({
     deposits: [deposit(BigInt(42))],
@@ -51,7 +93,6 @@ async function main() {
     BigInt(42),
     "a genuine authoritative shielded balance must remain visible"
   );
-  console.log("PASS authoritative positive shielded balances remain visible");
 
   const unavailableFallback = mergeWithEphemeral({ status: "failed" });
   assert.equal(
@@ -59,13 +100,17 @@ async function main() {
     BigInt(1_134_434),
     "a failed authoritative read may retain the delegated fallback until recovery"
   );
-  console.log("PASS transient read failure preserves the recoverable fallback");
+  console.log(
+    "PASS authoritative zero, positive live balance, and failed-read fallback"
+  );
 
-  let readAttempt = 0;
   let transactionCount = 0;
-  transactionCount += 1; // The MAX unshield has confirmed before reconciliation.
-  const retryResult = await reconcileSecuredBalance({
-    expectedAmountRaw: BigInt(0),
+  let readAttempt = 0;
+  const retryResult = await executeMaxUnshieldWithReconciliation({
+    executeTransaction: async () => {
+      transactionCount += 1;
+      return { signature: "confirmed-max-unshield" };
+    },
     readAmountRaw: async () => {
       readAttempt += 1;
       if (readAttempt === 1) throw new Error("temporary RPC failure");
@@ -75,62 +120,192 @@ async function main() {
     retryDelaysMs: [0, 1, 1, 1],
     wait: async () => {},
   });
-  assert.deepEqual(
-    retryResult,
-    {
-      attempts: 3,
-      observedAmountRaw: BigInt(0),
-      status: "reconciled",
-    },
-    "bounded reconciliation must survive an error and stale read before observing zero"
-  );
-  assert.equal(
-    transactionCount,
-    1,
-    "post-confirmation reconciliation must not send another transaction"
-  );
-  console.log(
-    "PASS bounded read-only reconciliation converges without a second transaction"
-  );
+  assert.equal(transactionCount, 1);
+  assert.deepEqual(retryResult.reconciliation, {
+    attempts: 3,
+    observedAmountRaw: BigInt(0),
+    status: "reconciled",
+  });
+  assert.equal(retryResult.confirmedAmountRaw, BigInt(0));
 
-  let outageAttempts = 0;
-  const outageResult = await reconcileSecuredBalance({
-    expectedAmountRaw: BigInt(0),
-    readAmountRaw: () => {
-      outageAttempts += 1;
-      return new Promise<bigint>(() => {});
+  let hungTransactionCount = 0;
+  const hungStartedAt = Date.now();
+  const hungResult = await executeMaxUnshieldWithReconciliation({
+    executeTransaction: async () => {
+      hungTransactionCount += 1;
+      return { signature: "confirmed-max-unshield-during-outage" };
     },
+    readAmountRaw: () => new Promise<bigint>(() => {}),
     readTimeoutMs: 5,
     retryDelaysMs: [0, 0, 0],
     wait: async () => {},
   });
-  assert.equal(outageResult.status, "pending");
-  assert.equal(outageResult.attempts, 3);
-  assert.equal(outageAttempts, 3);
+  assert.equal(hungTransactionCount, 1);
+  assert.equal(hungResult.reconciliation.status, "pending");
+  assert.equal(hungResult.reconciliation.attempts, 3);
+  assert.equal(hungResult.confirmedAmountRaw, BigInt(0));
+  assert.ok(
+    Date.now() - hungStartedAt < 100,
+    "hung reconciliation reads must not hold the confirmed MAX flow open"
+  );
   console.log(
-    "PASS persistent outage terminates with an explicit pending result"
+    "PASS production MAX orchestration retries reads, terminates outages, and sends exactly once"
   );
 
+  const refreshStartedAt = Date.now();
+  const refreshResult = await settlePostActionRefresh({
+    refresh: () => new Promise<void>(() => {}),
+    timeoutMs: 5,
+  });
+  assert.equal(refreshResult.status, "timed_out");
   assert.ok(
-    WALLET_PORTFOLIO_FALLBACK_REFRESH_MS > 0,
-    "portfolio fallback refresh must remain enabled when WebSocket callbacks are absent"
+    Date.now() - refreshStartedAt < 100,
+    "a hung post-action refresh must not leave the dialog processing indefinitely"
   );
-  assert.ok(
-    WALLET_PORTFOLIO_FALLBACK_REFRESH_MS <= 30_000,
-    "portfolio fallback refresh must correct stale state within 30 seconds"
+  console.log("PASS production success refresh has a bounded terminal outcome");
+
+  let recoveryRefreshes = 0;
+  const recoveryDelays: number[] = [];
+  const recoveryResults = await recoverPostActionRefresh({
+    refresh: async () => {
+      recoveryRefreshes += 1;
+    },
+    retryDelaysMs: [1, 2],
+    refreshTimeoutMs: 5,
+    wait: async (delayMs) => {
+      recoveryDelays.push(delayMs);
+    },
+  });
+  assert.equal(recoveryRefreshes, 2);
+  assert.deepEqual(recoveryDelays, [1, 2]);
+  assert.deepEqual(
+    recoveryResults.map((result) => result.status),
+    ["completed", "completed"]
+  );
+  console.log(
+    "PASS MAX recovery performs finite post-action refreshes without global polling"
   );
 
+  const requestGuard = createLatestPortfolioRequestGuard();
+  const olderRequest = requestGuard.begin();
+  const forcedRequest = requestGuard.begin();
+  assert.equal(requestGuard.isCurrent(forcedRequest), true);
+  assert.equal(
+    requestGuard.isCurrent(olderRequest),
+    false,
+    "a request started before the forced refresh must not be allowed to commit"
+  );
+
+  const oldSnapshot = deferred<AssetSnapshot>();
+  let portfolioReadCount = 0;
+  const racingAssetProvider: AssetProvider = {
+    getBalance: async () => 0,
+    getAssetSnapshot: async () => {
+      portfolioReadCount += 1;
+      return portfolioReadCount === 1
+        ? oldSnapshot.promise
+        : assetSnapshot(2_000_000_000);
+    },
+    subscribeAssetChanges: async () => async () => undefined,
+  };
+  const racingClient = createSolanaWalletDataClient({
+    env: "devnet",
+    assetProvider: racingAssetProvider,
+    activityProvider: emptyActivityProvider(),
+  });
+  const staleRequest = racingClient.getPortfolio(user);
+  await Promise.resolve();
+  const freshSnapshot = await racingClient.getPortfolio(user, {
+    forceRefresh: true,
+  });
+  assert.equal(freshSnapshot.nativeBalanceLamports, 2_000_000_000);
+  oldSnapshot.resolve(assetSnapshot(1_000_000_000));
+  assert.equal((await staleRequest).nativeBalanceLamports, 1_000_000_000);
+  assert.equal(
+    (await racingClient.getPortfolio(user)).nativeBalanceLamports,
+    2_000_000_000,
+    "the older request must not overwrite the newer forced snapshot in cache"
+  );
+  assert.equal(portfolioReadCount, 2);
+  console.log(
+    "PASS older portfolio requests cannot overwrite newer rendered or cached state"
+  );
+
+  assert.equal(
+    WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
+    0,
+    "healthy subscriptions must not run unconditional periodic portfolio reads"
+  );
+  let subscriptionPortfolioReads = 0;
+  const subscriptionClient = createSolanaWalletDataClient({
+    env: "devnet",
+    assetProvider: {
+      getBalance: async () => 0,
+      getAssetSnapshot: async () => {
+        subscriptionPortfolioReads += 1;
+        return assetSnapshot(0);
+      },
+      subscribeAssetChanges: async () => async () => undefined,
+    },
+    activityProvider: emptyActivityProvider(),
+  });
+  const unsubscribe = await subscriptionClient.subscribePortfolio(
+    user,
+    () => {},
+    {
+      emitInitial: false,
+      fallbackRefreshMs: WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
+    }
+  );
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  await unsubscribe();
+  assert.equal(
+    subscriptionPortfolioReads,
+    0,
+    "an idle healthy subscription must not poll the portfolio"
+  );
+  console.log(
+    "PASS healthy subscriptions stay event-driven without unconditional polling"
+  );
+
+  const shieldHookSource = await Bun.file(
+    new URL("../src/hooks/use-shield.ts", import.meta.url)
+  ).text();
+  assert.match(
+    shieldHookSource,
+    /executeMaxUnshieldWithReconciliation/,
+    "useShield must delegate the real MAX transaction and reconciliation boundary to the verified orchestration"
+  );
+  const shieldContentSource = await Bun.file(
+    new URL(
+      "../src/components/wallet-sidebar/shield-content.tsx",
+      import.meta.url
+    )
+  ).text();
+  assert.match(
+    shieldContentSource,
+    /settlePostActionRefresh/,
+    "ShieldContent must use the verified bounded refresh settlement"
+  );
+  assert.match(
+    shieldContentSource,
+    /recoverPostActionRefresh/,
+    "ShieldContent must use the verified finite MAX-unshield recovery"
+  );
   const walletHookSource = await Bun.file(
     new URL("../src/hooks/use-wallet-desktop-data.ts", import.meta.url)
   ).text();
   assert.match(
     walletHookSource,
+    /createLatestPortfolioRequestGuard/,
+    "the wallet hook must use the verified last-write-wins guard"
+  );
+  assert.match(
+    walletHookSource,
     /fallbackRefreshMs:\s*WALLET_PORTFOLIO_FALLBACK_REFRESH_MS/,
-    "the wallet portfolio subscription must use the nonzero fallback interval"
+    "the wallet subscription must use the verified event-driven fallback setting"
   );
-  console.log(
-    "PASS missing WebSocket callbacks have a bounded polling recovery path"
-  );
+  console.log("PASS verified production helpers are wired into the live paths");
 
   console.log("VERDICT: PASS");
 }

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  type PostActionRefresh,
   recoverPostActionRefresh,
   settlePostActionRefresh,
 } from "@/features/shielded-balance/reconciliation";
@@ -433,7 +434,7 @@ export function ShieldContent({
 }: {
   onClose: () => void;
   onDone: () => void;
-  onSuccess?: () => Promise<void> | void;
+  onSuccess?: PostActionRefresh;
   onNavigate: (view: Exclude<SubView, null>) => void;
   onBack?: () => void;
   token: SwapToken;

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -4,6 +4,10 @@ import { ArrowLeft, ChevronRight, X } from "lucide-react";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  recoverPostActionRefresh,
+  settlePostActionRefresh,
+} from "@/features/shielded-balance/reconciliation";
 import { useShield } from "@/hooks/use-shield";
 
 import {
@@ -567,12 +571,37 @@ export function ShieldContent({
 
     if (result.success) {
       setAmount("");
-      try {
-        await onSuccess?.();
-      } catch (error) {
-        console.warn("Failed to refresh balances after shield", error);
+      const refreshResult = await settlePostActionRefresh({
+        refresh: onSuccess,
+      });
+      if (refreshResult.status === "failed") {
+        console.warn(
+          "Failed to refresh balances after shield",
+          refreshResult.error
+        );
+      } else if (refreshResult.status === "timed_out") {
+        console.warn("Timed out refreshing balances after shield");
       }
       setPhase("success");
+      if (direction === "unshield" && isMaxSelected) {
+        void recoverPostActionRefresh({ refresh: onSuccess })
+          .then((results) => {
+            if (
+              results.length > 0 &&
+              results.every((result) => result.status !== "completed")
+            ) {
+              console.warn(
+                "Balance refresh recovery remained unavailable after Max unshield"
+              );
+            }
+          })
+          .catch((error) => {
+            console.warn(
+              "Failed to schedule balance refresh recovery after Max unshield",
+              error
+            );
+          });
+      }
     } else {
       setErrorMessage(result.error);
       setPhase("error");

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -589,7 +589,7 @@ export function ShieldContent({
           .then((results) => {
             if (
               results.length > 0 &&
-              results.every((result) => result.status !== "completed")
+              !results.some((result) => result.status === "completed")
             ) {
               console.warn(
                 "Balance refresh recovery remained unavailable after Max unshield"

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -566,13 +566,13 @@ export function ShieldContent({
           });
 
     if (result.success) {
-      setPhase("success");
       setAmount("");
-      void Promise.resolve()
-        .then(() => onSuccess?.())
-        .catch((error) => {
-          console.warn("Failed to refresh balances after shield", error);
-        });
+      try {
+        await onSuccess?.();
+      } catch (error) {
+        console.warn("Failed to refresh balances after shield", error);
+      }
+      setPhase("success");
     } else {
       setErrorMessage(result.error);
       setPhase("error");

--- a/frontend/src/features/shielded-balance/reconciliation.ts
+++ b/frontend/src/features/shielded-balance/reconciliation.ts
@@ -5,6 +5,11 @@ const DEFAULT_READ_TIMEOUT_MS = 3_000;
 const DEFAULT_POST_ACTION_REFRESH_TIMEOUT_MS = 5_000;
 const DEFAULT_POST_ACTION_RECOVERY_DELAYS_MS = [1_000, 4_000] as const;
 
+const defaultWait = (delayMs: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
 export type SecuredBalanceReconciliationResult =
   | {
       status: "reconciled";
@@ -109,12 +114,7 @@ export async function reconcileSecuredBalance(args: {
     throw new Error("Secured balance reconciliation requires an attempt.");
   }
 
-  const wait =
-    args.wait ??
-    ((delayMs: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, delayMs);
-      }));
+  const wait = args.wait ?? defaultWait;
   const readTimeoutMs = args.readTimeoutMs ?? DEFAULT_READ_TIMEOUT_MS;
   let observedAmountRaw: bigint | null = null;
 
@@ -149,33 +149,6 @@ export async function reconcileSecuredBalance(args: {
     status: "pending",
     attempts: retryDelaysMs.length,
     observedAmountRaw,
-  };
-}
-
-export async function executeMaxUnshieldWithReconciliation<T>(args: {
-  executeTransaction: () => Promise<T>;
-  readAmountRaw: () => Promise<bigint>;
-  retryDelaysMs?: readonly number[];
-  readTimeoutMs?: number;
-  wait?: (delayMs: number) => Promise<void>;
-}): Promise<{
-  confirmedAmountRaw: bigint;
-  executionResult: T;
-  reconciliation: SecuredBalanceReconciliationResult;
-}> {
-  const executionResult = await args.executeTransaction();
-  const reconciliation = await reconcileSecuredBalance({
-    expectedAmountRaw: BigInt(0),
-    readAmountRaw: args.readAmountRaw,
-    retryDelaysMs: args.retryDelaysMs,
-    readTimeoutMs: args.readTimeoutMs,
-    wait: args.wait,
-  });
-
-  return {
-    confirmedAmountRaw: BigInt(0),
-    executionResult,
-    reconciliation,
   };
 }
 
@@ -227,12 +200,7 @@ export async function recoverPostActionRefresh(args: {
 
   const retryDelaysMs =
     args.retryDelaysMs ?? DEFAULT_POST_ACTION_RECOVERY_DELAYS_MS;
-  const wait =
-    args.wait ??
-    ((delayMs: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, delayMs);
-      }));
+  const wait = args.wait ?? defaultWait;
   const results: PostActionRefreshResult[] = [];
 
   for (const delayMs of retryDelaysMs) {

--- a/frontend/src/features/shielded-balance/reconciliation.ts
+++ b/frontend/src/features/shielded-balance/reconciliation.ts
@@ -28,6 +28,14 @@ export type PostActionRefreshResult =
   | { status: "failed"; error: unknown }
   | { status: "timed_out" };
 
+export type PostActionRefreshCommitContext = {
+  isCurrent: () => boolean;
+};
+
+export type PostActionRefresh = (
+  context: PostActionRefreshCommitContext
+) => Promise<void> | void;
+
 export function createLatestPortfolioRequestGuard(): LatestPortfolioRequestGuard {
   let latestRequestId = 0;
 
@@ -41,6 +49,25 @@ export function createLatestPortfolioRequestGuard(): LatestPortfolioRequestGuard
     },
     isCurrent: (requestId) => requestId === latestRequestId,
   };
+}
+
+export function settleLatestPortfolioRequest(args: {
+  requestGuard: LatestPortfolioRequestGuard;
+  requestId: number;
+  isScopeCurrent: () => boolean;
+  commit?: () => void;
+  setLoading: (isLoading: boolean) => void;
+}): boolean {
+  if (!args.isScopeCurrent() || !args.requestGuard.isCurrent(args.requestId)) {
+    return false;
+  }
+
+  try {
+    args.commit?.();
+  } finally {
+    args.setLoading(false);
+  }
+  return true;
 }
 
 function readWithTimeout(
@@ -153,7 +180,7 @@ export async function executeMaxUnshieldWithReconciliation<T>(args: {
 }
 
 export async function settlePostActionRefresh(args: {
-  refresh?: () => Promise<void> | void;
+  refresh?: PostActionRefresh;
   timeoutMs?: number;
 }): Promise<PostActionRefreshResult> {
   if (!args.refresh) {
@@ -166,8 +193,12 @@ export async function settlePostActionRefresh(args: {
   }
 
   let timeout: ReturnType<typeof setTimeout> | null = null;
+  let isCurrent = true;
+  const context: PostActionRefreshCommitContext = {
+    isCurrent: () => isCurrent,
+  };
   const refreshResult: Promise<PostActionRefreshResult> = Promise.resolve()
-    .then(args.refresh)
+    .then(() => args.refresh?.(context))
     .then((): PostActionRefreshResult => ({ status: "completed" }))
     .catch(
       (error: unknown): PostActionRefreshResult => ({ status: "failed", error })
@@ -177,6 +208,7 @@ export async function settlePostActionRefresh(args: {
   });
 
   return Promise.race([refreshResult, timeoutResult]).finally(() => {
+    isCurrent = false;
     if (timeout) {
       clearTimeout(timeout);
     }
@@ -184,7 +216,7 @@ export async function settlePostActionRefresh(args: {
 }
 
 export async function recoverPostActionRefresh(args: {
-  refresh?: () => Promise<void> | void;
+  refresh?: PostActionRefresh;
   retryDelaysMs?: readonly number[];
   refreshTimeoutMs?: number;
   wait?: (delayMs: number) => Promise<void>;

--- a/frontend/src/features/shielded-balance/reconciliation.ts
+++ b/frontend/src/features/shielded-balance/reconciliation.ts
@@ -1,0 +1,98 @@
+export const WALLET_PORTFOLIO_FALLBACK_REFRESH_MS = 30_000;
+
+const DEFAULT_RETRY_DELAYS_MS = [0, 250, 750, 1_500] as const;
+const DEFAULT_READ_TIMEOUT_MS = 3_000;
+
+export type SecuredBalanceReconciliationResult =
+  | {
+      status: "reconciled";
+      attempts: number;
+      observedAmountRaw: bigint;
+    }
+  | {
+      status: "pending";
+      attempts: number;
+      observedAmountRaw: bigint | null;
+    };
+
+function readWithTimeout(
+  readAmountRaw: () => Promise<bigint>,
+  timeoutMs: number
+): Promise<bigint> {
+  if (timeoutMs <= 0) {
+    return readAmountRaw();
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error("Secured balance read timed out.")),
+      timeoutMs
+    );
+  });
+
+  const readPromise = Promise.resolve().then(readAmountRaw);
+  return Promise.race([readPromise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
+
+/**
+ * Reconcile a confirmed balance mutation with the authoritative ephemeral
+ * account. This performs reads only; the transaction has already confirmed
+ * before the caller enters this boundary.
+ */
+export async function reconcileSecuredBalance(args: {
+  expectedAmountRaw: bigint;
+  readAmountRaw: () => Promise<bigint>;
+  retryDelaysMs?: readonly number[];
+  readTimeoutMs?: number;
+  wait?: (delayMs: number) => Promise<void>;
+}): Promise<SecuredBalanceReconciliationResult> {
+  const retryDelaysMs = args.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  if (retryDelaysMs.length === 0) {
+    throw new Error("Secured balance reconciliation requires an attempt.");
+  }
+
+  const wait =
+    args.wait ??
+    ((delayMs: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs);
+      }));
+  const readTimeoutMs = args.readTimeoutMs ?? DEFAULT_READ_TIMEOUT_MS;
+  let observedAmountRaw: bigint | null = null;
+
+  for (
+    let attemptIndex = 0;
+    attemptIndex < retryDelaysMs.length;
+    attemptIndex++
+  ) {
+    const delayMs = retryDelaysMs[attemptIndex] ?? 0;
+    if (delayMs > 0) {
+      await wait(delayMs);
+    }
+
+    try {
+      observedAmountRaw = await readWithTimeout(
+        args.readAmountRaw,
+        readTimeoutMs
+      );
+      if (observedAmountRaw === args.expectedAmountRaw) {
+        return {
+          status: "reconciled",
+          attempts: attemptIndex + 1,
+          observedAmountRaw,
+        };
+      }
+    } catch {
+      // A later bounded attempt may observe the confirmed state.
+    }
+  }
+
+  return {
+    status: "pending",
+    attempts: retryDelaysMs.length,
+    observedAmountRaw,
+  };
+}

--- a/frontend/src/features/shielded-balance/reconciliation.ts
+++ b/frontend/src/features/shielded-balance/reconciliation.ts
@@ -1,7 +1,9 @@
-export const WALLET_PORTFOLIO_FALLBACK_REFRESH_MS = 30_000;
+export const WALLET_PORTFOLIO_FALLBACK_REFRESH_MS = 0;
 
 const DEFAULT_RETRY_DELAYS_MS = [0, 250, 750, 1_500] as const;
 const DEFAULT_READ_TIMEOUT_MS = 3_000;
+const DEFAULT_POST_ACTION_REFRESH_TIMEOUT_MS = 5_000;
+const DEFAULT_POST_ACTION_RECOVERY_DELAYS_MS = [1_000, 4_000] as const;
 
 export type SecuredBalanceReconciliationResult =
   | {
@@ -14,6 +16,32 @@ export type SecuredBalanceReconciliationResult =
       attempts: number;
       observedAmountRaw: bigint | null;
     };
+
+export type LatestPortfolioRequestGuard = {
+  begin: () => number;
+  invalidate: () => void;
+  isCurrent: (requestId: number) => boolean;
+};
+
+export type PostActionRefreshResult =
+  | { status: "completed" }
+  | { status: "failed"; error: unknown }
+  | { status: "timed_out" };
+
+export function createLatestPortfolioRequestGuard(): LatestPortfolioRequestGuard {
+  let latestRequestId = 0;
+
+  return {
+    begin: () => {
+      latestRequestId += 1;
+      return latestRequestId;
+    },
+    invalidate: () => {
+      latestRequestId += 1;
+    },
+    isCurrent: (requestId) => requestId === latestRequestId,
+  };
+}
 
 function readWithTimeout(
   readAmountRaw: () => Promise<bigint>,
@@ -95,4 +123,97 @@ export async function reconcileSecuredBalance(args: {
     attempts: retryDelaysMs.length,
     observedAmountRaw,
   };
+}
+
+export async function executeMaxUnshieldWithReconciliation<T>(args: {
+  executeTransaction: () => Promise<T>;
+  readAmountRaw: () => Promise<bigint>;
+  retryDelaysMs?: readonly number[];
+  readTimeoutMs?: number;
+  wait?: (delayMs: number) => Promise<void>;
+}): Promise<{
+  confirmedAmountRaw: bigint;
+  executionResult: T;
+  reconciliation: SecuredBalanceReconciliationResult;
+}> {
+  const executionResult = await args.executeTransaction();
+  const reconciliation = await reconcileSecuredBalance({
+    expectedAmountRaw: BigInt(0),
+    readAmountRaw: args.readAmountRaw,
+    retryDelaysMs: args.retryDelaysMs,
+    readTimeoutMs: args.readTimeoutMs,
+    wait: args.wait,
+  });
+
+  return {
+    confirmedAmountRaw: BigInt(0),
+    executionResult,
+    reconciliation,
+  };
+}
+
+export async function settlePostActionRefresh(args: {
+  refresh?: () => Promise<void> | void;
+  timeoutMs?: number;
+}): Promise<PostActionRefreshResult> {
+  if (!args.refresh) {
+    return { status: "completed" };
+  }
+
+  const timeoutMs = args.timeoutMs ?? DEFAULT_POST_ACTION_REFRESH_TIMEOUT_MS;
+  if (timeoutMs <= 0) {
+    throw new Error("Post-action refresh timeout must be positive.");
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const refreshResult: Promise<PostActionRefreshResult> = Promise.resolve()
+    .then(args.refresh)
+    .then((): PostActionRefreshResult => ({ status: "completed" }))
+    .catch(
+      (error: unknown): PostActionRefreshResult => ({ status: "failed", error })
+    );
+  const timeoutResult = new Promise<PostActionRefreshResult>((resolve) => {
+    timeout = setTimeout(() => resolve({ status: "timed_out" }), timeoutMs);
+  });
+
+  return Promise.race([refreshResult, timeoutResult]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+export async function recoverPostActionRefresh(args: {
+  refresh?: () => Promise<void> | void;
+  retryDelaysMs?: readonly number[];
+  refreshTimeoutMs?: number;
+  wait?: (delayMs: number) => Promise<void>;
+}): Promise<PostActionRefreshResult[]> {
+  if (!args.refresh) {
+    return [];
+  }
+
+  const retryDelaysMs =
+    args.retryDelaysMs ?? DEFAULT_POST_ACTION_RECOVERY_DELAYS_MS;
+  const wait =
+    args.wait ??
+    ((delayMs: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs);
+      }));
+  const results: PostActionRefreshResult[] = [];
+
+  for (const delayMs of retryDelaysMs) {
+    if (delayMs > 0) {
+      await wait(delayMs);
+    }
+    results.push(
+      await settlePostActionRefresh({
+        refresh: args.refresh,
+        timeoutMs: args.refreshTimeoutMs,
+      })
+    );
+  }
+
+  return results;
 }

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -1,4 +1,5 @@
 import {
+  findDepositPda,
   type ShieldFlowExecutionResult,
   LoyalPrivateTransactionsClient,
   MAGIC_CONTEXT_ID,
@@ -15,6 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
+import { reconcileSecuredBalance } from "@/features/shielded-balance/reconciliation";
 import { trackWalletShieldCompleted } from "@/lib/core/analytics";
 import {
   recordKaminoUsdcShield,
@@ -53,6 +55,20 @@ async function getDepositAmount(params: {
   ]);
 
   return ephemeralDeposit?.amount ?? baseDeposit?.amount ?? BigInt(0);
+}
+
+async function getAuthoritativeEphemeralDepositAmount(params: {
+  client: LoyalPrivateTransactionsClient;
+  tokenMint: PublicKey;
+  user: PublicKey;
+}): Promise<bigint> {
+  const { client, tokenMint, user } = params;
+  const [depositPda] = findDepositPda(user, tokenMint);
+  const account = await client
+    .getEphemeralProgram()
+    .account.deposit.fetchNullable(depositPda);
+
+  return account ? BigInt(account.amount.toString()) : BigInt(0);
 }
 
 export type ShieldResult = {
@@ -280,13 +296,37 @@ export function useShield() {
           await client.executeUnshieldTokensTransactionPlan({
             plan,
           });
+        const maxUnshieldReconciliation = wantsMax
+          ? await reconcileSecuredBalance({
+              expectedAmountRaw: BigInt(0),
+              readAmountRaw: () =>
+                getAuthoritativeEphemeralDepositAmount({
+                  client,
+                  tokenMint,
+                  user,
+                }),
+            })
+          : null;
+
+        if (maxUnshieldReconciliation?.status === "pending") {
+          console.warn(
+            "Confirmed Max unshield is awaiting shielded balance reconciliation",
+            {
+              attempts: maxUnshieldReconciliation.attempts,
+              tokenMint: tokenMint.toBase58(),
+            }
+          );
+        }
 
         if (isTrackedKaminoToken) {
-          const collateralSharesAfter = await getDepositAmount({
-            client,
-            tokenMint,
-            user,
-          });
+          const collateralSharesAfter =
+            maxUnshieldReconciliation?.status === "reconciled"
+              ? maxUnshieldReconciliation.observedAmountRaw
+              : await getDepositAmount({
+                  client,
+                  tokenMint,
+                  user,
+                });
           const burnedCollateralSharesAmountRaw =
             collateralSharesBefore - collateralSharesAfter;
 

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -16,7 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
-import { executeMaxUnshieldWithReconciliation } from "@/features/shielded-balance/reconciliation";
+import { reconcileSecuredBalance } from "@/features/shielded-balance/reconciliation";
 import { trackWalletShieldCompleted } from "@/lib/core/analytics";
 import {
   recordKaminoUsdcShield,
@@ -292,12 +292,16 @@ export function useShield() {
           magicProgram: MAGIC_PROGRAM_ID,
           magicContext: MAGIC_CONTEXT_ID,
         });
-        const maxUnshieldExecution = wantsMax
-          ? await executeMaxUnshieldWithReconciliation({
-              executeTransaction: () =>
-                client.executeUnshieldTokensTransactionPlan({
-                  plan,
-                }),
+        const executionResult =
+          await client.executeUnshieldTokensTransactionPlan({
+            plan,
+          });
+        // A confirmed MAX unshield drains the delegated balance to zero. Read
+        // back the authoritative ephemeral account (read-only, bounded) so a
+        // stale delegated snapshot is not presented as current.
+        const maxUnshieldReconciliation = wantsMax
+          ? await reconcileSecuredBalance({
+              expectedAmountRaw: BigInt(0),
               readAmountRaw: () =>
                 getAuthoritativeEphemeralDepositAmount({
                   client,
@@ -306,13 +310,6 @@ export function useShield() {
                 }),
             })
           : null;
-        const executionResult = maxUnshieldExecution
-          ? maxUnshieldExecution.executionResult
-          : await client.executeUnshieldTokensTransactionPlan({
-              plan,
-            });
-        const maxUnshieldReconciliation =
-          maxUnshieldExecution?.reconciliation ?? null;
 
         if (maxUnshieldReconciliation?.status === "pending") {
           console.warn(
@@ -325,8 +322,8 @@ export function useShield() {
         }
 
         if (isTrackedKaminoToken) {
-          const collateralSharesAfter = maxUnshieldExecution
-            ? maxUnshieldExecution.confirmedAmountRaw
+          const collateralSharesAfter = wantsMax
+            ? BigInt(0)
             : await getDepositAmount({
                 client,
                 tokenMint,

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -16,7 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useCallback, useState } from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
-import { reconcileSecuredBalance } from "@/features/shielded-balance/reconciliation";
+import { executeMaxUnshieldWithReconciliation } from "@/features/shielded-balance/reconciliation";
 import { trackWalletShieldCompleted } from "@/lib/core/analytics";
 import {
   recordKaminoUsdcShield,
@@ -292,13 +292,12 @@ export function useShield() {
           magicProgram: MAGIC_PROGRAM_ID,
           magicContext: MAGIC_CONTEXT_ID,
         });
-        const executionResult =
-          await client.executeUnshieldTokensTransactionPlan({
-            plan,
-          });
-        const maxUnshieldReconciliation = wantsMax
-          ? await reconcileSecuredBalance({
-              expectedAmountRaw: BigInt(0),
+        const maxUnshieldExecution = wantsMax
+          ? await executeMaxUnshieldWithReconciliation({
+              executeTransaction: () =>
+                client.executeUnshieldTokensTransactionPlan({
+                  plan,
+                }),
               readAmountRaw: () =>
                 getAuthoritativeEphemeralDepositAmount({
                   client,
@@ -307,6 +306,13 @@ export function useShield() {
                 }),
             })
           : null;
+        const executionResult = maxUnshieldExecution
+          ? maxUnshieldExecution.executionResult
+          : await client.executeUnshieldTokensTransactionPlan({
+              plan,
+            });
+        const maxUnshieldReconciliation =
+          maxUnshieldExecution?.reconciliation ?? null;
 
         if (maxUnshieldReconciliation?.status === "pending") {
           console.warn(
@@ -319,14 +325,13 @@ export function useShield() {
         }
 
         if (isTrackedKaminoToken) {
-          const collateralSharesAfter =
-            maxUnshieldReconciliation?.status === "reconciled"
-              ? maxUnshieldReconciliation.observedAmountRaw
-              : await getDepositAmount({
-                  client,
-                  tokenMint,
-                  user,
-                });
+          const collateralSharesAfter = maxUnshieldExecution
+            ? maxUnshieldExecution.confirmedAmountRaw
+            : await getDepositAmount({
+                client,
+                tokenMint,
+                user,
+              });
           const burnedCollateralSharesAmountRaw =
             collateralSharesBefore - collateralSharesAfter;
 

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -18,6 +18,7 @@ import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import {
   createLatestPortfolioRequestGuard,
+  settleLatestPortfolioRequest,
   WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
 } from "@/features/shielded-balance/reconciliation";
 import {
@@ -757,22 +758,33 @@ export function useWalletDesktopData(
           .getPortfolio(publicKey, { forceRefresh: true })
           .then(async (nextPortfolio) => {
             const enriched = await applyEnrichment(nextPortfolio, address);
-            if (
-              ownerAddressRef.current !== address ||
-              !isCurrent() ||
-              !portfolioRequestGuard.isCurrent(requestId)
-            ) {
-              return;
-            }
-            applyPortfolioState({
-              portfolioSnapshot: enriched.snapshot,
-              earningsByMint: enriched.earningsByMint,
-              earningsSummary: toWalletEarningsSummary(enriched.earningsTotals),
-              walletAddress: address,
+            settleLatestPortfolioRequest({
+              requestGuard: portfolioRequestGuard,
+              requestId,
+              isScopeCurrent: () =>
+                ownerAddressRef.current === address && isCurrent(),
+              commit: () => {
+                applyPortfolioState({
+                  portfolioSnapshot: enriched.snapshot,
+                  earningsByMint: enriched.earningsByMint,
+                  earningsSummary: toWalletEarningsSummary(
+                    enriched.earningsTotals
+                  ),
+                  walletAddress: address,
+                });
+              },
+              setLoading: setIsLoading,
             });
           })
           .catch((error) => {
             console.error("Failed to refresh wallet portfolio", error);
+            settleLatestPortfolioRequest({
+              requestGuard: portfolioRequestGuard,
+              requestId,
+              isScopeCurrent: () =>
+                ownerAddressRef.current === address && isCurrent(),
+              setLoading: setIsLoading,
+            });
           })
       );
 
@@ -868,19 +880,31 @@ export function useWalletDesktopData(
           return;
         }
 
-        applyPortfolioState({
-          portfolioSnapshot: enriched.snapshot,
-          earningsByMint: enriched.earningsByMint,
-          earningsSummary: toWalletEarningsSummary(enriched.earningsTotals),
-          walletAddress: address,
+        settleLatestPortfolioRequest({
+          requestGuard: portfolioRequestGuard,
+          requestId,
+          isScopeCurrent: () =>
+            !cancelled && ownerAddressRef.current === address,
+          commit: () => {
+            applyPortfolioState({
+              portfolioSnapshot: enriched.snapshot,
+              earningsByMint: enriched.earningsByMint,
+              earningsSummary: toWalletEarningsSummary(enriched.earningsTotals),
+              walletAddress: address,
+            });
+          },
+          setLoading: setIsLoading,
         });
-        setIsLoading(false);
       })
       .catch((error) => {
         console.error("Failed to load wallet desktop data", error);
-        if (!cancelled && portfolioRequestGuard.isCurrent(requestId)) {
-          setIsLoading(false);
-        }
+        settleLatestPortfolioRequest({
+          requestGuard: portfolioRequestGuard,
+          requestId,
+          isScopeCurrent: () =>
+            !cancelled && ownerAddressRef.current === address,
+          setLoading: setIsLoading,
+        });
       });
 
     return () => {
@@ -916,16 +940,22 @@ export function useWalletDesktopData(
           const requestId = portfolioRequestGuard.begin();
           void applyEnrichment(snapshot, subscriptionAddress).then(
             (enriched) => {
-              if (closed || !portfolioRequestGuard.isCurrent(requestId)) {
-                return;
-              }
-              applyPortfolioState({
-                portfolioSnapshot: enriched.snapshot,
-                earningsByMint: enriched.earningsByMint,
-                earningsSummary: toWalletEarningsSummary(
-                  enriched.earningsTotals
-                ),
-                walletAddress: subscriptionAddress,
+              settleLatestPortfolioRequest({
+                requestGuard: portfolioRequestGuard,
+                requestId,
+                isScopeCurrent: () =>
+                  !closed && ownerAddressRef.current === subscriptionAddress,
+                commit: () => {
+                  applyPortfolioState({
+                    portfolioSnapshot: enriched.snapshot,
+                    earningsByMint: enriched.earningsByMint,
+                    earningsSummary: toWalletEarningsSummary(
+                      enriched.earningsTotals
+                    ),
+                    walletAddress: subscriptionAddress,
+                  });
+                },
+                setLoading: setIsLoading,
               });
             }
           );

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -16,7 +16,10 @@ import type {
 } from "@/components/wallet-sidebar/types";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
-import { WALLET_PORTFOLIO_FALLBACK_REFRESH_MS } from "@/features/shielded-balance/reconciliation";
+import {
+  createLatestPortfolioRequestGuard,
+  WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
+} from "@/features/shielded-balance/reconciliation";
 import {
   readClientCache,
   writeClientCache,
@@ -598,6 +601,10 @@ export function useWalletDesktopData(
   const [activities, setActivities] = useState<WalletActivity[]>([]);
   const [hasRequestedActivity, setHasRequestedActivity] = useState(false);
   const activityLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const portfolioRequestGuard = useMemo(
+    () => createLatestPortfolioRequestGuard(),
+    []
+  );
   const ownerAddressRef = useRef<string | null>(null);
   ownerAddressRef.current = ownerPublicKey?.toBase58() ?? null;
   const [isLoading, setIsLoading] = useState(false);
@@ -736,6 +743,7 @@ export function useWalletDesktopData(
 
       const publicKey = ownerPublicKey;
       const address = publicKey.toBase58();
+      const requestId = portfolioRequestGuard.begin();
 
       client.invalidateCaches({
         portfolio: [publicKey],
@@ -749,7 +757,11 @@ export function useWalletDesktopData(
           .getPortfolio(publicKey, { forceRefresh: true })
           .then(async (nextPortfolio) => {
             const enriched = await applyEnrichment(nextPortfolio, address);
-            if (ownerAddressRef.current !== address || !isCurrent()) {
+            if (
+              ownerAddressRef.current !== address ||
+              !isCurrent() ||
+              !portfolioRequestGuard.isCurrent(requestId)
+            ) {
               return;
             }
             applyPortfolioState({
@@ -791,15 +803,17 @@ export function useWalletDesktopData(
       enabled,
       hasRequestedActivity,
       ownerPublicKey,
+      portfolioRequestGuard,
     ]
   );
 
   useEffect(() => {
+    portfolioRequestGuard.invalidate();
     ownerAddressRef.current = ownerPublicKey?.toBase58() ?? null;
     setActivities([]);
     setHasRequestedActivity(false);
     activityLoadPromiseRef.current = null;
-  }, [ownerPublicKey]);
+  }, [ownerPublicKey, portfolioRequestGuard]);
 
   useEffect(() => {
     if (!ownerPublicKey) {
@@ -812,6 +826,7 @@ export function useWalletDesktopData(
     }
 
     let cancelled = false;
+    const requestId = portfolioRequestGuard.begin();
 
     const publicKey = ownerPublicKey;
     const address = publicKey.toBase58();
@@ -844,12 +859,12 @@ export function useWalletDesktopData(
     void client
       .getPortfolio(publicKey)
       .then(async (nextPortfolio) => {
-        if (cancelled) {
+        if (cancelled || !portfolioRequestGuard.isCurrent(requestId)) {
           return;
         }
 
         const enriched = await applyEnrichment(nextPortfolio, address);
-        if (cancelled) {
+        if (cancelled || !portfolioRequestGuard.isCurrent(requestId)) {
           return;
         }
 
@@ -863,7 +878,7 @@ export function useWalletDesktopData(
       })
       .catch((error) => {
         console.error("Failed to load wallet desktop data", error);
-        if (!cancelled) {
+        if (!cancelled && portfolioRequestGuard.isCurrent(requestId)) {
           setIsLoading(false);
         }
       });
@@ -877,6 +892,7 @@ export function useWalletDesktopData(
     applyEnrichment,
     applyPortfolioState,
     enabled,
+    portfolioRequestGuard,
     publicEnv.solanaEnv,
   ]);
 
@@ -897,9 +913,12 @@ export function useWalletDesktopData(
         subscriptionPublicKey,
         (snapshot) => {
           if (closed) return;
+          const requestId = portfolioRequestGuard.begin();
           void applyEnrichment(snapshot, subscriptionAddress).then(
             (enriched) => {
-              if (closed) return;
+              if (closed || !portfolioRequestGuard.isCurrent(requestId)) {
+                return;
+              }
               applyPortfolioState({
                 portfolioSnapshot: enriched.snapshot,
                 earningsByMint: enriched.earningsByMint,
@@ -985,6 +1004,7 @@ export function useWalletDesktopData(
     applyPortfolioState,
     enabled,
     hasRequestedActivity,
+    portfolioRequestGuard,
   ]);
 
   // Fetch LOYAL token price for the always-visible placeholder row.

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/components/wallet-sidebar/types";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
+import { WALLET_PORTFOLIO_FALLBACK_REFRESH_MS } from "@/features/shielded-balance/reconciliation";
 import {
   readClientCache,
   writeClientCache,
@@ -910,7 +911,10 @@ export function useWalletDesktopData(
             }
           );
         },
-        { emitInitial: false, fallbackRefreshMs: 0 }
+        {
+          emitInitial: false,
+          fallbackRefreshMs: WALLET_PORTFOLIO_FALLBACK_REFRESH_MS,
+        }
       )
       .then((unsubscribe) => {
         unsubscribePortfolio = unsubscribe;

--- a/packages/solana-wallet/src/__tests__/client.test.ts
+++ b/packages/solana-wallet/src/__tests__/client.test.ts
@@ -3,7 +3,27 @@ import { PublicKey } from "@solana/web3.js";
 
 import { USDC_MINT, WALLET_ADDRESS } from "../__fixtures__/asset-fixtures";
 import { createSolanaWalletDataClient } from "../client";
-import type { ActivityProvider, AssetProvider } from "../types";
+import type { ActivityProvider, AssetProvider, AssetSnapshot } from "../types";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return {
+    promise,
+    resolve: (value) => {
+      if (!resolve) {
+        throw new Error("Deferred promise was not initialized.");
+      }
+      resolve(value);
+    },
+  };
+}
 
 describe("createSolanaWalletDataClient", () => {
   test("caches portfolio snapshots and merges secure balances", async () => {
@@ -72,6 +92,105 @@ describe("createSolanaWalletDataClient", () => {
     expect(firstUsdc?.securedBalance).toBe(0.5);
     expect(firstUsdc?.totalBalance).toBe(2.5);
     expect(second.totals.totalUsd).toBe(102.5);
+  });
+
+  test("does not let an older portfolio request overwrite a forced refresh", async () => {
+    const oldSnapshot = deferred<AssetSnapshot>();
+    let assetCalls = 0;
+    const makeSnapshot = (nativeBalanceLamports: number): AssetSnapshot => ({
+      owner: WALLET_ADDRESS,
+      nativeBalanceLamports,
+      fetchedAt: Date.now(),
+      assets: [],
+    });
+    const assetProvider: AssetProvider = {
+      getBalance: async () => 0,
+      getAssetSnapshot: async () => {
+        assetCalls += 1;
+        return assetCalls === 1
+          ? oldSnapshot.promise
+          : makeSnapshot(2_000_000_000);
+      },
+      subscribeAssetChanges: async () => async () => undefined,
+    };
+    const client = createSolanaWalletDataClient({
+      env: "devnet",
+      assetProvider,
+      activityProvider: {
+        getActivity: async () => ({ activities: [] }),
+        subscribeActivity: async () => async () => undefined,
+      },
+    });
+
+    const staleRequest = client.getPortfolio(WALLET_ADDRESS);
+    await Promise.resolve();
+    const freshSnapshot = await client.getPortfolio(WALLET_ADDRESS, {
+      forceRefresh: true,
+    });
+    oldSnapshot.resolve(makeSnapshot(1_000_000_000));
+
+    expect(freshSnapshot.nativeBalanceLamports).toBe(2_000_000_000);
+    expect((await staleRequest).nativeBalanceLamports).toBe(1_000_000_000);
+    expect(
+      (await client.getPortfolio(WALLET_ADDRESS)).nativeBalanceLamports
+    ).toBe(2_000_000_000);
+    expect(assetCalls).toBe(2);
+  });
+
+  test("does not emit a subscription snapshot superseded by a forced refresh", async () => {
+    const oldSnapshot = deferred<AssetSnapshot>();
+    let assetCalls = 0;
+    let emitAssetChange: (() => void) | null = null;
+    const emittedBalances: number[] = [];
+    const makeSnapshot = (nativeBalanceLamports: number): AssetSnapshot => ({
+      owner: WALLET_ADDRESS,
+      nativeBalanceLamports,
+      fetchedAt: Date.now(),
+      assets: [],
+    });
+    const client = createSolanaWalletDataClient({
+      env: "devnet",
+      assetProvider: {
+        getBalance: async () => 0,
+        getAssetSnapshot: async () => {
+          assetCalls += 1;
+          return assetCalls === 1
+            ? oldSnapshot.promise
+            : makeSnapshot(2_000_000_000);
+        },
+        subscribeAssetChanges: async (_owner, onChange) => {
+          emitAssetChange = onChange;
+          return async () => undefined;
+        },
+      },
+      activityProvider: {
+        getActivity: async () => ({ activities: [] }),
+        subscribeActivity: async () => async () => undefined,
+      },
+    });
+    const unsubscribe = await client.subscribePortfolio(
+      WALLET_ADDRESS,
+      (snapshot) => {
+        emittedBalances.push(snapshot.nativeBalanceLamports);
+      },
+      { emitInitial: false, fallbackRefreshMs: 0 }
+    );
+    if (!emitAssetChange) {
+      throw new Error("Asset subscription callback was not registered.");
+    }
+
+    emitAssetChange();
+    await Promise.resolve();
+    const freshSnapshot = await client.getPortfolio(WALLET_ADDRESS, {
+      forceRefresh: true,
+    });
+    oldSnapshot.resolve(makeSnapshot(1_000_000_000));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await unsubscribe();
+
+    expect(freshSnapshot.nativeBalanceLamports).toBe(2_000_000_000);
+    expect(emittedBalances).toEqual([]);
+    expect(assetCalls).toBe(2);
   });
 
   test("surfaces shielded-only mints by resolving descriptors via the asset provider", async () => {

--- a/packages/solana-wallet/src/client.ts
+++ b/packages/solana-wallet/src/client.ts
@@ -165,6 +165,7 @@ export function createSolanaWalletDataClient(
     string,
     Promise<PortfolioSnapshot>
   >();
+  const portfolioRequestGenerations = new Map<string, number>();
   const activityCache = new Map<string, CachedActivity>();
   const inflightActivityRequests = new Map<string, Promise<ActivityPage>>();
 
@@ -227,6 +228,9 @@ export function createSolanaWalletDataClient(
       return inflight;
     }
 
+    const requestGeneration =
+      (portfolioRequestGenerations.get(ownerKey) ?? 0) + 1;
+    portfolioRequestGenerations.set(ownerKey, requestGeneration);
     const loader = (async () => {
       const assetSnapshot = await assetProvider.getAssetSnapshot(owner);
       const secureBalances: SecureBalanceMap = config.secureBalanceProvider
@@ -260,10 +264,12 @@ export function createSolanaWalletDataClient(
         fallbackSolPriceUsd: options.fallbackSolPriceUsd,
       });
 
-      portfolioCache.set(ownerKey, {
-        snapshot,
-        fetchedAt: Date.now(),
-      });
+      if (portfolioRequestGenerations.get(ownerKey) === requestGeneration) {
+        portfolioCache.set(ownerKey, {
+          snapshot,
+          fetchedAt: Date.now(),
+        });
+      }
 
       return snapshot;
     })();
@@ -285,6 +291,7 @@ export function createSolanaWalletDataClient(
     options: SubscribePortfolioOptions = {}
   ): Promise<() => Promise<void>> => {
     const owner = parsePublicKey(publicKey);
+    const ownerKey = owner.toBase58();
     const emitInitial = options.emitInitial ?? true;
     const fallbackRefreshMs =
       options.fallbackRefreshMs ?? DEFAULT_PORTFOLIO_FALLBACK_REFRESH_MS;
@@ -306,11 +313,17 @@ export function createSolanaWalletDataClient(
       isRefreshing = true;
 
       try {
-        const snapshot = await getPortfolio(owner, {
+        const portfolioPromise = getPortfolio(owner, {
           forceRefresh,
           fallbackSolPriceUsd: options.fallbackSolPriceUsd,
         });
-        if (!closed) {
+        const requestGeneration =
+          portfolioRequestGenerations.get(ownerKey) ?? 0;
+        const snapshot = await portfolioPromise;
+        if (
+          !closed &&
+          portfolioRequestGenerations.get(ownerKey) === requestGeneration
+        ) {
           onPortfolio(snapshot);
         }
       } catch (error) {
@@ -516,6 +529,10 @@ export function createSolanaWalletDataClient(
       for (const address of options.portfolio) {
         const ownerKey = parsePublicKey(address).toBase58();
         portfolioCache.delete(ownerKey);
+        portfolioRequestGenerations.set(
+          ownerKey,
+          (portfolioRequestGenerations.get(ownerKey) ?? 0) + 1
+        );
       }
     }
 

--- a/sdk/private-transactions/dist/index.js
+++ b/sdk/private-transactions/dist/index.js
@@ -2019,6 +2019,32 @@ async function readDelegatedDepositsOnBase(baseConnection, user) {
   }
   return result;
 }
+function mergeDepositEnumerationSources(args) {
+  const byPda = new Map;
+  const ingest = (deposits, preferOverwrite) => {
+    for (const deposit of deposits) {
+      const key = deposit.address.toBase58();
+      if (!preferOverwrite && byPda.has(key))
+        continue;
+      byPda.set(key, deposit);
+    }
+  };
+  ingest(args.baseUndelegated, false);
+  if (args.ephemeral.status === "succeeded") {
+    ingest(args.ephemeral.deposits, true);
+  } else {
+    ingest(args.baseDelegated, true);
+  }
+  return Array.from(byPda.values());
+}
+function normalizeAnchorDeposits(results) {
+  return results.map(({ publicKey, account }) => ({
+    user: account.user,
+    tokenMint: account.tokenMint,
+    amount: BigInt(account.amount.toString()),
+    address: publicKey
+  }));
+}
 async function enumerateDepositsByUser(args) {
   const userFilter = [
     {
@@ -2035,44 +2061,26 @@ async function enumerateDepositsByUser(args) {
     readDelegatedDepositsOnBase(args.baseConnection, args.user),
     ephemeralProgram ? ephemeralProgram.account.deposit.all(userFilter) : Promise.resolve([])
   ]);
-  const byPda = new Map;
-  const ingestAnchor = (results, preferOverwrite) => {
-    for (const { publicKey, account } of results) {
-      const key = publicKey.toBase58();
-      if (!preferOverwrite && byPda.has(key))
-        continue;
-      byPda.set(key, {
-        user: account.user,
-        tokenMint: account.tokenMint,
-        amount: BigInt(account.amount.toString()),
-        address: publicKey
-      });
-    }
-  };
-  const ingestRaw = (results, preferOverwrite) => {
-    for (const data of results) {
-      const key = data.address.toBase58();
-      if (!preferOverwrite && byPda.has(key))
-        continue;
-      byPda.set(key, data);
-    }
-  };
-  if (baseUndelegatedResult.status === "fulfilled") {
-    ingestAnchor(baseUndelegatedResult.value, false);
-  } else {
+  if (baseUndelegatedResult.status === "rejected") {
     console.warn("[enumerateDepositsByUser] base undelegated enumeration failed", baseUndelegatedResult.reason);
   }
-  if (baseDelegatedResult.status === "fulfilled") {
-    ingestRaw(baseDelegatedResult.value, true);
-  } else {
+  if (baseDelegatedResult.status === "rejected") {
     console.warn("[enumerateDepositsByUser] base delegated enumeration failed", baseDelegatedResult.reason);
   }
-  if (ephemeralResult.status === "fulfilled" && ephemeralProgram) {
-    ingestAnchor(ephemeralResult.value, true);
-  } else if (ephemeralProgram && ephemeralResult.status === "rejected") {
+  if (ephemeralProgram && ephemeralResult.status === "rejected") {
     console.warn("[enumerateDepositsByUser] ephemeral enumeration failed", ephemeralResult.reason);
   }
-  return Array.from(byPda.values());
+  const baseUndelegated = baseUndelegatedResult.status === "fulfilled" ? normalizeAnchorDeposits(baseUndelegatedResult.value) : [];
+  const baseDelegated = baseDelegatedResult.status === "fulfilled" ? baseDelegatedResult.value : [];
+  const ephemeral = !ephemeralProgram ? { status: "unavailable" } : ephemeralResult.status === "fulfilled" ? {
+    status: "succeeded",
+    deposits: normalizeAnchorDeposits(ephemeralResult.value)
+  } : { status: "failed" };
+  return mergeDepositEnumerationSources({
+    baseUndelegated,
+    baseDelegated,
+    ephemeral
+  });
 }
 
 // src/kamino.ts

--- a/sdk/private-transactions/src/enumerate-deposits.ts
+++ b/sdk/private-transactions/src/enumerate-deposits.ts
@@ -111,6 +111,64 @@ async function readDelegatedDepositsOnBase(
   return result;
 }
 
+export type EphemeralDepositEnumeration =
+  | {
+      status: "succeeded";
+      deposits: DepositData[];
+    }
+  | {
+      status: "failed" | "unavailable";
+    };
+
+/**
+ * Merge normalized deposit reads without presenting a delegated base snapshot
+ * as live when the ephemeral enumeration succeeded.
+ *
+ * A successful ephemeral enumeration is authoritative for the complete set of
+ * delegated deposits. In particular, an empty result means a previously
+ * delegated account no longer exists there after a full unshield. The base
+ * delegated copy remains useful only when the live source cannot be queried.
+ */
+export function mergeDepositEnumerationSources(args: {
+  baseUndelegated: DepositData[];
+  baseDelegated: DepositData[];
+  ephemeral: EphemeralDepositEnumeration;
+}): DepositData[] {
+  const byPda = new Map<string, DepositData>();
+
+  const ingest = (deposits: DepositData[], preferOverwrite: boolean) => {
+    for (const deposit of deposits) {
+      const key = deposit.address.toBase58();
+      if (!preferOverwrite && byPda.has(key)) continue;
+      byPda.set(key, deposit);
+    }
+  };
+
+  ingest(args.baseUndelegated, false);
+
+  if (args.ephemeral.status === "succeeded") {
+    ingest(args.ephemeral.deposits, true);
+  } else {
+    ingest(args.baseDelegated, true);
+  }
+
+  return Array.from(byPda.values());
+}
+
+function normalizeAnchorDeposits(
+  results: Array<{
+    publicKey: PublicKey;
+    account: { user: PublicKey; tokenMint: PublicKey; amount: BN };
+  }>
+): DepositData[] {
+  return results.map(({ publicKey, account }) => ({
+    user: account.user,
+    tokenMint: account.tokenMint,
+    amount: BigInt(account.amount.toString()),
+    address: publicKey,
+  }));
+}
+
 /**
  * Enumerate every Deposit account belonging to `user` across the base program
  * and (optionally) the ephemeral program. Read-only — no signer required.
@@ -121,7 +179,8 @@ async function readDelegatedDepositsOnBase(
  *      bytes are still readable on base. Required when no authenticated
  *      ephemeral connection is available (e.g. browser wallet UI).
  *   3. Ephemeral, owned by the deposit program — delegated deposits with the
- *      live balance (Anchor). Wins over (2) for the same PDA when present.
+ *      live balance (Anchor). A successful read replaces (2) as the
+ *      authoritative delegated set, including when the set is empty.
  *
  * Used by wallet UIs to discover shielded holdings even when the user has no
  * matching base-chain token balance — e.g. after fully shielding an SPL mint,
@@ -157,64 +216,45 @@ export async function enumerateDepositsByUser(args: {
           ),
     ]);
 
-  const byPda = new Map<string, DepositData>();
-
-  const ingestAnchor = (
-    results: Array<{
-      publicKey: PublicKey;
-      account: { user: PublicKey; tokenMint: PublicKey; amount: BN };
-    }>,
-    preferOverwrite: boolean
-  ) => {
-    for (const { publicKey, account } of results) {
-      const key = publicKey.toBase58();
-      if (!preferOverwrite && byPda.has(key)) continue;
-      byPda.set(key, {
-        user: account.user,
-        tokenMint: account.tokenMint,
-        amount: BigInt(account.amount.toString()),
-        address: publicKey,
-      });
-    }
-  };
-
-  const ingestRaw = (results: DepositData[], preferOverwrite: boolean) => {
-    for (const data of results) {
-      const key = data.address.toBase58();
-      if (!preferOverwrite && byPda.has(key)) continue;
-      byPda.set(key, data);
-    }
-  };
-
-  if (baseUndelegatedResult.status === "fulfilled") {
-    ingestAnchor(baseUndelegatedResult.value, /* preferOverwrite */ false);
-  } else {
+  if (baseUndelegatedResult.status === "rejected") {
     console.warn(
       "[enumerateDepositsByUser] base undelegated enumeration failed",
       baseUndelegatedResult.reason
     );
   }
 
-  // Base-delegated reads have stale amounts vs. ephemeral, but they are
-  // recoverable without auth — pick them up before ephemeral so ephemeral
-  // (when present) overwrites with the live value.
-  if (baseDelegatedResult.status === "fulfilled") {
-    ingestRaw(baseDelegatedResult.value, /* preferOverwrite */ true);
-  } else {
+  if (baseDelegatedResult.status === "rejected") {
     console.warn(
       "[enumerateDepositsByUser] base delegated enumeration failed",
       baseDelegatedResult.reason
     );
   }
 
-  if (ephemeralResult.status === "fulfilled" && ephemeralProgram) {
-    ingestAnchor(ephemeralResult.value, /* preferOverwrite */ true);
-  } else if (ephemeralProgram && ephemeralResult.status === "rejected") {
+  if (ephemeralProgram && ephemeralResult.status === "rejected") {
     console.warn(
       "[enumerateDepositsByUser] ephemeral enumeration failed",
       ephemeralResult.reason
     );
   }
 
-  return Array.from(byPda.values());
+  const baseUndelegated =
+    baseUndelegatedResult.status === "fulfilled"
+      ? normalizeAnchorDeposits(baseUndelegatedResult.value)
+      : [];
+  const baseDelegated =
+    baseDelegatedResult.status === "fulfilled" ? baseDelegatedResult.value : [];
+  const ephemeral: EphemeralDepositEnumeration = !ephemeralProgram
+    ? { status: "unavailable" }
+    : ephemeralResult.status === "fulfilled"
+    ? {
+        status: "succeeded",
+        deposits: normalizeAnchorDeposits(ephemeralResult.value),
+      }
+    : { status: "failed" };
+
+  return mergeDepositEnumerationSources({
+    baseUndelegated,
+    baseDelegated,
+    ephemeral,
+  });
 }


### PR DESCRIPTION
## Summary

- treat a successful ephemeral deposit enumeration as the authoritative delegated set, including an empty set after a full unshield
- execute confirmed MAX unshield reconciliation through a single-send, bounded read-only boundary with no unbounded post-confirmation fallback read
- bound the success-dialog refresh and use finite MAX-only follow-up refreshes instead of continuous healthy-session polling
- make forced portfolio refreshes last-write-wins across rendered state, client cache, and subscription emissions
- verify the production orchestration, hung-RPC path, no-second-transaction invariant, idle subscription behavior, and overlapping request races

## Root cause

The balance merge retained the known-stale delegated base account and only overwrote it when the ephemeral enumeration returned a matching row. After a full unshield, the authoritative ephemeral result can be empty, so there was no row to overwrite the stale base amount. The first fix still had three race paths: a pending reconciliation could enter an unbounded fallback read, a hung post-action refresh could keep the dialog processing, and an older portfolio request could overwrite the newer forced snapshot.

## User impact

A confirmed MAX USDC unshield now converges to the public-only balance without presenting the old delegated amount as current. Post-confirmation reads are bounded and never send a replacement transaction. Transient propagation is covered by finite MAX-only refresh recovery, while healthy WebSocket sessions stay event-driven without unconditional polling.

## Validation

- `cd frontend && bun run verify:shielded-balance`
- `bun test packages/solana-wallet/src/__tests__/client.test.ts` (7 passed)
- `bun run --cwd packages/solana-wallet test` (19 passed)
- `bun run --cwd packages/solana-wallet build`
- `bun run --cwd sdk/private-transactions build`
- `cd frontend && bunx tsc --noEmit`
- `cd frontend && bun run lint` (passes with existing warnings)
- scoped Prettier check
- `git diff --check origin/main...HEAD`
- `bun run commitlint:head`

The frontend build was not run because repository instructions explicitly forbid local frontend builds.

Linear: https://linear.app/askloyal/issue/ASK-1862/fix-stale-shielded-balance-after-max-unshield