### PR TITLE
fix(admin): show last 30 days of rebalance outcomes

### DIFF
--- a/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
+++ b/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
@@ -16,7 +16,7 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart";
 
-import type { PreviousMonthRebalancePoint } from "./rebalance-data";
+import type { Last30DaysRebalancePoint } from "./rebalance-data";
 
 const chartConfig = {
   confirmed: {
@@ -65,23 +65,10 @@ function formatTooltipDate(value: unknown) {
   }).format(date);
 }
 
-function formatMonth(value: string | undefined) {
-  const date = parseDate(value);
-  if (!date) {
-    return "previous calendar month";
-  }
-
-  return new Intl.DateTimeFormat("en-US", {
-    month: "long",
-    timeZone: "UTC",
-    year: "numeric",
-  }).format(date);
-}
-
-export function PreviousMonthRebalanceChart({
+export function Last30DaysRebalanceChart({
   data,
 }: {
-  data: PreviousMonthRebalancePoint[];
+  data: Last30DaysRebalancePoint[];
 }) {
   const totals = data.reduce(
     (result, point) => ({
@@ -90,18 +77,17 @@ export function PreviousMonthRebalanceChart({
     }),
     { confirmed: 0, failed: 0 }
   );
-  const monthLabel = formatMonth(data[0]?.date);
-
   return (
     <Card className="w-full py-4 sm:py-0">
       <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">
-            Previous-month rebalance outcomes
+            Last 30 days of rebalance outcomes
           </CardTitle>
           <CardDescription>
-            Daily terminal same-mint decisions for {monthLabel}, using UTC
-            calendar boundaries. Render-only errors are not included.
+            Daily terminal same-mint decisions for the current UTC day and the
+            preceding 29 calendar days. Today is partial. Render-only errors are
+            not included.
           </CardDescription>
         </div>
         <div className="flex">

--- a/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -91,7 +91,7 @@ export type OptimizationVolumePoint = {
   date: string;
 };
 
-export type PreviousMonthRebalancePoint = {
+export type Last30DaysRebalancePoint = {
   confirmed: number;
   date: string;
   failed: number;
@@ -210,7 +210,7 @@ type OptimizationVolumeSqlRow = {
   date: string;
 };
 
-type PreviousMonthRebalanceSqlRow = {
+type Last30DaysRebalanceSqlRow = {
   confirmed: SqlScalar;
   date: string;
   failed: SqlScalar;
@@ -1238,22 +1238,21 @@ export async function getOptimizationVolumeSeries(): Promise<
   }));
 }
 
-export async function getPreviousMonthRebalanceSeries(): Promise<
-  PreviousMonthRebalancePoint[]
+export async function getLast30DaysRebalanceSeries(): Promise<
+  Last30DaysRebalancePoint[]
 > {
-  const rows = await queryRows<PreviousMonthRebalanceSqlRow>(
+  const rows = await queryRows<Last30DaysRebalanceSqlRow>(
     `
       WITH bounds AS (
         SELECT
-          (
-            date_trunc('month', now() AT TIME ZONE 'UTC') - interval '1 month'
-          ) AS started_at,
-          date_trunc('month', now() AT TIME ZONE 'UTC') AS ended_at
+          date_trunc('day', now() AT TIME ZONE 'UTC') - interval '29 days'
+            AS started_at,
+          now() AT TIME ZONE 'UTC' AS ended_at
       ),
       days AS (
         SELECT generate_series(
           (SELECT started_at::date FROM bounds),
-          (SELECT (ended_at - interval '1 day')::date FROM bounds),
+          (SELECT ended_at::date FROM bounds),
           interval '1 day'
         )::date AS date
       ),

--- a/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -45,12 +45,12 @@ import {
   AutodepositFailuresChart,
   type SerializedAutodepositFailureRange,
 } from "./autodeposit-failures-chart";
-import { PreviousMonthRebalanceChart } from "./previous-month-rebalance-chart";
+import { Last30DaysRebalanceChart } from "./last-30-days-rebalance-chart";
 import { RebalanceActivityChart } from "./rebalance-activity-chart";
 import type {
   EarnActiveReserveRouteRow,
   EarnRebalanceDecisionRow,
-  PreviousMonthRebalancePoint,
+  Last30DaysRebalancePoint,
   RebalanceActivityPoint,
   RebalanceAuditErrorFilter,
   RebalanceAuditLane,
@@ -93,7 +93,7 @@ type RebalanceApiData = {
   apyData: SafeReserveApyMonitorData;
   autodeposit: SerializedAutodepositFailureRange[];
   decisions: SerializedRebalanceDecisionRow[];
-  previousMonthRebalances: PreviousMonthRebalancePoint[];
+  last30DaysRebalances: Last30DaysRebalancePoint[];
   routes: SerializedActiveReserveRouteRow[];
 };
 
@@ -1354,7 +1354,7 @@ export function RebalanceMonitorClient() {
         decisionMarkers={toDecisionMarkers(state.data.decisions)}
       />
       <RebalanceActivityChart data={state.data.activity} />
-      <PreviousMonthRebalanceChart data={state.data.previousMonthRebalances} />
+      <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />
       <AutodepositFailuresChart data={state.data.autodeposit} />
       <RebalanceAuditCard reserveLabels={reserveLabels} />
     </div>

--- a/admin/src/app/api/earn/rebalance/route.ts
+++ b/admin/src/app/api/earn/rebalance/route.ts
@@ -7,7 +7,7 @@ import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
 import {
   getActiveReserveRoutes,
   getAutodepositTimeSeries,
-  getPreviousMonthRebalanceSeries,
+  getLast30DaysRebalanceSeries,
   getRebalanceActivity,
   getRecentRebalanceDecisions,
 } from "../../../(admin)/earn/rebalance/rebalance-data";
@@ -21,14 +21,14 @@ async function loadRebalanceMonitorData() {
     routes,
     decisions,
     activity,
-    previousMonthRebalances,
+    last30DaysRebalances,
     autodeposit,
   ] = await Promise.all([
     getSafeReserveApyMonitorData(),
     getActiveReserveRoutes(),
     getRecentRebalanceDecisions(),
     getRebalanceActivity(),
-    getPreviousMonthRebalanceSeries(),
+    getLast30DaysRebalanceSeries(),
     getAutodepositTimeSeries(),
   ]);
 
@@ -54,7 +54,7 @@ async function loadRebalanceMonitorData() {
       amountRaw: decision.amountRaw?.toString() ?? null,
       confirmedSlot: decision.confirmedSlot?.toString() ?? null,
     })),
-    previousMonthRebalances,
+    last30DaysRebalances,
     routes: routes.map((route) => ({
       ...route,
       activeAumRaw: route.activeAumRaw.toString(),


### PR DESCRIPTION
Updates the rebalance outcomes chart from the previous calendar month to the current UTC day plus the preceding 29 calendar days. Renames the chart, API payload, and data helpers so the displayed 30-day window is explicit throughout the admin slice.