### PR TITLE
fix(observability): drop Cap captcha widget internal errors from reporting

### DIFF
--- a/frontend/src/app/api/observability/errors/route.ts
+++ b/frontend/src/app/api/observability/errors/route.ts
@@ -1,5 +1,6 @@
 import {
   InvalidObservabilityEnvelopeError,
+  isCapWidgetInternalError,
   isThirdPartyExtensionError,
   MAX_OBSERVABILITY_REQUEST_BYTES,
   parseBrowserErrorEnvelope,
@@ -86,9 +87,13 @@ export async function POST(request: Request): Promise<Response> {
     const envelope = parseBrowserErrorEnvelope(await readJsonBody(request), {
       expectedChunkOrigin: new URL(request.url).origin,
     });
-    // Browsers running a cached bundle still post extension noise; drop it here
-    // too, and acknowledge so the client never treats telemetry as a failure.
-    if (isThirdPartyExtensionError(envelope.operation, envelope.stack)) {
+    // Browsers running a cached bundle still post third-party noise; drop it
+    // here too, and acknowledge so the client never treats telemetry as a
+    // failure.
+    if (
+      isThirdPartyExtensionError(envelope.operation, envelope.stack) ||
+      isCapWidgetInternalError(envelope.operation, envelope.message)
+    ) {
       return jsonResponse({ accepted: true }, 202);
     }
     await reportBrowserErrorEnvelope(envelope);

--- a/frontend/src/features/observability/client.ts
+++ b/frontend/src/features/observability/client.ts
@@ -12,6 +12,7 @@ import {
   createBrowserErrorEnvelope,
   createErrorDeduplicator,
   type ErrorDeduplicator,
+  isCapWidgetInternalError,
   isThirdPartyExtensionError,
   OBSERVABILITY_ERROR_ENDPOINT,
 } from "./error-contract";
@@ -144,7 +145,10 @@ export function createBrowserErrorProcessor(
         const captured = createBrowserErrorEnvelope(error, operation, {
           ...(chunkFailure?.telemetry ?? {}),
         });
-        if (isThirdPartyExtensionError(captured.operation, captured.stack)) {
+        if (
+          isThirdPartyExtensionError(captured.operation, captured.stack) ||
+          isCapWidgetInternalError(captured.operation, captured.message)
+        ) {
           return;
         }
         if (deduplicator.isDuplicate(captured)) {

--- a/frontend/src/features/observability/error-contract.ts
+++ b/frontend/src/features/observability/error-contract.ts
@@ -271,6 +271,23 @@ export function isThirdPartyExtensionError(
   );
 }
 
+// The Cap captcha widget (@cap.js/widget) rejects with this internal error
+// when it is torn down mid-solve: its worker pool is nulled while a solve
+// promise is still in flight. Not a Loyal failure. `_ensureSize` is a Cap
+// worker-pool method distinctive enough to match on message alone — the stack
+// only shows a hash-named first-party chunk, so it cannot anchor the match.
+const CAP_WIDGET_ERROR_PATTERN = /\b_ensureSize\b/;
+
+export function isCapWidgetInternalError(
+  operation: BrowserErrorOperation,
+  message: string
+): boolean {
+  return (
+    AMBIENT_BROWSER_ERROR_OPERATIONS.includes(operation) &&
+    CAP_WIDGET_ERROR_PATTERN.test(message)
+  );
+}
+
 function isAllowedBrowserOperation(
   value: unknown
 ): value is BrowserErrorOperation {


### PR DESCRIPTION
Silences the Cap captcha widget's `_ensureSize` TypeError (third-party teardown noise firing the loyal-frontend Errors alert) by filtering it in the browser error processor and the API route backstop, following the ASK-1860 extension-noise pattern. ASK-1948.