### PR TITLE
feat(frontend): add handwritten Milo hover easter egg to the earn dog

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3145,3 +3145,74 @@ cap-widget {
     transition: none !important;
   }
 }
+
+/* Milo — hovering the empty-Earn dog signs his handwritten name and an arrow
+   pointing at him (earn-empty-pane.tsx). Each stroke is a pathLength=1 path,
+   so dasharray 1 covers it and dashoffset 1→0 draws it on. Hover staggers
+   the strokes in pen order — M, i, l, o, then the i's dot, then the arrow —
+   on an easeInOutSine pen pull; unhover retracts every stroke together on
+   the quick base transition (no delays), like the pen lifting away. */
+.milo-hitbox {
+  pointer-events: auto;
+}
+/* Short viewports pull the dog up under the headline/CTA — no room for the
+   name there, so the easter egg only exists at 800px+ of height. */
+@media (height < 800px) {
+  .milo-hitbox {
+    display: none;
+  }
+}
+.milo-tag path {
+  fill: none;
+  stroke: #f9363c;
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  /* Round caps paint a dot at each path start even at full dashoffset, so
+     the strokes stay opacity-hidden at rest; the hide waits out the 240ms
+     retract so unhover still shows the ink rewinding. */
+  opacity: 0;
+  transition: stroke-dashoffset 240ms ease-in, opacity 0ms linear 240ms;
+}
+.milo-hitbox:hover + .milo-tag path {
+  stroke-dashoffset: 0;
+  opacity: 1;
+  transition-timing-function: cubic-bezier(0.45, 0.05, 0.55, 0.95);
+}
+/* Durations pair [stroke-dashoffset, opacity]: the draw animates, the
+   opacity un-hide snaps at the same stroke's delay so ink only ever exists
+   where the pen has been. */
+.milo-hitbox:hover + .milo-tag path:nth-child(1) {
+  transition-duration: 340ms, 0ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(2) {
+  transition-duration: 130ms, 0ms;
+  transition-delay: 320ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(3) {
+  transition-duration: 170ms, 0ms;
+  transition-delay: 430ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(4) {
+  transition-duration: 220ms, 0ms;
+  transition-delay: 580ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(5) {
+  transition-duration: 60ms, 0ms;
+  transition-delay: 860ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(6) {
+  transition-duration: 240ms, 0ms;
+  transition-delay: 980ms;
+}
+.milo-hitbox:hover + .milo-tag path:nth-child(7) {
+  transition-duration: 140ms, 0ms;
+  transition-delay: 1200ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  .milo-tag path {
+    transition: none !important;
+  }
+}

--- a/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
@@ -162,10 +162,49 @@ export function EarnEmptyPane({
           On desktop it ignores the pane instead: unclipped and dropped by the
           shell's 8px gap (p-2) so it sits flush with the viewport bottom. */}
       <div className="-bottom-2 pointer-events-none absolute inset-x-0 flex justify-center max-[795px]:bottom-0 max-[795px]:overflow-clip max-[795px]:rounded-b-3xl">
-        <DogLottie
-          className="aspect-square w-full max-h-[420px] max-w-[420px]"
-          variant="playful"
-        />
+        <div className="relative w-full max-w-[420px]">
+          <DogLottie
+            className="aspect-square max-h-[420px] w-full"
+            variant="playful"
+          />
+          {/* Hover hitbox over the dog's head — top quarter left out so the
+              pointer-events-none wrapper keeps the CTA clickable, and
+              globals.css hides it entirely under 800px viewport height
+              (where the dog rides up into the content). */}
+          <div
+            aria-hidden="true"
+            className="milo-hitbox absolute inset-x-[6%] top-1/4 bottom-0"
+          />
+          {/* Milo — hovering the dog signs his handwritten name + an arrow
+              pointing at him (stroke draw-on, globals.css .milo-tag). Must
+              stay the hitbox's next sibling; paths are in pen order (the i
+              is dotted last), each pathLength-normalized for the dash trick. */}
+          <svg
+            aria-hidden="true"
+            className="milo-tag -rotate-[20deg] pointer-events-none absolute top-[4%] left-[33%] w-[33%]"
+            fill="none"
+            viewBox="0 0 240 160"
+          >
+            <path
+              d="M14,97 C16,76 21,50 27,27 C33,48 38,64 44,79 C50,62 55,45 61,28 C65,51 68,74 70,96"
+              pathLength={1}
+            />
+            <path d="M85,58 C84,71 83,84 84,96" pathLength={1} />
+            <path d="M104,24 C101,48 100,72 103,96" pathLength={1} />
+            <path
+              d="M139,64 C134,56 124,57 119,66 C114,76 117,90 127,93 C136,95 142,87 141,76 C140,70 139,67 136,65"
+              pathLength={1}
+            />
+            <path d="M85,44 C86,43.5 87,44.5 86,45.5" pathLength={1} />
+            {/* Arrow hooks down-right: the face is below the name, and the
+                -20° tilt swings "down" in path space toward the dog's eyes. */}
+            <path d="M154,86 C172,92 184,108 190,130" pathLength={1} />
+            <path
+              d="M178,118 C182,122 186,126 190,130 C193,125 196,120 198,116"
+              pathLength={1}
+            />
+          </svg>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
Hovering the empty-Earn dog (800px+ viewports) draws his handwritten name and an arrow pointing at him, stroke by stroke in pen order; unhovering rewinds the ink.