### PR TITLE
feat(frontend): swap disconnect icon and hide mobile settings gear

### DIFF
--- a/frontend/public/wallet-workspace/facelift/icon-logout.svg
+++ b/frontend/public/wallet-workspace/facelift/icon-logout.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.25 20H7C5.34315 20 4 18.6569 4 17L4 7C4 5.34315 5.34315 4 7 4L11.25 4" stroke="#B1B1B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.5 16.5L20 12C18.2426 10.2426 17.2574 9.25735 15.5 7.5" stroke="#B1B1B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.5 12L9 12" stroke="#B1B1B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/wallet-workspace/facelift/sidebar.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useWallet } from "@solana/wallet-adapter-react";
-import { LogOut } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -664,7 +663,13 @@ export function FaceliftSidebar({
               }}
               type="button"
             >
-              <LogOut size={20} strokeWidth={1.8} />
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt=""
+                aria-hidden="true"
+                className="size-5"
+                src={`${ASSET_BASE}/icon-logout.svg`}
+              />
               Disconnect
             </button>
           </DropdownReveal>

--- a/frontend/src/components/wallet-workspace/facelift/wallet-home-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/wallet-home-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useWallet } from "@solana/wallet-adapter-react";
-import { LogOut } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -201,10 +200,12 @@ export function WalletHomePage({
                 </div>
               )}
               <div className="flex min-w-0 flex-1 items-center justify-end pl-3">
-                {/* ponytail: settings destination ships with a later screen */}
+                {/* ponytail: settings icon returns when its screen ships */}
                 <button
-                  aria-label="Settings"
-                  className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                  aria-label="Disconnect wallet"
+                  className="t-hover flex size-11 items-center justify-center rounded-3xl enabled:hover:bg-black/[0.04] disabled:opacity-40"
+                  disabled={!canDisconnect}
+                  onClick={handleDisconnect}
                   type="button"
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -212,17 +213,8 @@ export function WalletHomePage({
                     alt=""
                     aria-hidden="true"
                     className="size-6"
-                    src={`${ASSET_BASE}/icon-gear.svg`}
+                    src={`${ASSET_BASE}/icon-logout.svg`}
                   />
-                </button>
-                <button
-                  aria-label="Disconnect wallet"
-                  className="t-hover flex size-11 items-center justify-center rounded-3xl text-black enabled:hover:bg-black/[0.04] disabled:text-[#d8d8d9]"
-                  disabled={!canDisconnect}
-                  onClick={handleDisconnect}
-                  type="button"
-                >
-                  <LogOut size={24} strokeWidth={1.8} />
                 </button>
               </div>
             </div>


### PR DESCRIPTION
Replaces the lucide LogOut icon with the design's arrow-box logout SVG in both the mobile wallet home header and the desktop sidebar disconnect dropdown. Also hides the mobile settings gear until its screen ships.