### PR TITLE
fix(earn): serialize Earn vault snapshot reconciles per vault

### DIFF
--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
@@ -325,6 +325,7 @@ describe("yield deposit repository idempotency", () => {
             batchCalls.push(items);
             return [];
           }),
+          execute: mock(() => ({ kind: "advisory-lock" })),
           insert: mock(() => {
             const index = insertIndex++;
             return {
@@ -461,6 +462,7 @@ describe("yield deposit repository idempotency", () => {
           delete: mock(() => ({
             where: () => ({}),
           })),
+          execute: mock(() => ({ kind: "advisory-lock" })),
           insert: mock(() => {
             const index = insertIndex++;
             return {
@@ -534,7 +536,7 @@ describe("yield deposit repository idempotency", () => {
       now: () => new Date("2026-06-02T00:00:00.000Z"),
     };
 
-    return { dependencies, insertedValues, updateSets };
+    return { batchCalls, dependencies, insertedValues, updateSets };
   }
 
   const reserveWithdrawalOverrides = {
@@ -560,6 +562,26 @@ describe("yield deposit repository idempotency", () => {
     sourceId: "reserve",
     sourceType: "reserve" as const,
   };
+
+  // The confirmed-withdrawal path swaps the current snapshot in exactly the
+  // same demote-then-promote shape as the holdings reconcile, and the two race
+  // each other on one vault — locking only the reconcile would leave the
+  // pairing that actually pages still open (ASK-1902).
+  test("locks the vault before the confirmed-withdrawal snapshot swap", async () => {
+    const { batchCalls, dependencies } = createRecordedWithdrawalDependencies();
+
+    await recordConfirmedYieldWithdrawal(
+      createWithdrawalInput(reserveWithdrawalOverrides),
+      dependencies as never
+    );
+
+    // The two-statement batch is the reserve/idle read; the snapshot swap is
+    // the long one, and it has to open with the lock or the demote it guards
+    // has already run.
+    const swapBatch = batchCalls.find((items) => items.length > 2);
+    expect(swapBatch).toBeDefined();
+    expect(swapBatch?.[0]).toMatchObject({ kind: "advisory-lock" });
+  });
 
   test("records a zero-balance full withdrawal without closing position or policy state", async () => {
     const { dependencies, insertedValues, updateSets } =

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
@@ -18,6 +18,9 @@ const { verifyUserYieldPositions } = await import(
 const { syncConfirmedRebalanceHoldingEventsForVault } = await import(
   "./yield-deposit-repository.server"
 );
+const { recordReconciledYieldVaultSnapshot } = await import(
+  "./yield-deposit-repository.server"
+);
 
 function createDepositInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -686,6 +689,111 @@ describe("confirmed rebalance history projection", () => {
     );
     expect(renderedSql).toContain("latest_projected_rebalance");
     expect(execute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("reconciled vault snapshot concurrency", () => {
+  // Demote-then-promote across two uncoordinated transactions is what put two
+  // `is_current` rows on one vault and failed the second batch on
+  // `vault_position_snapshots_one_current_idx` (ASK-1902). The lock has to be
+  // the FIRST statement, or the demote it is meant to guard already ran.
+  function createSnapshotWriterDependencies() {
+    const dialect = new PgDialect();
+    const executedSql: string[] = [];
+    let batched: unknown[] = [];
+
+    function chain(kind: string) {
+      const node: Record<string, unknown> = { kind };
+      node.onConflictDoUpdate = () => node;
+      node.returning = async () => [{ id: BigInt(42) }];
+      node.set = () => node;
+      node.values = () => node;
+      node.where = () => node;
+      return node;
+    }
+
+    const db = {
+      batch: mock(async (items: unknown[]) => {
+        batched = items;
+        return [];
+      }),
+      delete: mock(() => chain("delete")),
+      execute: mock((query: unknown) => {
+        const rendered = dialect.sqlToQuery(query as never);
+        executedSql.push(rendered.sql);
+        return { kind: "execute", params: rendered.params };
+      }),
+      insert: mock(() => chain("insert")),
+      update: mock(() => chain("update")),
+    };
+
+    return {
+      batchedStatements: () => batched,
+      dependencies: {
+        client: { db },
+        now: () => new Date("2026-07-27T23:35:26.000Z"),
+      },
+      executedSql,
+    };
+  }
+
+  function createSnapshotInput(vaultId: bigint) {
+    return {
+      context: { source: "test" },
+      idleTokenBalance: {
+        amountRaw: BigInt(10_000),
+        mint: "usdc",
+        owner: "owner",
+        tokenAccount: "idle-token-account",
+      },
+      observedSlot: BigInt(900),
+      policyId: BigInt(7),
+      positions: [],
+      sourceCommitment: "confirmed",
+      vaultId,
+    };
+  }
+
+  test("locks the vault before demoting, in the same batch as the promote", async () => {
+    const { batchedStatements, dependencies, executedSql } =
+      createSnapshotWriterDependencies();
+
+    await recordReconciledYieldVaultSnapshot(
+      createSnapshotInput(BigInt(77)),
+      dependencies as never
+    );
+
+    const statements = batchedStatements();
+    expect(executedSql[0]).toContain("pg_advisory_xact_lock");
+    expect(statements[0]).toMatchObject({ kind: "execute" });
+    expect(statements[1]).toMatchObject({ kind: "update" });
+    expect(statements.length).toBeGreaterThan(2);
+  });
+
+  test("keys the lock on the vault so unrelated vaults never block", async () => {
+    const first = createSnapshotWriterDependencies();
+    const second = createSnapshotWriterDependencies();
+
+    await recordReconciledYieldVaultSnapshot(
+      createSnapshotInput(BigInt(77)),
+      first.dependencies as never
+    );
+    await recordReconciledYieldVaultSnapshot(
+      createSnapshotInput(BigInt(78)),
+      second.dependencies as never
+    );
+
+    const firstKey = (first.batchedStatements()[0] as { params: unknown[] })
+      .params;
+    const secondKey = (second.batchedStatements()[0] as { params: unknown[] })
+      .params;
+
+    expect(firstKey).toContain(
+      "loyal_yield.vault_position_snapshots.is_current:77"
+    );
+    expect(secondKey).toContain(
+      "loyal_yield.vault_position_snapshots.is_current:78"
+    );
   });
 });
 

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -696,6 +696,19 @@ export async function recordConfirmedEarnCleanup(
 // withdrawal) and `recordReconciledYieldVaultSnapshot` (holdings reconcile),
 // which race each other, not just themselves.
 //
+// What this lock does NOT do, so nobody reads it as more than it is: it
+// serializes the SWAP, not the state the swap was built from. Both callers
+// compute their rows from a read taken in an earlier transaction —
+// `resolveWithdrawalSource` selects `reserveRows` in its own batch, then
+// `recordCurrentVaultSourceWithdrawal` subtracts in JS — so two confirmed
+// withdrawals can each read 1000, debit 300 and 400, and serialize here to
+// leave 600 instead of 300. That lost update predates this lock (the demote
+// only collided in the narrow window where it ran before the other promote
+// committed; the common interleaving always just clobbered), and closing it
+// needs the debit to happen in SQL against the live row, not in JS against a
+// stale copy. Tracked separately — do not treat concurrent Earn accounting as
+// safe because this lock exists.
+//
 // Scope note: loyal-yield-routing's orchestrator
 // (`crates/loyal-yield-orchestrator/src/store.rs`) writes this same invariant
 // in this same shape from a different process and does not take this lock yet.

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -3342,6 +3342,24 @@ export async function findCurrentEarnDepositOnboardingAttempt(
   return (attempt as EarnDepositOnboardingAttemptRecord | undefined) ?? null;
 }
 
+// `vault_position_snapshots_one_current_idx` (a UNIQUE index on `vault_id`
+// WHERE `is_current`, declared in loyal-yield-routing's migration 0001) allows
+// exactly one current snapshot per vault, and this function reaches that state
+// in two steps: demote whatever is current, then promote the row it just
+// inserted. Two reconciles for one vault run as two separate transactions, so
+// B's demote can miss A's not-yet-committed promote and then promote its own
+// row on top of it — two current rows, and Postgres fails the second batch.
+// That surfaced as a 500 on `mobile/earn/withdraw/prepare-context`, which fans
+// into holdings, and paged as `earn.withdrawal.prepare.failed` (ASK-1902).
+//
+// A transaction-scoped advisory lock keyed on the vault makes the demote and
+// the promote inseparable: the second reconcile waits at the head of its batch
+// and re-reads a settled table. Scope note — this serializes loyal-app writers
+// only. loyal-yield-routing's orchestrator (`store.rs`, the same demote-then-
+// insert shape) writes this invariant too and does not take this lock yet.
+const CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE =
+  "loyal_yield.vault_position_snapshots.is_current";
+
 export async function recordReconciledYieldVaultSnapshot(
   input: ReconciledYieldVaultSnapshotInput,
   dependencies: YieldDepositRepositoryDependencies = createDependencies()
@@ -3396,6 +3414,11 @@ export async function recordReconciledYieldVaultSnapshot(
   }));
 
   const statements: never[] = [
+    // Must stay first: everything after it is only safe once this vault's
+    // demote/promote pair is exclusive to this transaction.
+    dependencies.client.db.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`${CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE}:${input.vaultId}`}, 0))`
+    ) as never,
     dependencies.client.db
       .update(vaultPositionSnapshots)
       .set({ isCurrent: false })

--- a/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -678,6 +678,39 @@ export async function recordConfirmedEarnCleanup(
   ]);
 }
 
+// `vault_position_snapshots_one_current_idx` (a UNIQUE index on `vault_id`
+// WHERE `is_current`, declared in loyal-yield-routing's migration 0001) allows
+// exactly one current snapshot per vault. Every writer reaches that state in
+// two steps — demote whatever is current, then promote the row it just
+// inserted — and each `db.batch` is its own transaction, so B's demote can
+// miss A's uncommitted promote and then promote on top of it. Two current
+// rows, and Postgres fails the second batch. That surfaced as a 500 on
+// `mobile/earn/withdraw/prepare-context`, which fans into holdings, and paged
+// as `earn.withdrawal.prepare.failed` (ASK-1902).
+//
+// A transaction-scoped advisory lock keyed on the vault makes the demote and
+// the promote inseparable: the loser waits at the head of its batch and
+// re-reads a settled table. It only binds writers that take it, so this must
+// be the FIRST statement of EVERY batch in this module that touches
+// `is_current` — today `recordCurrentVaultSourceWithdrawal` (confirmed
+// withdrawal) and `recordReconciledYieldVaultSnapshot` (holdings reconcile),
+// which race each other, not just themselves.
+//
+// Scope note: loyal-yield-routing's orchestrator
+// (`crates/loyal-yield-orchestrator/src/store.rs`) writes this same invariant
+// in this same shape from a different process and does not take this lock yet.
+const CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE =
+  "loyal_yield.vault_position_snapshots.is_current";
+
+function lockCurrentVaultSnapshot(
+  db: YieldDepositRepositoryDependencies["client"]["db"],
+  vaultId: bigint
+) {
+  return db.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${`${CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE}:${vaultId}`}, 0))`
+  );
+}
+
 async function recordCurrentVaultSourceWithdrawal(args: {
   dependencies: Pick<YieldDepositRepositoryDependencies, "client" | "now">;
   input: ConfirmedYieldWithdrawalInput;
@@ -790,6 +823,12 @@ async function recordCurrentVaultSourceWithdrawal(args: {
   }));
 
   await dependencies.client.db.batch([
+    // Must stay first — see lockCurrentVaultSnapshot. A confirmed withdrawal
+    // and a holdings reconcile land on the same vault routinely.
+    lockCurrentVaultSnapshot(
+      dependencies.client.db,
+      resolution.vault.id
+    ) as never,
     dependencies.client.db
       .update(vaultPositionSnapshots)
       .set({ isCurrent: false })
@@ -3342,24 +3381,6 @@ export async function findCurrentEarnDepositOnboardingAttempt(
   return (attempt as EarnDepositOnboardingAttemptRecord | undefined) ?? null;
 }
 
-// `vault_position_snapshots_one_current_idx` (a UNIQUE index on `vault_id`
-// WHERE `is_current`, declared in loyal-yield-routing's migration 0001) allows
-// exactly one current snapshot per vault, and this function reaches that state
-// in two steps: demote whatever is current, then promote the row it just
-// inserted. Two reconciles for one vault run as two separate transactions, so
-// B's demote can miss A's not-yet-committed promote and then promote its own
-// row on top of it — two current rows, and Postgres fails the second batch.
-// That surfaced as a 500 on `mobile/earn/withdraw/prepare-context`, which fans
-// into holdings, and paged as `earn.withdrawal.prepare.failed` (ASK-1902).
-//
-// A transaction-scoped advisory lock keyed on the vault makes the demote and
-// the promote inseparable: the second reconcile waits at the head of its batch
-// and re-reads a settled table. Scope note — this serializes loyal-app writers
-// only. loyal-yield-routing's orchestrator (`store.rs`, the same demote-then-
-// insert shape) writes this invariant too and does not take this lock yet.
-const CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE =
-  "loyal_yield.vault_position_snapshots.is_current";
-
 export async function recordReconciledYieldVaultSnapshot(
   input: ReconciledYieldVaultSnapshotInput,
   dependencies: YieldDepositRepositoryDependencies = createDependencies()
@@ -3416,9 +3437,7 @@ export async function recordReconciledYieldVaultSnapshot(
   const statements: never[] = [
     // Must stay first: everything after it is only safe once this vault's
     // demote/promote pair is exclusive to this transaction.
-    dependencies.client.db.execute(
-      sql`select pg_advisory_xact_lock(hashtextextended(${`${CURRENT_VAULT_SNAPSHOT_LOCK_NAMESPACE}:${input.vaultId}`}, 0))`
-    ) as never,
+    lockCurrentVaultSnapshot(dependencies.client.db, input.vaultId) as never,
     dependencies.client.db
       .update(vaultPositionSnapshots)
       .set({ isCurrent: false })


### PR DESCRIPTION
`recordReconciledYieldVaultSnapshot` and `recordCurrentVaultSourceWithdrawal` both swap the vault's current snapshot with a demote-then-promote pair, each in its own `db.batch` transaction, so they race each other on one vault and lose to `vault_position_snapshots_one_current_idx` — which the mobile withdraw `prepare-context` call surfaced as a 500. Both batches now open with a shared transaction-scoped advisory lock keyed on the vault, making the pair inseparable.

**Two things this deliberately does not fix**, both pre-existing and both stated in the code comment so nobody reads the lock as more than it is:

1. It serializes the *swap*, not the state the swap was built from. Both callers compute rows from a read taken in an earlier transaction, so two confirmed withdrawals can each read 1000, debit 300 and 400, and leave 600 instead of 300. That lost update already occurred on every interleaving except the narrow one that crashed; the lock removes the crash without making the arithmetic correct. Tracked in [ASK-1905](https://linear.app/askloyal/issue/ASK-1905/fixearn-debit-withdrawal-source-amounts-in-sql-concurrent-confirms).
2. It binds loyal-app writers only. loyal-yield-routing's orchestrator (`crates/loyal-yield-orchestrator/src/store.rs`) writes the same invariant in the same shape from a different process and needs the matching lock.

Linear: [ASK-1902](https://linear.app/askloyal/issue/ASK-1902/fixearn-make-the-earn-holdings-snapshot-reconcile-idempotent-under) · tracking [ASK-1878](https://linear.app/askloyal/issue/ASK-1878/track-alert-triage-2026-07-26-follow-up-6-unowned-clickstack-alerts)

Originating alert:

```
**🚨 Alert for "Errors"**
*Group: "ServiceName:loyal-mobile"*
*Time Range (UTC): [Jul 27 11:35:00 PM - Jul 27 11:36:00 PM)*
*1 event · 1 unique wallet · muted 6h24m*

🔴 **error** · 23:35:56 UTC · loyal-mobile
**earn.withdrawal.prepare.failed**
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: wGPqP4VPUn1ws4sVgmHKJ2uutWQs13TUuuPWEZv7psi

https://loyal-clickstack.onrender.com/search/6a5fb723dcc64beb0ded6cca?from=1785195300000&to=1785195360000&isLive=false
```