### PR TITLE
feat(frontend): earn-only activity feed with transaction details

### DIFF
--- a/frontend/src/components/wallet-workspace/facelift/activity-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/activity-page.tsx
@@ -2,14 +2,14 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type {
-  ActivityRow,
-  TransactionDetail,
-} from "@/components/wallet-sidebar/types";
 import {
-  ScrambleText,
-  useBalanceVisibility,
-} from "@/components/wallet-workspace/facelift/balance-visibility";
+  groupEarnTransactions,
+  resolveEarnTransactionDisplayTimeZone,
+} from "@/components/wallet-workspace/earn-transactions-pane";
+import {
+  GroupHeader,
+  TransactionRow,
+} from "@/components/wallet-workspace/facelift/earn-activity-card";
 import { MobileTabBar } from "@/components/wallet-workspace/facelift/mobile-tab-bar";
 import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transitions";
 import type { WorkspacePage } from "@/components/wallet-workspace/facelift/shell";
@@ -18,275 +18,154 @@ import {
   StaggerLine,
   StaggerReveal,
 } from "@/components/wallet-workspace/facelift/stagger-reveal";
+import { EarnTransactionDetailPane } from "@/components/wallet-workspace/facelift/transaction-detail-pane";
+import { useAuthSession } from "@/contexts/auth-session-context";
+import { usePublicEnv } from "@/contexts/public-env-context";
 import {
-  TransactionDetailPane,
-  type TransactionSwapDetail,
-} from "@/components/wallet-workspace/facelift/transaction-detail-pane";
-import { useWalletDesktopData } from "@/hooks/use-wallet-desktop-data";
-import { getTokenIconUrl } from "@/lib/token-icon";
+  fetchEarnTransactions,
+  type EarnTransactionItem,
+} from "@/lib/yield-optimization/earn-transactions.client";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
-// The mapped ActivityRow keeps only one leg of a swap; the raw activity has
-// both, so swap rows re-derive their display from it (two icons, from → to
-// subtitle, the received leg as the amount). The detail pane needs the full
-// two-leg shape on top.
-type SwapDisplay = TransactionSwapDetail & {
-  amountLabel: string;
-};
+// Rows revealed per scroll step; the full list is already client-side (the
+// earn-transactions response has no pagination), so "loading on scroll" is
+// windowed rendering over the shared 5-minute cache.
+const PAGE_SIZE = 30;
 
-function truncateAddress(addr: string): string {
-  if (addr.length <= 12) {
-    return addr;
-  }
-  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
-}
-
-// Rows carry a preformatted "±1,010.22 USDC" amount — the symbol is its last
-// word (used for shield-row subtitles and token icons, since the mapped row
-// icon is the legacy shield art).
-function parseSymbol(amount: string): string {
-  return amount.trim().split(" ").pop() ?? "";
-}
-
-const ROW_TITLES: Record<ActivityRow["type"], string> = {
-  received: "Received",
-  sent: "Sent",
-  shielded: "Shielded",
-  unshielded: "Unshielded",
-};
-
-// Figma 4813:340209 — one activity cell: composite icon, type title, context
-// subtitle, amount + time on the right.
-function ActivityCell({
-  isBalanceHidden,
-  isSelected,
-  onSelect,
-  row,
-  swap,
-}: {
-  isBalanceHidden: boolean;
-  isSelected: boolean;
-  onSelect: () => void;
-  row: ActivityRow;
-  swap: SwapDisplay | undefined;
-}) {
-  const isShieldType = row.type === "shielded" || row.type === "unshielded";
-  const symbol = parseSymbol(row.amount);
-  const tokenIcon = isShieldType ? getTokenIconUrl(symbol) : row.icon;
-  const amount = swap ? swap.amountLabel : row.amount;
-  const isPositive = amount.startsWith("+");
-
-  return (
-    <button
-      className={`flex w-full items-center rounded-2xl px-4 text-left transition-colors duration-150 ${
-        isSelected ? "bg-black/[0.04]" : "hover:bg-black/[0.04]"
-      }`}
-      onClick={onSelect}
-      type="button"
-    >
-      <span className="flex shrink-0 items-center py-2 pr-3">
-        <span className="relative block size-11 shrink-0">
-          {swap ? (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute top-0 left-0 size-[30px] rounded-full object-cover"
-                src={swap.fromIcon}
-              />
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute right-0 bottom-0 size-[30px] rounded-full object-cover"
-                src={swap.toIcon}
-              />
-            </>
-          ) : isShieldType ? (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute top-0 left-0 size-[30px] rounded-full object-cover"
-                src={tokenIcon}
-              />
-              {row.type === "shielded" ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt=""
-                  className="absolute right-px bottom-px size-7"
-                  src={`${ASSET_BASE}/icon-shield-badge.svg`}
-                />
-              ) : (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt=""
-                  className="-scale-x-100 absolute right-px bottom-px h-7 w-auto max-w-none"
-                  src={`${ASSET_BASE}/icon-unshield-badge.svg`}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="size-11 rounded-full object-cover"
-                src={tokenIcon}
-              />
-              {row.isPrivate ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt="Private"
-                  className="-bottom-0.5 -right-[3px] absolute size-5"
-                  src={`${ASSET_BASE}/icon-shield-badge.svg`}
-                />
-              ) : null}
-            </>
-          )}
-        </span>
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-        <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
-          {swap ? "Swapped" : row.titleOverride ?? ROW_TITLES[row.type]}
-        </span>
-        {swap ? (
-          <span className="flex items-center gap-1">
-            <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-              {swap.fromSymbol}
-            </span>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt="to"
-              className="size-4"
-              src={`${ASSET_BASE}/icon-arrow-right-circle.svg`}
-            />
-            <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-              {swap.toSymbol}
-            </span>
-          </span>
-        ) : (
-          <span className="truncate text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-            {row.subtitle ??
-              (isShieldType
-                ? symbol
-                : `${row.type === "received" ? "from" : "to"} ${truncateAddress(
-                    row.counterparty
-                  )}`)}
-          </span>
-        )}
-      </span>
-      <span className="flex shrink-0 flex-col items-end justify-center gap-0.5 py-[11px] pl-3">
-        <span
-          className={`whitespace-nowrap text-right text-[16px] leading-5 ${
-            isPositive ? "text-[#34c759]" : "text-black"
-          }`}
-        >
-          <ScrambleText isHidden={isBalanceHidden} text={amount} />
-        </span>
-        <span className="whitespace-nowrap text-right text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-          {row.timestamp}
-        </span>
-      </span>
-    </button>
-  );
-}
-
-// Activity screen (Figma 4813:339799 wide / 4813:340210 downsized): the
-// wallet-only activity feed — the design's Earn/Wallet tabs are intentionally
-// dropped (only wallet events exist here); an Earn Activity header pill
-// points to the Earn page instead. Right pane (4813:340199) shows the OG
-// transaction detail for the selected row, or the select-prompt placeholder.
+// Activity screen: the Earn feed in full — deposits, withdrawals and
+// rebalances rendered with the same rows as the Earn page's activity card,
+// date-grouped, extending as the user scrolls. Data comes through
+// fetchEarnTransactions, so Earn ↔ Activity switches reuse one cache and the
+// realtime stack's refreshKey bump refetches after a confirmed mutation.
 export function ActivityPage({
   onSelectPage,
+  refreshKey,
+  settingsPda,
+  walletAddress,
 }: {
   onSelectPage: (page: WorkspacePage) => void;
+  refreshKey: number;
+  settingsPda: string | null | undefined;
+  walletAddress: string | null;
 }) {
-  const data = useWalletDesktopData({});
-  const { isBalanceHidden } = useBalanceVisibility();
-  const [selectedDetail, setSelectedDetail] =
-    useState<TransactionDetail | null>(null);
+  const publicEnv = usePublicEnv();
+  const { isAuthenticated, isHydrated } = useAuthSession();
+  const [items, setItems] = useState<EarnTransactionItem[] | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [selectedItem, setSelectedItem] = useState<EarnTransactionItem | null>(
+    null
+  );
   // Keeps the last detail rendered through the sheet's close animation so
   // deselecting doesn't slide out an empty sheet.
-  const lastDetailRef = useRef<TransactionDetail | null>(null);
-  if (selectedDetail) {
-    lastDetailRef.current = selectedDetail;
+  const lastItemRef = useRef<EarnTransactionItem | null>(null);
+  if (selectedItem) {
+    lastItemRef.current = selectedItem;
   }
-  const sheetDetail = selectedDetail ?? lastDetailRef.current;
+  const sheetItem = selectedItem ?? lastItemRef.current;
 
-  // Activity is a lazy fetch — kick it on mount (no-op while signed out;
-  // reruns when the wallet lands because loadActivity's identity changes).
-  const [isActivityLoading, setIsActivityLoading] = useState(true);
-  const loadActivity = data.loadActivity;
+  // An open detail owns Esc: preventDefault marks it handled so the shell's
+  // Esc → Earn handoff (checked via microtask) stays put until the second
+  // press.
   useEffect(() => {
-    let cancelled = false;
-    setIsActivityLoading(true);
-    void loadActivity().finally(() => {
-      if (!cancelled) {
-        setIsActivityLoading(false);
+    if (!selectedItem) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSelectedItem(null);
       }
-    });
-    return () => {
-      cancelled = true;
     };
-  }, [loadActivity]);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedItem]);
 
-  const positions = data.positions;
-  const swapDisplayById = useMemo(() => {
-    const resolveLeg = (mint: string) => {
-      const position = positions.find((entry) => entry.asset.mint === mint);
-      // Same fallback the hook's own swap mapping uses.
-      const symbol = position?.asset.symbol ?? "SOL";
-      return {
-        icon: position?.asset.imageUrl ?? getTokenIconUrl(symbol),
-        symbol,
-      };
-    };
-    const map = new Map<string, SwapDisplay>();
-    for (const activity of data.walletActivities) {
-      if (activity.type !== "swap") {
-        continue;
-      }
-      const from = resolveLeg(activity.fromToken.mint);
-      const to = resolveLeg(activity.toToken.mint);
-      const fromNumber = parseFloat(activity.fromToken.amount.replace(/,/g, ""));
-      const toNumber = parseFloat(activity.toToken.amount.replace(/,/g, ""));
-      const rate =
-        Number.isFinite(fromNumber) && Number.isFinite(toNumber) && toNumber > 0
-          ? `1 ${to.symbol} = ${(fromNumber / toNumber).toLocaleString("en-US", {
-              maximumFractionDigits: 2,
-              minimumFractionDigits: 2,
-            })} ${from.symbol}`
-          : null;
-      map.set(activity.signature, {
-        amountLabel: `+${activity.toToken.amount} ${to.symbol}`,
-        fromAmount: activity.fromToken.amount,
-        fromIcon: from.icon,
-        fromSymbol: from.symbol,
-        rate,
-        toAmount: activity.toToken.amount,
-        toIcon: to.icon,
-        toSymbol: to.symbol,
+  useEffect(() => {
+    if (!(isAuthenticated && isHydrated && settingsPda && walletAddress)) {
+      return;
+    }
+    let isCurrent = true;
+    fetchEarnTransactions({
+      settingsPda,
+      solanaEnv: publicEnv.solanaEnv,
+      walletAddress,
+    })
+      .then((response) => {
+        if (isCurrent) {
+          setItems(response.transactions);
+          setHasError(false);
+        }
+      })
+      .catch(() => {
+        if (isCurrent) {
+          setHasError(true);
+        }
       });
-    }
-    return map;
-  }, [data.walletActivities, positions]);
+    return () => {
+      isCurrent = false;
+    };
+  }, [
+    isAuthenticated,
+    isHydrated,
+    publicEnv.solanaEnv,
+    refreshKey,
+    settingsPda,
+    walletAddress,
+  ]);
 
-  const rows = data.allActivityRows;
-  const groups = useMemo(() => {
-    const result: { date: string; items: ActivityRow[] }[] = [];
-    for (const row of rows) {
-      const existing = result[result.length - 1];
-      if (existing?.date === row.date) {
-        existing.items.push(row);
-      } else {
-        result.push({ date: row.date, items: [row] });
-      }
-    }
-    return result;
-  }, [rows]);
+  const groups = useMemo(
+    () =>
+      groupEarnTransactions(
+        (items ?? []).slice(0, visibleCount),
+        resolveEarnTransactionDisplayTimeZone()
+      ),
+    [items, visibleCount]
+  );
+  const hasMore = items !== null && items.length > visibleCount;
 
-  const showSkeleton = isActivityLoading && rows.length === 0;
+  // Extends the window when the tail sentinel nears the viewport. Re-created
+  // per visibleCount so a still-intersecting sentinel (list shorter than the
+  // viewport) re-fires through the fresh observer's initial callback.
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!(sentinel && hasMore)) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisibleCount((count) => count + PAGE_SIZE);
+        }
+      },
+      { rootMargin: "300px" }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, visibleCount]);
+
+  // Only the first loaded batch rides the mount stagger; groups appearing on
+  // scroll-extends or refetches render in place with no reveal (they enter
+  // off-screen anyway). Same decide-once mechanics as the earn activity card.
+  const hasRenderedRowsRef = useRef(false);
+  const groupKindsRef = useRef(new Map<string, "plain" | "stagger">());
+  useEffect(() => {
+    if (groups.length > 0) {
+      hasRenderedRowsRef.current = true;
+    }
+  }, [groups]);
+  const resolveGroupKind = (key: string): "plain" | "stagger" => {
+    const kinds = groupKindsRef.current;
+    const existing = kinds.get(key);
+    if (existing) {
+      return existing;
+    }
+    const kind = hasRenderedRowsRef.current ? "plain" : "stagger";
+    kinds.set(key, kind);
+    return kind;
+  };
 
   return (
     <>
@@ -299,27 +178,9 @@ export function ActivityPage({
                   Activity
                 </h1>
               </div>
-              <div className="flex shrink-0 items-start pl-3">
-                <button
-                  className="t-hover flex items-center justify-center gap-2 rounded-full bg-black/[0.04] p-2.5 hover:-translate-y-0.5 hover:bg-black/[0.08] active:translate-y-0"
-                  onClick={() => onSelectPage("earn")}
-                  type="button"
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-6"
-                    src={`${ASSET_BASE}/icon-coins-add-gray.svg`}
-                  />
-                  <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
-                    Earn Activity
-                  </span>
-                </button>
-              </div>
             </header>
             <div className="flex w-full flex-1 flex-col px-2 pb-2">
-              {showSkeleton ? (
+              {items === null && !hasError ? (
                 // transitions.dev skeleton pulse, same rows the earn activity
                 // card skeletons with.
                 <div className="t-skel-rows flex flex-col gap-2 px-2 py-1">
@@ -330,51 +191,65 @@ export function ActivityPage({
                     />
                   ))}
                 </div>
-              ) : groups.length === 0 ? (
+              ) : null}
+              {items === null && hasError ? (
+                <p className="px-4 py-3 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  Failed to load transactions.
+                </p>
+              ) : null}
+              {items !== null && items.length === 0 ? (
                 <p className="px-4 py-8 text-center text-[14px] leading-5 text-[rgba(60,60,67,0.6)]">
                   No activity yet
                 </p>
-              ) : (
-                <StaggerReveal>
-                  {groups.map((group, index) => (
-                    <StaggerLine index={index} key={group.date}>
-                      <div className="flex items-start px-4 pt-1">
-                        <p className="min-w-0 flex-1 pt-3 pb-2 text-[16px] leading-5 text-[rgba(60,60,67,0.6)] tracking-[-0.176px]">
-                          {group.date}
-                        </p>
-                      </div>
-                      {group.items.map((row) => (
-                        <ActivityCell
-                          isBalanceHidden={isBalanceHidden}
-                          isSelected={selectedDetail?.activity.id === row.id}
-                          key={row.id}
-                          onSelect={() => {
-                            const detail = data.transactionDetails[row.id];
-                            if (detail) {
-                              setSelectedDetail(detail);
-                            }
-                          }}
-                          row={row}
-                          swap={swapDisplayById.get(row.id)}
-                        />
-                      ))}
-                    </StaggerLine>
-                  ))}
+              ) : null}
+              {items !== null && groups.length > 0 ? (
+                <StaggerReveal className="flex w-full flex-col">
+                  {(() => {
+                    let lineIndex = 0;
+                    return groups.map((group) => {
+                      const content = (
+                        <>
+                          <GroupHeader label={group.date} />
+                          {group.items.map((item) => (
+                            <TransactionRow
+                              isSelected={selectedItem?.id === item.id}
+                              item={item}
+                              key={item.id}
+                              onSelect={() => setSelectedItem(item)}
+                            />
+                          ))}
+                        </>
+                      );
+                      return resolveGroupKind(group.date) === "stagger" ? (
+                        <StaggerLine index={lineIndex++} key={group.date}>
+                          {content}
+                        </StaggerLine>
+                      ) : (
+                        <div key={group.date}>{content}</div>
+                      );
+                    });
+                  })()}
                 </StaggerReveal>
-              )}
+              ) : null}
+              {hasMore ? (
+                <div
+                  aria-hidden="true"
+                  className="h-px w-full shrink-0"
+                  ref={sentinelRef}
+                />
+              ) : null}
             </div>
           </section>
         </PaneReveal>
-        {selectedDetail ? (
+        {selectedItem ? (
           <aside className="hidden h-full w-[400px] shrink-0 flex-col overflow-clip rounded-3xl bg-white min-[1204px]:flex">
             {/* Keyed by tx so switching rows replays the reveal — same as
                 the send flow's per-step PaneReveal. */}
-            <PaneReveal key={selectedDetail.activity.id}>
-              <TransactionDetailPane
-                detail={selectedDetail}
-                onClose={() => setSelectedDetail(null)}
-                swap={swapDisplayById.get(selectedDetail.activity.id)}
-                walletAddress={data.walletAddress}
+            <PaneReveal key={selectedItem.id}>
+              <EarnTransactionDetailPane
+                item={selectedItem}
+                onClose={() => setSelectedItem(null)}
+                walletAddress={walletAddress}
               />
             </PaneReveal>
           </aside>
@@ -397,23 +272,22 @@ export function ActivityPage({
       </div>
       <MobileTabBar activeTab="activity" onSelect={onSelectPage} />
       {/* Below 1204px the right pane is gone, so the same selection opens the
-          detail as the chart-enlarge sheet (Figma 4813:366475): a 400px
-          right-pinned card on the dark scrim, a full bottom sheet on the
-          white one below 796px. On desktop the scrim is display:none, so the
-          mounted sheet is inert while the aside shows the detail. */}
+          detail as a sheet: a 400px right-pinned card on the dark scrim, a
+          full bottom sheet on the white one below 796px. On desktop the scrim
+          is display:none, so the mounted sheet is inert while the aside shows
+          the detail. */}
       <SheetReveal
-        isOpen={selectedDetail !== null}
-        onClose={() => setSelectedDetail(null)}
+        isOpen={selectedItem !== null}
+        onClose={() => setSelectedItem(null)}
         scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
         sheetClassName="ml-auto flex h-full w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
       >
-        {sheetDetail ? (
-          <TransactionDetailPane
-            detail={sheetDetail}
-            key={sheetDetail.activity.id}
-            onClose={() => setSelectedDetail(null)}
-            swap={swapDisplayById.get(sheetDetail.activity.id)}
-            walletAddress={data.walletAddress}
+        {sheetItem ? (
+          <EarnTransactionDetailPane
+            item={sheetItem}
+            key={sheetItem.id}
+            onClose={() => setSelectedItem(null)}
+            walletAddress={walletAddress}
           />
         ) : null}
       </SheetReveal>

--- a/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
@@ -56,7 +56,7 @@ const ACTIVITY_TABS = ["Transactions", "Positions"] as const;
 
 type ActivityTab = (typeof ACTIVITY_TABS)[number];
 
-function UsdcCoinImage() {
+export function UsdcCoinImage() {
   return (
     <>
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -142,7 +142,7 @@ function RouteLabel({
   );
 }
 
-function GroupHeader({ label }: { label: string }) {
+export function GroupHeader({ label }: { label: string }) {
   return (
     <div className="flex w-full items-start px-4 pt-1">
       <p className="min-w-0 flex-1 pt-3 pb-2 text-[16px] leading-5 tracking-[-0.176px] text-[rgba(60,60,67,0.6)]">
@@ -282,7 +282,15 @@ function ScheduledSweepRow({
   );
 }
 
-function TransactionRow({ item }: { item: EarnTransactionItem }) {
+export function TransactionRow({
+  isSelected = false,
+  item,
+  onSelect,
+}: {
+  isSelected?: boolean;
+  item: EarnTransactionItem;
+  onSelect?: () => void;
+}) {
   const { isBalanceHidden } = useBalanceVisibility();
   const isMovement =
     item.kind === "rebalance" || item.kind === "reconciliation";
@@ -294,9 +302,9 @@ function TransactionRow({ item }: { item: EarnTransactionItem }) {
     formatEarnTransactionTimestamp(item.confirmedAt ?? item.sortTimestamp) ??
     item.timestamp;
 
-  return (
-    <div className="flex w-full items-center rounded-2xl px-4">
-      <div className="flex items-center py-2 pr-3">
+  const content = (
+    <>
+      <span className="flex items-center py-2 pr-3">
         {item.kind === "autodeposit_action" ? (
           <span className="inline-flex size-11 shrink-0 overflow-hidden rounded-full">
             <EarnYieldIcon />
@@ -308,30 +316,50 @@ function TransactionRow({ item }: { item: EarnTransactionItem }) {
             isWithdraw={item.kind === "withdraw"}
           />
         )}
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-        <p className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
+        <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
           {getEarnTransactionRowLabel(item)}
-        </p>
-        <p className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        </span>
+        <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
           {timeLabel}
-        </p>
-      </div>
-      <div className="flex flex-col items-end gap-0.5 py-[11px] pl-3">
-        <p
+        </span>
+      </span>
+      <span className="flex flex-col items-end gap-0.5 py-[11px] pl-3">
+        <span
           className="whitespace-nowrap text-[16px] leading-5 text-right"
           style={{
             color: getEarnTransactionAmountColor({ kind: item.kind }),
           }}
         >
           <ScrambleText isHidden={isBalanceHidden} text={item.amount} />
-        </p>
+        </span>
         <RouteLabel
           destination={item.destination.label}
           source={item.source.label}
         />
-      </div>
-    </div>
+      </span>
+    </>
+  );
+
+  // Without a select handler (the Earn card's recent-5 list) the row stays a
+  // plain, non-interactive cell; the Activity feed passes one to open the
+  // transaction detail.
+  if (!onSelect) {
+    return (
+      <div className="flex w-full items-center rounded-2xl px-4">{content}</div>
+    );
+  }
+  return (
+    <button
+      className={`flex w-full items-center rounded-2xl px-4 text-left transition-colors duration-150 ${
+        isSelected ? "bg-black/[0.04]" : "hover:bg-black/[0.04]"
+      }`}
+      onClick={onSelect}
+      type="button"
+    >
+      {content}
+    </button>
   );
 }
 
@@ -368,6 +396,7 @@ function NewRowReveal({ children }: { children: ReactNode }) {
 
 function TransactionsTab({
   executeNow,
+  onViewAllActivity,
   pendingSignatures,
   refreshKey,
   scheduledSweeps,
@@ -375,6 +404,7 @@ function TransactionsTab({
   walletAddress,
 }: {
   executeNow: ExecuteNowControls;
+  onViewAllActivity: () => void;
   pendingSignatures: string[];
   refreshKey: number;
   scheduledSweeps: LoadedEarnAutodepositScheduledSweep[];
@@ -559,7 +589,7 @@ function TransactionsTab({
         <StaggerReveal className="flex w-full flex-col">
           {(() => {
             let lineIndex = 0;
-            return groups.map((group) => (
+            const renderedGroups = groups.map((group) => (
               <div className="flex w-full flex-col" key={group.date}>
                 {resolveRevealKind(`h:${group.date}`) === "insert" ? (
                   <NewRowReveal>
@@ -583,6 +613,20 @@ function TransactionsTab({
                 )}
               </div>
             ));
+            return (
+              <>
+                {renderedGroups}
+                <StaggerLine index={lineIndex}>
+                  <button
+                    className="t-hover flex h-11 w-full items-center justify-center rounded-2xl font-medium text-[14px] text-black leading-5 hover:bg-black/[0.04]"
+                    onClick={onViewAllActivity}
+                    type="button"
+                  >
+                    View all activity
+                  </button>
+                </StaggerLine>
+              </>
+            );
           })()}
         </StaggerReveal>
       ) : null}
@@ -677,6 +721,7 @@ function PositionsTab({
 export function EarnActivityCard({
   executeNow,
   holdings,
+  onViewAllActivity,
   onWithdrawSource,
   pendingSignatures,
   refreshKey,
@@ -686,6 +731,7 @@ export function EarnActivityCard({
 }: {
   executeNow: ExecuteNowControls;
   holdings: ActiveEarnPositionHolding[];
+  onViewAllActivity: () => void;
   onWithdrawSource: (sourceKey: string) => void;
   pendingSignatures: string[];
   refreshKey: number;
@@ -849,6 +895,7 @@ export function EarnActivityCard({
         {activeTab === "Transactions" ? (
           <TransactionsTab
             executeNow={executeNow}
+            onViewAllActivity={onViewAllActivity}
             pendingSignatures={pendingSignatures}
             refreshKey={refreshKey}
             scheduledSweeps={scheduledSweeps}

--- a/frontend/src/components/wallet-workspace/facelift/earn-position-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-position-pane.tsx
@@ -37,6 +37,7 @@ export function EarnPositionPane({
   onOpenAutodeposit,
   onOpenChart,
   onSelectChartTab,
+  onViewAllActivity,
   onWithdraw,
   selectedChartTab,
 }: {
@@ -45,6 +46,7 @@ export function EarnPositionPane({
   onOpenAutodeposit: () => void;
   onOpenChart: () => void;
   onSelectChartTab: (tab: ChartTab) => void;
+  onViewAllActivity: () => void;
   onWithdraw: (sourceKey?: string) => void;
   selectedChartTab: ChartTab | null;
 }) {
@@ -283,6 +285,7 @@ export function EarnPositionPane({
             run: data.actions.executeScheduledSweep,
           }}
           holdings={data.position?.holdings ?? []}
+          onViewAllActivity={onViewAllActivity}
           onWithdrawSource={onWithdraw}
           pendingSignatures={data.actions.pendingTransactionSignatures}
           refreshKey={data.actions.earnTransactionsRefreshKey}

--- a/frontend/src/components/wallet-workspace/facelift/shell.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/shell.tsx
@@ -163,7 +163,10 @@ export function WorkspaceFaceliftShell() {
       openSignIn();
       return;
     }
-    setActivePage(page);
+    // Re-selecting Activity toggles it closed, back to the Earn home.
+    setActivePage(
+      page === "activity" && activePage === "activity" ? "earn" : page
+    );
     // Leaving Earn abandons any in-progress action screen.
     setMiddleView("earn");
     setNavigationNonce((nonce) => nonce + 1);
@@ -190,6 +193,15 @@ export function WorkspaceFaceliftShell() {
       if (event.key === "Escape") {
         // Numbers-only amount fields don't swallow Esc — only free text does.
         if (isEscapeGuardedTarget(event.target)) {
+          return;
+        }
+        // Activity is an Earn detour — Esc backs out to the Earn home.
+        if (activePage === "activity") {
+          queueMicrotask(() => {
+            if (!event.defaultPrevented) {
+              setActivePage("earn");
+            }
+          });
           return;
         }
         if (
@@ -282,7 +294,12 @@ export function WorkspaceFaceliftShell() {
               showActivityBadge={hasUnseenActivity}
             />
           ) : activePage === "activity" ? (
-            <ActivityPage onSelectPage={handleSelectPage} />
+            <ActivityPage
+              onSelectPage={handleSelectPage}
+              refreshKey={earnData.actions.earnTransactionsRefreshKey}
+              settingsPda={earnData.settingsPda}
+              walletAddress={earnData.walletAddress}
+            />
           ) : activePage !== "earn" ? (
             <CryptoPage
               navigationNonce={navigationNonce}
@@ -330,6 +347,7 @@ export function WorkspaceFaceliftShell() {
                         onOpenAutodeposit={() => setMiddleView("autodeposit")}
                         onOpenChart={() => setIsChartExpanded(true)}
                         onSelectChartTab={setChartTab}
+                        onViewAllActivity={() => handleSelectPage("activity")}
                         onWithdraw={(sourceKey) => {
                           setWithdrawSourceKey(sourceKey ?? null);
                           setMiddleView("withdraw");

--- a/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
@@ -2,91 +2,43 @@
 
 import { useState } from "react";
 
-import type { TransactionDetail } from "@/components/wallet-sidebar/types";
+import { EarnYieldIcon } from "@/components/wallet-sidebar/portfolio-content";
+import {
+  formatEarnTransactionDateGroup,
+  formatEarnTransactionTimestamp,
+  getEarnTransactionAmountColor,
+  getEarnTransactionRowLabel,
+} from "@/components/wallet-workspace/earn-transactions-pane";
 import { copyTextToClipboard } from "@/components/wallet-workspace/facelift/copy-text";
+import {
+  DualIcon,
+  UsdcCoinImage,
+} from "@/components/wallet-workspace/facelift/earn-activity-card";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { openTrackedLink } from "@/lib/core/analytics";
-import { getTokenIconUrl } from "@/lib/token-icon";
+import type { EarnTransactionItem } from "@/lib/yield-optimization/earn-transactions.client";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
-// Swap rows carry both legs (from the raw activity) so the detail can show
-// the two-line hero and the rate — the mapped ActivityRow keeps only one.
-export type TransactionSwapDetail = {
-  fromAmount: string;
-  fromSymbol: string;
-  fromIcon: string;
-  toAmount: string;
-  toSymbol: string;
-  toIcon: string;
-  rate: string | null;
-};
-
-type DetailKind =
-  | "sent"
-  | "received"
-  | "swap"
-  | "earn_deposit"
-  | "earn_withdraw"
-  | "shielded"
-  | "unshielded";
-
-const KIND_TITLES: Record<DetailKind, string> = {
-  earn_deposit: "Deposited",
-  earn_withdraw: "Withdrawn",
-  received: "Received",
-  sent: "Sent",
-  shielded: "Shielded",
-  swap: "Swapped",
-  unshielded: "Unshielded",
-};
-
-function truncateAddress(addr: string): string {
-  if (addr.length <= 12) {
-    return addr;
+function truncateMiddle(value: string): string {
+  if (value.length <= 12) {
+    return value;
   }
-  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
-}
-
-function resolveKind(
-  detail: TransactionDetail,
-  swap: TransactionSwapDetail | undefined
-): DetailKind {
-  if (swap) {
-    return "swap";
-  }
-  const override = detail.activity.titleOverride;
-  if (override === "Earn Deposit") {
-    return "earn_deposit";
-  }
-  if (override === "Earn Withdrawal") {
-    return "earn_withdraw";
-  }
-  if (detail.activity.type === "shielded") {
-    return "shielded";
-  }
-  if (detail.activity.type === "unshielded") {
-    return "unshielded";
-  }
-  return detail.activity.type === "sent" ? "sent" : "received";
+  return `${value.slice(0, 4)}…${value.slice(-4)}`;
 }
 
 // One From/To style row (Figma "Cell"): 44px tile, 13px label, 16px value.
 function RouteRow({
-  copyValue,
   icon,
   label,
   value,
   valueSuffix,
 }: {
-  copyValue?: string;
   icon: React.ReactNode;
   label: string;
   value: string;
   valueSuffix?: string;
 }) {
-  const [copied, setCopied] = useState(false);
-
   return (
     <div className="flex h-[60px] w-full items-center rounded-2xl px-4">
       <div className="flex shrink-0 items-center py-2 pr-3">{icon}</div>
@@ -101,44 +53,41 @@ function RouteRow({
           ) : null}
         </p>
       </div>
-      {copyValue ? (
-        <button
-          aria-label={`Copy ${label.toLowerCase()} address`}
-          className="t-hover flex shrink-0 items-center justify-center pl-3"
-          onClick={() => {
-            void copyTextToClipboard(copyValue).then((didCopy) => {
-              if (didCopy) {
-                setCopied(true);
-                window.setTimeout(() => setCopied(false), 1500);
-              }
-            });
-          }}
-          type="button"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
-            src={`${ASSET_BASE}/${copied ? "icon-check.svg" : "icon-copy.svg"}`}
-          />
-        </button>
-      ) : null}
     </div>
   );
 }
 
-function WalletTile() {
-  return (
-    <span className="flex size-11 items-center justify-center rounded-[11px] bg-black/[0.04]">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
+// The wallet side ("Main") renders as the same USDC coin art the activity
+// rows use — the API's icon for it is the legacy agent avatar. Market sides
+// carry their own logos; abstract sides (Earn / Autodeposit) fall back to the
+// Earn glyph.
+function RouteTile({ side }: { side: EarnTransactionItem["source"] }) {
+  if (side.label === "Main") {
+    return (
+      <span className="relative block size-11 overflow-hidden rounded-full">
+        <UsdcCoinImage />
+      </span>
+    );
+  }
+  if (side.icon) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
       <img
         alt=""
         aria-hidden="true"
-        className="h-[19px] w-[25px]"
-        src={`${ASSET_BASE}/icon-wallet-fill.svg`}
+        className="size-11 rounded-full object-cover"
+        src={side.icon}
       />
-    </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      alt=""
+      aria-hidden="true"
+      className="size-11"
+      src={`${ASSET_BASE}/earn-icon.svg`}
+    />
   );
 }
 
@@ -153,114 +102,97 @@ function DetailCell({ label, value }: { label: string; value: string }) {
   );
 }
 
-// Facelift transaction detail (Figma 4880:74020 Sent, 4879:68721 Received,
-// 4880:74295 Swapped, 4879:69018 Deposited, 4880:74343 Withdrawn,
-// 4880:74400 Shielded, 4880:74481 Unshielded): identity in the header,
-// amount hero, From/To route rows, fee card, Solscan button pinned bottom.
-export function TransactionDetailPane({
-  detail,
+function SignatureCell({ signature }: { signature: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="flex w-full items-center">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5 px-4 py-[11px]">
+        <p className="text-[13px] leading-4 text-[#8a8a8e]">Signature</p>
+        <p className="truncate text-[16px] text-black leading-5 tracking-[-0.176px]">
+          {truncateMiddle(signature)}
+        </p>
+      </div>
+      <button
+        aria-label="Copy transaction signature"
+        className="t-hover flex shrink-0 items-center justify-center px-4"
+        onClick={() => {
+          void copyTextToClipboard(signature).then((didCopy) => {
+            if (didCopy) {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1500);
+            }
+          });
+        }}
+        type="button"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt=""
+          aria-hidden="true"
+          className="size-6"
+          src={`${ASSET_BASE}/${copied ? "icon-check.svg" : "icon-copy.svg"}`}
+        />
+      </button>
+    </div>
+  );
+}
+
+// Earn transaction detail in the wallet detail's design (Figma 4879:69018
+// Deposited / 4880:74343 Withdrawn): identity header, amount hero, From → To
+// route rows, details card, Solscan button pinned bottom. Covers every
+// indexed Earn event — create & deposit, deposit, withdraw, withdraw & close,
+// create/remove allowance, balance sweep, rebalanced, reconciled. Allowance
+// events skip the hero (their indexed amount is always $0.00) and rebalances
+// without a signature drop the signature cell and Solscan button.
+export function EarnTransactionDetailPane({
+  item,
   onClose,
-  swap,
   walletAddress,
 }: {
-  detail: TransactionDetail;
+  item: EarnTransactionItem;
   onClose: () => void;
-  swap?: TransactionSwapDetail;
   walletAddress: string | null;
 }) {
   const publicEnv = usePublicEnv();
-  const kind = resolveKind(detail, swap);
-  const row = detail.activity;
-  const title = swap ? "Swapped" : row.titleOverride ?? KIND_TITLES[kind];
-  const isPrivate = detail.isPrivate || row.isPrivate;
-  const isShieldKind = kind === "shielded" || kind === "unshielded";
-  const isEarnKind = kind === "earn_deposit" || kind === "earn_withdraw";
-
-  // "+1,010.22 USDC" → sign-stripped number + symbol for the hero.
-  const rawAmount = row.amount.replace(/^[+−-]/, "");
-  const amountParts = rawAmount.split(" ");
-  const amountNumber = amountParts[0];
-  const amountSymbol = amountParts.slice(1).join(" ");
-  // Shield rows keep the legacy shield art as row.icon — the detail wants
-  // the token image, so re-derive it from the amount's symbol.
-  const tokenIcon = isShieldKind ? getTokenIconUrl(amountSymbol) : row.icon;
-
-  const ownAddress = walletAddress ? truncateAddress(walletAddress) : null;
-  const solscanUrl = `https://solscan.io/tx/${row.id}${
+  const isMovement =
+    item.kind === "rebalance" || item.kind === "reconciliation";
+  const isAllowanceAction = item.kind === "autodeposit_action";
+  const title = getEarnTransactionRowLabel(item);
+  const confirmedAt = item.confirmedAt ?? item.sortTimestamp;
+  const dateLabel =
+    formatEarnTransactionDateGroup(confirmedAt) ?? item.dateGroup;
+  const timeLabel =
+    formatEarnTransactionTimestamp(confirmedAt) ?? item.timestamp;
+  const ownAddress = walletAddress ? truncateMiddle(walletAddress) : null;
+  const hasSignature = item.signature.length > 0;
+  const solscanUrl = `https://solscan.io/tx/${item.signature}${
     publicEnv.solanaEnv === "mainnet"
       ? ""
       : `?cluster=${publicEnv.solanaEnv === "devnet" ? "devnet" : "custom"}`
   }`;
-
-  const earnTile = (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img alt="" aria-hidden="true" className="size-11" src={`${ASSET_BASE}/earn-icon.svg`} />
-  );
-  const stablecoinsTile = (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img alt="" aria-hidden="true" className="size-11" src={`${ASSET_BASE}/stash-stablecoins.svg`} />
-  );
-  const stablecoinsRow = (label: string) => (
-    <RouteRow
-      icon={stablecoinsTile}
-      label={label}
-      value="Stablecoins"
-      valueSuffix={ownAddress ?? undefined}
-    />
-  );
-  const earnRow = (label: string) => (
-    <RouteRow icon={earnTile} label={label} value="Earn" />
-  );
+  // Same art derivation as the activity list's TransactionRow, so the header
+  // identity matches the row that opened it.
+  const backSrc =
+    isMovement || item.kind === "withdraw" ? item.source.icon : null;
+  const frontSrc =
+    isMovement || item.kind === "deposit" ? item.destination.icon : null;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
       <header className="flex w-full shrink-0 items-center p-2">
-        <div className="flex shrink-0 items-center pr-3">
-          {swap ? (
-            <span className="relative block size-11">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute top-0 left-0 size-[30px] rounded-full object-cover"
-                src={swap.fromIcon}
-              />
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute right-0 bottom-0 size-[30px] rounded-full object-cover"
-                src={swap.toIcon}
-              />
-            </span>
-          ) : isShieldKind ? (
-            <span className="relative block size-11">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                className="absolute top-0 left-0 size-[30px] rounded-full object-cover"
-                src={tokenIcon}
-              />
-              {kind === "shielded" ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt=""
-                  className="absolute right-px bottom-px size-7"
-                  src={`${ASSET_BASE}/icon-shield-badge.svg`}
-                />
-              ) : (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt=""
-                  className="-scale-x-100 absolute right-px bottom-px h-7 w-auto max-w-none"
-                  src={`${ASSET_BASE}/icon-unshield-badge.svg`}
-                />
-              )}
+        {/* pl-4 puts the icon on the same 24px inset as the route rows and
+            cards below (title lands on their 80px text column). */}
+        <div className="flex shrink-0 items-center pl-4 pr-3">
+          {isAllowanceAction ? (
+            <span className="inline-flex size-11 shrink-0 overflow-hidden rounded-full">
+              <EarnYieldIcon />
             </span>
           ) : (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt=""
-              className="size-11 rounded-full object-cover"
-              src={tokenIcon}
+            <DualIcon
+              backSrc={backSrc}
+              frontSrc={frontSrc}
+              isWithdraw={item.kind === "withdraw"}
             />
           )}
         </div>
@@ -269,7 +201,7 @@ export function TransactionDetailPane({
             {title}
           </h2>
           <p className="truncate text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-            {row.date}, {row.timestamp}
+            {dateLabel}, {timeLabel}
           </p>
         </div>
         <button
@@ -288,85 +220,56 @@ export function TransactionDetailPane({
         </button>
       </header>
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
-        <div className="w-full p-2">
-          <div className="flex w-full flex-col gap-0.5 px-4 pt-[30px] pb-2">
-            {swap ? (
-              <>
-                <p className="whitespace-nowrap font-semibold text-[40px] text-black leading-[48px] tracking-[-0.44px]">
-                  −{swap.fromAmount}{" "}
-                  <span className="text-[#b1b1b4] text-[28px] leading-8 tracking-[-0.308px]">
-                    {swap.fromSymbol}
-                  </span>
-                </p>
-                <p className="whitespace-nowrap font-semibold text-[#34c759] text-[40px] leading-[48px] tracking-[-0.44px]">
-                  +{swap.toAmount}{" "}
-                  <span className="text-[#b1b1b4] text-[28px] leading-8 tracking-[-0.308px]">
-                    {swap.toSymbol}
-                  </span>
-                </p>
-              </>
-            ) : (
+        {isAllowanceAction ? null : (
+          <div className="w-full p-2">
+            <div className="flex w-full flex-col gap-0.5 px-4 pt-[30px] pb-2">
               <p
-                className={`whitespace-nowrap font-semibold text-[40px] leading-[48px] tracking-[-0.44px] ${
-                  kind === "received" ? "text-[#34c759]" : "text-black"
-                }`}
+                className="whitespace-nowrap font-semibold text-[40px] leading-[48px] tracking-[-0.44px]"
+                style={{
+                  color: getEarnTransactionAmountColor({ kind: item.kind }),
+                }}
               >
-                {isShieldKind || isEarnKind
-                  ? ""
-                  : kind === "received"
-                  ? "+"
-                  : "−"}
-                {amountNumber}{" "}
+                {item.amount}{" "}
                 <span className="text-[#b1b1b4] text-[28px] leading-8 tracking-[-0.308px]">
-                  {amountSymbol}
+                  USDC
                 </span>
               </p>
-            )}
-            <p className="text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
-              {detail.usdValue}
-            </p>
+              <p className="text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                {item.rawAmount}
+              </p>
+            </div>
           </div>
+        )}
+        <div className="relative w-full px-2 pb-2">
+          <RouteRow
+            icon={<RouteTile side={item.source} />}
+            label="From"
+            value={item.source.label}
+            valueSuffix={
+              item.source.label === "Main" ? ownAddress ?? undefined : undefined
+            }
+          />
+          <RouteRow
+            icon={<RouteTile side={item.destination} />}
+            label="To"
+            value={item.destination.label}
+            valueSuffix={
+              item.destination.label === "Main"
+                ? ownAddress ?? undefined
+                : undefined
+            }
+          />
+          {/* Connector between the two 60px route rows. */}
+          <span className="absolute top-[54px] left-[45px] h-3 w-0.5 rounded-xl bg-[#d9d9d9]" />
         </div>
-        {kind === "sent" || kind === "received" ? (
-          <div className="w-full px-2 pb-2">
-            <RouteRow
-              copyValue={row.counterparty}
-              icon={<WalletTile />}
-              label={kind === "sent" ? "To" : "From"}
-              value={truncateAddress(row.counterparty)}
-            />
-          </div>
-        ) : isEarnKind ? (
-          <div className="relative w-full px-2 pb-2">
-            {kind === "earn_deposit" ? (
-              <>
-                {stablecoinsRow("From")}
-                {earnRow("To")}
-              </>
-            ) : (
-              <>
-                {earnRow("From")}
-                {stablecoinsRow("To")}
-              </>
-            )}
-            {/* Connector between the two 60px route rows. */}
-            <span className="absolute top-[54px] left-[45px] h-3 w-0.5 rounded-xl bg-[#d9d9d9]" />
-          </div>
-        ) : null}
         <div className="w-full p-2">
           <div className="flex w-full flex-col rounded-2xl bg-black/[0.04]">
-            {detail.status === "Failed" ? (
-              <DetailCell label="Status" value="Failed" />
-            ) : null}
-            {swap?.rate ? <DetailCell label="Rate" value={swap.rate} /> : null}
-            <DetailCell
-              label="Network Fee"
-              value={`${detail.networkFee} ~ ${detail.networkFeeUsd}`}
-            />
+            {hasSignature ? <SignatureCell signature={item.signature} /> : null}
+            <DetailCell label="Slot" value={item.confirmedSlot} />
           </div>
         </div>
       </div>
-      {isPrivate ? null : (
+      {hasSignature ? (
         <div className="w-full shrink-0 bg-white px-5 pt-2 pb-4">
           <button
             className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
@@ -382,7 +285,7 @@ export function TransactionDetailPane({
             View on Solscan
           </button>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Reworks the facelift Activity page into an Earn-only feed and adds a transaction details pane wired into the workspace shell.