### PR TITLE
fix(earn): return 4xx for Earn withdraw resolution rejections

### DIFF
--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -323,7 +323,11 @@ describe("Earn withdrawal prepare route", () => {
     );
     const payload = await response.json();
 
-    expect(response.status).toBe(500);
+    // 409, not 500: the caller's balance was stale, which is not a server
+    // fault. Reporting it as one paged the team every time a user typed an
+    // amount their source no longer covered (ASK-1903).
+    expect(response.status).toBe(409);
+    expect(payload.error.code).toBe("earn_withdraw_amount_exceeds_source");
     expect(payload.error.message).toBe(
       "Withdrawal exceeds the selected Earn source amount."
     );
@@ -354,5 +358,40 @@ describe("Earn withdrawal prepare route", () => {
 
     expect(response.status).toBe(409);
     expect(payload.error.code).toBe("missing_earn_position");
+  });
+
+  test("returns missing_earn_withdraw_source when the snapshot holds nothing", async () => {
+    const { POST } = await import("./route");
+    currentSnapshot = holdingsSnapshot([]);
+
+    const response = await POST(
+      createRequest({ amountRaw: "1", mode: "full" })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload.error.code).toBe("missing_earn_withdraw_source");
+    expect(prepareCalls).toHaveLength(0);
+  });
+
+  test("returns earn_withdraw_source_required when a partial names no known source", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "1000",
+        mode: "partial",
+        source: {
+          id: "11111111111111111111111111111121",
+          reserve: "11111111111111111111111111111121",
+          type: "reserve",
+        },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("earn_withdraw_source_required");
+    expect(prepareCalls).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -29,7 +29,11 @@ import {
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
 // Resolution failures the routes surface as specific HTTP responses rather
-// than a generic 500 (`missing_earn_policy` / `missing_earn_position`).
+// than a generic 500. Every rejection that describes the CALLER's state — no
+// policy, no position, no source, a source that no longer covers the amount —
+// belongs here: answering 500 for those made a stale client balance page the
+// team as a server fault, and the device reported it as `request_failed` with
+// `httpStatus: 500` (ASK-1903). Only genuine server faults fall through.
 export class EarnWithdrawResolveError extends Error {
   readonly status: number;
   readonly code: string;
@@ -380,7 +384,11 @@ export async function resolveEarnUsdcWithdrawInput(args: {
   });
   const snapshotSources = buildSnapshotWithdrawSources(snapshot.holdings);
   if (snapshotSources.length === 0) {
-    throw new Error("No active Earn withdrawal source was found.");
+    throw new EarnWithdrawResolveError(
+      409,
+      "missing_earn_withdraw_source",
+      "No active Earn withdrawal source was found."
+    );
   }
 
   let selectedSource: SelectedEarnWithdrawSource;
@@ -392,10 +400,18 @@ export async function resolveEarnUsdcWithdrawInput(args: {
       args.sourceRequest
     );
     if (!selected) {
-      throw new Error("Select an Earn source before withdrawing.");
+      throw new EarnWithdrawResolveError(
+        400,
+        "earn_withdraw_source_required",
+        "Select an Earn source before withdrawing."
+      );
     }
     if (amountRaw > selected.amountRaw) {
-      throw new Error("Withdrawal exceeds the selected Earn source amount.");
+      throw new EarnWithdrawResolveError(
+        409,
+        "earn_withdraw_amount_exceeds_source",
+        "Withdrawal exceeds the selected Earn source amount."
+      );
     }
     selectedSource = selected;
     effectiveAmountRaw = amountRaw;


### PR DESCRIPTION
`resolveEarnUsdcWithdrawInput` threw plain `Error` for three caller-state rejections (no active source, no source selected, amount exceeds the selected source), so all three consuming routes answered 500 and the device reported `request_failed` with `httpStatus: 500` — paging the team for a stale client balance. They are now `EarnWithdrawResolveError` with 409/400/409 and stable codes; messages are unchanged because the confirm-path idempotency guard string-matches on the exact text.

Linear: [ASK-1903](https://linear.app/askloyal/issue/ASK-1903/fixearn-return-4xx-for-earn-withdraw-resolution-rejections-instead-of) · tracking [ASK-1878](https://linear.app/askloyal/issue/ASK-1878/track-alert-triage-2026-07-26-follow-up-6-unowned-clickstack-alerts)

Originating alert:

```
**🚨 Alert for "Errors"**
*Group: "ServiceName:loyal-mobile"*
*Time Range (UTC): [Jul 27 11:35:00 PM - Jul 27 11:36:00 PM)*
*1 event · 1 unique wallet · muted 6h24m*

🔴 **error** · 23:35:56 UTC · loyal-mobile
**earn.withdrawal.prepare.failed**
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: wGPqP4VPUn1ws4sVgmHKJ2uutWQs13TUuuPWEZv7psi

https://loyal-clickstack.onrender.com/search/6a5fb723dcc64beb0ded6cca?from=1785195300000&to=1785195360000&isLive=false
```