### PR TITLE
fix(frontend): earn chart tab colors and allowance icon sizing

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1984,7 +1984,7 @@
 :root {
   --tabs-dur: 250ms;
   --tabs-ease: cubic-bezier(0.22, 1, 0.36, 1);
-  --tabs-text-muted: #000;
+  --tabs-text-muted: #8a8a8e;
   --tabs-text-active: #000;
   --tabs-bar-bg: rgba(0, 0, 0, 0.04);
   --tabs-pill-bg: #fff;

--- a/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
@@ -307,7 +307,7 @@ export function TransactionRow({
       <span className="flex items-center py-2 pr-3">
         {item.kind === "autodeposit_action" ? (
           <span className="inline-flex size-11 shrink-0 overflow-hidden rounded-full">
-            <EarnYieldIcon />
+            <EarnYieldIcon size={44} />
           </span>
         ) : (
           <DualIcon

--- a/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
@@ -186,7 +186,7 @@ export function EarnTransactionDetailPane({
         <div className="flex shrink-0 items-center pl-4 pr-3">
           {isAllowanceAction ? (
             <span className="inline-flex size-11 shrink-0 overflow-hidden rounded-full">
-              <EarnYieldIcon />
+              <EarnYieldIcon size={44} />
             </span>
           ) : (
             <DualIcon


### PR DESCRIPTION
Inactive Earn chart tabs now use the secondary text color and darken on hover; the allowance EarnYieldIcon is sized to its 44px circular mask so the coin art is centered in activity rows and transaction details.