### PR TITLE
feat(frontend): link trust page from footer

### DIFF
--- a/frontend/src/components/landing-footer.tsx
+++ b/frontend/src/components/landing-footer.tsx
@@ -30,6 +30,7 @@ const footerColumns = [
   {
     links: [
       { href: "/privacy-policy", label: "Privacy Policy" },
+      { href: "/trust", label: "Trust & Security" },
       {
         href: "https://docs.askloyal.com/transparency/q1-2026",
         label: "Transparency",


### PR DESCRIPTION
Adds a "Trust & Security" entry to the footer Legal column so /trust is reachable from the site. The page currently has no inbound links.