### PR TITLE
feat(frontend): add staged toasts and Enter submit for earn actions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3016,3 +3016,94 @@ cap-widget {
     animation: none !important;
   }
 }
+
+/* transitions.dev — Toast open / close (frontend/transitions/toast.md).
+   Earn action feedback pill (facelift/earn-toast.tsx): slides into the top
+   edge with fade + cross-blur + slight scale (the host flips
+   --toast-distance negative); opening runs the slower open clock while
+   dismissing uses the faster close clock. */
+:root {
+  --toast-open: 350ms;
+  --toast-close: 250ms;
+  --toast-distance: 16px;
+  --toast-blur: 2px;
+  --toast-scale: 0.97;
+  --toast-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.t-toast {
+  opacity: 0;
+  transform: translateY(var(--toast-distance)) scale(var(--toast-scale));
+  filter: blur(var(--toast-blur));
+  will-change: transform, opacity, filter;
+  transition: opacity var(--toast-close) var(--toast-ease),
+    transform var(--toast-close) var(--toast-ease),
+    filter var(--toast-close) var(--toast-ease);
+}
+.t-toast.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  filter: blur(0);
+  transition: opacity var(--toast-open) var(--toast-ease),
+    transform var(--toast-open) var(--toast-ease),
+    filter var(--toast-open) var(--toast-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-toast {
+    transition: none !important;
+  }
+}
+
+/* Facelift adaptation — the toast's status icon is an icon-swap with THREE
+   stacked states (a: pending spinner, b: success check, c: error cross).
+   The base recipe above only styles a/b, so state "c" gets the same
+   treatment here, scoped to the toast. The white arc spins while pending,
+   and the check strokes itself in on the morph to success (reusing
+   t-check-draw; 35 = the calibrated length of the shared check path). */
+:root {
+  --toast-spin-dur: 900ms;
+}
+
+.t-toast .t-icon-swap[data-state="c"] .t-icon[data-icon="c"] {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+.t-toast .t-icon-swap[data-state="a"] .t-icon[data-icon="c"],
+.t-toast .t-icon-swap[data-state="b"] .t-icon[data-icon="c"],
+.t-toast .t-icon-swap[data-state="c"] .t-icon[data-icon="a"],
+.t-toast .t-icon-swap[data-state="c"] .t-icon[data-icon="b"] {
+  opacity: 0;
+  filter: blur(var(--icon-swap-blur));
+  transform: scale(var(--icon-swap-start-scale));
+}
+
+.t-toast-spinner {
+  animation: t-toast-spin var(--toast-spin-dur) linear infinite;
+  transform-origin: center;
+}
+
+@keyframes t-toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.t-toast .t-icon[data-icon="b"] svg path {
+  stroke-dasharray: 35;
+  stroke-dashoffset: 35;
+}
+.t-toast .t-icon-swap[data-state="b"] .t-icon[data-icon="b"] svg path {
+  animation: t-check-draw var(--check-path-dur) var(--check-ease-path) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-toast-spinner {
+    animation: none !important;
+  }
+  .t-toast .t-icon[data-icon="b"] svg path {
+    animation: none !important;
+    stroke-dashoffset: 0 !important;
+  }
+}

--- a/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
@@ -278,6 +278,15 @@ export function AutodepositPane({
                     className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
                     inputMode="decimal"
                     onChange={(event) => handleAmountChange(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.repeat) {
+                        return;
+                      }
+                      event.preventDefault();
+                      if (hasChanges && !isSaving) {
+                        void handleSave();
+                      }
+                    }}
                     placeholder="0"
                     type="text"
                     value={amount}

--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -134,6 +134,15 @@ export function DepositPane({
                   className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
                   inputMode="decimal"
                   onChange={(event) => handleAmountChange(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" || event.repeat) {
+                      return;
+                    }
+                    event.preventDefault();
+                    if (isValidAmount && !isSubmitting) {
+                      void handleSubmit();
+                    }
+                  }}
                   placeholder="0"
                   type="text"
                   value={amount}

--- a/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+
+// Single-slot toast for the Earn action flows (deposit / withdraw /
+// autodeposit). use-earn-actions.ts reports lifecycle moments through
+// `earnToast`; the host mounted in shell.tsx renders them as a
+// bottom-center pill (transitions.dev toast recipe). The status icon is a
+// three-way icon-swap: pending spinner (a) morphs into the success check
+// (b) or the error cross (c).
+
+type EarnToastPhase = "error" | "loading" | "success";
+
+type EarnToastDetail = { message: string; phase: EarnToastPhase };
+
+type EarnToastListener = {
+  settle: () => void;
+  show: (detail: EarnToastDetail) => void;
+  signed: () => void;
+};
+
+let listener: EarnToastListener | null = null;
+
+// The wallet-sign stage message. The wallet adapter bridge calls
+// earnToast.signed() when a signature resolves, and the host only advances
+// the toast when this exact message is showing — keep them in sync.
+export const CONFIRM_IN_WALLET_MESSAGE = "Confirm in wallet";
+
+export const earnToast = {
+  error(message: string) {
+    listener?.show({ message, phase: "error" });
+  },
+  loading(message: string) {
+    listener?.show({ message, phase: "loading" });
+  },
+  // Close the toast if it is still in its loading phase — the flow ended
+  // without an outcome worth announcing (wallet cancel, review decline,
+  // sign-in gate). Safe to call unconditionally from `finally` blocks.
+  settle() {
+    listener?.settle();
+  },
+  // The wallet finished signing: advance a visible "Confirm in wallet"
+  // toast to "Confirming" (submission + chain/backend confirm). No-op for
+  // any other toast state, so non-Earn signature flows never surface one.
+  signed() {
+    listener?.signed();
+  },
+  success(message: string) {
+    listener?.show({ message, phase: "success" });
+  },
+};
+
+const SUCCESS_DISMISS_MS = 2500;
+const ERROR_DISMISS_MS = 5000;
+// Outlives --toast-close (250ms) so content stays mounted through the
+// close transition instead of emptying the pill mid-flight.
+const CLEAR_AFTER_CLOSE_MS = 300;
+
+const ICON_STATE: Record<EarnToastPhase, "a" | "b" | "c"> = {
+  error: "c",
+  loading: "a",
+  success: "b",
+};
+
+export function EarnToastHost() {
+  const [detail, setDetail] = useState<EarnToastDetail | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const detailRef = useRef<EarnToastDetail | null>(null);
+  const timersRef = useRef<{
+    clear?: ReturnType<typeof setTimeout>;
+    hide?: ReturnType<typeof setTimeout>;
+  }>({});
+
+  useEffect(() => {
+    const clearTimers = () => {
+      clearTimeout(timersRef.current.hide);
+      clearTimeout(timersRef.current.clear);
+    };
+    const close = () => {
+      detailRef.current = null;
+      setIsOpen(false);
+      timersRef.current.clear = setTimeout(
+        () => setDetail(null),
+        CLEAR_AFTER_CLOSE_MS
+      );
+    };
+    const show = (next: EarnToastDetail) => {
+      clearTimers();
+      detailRef.current = next;
+      setDetail(next);
+      setIsOpen(true);
+      if (next.phase !== "loading") {
+        timersRef.current.hide = setTimeout(
+          close,
+          next.phase === "success" ? SUCCESS_DISMISS_MS : ERROR_DISMISS_MS
+        );
+      }
+    };
+    listener = {
+      settle: () => {
+        if (detailRef.current?.phase === "loading") {
+          clearTimers();
+          close();
+        }
+      },
+      show,
+      signed: () => {
+        if (
+          detailRef.current?.phase === "loading" &&
+          detailRef.current.message === CONFIRM_IN_WALLET_MESSAGE
+        ) {
+          show({ message: "Confirming", phase: "loading" });
+        }
+      },
+    };
+    return () => {
+      listener = null;
+      clearTimers();
+    };
+  }, []);
+
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 top-6 z-[60] flex justify-center"
+      role="status"
+    >
+      <div
+        className={`t-toast flex h-12 items-center gap-2.5 rounded-full bg-white pr-5 pl-4 font-medium text-[14px] text-black leading-5 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] ${
+          isOpen ? "is-open" : ""
+        }`}
+        // Top-anchored, so the pill drops in from above its resting spot
+        // (the recipe's default +16px rises from below).
+        style={{ ["--toast-distance" as never]: "-16px" }}
+      >
+        {detail ? (
+          <>
+            <span
+              aria-hidden="true"
+              className="t-icon-swap size-5"
+              data-state={ICON_STATE[detail.phase]}
+            >
+              <span className="t-icon" data-icon="a">
+                <svg className="size-5" fill="none" viewBox="0 0 64 64">
+                  <circle cx="32" cy="32" fill="#ffb800" r="32" />
+                  <circle
+                    className="t-toast-spinner"
+                    cx="32"
+                    cy="32"
+                    fill="none"
+                    r="14"
+                    stroke="white"
+                    strokeDasharray="40 48"
+                    strokeLinecap="round"
+                    strokeWidth="6"
+                  />
+                </svg>
+              </span>
+              {/* Same circle + check pair as ActionSuccessBody's t-success-check. */}
+              <span className="t-icon" data-icon="b">
+                <svg className="size-5" fill="none" viewBox="0 0 64 64">
+                  <circle cx="32" cy="32" fill="#34c759" r="32" />
+                  <path
+                    d="M20 33l8 8 16-16"
+                    stroke="white"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="5"
+                  />
+                </svg>
+              </span>
+              <span className="t-icon" data-icon="c">
+                <svg className="size-5" fill="none" viewBox="0 0 64 64">
+                  <circle cx="32" cy="32" fill="#f9363c" r="32" />
+                  <path
+                    d="M23 23l18 18M41 23l-18 18"
+                    stroke="white"
+                    strokeLinecap="round"
+                    strokeWidth="5"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span>
+              <TextSwap text={detail.message} />
+              {detail.phase === "loading" ? (
+                <span aria-hidden="true" className="t-loading-dots">
+                  <span>.</span>
+                  <span>.</span>
+                  <span>.</span>
+                </span>
+              ) : null}
+            </span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wallet-workspace/facelift/shell.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/shell.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/wallet-workspace/facelift/earn-chart-pane";
 import { startEarnEarningsPrefetch } from "@/components/wallet-workspace/facelift/earn-earnings-prefetch";
 import { EarnEmptyPane } from "@/components/wallet-workspace/facelift/earn-empty-pane";
+import { EarnToastHost } from "@/components/wallet-workspace/facelift/earn-toast";
 import { EarnStatsPanel } from "@/components/wallet-workspace/facelift/earn-stats-panel";
 import { EarnPositionPane } from "@/components/wallet-workspace/facelift/earn-position-pane";
 import { MobileTabBar } from "@/components/wallet-workspace/facelift/mobile-tab-bar";
@@ -283,6 +284,9 @@ export function WorkspaceFaceliftShell() {
         {/* OG-style approval review for Earn deposit/withdraw/autodeposit —
             flows park between prepare and sign until the user responds. */}
         <EarnApprovalSheet approval={earnData.actions.pendingApproval} />
+        {/* Status pill for Earn deposit/withdraw/autodeposit flows —
+            use-earn-actions.ts drives it through the earnToast emitter. */}
+        <EarnToastHost />
         <FaceliftSidebar
           activePage={activePage}
           earnBalanceUsd={earnData.earnBalanceUsd}

--- a/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -60,6 +60,10 @@ import {
   toEarnWithdrawVaultsSource,
   type EarnDepositYieldRoutingPolicy,
 } from "@/components/wallet-workspace/facelift/earn-actions-support";
+import {
+  CONFIRM_IN_WALLET_MESSAGE,
+  earnToast,
+} from "@/components/wallet-workspace/facelift/earn-toast";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { useSignInModal } from "@/contexts/sign-in-modal-context";
@@ -960,6 +964,7 @@ export function useEarnActions(deps: {
       });
       setDepositError(null);
       setIsDepositPending(true);
+      earnToast.loading("Preparing deposit");
       let phase: "prepare" | "sign" = "prepare";
 
       const commitDepositSuccess = (commit: {
@@ -1009,6 +1014,7 @@ export function useEarnActions(deps: {
               ? "failed"
               : "recorded",
         });
+        earnToast.success("Deposited");
       };
 
       try {
@@ -1034,6 +1040,7 @@ export function useEarnActions(deps: {
         // even when the prepare bundles policy repair — the wallet still
         // prompts per signature.
         if (!hasPosition) {
+          earnToast.loading("Waiting for approval");
           const approved = await requestApproval(
             buildEarnDepositReviewItem({
               draft,
@@ -1052,6 +1059,7 @@ export function useEarnActions(deps: {
           return false;
         }
         phase = "sign";
+        earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
 
         if (shouldBypassTopUpPreview) {
           tracker.observe("wallet_submit_confirm", {
@@ -1177,6 +1185,7 @@ export function useEarnActions(deps: {
               chainState: "submitted",
               executionMode: "sequential",
             });
+            earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
             const result = await smartAccountData.executeEarnDepositPolicyStage(
               {
                 observabilityFlowId: tracker.flowId,
@@ -1227,6 +1236,7 @@ export function useEarnActions(deps: {
             chainState: "submitted",
             executionMode: "sequential",
           });
+          earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
           const result = await smartAccountData.executeEarnDeposit({
             amountRaw,
             observabilityFlowId: tracker.flowId,
@@ -1277,9 +1287,13 @@ export function useEarnActions(deps: {
             errorCode: "unexpected_error",
           });
         }
+        if (!isWalletCancellation(error)) {
+          earnToast.error("Deposit failed");
+        }
         return false;
       } finally {
         setIsDepositPending(false);
+        earnToast.settle();
       }
     },
     [
@@ -1316,6 +1330,7 @@ export function useEarnActions(deps: {
       tracker.start("intent", { cleanupRequired: draft.mode === "full" });
       setWithdrawError(null);
       setIsWithdrawPending(true);
+      earnToast.loading("Preparing withdrawal");
 
       try {
         tracker.observe("prepare", {
@@ -1331,6 +1346,7 @@ export function useEarnActions(deps: {
         // it even when they carry an autodeposit close — the wallet still
         // prompts per signature.
         if (draft.mode === "full") {
+          earnToast.loading("Waiting for approval");
           const approved = await requestApproval(
             buildEarnWithdrawReviewItem({
               draft,
@@ -1352,6 +1368,7 @@ export function useEarnActions(deps: {
         if (!ensureCanSignAccountAction()) {
           return false;
         }
+        earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
 
         if (shouldBypassWithdrawPreview) {
           const stepCount = Math.max(1, preparedWithdraw.withdrawSteps.length);
@@ -1364,6 +1381,7 @@ export function useEarnActions(deps: {
               stageCount: stepCount,
               stageIndex: stepIndex,
             });
+            earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
             const result = await smartAccountData.executeEarnWithdraw({
               amountRaw,
               mode: draft.mode,
@@ -1406,6 +1424,7 @@ export function useEarnActions(deps: {
             persistenceState: "recorded",
           });
           withdrawTrackerRef.current = null;
+          earnToast.success("Withdrawn");
           return true;
         }
 
@@ -1432,6 +1451,7 @@ export function useEarnActions(deps: {
             if (!preparedClose) {
               throw new Error("Prepare the Autodeposit close before signing.");
             }
+            earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
             const result = await smartAccountData.executeEarnAutodepositClose({
               observabilityFlowId: tracker.flowId,
               policy: preparedClose.policy.account.toBase58(),
@@ -1479,6 +1499,7 @@ export function useEarnActions(deps: {
             stageCount: Math.max(1, preparedWithdraw.withdrawSteps.length),
             stageIndex: stepIndex,
           });
+          earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
           const result = await smartAccountData.executeEarnWithdraw({
             amountRaw,
             observabilityFlowId: tracker.flowId,
@@ -1543,6 +1564,7 @@ export function useEarnActions(deps: {
             });
             withdrawTrackerRef.current = null;
           }
+          earnToast.success("Withdrawn");
           return true;
         }
       } catch (error) {
@@ -1560,9 +1582,13 @@ export function useEarnActions(deps: {
             errorCode: "unexpected_error",
           });
         }
+        if (!isWalletCancellation(error)) {
+          earnToast.error("Withdrawal failed");
+        }
         return false;
       } finally {
         setIsWithdrawPending(false);
+        earnToast.settle();
       }
     },
     [
@@ -1590,6 +1616,7 @@ export function useEarnActions(deps: {
     const tracker = withdrawTrackerRef.current;
     setWithdrawError(null);
     setIsCleanupPending(true);
+    earnToast.loading("Closing policies");
     try {
       tracker?.observe("full_exit_verify", {
         chainState: "confirmed",
@@ -1616,6 +1643,7 @@ export function useEarnActions(deps: {
         chainState: "submitted",
         cleanupRequired: true,
       });
+      earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
       const result = await smartAccountData.executeEarnCleanup({
         observabilityFlowId: tracker?.flowId,
         preparedCleanup,
@@ -1644,6 +1672,7 @@ export function useEarnActions(deps: {
         persistenceState: "recorded",
       });
       withdrawTrackerRef.current = null;
+      earnToast.success("Policies closed");
       return true;
     } catch (error) {
       const message =
@@ -1651,10 +1680,13 @@ export function useEarnActions(deps: {
       setWithdrawError(message);
       if (isWalletCancellation(error)) {
         tracker?.cancel("cleanup", { errorCode: "wallet_rejected" });
+      } else {
+        earnToast.error("Couldn't close policies");
       }
       return false;
     } finally {
       setIsCleanupPending(false);
+      earnToast.settle();
     }
   }, [
     ensureCanSignAccountAction,
@@ -1757,6 +1789,7 @@ export function useEarnActions(deps: {
         tracker.observe("prepare");
         autodepositFloorInFlightRef.current = true;
         setIsAutodepositPending(true);
+        earnToast.loading("Updating Autodeposit");
         try {
           const result =
             await smartAccountData.executeEarnAutodepositFloorUpdate({
@@ -1773,6 +1806,7 @@ export function useEarnActions(deps: {
             setAutodepositError(
               result.error ?? "Autodeposit wallet balance floor update failed."
             );
+            earnToast.error("Couldn't save Autodeposit");
             return false;
           }
           setAutodepositOverride({
@@ -1788,10 +1822,12 @@ export function useEarnActions(deps: {
             targetId: result.target?.id,
           });
           tracker.complete("ui_commit", { persistenceState: "recorded" });
+          earnToast.success("Autodeposit updated");
           return true;
         } finally {
           autodepositFloorInFlightRef.current = false;
           setIsAutodepositPending(false);
+          earnToast.settle();
         }
       }
 
@@ -1845,12 +1881,14 @@ export function useEarnActions(deps: {
         symbol: "USDC",
         tokenDecimals: source.decimals,
       };
+      earnToast.loading("Waiting for approval");
       const setupApproved = await requestApproval(
         buildEarnAutodepositSetupReviewItem({ draft: setupReviewDraft })
       );
       if (!setupApproved) {
         tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
         autodepositTrackerRef.current = null;
+        earnToast.settle();
         return false;
       }
 
@@ -1875,6 +1913,7 @@ export function useEarnActions(deps: {
             },
       });
       setIsAutodepositPending(true);
+      earnToast.loading("Preparing Autodeposit");
 
       try {
         let preparedSetup = null as Awaited<
@@ -1904,6 +1943,7 @@ export function useEarnActions(deps: {
             chainState: "submitted",
             executionMode: "sequential",
           });
+          earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
           const result = await smartAccountData.executeEarnAutodepositSetup({
             amountRaw,
             observabilityFlowId: tracker.flowId,
@@ -1986,6 +2026,9 @@ export function useEarnActions(deps: {
             chainState: "confirmed",
             persistenceState: "recorded",
           });
+          earnToast.success(
+            previousConfig ? "Autodeposit updated" : "Autodeposit created"
+          );
           return true;
         }
       } catch (error) {
@@ -2001,10 +2044,12 @@ export function useEarnActions(deps: {
           tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
         } else {
           tracker.fail("backend_confirm", { errorCode: "unexpected_error" });
+          earnToast.error("Couldn't save Autodeposit");
         }
         return false;
       } finally {
         setIsAutodepositPending(false);
+        earnToast.settle();
       }
     },
     [
@@ -2090,6 +2135,7 @@ export function useEarnActions(deps: {
     tracker.start("intent");
     tracker.observe("prepare");
 
+    earnToast.loading("Waiting for approval");
     const closeApproved = await requestApproval(
       buildEarnAutodepositCloseReviewItem({
         amountLabel: config.amount,
@@ -2099,12 +2145,14 @@ export function useEarnActions(deps: {
     if (!closeApproved) {
       tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
       autodepositTrackerRef.current = null;
+      earnToast.settle();
       return false;
     }
 
     setAutodepositError(null);
     setAutodepositOverride({ config: { ...config, state: "closing" } });
     setIsAutodepositPending(true);
+    earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
 
     try {
       tracker.observe("wallet_approval", {
@@ -2143,6 +2191,7 @@ export function useEarnActions(deps: {
         chainState: "confirmed",
         persistenceState: "recorded",
       });
+      earnToast.success("Autodeposit deleted");
       return true;
     } catch (error) {
       setAutodepositOverride({ config: previousConfig });
@@ -2155,10 +2204,12 @@ export function useEarnActions(deps: {
         tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
       } else {
         tracker.fail("backend_confirm", { errorCode: "unexpected_error" });
+        earnToast.error("Couldn't delete Autodeposit");
       }
       return false;
     } finally {
       setIsAutodepositPending(false);
+      earnToast.settle();
     }
   }, [
     autodepositConfig,

--- a/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -263,6 +263,15 @@ export function WithdrawPane({
                     className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
                     inputMode="decimal"
                     onChange={(event) => handleAmountChange(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.repeat) {
+                        return;
+                      }
+                      event.preventDefault();
+                      if (canWithdraw && !isSubmitting) {
+                        void handleSubmit();
+                      }
+                    }}
                     placeholder="0"
                     type="text"
                     value={amount}

--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -55,6 +55,7 @@ import type {
   TokenRow,
   TransactionDetail,
 } from "@/components/wallet-sidebar/types";
+import { earnToast } from "@/components/wallet-workspace/facelift/earn-toast";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { captureBrowserError } from "@/features/observability/client";
@@ -2538,6 +2539,9 @@ function createWalletAdapterBridge(
     return null;
   }
 
+  // earnToast.signed() advances a visible "Confirm in wallet" Earn toast to
+  // "Confirming" the moment the user approves in the wallet; it is a no-op
+  // for every other flow that signs through this bridge.
   return {
     publicKey: wallet.publicKey,
     signTransaction: async <T extends Transaction | VersionedTransaction>(
@@ -2547,23 +2551,38 @@ function createWalletAdapterBridge(
         throw new Error("Connected wallet does not support signTransaction.");
       }
 
-      return wallet.signTransaction(transaction);
+      const signed = await wallet.signTransaction(transaction);
+      earnToast.signed();
+      return signed;
     },
     ...(wallet.signAllTransactions
       ? {
-          signAllTransactions: <T extends Transaction | VersionedTransaction>(
+          signAllTransactions: async <
+            T extends Transaction | VersionedTransaction
+          >(
             transactions: T[]
-          ): Promise<T[]> => wallet.signAllTransactions!(transactions),
+          ): Promise<T[]> => {
+            const signed = await wallet.signAllTransactions!(transactions);
+            earnToast.signed();
+            return signed;
+          },
         }
       : {}),
     ...(!shouldSignThenSendRaw
       ? {
-          sendTransaction: (
+          sendTransaction: async (
             transaction: Transaction | VersionedTransaction,
             nextConnection: ReturnType<typeof useConnection>["connection"],
             sendOptions?: SendOptions
-          ) =>
-            wallet.sendTransaction!(transaction, nextConnection, sendOptions),
+          ) => {
+            const signature = await wallet.sendTransaction!(
+              transaction,
+              nextConnection,
+              sendOptions
+            );
+            earnToast.signed();
+            return signature;
+          },
         }
       : {}),
   };


### PR DESCRIPTION
Adds a transitions.dev toast (top-center, icon morphs yellow spinner → green check / red cross, text-swap messages) narrating each Earn action stage — prepare, approval, wallet sign, confirming — driven from use-earn-actions and advanced to "Confirming" the moment the wallet signature resolves via the wallet adapter bridge. Also lets Enter in the deposit/withdraw/autodeposit amount fields trigger the primary action under the same gates as the buttons.