### PR TITLE
fix(mobile): lock Earn withdrawal submissions

### DIFF
--- a/mobile/src/components/earn/WithdrawSheet.tsx
+++ b/mobile/src/components/earn/WithdrawSheet.tsx
@@ -28,6 +28,7 @@ import { resolveEarnPositionDisplay } from "@/lib/solana/earn/earn-position-disp
 import { resolveTokenIcon } from "@/lib/solana/token-holdings/resolve-token-info";
 
 import { VenueBadge } from "./venueBadge";
+import { acquireWithdrawSubmitLock } from "./withdraw-submit-lock";
 
 const usdcLogo = require("../../../assets/images/earn/usdc.png");
 
@@ -196,6 +197,7 @@ export function WithdrawSheet({
   const sheetRef = useRef<BottomSheetModal>(null);
   const sourceSheetRef = useRef<BottomSheetModal>(null);
   const inputRef = useRef<{ focus: () => void } | null>(null);
+  const submitInFlightRef = useRef(false);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
   const [isFocused, setIsFocused] = useState(false);
@@ -238,7 +240,6 @@ export function WithdrawSheet({
     if (open) {
       setAmount("");
       setSubmitError(null);
-      setSubmitting(false);
       setSelectedSourceId(null);
       setMaxSelected(false);
       sheetRef.current?.present();
@@ -324,29 +325,29 @@ export function WithdrawSheet({
     if (disabled) {
       return;
     }
+    const releaseSubmitLock = acquireWithdrawSubmitLock(submitInFlightRef);
+    if (!releaseSubmitLock) {
+      return;
+    }
+
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     Keyboard.dismiss();
     setSubmitError(null);
-    // MAX (or typing the visible floored max — the input only takes cents) means
-    // "empty this source": submit the exact balance and an explicit "full" mode.
-    // Reconstructing the intent later from float comparisons across different
-    // reads degraded MAX to a partial withdraw that stranded dust and kept the
-    // position open at $0.00 (no close, no SOL rent refund). Mirrors the web
-    // `deriveEarnWithdrawMode`.
-    const isMax = maxSelected || enteredUsd >= floorTo2(available);
-    const amountToWithdraw = isMax ? available : enteredUsd;
-    const result = onWithdraw?.(
-      amountToWithdraw,
-      selectedSource,
-      isMax ? "full" : "partial",
-    );
-    if (!(result instanceof Promise)) {
-      sheetRef.current?.dismiss();
-      return;
-    }
     setSubmitting(true);
     try {
-      await result;
+      // MAX (or typing the visible floored max — the input only takes cents)
+      // means "empty this source": submit the exact balance and an explicit
+      // "full" mode. Reconstructing the intent later from float comparisons
+      // across different reads degraded MAX to a partial withdraw that
+      // stranded dust and kept the position open at $0.00 (no close, no SOL
+      // rent refund). Mirrors the web `deriveEarnWithdrawMode`.
+      const isMax = maxSelected || enteredUsd >= floorTo2(available);
+      const amountToWithdraw = isMax ? available : enteredUsd;
+      await onWithdraw?.(
+        amountToWithdraw,
+        selectedSource,
+        isMax ? "full" : "partial",
+      );
       sheetRef.current?.dismiss();
     } catch (error) {
       setSubmitError(
@@ -355,6 +356,7 @@ export function WithdrawSheet({
           : "Withdrawal failed. Please try again.",
       );
     } finally {
+      releaseSubmitLock();
       setSubmitting(false);
     }
   }, [disabled, enteredUsd, maxSelected, available, onWithdraw, selectedSource]);

--- a/mobile/src/components/earn/__tests__/withdraw-submit-lock.test.ts
+++ b/mobile/src/components/earn/__tests__/withdraw-submit-lock.test.ts
@@ -1,0 +1,58 @@
+import { acquireWithdrawSubmitLock } from "../withdraw-submit-lock";
+
+describe("withdraw submit lock", () => {
+  it("prevents an overlapping submit and permits the next one after release", async () => {
+    const lock = { current: false };
+    const effects: string[] = [];
+    let finishFirst: (() => void) | undefined;
+
+    const submit = async (
+      effect: () => void | Promise<void>,
+    ): Promise<boolean> => {
+      const release = acquireWithdrawSubmitLock(lock);
+      if (!release) {
+        return false;
+      }
+      try {
+        await effect();
+        return true;
+      } finally {
+        release();
+      }
+    };
+
+    const first = submit(
+      () =>
+        new Promise<void>((resolve) => {
+          effects.push("first");
+          finishFirst = resolve;
+        }),
+    );
+    const overlapping = await submit(() => {
+      effects.push("overlapping");
+    });
+
+    expect(overlapping).toBe(false);
+    expect(effects).toEqual(["first"]);
+
+    finishFirst?.();
+    await first;
+
+    const next = await submit(() => {
+      effects.push("next");
+    });
+    expect(next).toBe(true);
+    expect(effects).toEqual(["first", "next"]);
+  });
+
+  it("makes release idempotent and allows reacquisition", async () => {
+    const lock = { current: false };
+    const release = acquireWithdrawSubmitLock(lock);
+
+    expect(release).not.toBeNull();
+    release?.();
+    release?.();
+
+    expect(acquireWithdrawSubmitLock(lock)).not.toBeNull();
+  });
+});

--- a/mobile/src/components/earn/withdraw-submit-lock.ts
+++ b/mobile/src/components/earn/withdraw-submit-lock.ts
@@ -1,0 +1,26 @@
+export type WithdrawSubmitLock = {
+  current: boolean;
+};
+
+/**
+ * Acquire the withdrawal lock synchronously, before React can render updated
+ * button state. The release callback is idempotent so every exit path can use
+ * the same `finally` block safely.
+ */
+export function acquireWithdrawSubmitLock(
+  lock: WithdrawSubmitLock,
+): (() => void) | null {
+  if (lock.current) {
+    return null;
+  }
+
+  lock.current = true;
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    lock.current = false;
+  };
+}

--- a/mobile/src/lib/wallet/__tests__/seed-vault-signer.test.ts
+++ b/mobile/src/lib/wallet/__tests__/seed-vault-signer.test.ts
@@ -49,6 +49,8 @@ jest.mock("../vault-account-storage", () => ({
 import { SeedVaultSigner } from "../seed-vault-signer";
 // eslint-disable-next-line import/first
 import { WalletRejectedError } from "../rejection";
+// eslint-disable-next-line import/first
+import { WalletSessionError } from "../wallet-session-error";
 
 const authToken = "42";
 const derivationPath = "m/44'/501'/0'/0'";
@@ -288,6 +290,27 @@ describe("SeedVaultSigner", () => {
     await expect(signer.signMessage(new Uint8Array([0]))).rejects.toThrow(
       "result=1004",
     );
+    expect(mockListAuthorizedSeeds).not.toHaveBeenCalled();
+    expect(mockClearVaultAccount).not.toHaveBeenCalled();
+  });
+
+  it("preserves coded native signMessage failures as wallet signing errors", async () => {
+    const signer = new SeedVaultSigner(authToken, derivationPath, address);
+    const nativeError = Object.assign(new Error("No activity available"), {
+      code: "NO_ACTIVITY",
+    });
+    mockSignMessage.mockRejectedValueOnce(nativeError);
+
+    const error = await signer
+      .signMessage(new Uint8Array([0]))
+      .catch((failure: unknown) => failure);
+
+    expect(error).toBeInstanceOf(WalletSessionError);
+    expect(error).toMatchObject({
+      failure: "signing_failed",
+      walletCode: "NO_ACTIVITY",
+      cause: nativeError,
+    });
     expect(mockListAuthorizedSeeds).not.toHaveBeenCalled();
     expect(mockClearVaultAccount).not.toHaveBeenCalled();
   });

--- a/mobile/src/lib/wallet/seed-vault-signer.ts
+++ b/mobile/src/lib/wallet/seed-vault-signer.ts
@@ -5,6 +5,7 @@ import { Buffer } from "buffer";
 import { WalletRejectedError } from "./rejection";
 import type { Signer } from "./signer";
 import { clearVaultAccount, storeVaultAccount } from "./vault-account-storage";
+import { WalletSessionError } from "./wallet-session-error";
 
 // The vault caps signing requests per authorization intent
 // (IMPLEMENTATION_LIMITS_MAX_SIGNING_REQUESTS — 3 on current Saga/Seeker
@@ -41,6 +42,16 @@ function isInvalidAuthTokenError(error: unknown): boolean {
  */
 export function isSeedVaultUserDecline(error: unknown): boolean {
   return error instanceof Error && USER_DECLINED_RESULT.test(error.message);
+}
+
+function nativeErrorCode(error: unknown): string | number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" || typeof code === "number"
+    ? code
+    : undefined;
 }
 
 // The vault signs the message bytes, not the full serialized transaction
@@ -81,13 +92,21 @@ export class SeedVaultSigner implements Signer {
   }
 
   async signMessage(bytes: Uint8Array): Promise<Uint8Array> {
-    return this.withAuthTokenRecovery(() =>
-      SeedVault.signMessage({
-        authToken: this.authToken,
-        derivationPath: this.derivationPath,
-        message: bytes,
-      }),
-    );
+    try {
+      return await this.withAuthTokenRecovery(() =>
+        SeedVault.signMessage({
+          authToken: this.authToken,
+          derivationPath: this.derivationPath,
+          message: bytes,
+        }),
+      );
+    } catch (error) {
+      const code = nativeErrorCode(error);
+      if (code !== undefined) {
+        throw new WalletSessionError("signing_failed", code, error);
+      }
+      throw error;
+    }
   }
 
   async signTransaction<T extends Transaction | VersionedTransaction>(

--- a/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/mobile/src/lib/wallet/wallet-session-error.ts
@@ -26,7 +26,7 @@ export type WalletSessionFailure =
   | "connection_failed"
   /** The wallet app was reachable but did not answer in time. */
   | "timeout"
-  /** The session opened; the wallet errored while producing the signature. */
+  /** The wallet-native signer errored while producing the signature. */
   | "signing_failed";
 
 // What the user is told, per failure. Owned here so the advice can never drift

--- a/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -172,6 +172,21 @@ describe("wallet session classification", () => {
     expect(mapLifecycleErrorCode(error)).toBe("wallet_connection_failed");
   });
 
+  it("classifies a Seed Vault native signing code as wallet_signing_failed", () => {
+    const nativeError = Object.assign(new Error("No activity available"), {
+      code: "NO_ACTIVITY",
+    });
+    const error = new WalletSessionError(
+      "signing_failed",
+      nativeError.code,
+      nativeError,
+    );
+
+    expect(mapLifecycleErrorCode(error)).toBe("wallet_signing_failed");
+    expect(error.walletCode).toBe("NO_ACTIVITY");
+    expect(error.cause).toBe(nativeError);
+  });
+
   it("emits failed with the session code and no httpStatus", async () => {
     const sent = captureEnvelopes();
     newFlow().failFrom("prepare", new WalletSessionError("connection_failed"));


### PR DESCRIPTION
## Summary

- acquire a synchronous in-flight lock before `WithdrawSheet` invokes `onWithdraw`, so rapid taps cannot start overlapping full-withdrawal authorization flows
- preserve coded Seed Vault `signMessage` failures as `WalletSessionError("signing_failed")`, including the native code and original cause for local diagnosis
- classify those local wallet failures as `wallet_signing_failed` instead of the generic backend-looking `request_failed`
- add focused regression coverage for the reentrancy invariant and error classification

Linear: [ASK-1927](https://linear.app/askloyal/issue/ASK-1927/fixmobile-lock-earn-withdrawal-submission-and-classify-native-signing)
Parent tracker: [ASK-1878](https://linear.app/askloyal/issue/ASK-1878/track-alert-triage-2026-07-26-follow-up-6-unowned-clickstack-alerts)

## Original alert

```text
🚨 Alert for "Errors"
Group: "ServiceName:loyal-mobile"
Time Range (UTC): [Jul 28 10:22:00 AM - Jul 28 10:23:00 AM)
4 events · 1 unique wallet · muted 19h37m

🔴 error · 10:22:24 UTC · loyal-mobile
earn.withdrawal.prepare.failed
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: 5si1zrQJN7bBjT9xFXJ8FUp3VUeysTMsRRu6Z9cx73ma

🔴 error · 10:22:37 UTC · loyal-mobile
earn.withdrawal.prepare.failed
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: 5si1zrQJN7bBjT9xFXJ8FUp3VUeysTMsRRu6Z9cx73ma

🔴 error · 10:22:45 UTC · loyal-mobile
earn.withdrawal.prepare.failed
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: 5si1zrQJN7bBjT9xFXJ8FUp3VUeysTMsRRu6Z9cx73ma

🔴 error · 10:22:52 UTC · loyal-mobile
earn.withdrawal.prepare.failed
env: prod
flow: earn.withdrawal
stage: prepare
error_code: request_failed
wallet: 5si1zrQJN7bBjT9xFXJ8FUp3VUeysTMsRRu6Z9cx73ma

https://loyal-clickstack.onrender.com/search/6a5fb723dcc64beb0ded6cca?from=1785234120000&to=1785234180000
```

## Confirmed root cause

ClickStack recorded 30 full-withdrawal failures for one wallet on build `0.1.2_019fa41e` from 2026-07-28 10:22:11 through 10:46:37 UTC (15:22:11–15:46:37 Asia/Yekaterinburg). Four flow starts occurred within 4 ms at 10:26:21.727/.729/.730/.731 UTC.

`WithdrawSheet` previously called `onWithdraw` before setting `submitting`. Rapid taps therefore entered `executeEarnWithdraw` in parallel. Each flow requests its on-device Earn authorization signature before calling prepare-context. The native wallet bridge rejected/failed the concurrent signing request with a coded error, and the generic lifecycle mapper converted any coded error to `request_failed`.

Vercel had no matching `/api/smart-accounts/mobile/earn/withdraw/prepare-context` request in the burst window. The Yield database retained the active position with zero confirmed withdrawals, and no corresponding transaction landed. This was an on-device reentrancy/signing failure, not a backend, database, or chain failure. The existing telemetry does not expose the exact native code, so this PR intentionally does not claim one.

## Scope

In scope:

- withdrawal-submit reentrancy guard
- coded Seed Vault message-signing classification
- local preservation of native code/cause

Out of scope:

- Kamino retry behavior from ASK-1887 / PR #531
- backend prepare/confirm changes from PRs #534 and #535
- alert filtering or unrestricted native error-detail telemetry

## Verification

- `npm test -- --runInBand src/components/earn/__tests__/withdraw-submit-lock.test.ts src/lib/wallet/__tests__/seed-vault-signer.test.ts src/services/__tests__/lifecycle-rejection.test.ts` — 3 suites, 28 tests passed
- `npx expo lint` — 0 errors; 9 pre-existing warnings in unrelated files
- full `npm test -- --runInBand` — 43/45 suites passed, 251 tests passed; two unrelated suites fail before test execution because the existing Jest setup cannot parse `react-native-mmkv` and the ESM `@loyal-labs/solana-rpc` build
- `git diff --check` — passed
- changed files contain no Cyrillic text

## Safety

Merge safety: the change is limited to the mobile withdrawal UI and wallet-error classification, with focused contract tests.

Deployment safety: merging alone does not change production. No native module or backend contract changes are included; the mobile bundle still needs its normal deployment and post-deploy ClickStack verification.