### PR TITLE
fix(mobile): report unexpected withdrawal exceptions

### DIFF
--- a/mobile/src/lib/solana/earn/withdraw.ts
+++ b/mobile/src/lib/solana/earn/withdraw.ts
@@ -388,6 +388,7 @@ export async function executeEarnWithdraw(args: {
   const flow = startLifecycleFlow({
     flowName: "earn.withdrawal",
     flowVariant: args.mode === "full" ? "full" : "partial",
+    reportUnexpectedErrors: true,
     walletAddress: args.signer.publicKey.toBase58(),
   });
   flow.start("prepare");

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -178,11 +178,24 @@ function postEnvelope(envelope: MobileErrorEnvelope): Promise<void> {
   return postJson("/api/observability/mobile/errors", envelope);
 }
 
-function report(error: unknown, operation: MobileErrorOperation): void {
+function report(
+  error: unknown,
+  operation: MobileErrorOperation,
+  messagePrefix?: string,
+): void {
   try {
+    const normalized = normalizeError(error);
     const envelope: MobileErrorEnvelope = {
-      ...normalizeError(error),
+      ...normalized,
       environment: getEnvironment(),
+      ...(messagePrefix
+        ? {
+            message: truncate(
+              `${messagePrefix} ${normalized.message}`,
+              MAX_ERROR_MESSAGE_LENGTH,
+            ),
+          }
+        : {}),
       operation,
       pathname: currentPathname,
       release: getRelease(),
@@ -442,6 +455,8 @@ const WALLET_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
   flowName: F;
   flowVariant: LifecycleVariantMap[F];
+  /** Emit a correlated exception record when failFrom maps to unexpected_error. */
+  reportUnexpectedErrors?: boolean;
   walletAddress?: string;
 }): LifecycleFlow<F> {
   const flowId = generateFlowId();
@@ -498,6 +513,7 @@ export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
     complete: (stage, diagnostics) => emit("completed", stage, diagnostics),
     fail: (stage, diagnostics) => emit("failed", stage, diagnostics),
     failFrom: (stage, error, diagnostics) => {
+      if (terminal) return;
       const errorCode = mapLifecycleErrorCode(error);
       // Only a decline that changed nothing on-chain is a clean cancellation.
       // Declining after an earlier step landed leaves confirmed-but-unrecorded
@@ -510,6 +526,15 @@ export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
         errorCode,
         ...(httpStatus !== undefined ? { httpStatus } : {}),
       });
+      if (errorCode === "unexpected_error" && args.reportUnexpectedErrors) {
+        // Lifecycle `errorDetail` is deliberately enum-only. Use the existing
+        // sanitized error ingest and add searchable flow context instead.
+        report(
+          error,
+          "mobile.global_error",
+          `[flow_id=${flowId} flow_name=${args.flowName} flow_stage=${stage}]`,
+        );
+      }
     },
     flowId,
     observe: (stage, diagnostics) => emit("observed", stage, diagnostics),


### PR DESCRIPTION
## Summary

- emit a companion mobile exception event when an Earn withdrawal maps to `unexpected_error`
- preserve the original exception type, message, and stack while adding searchable flow ID, flow name, and stage context
- keep `loyal.error.detail` enum-only and limit the new reporting behavior to Earn withdrawals

## Root cause

The withdrawal lifecycle classifier reduced an untyped on-device preparation exception to `unexpected_error`. The lifecycle event did not carry exception telemetry, so the original SDK exception was unavailable after the alert.

## Impact

Future unexpected Earn withdrawal failures retain the existing lifecycle alert and also emit a correlated exception record through the sanitized mobile error ingest. Request failures, wallet cancellations, transaction behavior, and backend contracts are unchanged.

## Verification

- simulated an `earn.withdrawal` device-prepare exception and confirmed the lifecycle event carried `unexpected_error`
- confirmed the companion event preserved the simulated exception type, message, and stack with the same flow ID and `prepare` stage
- `cd mobile && npx expo lint` (0 errors; 9 unrelated existing warnings)
- `cd mobile && npx tsc --noEmit --incremental false`
- `git diff --check`

No tests were added or changed per the requested scope.
