### PR TITLE
fix(wallet): recover interrupted max unshield

### DIFF
--- a/docs/verifiers/ASK-1865-pullguard-followup.md
+++ b/docs/verifiers/ASK-1865-pullguard-followup.md
@@ -1,0 +1,79 @@
+# ASK-1865 PullGuard Follow-up Verifier
+
+## Incident boundary
+
+This verifier covers the follow-up findings from the PullGuard review of
+`loyal-labs/loyal-app#524`. The user flow is:
+
+1. Shield MAX USDC.
+2. Unshield MAX USDC.
+3. Lose one or more Solana RPC reads while the wallet refreshes.
+
+The frontend must never turn an incomplete balance read into an authoritative
+zero balance. This follow-up also protects shielding availability, retry
+classification, and the unavailable-wallet presentation.
+
+## Required conditions
+
+### 1. Incomplete secure-balance reads fail closed
+
+- A failure from any configured deposit-enumeration source rejects the secure
+  balance read instead of returning a partial or empty deposit list.
+- A wallet portfolio refresh whose secure-balance provider rejects must reject;
+  it must not cache or return a fresh portfolio with zero shielded balances.
+- A later successful refresh must read the live secure balance. The preceding
+  failure must not poison the portfolio cache.
+- With a previously confirmed snapshot, refresh failure preserves it as stale.
+  Without one, the balance remains unavailable.
+
+### 2. Shield accounting pre-reads are best-effort
+
+- For tracked USDC, failure to read the pre-shield deposit amount used only for
+  local Kamino basis accounting must not prevent transaction construction,
+  wallet execution, or confirmed shield success.
+- If the accounting baseline is unavailable, basis reconciliation is skipped
+  and logged. No unconfirmed transaction may be presented as successful.
+
+### 3. Retry is offered only for transient connection failures
+
+- Network, CORS, socket, timeout, and RPC transport failures are retryable.
+- User rejection is not retryable.
+- Deterministic transaction construction, simulation, and program failures are
+  not retryable and remain visible as failures.
+
+### 4. Unavailable balances are not rendered as an empty wallet
+
+- An unavailable portfolio displays the unavailable warning and `$—`.
+- It does not display `No cash yet` or the zero-valued LOYL placeholder.
+- A stale portfolio may keep rendering its last confirmed token rows while
+  clearly marked stale.
+
+### 5. Original MAX-unshield invariants remain intact
+
+- Base-chain confirmation is still required before an unshield is successful.
+- A transient failure before confirmation can be retried.
+- Retry rebuilds from the current live deposit amount rather than reusing the
+  original MAX amount.
+- One successful retry decreases the shielded balance exactly once.
+
+## Verification procedure
+
+Run from the ASK-1865 worktree:
+
+```sh
+cd frontend
+bun run verify:max-unshield-recovery
+bunx tsc --noEmit --incremental false
+bun run lint
+cd ..
+git diff --check
+```
+
+Do not run a local frontend production build; Vercel is the build gate for this
+repository.
+
+Review the focused verifier output against every Required condition above.
+Report each condition as `PASS` or `FAIL`, including the command or observation
+that proves it. The overall verdict is `PASS` only when all five Required
+conditions pass. Otherwise, fix the implementation without weakening this
+verifier and rerun it.

--- a/docs/verifiers/ASK-1865.md
+++ b/docs/verifiers/ASK-1865.md
@@ -1,0 +1,60 @@
+# ASK-1865 verifier
+
+Run this verifier cold against the ASK-1865 implementation branch.
+
+## Required conditions
+
+1. **RPC interruption does not turn a recoverable unshield into an apparent success**
+
+   - Run the focused unshield/RPC resilience verifier with the primary base RPC
+     failing at each externally observable stage: authoritative deposit read,
+     transaction submission, and confirmation.
+   - Each interrupted case must either complete through an explicitly configured
+     fallback transport or return a caller-visible failure.
+   - No interrupted case may return `success: true` without a confirmed base-layer
+     unshield signature.
+
+2. **An incomplete MAX unshield remains safely retryable**
+
+   - In the focused verifier, begin with a delegated USDC deposit, interrupt the
+     first MAX attempt before its base transaction is confirmed, then retry.
+   - The retry must re-read authoritative deposit state, use the current full
+     deposit amount, and produce exactly one confirmed base-layer decrease.
+   - It must not reuse a stale amount, double-decrease the deposit, or require the
+     user to shield again.
+
+3. **Wallet state fails closed**
+
+   - Start with a last-confirmed portfolio containing public and shielded USDC,
+     then force a portfolio refresh RPC failure.
+   - The wallet must retain that last-confirmed portfolio and expose a refresh
+     failure/retry state. It must not replace the snapshot with an empty portfolio
+     or present the failed refresh as authoritative zero.
+
+4. **Deterministic transaction errors are not hidden**
+
+   - A Solana JSON-RPC response containing a deterministic transaction/program
+     error must reach the caller as a failure; transport fallback/retry must not
+     rewrite it into success.
+
+5. **Relevant validation passes**
+   - Run `cd frontend && bun run verify:max-unshield-recovery`; it must print
+     `PASS` for Required conditions 1–4.
+   - Run `cd frontend && bun run lint` without a frontend production build.
+   - Run `cd frontend && bunx tsc --noEmit`.
+   - Run `git diff --check`.
+   - Confirm the implementation diff does not include unrelated pre-existing
+     changes or plaintext secrets.
+
+## Nice to have
+
+- Stage-level structured telemetry identifies deposit read, undelegation, base
+  submission, confirmation, and portfolio refresh failures without logging
+  wallet signatures, auth tokens, or transaction contents.
+
+## Verdict format
+
+Report each Required condition as `PASS` or `FAIL` with the command/output or
+code evidence that proves it. The overall verdict is `PASS` only when all five
+Required conditions pass. If any condition fails, keep this verifier unchanged,
+make the smallest corrective change, and run it again.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "dev:1pass:dev": "op run --env-file=../.env.1password -- sh -c 'bun dev'",
     "dev:1pass:main": "op run --env-file=../.env.mainnet.1password -- sh -c 'bun dev'",
     "generate-grpc": "buf generate src/lib/proto",
+    "verify:max-unshield-recovery": "bun run scripts/verify-max-unshield-recovery.ts",
     "prebuild": "bun run --cwd .. build:packages",
     "build": "next build",
     "start": "next start",

--- a/frontend/scripts/verify-max-unshield-recovery.ts
+++ b/frontend/scripts/verify-max-unshield-recovery.ts
@@ -1,9 +1,18 @@
 import assert from "node:assert/strict";
 
 import type { ShieldFlowExecutionResult } from "@loyal-labs/private-transactions";
-import { PublicKey } from "@solana/web3.js";
+import { type Connection, PublicKey } from "@solana/web3.js";
 
+import { createSolanaWalletDataClient } from "../../packages/solana-wallet/src/client";
+import type {
+  ActivityProvider,
+  AssetProvider,
+} from "../../packages/solana-wallet/src/types";
+import { DELEGATION_PROGRAM_ID } from "../../sdk/private-transactions/src/constants";
+import { enumerateDepositsByUser } from "../../sdk/private-transactions/src/enumerate-deposits";
+import { runShieldAttemptWithOptionalAccounting } from "../src/lib/solana/shield-recovery";
 import {
+  isRetryableUnshieldError,
   readDepositAmountFailClosed,
   runConfirmedUnshieldAttempt,
   UnshieldAttemptError,
@@ -15,9 +24,11 @@ import {
   getPortfolioFreshness,
   markPortfolioRefreshFailed,
   markPortfolioRefreshSucceeded,
+  shouldRenderPortfolioEmptyState,
 } from "../src/lib/wallet/portfolio-refresh-state";
 
 const TEST_KEY = new PublicKey("11111111111111111111111111111111");
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 function createExecutionResult(
   signatures: ShieldFlowExecutionResult["signatures"],
@@ -48,7 +59,224 @@ async function expectAttemptFailure(
   throw new Error(`Expected unshield failure at ${expectedStage}`);
 }
 
-async function verifyInterruptedAttemptsFailClosed(): Promise<void> {
+function createEnumerationConnection(args: {
+  rejectDelegated?: boolean;
+  rejectProgram?: boolean;
+}): Connection {
+  return {
+    commitment: "confirmed",
+    getProgramAccounts: async (programId: PublicKey) => {
+      const isDelegatedRead = programId.equals(DELEGATION_PROGRAM_ID);
+      if (
+        (isDelegatedRead && args.rejectDelegated) ||
+        (!isDelegatedRead && args.rejectProgram)
+      ) {
+        throw new TypeError("Failed to fetch configured deposit source");
+      }
+      return [];
+    },
+  } as unknown as Connection;
+}
+
+async function verifyIncompleteSecureBalanceReadsFailClosed(): Promise<void> {
+  const allSourcesAvailable = createEnumerationConnection({});
+
+  assert.deepEqual(
+    await enumerateDepositsByUser({
+      user: TEST_KEY,
+      baseConnection: allSourcesAvailable,
+      ephemeralConnection: allSourcesAvailable,
+    }),
+    []
+  );
+
+  await assert.rejects(
+    enumerateDepositsByUser({
+      user: TEST_KEY,
+      baseConnection: createEnumerationConnection({ rejectProgram: true }),
+      ephemeralConnection: allSourcesAvailable,
+    }),
+    /could not enumerate complete private deposits/i
+  );
+  await assert.rejects(
+    enumerateDepositsByUser({
+      user: TEST_KEY,
+      baseConnection: createEnumerationConnection({ rejectDelegated: true }),
+      ephemeralConnection: allSourcesAvailable,
+    }),
+    /could not enumerate complete private deposits/i
+  );
+  await assert.rejects(
+    enumerateDepositsByUser({
+      user: TEST_KEY,
+      baseConnection: allSourcesAvailable,
+      ephemeralConnection: createEnumerationConnection({
+        rejectProgram: true,
+      }),
+    }),
+    /could not enumerate complete private deposits/i
+  );
+
+  const assetProvider: AssetProvider = {
+    getBalance: async () => 0,
+    getAssetSnapshot: async () => ({
+      owner: TEST_KEY.toBase58(),
+      nativeBalanceLamports: 0,
+      fetchedAt: Date.now(),
+      assets: [
+        {
+          asset: {
+            mint: USDC_MINT,
+            symbol: "USDC",
+            name: "USD Coin",
+            decimals: 6,
+            imageUrl: null,
+            isNative: false,
+          },
+          balance: 0.000_038,
+          priceUsd: 1,
+          valueUsd: 0.000_038,
+        },
+      ],
+    }),
+    subscribeAssetChanges: async () => async () => undefined,
+  };
+  const activityProvider: ActivityProvider = {
+    getActivity: async () => ({ activities: [] }),
+    subscribeActivity: async () => async () => undefined,
+  };
+  let secureBalanceRaw: bigint | null = null;
+  let secureBalanceReads = 0;
+  const client = createSolanaWalletDataClient({
+    env: "devnet",
+    assetProvider,
+    activityProvider,
+    secureBalanceProvider: async () => {
+      secureBalanceReads += 1;
+      if (secureBalanceRaw === null) {
+        throw new TypeError("Secure balance RPC unavailable");
+      }
+      return new Map([[USDC_MINT, secureBalanceRaw]]);
+    },
+  });
+
+  await assert.rejects(
+    client.getPortfolio(TEST_KEY),
+    /secure balance rpc unavailable/i
+  );
+
+  secureBalanceRaw = BigInt(1_134_434);
+  const confirmed = await client.getPortfolio(TEST_KEY);
+  assert.equal(
+    confirmed.positions.find(({ asset }) => asset.mint === USDC_MINT)
+      ?.securedBalance,
+    1.134_434
+  );
+
+  secureBalanceRaw = null;
+  await assert.rejects(
+    client.getPortfolio(TEST_KEY, { forceRefresh: true }),
+    /secure balance rpc unavailable/i
+  );
+  const retained = await client.getPortfolio(TEST_KEY);
+  assert.equal(retained, confirmed);
+
+  secureBalanceRaw = BigInt(1_130_000);
+  const refreshed = await client.getPortfolio(TEST_KEY, {
+    forceRefresh: true,
+  });
+  assert.equal(
+    refreshed.positions.find(({ asset }) => asset.mint === USDC_MINT)
+      ?.securedBalance,
+    1.13
+  );
+  assert.equal(secureBalanceReads, 4);
+}
+
+async function verifyShieldAccountingReadIsBestEffort(): Promise<void> {
+  let buildCalls = 0;
+  let executeCalls = 0;
+  let accountingWarnings = 0;
+  const result = await runShieldAttemptWithOptionalAccounting({
+    readAccountingBaseline: async () => {
+      throw new TypeError("Failed to fetch accounting baseline");
+    },
+    buildPlan: async () => {
+      buildCalls += 1;
+      return { amount: BigInt(1_000_000) };
+    },
+    executePlan: async (plan) => {
+      executeCalls += 1;
+      return { confirmed: true, plan };
+    },
+    onAccountingReadError: () => {
+      accountingWarnings += 1;
+    },
+  });
+
+  assert.equal(result.accountingBaseline, null);
+  assert.equal(result.executionResult.confirmed, true);
+  assert.equal(buildCalls, 1);
+  assert.equal(executeCalls, 1);
+  assert.equal(accountingWarnings, 1);
+
+  await assert.rejects(
+    runShieldAttemptWithOptionalAccounting({
+      readAccountingBaseline: async () => {
+        throw new TypeError("Failed to fetch accounting baseline");
+      },
+      buildPlan: async () => ({ amount: BigInt(1_000_000) }),
+      executePlan: async () => {
+        throw new Error("Shield confirmation failed");
+      },
+    }),
+    /shield confirmation failed/i
+  );
+}
+
+function verifyRetryClassification(): void {
+  const nestedFetchError = new UnshieldAttemptError(
+    "execute-plan",
+    "Could not execute the unshield transaction",
+    new TypeError("Failed to fetch")
+  );
+  assert.equal(isRetryableUnshieldError(nestedFetchError), true);
+  assert.equal(
+    isRetryableUnshieldError(
+      new Error("WebSocket connection closed before submission")
+    ),
+    true
+  );
+  for (const transientMessage of [
+    "Blocked by CORS policy",
+    "ERR_SOCKET_NOT_CONNECTED",
+    "Request TimeoutError",
+    "RPC transport unavailable",
+    "HTTP 503 Service Unavailable",
+  ]) {
+    assert.equal(
+      isRetryableUnshieldError(new Error(transientMessage)),
+      true,
+      transientMessage
+    );
+  }
+  assert.equal(
+    isRetryableUnshieldError(new Error("User rejected the request")),
+    false
+  );
+  assert.equal(
+    isRetryableUnshieldError(
+      new Error("Transaction simulation failed: custom program error: 0x1771")
+    ),
+    false
+  );
+  assert.equal(
+    isRetryableUnshieldError(new Error("Invalid connection account owner")),
+    false
+  );
+}
+
+async function verifyOriginalMaxUnshieldInvariants(): Promise<void> {
   await assert.rejects(
     readDepositAmountFailClosed({
       readEphemeral: async () => null,
@@ -124,9 +352,7 @@ async function verifyInterruptedAttemptsFailClosed(): Promise<void> {
       ),
   });
   assert.equal(success.signature, "confirmed-base-signature");
-}
 
-async function verifyMaxRetryUsesLiveDeposit(): Promise<void> {
   let liveDepositRaw = BigInt(1_134_434);
   let shouldInterrupt = true;
   let confirmedBaseDecreases = 0;
@@ -178,7 +404,7 @@ async function verifyMaxRetryUsesLiveDeposit(): Promise<void> {
   assert.equal(liveDepositRaw, BigInt(0));
 }
 
-function verifyPortfolioFailureRetainsConfirmedState(): void {
+function verifyUnavailablePortfolioPresentation(): void {
   const confirmedSnapshot = {
     publicUsdcRaw: "38",
     shieldedUsdcSharesRaw: "1134434",
@@ -213,6 +439,9 @@ function verifyPortfolioFailureRetainsConfirmedState(): void {
     }),
     { balanceFraction: ".23", balanceWhole: "$1" }
   );
+  assert.equal(shouldRenderPortfolioEmptyState("unavailable"), false);
+  assert.equal(shouldRenderPortfolioEmptyState("stale"), true);
+  assert.equal(shouldRenderPortfolioEmptyState("current"), true);
 
   const refreshed = markPortfolioRefreshSucceeded({
     publicUsdcRaw: "1172338",
@@ -242,20 +471,22 @@ async function verifyDeterministicErrorsStayFailures(): Promise<void> {
   assert.match(failure.message, /custom program error: 0x1771/i);
 }
 
-await verifyInterruptedAttemptsFailClosed();
-console.log("PASS Required 1: interrupted attempts fail closed");
+await verifyIncompleteSecureBalanceReadsFailClosed();
+console.log("PASS Required 1: incomplete secure-balance reads fail closed");
 
-await verifyMaxRetryUsesLiveDeposit();
-console.log("PASS Required 2: MAX retry uses authoritative live deposit state");
+await verifyShieldAccountingReadIsBestEffort();
+console.log("PASS Required 2: shield accounting pre-read is best-effort");
 
-verifyPortfolioFailureRetainsConfirmedState();
-console.log(
-  "PASS Required 3: failed refresh retains confirmed portfolio state"
-);
-
+verifyRetryClassification();
 await verifyDeterministicErrorsStayFailures();
+console.log("PASS Required 3: only transient connection errors are retryable");
+
+verifyUnavailablePortfolioPresentation();
 console.log(
-  "PASS Required 4: deterministic transaction errors remain failures"
+  "PASS Required 4: unavailable balances are not presented as an empty wallet"
 );
+
+await verifyOriginalMaxUnshieldInvariants();
+console.log("PASS Required 5: original MAX-unshield invariants remain intact");
 
 console.log("PASS focused ASK-1865 verifier");

--- a/frontend/scripts/verify-max-unshield-recovery.ts
+++ b/frontend/scripts/verify-max-unshield-recovery.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+
+import type { ShieldFlowExecutionResult } from "@loyal-labs/private-transactions";
+import { PublicKey } from "@solana/web3.js";
+
+import {
+  readDepositAmountFailClosed,
+  runConfirmedUnshieldAttempt,
+  UnshieldAttemptError,
+  type UnshieldAttemptStage,
+} from "../src/lib/solana/unshield-recovery";
+import {
+  createPortfolioRefreshState,
+  getPortfolioBalanceDisplay,
+  getPortfolioFreshness,
+  markPortfolioRefreshFailed,
+  markPortfolioRefreshSucceeded,
+} from "../src/lib/wallet/portfolio-refresh-state";
+
+const TEST_KEY = new PublicKey("11111111111111111111111111111111");
+
+function createExecutionResult(
+  signatures: ShieldFlowExecutionResult["signatures"],
+  amount = BigInt(1_134_434)
+): ShieldFlowExecutionResult {
+  return {
+    amount,
+    kind: "unshield",
+    payer: TEST_KEY,
+    signatures,
+    tokenMint: TEST_KEY,
+    user: TEST_KEY,
+  };
+}
+
+async function expectAttemptFailure(
+  operation: () => Promise<unknown>,
+  expectedStage: UnshieldAttemptStage
+): Promise<UnshieldAttemptError> {
+  try {
+    await operation();
+  } catch (error) {
+    assert.ok(error instanceof UnshieldAttemptError);
+    assert.equal(error.stage, expectedStage);
+    return error;
+  }
+
+  throw new Error(`Expected unshield failure at ${expectedStage}`);
+}
+
+async function verifyInterruptedAttemptsFailClosed(): Promise<void> {
+  await assert.rejects(
+    readDepositAmountFailClosed({
+      readEphemeral: async () => null,
+      readBase: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+    }),
+    /failed to fetch/i
+  );
+
+  await expectAttemptFailure(
+    () =>
+      runConfirmedUnshieldAttempt({
+        resolveAmount: async () => {
+          throw new TypeError("Failed to fetch");
+        },
+        buildPlan: async (amount) => ({ amount }),
+        executePlan: async () => createExecutionResult([]),
+      }),
+    "read-deposit"
+  );
+
+  await expectAttemptFailure(
+    () =>
+      runConfirmedUnshieldAttempt({
+        resolveAmount: async () => BigInt(1_134_434),
+        buildPlan: async (amount) => ({ amount }),
+        executePlan: async () => {
+          throw new Error("WebSocket connection closed before submission");
+        },
+      }),
+    "execute-plan"
+  );
+
+  await expectAttemptFailure(
+    () =>
+      runConfirmedUnshieldAttempt({
+        resolveAmount: async () => BigInt(1_134_434),
+        buildPlan: async (amount) => ({ amount }),
+        executePlan: async () =>
+          createExecutionResult([
+            {
+              cluster: "ephemeral",
+              index: 0,
+              label: "unshield:undelegate",
+              signature: "ephemeral-signature",
+            },
+          ]),
+      }),
+    "confirm-base"
+  );
+
+  const success = await runConfirmedUnshieldAttempt({
+    resolveAmount: async () => BigInt(1_134_434),
+    buildPlan: async (amount) => ({ amount }),
+    executePlan: async ({ amount }) =>
+      createExecutionResult(
+        [
+          {
+            cluster: "ephemeral",
+            index: 0,
+            label: "unshield:undelegate",
+            signature: "ephemeral-signature",
+          },
+          {
+            cluster: "base",
+            index: 1,
+            label: "unshield",
+            signature: "confirmed-base-signature",
+          },
+        ],
+        amount
+      ),
+  });
+  assert.equal(success.signature, "confirmed-base-signature");
+}
+
+async function verifyMaxRetryUsesLiveDeposit(): Promise<void> {
+  let liveDepositRaw = BigInt(1_134_434);
+  let shouldInterrupt = true;
+  let confirmedBaseDecreases = 0;
+  let depositReads = 0;
+  const plannedAmounts: bigint[] = [];
+
+  const attempt = () =>
+    runConfirmedUnshieldAttempt({
+      resolveAmount: async () => {
+        depositReads += 1;
+        return liveDepositRaw;
+      },
+      buildPlan: async (amount) => {
+        plannedAmounts.push(amount);
+        return { amount };
+      },
+      executePlan: async ({ amount }) => {
+        if (shouldInterrupt) {
+          shouldInterrupt = false;
+          throw new TypeError("Failed to fetch");
+        }
+
+        assert.equal(amount, liveDepositRaw);
+        liveDepositRaw = BigInt(0);
+        confirmedBaseDecreases += 1;
+        return createExecutionResult(
+          [
+            {
+              cluster: "base",
+              index: 0,
+              label: "unshield",
+              signature: "retry-confirmed-base-signature",
+            },
+          ],
+          amount
+        );
+      },
+    });
+
+  await expectAttemptFailure(attempt, "execute-plan");
+  liveDepositRaw = BigInt(1_130_000);
+
+  const retry = await attempt();
+  assert.equal(retry.amount, BigInt(1_130_000));
+  assert.equal(retry.signature, "retry-confirmed-base-signature");
+  assert.deepEqual(plannedAmounts, [BigInt(1_134_434), BigInt(1_130_000)]);
+  assert.equal(depositReads, 2);
+  assert.equal(confirmedBaseDecreases, 1);
+  assert.equal(liveDepositRaw, BigInt(0));
+}
+
+function verifyPortfolioFailureRetainsConfirmedState(): void {
+  const confirmedSnapshot = {
+    publicUsdcRaw: "38",
+    shieldedUsdcSharesRaw: "1134434",
+  };
+  const current = createPortfolioRefreshState(confirmedSnapshot);
+  const failed = markPortfolioRefreshFailed(
+    current,
+    new TypeError("Failed to fetch")
+  );
+
+  assert.equal(failed.snapshot, confirmedSnapshot);
+  assert.equal(getPortfolioFreshness(failed, false), "stale");
+  assert.match(failed.error ?? "", /failed to fetch/i);
+
+  const unavailable = markPortfolioRefreshFailed(
+    createPortfolioRefreshState<typeof confirmedSnapshot>(),
+    new TypeError("Failed to fetch")
+  );
+  assert.equal(unavailable.snapshot, null);
+  assert.equal(getPortfolioFreshness(unavailable, false), "unavailable");
+  assert.deepEqual(
+    getPortfolioBalanceDisplay("unavailable", {
+      balanceFraction: ".00",
+      balanceWhole: "$0",
+    }),
+    { balanceFraction: "", balanceWhole: "$—" }
+  );
+  assert.deepEqual(
+    getPortfolioBalanceDisplay("stale", {
+      balanceFraction: ".23",
+      balanceWhole: "$1",
+    }),
+    { balanceFraction: ".23", balanceWhole: "$1" }
+  );
+
+  const refreshed = markPortfolioRefreshSucceeded({
+    publicUsdcRaw: "1172338",
+    shieldedUsdcSharesRaw: "0",
+  });
+  assert.equal(getPortfolioFreshness(refreshed, false), "current");
+  assert.equal(refreshed.error, null);
+}
+
+async function verifyDeterministicErrorsStayFailures(): Promise<void> {
+  const programError = new Error(
+    "Transaction simulation failed: custom program error: 0x1771"
+  );
+  const failure = await expectAttemptFailure(
+    () =>
+      runConfirmedUnshieldAttempt({
+        resolveAmount: async () => BigInt(1_134_434),
+        buildPlan: async (amount) => ({ amount }),
+        executePlan: async () => {
+          throw programError;
+        },
+      }),
+    "execute-plan"
+  );
+
+  assert.equal(failure.cause, programError);
+  assert.match(failure.message, /custom program error: 0x1771/i);
+}
+
+await verifyInterruptedAttemptsFailClosed();
+console.log("PASS Required 1: interrupted attempts fail closed");
+
+await verifyMaxRetryUsesLiveDeposit();
+console.log("PASS Required 2: MAX retry uses authoritative live deposit state");
+
+verifyPortfolioFailureRetainsConfirmedState();
+console.log(
+  "PASS Required 3: failed refresh retains confirmed portfolio state"
+);
+
+await verifyDeterministicErrorsStayFailures();
+console.log(
+  "PASS Required 4: deterministic transaction errors remain failures"
+);
+
+console.log("PASS focused ASK-1865 verifier");

--- a/frontend/src/components/wallet-sidebar/index.tsx
+++ b/frontend/src/components/wallet-sidebar/index.tsx
@@ -28,6 +28,7 @@ import {
   trackWalletSidebarTabOpen,
 } from "@/lib/core/analytics";
 import { getTokenIconUrl } from "@/lib/token-icon";
+import { getPortfolioBalanceDisplay } from "@/lib/wallet/portfolio-refresh-state";
 
 import { AllActivityView } from "./all-activity-view";
 import { AllApprovalsView } from "./all-approvals-view";
@@ -90,6 +91,10 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
         props.walletDesktopData.totalUsd + props.smartAccountData.totalUsd
       ),
     [props.walletDesktopData.totalUsd, props.smartAccountData.totalUsd]
+  );
+  const totalBalanceDisplay = getPortfolioBalanceDisplay(
+    props.walletDesktopData.portfolioStatus,
+    totalBalance
   );
 
   // Turnstile captcha gate for sign-in tab
@@ -1302,8 +1307,8 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
             >
               {displayTab === "portfolio" && (
                 <PortfolioContent
-                  balanceFraction={totalBalance.balanceFraction}
-                  balanceWhole={totalBalance.balanceWhole}
+                  balanceFraction={totalBalanceDisplay.balanceFraction}
+                  balanceWhole={totalBalanceDisplay.balanceWhole}
                   isBalanceHidden={props.isBalanceHidden}
                   isLoading={
                     props.walletDesktopData.isLoading &&
@@ -1332,8 +1337,12 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
                     handleSwapModeChange("shield");
                     pushView({ type: "swapPanel", mode: "shield" });
                   }}
+                  onWalletBalanceRetry={() => {
+                    void props.walletDesktopData.refresh();
+                  }}
                   onOpenVault={openVaultAccount}
                   onOpenAgent={openAgentPage}
+                  walletBalanceStatus={props.walletDesktopData.portfolioStatus}
                 />
               )}
               {displayTab === "receive" && (

--- a/frontend/src/components/wallet-sidebar/portfolio-content.tsx
+++ b/frontend/src/components/wallet-sidebar/portfolio-content.tsx
@@ -27,6 +27,10 @@ import type {
 import { useEarnForecastApy } from "@/hooks/use-earn-forecast-apy";
 import { formatEarnApyLabel } from "@/lib/kamino/earn-forecast.shared";
 import { getTokenIconUrl } from "@/lib/token-icon";
+import {
+  getPortfolioBalanceDisplay,
+  type PortfolioFreshness,
+} from "@/lib/wallet/portfolio-refresh-state";
 import { openAutodepositMockSheet } from "./autodeposit-mock-sheet";
 import { getVaultIcon } from "./vault-icon";
 
@@ -67,15 +71,15 @@ function getSmartAccountErrorCopy(error: string | null | undefined) {
   };
 }
 
-function SmartAccountInlineError({
-  error,
+function InlineRefreshNotice({
+  body,
   onRetry,
+  title,
 }: {
-  error: string | null | undefined;
+  body: string;
   onRetry?: () => void;
+  title: string;
 }) {
-  const copy = getSmartAccountErrorCopy(error);
-
   return (
     <div
       style={{
@@ -115,7 +119,7 @@ function SmartAccountInlineError({
               margin: 0,
             }}
           >
-            {copy.title}
+            {title}
           </p>
           <p
             style={{
@@ -126,7 +130,7 @@ function SmartAccountInlineError({
               margin: "4px 0 0",
             }}
           >
-            {copy.body}
+            {body}
           </p>
         </div>
       </div>
@@ -152,6 +156,24 @@ function SmartAccountInlineError({
         </button>
       ) : null}
     </div>
+  );
+}
+
+function SmartAccountInlineError({
+  error,
+  onRetry,
+}: {
+  error: string | null | undefined;
+  onRetry?: () => void;
+}) {
+  const copy = getSmartAccountErrorCopy(error);
+
+  return (
+    <InlineRefreshNotice
+      body={copy.body}
+      onRetry={onRetry}
+      title={copy.title}
+    />
   );
 }
 
@@ -1136,16 +1158,23 @@ function MockRootSignerRow({
 }
 
 function MainAccountRow({
+  balanceStatus,
   isBalanceHidden,
   isSelected,
   onOpen,
   signer,
 }: {
+  balanceStatus: PortfolioFreshness;
   isBalanceHidden: boolean;
   isSelected: boolean;
   onOpen: () => void;
   signer: SmartAccountSignerEntry;
 }) {
+  const balanceDisplay = getPortfolioBalanceDisplay(balanceStatus, {
+    balanceFraction: signer.balanceFraction,
+    balanceWhole: signer.balanceWhole,
+  });
+
   return (
     <button
       className="portfolio-account-row"
@@ -1203,14 +1232,16 @@ function MainAccountRow({
               display: "block",
             }}
           >
-            {signer.balanceWhole}
-            <span
-              style={{
-                color: isBalanceHidden ? "#BBBBC0" : "rgba(60, 60, 67, 0.4)",
-              }}
-            >
-              {signer.balanceFraction}
-            </span>
+            {balanceDisplay.balanceWhole}
+            {balanceStatus !== "unavailable" && (
+              <span
+                style={{
+                  color: isBalanceHidden ? "#BBBBC0" : "rgba(60, 60, 67, 0.4)",
+                }}
+              >
+                {balanceDisplay.balanceFraction}
+              </span>
+            )}
           </span>
         </div>
         <div
@@ -1283,6 +1314,7 @@ export function PortfolioContent({
   onOpenAddSigner,
   onOpenMockRootSigner,
   onSmartAccountRetry,
+  onWalletBalanceRetry,
   portfolioChange24h = null,
   earningsSummary = null,
   earnDepositLabel = "Deposit",
@@ -1308,6 +1340,7 @@ export function PortfolioContent({
   showMainAccountOnly = false,
   mockRootSigners = [],
   topInset = 0,
+  walletBalanceStatus = "current",
 }: {
   balanceFraction: string;
   balanceWhole: string;
@@ -1337,6 +1370,7 @@ export function PortfolioContent({
   onOpenAddSigner?: (accountIndex: number) => void;
   onOpenMockRootSigner?: (signer: MockRootSignerEntry) => void;
   onSmartAccountRetry?: () => void;
+  onWalletBalanceRetry?: () => void;
   portfolioChange24h?: WalletPortfolioChange24h | null;
   earningsSummary?: WalletEarningsSummary | null;
   earnDepositLabel?: string;
@@ -1360,6 +1394,7 @@ export function PortfolioContent({
   showMainAccountOnly?: boolean;
   mockRootSigners?: MockRootSignerEntry[];
   topInset?: number;
+  walletBalanceStatus?: PortfolioFreshness;
 }) {
   const [isScrolled, setIsScrolled] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -2056,6 +2091,22 @@ export function PortfolioContent({
         <div
           style={{ display: "flex", flexDirection: "column", padding: "8px" }}
         >
+          {walletBalanceStatus === "stale" ||
+          walletBalanceStatus === "unavailable" ? (
+            <InlineRefreshNotice
+              body={
+                walletBalanceStatus === "stale"
+                  ? "Showing your last confirmed wallet balances."
+                  : "Wallet balances are temporarily unavailable."
+              }
+              onRetry={onWalletBalanceRetry}
+              title={
+                walletBalanceStatus === "stale"
+                  ? "Balances may be out of date"
+                  : "Could not load balances"
+              }
+            />
+          ) : null}
           {onOpenEarn ? (
             <EarnPortfolioRow
               balance={earnBalance}
@@ -2103,6 +2154,7 @@ export function PortfolioContent({
                       style={{ display: "flex", flexDirection: "column" }}
                     >
                       <MainAccountRow
+                        balanceStatus={walletBalanceStatus}
                         isBalanceHidden={isBalanceHidden}
                         isSelected={selectedSignerId === mainSigner.id}
                         onOpen={() => onOpenAgent(mainSigner)}

--- a/frontend/src/components/wallet-sidebar/shield-content.tsx
+++ b/frontend/src/components/wallet-sidebar/shield-content.tsx
@@ -450,6 +450,7 @@ export function ShieldContent({
   const [isMaxSelected, setIsMaxSelected] = useState(false);
   const [phase, setPhase] = useState<ShieldPhase>("form");
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [isRetryableError, setIsRetryableError] = useState(false);
   const [resultAmount, setResultAmount] = useState("");
   const [resultUsd, setResultUsd] = useState("");
 
@@ -527,6 +528,7 @@ export function ShieldContent({
 
   useEffect(() => {
     setIsMaxSelected(false);
+    setIsRetryableError(false);
   }, [direction, token.mint]);
 
   const handleConfirm = useCallback(async () => {
@@ -540,6 +542,7 @@ export function ShieldContent({
       })}`
     );
     setErrorMessage(undefined);
+    setIsRetryableError(false);
     setPhase("processing");
 
     const params = {
@@ -575,6 +578,9 @@ export function ShieldContent({
         });
     } else {
       setErrorMessage(result.error);
+      setIsRetryableError(
+        direction === "unshield" && result.retryable !== false
+      );
       setPhase("error");
     }
   }, [
@@ -591,6 +597,17 @@ export function ShieldContent({
     usdValue,
     isMaxSelected,
   ]);
+
+  const handleRetry = useCallback(() => {
+    setErrorMessage(undefined);
+    setIsRetryableError(false);
+    setPhase("form");
+    void Promise.resolve()
+      .then(() => onSuccess?.())
+      .catch((error) => {
+        console.warn("Failed to refresh balances before retry", error);
+      });
+  }, [onSuccess]);
 
   // Report form button props to parent when chrome is managed externally
   useEffect(() => {
@@ -929,9 +946,35 @@ export function ShieldContent({
                 Transaction Details
               </button>
             )}
+            {!isSuccess && isRetryableError && (
+              <button
+                className="shield-done-btn"
+                onClick={handleRetry}
+                style={{
+                  width: "100%",
+                  padding: "12px 16px",
+                  borderRadius: "9999px",
+                  background: "#000",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: font,
+                  fontSize: "16px",
+                  fontWeight: 400,
+                  lineHeight: "20px",
+                  color: "#fff",
+                  textAlign: "center",
+                  transition: "background 0.15s ease",
+                }}
+                type="button"
+              >
+                Try again
+              </button>
+            )}
             <button
               className={
-                isSuccess ? "shield-done-secondary-btn" : "shield-done-btn"
+                isSuccess || isRetryableError
+                  ? "shield-done-secondary-btn"
+                  : "shield-done-btn"
               }
               onClick={() => {
                 setPhase("form");
@@ -941,14 +984,17 @@ export function ShieldContent({
                 width: "100%",
                 padding: "12px 16px",
                 borderRadius: "9999px",
-                background: isSuccess ? "rgba(0, 0, 0, 0.04)" : "#000",
+                background:
+                  isSuccess || isRetryableError
+                    ? "rgba(0, 0, 0, 0.04)"
+                    : "#000",
                 border: "none",
                 cursor: "pointer",
                 fontFamily: font,
                 fontSize: "16px",
                 fontWeight: 400,
                 lineHeight: "20px",
-                color: isSuccess ? "#000" : "#fff",
+                color: isSuccess || isRetryableError ? "#000" : "#fff",
                 textAlign: "center",
                 transition: "background 0.15s ease",
               }}

--- a/frontend/src/components/wallet-sidebar/wallet-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/wallet-detail-view.tsx
@@ -7,12 +7,14 @@ import {
   Check,
   ChevronRight,
   Copy,
+  RefreshCw,
   Repeat2,
 } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 
 import { useLoyalPriceUsd } from "@/hooks/use-loyal-price";
+import type { PortfolioFreshness } from "@/lib/wallet/portfolio-refresh-state";
 import { AccessLevelIcon, type AccessLevel } from "./agent-page-view";
 import { buildLoyalPlaceholderRow } from "./loyal-placeholder";
 import { SpendingLimitSection } from "./spending-limit-section";
@@ -76,6 +78,7 @@ export function WalletDetailView({
   icon,
   balanceWhole,
   balanceFraction,
+  balanceStatus = "current",
   isBalanceHidden,
   cashTokenRows,
   investmentTokenRows,
@@ -83,6 +86,7 @@ export function WalletDetailView({
   onOpenSend,
   onOpenSwap,
   onOpenShield,
+  onRetryBalance,
   onRemoveSigner,
   getTokenActions,
   onTokenDetail,
@@ -101,6 +105,7 @@ export function WalletDetailView({
   icon: string;
   balanceWhole: string;
   balanceFraction: string;
+  balanceStatus?: PortfolioFreshness;
   isBalanceHidden: boolean;
   tokenRows: TokenRow[];
   cashTokenRows: TokenRow[];
@@ -112,6 +117,7 @@ export function WalletDetailView({
   onOpenSend: () => void;
   onOpenSwap: () => void;
   onOpenShield: () => void;
+  onRetryBalance?: () => Promise<void> | void;
   onRemoveSigner?: () => void;
   getTokenActions?: (token: TokenRow) => TokenRowActions | undefined;
   onTokenDetail?: (token: TokenRow) => void;
@@ -407,6 +413,61 @@ export function WalletDetailView({
             </div>
           </div>
         </div>
+
+        {(balanceStatus === "stale" || balanceStatus === "unavailable") && (
+          <div
+            aria-live="polite"
+            style={{
+              alignItems: "center",
+              background: "rgba(249, 159, 54, 0.12)",
+              borderRadius: "12px",
+              display: "flex",
+              gap: "10px",
+              justifyContent: "space-between",
+              margin: "0 20px 8px",
+              padding: "10px 12px",
+            }}
+          >
+            <span
+              style={{
+                color: "rgba(60, 60, 67, 0.72)",
+                fontFamily: font,
+                fontSize: "13px",
+                lineHeight: "16px",
+              }}
+            >
+              {balanceStatus === "stale"
+                ? "Balances may be out of date."
+                : "Balances are temporarily unavailable."}
+            </span>
+            {onRetryBalance && (
+              <button
+                aria-label="Retry balance refresh"
+                onClick={() => {
+                  void onRetryBalance();
+                }}
+                style={{
+                  alignItems: "center",
+                  background: "transparent",
+                  border: "none",
+                  color: "#000",
+                  cursor: "pointer",
+                  display: "inline-flex",
+                  flexShrink: 0,
+                  fontFamily: font,
+                  fontSize: "13px",
+                  fontWeight: 600,
+                  gap: "5px",
+                  padding: "4px",
+                }}
+                type="button"
+              >
+                <RefreshCw aria-hidden="true" size={14} strokeWidth={2} />
+                Retry
+              </button>
+            )}
+          </div>
+        )}
 
         <div
           style={{

--- a/frontend/src/components/wallet-sidebar/wallet-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/wallet-detail-view.tsx
@@ -14,7 +14,10 @@ import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 
 import { useLoyalPriceUsd } from "@/hooks/use-loyal-price";
-import type { PortfolioFreshness } from "@/lib/wallet/portfolio-refresh-state";
+import {
+  shouldRenderPortfolioEmptyState,
+  type PortfolioFreshness,
+} from "@/lib/wallet/portfolio-refresh-state";
 import { AccessLevelIcon, type AccessLevel } from "./agent-page-view";
 import { buildLoyalPlaceholderRow } from "./loyal-placeholder";
 import { SpendingLimitSection } from "./spending-limit-section";
@@ -160,6 +163,8 @@ export function WalletDetailView({
     () => buildLoyalPlaceholderRow(loyalPriceUsd),
     [loyalPriceUsd]
   );
+  const showEmptyPortfolioState =
+    shouldRenderPortfolioEmptyState(balanceStatus);
 
   const copyAddress = async () => {
     if (!address) return;
@@ -940,28 +945,32 @@ export function WalletDetailView({
                 />
               ))}
 
-            {activeTab === "cash" && cashTokenRows.length === 0 && (
-              <div
-                style={{
-                  padding: "12px",
-                  textAlign: "left",
-                  fontFamily: font,
-                  fontSize: "14px",
-                  color: secondary,
-                  width: "100%",
-                }}
-              >
-                No cash yet
-              </div>
-            )}
+            {showEmptyPortfolioState &&
+              activeTab === "cash" &&
+              cashTokenRows.length === 0 && (
+                <div
+                  style={{
+                    padding: "12px",
+                    textAlign: "left",
+                    fontFamily: font,
+                    fontSize: "14px",
+                    color: secondary,
+                    width: "100%",
+                  }}
+                >
+                  No cash yet
+                </div>
+              )}
 
-            {activeTab === "investment" && investmentTokenRows.length === 0 && (
-              <TokenRowItem
-                isBalanceHidden={isBalanceHidden}
-                onDetail={onTokenDetail}
-                token={loyalPlaceholderRow}
-              />
-            )}
+            {showEmptyPortfolioState &&
+              activeTab === "investment" &&
+              investmentTokenRows.length === 0 && (
+                <TokenRowItem
+                  isBalanceHidden={isBalanceHidden}
+                  onDetail={onTokenDetail}
+                  token={loyalPlaceholderRow}
+                />
+              )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -193,6 +193,7 @@ import {
   getStablecoinMintSetForSolanaEnv,
   sumPublicStablecoinParValueUsd,
 } from "@/lib/wallet/stablecoin-classification";
+import { getPortfolioBalanceDisplay } from "@/lib/wallet/portfolio-refresh-state";
 import {
   getFrontendPrivateClient,
   hasReusableFrontendPrivateClientAuth,
@@ -3448,6 +3449,10 @@ export function AppWalletWorkspace({
           earnCurrentBalanceAmount
       ),
     [earnCurrentBalanceAmount, mainAccountDisplayUsd, smartAccountData.totalUsd]
+  );
+  const totalBalanceDisplay = getPortfolioBalanceDisplay(
+    walletDesktopData.portfolioStatus,
+    totalBalance
   );
   const swapTargetTokens = useMemo<SwapToken[]>(() => {
     const heldMints = new Set(
@@ -7589,16 +7594,21 @@ export function AppWalletWorkspace({
         : "00";
       const canUseWalletDetailData =
         canLoadPersonalAccount && !selectedMockRootSigner;
-      const walletDetailBalanceWhole =
-        selectedMockRootSigner?.balanceWhole ??
-        (isMainAccountDetail
-          ? mainAccountDisplayBalance.balanceWhole
-          : walletFallbackBalanceWhole);
-      const walletDetailBalanceFraction =
-        selectedMockRootSigner?.balanceFraction ??
-        (isMainAccountDetail
-          ? mainAccountDisplayBalance.balanceFraction
-          : walletFallbackBalanceFraction);
+      const walletDetailBalance = getPortfolioBalanceDisplay(
+        canUseWalletDetailData ? walletDesktopData.portfolioStatus : "current",
+        {
+          balanceFraction:
+            selectedMockRootSigner?.balanceFraction ??
+            (isMainAccountDetail
+              ? mainAccountDisplayBalance.balanceFraction
+              : walletFallbackBalanceFraction),
+          balanceWhole:
+            selectedMockRootSigner?.balanceWhole ??
+            (isMainAccountDetail
+              ? mainAccountDisplayBalance.balanceWhole
+              : walletFallbackBalanceWhole),
+        }
+      );
       const walletDetailTokenRows = canUseWalletDetailData
         ? personalWalletAllTokenRows
         : [];
@@ -7619,8 +7629,13 @@ export function AppWalletWorkspace({
         <WalletDetailView
           address={walletDetailAddress}
           activityRows={walletDetailActivityRows}
-          balanceFraction={walletDetailBalanceFraction}
-          balanceWhole={walletDetailBalanceWhole}
+          balanceFraction={walletDetailBalance.balanceFraction}
+          balanceStatus={
+            canUseWalletDetailData
+              ? walletDesktopData.portfolioStatus
+              : undefined
+          }
+          balanceWhole={walletDetailBalance.balanceWhole}
           cashTokenRows={walletDetailCashTokenRows}
           icon={walletDetailIcon}
           initialTab={detailInitialTab}
@@ -7650,6 +7665,7 @@ export function AppWalletWorkspace({
           onOpenShield={() => {
             handleOpenMainAccountShield();
           }}
+          onRetryBalance={refreshMainAccountBalances}
           onOpenSwap={() => {
             openActionView(
               { type: "swapPanel", mode: "swap" },
@@ -8583,8 +8599,8 @@ export function AppWalletWorkspace({
             ) : (
               <PortfolioContent
                 approvals={smartAccountData.approvals}
-                balanceFraction={totalBalance.balanceFraction}
-                balanceWhole={totalBalance.balanceWhole}
+                balanceFraction={totalBalanceDisplay.balanceFraction}
+                balanceWhole={totalBalanceDisplay.balanceWhole}
                 earnDepositLabel={canMutateAccount ? "Deposit" : "Connect"}
                 earnBalance={earnCurrentBalanceAmount}
                 hasEarnPolicy={hasEarnPolicy}
@@ -8613,6 +8629,9 @@ export function AppWalletWorkspace({
                 onOpenSend={() => handleRailAction("send")}
                 onOpenShield={() => handleRailAction("shield")}
                 onOpenSwap={() => handleRailAction("swap")}
+                onWalletBalanceRetry={() => {
+                  void refreshMainAccountBalances();
+                }}
                 onOpenEarnDeposit={
                   canMutateAccount ? handleOpenEarnDeposit : openSignIn
                 }
@@ -8664,6 +8683,7 @@ export function AppWalletWorkspace({
                 smartAccountError={smartAccountData.error}
                 topInset={47}
                 vaultEntries={smartAccountData.vaultEntries}
+                walletBalanceStatus={walletDesktopData.portfolioStatus}
                 portfolioChange24h={
                   canLoadPersonalAccount
                     ? walletDesktopData.portfolioChange24h

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -28,10 +28,12 @@ import {
   type FrontendPrivateClientSigner,
 } from "@/lib/solana/private-client-cache";
 import {
+  isRetryableUnshieldError,
   readDepositAmountFailClosed,
   runConfirmedUnshieldAttempt,
   UnshieldAttemptError,
 } from "@/lib/solana/unshield-recovery";
+import { runShieldAttemptWithOptionalAccounting } from "@/lib/solana/shield-recovery";
 
 function cleanSolanaErrorMessage(message: string): string {
   const logsIndex = message.indexOf("Logs:");
@@ -39,24 +41,6 @@ function cleanSolanaErrorMessage(message: string): string {
     return message.slice(0, logsIndex).trim();
   }
   return message;
-}
-
-function getNestedErrorText(error: unknown): string {
-  if (error instanceof Error) {
-    const cause =
-      "cause" in error
-        ? getNestedErrorText((error as Error & { cause?: unknown }).cause)
-        : "";
-    return `${error.name} ${error.message} ${cause}`.trim();
-  }
-
-  return typeof error === "string" ? error : "";
-}
-
-function isTransientSolanaConnectionError(error: unknown): boolean {
-  return /failed to fetch|network|socket|cors|connection|timeout/i.test(
-    getNestedErrorText(error)
-  );
 }
 
 function getLastSignature(
@@ -158,25 +142,33 @@ export function useShield() {
           publicEnv.solanaEnv
         );
         const isTrackedKaminoToken = trackedKaminoMint === tokenMint.toBase58();
-        const collateralSharesBefore = isTrackedKaminoToken
-          ? await getDepositAmount({ client, tokenMint, user })
-          : BigInt(0);
-
-        const plan = await client.buildShieldTokensTransactionPlan({
-          tokenMint,
-          amount: rawAmount,
-          user,
-          payer: user,
-        });
-        const executionResult = await client.executeShieldTokensTransactionPlan(
-          {
-            plan,
-          }
-        );
+        const { accountingBaseline, executionResult } =
+          await runShieldAttemptWithOptionalAccounting({
+            readAccountingBaseline: isTrackedKaminoToken
+              ? () => getDepositAmount({ client, tokenMint, user })
+              : undefined,
+            buildPlan: () =>
+              client.buildShieldTokensTransactionPlan({
+                tokenMint,
+                amount: rawAmount,
+                user,
+                payer: user,
+              }),
+            executePlan: (plan) =>
+              client.executeShieldTokensTransactionPlan({
+                plan,
+              }),
+            onAccountingReadError: (readError) => {
+              console.warn(
+                "Could not read Kamino USDC shield basis before execution; basis reconciliation will be skipped",
+                readError
+              );
+            },
+          });
 
         // Persist Kamino principal basis for tracked USDC so the "earned"
         // split on the portfolio can be computed without manual seeding.
-        if (isTrackedKaminoToken) {
+        if (isTrackedKaminoToken && accountingBaseline !== null) {
           try {
             const collateralSharesAfter = await getDepositAmount({
               client,
@@ -184,7 +176,7 @@ export function useShield() {
               user,
             });
             const addedCollateralSharesAmountRaw =
-              collateralSharesAfter - collateralSharesBefore;
+              collateralSharesAfter - accountingBaseline;
 
             if (addedCollateralSharesAmountRaw > BigInt(0)) {
               recordKaminoUsdcShield({
@@ -350,10 +342,11 @@ export function useShield() {
         }
         const userRejected =
           err instanceof Error && /user rejected/i.test(err.message);
+        const retryable = isRetryableUnshieldError(err);
         let errorMessage = "Unshield failed";
         if (userRejected) {
           errorMessage = "Transaction was rejected in your wallet.";
-        } else if (isTransientSolanaConnectionError(err)) {
+        } else if (retryable) {
           errorMessage =
             "Loyal could not confirm the unshield. Check your connection and try again; retry reads the live shielded balance first.";
         } else if (err instanceof Error) {
@@ -375,7 +368,7 @@ export function useShield() {
         return {
           success: false,
           error: errorMessage,
-          retryable: !userRejected,
+          retryable,
         };
       }
     },

--- a/frontend/src/hooks/use-shield.ts
+++ b/frontend/src/hooks/use-shield.ts
@@ -1,5 +1,6 @@
 import {
   type ShieldFlowExecutionResult,
+  findDepositPda,
   LoyalPrivateTransactionsClient,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
@@ -26,6 +27,11 @@ import {
   invalidateFrontendPrivateClientForError,
   type FrontendPrivateClientSigner,
 } from "@/lib/solana/private-client-cache";
+import {
+  readDepositAmountFailClosed,
+  runConfirmedUnshieldAttempt,
+  UnshieldAttemptError,
+} from "@/lib/solana/unshield-recovery";
 
 function cleanSolanaErrorMessage(message: string): string {
   const logsIndex = message.indexOf("Logs:");
@@ -33,6 +39,24 @@ function cleanSolanaErrorMessage(message: string): string {
     return message.slice(0, logsIndex).trim();
   }
   return message;
+}
+
+function getNestedErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    const cause =
+      "cause" in error
+        ? getNestedErrorText((error as Error & { cause?: unknown }).cause)
+        : "";
+    return `${error.name} ${error.message} ${cause}`.trim();
+  }
+
+  return typeof error === "string" ? error : "";
+}
+
+function isTransientSolanaConnectionError(error: unknown): boolean {
+  return /failed to fetch|network|socket|cors|connection|timeout/i.test(
+    getNestedErrorText(error)
+  );
 }
 
 function getLastSignature(
@@ -47,18 +71,21 @@ async function getDepositAmount(params: {
   user: PublicKey;
 }): Promise<bigint> {
   const { client, tokenMint, user } = params;
-  const [ephemeralDeposit, baseDeposit] = await Promise.all([
-    client.getEphemeralDeposit(user, tokenMint).catch(() => null),
-    client.getBaseDeposit(user, tokenMint).catch(() => null),
-  ]);
+  const [depositPda] = findDepositPda(user, tokenMint);
 
-  return ephemeralDeposit?.amount ?? baseDeposit?.amount ?? BigInt(0);
+  return readDepositAmountFailClosed({
+    readEphemeral: () =>
+      client.ephemeralProgram.account.deposit.fetchNullable(depositPda),
+    readBase: () =>
+      client.baseProgram.account.deposit.fetchNullable(depositPda),
+  });
 }
 
 export type ShieldResult = {
   signature?: string;
   success: boolean;
   error?: string;
+  retryable?: boolean;
 };
 
 export function useShield() {
@@ -150,28 +177,28 @@ export function useShield() {
         // Persist Kamino principal basis for tracked USDC so the "earned"
         // split on the portfolio can be computed without manual seeding.
         if (isTrackedKaminoToken) {
-          const collateralSharesAfter = await getDepositAmount({
-            client,
-            tokenMint,
-            user,
-          });
-          const addedCollateralSharesAmountRaw =
-            collateralSharesAfter - collateralSharesBefore;
+          try {
+            const collateralSharesAfter = await getDepositAmount({
+              client,
+              tokenMint,
+              user,
+            });
+            const addedCollateralSharesAmountRaw =
+              collateralSharesAfter - collateralSharesBefore;
 
-          if (addedCollateralSharesAmountRaw > BigInt(0)) {
-            try {
+            if (addedCollateralSharesAmountRaw > BigInt(0)) {
               recordKaminoUsdcShield({
                 publicKey: user.toBase58(),
                 solanaEnv: publicEnv.solanaEnv,
                 addedPrincipalLiquidityAmountRaw: rawAmount,
                 addedCollateralSharesAmountRaw,
               });
-            } catch (persistError) {
-              console.warn(
-                "Failed to persist Kamino USDC shield basis",
-                persistError
-              );
             }
+          } catch (persistError) {
+            console.warn(
+              "Failed to reconcile Kamino USDC shield basis",
+              persistError
+            );
           }
         }
 
@@ -248,66 +275,71 @@ export function useShield() {
         const isTrackedKaminoToken = trackedKaminoMint === tokenMint.toBase58();
         const wantsMax = params.isMax === true;
 
-        const collateralSharesBefore = isTrackedKaminoToken
-          ? await getDepositAmount({ client, tokenMint, user })
-          : BigInt(0);
-
         const requestedRawAmount = rawAmount;
-        const quotedShares =
-          isTrackedKaminoToken && !wantsMax
-            ? await client.getKaminoCollateralSharesForLiquidityAmount({
-                tokenMint,
-                liquidityAmountRaw: requestedRawAmount,
-              })
-            : null;
-        const planAmount = computeUnshieldModifyAmount({
-          currentDepositRaw: collateralSharesBefore,
-          isMax: wantsMax,
-          isTrackedKaminoToken,
-          kaminoQuotedShares: quotedShares,
-          requestedRawAmount,
-        });
+        let collateralSharesBefore = BigInt(0);
+        const attempt = await runConfirmedUnshieldAttempt({
+          resolveAmount: async () => {
+            collateralSharesBefore = isTrackedKaminoToken
+              ? await getDepositAmount({ client, tokenMint, user })
+              : BigInt(0);
+            const quotedShares =
+              isTrackedKaminoToken && !wantsMax
+                ? await client.getKaminoCollateralSharesForLiquidityAmount({
+                    tokenMint,
+                    liquidityAmountRaw: requestedRawAmount,
+                  })
+                : null;
 
-        const plan = await client.buildUnshieldTokensTransactionPlan({
-          tokenMint,
-          amount: planAmount,
-          user,
-          payer: user,
-          magicProgram: MAGIC_PROGRAM_ID,
-          magicContext: MAGIC_CONTEXT_ID,
+            return computeUnshieldModifyAmount({
+              currentDepositRaw: collateralSharesBefore,
+              isMax: wantsMax,
+              isTrackedKaminoToken,
+              kaminoQuotedShares: quotedShares,
+              requestedRawAmount,
+            });
+          },
+          buildPlan: (amount) =>
+            client.buildUnshieldTokensTransactionPlan({
+              tokenMint,
+              amount,
+              user,
+              payer: user,
+              magicProgram: MAGIC_PROGRAM_ID,
+              magicContext: MAGIC_CONTEXT_ID,
+            }),
+          executePlan: (plan) =>
+            client.executeUnshieldTokensTransactionPlan({
+              plan,
+            }),
         });
-        const executionResult =
-          await client.executeUnshieldTokensTransactionPlan({
-            plan,
-          });
 
         if (isTrackedKaminoToken) {
-          const collateralSharesAfter = await getDepositAmount({
-            client,
-            tokenMint,
-            user,
-          });
-          const burnedCollateralSharesAmountRaw =
-            collateralSharesBefore - collateralSharesAfter;
+          try {
+            const collateralSharesAfter = await getDepositAmount({
+              client,
+              tokenMint,
+              user,
+            });
+            const burnedCollateralSharesAmountRaw =
+              collateralSharesBefore - collateralSharesAfter;
 
-          if (burnedCollateralSharesAmountRaw > BigInt(0)) {
-            try {
+            if (burnedCollateralSharesAmountRaw > BigInt(0)) {
               recordKaminoUsdcUnshield({
                 publicKey: user.toBase58(),
                 solanaEnv: publicEnv.solanaEnv,
                 burnedCollateralSharesAmountRaw,
               });
-            } catch (persistError) {
-              console.warn(
-                "Failed to persist Kamino USDC unshield basis",
-                persistError
-              );
             }
+          } catch (persistError) {
+            console.warn(
+              "Failed to reconcile Kamino USDC unshield basis",
+              persistError
+            );
           }
         }
 
         setLoading(false);
-        return { success: true, signature: getLastSignature(executionResult) };
+        return { success: true, signature: attempt.signature };
       } catch (err) {
         if (wallet.publicKey) {
           invalidateFrontendPrivateClientForError({
@@ -316,15 +348,35 @@ export function useShield() {
             error: err,
           });
         }
+        const userRejected =
+          err instanceof Error && /user rejected/i.test(err.message);
         let errorMessage = "Unshield failed";
-        if (err instanceof Error) {
-          errorMessage = err.message.includes("User rejected")
-            ? "Transaction was rejected in your wallet."
-            : cleanSolanaErrorMessage(err.message);
+        if (userRejected) {
+          errorMessage = "Transaction was rejected in your wallet.";
+        } else if (isTransientSolanaConnectionError(err)) {
+          errorMessage =
+            "Loyal could not confirm the unshield. Check your connection and try again; retry reads the live shielded balance first.";
+        } else if (err instanceof Error) {
+          errorMessage = cleanSolanaErrorMessage(err.message);
+        }
+        if (wallet.publicKey) {
+          console.error("[wallet-unshield] attempt failed", {
+            errorMessage,
+            errorName: err instanceof Error ? err.name : "UnknownError",
+            isMax: params.isMax === true,
+            stage: err instanceof UnshieldAttemptError ? err.stage : "unknown",
+            tokenMint: params.tokenMint ?? null,
+            tokenSymbol: params.tokenSymbol,
+            walletAddress: wallet.publicKey.toBase58(),
+          });
         }
         setError(errorMessage);
         setLoading(false);
-        return { success: false, error: errorMessage };
+        return {
+          success: false,
+          error: errorMessage,
+          retryable: !userRejected,
+        };
       }
     },
     [

--- a/frontend/src/hooks/use-wallet-desktop-data.ts
+++ b/frontend/src/hooks/use-wallet-desktop-data.ts
@@ -36,6 +36,13 @@ import {
   getStablecoinMintSetForSolanaEnv,
   isStablecoinMint,
 } from "@/lib/wallet/stablecoin-classification";
+import {
+  createPortfolioRefreshState,
+  getPortfolioFreshness,
+  markPortfolioRefreshFailed,
+  markPortfolioRefreshSucceeded,
+  type PortfolioFreshness,
+} from "@/lib/wallet/portfolio-refresh-state";
 
 import { useSolanaWalletDataClient } from "./use-solana-wallet-data-client";
 
@@ -77,6 +84,8 @@ export type WalletDesktopData = {
   balanceHistory: BalanceHistoryPoint[];
   earningsSummary: WalletEarningsSummary | null;
   portfolioChange24h: WalletPortfolioChange24h | null;
+  portfolioError: string | null;
+  portfolioStatus: PortfolioFreshness;
   loadActivity: () => Promise<void>;
   refresh: (isCurrent?: () => boolean) => Promise<void>;
   addLocalActivity: (row: ActivityRow, detail: TransactionDetail) => void;
@@ -586,8 +595,10 @@ export function useWalletDesktopData(
       return null;
     }
   }, [wallet.publicKey, walletAddress]);
-  const [portfolioSnapshot, setPortfolioSnapshot] =
-    useState<PortfolioSnapshot | null>(null);
+  const [portfolioRefreshState, setPortfolioRefreshState] = useState(() =>
+    createPortfolioRefreshState<PortfolioSnapshot>()
+  );
+  const portfolioSnapshot = portfolioRefreshState.snapshot;
   const [earningsByMint, setEarningsByMint] = useState<
     ReadonlyMap<string, KaminoEarnings>
   >(EMPTY_EARNINGS_BY_MINT);
@@ -613,7 +624,9 @@ export function useWalletDesktopData(
       walletAddress: string;
       persist?: boolean;
     }) => {
-      setPortfolioSnapshot(args.portfolioSnapshot);
+      setPortfolioRefreshState(
+        markPortfolioRefreshSucceeded(args.portfolioSnapshot)
+      );
       setEarningsByMint(args.earningsByMint);
       setEarningsSummary(args.earningsSummary);
 
@@ -760,6 +773,11 @@ export function useWalletDesktopData(
           })
           .catch((error) => {
             console.error("Failed to refresh wallet portfolio", error);
+            if (ownerAddressRef.current === address && isCurrent()) {
+              setPortfolioRefreshState((current) =>
+                markPortfolioRefreshFailed(current, error)
+              );
+            }
           })
       );
 
@@ -802,7 +820,7 @@ export function useWalletDesktopData(
 
   useEffect(() => {
     if (!ownerPublicKey) {
-      setPortfolioSnapshot(null);
+      setPortfolioRefreshState(createPortfolioRefreshState());
       setEarningsByMint(EMPTY_EARNINGS_BY_MINT);
       setEarningsSummary(null);
       setActivities([]);
@@ -828,7 +846,7 @@ export function useWalletDesktopData(
         persist: false,
       });
     } else {
-      setPortfolioSnapshot(null);
+      setPortfolioRefreshState(createPortfolioRefreshState());
       setEarningsByMint(EMPTY_EARNINGS_BY_MINT);
       setEarningsSummary(null);
     }
@@ -863,6 +881,9 @@ export function useWalletDesktopData(
       .catch((error) => {
         console.error("Failed to load wallet desktop data", error);
         if (!cancelled) {
+          setPortfolioRefreshState((current) =>
+            markPortfolioRefreshFailed(current, error)
+          );
           setIsLoading(false);
         }
       });
@@ -917,6 +938,11 @@ export function useWalletDesktopData(
       })
       .catch((error) => {
         console.error("Failed to subscribe to wallet portfolio", error);
+        if (!closed) {
+          setPortfolioRefreshState((current) =>
+            markPortfolioRefreshFailed(current, error)
+          );
+        }
       });
 
     if (hasRequestedActivity) {
@@ -1339,6 +1365,10 @@ export function useWalletDesktopData(
   ]);
 
   const balance = splitUsdBalance(totals.totalUsd);
+  const portfolioStatus = getPortfolioFreshness(
+    portfolioRefreshState,
+    isLoading
+  );
   const walletLabel = walletAddress
     ? `${
         { mainnet: "Mainnet", devnet: "Devnet", localnet: "Localnet" }[
@@ -1377,6 +1407,8 @@ export function useWalletDesktopData(
     balanceHistory,
     earningsSummary,
     portfolioChange24h,
+    portfolioError: portfolioRefreshState.error,
+    portfolioStatus,
     loadActivity,
     refresh,
     addLocalActivity,

--- a/frontend/src/lib/solana/shield-recovery.ts
+++ b/frontend/src/lib/solana/shield-recovery.ts
@@ -1,0 +1,27 @@
+export async function runShieldAttemptWithOptionalAccounting<
+  TPlan,
+  TExecutionResult
+>(args: {
+  readAccountingBaseline?: () => Promise<bigint>;
+  buildPlan: () => Promise<TPlan>;
+  executePlan: (plan: TPlan) => Promise<TExecutionResult>;
+  onAccountingReadError?: (error: unknown) => void;
+}): Promise<{
+  accountingBaseline: bigint | null;
+  executionResult: TExecutionResult;
+}> {
+  let accountingBaseline: bigint | null = null;
+
+  if (args.readAccountingBaseline) {
+    try {
+      accountingBaseline = await args.readAccountingBaseline();
+    } catch (error) {
+      args.onAccountingReadError?.(error);
+    }
+  }
+
+  const plan = await args.buildPlan();
+  const executionResult = await args.executePlan(plan);
+
+  return { accountingBaseline, executionResult };
+}

--- a/frontend/src/lib/solana/unshield-recovery.ts
+++ b/frontend/src/lib/solana/unshield-recovery.ts
@@ -36,6 +36,41 @@ function getErrorMessage(error: unknown): string {
   return "Unknown error";
 }
 
+function getNestedErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    const cause =
+      "cause" in error
+        ? getNestedErrorText((error as Error & { cause?: unknown }).cause)
+        : "";
+    return `${error.name} ${error.message} ${cause}`.trim();
+  }
+
+  return typeof error === "string" ? error : "";
+}
+
+export function isRetryableUnshieldError(error: unknown): boolean {
+  const errorText = getNestedErrorText(error);
+  if (/user rejected/i.test(errorText)) {
+    return false;
+  }
+
+  const transientPatterns = [
+    /failed to fetch|fetch failed/i,
+    /network(?:error| request failed)/i,
+    /socket (?:closed|hang up|not connected)/i,
+    /\b(?:econnreset|econnrefused|enotfound|err_socket_not_connected|err_connection_refused)\b/i,
+    /cors/i,
+    /connection (?:closed|refused|reset|timed out)/i,
+    /\btimeout(?:error)?\b|\btimed out\b/i,
+    /websocket .*failed/i,
+    /rpc .*?(?:transport|unavailable|timeout)/i,
+    /(?:http|status) (?:408|425|429|500|502|503|504)\b/i,
+    /too many requests|service unavailable|gateway timeout/i,
+  ];
+
+  return transientPatterns.some((pattern) => pattern.test(errorText));
+}
+
 async function runStage<T>(
   stage: UnshieldAttemptStage,
   description: string,

--- a/frontend/src/lib/solana/unshield-recovery.ts
+++ b/frontend/src/lib/solana/unshield-recovery.ts
@@ -1,0 +1,143 @@
+import type { ShieldFlowExecutionResult } from "@loyal-labs/private-transactions";
+
+export type UnshieldAttemptStage =
+  | "read-deposit"
+  | "build-plan"
+  | "execute-plan"
+  | "confirm-base";
+
+type DepositAmountAccount = {
+  amount: {
+    toString(): string;
+  };
+};
+
+export class UnshieldAttemptError extends Error {
+  readonly cause: unknown;
+  readonly stage: UnshieldAttemptStage;
+
+  constructor(stage: UnshieldAttemptStage, message: string, cause?: unknown) {
+    super(message);
+    this.name = "UnshieldAttemptError";
+    this.stage = stage;
+    this.cause = cause;
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+
+  return "Unknown error";
+}
+
+async function runStage<T>(
+  stage: UnshieldAttemptStage,
+  description: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof UnshieldAttemptError) {
+      throw error;
+    }
+
+    throw new UnshieldAttemptError(
+      stage,
+      `${description}: ${getErrorMessage(error)}`,
+      error
+    );
+  }
+}
+
+export async function readDepositAmountFailClosed(args: {
+  readEphemeral: () => Promise<DepositAmountAccount | null>;
+  readBase: () => Promise<DepositAmountAccount | null>;
+}): Promise<bigint> {
+  const [ephemeralRead, baseRead] = await Promise.allSettled([
+    args.readEphemeral(),
+    args.readBase(),
+  ]);
+
+  if (ephemeralRead.status === "fulfilled" && ephemeralRead.value) {
+    return BigInt(ephemeralRead.value.amount.toString());
+  }
+  if (baseRead.status === "fulfilled" && baseRead.value) {
+    return BigInt(baseRead.value.amount.toString());
+  }
+  if (ephemeralRead.status === "fulfilled" && baseRead.status === "fulfilled") {
+    return BigInt(0);
+  }
+
+  const failure =
+    ephemeralRead.status === "rejected"
+      ? ephemeralRead.reason
+      : baseRead.status === "rejected"
+      ? baseRead.reason
+      : undefined;
+  throw failure instanceof Error
+    ? failure
+    : new Error("Could not read the current shielded balance");
+}
+
+export function getConfirmedBaseUnshieldSignature(
+  result: ShieldFlowExecutionResult
+): string {
+  const confirmedBaseTransaction = result.signatures.findLast(
+    (entry) =>
+      entry.cluster === "base" &&
+      entry.label === "unshield" &&
+      entry.signature.trim().length > 0
+  );
+
+  if (!confirmedBaseTransaction) {
+    throw new UnshieldAttemptError(
+      "confirm-base",
+      "Unshield did not return a confirmed base-layer signature"
+    );
+  }
+
+  return confirmedBaseTransaction.signature;
+}
+
+export async function runConfirmedUnshieldAttempt<TPlan>(args: {
+  resolveAmount: () => Promise<bigint>;
+  buildPlan: (amount: bigint) => Promise<TPlan>;
+  executePlan: (plan: TPlan) => Promise<ShieldFlowExecutionResult>;
+}): Promise<{
+  amount: bigint;
+  executionResult: ShieldFlowExecutionResult;
+  signature: string;
+}> {
+  const amount = await runStage(
+    "read-deposit",
+    "Could not read the current shielded balance",
+    args.resolveAmount
+  );
+  if (amount <= BigInt(0)) {
+    throw new UnshieldAttemptError(
+      "read-deposit",
+      "No shielded balance is available to unshield"
+    );
+  }
+
+  const plan = await runStage(
+    "build-plan",
+    "Could not prepare the unshield transaction",
+    () => args.buildPlan(amount)
+  );
+  const executionResult = await runStage(
+    "execute-plan",
+    "Could not execute the unshield transaction",
+    () => args.executePlan(plan)
+  );
+  const signature = getConfirmedBaseUnshieldSignature(executionResult);
+
+  return { amount, executionResult, signature };
+}

--- a/frontend/src/lib/wallet/portfolio-refresh-state.ts
+++ b/frontend/src/lib/wallet/portfolio-refresh-state.ts
@@ -64,3 +64,9 @@ export function getPortfolioBalanceDisplay(
     ? { balanceFraction: "", balanceWhole: "$—" }
     : confirmed;
 }
+
+export function shouldRenderPortfolioEmptyState(
+  freshness: PortfolioFreshness
+): boolean {
+  return freshness !== "unavailable";
+}

--- a/frontend/src/lib/wallet/portfolio-refresh-state.ts
+++ b/frontend/src/lib/wallet/portfolio-refresh-state.ts
@@ -1,0 +1,66 @@
+export type PortfolioFreshness =
+  | "loading"
+  | "current"
+  | "stale"
+  | "unavailable";
+
+export type PortfolioRefreshState<TSnapshot> = {
+  error: string | null;
+  snapshot: TSnapshot | null;
+};
+
+export type PortfolioBalanceDisplay = {
+  balanceFraction: string;
+  balanceWhole: string;
+};
+
+export function createPortfolioRefreshState<TSnapshot>(
+  snapshot: TSnapshot | null = null
+): PortfolioRefreshState<TSnapshot> {
+  return { error: null, snapshot };
+}
+
+export function markPortfolioRefreshSucceeded<TSnapshot>(
+  snapshot: TSnapshot
+): PortfolioRefreshState<TSnapshot> {
+  return { error: null, snapshot };
+}
+
+export function markPortfolioRefreshFailed<TSnapshot>(
+  current: PortfolioRefreshState<TSnapshot>,
+  error: unknown
+): PortfolioRefreshState<TSnapshot> {
+  const message =
+    error instanceof Error && error.message.trim()
+      ? error.message.trim()
+      : "Wallet balances could not be refreshed";
+
+  return {
+    error: message,
+    snapshot: current.snapshot,
+  };
+}
+
+export function getPortfolioFreshness<TSnapshot>(
+  state: PortfolioRefreshState<TSnapshot>,
+  isLoading: boolean
+): PortfolioFreshness {
+  if (state.error) {
+    return state.snapshot ? "stale" : "unavailable";
+  }
+
+  if (isLoading && !state.snapshot) {
+    return "loading";
+  }
+
+  return "current";
+}
+
+export function getPortfolioBalanceDisplay(
+  freshness: PortfolioFreshness,
+  confirmed: PortfolioBalanceDisplay
+): PortfolioBalanceDisplay {
+  return freshness === "unavailable"
+    ? { balanceFraction: "", balanceWhole: "$—" }
+    : confirmed;
+}

--- a/packages/solana-wallet/src/client.ts
+++ b/packages/solana-wallet/src/client.ts
@@ -230,19 +230,14 @@ export function createSolanaWalletDataClient(
     const loader = (async () => {
       const assetSnapshot = await assetProvider.getAssetSnapshot(owner);
       const secureBalances: SecureBalanceMap = config.secureBalanceProvider
-        ? await config
-            .secureBalanceProvider({
-              owner,
-              env,
-              tokenMints: assetSnapshot.assets.map(
-                (assetBalance) => new PublicKey(assetBalance.asset.mint)
-              ),
-              assetBalances: assetSnapshot.assets,
-            })
-            .catch((error) => {
-              logger.warn?.("Failed to fetch secure balances", error);
-              return new Map<string, bigint>();
-            })
+        ? await config.secureBalanceProvider({
+            owner,
+            env,
+            tokenMints: assetSnapshot.assets.map(
+              (assetBalance) => new PublicKey(assetBalance.asset.mint)
+            ),
+            assetBalances: assetSnapshot.assets,
+          })
         : new Map<string, bigint>();
 
       const shieldedOnly = await resolveShieldedOnlyAssets({

--- a/sdk/private-transactions/src/enumerate-deposits.ts
+++ b/sdk/private-transactions/src/enumerate-deposits.ts
@@ -158,6 +158,7 @@ export async function enumerateDepositsByUser(args: {
     ]);
 
   const byPda = new Map<string, DepositData>();
+  const failures: Array<{ source: string; reason: unknown }> = [];
 
   const ingestAnchor = (
     results: Array<{
@@ -189,6 +190,10 @@ export async function enumerateDepositsByUser(args: {
   if (baseUndelegatedResult.status === "fulfilled") {
     ingestAnchor(baseUndelegatedResult.value, /* preferOverwrite */ false);
   } else {
+    failures.push({
+      source: "base undelegated",
+      reason: baseUndelegatedResult.reason,
+    });
     console.warn(
       "[enumerateDepositsByUser] base undelegated enumeration failed",
       baseUndelegatedResult.reason
@@ -201,6 +206,10 @@ export async function enumerateDepositsByUser(args: {
   if (baseDelegatedResult.status === "fulfilled") {
     ingestRaw(baseDelegatedResult.value, /* preferOverwrite */ true);
   } else {
+    failures.push({
+      source: "base delegated",
+      reason: baseDelegatedResult.reason,
+    });
     console.warn(
       "[enumerateDepositsByUser] base delegated enumeration failed",
       baseDelegatedResult.reason
@@ -210,10 +219,23 @@ export async function enumerateDepositsByUser(args: {
   if (ephemeralResult.status === "fulfilled" && ephemeralProgram) {
     ingestAnchor(ephemeralResult.value, /* preferOverwrite */ true);
   } else if (ephemeralProgram && ephemeralResult.status === "rejected") {
+    failures.push({
+      source: "ephemeral",
+      reason: ephemeralResult.reason,
+    });
     console.warn(
       "[enumerateDepositsByUser] ephemeral enumeration failed",
       ephemeralResult.reason
     );
+  }
+
+  if (failures.length > 0) {
+    const sourceNames = failures.map(({ source }) => source).join(", ");
+    const error = new Error(
+      `Could not enumerate complete private deposits; failed sources: ${sourceNames}`
+    );
+    (error as Error & { cause?: unknown }).cause = failures[0]?.reason;
+    throw error;
   }
 
   return Array.from(byPda.values());


### PR DESCRIPTION
## Summary

- fail closed when an unshield attempt cannot produce a confirmed base-layer `unshield` signature
- re-read strict live deposit state for every MAX attempt so an interrupted flow can be retried without stale amounts or a double decrease
- preserve the last confirmed portfolio on RPC refresh failures; render unknown balances as `$—` and expose Retry instead of showing authoritative `$0.00`
- add the verifier-first ASK-1865 regression script and acceptance document

## Root cause

On the ASK-1845 preview, the second shield transaction landed, but concurrent base RPC/WebSocket failures interrupted the following unshield/portfolio refresh. No second base-layer unshield transaction landed. Legacy deposit reads converted RPC failures to `null`, while an unavailable portfolio could be presented as an empty/zero wallet.

## Verification

- `cd frontend && bun run verify:max-unshield-recovery`
- `cd frontend && bun run lint` (passes with existing repository warnings)
- `cd frontend && bunx tsc --noEmit --incremental false`
- `git diff --check`
- staged diff checked for unrelated files, Cyrillic, and secret-like material

A local frontend production build was intentionally not run because this checkout explicitly forbids it; Vercel remains the build/deploy gate.

Linear: [ASK-1865](https://linear.app/askloyal/issue/ASK-1865/frontend-recover-max-unshield-after-rpc-interruption)
Related: ASK-1845