### PR TITLE
fix(earn): retry transient Kamino upstream failures in withdraw prepare

### DIFF
--- a/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
+++ b/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
@@ -1,0 +1,151 @@
+// Mirrors the real KaminoUpstreamError. The retry predicate keys off this
+// class, so a mock that drifts from `packages/smart-account-vaults` would make
+// these tests pass while production keeps throwing through un-retried.
+class MockKaminoUpstreamError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "KaminoUpstreamError";
+    this.status = status;
+  }
+}
+
+// Mirrors the real EarnApiError. Mocked rather than imported because
+// `earn-api` reaches `@/config/env` → `@loyal-labs/solana-rpc`, whose ESM dist
+// Jest does not transform.
+class MockEarnApiError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "EarnApiError";
+    this.code = code;
+  }
+}
+
+jest.mock(
+  "@loyal-labs/smart-account-vaults",
+  () => ({
+    KaminoUpstreamError: MockKaminoUpstreamError,
+  }),
+  { virtual: true },
+);
+
+jest.mock("../earn-api", () => ({
+  EarnApiError: MockEarnApiError,
+}));
+
+// Keep the subject import after mock initialization: this test uses a virtual
+// workspace-package mock that cannot be referenced before its declaration.
+// eslint-disable-next-line import/first
+import { withConnectionRetry } from "../connection-retry";
+
+const EXHAUSTED = "network exhausted";
+
+beforeEach(() => {
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+// The helper sleeps between attempts; advance timers as they are scheduled so
+// the assertions do not wait out the real 1s backoff.
+async function runWithTimers<T>(promise: Promise<T>): Promise<T> {
+  const settled = promise.then(
+    (value) => ({ ok: true as const, value }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+  await jest.runAllTimersAsync();
+  const result = await settled;
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+describe("withConnectionRetry", () => {
+  test("retries a transient Kamino 5xx and returns the eventual success", async () => {
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(new MockKaminoUpstreamError(502, "bad gateway"))
+      .mockResolvedValueOnce("prepared");
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).resolves.toBe("prepared");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries a Kamino 429", async () => {
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(new MockKaminoUpstreamError(429, "slow down"))
+      .mockResolvedValueOnce("prepared");
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).resolves.toBe("prepared");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  // A rejected request is rejected identically on every retry — spending the
+  // budget on it only delays the error the user needs to see.
+  test("throws a Kamino 4xx straight through without retrying", async () => {
+    const error = new MockKaminoUpstreamError(400, "bad request");
+    const run = jest.fn().mockRejectedValue(error);
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).rejects.toBe(error);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("still retries RN connection-level TypeErrors", async () => {
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce("prepared");
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).resolves.toBe("prepared");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  test("still throws a backend EarnApiError through untouched", async () => {
+    const error = new MockEarnApiError("nope", "resolve_failed");
+    const run = jest.fn().mockRejectedValue(error);
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).rejects.toBe(error);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  // A plain Error is a build/validation bug, not a network blip.
+  test("throws an unbranded Error through without retrying", async () => {
+    const error = new Error("Kamino did not return a withdraw instruction.");
+    const run = jest.fn().mockRejectedValue(error);
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).rejects.toBe(error);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("gives up as EarnApiError once the retry budget is spent", async () => {
+    const run = jest
+      .fn()
+      .mockRejectedValue(new MockKaminoUpstreamError(503, "unavailable"));
+
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).rejects.toThrow(EXHAUSTED);
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+});

--- a/mobile/src/lib/solana/earn/__tests__/withdraw.test.ts
+++ b/mobile/src/lib/solana/earn/__tests__/withdraw.test.ts
@@ -32,10 +32,23 @@ jest.mock(
   { virtual: true },
 );
 
+// Mirrors the real KaminoUpstreamError; connection-retry.ts instanceof-checks
+// it to decide whether a device-prepare failure is worth retrying.
+class MockKaminoUpstreamError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "KaminoUpstreamError";
+    this.status = status;
+  }
+}
+
 jest.mock(
   "@loyal-labs/smart-account-vaults",
   () => ({
     createSmartAccountVaultsClient,
+    KaminoUpstreamError: MockKaminoUpstreamError,
   }),
   { virtual: true },
 );

--- a/mobile/src/lib/solana/earn/connection-retry.ts
+++ b/mobile/src/lib/solana/earn/connection-retry.ts
@@ -1,3 +1,5 @@
+import { KaminoUpstreamError } from "@loyal-labs/smart-account-vaults";
+
 import { EarnApiError } from "./earn-api";
 
 // RN surfaces connection-level fetch failures (DNS/TLS/socket reset) as a bare
@@ -7,6 +9,41 @@ import { EarnApiError } from "./earn-api";
 // own semantics and are deliberately NOT wrapped.
 const NETWORK_RETRY_ATTEMPTS = 3;
 const NETWORK_RETRY_DELAY_MS = 1_000;
+
+// Device prepare calls Kamino's instruction API directly (RN bypasses the web
+// proxy), once per reserve — so a full exit fans out several of these and any
+// one transient failure used to sink the whole prepare, which is where the
+// ~24 % full-exit prepare failure rate came from (ASK-1887). 5xx and 429 are
+// the upstream having a bad moment; a 4xx is a rejected request and will be
+// rejected identically on every retry.
+function isRetryableKaminoStatus(status: number): boolean {
+  return status >= 500 || status === 429;
+}
+
+// Metro can resolve a workspace package to more than one module instance, and
+// a second copy would make `instanceof` quietly false — so brand-check by name
+// as well. Both arms require a numeric `status`, so nothing else matches.
+function isKaminoUpstreamError(
+  error: unknown,
+): error is { status: number } & Error {
+  if (error instanceof KaminoUpstreamError) {
+    return true;
+  }
+  return (
+    error instanceof Error &&
+    error.name === "KaminoUpstreamError" &&
+    typeof (error as { status?: unknown }).status === "number"
+  );
+}
+
+function isRetryableNetworkError(error: unknown): error is Error {
+  // fetch rejects with TypeError only for connection-level failures;
+  // API rejections are EarnApiError and SDK/build errors are plain Error.
+  if (error instanceof TypeError) {
+    return true;
+  }
+  return isKaminoUpstreamError(error) && isRetryableKaminoStatus(error.status);
+}
 
 export async function withConnectionRetry<T>(
   label: string,
@@ -23,9 +60,7 @@ export async function withConnectionRetry<T>(
     try {
       return await run();
     } catch (error) {
-      // fetch rejects with TypeError only for connection-level failures;
-      // API rejections are EarnApiError and SDK/build errors are plain Error.
-      if (!(error instanceof TypeError)) {
+      if (!isRetryableNetworkError(error)) {
         throw error;
       }
       lastError = error;

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -2255,6 +2255,22 @@ function readKaminoDepositInstruction(
   ).instruction;
 }
 
+// A non-OK response from Kamino's instruction API used to be a bare `Error`,
+// indistinguishable from a build/validation bug by anything upstream. Callers
+// need that distinction to decide whether retrying can help: a full exit fans
+// one of these calls out per reserve, so a single transient 5xx would
+// otherwise fail the whole prepare (ASK-1887). `status` is carried so the
+// caller — not this module — owns the retry policy.
+export class KaminoUpstreamError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "KaminoUpstreamError";
+    this.status = status;
+  }
+}
+
 async function fetchKaminoDepositInstruction(args: {
   amountRaw: bigint;
   depositDiscriminator: readonly number[];
@@ -2285,7 +2301,8 @@ async function fetchKaminoDepositInstruction(args: {
   );
 
   if (!response.ok) {
-    throw new Error(
+    throw new KaminoUpstreamError(
+      response.status,
       `Kamino deposit instruction request failed with status ${response.status}.`
     );
   }
@@ -2327,7 +2344,8 @@ async function fetchKaminoWithdrawInstruction(args: {
 
   if (!response.ok) {
     const responseText = await response.text().catch(() => "");
-    throw new Error(
+    throw new KaminoUpstreamError(
+      response.status,
       `Kamino withdraw instruction request failed with status ${response.status}: ${responseText}`
     );
   }


### PR DESCRIPTION
Full-exit Earn withdrawals failed at `prepare` 23.7% of the time over 9 days (120/506) against 2.2% for partial, because the device's per-reserve Kamino instruction calls were never retried — `withConnectionRetry` only caught `TypeError`, while a non-OK Kamino response arrived as a plain `Error`.

The SDK now throws a typed `KaminoUpstreamError` carrying the upstream status, and mobile retries it on 5xx/429 while letting 4xx throw straight through. One observable side effect: an exhausted retry now surfaces as `request_failed` rather than `unexpected_error`, so `unexpected_error` at `earn.withdrawal.prepare` should fall toward zero — that is the signal to watch after release.

Closes ASK-1887.