### PR TITLE
fix(admin): report operational wallet spend and add the settings authority

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -11,6 +11,7 @@ APP_API_BASE_URL=https://solana-telegram-transactions.vercel.app
 # for config-vs-observed checks; private keys must never be placed here.
 DEPLOYMENT_PUBLIC_KEY=
 EARN_POLICY_SIGNER_PUBLIC_KEY=
+EARN_SETTINGS_AUTHORITY_PUBLIC_KEY=
 EARN_YIELD_ROUTER_PUBLIC_KEY=
 SMART_ACCOUNT_SPONSOR_PUBLIC_KEY=
 SOLANA_MAINNET_RPC_URL=

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -28,7 +28,22 @@ const MAINNET_YIELD_CLUSTER = "mainnet-beta";
 const DEFAULT_MAINNET_RPC_URL =
   "https://fredra-z7l52f-fast-mainnet.helius-rpc.com";
 
-type FundingRole = "sponsorship" | "policy" | "deployment" | "route_fee_payer";
+type FundingRole =
+  | "sponsorship"
+  | "policy"
+  | "deployment"
+  | "route_fee_payer"
+  | "settings_authority";
+
+// Roles whose outflow lands in a table this page reads. A wallet with no such
+// role has no spend history to consult, which is different from having one that
+// came back empty — see loadWalletSpend and calculateStatus.
+const SPEND_TRACKED_ROLES = new Set<FundingRole>([
+  "sponsorship",
+  "policy",
+  "deployment",
+  "route_fee_payer",
+]);
 
 export type FundingStatus = "healthy" | "low" | "critical" | "unknown";
 
@@ -247,15 +262,46 @@ async function loadAppIdentityObservations(): Promise<{
   }
 }
 
-async function loadYieldIdentityObservations(): Promise<{
+// Settings authorities are per smart account, so there are thousands of them.
+// Only the configured operational authority is looked up; enumerating the
+// column would turn every user's account into a funding wallet card.
+async function loadSettingsAuthorityObservations(
+  sql: ReturnType<typeof getYieldNeonSql>,
+  configuredAddresses: string[]
+): Promise<PolicyObservationRow[]> {
+  if (configuredAddresses.length === 0) {
+    return [];
+  }
+
+  return sql.query(
+    `
+    SELECT
+      authority AS address,
+      COUNT(*)::text AS active_policy_count,
+      MAX(last_seen_at) AS latest_seen_at
+    FROM loyal_yield.route_policies
+    WHERE active = true
+      AND authority = ANY($1::text[])
+    GROUP BY authority
+    ORDER BY COUNT(*) DESC, MAX(last_seen_at) DESC
+  `,
+    [configuredAddresses]
+  ) as unknown as Promise<PolicyObservationRow[]>;
+}
+
+async function loadYieldIdentityObservations(
+  configuredSettingsAuthorities: string[]
+): Promise<{
   policy: IdentityObservation[];
   routeFeePayer: IdentityObservation[];
+  settingsAuthority: IdentityObservation[];
   sourceError: string | null;
 }> {
   try {
     const sql = getYieldNeonSql();
-    const [policyRows, feePayerRows] = await Promise.all([
-      sql.query(`
+    const [policyRows, feePayerRows, settingsAuthorityRows] = await Promise.all(
+      [
+        sql.query(`
         SELECT
           signer.address AS address,
           COUNT(*)::text AS active_policy_count,
@@ -266,7 +312,7 @@ async function loadYieldIdentityObservations(): Promise<{
         GROUP BY signer.address
         ORDER BY COUNT(*) DESC, MAX(last_seen_at) DESC
       `) as unknown as Promise<PolicyObservationRow[]>,
-      sql.query(`
+        sql.query(`
         SELECT
           fee_payer AS address,
           COUNT(*)::text AS active_shard_count,
@@ -277,7 +323,9 @@ async function loadYieldIdentityObservations(): Promise<{
         GROUP BY fee_payer
         ORDER BY COUNT(*) DESC, MAX(updated_at) DESC
       `) as unknown as Promise<FeePayerObservationRow[]>,
-    ]);
+        loadSettingsAuthorityObservations(sql, configuredSettingsAuthorities),
+      ]
+    );
 
     return {
       policy: policyRows
@@ -298,12 +346,22 @@ async function loadYieldIdentityObservations(): Promise<{
           )
         )
         .filter((row): row is IdentityObservation => Boolean(row)),
+      settingsAuthority: settingsAuthorityRows
+        .map((row) =>
+          toObservedAddress(
+            row.address,
+            row.active_policy_count,
+            row.latest_seen_at
+          )
+        )
+        .filter((row): row is IdentityObservation => Boolean(row)),
       sourceError: null,
     };
   } catch {
     return {
       policy: [],
       routeFeePayer: [],
+      settingsAuthority: [],
       sourceError: "Yield database identity observations unavailable",
     };
   }
@@ -661,6 +719,7 @@ function calculateStatus(args: {
   roleKeys: FundingRole[];
   runwayHours: number | null;
   spendAvailable: boolean;
+  spendTracked: boolean;
 }): { status: FundingStatus; detail: string } {
   if (args.balanceLamports === null) {
     return {
@@ -708,6 +767,16 @@ function calculateStatus(args: {
     };
   }
 
+  // No source records this wallet's outflow, so there is no runway to report
+  // and nothing to warn about. Say so rather than implying a reading of zero.
+  if (!args.spendTracked) {
+    return {
+      detail:
+        "Balance is above the configured operating thresholds; spend is not tracked for this wallet",
+      status: "healthy",
+    };
+  }
+
   // A wallet whose spend history could not be read has no runway to stand on,
   // so it must not claim to clear the operating thresholds. Spend that is
   // present but zero is a real observation and stays healthy.
@@ -728,6 +797,7 @@ function createRoleDefinitions(args: {
   app: Awaited<ReturnType<typeof loadAppIdentityObservations>>;
   configuredDeployment: string | undefined;
   configuredPolicy: string | undefined;
+  configuredSettingsAuthority: string | undefined;
   configuredSponsor: string | undefined;
   yield: Awaited<ReturnType<typeof loadYieldIdentityObservations>>;
 }): RoleDefinition[] {
@@ -754,6 +824,16 @@ function createRoleDefinitions(args: {
       observation: {
         configuredAddresses: uniqueAddresses([args.configuredDeployment]),
         observedAddresses: args.app.deployment,
+      },
+    },
+    {
+      key: "settings_authority",
+      label: "Earn settings authority",
+      observation: {
+        configuredAddresses: uniqueAddresses([
+          args.configuredSettingsAuthority,
+        ]),
+        observedAddresses: args.yield.settingsAuthority,
       },
     },
     ...args.yield.routeFeePayer.map((observation) => ({
@@ -854,7 +934,10 @@ function createWallets(args: {
       );
       const minimumLamports = roleKeys.some(
         (key) =>
-          key === "policy" || key === "deployment" || key === "route_fee_payer"
+          key === "policy" ||
+          key === "deployment" ||
+          key === "route_fee_payer" ||
+          key === "settings_authority"
       )
         ? POLICY_MINIMUM_LAMPORTS
         : null;
@@ -864,6 +947,7 @@ function createWallets(args: {
         roleKeys,
         runwayHours,
         spendAvailable: spend.spend7dLamports !== null,
+        spendTracked: roleKeys.some((key) => SPEND_TRACKED_ROLES.has(key)),
       });
       const mismatch = wallet.roles.some((role) => {
         const definition = args.definitions.find(
@@ -913,9 +997,12 @@ function createWallets(args: {
 }
 
 async function loadFundingData(): Promise<EarnFundingData> {
+  const configuredSettingsAuthority = serverEnv.earnSettingsAuthorityPublicKey;
   const [appObservations, yieldObservations] = await Promise.all([
     loadAppIdentityObservations(),
-    loadYieldIdentityObservations(),
+    loadYieldIdentityObservations(
+      uniqueAddresses([configuredSettingsAuthority])
+    ),
   ]);
   const sourceErrors = [
     appObservations.sourceError,
@@ -925,6 +1012,7 @@ async function loadFundingData(): Promise<EarnFundingData> {
     app: appObservations,
     configuredDeployment: serverEnv.deploymentPublicKey,
     configuredPolicy: serverEnv.earnPolicySignerPublicKey,
+    configuredSettingsAuthority,
     configuredSponsor: serverEnv.smartAccountSponsorPublicKey,
     yield: yieldObservations,
   });
@@ -939,7 +1027,18 @@ async function loadFundingData(): Promise<EarnFundingData> {
     sourceErrors.push(balanceResult.error);
   }
 
-  const spendResult = await loadWalletSpend(addresses);
+  // Only addresses with a spend-tracked role are queried. Seeding a zero for a
+  // wallet no source covers would report "spent nothing" for outflow that is
+  // simply never recorded.
+  const spendTrackedAddresses = uniqueAddresses(
+    definitions
+      .filter((definition) => SPEND_TRACKED_ROLES.has(definition.key))
+      .flatMap((definition) => [
+        ...definition.observation.configuredAddresses,
+        ...definition.observation.observedAddresses.map((row) => row.address),
+      ])
+  );
+  const spendResult = await loadWalletSpend(spendTrackedAddresses);
   sourceErrors.push(...spendResult.sourceErrors);
 
   const walletResult = createWallets({

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -92,6 +92,11 @@ type SpendRow = {
   lamports7d: bigint;
 };
 
+type SpendSourceResult = {
+  rows: SpendRow[];
+  failed: boolean;
+};
+
 type WalletSpend = {
   spend24hLamports: string | null;
   spend7dLamports: string | null;
@@ -339,7 +344,7 @@ function toSpendRow(
 // sponsored transaction finalizes.
 async function loadSponsorshipSpendRows(
   addresses: string[]
-): Promise<SpendRow[]> {
+): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
     const rows = await db
@@ -364,11 +369,14 @@ async function loadSponsorshipSpendRows(
       )
       .groupBy(appSmartAccountSponsorshipTransactions.payerAddress);
 
-    return rows
-      .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
-      .filter((row): row is SpendRow => Boolean(row));
+    return {
+      failed: false,
+      rows: rows
+        .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
+        .filter((row): row is SpendRow => Boolean(row)),
+    };
   } catch {
-    return [];
+    return { failed: true, rows: [] };
   }
 }
 
@@ -376,7 +384,7 @@ async function loadSponsorshipSpendRows(
 // private-transfer-analytics cron.
 async function loadGaslessClaimSpendRows(
   addresses: string[]
-): Promise<SpendRow[]> {
+): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
     const rows = await db
@@ -398,17 +406,22 @@ async function loadGaslessClaimSpendRows(
       )
       .groupBy(gaslessClaimTransactions.payerAddress);
 
-    return rows
-      .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
-      .filter((row): row is SpendRow => Boolean(row));
+    return {
+      failed: false,
+      rows: rows
+        .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
+        .filter((row): row is SpendRow => Boolean(row)),
+    };
   } catch {
-    return [];
+    return { failed: true, rows: [] };
   }
 }
 
 // Route execution fees plus lookup-table provisioning fees and unreclaimed
 // rent, both paid by the Earn policy wallet.
-async function loadYieldSpendRows(addresses: string[]): Promise<SpendRow[]> {
+async function loadYieldSpendRows(
+  addresses: string[]
+): Promise<SpendSourceResult> {
   try {
     const sql = getYieldNeonSql();
     const [routeRows, lookupTableRows] = await Promise.all([
@@ -444,29 +457,71 @@ async function loadYieldSpendRows(addresses: string[]): Promise<SpendRow[]> {
       ) as unknown as Promise<SpendObservationRow[]>,
     ]);
 
-    return [...routeRows, ...lookupTableRows]
-      .map((row) => toSpendRow(row.address, row.lamports_24h, row.lamports_7d))
-      .filter((row): row is SpendRow => Boolean(row));
+    return {
+      failed: false,
+      rows: [...routeRows, ...lookupTableRows]
+        .map((row) =>
+          toSpendRow(row.address, row.lamports_24h, row.lamports_7d)
+        )
+        .filter((row): row is SpendRow => Boolean(row)),
+    };
   } catch {
-    return [];
+    return { failed: true, rows: [] };
   }
 }
 
-async function loadWalletSpend(
-  addresses: string[]
-): Promise<Map<string, WalletSpend>> {
+// A wallet's spend is only meaningful once every source covering its roles has
+// answered. Summing what is left after a source fails would understate spend
+// and inflate the runway without any visible sign, so the affected wallets fall
+// back to "unknown" and the failure is surfaced as a source error instead.
+async function loadWalletSpend(addresses: string[]): Promise<{
+  spend: Map<string, WalletSpend>;
+  unavailableRoles: Set<FundingRole>;
+  sourceErrors: string[];
+}> {
+  const unavailableRoles = new Set<FundingRole>();
+  const sourceErrors: string[] = [];
   if (addresses.length === 0) {
-    return new Map();
+    return { sourceErrors, spend: new Map(), unavailableRoles };
   }
 
-  const rowGroups = await Promise.all([
+  const [sponsorship, gasless, yieldSpend] = await Promise.all([
     loadSponsorshipSpendRows(addresses),
     loadGaslessClaimSpendRows(addresses),
     loadYieldSpendRows(addresses),
   ]);
 
+  const sources: Array<{
+    error: string;
+    result: SpendSourceResult;
+    roles: FundingRole[];
+  }> = [
+    {
+      error: "Smart-account sponsorship spend history unavailable",
+      result: sponsorship,
+      roles: ["sponsorship"],
+    },
+    {
+      error: "Gasless deployment spend history unavailable",
+      result: gasless,
+      roles: ["deployment"],
+    },
+    {
+      error: "Yield execution spend history unavailable",
+      result: yieldSpend,
+      roles: ["policy", "route_fee_payer"],
+    },
+  ];
+
+  for (const source of sources) {
+    if (source.result.failed) {
+      sourceErrors.push(source.error);
+      source.roles.forEach((role) => unavailableRoles.add(role));
+    }
+  }
+
   const totals = new Map<string, { lamports24h: bigint; lamports7d: bigint }>();
-  for (const row of rowGroups.flat()) {
+  for (const row of sources.flatMap((source) => source.result.rows)) {
     const existing = totals.get(row.address) ?? {
       lamports24h: BigInt(0),
       lamports7d: BigInt(0),
@@ -477,15 +532,19 @@ async function loadWalletSpend(
     });
   }
 
-  return new Map(
-    Array.from(totals.entries()).map(([address, total]) => [
-      address,
-      {
-        spend24hLamports: total.lamports24h.toString(),
-        spend7dLamports: total.lamports7d.toString(),
-      },
-    ])
-  );
+  return {
+    sourceErrors,
+    spend: new Map(
+      Array.from(totals.entries()).map(([address, total]) => [
+        address,
+        {
+          spend24hLamports: total.lamports24h.toString(),
+          spend7dLamports: total.lamports7d.toString(),
+        },
+      ])
+    ),
+    unavailableRoles,
+  };
 }
 
 async function loadBalances(addresses: string[]): Promise<{
@@ -698,6 +757,7 @@ function createWallets(args: {
   balances: Map<string, string>;
   definitions: RoleDefinition[];
   spend: Map<string, WalletSpend>;
+  spendUnavailableRoles: Set<FundingRole>;
   rpcError: string | null;
   rpcObservedAt: string;
   rpcSlot: number | null;
@@ -767,10 +827,14 @@ function createWallets(args: {
       const balanceLamportsText = args.balances.get(address) ?? null;
       const balanceLamports =
         balanceLamportsText === null ? null : BigInt(balanceLamportsText);
-      const spend = args.spend.get(address) ?? {
-        spend24hLamports: null,
-        spend7dLamports: null,
-      };
+      const roleKeys = wallet.roles.map((role) => role.key);
+      const spendUnavailable = roleKeys.some((key) =>
+        args.spendUnavailableRoles.has(key)
+      );
+      const spend =
+        spendUnavailable || !args.spend.has(address)
+          ? { spend24hLamports: null, spend7dLamports: null }
+          : (args.spend.get(address) as WalletSpend);
       const spend7dLamports = spend.spend7dLamports
         ? BigInt(spend.spend7dLamports)
         : null;
@@ -778,7 +842,6 @@ function createWallets(args: {
         balanceLamports,
         spend7dLamports
       );
-      const roleKeys = wallet.roles.map((role) => role.key);
       const minimumLamports = roleKeys.some(
         (key) =>
           key === "policy" || key === "deployment" || key === "route_fee_payer"
@@ -865,7 +928,8 @@ async function loadFundingData(): Promise<EarnFundingData> {
     sourceErrors.push(balanceResult.error);
   }
 
-  const spend = await loadWalletSpend(addresses);
+  const spendResult = await loadWalletSpend(addresses);
+  sourceErrors.push(...spendResult.sourceErrors);
 
   const walletResult = createWallets({
     balances: balanceResult.balances,
@@ -873,7 +937,8 @@ async function loadFundingData(): Promise<EarnFundingData> {
     rpcError: balanceResult.error,
     rpcObservedAt: balanceResult.observedAt,
     rpcSlot: balanceResult.slot,
-    spend,
+    spend: spendResult.spend,
+    spendUnavailableRoles: spendResult.unavailableRoles,
   });
 
   return {

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -767,13 +767,14 @@ function calculateStatus(args: {
     };
   }
 
-  // No source records this wallet's outflow, so there is no runway to report
-  // and nothing to warn about. Say so rather than implying a reading of zero.
+  // No source records this wallet's outflow. It pays transaction fees, so
+  // clearing the safety floor is not evidence of health: an unmeasured burn
+  // rate is unknown, and only the floor above would catch a drain.
   if (!args.spendTracked) {
     return {
       detail:
-        "Balance is above the configured operating thresholds; spend is not tracked for this wallet",
-      status: "healthy",
+        "Balance is above the safety floor, but spend is not tracked for this wallet so runway cannot be assessed",
+      status: "unknown",
     };
   }
 

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -4,7 +4,16 @@ import {
   appSmartAccountSponsorshipTransactions,
   gaslessClaimTransactions,
 } from "@loyal-labs/db-core/schema";
-import { and, count, desc, eq, max, sql as drizzleSql, sum } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  inArray,
+  max,
+  sql as drizzleSql,
+  sum,
+} from "drizzle-orm";
 
 import { getDatabase } from "@/lib/core/database";
 import { serverEnv } from "@/lib/core/config/server";
@@ -69,6 +78,23 @@ type FeePayerObservationRow = {
   address: string | null;
   active_shard_count: string | number | null;
   latest_seen_at: string | Date | null;
+};
+
+type SpendObservationRow = {
+  address: string | null;
+  lamports_24h: string | number | null;
+  lamports_7d: string | number | null;
+};
+
+type SpendRow = {
+  address: string;
+  lamports24h: bigint;
+  lamports7d: bigint;
+};
+
+type WalletSpend = {
+  spend24hLamports: string | null;
+  spend7dLamports: string | null;
 };
 
 type RpcAccount = {
@@ -278,18 +304,51 @@ async function loadYieldIdentityObservations(): Promise<{
   }
 }
 
-async function loadSponsorshipSpend(address: string): Promise<{
-  spend24hLamports: string | null;
-  spend7dLamports: string | null;
-}> {
+function toSpendLamports(value: string | number | null | undefined): bigint {
+  if (value === null || value === undefined) {
+    return BigInt(0);
+  }
+
+  const text = String(value).trim();
+  if (!/^-?\d+$/.test(text)) {
+    return BigInt(0);
+  }
+
+  const parsed = BigInt(text);
+  return parsed > BigInt(0) ? parsed : BigInt(0);
+}
+
+function toSpendRow(
+  address: string | null | undefined,
+  lamports24h: string | number | null | undefined,
+  lamports7d: string | number | null | undefined
+): SpendRow | null {
+  const normalizedAddress = normalizeAddress(address);
+  if (!normalizedAddress) {
+    return null;
+  }
+
+  return {
+    address: normalizedAddress,
+    lamports24h: toSpendLamports(lamports24h),
+    lamports7d: toSpendLamports(lamports7d),
+  };
+}
+
+// Sponsored smart-account deployments; rows are written by the app when each
+// sponsored transaction finalizes.
+async function loadSponsorshipSpendRows(
+  addresses: string[]
+): Promise<SpendRow[]> {
   try {
     const db = getDatabase();
     const rows = await db
       .select({
-        spend24hLamports: sum(
+        address: appSmartAccountSponsorshipTransactions.payerAddress,
+        lamports24h: sum(
           drizzleSql`CASE WHEN ${appSmartAccountSponsorshipTransactions.occurredAt} >= NOW() - INTERVAL '24 hours' THEN ${appSmartAccountSponsorshipTransactions.spentLamports} ELSE 0 END`
         ),
-        spend7dLamports: sum(
+        lamports7d: sum(
           drizzleSql`CASE WHEN ${appSmartAccountSponsorshipTransactions.occurredAt} >= NOW() - INTERVAL '7 days' THEN ${appSmartAccountSponsorshipTransactions.spentLamports} ELSE 0 END`
         ),
       })
@@ -297,17 +356,136 @@ async function loadSponsorshipSpend(address: string): Promise<{
       .where(
         and(
           eq(appSmartAccountSponsorshipTransactions.solanaEnv, MAINNET_APP_ENV),
-          eq(appSmartAccountSponsorshipTransactions.payerAddress, address)
+          inArray(
+            appSmartAccountSponsorshipTransactions.payerAddress,
+            addresses
+          )
         )
-      );
+      )
+      .groupBy(appSmartAccountSponsorshipTransactions.payerAddress);
 
-    return {
-      spend24hLamports: rows[0]?.spend24hLamports?.toString() ?? null,
-      spend7dLamports: rows[0]?.spend7dLamports?.toString() ?? null,
-    };
+    return rows
+      .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
+      .filter((row): row is SpendRow => Boolean(row));
   } catch {
-    return { spend24hLamports: null, spend7dLamports: null };
+    return [];
   }
+}
+
+// Gasless claim/verification transactions; rows are backfilled by the app's
+// private-transfer-analytics cron.
+async function loadGaslessClaimSpendRows(
+  addresses: string[]
+): Promise<SpendRow[]> {
+  try {
+    const db = getDatabase();
+    const rows = await db
+      .select({
+        address: gaslessClaimTransactions.payerAddress,
+        lamports24h: sum(
+          drizzleSql`CASE WHEN ${gaslessClaimTransactions.occurredAt} >= NOW() - INTERVAL '24 hours' THEN ${gaslessClaimTransactions.spentLamports} ELSE 0 END`
+        ),
+        lamports7d: sum(
+          drizzleSql`CASE WHEN ${gaslessClaimTransactions.occurredAt} >= NOW() - INTERVAL '7 days' THEN ${gaslessClaimTransactions.spentLamports} ELSE 0 END`
+        ),
+      })
+      .from(gaslessClaimTransactions)
+      .where(
+        and(
+          eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
+          inArray(gaslessClaimTransactions.payerAddress, addresses)
+        )
+      )
+      .groupBy(gaslessClaimTransactions.payerAddress);
+
+    return rows
+      .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
+      .filter((row): row is SpendRow => Boolean(row));
+  } catch {
+    return [];
+  }
+}
+
+// Route execution fees plus lookup-table provisioning fees and unreclaimed
+// rent, both paid by the Earn policy wallet.
+async function loadYieldSpendRows(addresses: string[]): Promise<SpendRow[]> {
+  try {
+    const sql = getYieldNeonSql();
+    const [routeRows, lookupTableRows] = await Promise.all([
+      sql.query(
+        `
+        SELECT
+          fee_payer AS address,
+          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= NOW() - INTERVAL '24 hours'), 0)::text AS lamports_24h,
+          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= NOW() - INTERVAL '7 days'), 0)::text AS lamports_7d
+        FROM loyal_yield.signed_route_submissions
+        WHERE cluster = $1
+          AND confirmed_at IS NOT NULL
+          AND fee_payer = ANY($2::text[])
+        GROUP BY fee_payer
+      `,
+        [MAINNET_YIELD_CLUSTER, addresses]
+      ) as unknown as Promise<SpendObservationRow[]>,
+      sql.query(
+        `
+        SELECT
+          family.payer AS address,
+          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= NOW() - INTERVAL '24 hours'), 0)::text AS lamports_24h,
+          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= NOW() - INTERVAL '7 days'), 0)::text AS lamports_7d
+        FROM loyal_yield.lookup_table_operations AS operation
+        JOIN loyal_yield.lookup_table_families AS family
+          ON family.id = operation.family_id
+        WHERE family.cluster = $1
+          AND operation.confirmed_at IS NOT NULL
+          AND family.payer = ANY($2::text[])
+        GROUP BY family.payer
+      `,
+        [MAINNET_YIELD_CLUSTER, addresses]
+      ) as unknown as Promise<SpendObservationRow[]>,
+    ]);
+
+    return [...routeRows, ...lookupTableRows]
+      .map((row) => toSpendRow(row.address, row.lamports_24h, row.lamports_7d))
+      .filter((row): row is SpendRow => Boolean(row));
+  } catch {
+    return [];
+  }
+}
+
+async function loadWalletSpend(
+  addresses: string[]
+): Promise<Map<string, WalletSpend>> {
+  if (addresses.length === 0) {
+    return new Map();
+  }
+
+  const rowGroups = await Promise.all([
+    loadSponsorshipSpendRows(addresses),
+    loadGaslessClaimSpendRows(addresses),
+    loadYieldSpendRows(addresses),
+  ]);
+
+  const totals = new Map<string, { lamports24h: bigint; lamports7d: bigint }>();
+  for (const row of rowGroups.flat()) {
+    const existing = totals.get(row.address) ?? {
+      lamports24h: BigInt(0),
+      lamports7d: BigInt(0),
+    };
+    totals.set(row.address, {
+      lamports24h: existing.lamports24h + row.lamports24h,
+      lamports7d: existing.lamports7d + row.lamports7d,
+    });
+  }
+
+  return new Map(
+    Array.from(totals.entries()).map(([address, total]) => [
+      address,
+      {
+        spend24hLamports: total.lamports24h.toString(),
+        spend7dLamports: total.lamports7d.toString(),
+      },
+    ])
+  );
 }
 
 async function loadBalances(addresses: string[]): Promise<{
@@ -519,10 +697,7 @@ function createRoleDefinitions(args: {
 function createWallets(args: {
   balances: Map<string, string>;
   definitions: RoleDefinition[];
-  spend: Map<
-    string,
-    { spend24hLamports: string | null; spend7dLamports: string | null }
-  >;
+  spend: Map<string, WalletSpend>;
   rpcError: string | null;
   rpcObservedAt: string;
   rpcSlot: number | null;
@@ -690,17 +865,7 @@ async function loadFundingData(): Promise<EarnFundingData> {
     sourceErrors.push(balanceResult.error);
   }
 
-  const sponsorshipAddress = appObservations.sponsorship[0]?.address;
-  const spend = new Map<
-    string,
-    { spend24hLamports: string | null; spend7dLamports: string | null }
-  >();
-  if (sponsorshipAddress) {
-    spend.set(
-      sponsorshipAddress,
-      await loadSponsorshipSpend(sponsorshipAddress)
-    );
-  }
+  const spend = await loadWalletSpend(addresses);
 
   const walletResult = createWallets({
     balances: balanceResult.balances,

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -652,6 +652,7 @@ function calculateStatus(args: {
   minimumLamports: bigint | null;
   roleKeys: FundingRole[];
   runwayHours: number | null;
+  spendAvailable: boolean;
 }): { status: FundingStatus; detail: string } {
   if (args.balanceLamports === null) {
     return {
@@ -695,6 +696,16 @@ function calculateStatus(args: {
   if (args.roleKeys.includes("sponsorship") && args.runwayHours === null) {
     return {
       detail: "Balance available; recent sponsorship spend is unavailable",
+      status: "low",
+    };
+  }
+
+  // A wallet whose spend history could not be read has no runway to stand on,
+  // so it must not claim to clear the operating thresholds. Spend that is
+  // present but zero is a real observation and stays healthy.
+  if (!args.spendAvailable) {
+    return {
+      detail: "Balance available; recent spend history is unavailable",
       status: "low",
     };
   }
@@ -844,6 +855,7 @@ function createWallets(args: {
         minimumLamports,
         roleKeys,
         runwayHours,
+        spendAvailable: spend.spend7dLamports !== null,
       });
       const mismatch = wallet.roles.some((role) => {
         const definition = args.definitions.find(

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -470,19 +470,19 @@ async function loadYieldSpendRows(
   }
 }
 
-// A wallet's spend is only meaningful once every source covering its roles has
-// answered. Summing what is left after a source fails would understate spend
-// and inflate the runway without any visible sign, so the affected wallets fall
-// back to "unknown" and the failure is surfaced as a source error instead.
+// Spend is summed per address across every source, because a wallet's roles do
+// not partition the sources it appears in: the policy signer also has rows in
+// the sponsorship table, and any key can turn up as a gasless payer. That makes
+// a partial answer unusable — the missing source would understate some wallet's
+// spend and inflate its runway with no way to tell which one. So if any source
+// fails, no wallet reports spend and the failure is surfaced instead.
 async function loadWalletSpend(addresses: string[]): Promise<{
   spend: Map<string, WalletSpend>;
-  unavailableRoles: Set<FundingRole>;
   sourceErrors: string[];
 }> {
-  const unavailableRoles = new Set<FundingRole>();
   const sourceErrors: string[] = [];
   if (addresses.length === 0) {
-    return { sourceErrors, spend: new Map(), unavailableRoles };
+    return { sourceErrors, spend: new Map() };
   }
 
   const [sponsorship, gasless, yieldSpend] = await Promise.all([
@@ -491,33 +491,29 @@ async function loadWalletSpend(addresses: string[]): Promise<{
     loadYieldSpendRows(addresses),
   ]);
 
-  const sources: Array<{
-    error: string;
-    result: SpendSourceResult;
-    roles: FundingRole[];
-  }> = [
+  const sources: Array<{ error: string; result: SpendSourceResult }> = [
     {
       error: "Smart-account sponsorship spend history unavailable",
       result: sponsorship,
-      roles: ["sponsorship"],
     },
     {
       error: "Gasless deployment spend history unavailable",
       result: gasless,
-      roles: ["deployment"],
     },
     {
       error: "Yield execution spend history unavailable",
       result: yieldSpend,
-      roles: ["policy", "route_fee_payer"],
     },
   ];
 
   for (const source of sources) {
     if (source.result.failed) {
       sourceErrors.push(source.error);
-      source.roles.forEach((role) => unavailableRoles.add(role));
     }
+  }
+
+  if (sourceErrors.length > 0) {
+    return { sourceErrors, spend: new Map() };
   }
 
   const totals = new Map<string, { lamports24h: bigint; lamports7d: bigint }>();
@@ -543,7 +539,6 @@ async function loadWalletSpend(addresses: string[]): Promise<{
         },
       ])
     ),
-    unavailableRoles,
   };
 }
 
@@ -757,7 +752,6 @@ function createWallets(args: {
   balances: Map<string, string>;
   definitions: RoleDefinition[];
   spend: Map<string, WalletSpend>;
-  spendUnavailableRoles: Set<FundingRole>;
   rpcError: string | null;
   rpcObservedAt: string;
   rpcSlot: number | null;
@@ -828,13 +822,10 @@ function createWallets(args: {
       const balanceLamports =
         balanceLamportsText === null ? null : BigInt(balanceLamportsText);
       const roleKeys = wallet.roles.map((role) => role.key);
-      const spendUnavailable = roleKeys.some((key) =>
-        args.spendUnavailableRoles.has(key)
-      );
-      const spend =
-        spendUnavailable || !args.spend.has(address)
-          ? { spend24hLamports: null, spend7dLamports: null }
-          : (args.spend.get(address) as WalletSpend);
+      const spend = args.spend.get(address) ?? {
+        spend24hLamports: null,
+        spend7dLamports: null,
+      };
       const spend7dLamports = spend.spend7dLamports
         ? BigInt(spend.spend7dLamports)
         : null;
@@ -938,7 +929,6 @@ async function loadFundingData(): Promise<EarnFundingData> {
     rpcObservedAt: balanceResult.observedAt,
     rpcSlot: balanceResult.slot,
     spend: spendResult.spend,
-    spendUnavailableRoles: spendResult.unavailableRoles,
   });
 
   return {

--- a/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -516,7 +516,15 @@ async function loadWalletSpend(addresses: string[]): Promise<{
     return { sourceErrors, spend: new Map() };
   }
 
-  const totals = new Map<string, { lamports24h: bigint; lamports7d: bigint }>();
+  // Every source answered, so each requested address now has a known spend.
+  // Seed them all at zero: an address with no rows anywhere spent nothing,
+  // which is an observation rather than missing data.
+  const totals = new Map<string, { lamports24h: bigint; lamports7d: bigint }>(
+    addresses.map((address) => [
+      address,
+      { lamports24h: BigInt(0), lamports7d: BigInt(0) },
+    ])
+  );
   for (const row of sources.flatMap((source) => source.result.rows)) {
     const existing = totals.get(row.address) ?? {
       lamports24h: BigInt(0),

--- a/admin/src/lib/core/config/server.ts
+++ b/admin/src/lib/core/config/server.ts
@@ -27,6 +27,9 @@ export const serverEnv = {
       getOptionalEnv("EARN_YIELD_ROUTER_PUBLIC_KEY")
     );
   },
+  get earnSettingsAuthorityPublicKey(): string | undefined {
+    return getOptionalEnv("EARN_SETTINGS_AUTHORITY_PUBLIC_KEY");
+  },
   get smartAccountSponsorPublicKey(): string | undefined {
     return getOptionalEnv("SMART_ACCOUNT_SPONSOR_PUBLIC_KEY");
   },


### PR DESCRIPTION
The Operational wallets section only computed spend for the smart-account sponsor, so the policy + deployment wallet showed "Unknown" 24h spend and "No spend data" runway even though its outflow is already recorded. Spend is now aggregated per wallet address across sponsorship transactions, gasless claim transactions, confirmed route submissions, and lookup-table provisioning fees plus unreclaimed rent, and any source failure blanks spend rather than silently under-reporting it.

Also adds the Earn settings authority (BAqgbERm…) as a third operational wallet. It signs and pays for policy install/update/close and wallet recovery; no table records that outflow, so it reports spend as untracked instead of zero. Requires EARN_SETTINGS_AUTHORITY_PUBLIC_KEY in the admin environment.