### PR TITLE
fix(frontend): stop row action clicks opening token detail sheet on tablet

### DIFF
--- a/frontend/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -784,26 +784,44 @@ export function CryptoPage({
     });
   };
 
+  // Row actions also select the token (without opening the <1204 detail
+  // sheet) so the desktop aside shows its detail once the action closes.
+  const selectRowDetail = (row: TokenRow) =>
+    setDetailToken(tokenRowToSwapToken(row));
+
   const rowActions: CryptoRowActions = {
     // ponytail: the deposit pane picks its own source token, so row-level
     // Earn lands on the same screen as the header button.
-    onEarn: () => onEarn(),
+    onEarn: (row) => {
+      selectRowDetail(row);
+      onEarn();
+    },
     onSelect: (row) => {
       setDetailToken(tokenRowToSwapToken(row));
       setIsDetailSheetOpen(true);
     },
-    onSend: (row) => openSend(tokenRowToSwapToken(row)),
+    onSend: (row) => {
+      selectRowDetail(row);
+      openSend(tokenRowToSwapToken(row));
+    },
     // Shield and Unshield land on the same screen — the row token's secured
     // flag picks the direction.
-    onShield: (row) => openShield(tokenRowToSwapToken(row)),
+    onShield: (row) => {
+      selectRowDetail(row);
+      openShield(tokenRowToSwapToken(row));
+    },
     onSwap: (row) => {
+      selectRowDetail(row);
       const mint = row.id?.replace(/-secured$/, "");
       const base =
         derivedTokens.find((token) => token.mint === mint) ??
         tokenRowToSwapToken(row);
       openSwap(base);
     },
-    onUnshield: (row) => openShield(tokenRowToSwapToken(row)),
+    onUnshield: (row) => {
+      selectRowDetail(row);
+      openShield(tokenRowToSwapToken(row));
+    },
   };
 
   const handleShield = () => openShield();

--- a/frontend/src/components/wallet-workspace/facelift/crypto-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/crypto-pane.tsx
@@ -114,7 +114,12 @@ function RowPill({
           ? "bg-black text-white hover:bg-[#171717]"
           : "bg-black/[0.04] text-black hover:bg-black/[0.08]"
       }`}
-      onClick={onClick}
+      onClick={(event) => {
+        // Don't bubble into the row click — below 1204px that would slide
+        // the token detail sheet over the action pane being opened.
+        event.stopPropagation();
+        onClick();
+      }}
       type="button"
     >
       <span className="max-[999px]:hidden">{label}</span>
@@ -149,7 +154,8 @@ function TokenCell({
   const isStables = variant === "stables";
   return (
     // Row click selects the token for the detail right pane; the action
-    // pills' clicks bubbling into the selection is intentional.
+    // pills stop propagation (the page's row actions select the token
+    // themselves without opening the <1204 detail sheet).
     <div
       className="group relative flex w-full cursor-pointer items-center rounded-2xl px-4 transition-colors duration-150 hover:bg-black/[0.04]"
       onClick={() => actions.onSelect?.(row)}


### PR DESCRIPTION
Between 796–1203px, clicking a hover action pill (Swap/Send/Shield/Earn) on a Crypto/Stablecoins token row also slid the token detail sheet over the opened action pane, because pill clicks bubbled into the row's select handler. Pills now stop propagation, and row actions set the detail token explicitly so the desktop aside behavior is unchanged.