### PR TITLE
fix(auth): surface ledger mode on sign-in errors and classify completion failures

### DIFF
--- a/frontend/src/components/auth/wallet-tab.tsx
+++ b/frontend/src/components/auth/wallet-tab.tsx
@@ -238,6 +238,17 @@ export function WalletTab({
             </div>
           </div>
         </div>
+        {/* Hardware wallets refuse message signing without any prompt, which
+            lands here as an opaque wallet error. Keep the Ledger escape hatch
+            visible so those users can self-serve — but not after a deliberate
+            cancellation, which is not a capability problem. */}
+        {state.status !== "rejected" && (
+          <LedgerModeToggle
+            checked={useLedgerProof}
+            disabled={!isVerified}
+            onChange={setUseLedgerProof}
+          />
+        )}
         <button
           className="h-12 rounded-full bg-neutral-950 px-4 font-medium text-sm text-white transition hover:bg-neutral-800"
           onClick={handleChooseAnotherWallet}

--- a/frontend/src/features/identity/server/wallet-onboarding.ts
+++ b/frontend/src/features/identity/server/wallet-onboarding.ts
@@ -729,7 +729,10 @@ export async function completeWalletOnboarding(
           ? error.code
           : isSmartAccountProvisioningError(error)
           ? error.code
-          : undefined
+          : // The proof already verified; anything raw here is an
+            // infrastructure failure inside provisioning (RPC, DB), not an
+            // unknown condition.
+            "smart_account_provisioning_failed"
       ),
     });
     if (isSmartAccountProvisioningError(error)) {
@@ -780,6 +783,27 @@ export async function completeWalletOnboarding(
       }
     }
 
-    throw error;
+    if (
+      error instanceof WalletAuthError ||
+      isSmartAccountProvisioningError(error)
+    ) {
+      throw error;
+    }
+
+    // A raw error here (RPC outage, DB failure) would bubble out of the route
+    // as a bare 500 with no error envelope, showing the user a generic
+    // failure for a signature that already verified — which reads as a wallet
+    // problem and sends them down the wrong path (ASK-1961).
+    console.error("[wallet-onboarding] wallet onboarding failed unexpectedly", {
+      challengeHash,
+      walletAddress,
+      errorName: error instanceof Error ? error.name : undefined,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      error,
+    });
+    throw new WalletAuthError(
+      "We could not finish setting up your session due to a temporary server issue. Your wallet signature was valid — please try again.",
+      { code: "smart_account_provisioning_failed", status: 503 }
+    );
   }
 }


### PR DESCRIPTION
Renders the Ledger/hardware-wallet toggle in the wallet sign-in error state so users whose wallets silently refuse message signing can self-serve, and wraps unclassified errors after a verified proof in /api/auth/wallet/complete into a retryable 503 (smart_account_provisioning_failed) instead of a bare 500 with unexpected_error telemetry. Closes ASK-1969 (context: ASK-1961 diagnosis).