### PR TITLE
fix(frontend): earn facelift amount labels, max rounding, dog and breakpoint fixes

### DIFF
--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -56,6 +56,9 @@ export function DepositPane({
   const usdcBalance = splitUsdBalance(usdcUsd);
 
   const amountUsd = Number.parseFloat(amount.replace(/,/g, "")) || 0;
+  const amountLabel = amountUsd.toLocaleString("en-US", {
+    maximumFractionDigits: 2,
+  });
   const isBelowMinimum = amountUsd < MIN_DEPOSIT_USD;
   const isInsufficient = !isBelowMinimum && amountUsd > usdcUsd;
   const isValidAmount = !isBelowMinimum && !isInsufficient;
@@ -195,7 +198,12 @@ export function DepositPane({
                 className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
                 onClick={() => {
                   if (usdcUsd > 0) {
-                    handleAmountChange(usdcUsd.toFixed(2));
+                    // Floor to cents so the fill never rounds above the real
+                    // balance (toFixed would turn 1.8699 into an
+                    // "insufficient" 1.87), same as the withdraw pane's MAX.
+                    handleAmountChange(
+                      (Math.floor(usdcUsd * 100) / 100).toFixed(2)
+                    );
                   }
                 }}
                 type="button"
@@ -278,7 +286,7 @@ export function DepositPane({
                 : isInsufficient
                 ? "Insufficient balance"
                 : isValidAmount
-                ? "Deposit"
+                ? `Deposit ${amountLabel} USDC`
                 : `Minimum deposit is $${MIN_DEPOSIT_USD}`
             }
           />

--- a/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
@@ -52,7 +52,7 @@ export function EarnEmptyPane({
   ];
 
   return (
-    <section className="relative flex h-full min-w-0 flex-1 flex-col items-center overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
+    <section className="relative flex h-full min-w-0 flex-1 flex-col items-center rounded-3xl bg-white max-[795px]:overflow-clip max-[795px]:rounded-none">
       <header className="flex w-full items-center p-2">
         <div className="flex min-w-0 flex-1 items-center gap-2 py-2 pl-4">
           <h1 className="whitespace-nowrap font-semibold text-[24px] text-black leading-7">
@@ -158,8 +158,10 @@ export function EarnEmptyPane({
       </div>
 
       {/* On mobile the dog clips to the rounded bottom above the tab bar
-          (Figma 4693:69958); the white body makes the corners read clean. */}
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center max-[795px]:overflow-clip max-[795px]:rounded-b-3xl">
+          (Figma 4693:69958); the white body makes the corners read clean.
+          On desktop it ignores the pane instead: unclipped and dropped by the
+          shell's 8px gap (p-2) so it sits flush with the viewport bottom. */}
+      <div className="-bottom-2 pointer-events-none absolute inset-x-0 flex justify-center max-[795px]:bottom-0 max-[795px]:overflow-clip max-[795px]:rounded-b-3xl">
         <DogLottie
           className="aspect-square w-full max-h-[420px] max-w-[420px]"
           variant="playful"

--- a/frontend/src/components/wallet-workspace/facelift/shell.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/shell.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/wallet-workspace/facelift/keyboard";
 import { FaceliftSidebar } from "@/components/wallet-workspace/facelift/sidebar";
 import { useEarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
+import { useIsNarrowViewport } from "@/components/wallet-workspace/facelift/use-is-narrow-viewport";
 import { WalletHomePage } from "@/components/wallet-workspace/facelift/wallet-home-page";
 import { WithdrawPane } from "@/components/wallet-workspace/facelift/withdraw-pane";
 import { usePublicEnv } from "@/contexts/public-env-context";
@@ -112,6 +113,15 @@ export function WorkspaceFaceliftShell() {
       setActivePage("earn");
     }
   }, [activePage, isHydrated, isSignedIn]);
+  // The wallet home is mobile-only (tab bar's Wallet tab) — no sidebar entry
+  // can leave it, so growing past the breakpoint (resize or a desktop reload
+  // restoring a stored "wallet") snaps back to the Earn home.
+  const isNarrowViewport = useIsNarrowViewport();
+  useEffect(() => {
+    if (!isNarrowViewport && activePage === "wallet") {
+      setActivePage("earn");
+    }
+  }, [activePage, isNarrowViewport]);
   const [middleView, setMiddleView] = useState<MiddleView>("earn");
   // Set when a positions-tab row's Withdraw pill opened the screen — the
   // withdraw pane preselects that source; header Withdraw clears it.

--- a/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -144,6 +144,9 @@ export function WithdrawPane({
   const fromBalance = splitUsdBalance(selectedOption?.usd ?? 0);
 
   const amountUsd = Number.parseFloat(amount.replace(/,/g, "")) || 0;
+  const amountLabel = amountUsd.toLocaleString("en-US", {
+    maximumFractionDigits: 2,
+  });
   // Same mode derivation as the old workspace: compared against the floored
   // TOTAL of all sources, so the visible max registers as a full exit.
   const withdrawMode = deriveEarnWithdrawMode({ amount: amountUsd, sources });
@@ -499,7 +502,7 @@ export function WithdrawPane({
                 text={
                   isSubmitting
                     ? "Withdrawing…"
-                    : withdrawValidationError ?? "Withdraw"
+                    : withdrawValidationError ?? `Withdraw ${amountLabel} USDC`
                 }
               />
             </button>


### PR DESCRIPTION
Mirrors the typed amount on the Earn deposit/withdraw buttons ("Deposit 10 USDC"), floors the deposit MAX fill to cents so it can't exceed the real balance, pins the empty-state dog to the viewport bottom edge on desktop, and snaps the mobile-only wallet home back to Earn when the viewport grows past the breakpoint.