### PR TITLE
feat(observability): carry the originating error token on lifecycle events

### DIFF
--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -185,6 +185,25 @@ export const LIFECYCLE_ERROR_CODES = [
 ] as const;
 export type LifecycleErrorCode = (typeof LIFECYCLE_ERROR_CODES)[number];
 
+// Underlying causes behind a broad `errorCode`. Every value is a token this
+// repo defines — never a string forwarded from a vendor SDK — so nothing a
+// client holds can reach `loyal.error.detail`. Emitters map their native error
+// onto one of these; add a token here when a new cause needs telling apart.
+//
+// `mwa_*` are Mobile Wallet Adapter session failures, whose native codes are
+// EUNSPECIFIED (the module's catch-all), ERROR_WALLET_NOT_FOUND,
+// ERROR_SESSION_TIMEOUT, ERROR_SESSION_CLOSED, "Timed out waiting for local
+// association to be ready", and "Failed to end session".
+export const LIFECYCLE_ERROR_DETAILS = [
+  "mwa_unspecified",
+  "mwa_wallet_not_found",
+  "mwa_session_timeout",
+  "mwa_association_timeout",
+  "mwa_session_closed",
+  "mwa_end_session_failed",
+] as const;
+export type LifecycleErrorDetail = (typeof LIFECYCLE_ERROR_DETAILS)[number];
+
 export const EXECUTE_NOW_STATES = [
   "requested",
   "selected",
@@ -235,16 +254,17 @@ export type LifecycleDiagnostics = {
   cleanupRequired?: boolean;
   errorCode?: LifecycleErrorCode;
   /**
-   * The originating system's own short error token, for when `errorCode` is a
-   * category that several distinct causes collapse into — a mobile wallet
-   * adapter code such as `EUNSPECIFIED` or `ERROR_SESSION_TIMEOUT`, say. Names
-   * the cause without minting a lifecycle code per vendor error.
+   * Which underlying cause produced `errorCode`, for codes that several
+   * distinct causes collapse into — every mobile wallet-session failure, for
+   * instance. Names the cause without minting a lifecycle code per vendor
+   * error.
    *
-   * A machine token, never prose: it is sanitized to `[A-Za-z0-9._-]` and
-   * truncated, so free text arrives mangled, and anything resembling a
-   * message, address or secret must not be put here.
+   * An enum, not a string: clients map their native error onto one of the
+   * tokens below and anything else is dropped. Character-level sanitizing
+   * would not do — base58 addresses, JWTs and API keys consist entirely of
+   * token-safe characters, so a free-text field would export them intact.
    */
-  errorDetail?: string;
+  errorDetail?: LifecycleErrorDetail;
   executeNowState?: ExecuteNowState;
   executionMode?: (typeof EXECUTION_MODES)[number];
   httpStatus?: number;
@@ -349,23 +369,17 @@ function assertOptionalBoolean(
   }
 }
 
-const MAX_ERROR_DETAIL_LENGTH = 64;
-
 /**
- * Reduce a reported error token to a bounded `[A-Za-z0-9._-]` string, or
- * undefined when nothing usable remains. Sanitizing (rather than rejecting)
- * keeps a malformed detail from costing the event it annotates, and the
- * character class means prose accidentally sent here cannot smuggle a message,
- * address or secret into telemetry intact.
+ * Keep a reported detail only when it is one of our own tokens, else drop it.
+ *
+ * Dropping (rather than rejecting the envelope) because the field only ever
+ * annotates an event, so an unrecognized value must not cost the event it
+ * describes. Matching against the enum (rather than sanitizing characters)
+ * because base58 addresses, JWTs and API keys are made entirely of token-safe
+ * characters and would survive any character filter intact.
  */
-function normalizeErrorDetail(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  return (
-    normalizeResourceValue(value, MAX_ERROR_DETAIL_LENGTH)?.replace(
-      /^_+|_+$/g,
-      ""
-    ) || undefined
-  );
+function normalizeErrorDetail(value: unknown): LifecycleErrorDetail | undefined {
+  return includes(LIFECYCLE_ERROR_DETAILS, value) ? value : undefined;
 }
 
 export function parseBrowserLifecycleEnvelope(
@@ -465,12 +479,7 @@ export function parseBrowserLifecycleEnvelope(
   }
 
   assertOptionalEnum(record.errorCode, LIFECYCLE_ERROR_CODES);
-  // Sanitized rather than rejected: this field only ever adds detail, so a
-  // value that normalizes away must never cost the whole event.
-  const errorDetail =
-    record.errorDetail === undefined
-      ? undefined
-      : normalizeErrorDetail(record.errorDetail);
+  const errorDetail = normalizeErrorDetail(record.errorDetail);
   assertOptionalEnum(record.executeNowState, EXECUTE_NOW_STATES);
   assertOptionalEnum(record.authProofKind, PROOF_KINDS);
   assertOptionalEnum(record.executionMode, EXECUTION_MODES);

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -234,6 +234,17 @@ export type LifecycleDiagnostics = {
   chainState?: (typeof CHAIN_STATES)[number];
   cleanupRequired?: boolean;
   errorCode?: LifecycleErrorCode;
+  /**
+   * The originating system's own short error token, for when `errorCode` is a
+   * category that several distinct causes collapse into — a mobile wallet
+   * adapter code such as `EUNSPECIFIED` or `ERROR_SESSION_TIMEOUT`, say. Names
+   * the cause without minting a lifecycle code per vendor error.
+   *
+   * A machine token, never prose: it is sanitized to `[A-Za-z0-9._-]` and
+   * truncated, so free text arrives mangled, and anything resembling a
+   * message, address or secret must not be put here.
+   */
+  errorDetail?: string;
   executeNowState?: ExecuteNowState;
   executionMode?: (typeof EXECUTION_MODES)[number];
   httpStatus?: number;
@@ -338,6 +349,25 @@ function assertOptionalBoolean(
   }
 }
 
+const MAX_ERROR_DETAIL_LENGTH = 64;
+
+/**
+ * Reduce a reported error token to a bounded `[A-Za-z0-9._-]` string, or
+ * undefined when nothing usable remains. Sanitizing (rather than rejecting)
+ * keeps a malformed detail from costing the event it annotates, and the
+ * character class means prose accidentally sent here cannot smuggle a message,
+ * address or secret into telemetry intact.
+ */
+function normalizeErrorDetail(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return (
+    normalizeResourceValue(value, MAX_ERROR_DETAIL_LENGTH)?.replace(
+      /^_+|_+$/g,
+      ""
+    ) || undefined
+  );
+}
+
 export function parseBrowserLifecycleEnvelope(
   value: unknown,
   now = Date.now()
@@ -354,6 +384,7 @@ export function parseBrowserLifecycleEnvelope(
     "durationMs",
     "elapsedMs",
     "errorCode",
+    "errorDetail",
     "executeNowState",
     "executionMode",
     "flowId",
@@ -434,6 +465,12 @@ export function parseBrowserLifecycleEnvelope(
   }
 
   assertOptionalEnum(record.errorCode, LIFECYCLE_ERROR_CODES);
+  // Sanitized rather than rejected: this field only ever adds detail, so a
+  // value that normalizes away must never cost the whole event.
+  const errorDetail =
+    record.errorDetail === undefined
+      ? undefined
+      : normalizeErrorDetail(record.errorDetail);
   assertOptionalEnum(record.executeNowState, EXECUTE_NOW_STATES);
   assertOptionalEnum(record.authProofKind, PROOF_KINDS);
   assertOptionalEnum(record.executionMode, EXECUTION_MODES);
@@ -553,7 +590,9 @@ export function parseBrowserLifecycleEnvelope(
     }
   }
 
-  return { ...record, pathname } as BrowserLifecycleEnvelope;
+  // `errorDetail` always overwrites the raw value; undefined when it was
+  // absent or normalized away, which downstream treats as "not set".
+  return { ...record, pathname, errorDetail } as BrowserLifecycleEnvelope;
 }
 
 const WALLET_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;

--- a/frontend/src/features/observability/lifecycle-error-detail.test.ts
+++ b/frontend/src/features/observability/lifecycle-error-detail.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseBrowserLifecycleEnvelope } from "./lifecycle-contract";
+import {
+  LIFECYCLE_ERROR_DETAILS,
+  parseBrowserLifecycleEnvelope,
+} from "./lifecycle-contract";
 
 // `errorDetail` names the cause behind a broad `errorCode` (ASK-1872): mobile
 // wallet failures all collapse into a handful of categories, and this is what
-// distinguishes `EUNSPECIFIED` from `ERROR_SESSION_TIMEOUT` inside one of them.
+// tells them apart inside one of them.
 //
-// Two invariants the type system cannot hold. The envelope parser rejects
-// unknown keys outright, so a client sending this before the field exists
-// loses the whole event — and because it only ever *adds* detail, a malformed
-// value must be dropped rather than take the event down with it.
+// Two invariants the type system cannot hold, both of which cost more than the
+// field is worth if they break. It is an enum, so no string a client holds can
+// reach the exported `loyal.error.detail` attribute — a character filter would
+// not do, since base58 addresses, JWTs and API keys are built entirely from
+// token-safe characters. And an unrecognized value is dropped rather than
+// rejected, because the field only annotates an event and must never cost the
+// event it describes.
 
 function envelope(overrides: Record<string, unknown> = {}) {
   return {
@@ -33,48 +39,41 @@ describe("lifecycle errorDetail", () => {
     const parsed = parseBrowserLifecycleEnvelope(
       envelope({
         errorCode: "wallet_connection_failed",
-        errorDetail: "EUNSPECIFIED",
+        errorDetail: "mwa_unspecified",
       })
     );
 
-    expect(parsed.errorDetail).toBe("EUNSPECIFIED");
+    expect(parsed.errorDetail).toBe("mwa_unspecified");
     expect(parsed.errorCode).toBe("wallet_connection_failed");
   });
 
-  test("keeps the tokens real wallet codes are made of", () => {
-    expect(
-      parseBrowserLifecycleEnvelope(
-        envelope({ errorDetail: "ERROR_SESSION_TIMEOUT" })
-      ).errorDetail
-    ).toBe("ERROR_SESSION_TIMEOUT");
-    expect(
-      parseBrowserLifecycleEnvelope(envelope({ errorDetail: "-100" }))
-        .errorDetail
-    ).toBe("-100");
+  test("accepts every declared token", () => {
+    for (const detail of LIFECYCLE_ERROR_DETAILS) {
+      expect(
+        parseBrowserLifecycleEnvelope(envelope({ errorDetail: detail }))
+          .errorDetail
+      ).toBe(detail);
+    }
   });
 
-  // The character class is the guard against prose — and anything hiding in
-  // it — reaching telemetry intact.
-  test("mangles prose instead of storing it verbatim", () => {
-    const parsed = parseBrowserLifecycleEnvelope(
-      envelope({ errorDetail: "user 5CjK@mail failed at 10:31" })
-    );
-
-    expect(parsed.errorDetail).not.toContain("@");
-    expect(parsed.errorDetail).not.toContain(" ");
-  });
-
-  test("truncates rather than storing an unbounded string", () => {
-    const parsed = parseBrowserLifecycleEnvelope(
-      envelope({ errorDetail: "E".repeat(500) })
-    );
-
-    expect(parsed.errorDetail!.length).toBeLessThanOrEqual(64);
+  // The whole reason this is an enum: every one of these is built from
+  // characters a sanitizer would have waved through intact.
+  test.each([
+    ["a wallet address", "BGtzTW2yczjR7FCpSvKfcjxCw811Rdori8aY96ZJdQ51"],
+    ["a JWT", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1"],
+    // Shaped like an API key without matching a real provider's pattern —
+    // secret scanners flag the genuine article even in a test fixture.
+    ["an API key", "EXAMPLE_NOT_A_REAL_KEY_0123456789abcdefghij"],
+    ["a raw vendor code", "EUNSPECIFIED"],
+  ])("never stores %s", (_label, errorDetail) => {
+    expect(
+      parseBrowserLifecycleEnvelope(envelope({ errorDetail })).errorDetail
+    ).toBeUndefined();
   });
 
   // Each of these would otherwise cost the entire event.
   test.each([
-    ["a value that normalizes away", "   "],
+    ["an unknown token", "mwa_something_new"],
     ["a non-string value", 42],
     ["null", null],
   ])("drops %s without failing the envelope", (_label, errorDetail) => {

--- a/frontend/src/features/observability/lifecycle-error-detail.test.ts
+++ b/frontend/src/features/observability/lifecycle-error-detail.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseBrowserLifecycleEnvelope } from "./lifecycle-contract";
+
+// `errorDetail` names the cause behind a broad `errorCode` (ASK-1872): mobile
+// wallet failures all collapse into a handful of categories, and this is what
+// distinguishes `EUNSPECIFIED` from `ERROR_SESSION_TIMEOUT` inside one of them.
+//
+// Two invariants the type system cannot hold. The envelope parser rejects
+// unknown keys outright, so a client sending this before the field exists
+// loses the whole event — and because it only ever *adds* detail, a malformed
+// value must be dropped rather than take the event down with it.
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    durationMs: 10,
+    elapsedMs: 10,
+    flowId: "6f9619ff-8b86-4d01-b42d-00cf4fc964ff",
+    flowName: "earn.withdrawal",
+    flowVariant: "full",
+    outcome: "failed",
+    pathname: "/",
+    runtime: "browser",
+    source: "browser",
+    stage: "prepare",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("lifecycle errorDetail", () => {
+  test("is accepted alongside a category error code", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({
+        errorCode: "wallet_connection_failed",
+        errorDetail: "EUNSPECIFIED",
+      })
+    );
+
+    expect(parsed.errorDetail).toBe("EUNSPECIFIED");
+    expect(parsed.errorCode).toBe("wallet_connection_failed");
+  });
+
+  test("keeps the tokens real wallet codes are made of", () => {
+    expect(
+      parseBrowserLifecycleEnvelope(
+        envelope({ errorDetail: "ERROR_SESSION_TIMEOUT" })
+      ).errorDetail
+    ).toBe("ERROR_SESSION_TIMEOUT");
+    expect(
+      parseBrowserLifecycleEnvelope(envelope({ errorDetail: "-100" }))
+        .errorDetail
+    ).toBe("-100");
+  });
+
+  // The character class is the guard against prose — and anything hiding in
+  // it — reaching telemetry intact.
+  test("mangles prose instead of storing it verbatim", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorDetail: "user 5CjK@mail failed at 10:31" })
+    );
+
+    expect(parsed.errorDetail).not.toContain("@");
+    expect(parsed.errorDetail).not.toContain(" ");
+  });
+
+  test("truncates rather than storing an unbounded string", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorDetail: "E".repeat(500) })
+    );
+
+    expect(parsed.errorDetail!.length).toBeLessThanOrEqual(64);
+  });
+
+  // Each of these would otherwise cost the entire event.
+  test.each([
+    ["a value that normalizes away", "   "],
+    ["a non-string value", 42],
+    ["null", null],
+  ])("drops %s without failing the envelope", (_label, errorDetail) => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorCode: "wallet_connection_failed", errorDetail })
+    );
+
+    expect(parsed.errorDetail).toBeUndefined();
+    expect(parsed.errorCode).toBe("wallet_connection_failed");
+  });
+
+  test("is optional", () => {
+    expect(parseBrowserLifecycleEnvelope(envelope()).errorDetail).toBeUndefined();
+  });
+});

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -104,6 +104,7 @@ export function buildOtlpLifecyclePayload(
   const strings: Array<[string, string | undefined]> = [
     ["loyal.wallet.address", event.walletAddress],
     ["loyal.error.code", event.errorCode],
+    ["loyal.error.detail", event.errorDetail],
     ["loyal.execute_now.state", event.executeNowState],
     ["loyal.chain.state", event.chainState],
     ["loyal.persistence.state", event.persistenceState],


### PR DESCRIPTION
Part of ASK-1872, and the backend half of review finding #2 on #526.

Lifecycle error codes are categories, so several distinct causes collapse into one. Every mobile wallet-session failure arrives as a `wallet_*` code with no way to tell `EUNSPECIFIED` (the wallet never connected back) from `ERROR_SESSION_TIMEOUT` — which is exactly the black box the ASK-1872 investigation ran into.

Adds an optional `errorDetail` to the lifecycle envelope, mapped to the `loyal.error.detail` attribute.

## Design notes

- **Sanitized, not rejected.** Every other optional field throws `InvalidLifecycleEnvelopeError` on a bad value, which drops the entire event. This field only ever annotates an event, so a malformed detail must not cost the event it describes. It normalizes to undefined instead.
- **An enum, not a string.** `errorDetail` accepts only tokens this repo defines (`LIFECYCLE_ERROR_DETAILS`); emitters map their native error onto one and anything else is dropped. The first cut sanitized arbitrary client strings to `[A-Za-z0-9._-]`, which review correctly called out as *not* a privacy boundary: base58 addresses, JWTs and API keys are built entirely from token-safe characters, so a key routed here would have been exported to `loyal.error.detail` intact. With an allowlist no client-held string can reach the attribute at all.
- **No new lifecycle codes.** Naming the vendor cause in a field avoids minting an error code per wallet-adapter error.

## Sequencing

`parseBrowserLifecycleEnvelope` rejects unknown keys, so a client that sends `errorDetail` before this deploys loses the **whole** envelope, not just the field. This must land and deploy before any emitter populates it — the mobile side (#526) deliberately does not send it yet.

## Validation

- `bun test src/features/observability/` — 15 pass, 0 fail (10 new), including fixtures asserting that a wallet address, JWT and API-key-shaped string are all dropped.
- `npx tsc --noEmit` — no errors in the changed files.
- `npm run lint` — no errors (pre-existing warnings elsewhere untouched).
