### PR TITLE
fix(earn): tolerate legacy policies in scan and classify reconciled pairs canonically

### DIFF
--- a/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -1247,6 +1247,9 @@ export function useEarnActions(deps: {
           return true;
         }
       } catch (error) {
+        // The user-facing copy below rewrites the underlying failure; keep the
+        // raw error findable in the console for support/debugging.
+        console.error(`[earn.deposit] ${phase} failed`, error);
         // app-wallet-workspace.tsx:5300-5312 (prepare) / 5804-5825 (signing)
         const raw = getEarnDepositUserErrorMessage(
           error,

--- a/frontend/src/lib/yield-optimization/earn-deposit-reconcile.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-reconcile.server.ts
@@ -692,11 +692,14 @@ type DiscoveredPolicyPair = {
   delegatedSigner: string;
 };
 
-// Probe policy PDAs at seeds 1..N and classify with the SDK's own codec,
-// mirroring smart-account-vaults' discoverEarnYieldRoutingPolicyPairOnChain
-// (not exported from the SDK): route policy = ProgramInteraction on vault
-// index 1 with 2 instruction constraints; its setup twin sits at seed+1 with 1.
+// Probe policy PDAs at seeds 1..N and classify with the SDK's own codec.
+// Classification must use the full canonical shape check, not constraint
+// counts: on 2026-07-29 a count-only version adopted a legacy-format pair
+// (single-mint allowlist, created by an external routing service) as the
+// wallet's route pair, which the web client then correctly refused to
+// deposit through — bricking web deposits for that wallet.
 async function discoverPolicyPairOnChain(args: {
+  cluster: LoyalCluster;
   connection: Connection;
   programId: PublicKey;
   settingsPda: PublicKey;
@@ -732,34 +735,36 @@ async function discoverPolicyPairOnChain(args: {
     });
   }
 
-  const earnConstraintCount = (
-    policy: ReturnType<typeof Policy.fromAccountInfo>[0]
-  ): number | null => {
-    const state = policy.policyState;
-    if (
-      state.__kind !== "ProgramInteraction" ||
-      state.fields[0].accountIndex !== EARN_VAULT_INDEX
-    ) {
-      return null;
-    }
-    return state.fields[0].instructionsConstraints.length;
-  };
+  const vault = deriveEarnVaultPda({
+    programId: args.programId,
+    settingsPda: args.settingsPda,
+  });
+  const isCanonical = (
+    policy: ReturnType<typeof Policy.fromAccountInfo>[0],
+    stage: "route" | "setup"
+  ): boolean =>
+    canonicalEarnPolicyStateMismatch({
+      cluster: args.cluster,
+      policy,
+      stage,
+      vault,
+    }) === null;
 
   const routeSeeds = [...policiesBySeed.entries()]
-    .filter(([, policy]) => earnConstraintCount(policy) === 2)
+    .filter(([, policy]) => isCanonical(policy, "route"))
     .map(([seed]) => seed)
     .sort((a, b) => b - a);
 
   if (routeSeeds.length === 0) {
     return {
       pair: null,
-      reason: `no earn route policy found at seeds 1..${POLICY_SEED_PROBE_MAX}`,
+      reason: `no canonical earn route policy found at seeds 1..${POLICY_SEED_PROBE_MAX}`,
     };
   }
 
   for (const routeSeed of routeSeeds) {
     const setup = policiesBySeed.get(routeSeed + 1);
-    if (!setup || earnConstraintCount(setup) !== 1) {
+    if (!setup || !isCanonical(setup, "setup")) {
       continue;
     }
     const route = policiesBySeed.get(routeSeed)!;
@@ -792,7 +797,7 @@ async function discoverPolicyPairOnChain(args: {
   return {
     pair: null,
     reason:
-      "route policy found on-chain but its setup twin (seed+1, 1 constraint) is missing",
+      "canonical route policy found on-chain but its canonical setup twin (seed+1) is missing",
   };
 }
 
@@ -1080,6 +1085,7 @@ async function reconcileWallet(args: {
 
   // 4. Recover the on-chain policy pair and its creation signatures.
   const discovery = await discoverPolicyPairOnChain({
+    cluster,
     connection: args.connection,
     programId: args.programId,
     settingsPda,

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -5531,6 +5531,93 @@ export function createSmartAccountVaultsClient(
         policyCreationPayloadToState(args.expectedState)
       )
     ) {
+      // The message alone cannot tell WHICH constraint diverged; log each
+      // divergent path on its own console line (with values capped) so the
+      // mismatch is diagnosable without console truncation. Array-length
+      // mismatches log lengths plus the raw (pre-normalize) entry types to
+      // separate decode divergence from normalize divergence.
+      const cap = (value: unknown) => {
+        const text = JSON.stringify(value) ?? String(value);
+        return text.length > 120 ? `${text.slice(0, 117)}...` : text;
+      };
+      const logDiff = (line: string) =>
+        console.error(`[canonical-diff] ${line}`);
+      const collectDiffs = (left: unknown, right: unknown, path: string) => {
+        if (JSON.stringify(left) === JSON.stringify(right)) {
+          return;
+        }
+        if (Array.isArray(left) && Array.isArray(right)) {
+          if (left.length !== right.length) {
+            logDiff(
+              `${path}: length expected=${left.length} onChain=${right.length}`
+            );
+          }
+          const max = Math.max(left.length, right.length);
+          for (let index = 0; index < max; index += 1) {
+            collectDiffs(left[index], right[index], `${path}.${index}`);
+          }
+          return;
+        }
+        const leftIsObject = left !== null && typeof left === "object";
+        const rightIsObject = right !== null && typeof right === "object";
+        if (!leftIsObject || !rightIsObject) {
+          logDiff(`${path}: expected=${cap(left)} onChain=${cap(right)}`);
+          return;
+        }
+        const keys = new Set([
+          ...Object.keys(left as Record<string, unknown>),
+          ...Object.keys(right as Record<string, unknown>),
+        ]);
+        for (const key of keys) {
+          collectDiffs(
+            (left as Record<string, unknown>)[key],
+            (right as Record<string, unknown>)[key],
+            `${path}.${key}`
+          );
+        }
+      };
+      console.error(`[smart-account-vaults] ${args.label} canonical mismatch`);
+      collectDiffs(
+        normalizeComparableGeneratedValue(
+          policyCreationPayloadToState(args.expectedState)
+        ),
+        normalizeComparableGeneratedValue(policy.policyState),
+        "policyState"
+      );
+      const describeRawEntry = (value: unknown) => {
+        if (value === null || typeof value !== "object") {
+          return typeof value;
+        }
+        const name = (value as object).constructor?.name ?? "object";
+        return value instanceof Map ? `Map(size=${value.size})` : name;
+      };
+      const rawConstraints = (
+        policy.policyState as unknown as {
+          fields?: { instructionsConstraints?: unknown[] }[];
+        }
+      ).fields?.[0]?.instructionsConstraints;
+      if (Array.isArray(rawConstraints)) {
+        for (const [index, constraint] of rawConstraints.entries()) {
+          if (constraint && typeof constraint === "object") {
+            for (const [key, value] of Object.entries(constraint)) {
+              if (Array.isArray(value)) {
+                logDiff(
+                  `raw onChain constraint ${index}.${key}: length=${
+                    value.length
+                  } entryTypes=[${value
+                    .slice(0, 8)
+                    .map((entry) => describeRawEntry(entry))
+                    .join(",")}]`
+                );
+              } else if (value instanceof Map) {
+                logDiff(
+                  `raw onChain constraint ${index}.${key}: Map size=${value.size}`
+                );
+              }
+            }
+          }
+        }
+      }
       throw new Error(
         `${args.label} instruction constraints are not canonical.`
       );
@@ -6015,9 +6102,10 @@ export function createSmartAccountVaultsClient(
           constraint.programId.equals(target.lendProgramId)
         )
       ) {
-        throw new Error(
-          `Earn policy ${entry.address.toBase58()} mixes incompatible instruction programs.`
-        );
+        // Not a route/setup candidate (e.g. an autodeposit sweep policy also
+        // touches this vault). Skip it — throwing here would brick deposits
+        // for every wallet that has any unrelated policy on the Earn vault.
+        continue;
       }
 
       const seed = toBigInt(entry.policy.seed);
@@ -6041,8 +6129,14 @@ export function createSmartAccountVaultsClient(
         setups.push(entry);
         continue;
       }
-      throw new Error(
-        `Earn policy ${entry.address.toBase58()} has non-canonical instruction constraints.`
+      // Kamino-shaped but not canonical: a legacy-format pair created by an
+      // older client (seen live 2026-07-29: external routing service recreated
+      // a pair with a single-mint allowlist). Skip it so a fresh canonical
+      // pair can be created at the next seed — policies are permission
+      // records, not fund holders, so leaving the legacy pair behind only
+      // costs its rent. Log so drift stays visible.
+      console.warn(
+        `[smart-account-vaults] skipping non-canonical Earn policy ${entry.address.toBase58()} (seed ${seed.toString()}) during policy scan`
       );
     }
 


### PR DESCRIPTION
Web deposits bricked when a legacy-format policy pair (single-mint allowlist, created by the external routing service) sat on the Earn vault: the client scan threw on any non-canonical Kamino policy, and the reconcile cron's count-only discovery adopted the legacy pair as the active route pair. The scan now skips foreign/legacy policies (with a warning plus a canonical-diff console dump on assert failure), and discovery classifies candidates with the full canonical shape check.