### PR TITLE
fix(mobile): classify wallet-session failures instead of request_failed

### DIFF
--- a/mobile/src/lib/solana/earn/earn-api.ts
+++ b/mobile/src/lib/solana/earn/earn-api.ts
@@ -1124,14 +1124,19 @@ export async function confirmEarnDepositSponsored(
     }
     return payload.sponsoredConfirmations;
   }
+  // Both throws carry `res.status`: the backend did answer, and telemetry
+  // reads a missing status as "no response was ever received".
   if (!res.ok) {
     throw new EarnApiError(
       payload?.error?.message ?? "Failed to execute sponsored Earn deposit.",
       payload?.error?.code,
+      res.status,
     );
   }
   throw new EarnApiError(
     "Sponsored Earn deposit response is missing confirmations.",
+    undefined,
+    res.status,
   );
 }
 

--- a/mobile/src/lib/solana/earn/earn-api.ts
+++ b/mobile/src/lib/solana/earn/earn-api.ts
@@ -79,14 +79,19 @@ export function earnHeaders(flowId?: string): Record<string, string> {
 }
 
 // Carries the backend's error `code` so flows can react to specific failures
-// (e.g. re-sign a fresh auth message on `stale_mobile_auth`).
+// (e.g. re-sign a fresh auth message on `stale_mobile_auth`), plus the response
+// `status` when one arrived. Telemetry reports `status` as `httpStatus`, which
+// is what separates a real backend failure from an error raised with no
+// response at all (ASK-1872).
 export class EarnApiError extends Error {
   readonly code?: string;
+  readonly status?: number;
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, code?: string, status?: number) {
     super(message);
     this.name = "EarnApiError";
     this.code = code;
+    this.status = status;
   }
 }
 
@@ -97,6 +102,7 @@ async function throwEarnError(res: Response, fallback: string): Promise<never> {
   throw new EarnApiError(
     payload?.error?.message ?? fallback,
     payload?.error?.code,
+    res.status,
   );
 }
 
@@ -338,12 +344,13 @@ export async function fetchEarnWithdrawPrepareContext(args: {
   amountRaw: string;
   mode: EarnWithdrawMode;
   source?: EarnWithdrawSource;
+  flowId?: string;
 }): Promise<EarnWithdrawPrepareContext | null> {
   const res = await fetch(
     `${env.earnApiBaseUrl}/api/smart-accounts/mobile/earn/withdraw/prepare-context`,
     {
       method: "POST",
-      headers: earnHeaders(),
+      headers: earnHeaders(args.flowId),
       body: JSON.stringify({
         ...args.auth,
         amountRaw: args.amountRaw,
@@ -383,12 +390,13 @@ export type EarnWithdrawCleanupPrepareContext = {
 export async function fetchEarnWithdrawCleanupPrepareContext(args: {
   auth: EarnAuthFields;
   minContextSlot: string;
+  flowId?: string;
 }): Promise<EarnWithdrawCleanupPrepareContext> {
   const res = await fetch(
     `${env.earnApiBaseUrl}/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context`,
     {
       method: "POST",
-      headers: earnHeaders(),
+      headers: earnHeaders(args.flowId),
       body: JSON.stringify({
         ...args.auth,
         minContextSlot: args.minContextSlot,

--- a/mobile/src/lib/solana/earn/withdraw.ts
+++ b/mobile/src/lib/solana/earn/withdraw.ts
@@ -259,6 +259,7 @@ async function fetchCleanupContextWithRetry(args: {
   signer: Signer;
   prepareAuth: EarnAuthFields;
   minContextSlot: string;
+  flowId: string;
 }): Promise<EarnWithdrawCleanupPrepareContext> {
   return retryEarnApiCall({
     attempts: CLEANUP_CONTEXT_ATTEMPTS,
@@ -272,6 +273,7 @@ async function fetchCleanupContextWithRetry(args: {
         (auth) =>
           fetchEarnWithdrawCleanupPrepareContext({
             auth,
+            flowId: args.flowId,
             minContextSlot: args.minContextSlot,
           }),
       ),
@@ -415,6 +417,7 @@ async function runEarnWithdraw(
         fetchEarnWithdrawPrepareContext({
           auth,
           amountRaw,
+          flowId: flow.flowId,
           mode: args.mode,
           source: args.source ?? null,
         }),
@@ -499,6 +502,7 @@ async function runEarnWithdraw(
     let cleanupSignature: string | undefined;
     try {
       const cleanupContext = await fetchCleanupContextWithRetry({
+        flowId: flow.flowId,
         signer: args.signer,
         prepareAuth,
         minContextSlot,

--- a/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -1,0 +1,173 @@
+// Guards the MWA rejection → failure-reason mapping behind ASK-1872. The
+// native module signals every session problem with a string `code`, and
+// lifecycle telemetry maps any coded error to `request_failed` — so an
+// unreachable wallet paged on-call as an HTTP failure that never happened.
+// Nothing in the type system catches a regression: every code is a valid
+// string, so the classification is asserted directly against the codes
+// SolanaMobileWalletAdapterModule.kt actually rejects with.
+
+import { PublicKey } from "@solana/web3.js";
+
+// web3.js loads its WebSocket client eagerly; these tests never touch RPC.
+jest.mock("rpc-websockets", () => ({
+  CommonClient: class CommonClient {},
+  WebSocket: jest.fn(),
+}));
+
+// react-native ships untransformed Flow syntax and jest.config.js only
+// transforms @noble — the signer's Platform/TurboModuleRegistry import would
+// otherwise fail the suite before any assertion runs.
+jest.mock("react-native", () => ({
+  Platform: { OS: "android" },
+  TurboModuleRegistry: { get: () => ({}) },
+}));
+
+const mockTransact = jest.fn();
+
+jest.mock(
+  "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
+  () => ({ transact: (...args: unknown[]) => mockTransact(...args) }),
+  { virtual: true },
+);
+
+jest.mock("@/config/env", () => ({ env: { solanaEnv: "mainnet" } }));
+
+// Pulled in by the signer for auth-token persistence; untransformed ESM, and
+// nothing here reaches the store.
+jest.mock("../mwa-account-storage", () => ({
+  clearMwaAccount: jest.fn(),
+  storeMwaAccount: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { MwaSigner } from "../mwa-signer";
+// eslint-disable-next-line import/first
+import { WalletRejectedError } from "../rejection";
+// eslint-disable-next-line import/first
+import { WalletSessionError } from "../wallet-session-error";
+
+function codedError(code: string | number, message = "native failure"): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+const publicKey = PublicKey.unique().toBase58();
+const authToken = "auth-token";
+
+function signer(): MwaSigner {
+  return new MwaSigner(authToken, publicKey);
+}
+
+/** Rejects before the callback runs — `startSession` never resolved. */
+function failBeforeSession(error: unknown) {
+  mockTransact.mockImplementation(async () => {
+    throw error;
+  });
+}
+
+/**
+ * Rejects after the callback runs — the session opened and reauthorized, so
+ * the failure belongs to the signing call.
+ */
+function failAfterSession(error: unknown) {
+  const wallet = {
+    authorize: async () => ({
+      accounts: [
+        { address: Buffer.from(new PublicKey(publicKey).toBytes()).toString("base64") },
+      ],
+      auth_token: authToken,
+    }),
+    signMessages: async () => {
+      throw error;
+    },
+  };
+  mockTransact.mockImplementation(async (callback: (w: unknown) => unknown) =>
+    callback(wallet),
+  );
+}
+
+async function failureOf(promise: Promise<unknown>) {
+  return promise.then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+}
+
+describe("MWA session error classification", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // The ExecutionException raised when the wallet app never connects back to
+  // the local association socket reaches JS as RN's catch-all EUNSPECIFIED.
+  it("reports an unreachable wallet as connection_failed", async () => {
+    failBeforeSession(codedError("EUNSPECIFIED"));
+
+    const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+    expect(error).toBeInstanceOf(WalletSessionError);
+    expect(error).toMatchObject({
+      failure: "connection_failed",
+      walletCode: "EUNSPECIFIED",
+    });
+  });
+
+  // The module rejects with a sentence as the code, not a symbolic constant.
+  it("reports the association wait as timeout", async () => {
+    failBeforeSession(
+      codedError("Timed out waiting for local association to be ready"),
+    );
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toMatchObject(
+      { failure: "timeout" },
+    );
+  });
+
+  it("reports a missing wallet app as unavailable", async () => {
+    failBeforeSession(codedError("ERROR_WALLET_NOT_FOUND"));
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toMatchObject(
+      { failure: "unavailable" },
+    );
+  });
+
+  // Same catch-all code as the unreachable case — only the session flag tells
+  // them apart, and confusing them would point triage at the wrong system.
+  it("reports a post-connect failure as signing_failed", async () => {
+    failAfterSession(codedError("EUNSPECIFIED"));
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toMatchObject(
+      { failure: "signing_failed" },
+    );
+  });
+
+  // Backing out of the chooser rejects with a sentence-shaped code that the
+  // pre-ASK-1872 cancellation check missed, so it read as a hard failure.
+  it("still treats backing out of the chooser as a rejection", async () => {
+    failBeforeSession(
+      codedError(
+        "Session not established: Local association cancelled by user",
+        "Local association cancelled by user",
+      ),
+    );
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBeInstanceOf(
+      WalletRejectedError,
+    );
+  });
+
+  it("still treats an in-wallet decline as a rejection", async () => {
+    // ERROR_NOT_SIGNED.
+    failAfterSession(codedError(-3));
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBeInstanceOf(
+      WalletRejectedError,
+    );
+  });
+
+  // Our own plain-Error instructions (reconnect, signature mismatch) must not
+  // be swallowed into a generic session failure.
+  it("passes uncoded errors through untouched", async () => {
+    const raw = new Error("Wallet authorization is no longer valid.");
+    failAfterSession(raw);
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBe(raw);
+  });
+});

--- a/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -170,4 +170,43 @@ describe("MWA session error classification", () => {
 
     expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBe(raw);
   });
+
+  // The protocol's numeric codes are deterministic app/config bugs, not wallet
+  // trouble: -2 and -5 mean we sent something malformed, -100 means our
+  // asset-links identity does not match. Folding them into a `wallet_*` code
+  // would hide our own bugs once alerting excludes that family, and would tell
+  // users to update a wallet that is behaving correctly.
+  it.each([
+    [-2, "ERROR_INVALID_PAYLOADS"],
+    [-5, "ERROR_TOO_MANY_PAYLOADS"],
+    [-100, "ERROR_ATTEST_ORIGIN_ANDROID"],
+  ])("leaves protocol error %i (%s) alertable", async (code) => {
+    const raw = codedError(code);
+    failAfterSession(raw);
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBe(raw);
+  });
+
+  // Same rule before the session opens — our own misconfiguration must not be
+  // reported as an unreachable wallet.
+  it.each(["ERROR_ASSOCIATION_PORT_OUT_OF_RANGE", "ERROR_FORBIDDEN_WALLET_BASE_URL"])(
+    "leaves configuration error %s alertable",
+    async (code) => {
+      const raw = codedError(code);
+      failBeforeSession(raw);
+
+      expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBe(raw);
+    },
+  );
+
+  // User-facing copy replaces the native message, so the original has to stay
+  // reachable or local debugging loses it entirely.
+  it("keeps the native rejection as the cause", async () => {
+    const raw = codedError("EUNSPECIFIED", "connect failed");
+    failBeforeSession(raw);
+
+    const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+    expect((error as Error).cause).toBe(raw);
+  });
 });

--- a/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -128,6 +128,19 @@ describe("MWA session error classification", () => {
     );
   });
 
+  // `transact` awaits endSession() in a `finally`, so a teardown rejection
+  // replaces whatever the call itself returned — including a success. Left
+  // unclassified it lands back on `request_failed`.
+  it("reports a failed session teardown as connection_failed", async () => {
+    mockTransact.mockImplementation(async () => {
+      throw codedError("Failed to end session");
+    });
+
+    expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toMatchObject(
+      { failure: "connection_failed" },
+    );
+  });
+
   // Same catch-all code as the unreachable case — only the session flag tells
   // them apart, and confusing them would point triage at the wrong system.
   it("reports a post-connect failure as signing_failed", async () => {

--- a/mobile/src/lib/wallet/mwa-signer.ts
+++ b/mobile/src/lib/wallet/mwa-signer.ts
@@ -13,7 +13,10 @@ import {
   storeMwaAccount,
   type StoredMwaAccount,
 } from "./mwa-account-storage";
-import { WalletSessionError } from "./wallet-session-error";
+import {
+  WalletSessionError,
+  type WalletSessionFailure,
+} from "./wallet-session-error";
 
 // Wallets verify this identity by resolving `uri` against the Digital Asset
 // Links statement at https://askloyal.com/.well-known/assetlinks.json, which
@@ -38,18 +41,6 @@ const SIGNING_CANCELLED_MESSAGE =
 
 const SIGNING_DECLINED_MESSAGE =
   "The request was declined in your wallet app. Try again and approve each prompt.";
-
-const WALLET_UNREACHABLE_MESSAGE =
-  "Couldn't reach your wallet app. Open it once so it's running, then try again.";
-
-const WALLET_TIMEOUT_MESSAGE =
-  "Your wallet app didn't respond in time. Try again with it already open.";
-
-const WALLET_SIGNING_FAILED_MESSAGE =
-  "Your wallet app couldn't sign the request. Try again, and update the wallet app if this keeps happening.";
-
-const WALLET_NOT_FOUND_MESSAGE =
-  "No compatible Solana wallet app was found. Install Phantom or Solflare and try again.";
 
 /**
  * True only when the binary actually contains the MWA native module. The
@@ -88,21 +79,23 @@ function errorCodeOf(error: unknown): string | number | undefined {
 // the message too keeps this working if that string is ever reworded.
 const ASSOCIATION_CANCELLED_TEXT = "Local association cancelled by user";
 
+// Backing out of the association UI, in either shape the native module reports
+// it: the symbolic code, or the sentence-as-code above.
+function isAssociationCancellation(error: unknown): boolean {
+  const code = errorCodeOf(error);
+  return (
+    code === "ERROR_ASSOCIATION_CANCELLED" ||
+    (typeof code === "string" && code.includes(ASSOCIATION_CANCELLED_TEXT)) ||
+    (error instanceof Error && error.message.includes(ASSOCIATION_CANCELLED_TEXT))
+  );
+}
+
 // The user backing out of the wallet's association or authorization UI is a
 // choice, not a failure.
 function isUserCancellation(error: unknown): boolean {
   return (
-    hasErrorCode(error, "ERROR_ASSOCIATION_CANCELLED") ||
-    hasErrorCode(error, -1) || // ERROR_AUTHORIZATION_FAILED
-    isAssociationCancellation(error)
-  );
-}
-
-function isAssociationCancellation(error: unknown): boolean {
-  const code = errorCodeOf(error);
-  return (
-    (typeof code === "string" && code.includes(ASSOCIATION_CANCELLED_TEXT)) ||
-    (error instanceof Error && error.message.includes(ASSOCIATION_CANCELLED_TEXT))
+    isAssociationCancellation(error) ||
+    hasErrorCode(error, -1) // ERROR_AUTHORIZATION_FAILED
   );
 }
 
@@ -112,43 +105,59 @@ function isAssociationCancellation(error: unknown): boolean {
 // than a coded protocol error.
 function isSessionCancellation(error: unknown): boolean {
   return (
-    hasErrorCode(error, "ERROR_ASSOCIATION_CANCELLED") ||
     isAssociationCancellation(error) ||
     (error instanceof Error && error.message.includes("CancellationException"))
   );
 }
 
 /**
- * Classify a non-cancellation MWA rejection so telemetry can name the actual
- * failure. `sessionEstablished` disambiguates the module's catch-all
- * `EUNSPECIFIED`: before the session opens it means the wallet app never
- * connected back; after, it means the wallet failed the signing call itself.
+ * Classify an MWA rejection that belongs to the *session layer* — the wallet
+ * app being absent, unreachable, or dropping the connection. Returns null for
+ * anything else so it keeps its own identity.
+ *
+ * Deliberately an allowlist. The protocol's numeric codes describe deterministic
+ * app or configuration bugs — `-2` ERROR_INVALID_PAYLOADS and `-5`
+ * ERROR_TOO_MANY_PAYLOADS mean we sent something malformed, `-100`
+ * ERROR_ATTEST_ORIGIN_ANDROID means our asset-links/signing identity does not
+ * match — and the string codes include our own misconfiguration
+ * (`ERROR_ASSOCIATION_PORT_OUT_OF_RANGE`, `ERROR_FORBIDDEN_WALLET_BASE_URL`).
+ * Folding those into a `wallet_*` code would hide our own bugs the moment
+ * alerting excludes that family, and would tell users to update a wallet app
+ * that is behaving correctly.
+ *
+ * `sessionEstablished` splits the module's catch-all `EUNSPECIFIED`: before the
+ * session opens it means the wallet never connected back; after, the wallet
+ * dropped the call itself.
  */
 function toWalletSessionError(
   error: unknown,
   sessionEstablished: boolean,
-): WalletSessionError {
+): WalletSessionError | null {
   const code = errorCodeOf(error);
-  if (code === "ERROR_WALLET_NOT_FOUND") {
-    return new WalletSessionError("unavailable", WALLET_NOT_FOUND_MESSAGE, code);
+  const failure = toWalletSessionFailure(code, sessionEstablished);
+  if (!failure) return null;
+  return new WalletSessionError(failure, code, error);
+}
+
+function toWalletSessionFailure(
+  code: string | number | undefined,
+  sessionEstablished: boolean,
+): WalletSessionFailure | null {
+  if (code === "ERROR_WALLET_NOT_FOUND") return "unavailable";
+  // `ERROR_SESSION_TIMEOUT`, plus the module's own uncoded waits: "Timed out
+  // waiting for local association to be ready" (10s) and "Timed out waiting
+  // for response" (90s).
+  if (
+    code === "ERROR_SESSION_TIMEOUT" ||
+    (typeof code === "string" && code.startsWith("Timed out waiting"))
+  ) {
+    return "timeout";
   }
-  // "Timed out waiting for local association to be ready" (10s association
-  // wait) and "Timed out waiting for response" (90s in-session wait).
-  if (typeof code === "string" && code.startsWith("Timed out waiting")) {
-    return new WalletSessionError("timeout", WALLET_TIMEOUT_MESSAGE, code);
+  if (code === "ERROR_SESSION_CLOSED") return "connection_failed";
+  if (code === "EUNSPECIFIED") {
+    return sessionEstablished ? "signing_failed" : "connection_failed";
   }
-  if (sessionEstablished) {
-    return new WalletSessionError(
-      "signing_failed",
-      WALLET_SIGNING_FAILED_MESSAGE,
-      code,
-    );
-  }
-  return new WalletSessionError(
-    "connection_failed",
-    WALLET_UNREACHABLE_MESSAGE,
-    code,
-  );
+  return null;
 }
 
 type TweetNaclVerify = (
@@ -203,12 +212,9 @@ export async function connectMwaWallet(): Promise<StoredMwaAccount | null> {
     });
   } catch (error) {
     if (isUserCancellation(error)) return null;
-    // Connecting is a single session, so any coded rejection here happened
-    // before it opened.
-    if (errorCodeOf(error) !== undefined) {
-      throw toWalletSessionError(error, false);
-    }
-    throw error;
+    // Connecting is a single session, so a session-layer rejection here
+    // happened before it opened. Protocol errors keep their own identity.
+    throw toWalletSessionError(error, false) ?? error;
   }
 }
 
@@ -348,13 +354,10 @@ export class MwaSigner implements Signer {
         // ERROR_NOT_SIGNED: the user tapped decline in the wallet app.
         throw new WalletRejectedError(SIGNING_DECLINED_MESSAGE);
       }
-      // `reauthorize` raises its own plain-Error instructions (reconnect), and
-      // our signature checks raise plain Errors too — only coded rejections
-      // from the native module are wallet-session failures.
-      if (errorCodeOf(error) !== undefined) {
-        throw toWalletSessionError(error, sessionEstablished);
-      }
-      throw error;
+      // Only session-layer rejections become wallet-session failures. Protocol
+      // errors, `reauthorize`'s reconnect instructions and our signature checks
+      // all keep their own identity so they stay alertable.
+      throw toWalletSessionError(error, sessionEstablished) ?? error;
     }
   }
 

--- a/mobile/src/lib/wallet/mwa-signer.ts
+++ b/mobile/src/lib/wallet/mwa-signer.ts
@@ -153,7 +153,13 @@ function toWalletSessionFailure(
   ) {
     return "timeout";
   }
-  if (code === "ERROR_SESSION_CLOSED") return "connection_failed";
+  // Association teardown. `transact` awaits `endSession()` in a `finally`, so
+  // a rejection there replaces the outcome of the call it was cleaning up —
+  // even a successful one. Session-layer by definition, and leaving it out
+  // would report the very `request_failed` this classification exists to stop.
+  if (code === "ERROR_SESSION_CLOSED" || code === "Failed to end session") {
+    return "connection_failed";
+  }
   if (code === "EUNSPECIFIED") {
     return sessionEstablished ? "signing_failed" : "connection_failed";
   }

--- a/mobile/src/lib/wallet/mwa-signer.ts
+++ b/mobile/src/lib/wallet/mwa-signer.ts
@@ -13,6 +13,7 @@ import {
   storeMwaAccount,
   type StoredMwaAccount,
 } from "./mwa-account-storage";
+import { WalletSessionError } from "./wallet-session-error";
 
 // Wallets verify this identity by resolving `uri` against the Digital Asset
 // Links statement at https://askloyal.com/.well-known/assetlinks.json, which
@@ -37,6 +38,18 @@ const SIGNING_CANCELLED_MESSAGE =
 
 const SIGNING_DECLINED_MESSAGE =
   "The request was declined in your wallet app. Try again and approve each prompt.";
+
+const WALLET_UNREACHABLE_MESSAGE =
+  "Couldn't reach your wallet app. Open it once so it's running, then try again.";
+
+const WALLET_TIMEOUT_MESSAGE =
+  "Your wallet app didn't respond in time. Try again with it already open.";
+
+const WALLET_SIGNING_FAILED_MESSAGE =
+  "Your wallet app couldn't sign the request. Try again, and update the wallet app if this keeps happening.";
+
+const WALLET_NOT_FOUND_MESSAGE =
+  "No compatible Solana wallet app was found. Install Phantom or Solflare and try again.";
 
 /**
  * True only when the binary actually contains the MWA native module. The
@@ -64,12 +77,32 @@ function hasErrorCode(error: unknown, code: string | number): boolean {
   );
 }
 
+function errorCodeOf(error: unknown): string | number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  return (error as { code?: string | number }).code;
+}
+
+// Backing out of the wallet chooser rejects with a *sentence* as the code:
+// the native module calls `promise.reject(String, Throwable)`, whose first
+// argument RN uses as the code (SolanaMobileWalletAdapterModule.kt). Matching
+// the message too keeps this working if that string is ever reworded.
+const ASSOCIATION_CANCELLED_TEXT = "Local association cancelled by user";
+
 // The user backing out of the wallet's association or authorization UI is a
 // choice, not a failure.
 function isUserCancellation(error: unknown): boolean {
   return (
     hasErrorCode(error, "ERROR_ASSOCIATION_CANCELLED") ||
-    hasErrorCode(error, -1) // ERROR_AUTHORIZATION_FAILED
+    hasErrorCode(error, -1) || // ERROR_AUTHORIZATION_FAILED
+    isAssociationCancellation(error)
+  );
+}
+
+function isAssociationCancellation(error: unknown): boolean {
+  const code = errorCodeOf(error);
+  return (
+    (typeof code === "string" && code.includes(ASSOCIATION_CANCELLED_TEXT)) ||
+    (error instanceof Error && error.message.includes(ASSOCIATION_CANCELLED_TEXT))
   );
 }
 
@@ -80,7 +113,41 @@ function isUserCancellation(error: unknown): boolean {
 function isSessionCancellation(error: unknown): boolean {
   return (
     hasErrorCode(error, "ERROR_ASSOCIATION_CANCELLED") ||
+    isAssociationCancellation(error) ||
     (error instanceof Error && error.message.includes("CancellationException"))
+  );
+}
+
+/**
+ * Classify a non-cancellation MWA rejection so telemetry can name the actual
+ * failure. `sessionEstablished` disambiguates the module's catch-all
+ * `EUNSPECIFIED`: before the session opens it means the wallet app never
+ * connected back; after, it means the wallet failed the signing call itself.
+ */
+function toWalletSessionError(
+  error: unknown,
+  sessionEstablished: boolean,
+): WalletSessionError {
+  const code = errorCodeOf(error);
+  if (code === "ERROR_WALLET_NOT_FOUND") {
+    return new WalletSessionError("unavailable", WALLET_NOT_FOUND_MESSAGE, code);
+  }
+  // "Timed out waiting for local association to be ready" (10s association
+  // wait) and "Timed out waiting for response" (90s in-session wait).
+  if (typeof code === "string" && code.startsWith("Timed out waiting")) {
+    return new WalletSessionError("timeout", WALLET_TIMEOUT_MESSAGE, code);
+  }
+  if (sessionEstablished) {
+    return new WalletSessionError(
+      "signing_failed",
+      WALLET_SIGNING_FAILED_MESSAGE,
+      code,
+    );
+  }
+  return new WalletSessionError(
+    "connection_failed",
+    WALLET_UNREACHABLE_MESSAGE,
+    code,
   );
 }
 
@@ -136,10 +203,10 @@ export async function connectMwaWallet(): Promise<StoredMwaAccount | null> {
     });
   } catch (error) {
     if (isUserCancellation(error)) return null;
-    if (hasErrorCode(error, "ERROR_WALLET_NOT_FOUND")) {
-      throw new Error(
-        "No compatible Solana wallet app was found. Install Phantom or Solflare and try again.",
-      );
+    // Connecting is a single session, so any coded rejection here happened
+    // before it opened.
+    if (errorCodeOf(error) !== undefined) {
+      throw toWalletSessionError(error, false);
     }
     throw error;
   }
@@ -263,8 +330,13 @@ export class MwaSigner implements Signer {
     op: (wallet: Web3MobileWallet) => Promise<T>,
   ): Promise<T> {
     const { transact } = await getMwa();
+    // Set once the wallet session is open — `transact` only runs the callback
+    // after `startSession` resolves. Tells a wallet that never connected apart
+    // from one that connected and then failed the signing call.
+    let sessionEstablished = false;
     try {
       return await transact(async (wallet) => {
+        sessionEstablished = true;
         await this.reauthorize(wallet);
         return op(wallet);
       });
@@ -275,6 +347,12 @@ export class MwaSigner implements Signer {
       if (hasErrorCode(error, -3)) {
         // ERROR_NOT_SIGNED: the user tapped decline in the wallet app.
         throw new WalletRejectedError(SIGNING_DECLINED_MESSAGE);
+      }
+      // `reauthorize` raises its own plain-Error instructions (reconnect), and
+      // our signature checks raise plain Errors too — only coded rejections
+      // from the native module are wallet-session failures.
+      if (errorCodeOf(error) !== undefined) {
+        throw toWalletSessionError(error, sessionEstablished);
       }
       throw error;
     }

--- a/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/mobile/src/lib/wallet/wallet-session-error.ts
@@ -1,0 +1,58 @@
+// A wallet session that never carried our request is not a request failure
+// (ASK-1872). The MWA native module rejects every session-level problem with a
+// string `code`, and lifecycle telemetry maps *any* coded error to
+// `request_failed` — so "the wallet app never connected back" reached ClickStack
+// looking exactly like "the backend returned 500", and paged on-call for a
+// failure that never left the device.
+//
+// The native module's rejection codes (SolanaMobileWalletAdapterModule.kt) are:
+//
+//   ERROR_WALLET_NOT_FOUND                                  no wallet installed
+//   "Timed out waiting for local association to be ready"    10s association wait
+//   "Session not established: Local association cancelled…"  user backed out
+//   "Timed out waiting for response"                         90s in-session wait
+//   EUNSPECIFIED                                             everything else,
+//     including the ExecutionException raised when the wallet app never
+//     connects back to the local association socket
+//
+// Every one of those throws `WalletSessionError` so callers can ask
+// `isWalletSessionError` instead of matching codes, and telemetry can report
+// the actual failure instead of a blanket `request_failed`.
+
+export type WalletSessionFailure =
+  /** No MWA-capable wallet app is installed. */
+  | "unavailable"
+  /** The wallet app never connected back — the session never opened. */
+  | "connection_failed"
+  /** The wallet app was reachable but did not answer in time. */
+  | "timeout"
+  /** The session opened; the wallet errored while producing the signature. */
+  | "signing_failed";
+
+export class WalletSessionError extends Error {
+  readonly failure: WalletSessionFailure;
+  /**
+   * The wallet backend's own code, kept for local logs only. Telemetry cannot
+   * carry it: the ingest rejects envelopes with unknown keys, so the failure
+   * discriminant above is what reaches ClickStack.
+   */
+  readonly walletCode?: string | number;
+
+  constructor(
+    failure: WalletSessionFailure,
+    message: string,
+    walletCode?: string | number,
+  ) {
+    super(message);
+    this.name = "WalletSessionError";
+    this.failure = failure;
+    this.walletCode = walletCode;
+  }
+}
+
+/** True when `error` is a wallet session that failed before or during signing. */
+export function isWalletSessionError(
+  error: unknown,
+): error is WalletSessionError {
+  return error instanceof WalletSessionError;
+}

--- a/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/mobile/src/lib/wallet/wallet-session-error.ts
@@ -29,21 +29,41 @@ export type WalletSessionFailure =
   /** The session opened; the wallet errored while producing the signature. */
   | "signing_failed";
 
+// What the user is told, per failure. Owned here so the advice can never drift
+// from the reason: telling someone to update a wallet app that simply was not
+// running sends them down the wrong path.
+const WALLET_SESSION_MESSAGES: Record<WalletSessionFailure, string> = {
+  connection_failed:
+    "Couldn't reach your wallet app. Open it once so it's running, then try again.",
+  signing_failed:
+    "Your wallet app couldn't sign the request. Try again, and update the wallet app if this keeps happening.",
+  timeout:
+    "Your wallet app didn't respond in time. Try again with it already open.",
+  unavailable:
+    "No compatible Solana wallet app was found. Install Phantom or Solflare and try again.",
+};
+
 export class WalletSessionError extends Error {
   readonly failure: WalletSessionFailure;
   /**
    * The wallet backend's own code, kept for local logs only. Telemetry cannot
-   * carry it: the ingest rejects envelopes with unknown keys, so the failure
-   * discriminant above is what reaches ClickStack.
+   * carry it yet: the ingest rejects envelopes with unknown keys, so until the
+   * backend contract gains a field for it the failure discriminant above is
+   * what reaches ClickStack.
    */
   readonly walletCode?: string | number;
 
   constructor(
     failure: WalletSessionFailure,
-    message: string,
     walletCode?: string | number,
+    // The native rejection this replaces. The message is user-facing copy, so
+    // without this the original message and stack would be lost to debugging.
+    cause?: unknown,
   ) {
-    super(message);
+    super(
+      WALLET_SESSION_MESSAGES[failure],
+      cause === undefined ? undefined : { cause },
+    );
     this.name = "WalletSessionError";
     this.failure = failure;
     this.walletCode = walletCode;

--- a/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -152,38 +152,29 @@ describe("wallet session classification", () => {
 
   it("maps each session failure to its own code, not request_failed", () => {
     expect(
-      mapLifecycleErrorCode(
-        new WalletSessionError("connection_failed", "unreachable"),
-      ),
+      mapLifecycleErrorCode(new WalletSessionError("connection_failed")),
     ).toBe("wallet_connection_failed");
-    expect(
-      mapLifecycleErrorCode(new WalletSessionError("timeout", "slow")),
-    ).toBe("wallet_connection_timeout");
-    expect(
-      mapLifecycleErrorCode(new WalletSessionError("unavailable", "none")),
-    ).toBe("wallet_unavailable");
-    expect(
-      mapLifecycleErrorCode(new WalletSessionError("signing_failed", "nope")),
-    ).toBe("wallet_signing_failed");
+    expect(mapLifecycleErrorCode(new WalletSessionError("timeout"))).toBe(
+      "wallet_connection_timeout",
+    );
+    expect(mapLifecycleErrorCode(new WalletSessionError("unavailable"))).toBe(
+      "wallet_unavailable",
+    );
+    expect(mapLifecycleErrorCode(new WalletSessionError("signing_failed"))).toBe(
+      "wallet_signing_failed",
+    );
   });
 
   // The native module's own codes must not leak through the generic probe.
   it("classifies by failure even when the wallet code looks transport-level", () => {
-    const error = new WalletSessionError(
-      "connection_failed",
-      "unreachable",
-      "EUNSPECIFIED",
-    );
+    const error = new WalletSessionError("connection_failed", "EUNSPECIFIED");
 
     expect(mapLifecycleErrorCode(error)).toBe("wallet_connection_failed");
   });
 
   it("emits failed with the session code and no httpStatus", async () => {
     const sent = captureEnvelopes();
-    newFlow().failFrom(
-      "prepare",
-      new WalletSessionError("connection_failed", "unreachable"),
-    );
+    newFlow().failFrom("prepare", new WalletSessionError("connection_failed"));
 
     expect(sent[0]).toMatchObject({
       outcome: "failed",

--- a/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -6,6 +6,7 @@
 
 import { WalletRejectedError } from "@/lib/wallet/rejection";
 import { UserRejectedSigningError } from "@/lib/wallet/sign-approval/with-confirmation";
+import { WalletSessionError } from "@/lib/wallet/wallet-session-error";
 import { mapLifecycleErrorCode, startLifecycleFlow } from "../observability";
 
 // Hoisted above the imports by babel-plugin-jest-hoist.
@@ -18,7 +19,12 @@ jest.mock("@/config/env", () => ({
   env: { earnApiBaseUrl: "https://example.test" },
 }));
 
-type Envelope = { outcome: string; stage: string; errorCode?: string };
+type Envelope = {
+  outcome: string;
+  stage: string;
+  errorCode?: string;
+  httpStatus?: number;
+};
 
 function captureEnvelopes(): Envelope[] {
   const sent: Envelope[] = [];
@@ -133,5 +139,90 @@ describe("wallet rejection classification", () => {
     );
 
     expect(sent[0]).toMatchObject({ outcome: "cancelled" });
+  });
+});
+
+// A wallet session that never opened is not a request failure (ASK-1872). MWA
+// rejects with a coded error, which the `code` probe used to collapse into
+// `request_failed` — an alert naming an HTTP failure for a flow that never
+// reached the network. Every code below must exist in the backend's
+// LIFECYCLE_ERROR_CODES; the ingest drops envelopes carrying an unknown one.
+describe("wallet session classification", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("maps each session failure to its own code, not request_failed", () => {
+    expect(
+      mapLifecycleErrorCode(
+        new WalletSessionError("connection_failed", "unreachable"),
+      ),
+    ).toBe("wallet_connection_failed");
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("timeout", "slow")),
+    ).toBe("wallet_connection_timeout");
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("unavailable", "none")),
+    ).toBe("wallet_unavailable");
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("signing_failed", "nope")),
+    ).toBe("wallet_signing_failed");
+  });
+
+  // The native module's own codes must not leak through the generic probe.
+  it("classifies by failure even when the wallet code looks transport-level", () => {
+    const error = new WalletSessionError(
+      "connection_failed",
+      "unreachable",
+      "EUNSPECIFIED",
+    );
+
+    expect(mapLifecycleErrorCode(error)).toBe("wallet_connection_failed");
+  });
+
+  it("emits failed with the session code and no httpStatus", async () => {
+    const sent = captureEnvelopes();
+    newFlow().failFrom(
+      "prepare",
+      new WalletSessionError("connection_failed", "unreachable"),
+    );
+
+    expect(sent[0]).toMatchObject({
+      outcome: "failed",
+      stage: "prepare",
+      errorCode: "wallet_connection_failed",
+    });
+    expect(sent[0].httpStatus).toBeUndefined();
+  });
+});
+
+// `httpStatus` is what separates a backend that answered from an error raised
+// with no response at all — the distinction this alert lacked.
+describe("http status reporting", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("reports the status when the backend answered", async () => {
+    const sent = captureEnvelopes();
+    newFlow().failFrom("prepare", { code: "context_failed", status: 502 });
+
+    expect(sent[0]).toMatchObject({
+      outcome: "failed",
+      errorCode: "request_failed",
+      httpStatus: 502,
+    });
+  });
+
+  it("omits it when the request never got a response", async () => {
+    const sent = captureEnvelopes();
+    newFlow().failFrom("prepare", { code: undefined });
+
+    expect(sent[0]).toMatchObject({ errorCode: "request_failed" });
+    expect(sent[0]).not.toHaveProperty("httpStatus");
+  });
+
+  // Out-of-range values would make the ingest reject the whole envelope.
+  it("drops a status the ingest would refuse", async () => {
+    const sent = captureEnvelopes();
+    newFlow().failFrom("prepare", { code: "weird", status: 0 });
+
+    expect(sent[0]).not.toHaveProperty("httpStatus");
   });
 });

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -13,6 +13,10 @@ import * as Updates from "expo-updates";
 
 import { env } from "@/config/env";
 import { hasLandedProgress, isWalletRejection } from "@/lib/wallet/rejection";
+import {
+  isWalletSessionError,
+  type WalletSessionFailure,
+} from "@/lib/wallet/wallet-session-error";
 
 type MobileErrorOperation =
   | "mobile.global_error"
@@ -296,13 +300,20 @@ type LifecycleStageMap = {
 
 type LifecycleFlowName = keyof LifecycleVariantMap;
 
+// Every value here must exist in the backend's LIFECYCLE_ERROR_CODES
+// (frontend/src/features/observability/lifecycle-contract.ts) — the ingest
+// drops the whole envelope on an unknown code, so a typo costs the event.
 type LifecycleErrorCode =
   | "unexpected_error"
   | "request_failed"
   | "unconfirmed_signature"
   | "backend_confirmation_failed"
   | "send_failed"
-  | "wallet_rejected";
+  | "wallet_rejected"
+  | "wallet_unavailable"
+  | "wallet_connection_failed"
+  | "wallet_connection_timeout"
+  | "wallet_signing_failed";
 
 export type LifecycleDiagnostics = {
   autodepositCloseRequired?: boolean;
@@ -311,6 +322,12 @@ export type LifecycleDiagnostics = {
   errorCode?: LifecycleErrorCode;
   executeNowState?: "requested" | "completed";
   executionMode?: "batch" | "sequential" | "single";
+  /**
+   * Status the backend actually answered with. Its presence is the signal that
+   * separates a real server failure from `request_failed` raised without any
+   * response — a dead connection, or a wallet error that never left the device.
+   */
+  httpStatus?: number;
   persistenceState?: "not_started" | "recorded" | "failed";
   policyMode?: "create" | "reuse";
   recoveryRequired?: boolean;
@@ -354,11 +371,25 @@ export type LifecycleFlow<F extends LifecycleFlowName> = {
   ) => void;
 };
 
+const WALLET_SESSION_ERROR_CODES: Record<
+  WalletSessionFailure,
+  LifecycleErrorCode
+> = {
+  connection_failed: "wallet_connection_failed",
+  signing_failed: "wallet_signing_failed",
+  timeout: "wallet_connection_timeout",
+  unavailable: "wallet_unavailable",
+};
+
 /** Map a flow failure onto the contract's error-code vocabulary. */
 export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
-  // Checked before the `code` probe below: a rejection is a user decision, and
-  // the wallet error it wraps may carry an unrelated transport-level code.
+  // Both wallet checks run before the `code` probe below: a rejection is a user
+  // decision and a dead wallet session never reached the network, yet both
+  // carry a `code` and so would otherwise report as `request_failed` (ASK-1872).
   if (isWalletRejection(error)) return "wallet_rejected";
+  if (isWalletSessionError(error)) {
+    return WALLET_SESSION_ERROR_CODES[error.failure];
+  }
   if (error && typeof error === "object" && "code" in error) {
     const code = (error as { code?: unknown }).code;
     if (code === "unconfirmed_signature") return "unconfirmed_signature";
@@ -366,6 +397,25 @@ export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
   }
   if (error instanceof TypeError) return "request_failed";
   return "unexpected_error";
+}
+
+/**
+ * The HTTP status an API error carried, when the backend actually answered.
+ * Duck-typed rather than imported so telemetry stays independent of the Earn
+ * API client. Absent for network-level failures, which is the point: a
+ * `request_failed` with no status never got a response.
+ */
+function httpStatusOf(error: unknown): number | undefined {
+  if (!error || typeof error !== "object" || !("status" in error)) {
+    return undefined;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" &&
+    Number.isInteger(status) &&
+    status >= 100 &&
+    status <= 599
+    ? status
+    : undefined;
 }
 
 function generateFlowId(): string {
@@ -454,9 +504,11 @@ export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
       // state, which has to stay at ERROR so on-call still sees it.
       const cancelled =
         errorCode === "wallet_rejected" && !hasLandedProgress(error);
+      const httpStatus = httpStatusOf(error);
       emit(cancelled ? "cancelled" : "failed", stage, {
         ...diagnostics,
         errorCode,
+        ...(httpStatus !== undefined ? { httpStatus } : {}),
       });
     },
     flowId,

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -406,10 +406,10 @@ export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
  * `request_failed` with no status never got a response.
  */
 function httpStatusOf(error: unknown): number | undefined {
-  if (!error || typeof error !== "object" || !("status" in error)) {
-    return undefined;
-  }
-  const status = (error as { status?: unknown }).status;
+  if (!error || typeof error !== "object") return undefined;
+  const { status } = error as { status?: unknown };
+  // Range-checked against the ingest's own bounds: an out-of-range value would
+  // fail envelope validation and cost the entire event, not just this field.
   return typeof status === "number" &&
     Number.isInteger(status) &&
     status >= 100 &&


### PR DESCRIPTION
Closes ASK-1872.

Wallet-session failures on mobile reported as `request_failed`, so the ClickStack "Errors" alert paged on-call for withdrawals that never reached the backend. This gives each wallet-session failure its own error code, records `httpStatus` when the backend actually answered, and forwards the flow id from the withdraw prepare-context calls.

## The alert

```
🚨 Alert for "Errors" - 1 lines found
Group: "ServiceName:loyal-mobile"
Time Range (UTC): [Jul 25 6:48:00 AM - Jul 25 6:49:00 AM)

🔴 error · 06:48:49 UTC · loyal-mobile
earn.withdrawal.prepare.failed
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
```

## Evidence

The alerted event is one of 12 consecutive failures from a single wallet (`BGtzTW2y…`) between 05:05 and 06:50 UTC on 2026-07-25:

| Time (UTC) | Flow / stage | Code | Duration |
| --- | --- | --- | --- |
| 05:05:41 – 05:07:41 | `earn.withdrawal` / prepare ×4 | `request_failed` | 4138–5275 ms |
| 05:06:55 – 06:49:56 | `earn.autodeposit.configuration` / wallet_approval ×6 | `request_failed` | 5293–5553 ms |
| 06:49:42 | `earn.autodeposit.configuration` / backend_confirm | `request_failed` | 5176 ms |
| **06:48:44 → 06:48:49** | **`earn.withdrawal` / prepare (alerted)** | **`request_failed`** | **5151 ms** |

1. **The backend never saw the request.** Vercel runtime logs for `loyal-frontend` show 29 calls to `/api/smart-accounts/mobile/earn/withdraw/prepare-context` between 04:00–07:00 UTC, all `200`, and zero requests in any of the five failure windows. The same device's `POST /api/observability/mobile/events` beacons returned `202` at 06:48:45 and 06:48:50 — same host, seconds either side — so device→backend connectivity was healthy.
2. **The common factor is wallet signing, not any endpoint.** The `autodeposit` / `wallet_approval` failures come from `signAndSendPreparedOperation`, which makes no askloyal.com call at all, yet fails with the same code at the same ~5.3 s. The withdrawal prepare fails inside `signEarnAuth` before `fetchEarnWithdrawPrepareContext` is ever invoked.
3. **The duration is a fixed signature, not variable latency.** 10 of 12 land in 5.1–5.6 s, matching MWA local-association connect exhaustion, not network jitter.

Over 7 days `request_failed` covered 138 events across 33 wallets with a median duration of 5182 ms — the median sits exactly on the wallet-session signature, so much of that bucket was never a request failure.

### Why it was labelled `request_failed`

`mapLifecycleErrorCode` mapped any error carrying a `code` to `request_failed`, and MWA wraps every native rejection in `SolanaMobileWalletAdapterError`, which always carries a string code. `MwaSigner.withWallet` only intercepted `ERROR_ASSOCIATION_CANCELLED`, `CancellationException` and `-3`, so a session that failed to *establish* passed straight through.

The native module's rejection codes (`SolanaMobileWalletAdapterModule.kt`) are:

| Native path | JS `code` |
| --- | --- |
| No wallet installed | `ERROR_WALLET_NOT_FOUND` |
| 10 s association wait elapsed | `"Timed out waiting for local association to be ready"` |
| 90 s in-session wait elapsed | `"Timed out waiting for response"` |
| User backed out of the chooser | `"Session not established: Local association cancelled by user"` |
| Everything else, including the wallet never connecting back | `EUNSPECIFIED` |

## Suggested fixes and what shipped

1. **Own error code for wallet-session failures** — `WalletSessionError` carries a failure reason mapped to `wallet_unavailable`, `wallet_connection_failed`, `wallet_connection_timeout` and `wallet_signing_failed`. All four already exist in the backend's `LIFECYCLE_ERROR_CODES`, so no ingest change is needed and the deployed backend accepts them today.
2. **Record the underlying failure** — the ingest rejects envelopes with unknown keys, so a free-form `errorName` would need a backend contract change and would be dropped by the deployed ingest. Instead the root cause is carried by the code itself, plus `httpStatus` (already in the allow-list) on failures where the backend answered. A `request_failed` with no `httpStatus` now means "no response was ever received"; the raw wallet code is kept on the error for local logs.
3. **`isSessionCancellation` misses the chooser back-out** — fixed; the module rejects it with a sentence as the code (RN's `promise.reject(String, Throwable)` overload), which the code-equality check never matched.
4. **Flow id not forwarded** — `fetchEarnWithdrawPrepareContext` and `fetchEarnWithdrawCleanupPrepareContext` now accept and send `flowId`, matching the deposit twin, so server stages join the withdrawal flow.
5. **Alert tuning** — not in this PR; with the codes split, the "Errors" alert can exclude the `wallet_*` codes so it tracks server-side failures.

Users also stop seeing the raw native error: each reason now maps to an actionable message ("Couldn't reach your wallet app. Open it once so it's running, then try again.") instead of `EUNSPECIFIED`.

## What this does not fix

The underlying condition — the wallet app not connecting back to the local association socket — is wallet/device-side and not something the app controls. What changes is that it is now named, separated from backend failures, and given a message the user can act on.

## Validation

- `cd mobile && npm test` — 169 passing (13 new), 0 failing. The 11 suites that fail to run are pre-existing ESM/transform failures on the base commit (156 passing there), unchanged by this PR.
- `cd mobile && npx expo lint` — 0 errors; the 9 warnings are pre-existing and in untouched files.
- `npx tsc --noEmit` — no errors in any changed file.
- Pushed with `SKIP_VERIFY=1`: the pre-push hook runs the frontend build, which this repo's guidance says not to run locally.

## Related

- ASK-1859 (#520, already on this branch) classifies deliberate declines as `wallet_rejected`/`cancelled`. It does not cover sessions that fail to establish — those still mapped to `request_failed` before this change.
- ASK-1857 adds wallet-connect classification on the web side; no file overlap.


---

## Review follow-up (17f3032)

**[P1] Non-session protocol errors were classified as wallet-session failures — agreed, fixed.** Real and the most serious point: the classifier wrapped *every* coded rejection, so `-2` ERROR_INVALID_PAYLOADS, `-5` ERROR_TOO_MANY_PAYLOADS and `-100` ERROR_ATTEST_ORIGIN_ANDROID — all deterministic app/config bugs on our side — became `wallet_signing_failed`. Once alerting excludes `wallet_*`, that hides our own bugs, and the copy told users to update a wallet that was behaving correctly. Wrapping is now an explicit allowlist (`ERROR_WALLET_NOT_FOUND`, `ERROR_SESSION_TIMEOUT` and the module's uncoded waits, `ERROR_SESSION_CLOSED`, `EUNSPECIFIED`); everything else keeps its own identity. Added coverage for `-2`, `-5`, `-100` plus the string-coded misconfigurations `ERROR_ASSOCIATION_PORT_OUT_OF_RANGE` and `ERROR_FORBIDDEN_WALLET_BASE_URL`.

**[P2] The underlying wallet failure never reaches telemetry — agreed, split across two PRs by necessity.** The backend half is #529, which adds a sanitized, length-capped `errorDetail` to the lifecycle contract and maps it to `loyal.error.detail`. It cannot ship here: `parseBrowserLifecycleEnvelope` rejects unknown keys, so emitting the field before that deploys would drop the **entire** envelope — strictly worse than the present gap. So this PR deliberately does not emit it; that follows once #529 is live. The half that needed no contract change is done here: `WalletSessionError` now keeps the native rejection as its `cause`, so the original message and stack survive for local debugging instead of being replaced by user-facing copy.

**[P2] Some backend responses produced no `httpStatus` — agreed, fixed.** `confirmEarnDepositSponsored` had `res` in scope and omitted the status on both throws, so a real backend response read as "no response received". Both now pass `res.status`. Audited every remaining `EarnApiError` construction: the only status-less ones are `FetchTimeoutError` and network-retry exhaustion, which genuinely have no response, so the invariant now holds throughout.

**Deployment safety.** Agreed and unchanged: this PR alone does not stop the paging. It ships the codes; the alert change is separate and should only follow once a build carrying them is actually in the field, otherwise the exclusion filters on codes nothing emits yet.

### Simplification pass

- Per-failure user copy moved next to `WalletSessionFailure`, and the constructor derives the message from the failure. The advice and the reason can no longer drift apart, and four loose message constants are gone.
- `toWalletSessionError` split into a pure code→failure mapping plus one construction site, replacing four near-identical `new WalletSessionError(...)` branches.
- `isUserCancellation` and `isSessionCancellation` had duplicated the `ERROR_ASSOCIATION_CANCELLED` check; both now build on one `isAssociationCancellation`.
- `httpStatusOf` dropped a redundant `in` check, with a note on why the range check mirrors the ingest's bounds — an out-of-range value would fail envelope validation and cost the whole event.

Validation after the follow-up: `npm test` 175 passing (19 new), 0 failing, same 11 pre-existing suite failures as the base commit; `npx expo lint` 0 errors; `tsc --noEmit` clean on changed files.


### Stop-review follow-up (b05fa16)

**Allowlist omitted the native `"Failed to end session"` code — agreed, fixed.** `transact` awaits `endSession()` in a `finally`, and a rejection there replaces the outcome of the call it was cleaning up, including a successful one. The code was missing from the session-layer allowlist, so it fell through to `request_failed` — reintroducing exactly the false paging this PR removes, and on a path where the signature may actually have succeeded. Added to the classification with a test.
