### PR TITLE
feat(frontend): add trust section to landing page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,6 +12,7 @@ import { LandingPhoneLottie } from "@/components/landing-phone-lottie";
 // Roadmap temporarily hidden — restore by uncommenting
 // import { LandingRoadmap } from "@/components/landing-roadmap";
 import { LandingScrollAnimations } from "@/components/landing-scroll-animations";
+import { LandingTrust } from "@/components/landing-trust";
 
 const featureCards: {
   image: { src: string; alt: string };
@@ -178,6 +179,8 @@ export default function LandingPage() {
 
       {/* Roadmap temporarily hidden — restore by uncommenting */}
       {/* <LandingRoadmap /> */}
+
+      <LandingTrust />
 
       <LandingFaq />
 

--- a/frontend/src/components/landing-trust.tsx
+++ b/frontend/src/components/landing-trust.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export function LandingTrust() {
+  return (
+    <section
+      className="flex w-full justify-center bg-white px-4 py-12 lg:px-6 lg:py-24"
+      id="trust"
+    >
+      <div className="w-full max-w-[528px] lg:max-w-[1560px]">
+        <article
+          className="relative flex min-w-0 flex-col overflow-hidden rounded-[24px] bg-[#f5f5f5]"
+          data-reveal="scale"
+        >
+          <div className="flex w-full flex-col items-start gap-6 px-6 pb-8 pt-10 lg:gap-8 lg:px-16 lg:py-20 lg:pr-[420px]">
+            <h2 className="max-w-[820px] text-[36px] font-semibold leading-none tracking-[-0.02em] text-black lg:text-[56px] lg:tracking-[-1.12px]">
+              Your funds are secured by Squads
+            </h2>
+
+            <p className="max-w-[620px] text-[18px] leading-[1.2] tracking-[-0.02em] text-black/60 lg:text-[24px] lg:tracking-[-0.48px]">
+              The smart account standard on Solana, trusted by 450+ teams to
+              secure over $15 billion. Loyal never holds your keys.
+            </p>
+
+            <Link
+              className="inline-flex h-[52px] items-center justify-center rounded-full bg-black px-5 text-center text-[20px] font-medium leading-6 text-white transition duration-150 ease-out hover:-translate-y-0.5 hover:bg-[#171717] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black active:translate-y-0"
+              href="/trust"
+            >
+              How your funds are secured
+            </Link>
+          </div>
+
+          <div
+            aria-hidden="true"
+            className="pointer-events-none flex justify-end overflow-hidden lg:absolute lg:bottom-0 lg:right-0 lg:translate-y-[14%]"
+          >
+            <Image
+              alt=""
+              className="h-[160px] w-[160px] translate-x-4 translate-y-4 lg:h-[300px] lg:w-[300px] lg:translate-x-0 lg:translate-y-0"
+              height={288}
+              src="/landing/figma/workflows-mascot.svg"
+              width={288}
+            />
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing-trust.tsx
+++ b/frontend/src/components/landing-trust.tsx
@@ -32,13 +32,13 @@ export function LandingTrust() {
 
           <div
             aria-hidden="true"
-            className="pointer-events-none flex justify-end overflow-hidden lg:absolute lg:bottom-0 lg:right-0 lg:translate-y-[14%]"
+            className="pointer-events-none flex justify-end overflow-hidden lg:absolute lg:bottom-0 lg:right-0 lg:translate-x-[8%] lg:translate-y-[16%]"
           >
             <Image
               alt=""
-              className="h-[160px] w-[160px] translate-x-4 translate-y-4 lg:h-[300px] lg:w-[300px] lg:translate-x-0 lg:translate-y-0"
+              className="h-[160px] w-[160px] translate-x-4 translate-y-4 lg:h-[280px] lg:w-[280px] lg:translate-x-0 lg:translate-y-0"
               height={288}
-              src="/landing/figma/workflows-mascot.svg"
+              src="/Shield.svg"
               width={288}
             />
           </div>

--- a/frontend/src/components/landing-trust.tsx
+++ b/frontend/src/components/landing-trust.tsx
@@ -32,11 +32,11 @@ export function LandingTrust() {
 
           <div
             aria-hidden="true"
-            className="pointer-events-none flex justify-end overflow-hidden lg:absolute lg:bottom-0 lg:right-0 lg:translate-x-[8%] lg:translate-y-[16%]"
+            className="pointer-events-none flex justify-end pb-6 pr-6 lg:absolute lg:bottom-12 lg:right-16 lg:p-0"
           >
             <Image
               alt=""
-              className="h-[160px] w-[160px] translate-x-4 translate-y-4 lg:h-[280px] lg:w-[280px] lg:translate-x-0 lg:translate-y-0"
+              className="h-[160px] w-[160px] lg:h-[280px] lg:w-[280px]"
               height={288}
               src="/Shield.svg"
               width={288}

--- a/frontend/src/components/landing-trust.tsx
+++ b/frontend/src/components/landing-trust.tsx
@@ -32,11 +32,11 @@ export function LandingTrust() {
 
           <div
             aria-hidden="true"
-            className="pointer-events-none flex justify-end pb-6 pr-6 lg:absolute lg:bottom-12 lg:right-16 lg:p-0"
+            className="pointer-events-none flex justify-center pb-10 lg:absolute lg:bottom-12 lg:right-16 lg:p-0"
           >
             <Image
               alt=""
-              className="h-[160px] w-[160px] lg:h-[280px] lg:w-[280px]"
+              className="h-[140px] w-[140px] lg:h-[280px] lg:w-[280px]"
               height={288}
               src="/Shield.svg"
               width={288}


### PR DESCRIPTION
Adds a trust section to the landing page between the developer cards and the FAQ, linking to /trust.

Full-width rounded card matching the existing developer-card treatment, with the mascot cropped bottom-right. Copy leads with Squads rather than a claim about Loyal, since borrowed credibility lands better than an assertion.