### PR TITLE
feat(observability): publish ClickStack agent skill

### DIFF
--- a/.agents/skills/loyal-observability/SKILL.md
+++ b/.agents/skills/loyal-observability/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: loyal-observability
+description: Investigate Loyal production incidents using the ClickStack MCP and, when needed, Render deployment evidence. Use for user reports, wallet or flow lookups, frontend or mobile errors, Earn and Autodeposit failures, regressions, missing telemetry, error-pattern comparisons, and production incident diagnosis in loyal-apps.
+---
+
+# Loyal Observability
+
+Use ClickStack as the telemetry truth. Use Render only to check the ClickStack deployment or its infrastructure.
+
+## Investigate
+
+| Phase | Action |
+| --- | --- |
+| Scope | Establish the environment and a bounded UTC window. Ask only when they cannot be inferred. |
+| Discover | List sources before assuming source IDs, tables, or schemas. |
+| Find | Use the strongest identifier available. Prefer a flow ID, wallet, page session, error code, service, or operation. |
+| Reconstruct | Order matching events by timestamp and follow each flow through its full attempt. |
+| Correlate | Compare `service.version` with `loyal.client.build_id` when a deploy or stale client may matter. |
+| Escalate | Check Render only when the evidence suggests an ingestion gap or infrastructure fault. |
+| Broaden | Expand the time range gradually. Prefer semantic search and pattern tools, then bounded SQL. |
+| Report | State the observed impact and timeline. Identify the failing stage, relevant version, likely cause, confidence, and unknowns. |
+
+Read [references/telemetry.md](references/telemetry.md) for Loyal fields and flow interpretation. Read [references/setup.md](references/setup.md) only for installation or connection work.
+
+## Evidence rules
+
+Separate observed facts from inference. Include reproducible timestamps and identifiers, but never print credentials. A missing terminal event is ambiguous because the user may have left, closed the app, crashed, or lost connectivity. Alert silence only means there was no new notification. When expected telemetry is missing, distinguish absent application activity from broken ingestion.
+
+Treat `chain.state=confirmed` with `persistence.state=failed` as an on-chain success followed by a Loyal recording failure. Resolve duplicate-action risk before recommending a retry.
+
+## Safety
+
+Default to read-only investigation. Require explicit approval before mutating ClickStack objects or changing Render state. Bound raw SQL by time and result size, and inspect unfamiliar source metadata first.
+
+Do not expose financial values, signatures, transactions, request data, authentication material, query strings, or chat content. Wallet addresses are searchable by design but must remain scoped to the investigation.

--- a/.agents/skills/loyal-observability/agents/openai.yaml
+++ b/.agents/skills/loyal-observability/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Loyal Observability"
+  short_description: "Investigate Loyal production telemetry"
+  default_prompt: "Use $loyal-observability to investigate this Loyal production issue with ClickStack evidence."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "clickstack"
+      description: "Loyal production logs, traces, metrics, and observability queries"
+      transport: "streamable_http"
+      url: "https://loyal-clickstack.onrender.com/api/mcp"
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/loyal-observability/references/setup.md
+++ b/.agents/skills/loyal-observability/references/setup.md
@@ -1,0 +1,57 @@
+# ClickStack agent setup
+
+ClickStack URL: `https://loyal-clickstack.onrender.com`
+
+The shared personal key is stored as concealed variable `LOYAL_CLICKSTACK_API_KEY` in the 1Password Environment `loyal-noncritical-env`. Never commit or paste the value into MCP configuration.
+
+## Codex
+
+1. Create a local 1Password Environment mount for `loyal-noncritical-env`, such as `.env.clickstack.1password`.
+2. Register the server once:
+
+```sh
+codex mcp add clickstack \
+  --url https://loyal-clickstack.onrender.com/api/mcp \
+  --bearer-token-env-var LOYAL_CLICKSTACK_API_KEY
+```
+
+3. Launch Codex with the mounted environment:
+
+```sh
+op run --env-file=.env.clickstack.1password -- codex
+```
+
+For the Codex desktop app, load the value into the macOS user launch environment:
+
+```sh
+op run --env-file=.env.clickstack.1password -- /bin/sh -c \
+  'launchctl setenv LOYAL_CLICKSTACK_API_KEY "$LOYAL_CLICKSTACK_API_KEY"'
+```
+
+Then fully quit and reopen Codex. Repeat this after signing out or restarting the Mac if the launch environment no longer contains the variable.
+
+4. Restart an already-running Codex client after adding the server or changing its environment.
+
+Current Codex uses `--url` and `--bearer-token-env-var`; the ClickStack-generated `--transport` and `--header` example is intended for clients whose CLI supports those flags.
+
+## Other MCP clients
+
+Use Streamable HTTP:
+
+- URL: `https://loyal-clickstack.onrender.com/api/mcp`
+- Header: `Authorization: Bearer <personal API access key>`
+
+Prefer the client's environment-variable or secret reference support. Obtain the value from the shared 1Password Environment instead of documentation or source control.
+
+## Verify
+
+Run the credential-safe smoke check after setup:
+
+```sh
+op run --env-file=.env.clickstack.1password -- \
+  .agents/skills/loyal-observability/scripts/verify-clickstack.sh
+```
+
+It initializes the MCP server, confirms the read-only investigation tools and four telemetry sources, and runs a bounded five-minute log query. It never prints the key or returned log rows.
+
+A credential-free request to `/api/mcp` should return `401`; an authenticated MCP initialize request should succeed.

--- a/.agents/skills/loyal-observability/references/telemetry.md
+++ b/.agents/skills/loyal-observability/references/telemetry.md
@@ -1,0 +1,54 @@
+# Loyal telemetry reference
+
+## Primary services and identifiers
+
+| Field | Meaning |
+| --- | --- |
+| `ServiceName` | Includes `loyal-frontend` and `loyal-mobile` |
+| `loyal.flow.id` | One operation attempt; use for a complete timeline |
+| `loyal.wallet.address` | Authenticated wallet lookup |
+| `loyal.flow.name` | Product flow |
+| `loyal.flow.variant` | Flow mode, such as initial, resumed, or top-up |
+| `loyal.flow.stage` | Last recorded step |
+| `loyal.flow.outcome` | `started`, `observed`, `completed`, `failed`, or `cancelled` |
+| `loyal.error.code` | Stable failure category |
+| `loyal.error.detail` | Bounded underlying cause where available |
+| `service.version` | Server-side deployment that ingested the event |
+| `loyal.client.build_id` | Full Git SHA compiled into the browser bundle |
+| `loyal.page_session.id` | Random identifier for one browser tab session |
+
+## Flows
+
+The recorded flows are `auth.sign_in`, `auth.smart_account_provisioning`, `earn.deposit`, `earn.withdrawal`, `earn.autodeposit.configuration`, and `earn.autodeposit.execute_now`.
+
+Deposit variants include `initial`, `resumed`, and `top_up`. Autodeposit configuration variants include `setup`, `floor_update`, `pause`, `resume`, and `close`.
+
+## Useful filters
+
+```sql
+ServiceName = 'loyal-frontend' AND SeverityText = 'error'
+```
+
+```sql
+LogAttributes['loyal.flow.id'] = '<flow-id>'
+```
+
+```sql
+LogAttributes['loyal.wallet.address'] = '<wallet>'
+```
+
+```sql
+LogAttributes['loyal.flow.name'] = 'earn.deposit'
+AND LogAttributes['loyal.flow.outcome'] = 'failed'
+```
+
+## Interpretation
+
+| Signal | Meaning |
+| --- | --- |
+| `completed` | The flow finished. |
+| `failed` | Loyal or a dependency failed. |
+| `cancelled` | The user dismissed the flow or rejected a wallet prompt. |
+| No terminal event | The user may have abandoned the flow, crashed, or lost connectivity. |
+| `chain.state=confirmed` with `persistence.state=failed` | The chain action succeeded and Loyal persistence failed afterward. |
+| `ChunkLoadError` | Recovery has not yet been evaluated. Check `loyal.chunk.recovery_action` and later events from the same page session. |

--- a/.agents/skills/loyal-observability/scripts/verify-clickstack.sh
+++ b/.agents/skills/loyal-observability/scripts/verify-clickstack.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+endpoint="${LOYAL_CLICKSTACK_MCP_URL:-https://loyal-clickstack.onrender.com/api/mcp}"
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+for command in curl node; do
+  command -v "$command" >/dev/null 2>&1 || fail "missing required command: $command"
+done
+
+[[ -n "${LOYAL_CLICKSTACK_API_KEY:-}" ]] || fail "LOYAL_CLICKSTACK_API_KEY is not set"
+
+mcp_call() {
+  local payload="$1"
+
+  curl --fail --silent --show-error \
+    --request POST "$endpoint" \
+    --header "Authorization: Bearer $LOYAL_CLICKSTACK_API_KEY" \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json, text/event-stream' \
+    --data-binary "$payload"
+}
+
+extract_sse_data() {
+  node -e '
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { input += chunk; });
+    process.stdin.on("end", () => {
+      const line = input.split(/\r?\n/).find((entry) => entry.startsWith("data: "));
+      if (!line) process.exit(1);
+      process.stdout.write(line.slice(6));
+    });
+  '
+}
+
+initialize_response="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"loyal-observability-verify","version":"1.0"}}}' | extract_sse_data)"
+node -e '
+  const response = JSON.parse(process.argv[1]);
+  if (response.error || response.result?.serverInfo?.name !== "clickstack") process.exit(1);
+' "$initialize_response" || fail "ClickStack MCP initialize failed"
+pass "ClickStack MCP initialized"
+
+tools_response="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | extract_sse_data)"
+node -e '
+  const response = JSON.parse(process.argv[1]);
+  const names = new Set((response.result?.tools ?? []).map((tool) => tool.name));
+  for (const required of ["clickstack_list_sources", "clickstack_describe_source", "clickstack_search", "clickstack_event_patterns"]) {
+    if (!names.has(required)) process.exit(1);
+  }
+' "$tools_response" || fail "required read-only ClickStack tools are unavailable"
+pass "read-only investigation tools are available"
+
+sources_response="$(mcp_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"clickstack_list_sources","arguments":{}}}' | extract_sse_data)"
+logs_source_id="$(node -e '
+  const response = JSON.parse(process.argv[1]);
+  if (response.error || response.result?.isError) process.exit(1);
+  const content = response.result?.content?.find((item) => item.type === "text")?.text;
+  const sources = JSON.parse(content).sources ?? [];
+  const names = new Set(sources.map((source) => source.name));
+  for (const required of ["Logs", "Traces", "Metrics", "Sessions"]) {
+    if (!names.has(required)) process.exit(1);
+  }
+  const logs = sources.find((source) => source.name === "Logs");
+  if (!logs?.id) process.exit(1);
+  process.stdout.write(logs.id);
+' "$sources_response")" || fail "ClickStack source discovery failed"
+pass "Logs, Traces, Metrics, and Sessions sources are available"
+
+end_time="$(node -e 'process.stdout.write(new Date().toISOString())')"
+start_time="$(node -e 'process.stdout.write(new Date(Date.now() - 5 * 60 * 1000).toISOString())')"
+search_payload="$(node -e '
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "clickstack_search",
+      arguments: {
+        sourceId: process.argv[1],
+        startTime: process.argv[2],
+        endTime: process.argv[3],
+        where: "1 = 1",
+        whereLanguage: "sql",
+        columns: "Timestamp,ServiceName,SeverityText,Body",
+        maxResults: 1
+      }
+    }
+  }));
+' "$logs_source_id" "$start_time" "$end_time")"
+search_response="$(mcp_call "$search_payload" | extract_sse_data)"
+node -e '
+  const response = JSON.parse(process.argv[1]);
+  if (response.error || response.result?.isError) process.exit(1);
+  const content = response.result?.content?.find((item) => item.type === "text")?.text;
+  const result = JSON.parse(content).result;
+  if (!result || !Array.isArray(result.data)) process.exit(1);
+' "$search_response" || fail "bounded five-minute ClickStack log query failed"
+pass "bounded five-minute log query succeeded"

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ docs/superpowers
 .superpowers
 
 .agents/**
+!.agents/skills/
+!.agents/skills/loyal-observability/
+!.agents/skills/loyal-observability/**
 # Track shared Charlie daemon config (must live on the default branch to be ingested)
 !.agents/daemons/
 !.agents/daemons/**


### PR DESCRIPTION
Publishes the shared Loyal observability skill with ClickStack setup, telemetry guidance, and read-only incident guardrails. Adds a credential-safe smoke script that verifies MCP initialization, source discovery, and a bounded log query.