### PR TITLE
feat(wallet): render earn toast as step-by-step progress card

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3108,6 +3108,123 @@ cap-widget {
   }
 }
 
+/* Facelift adaptation — Earn step card (earn-toast.tsx). Multi-stage flows
+   expand the pill into a task-steps card; height/width come from inline
+   styles and morph on the resize clock (interpolate-size lets width tween
+   back to the pill's auto width where supported; elsewhere it snaps). The
+   open/close transition list must be restated here because .is-open resets
+   `transition` wholesale. */
+.t-toast.t-toast-resize {
+  interpolate-size: allow-keywords;
+  transition: opacity var(--toast-close) var(--toast-ease),
+    transform var(--toast-close) var(--toast-ease),
+    filter var(--toast-close) var(--toast-ease),
+    height var(--resize-dur) var(--resize-ease),
+    width var(--resize-dur) var(--resize-ease);
+}
+.t-toast.t-toast-resize.is-open {
+  transition: opacity var(--toast-open) var(--toast-ease),
+    transform var(--toast-open) var(--toast-ease),
+    filter var(--toast-open) var(--toast-ease),
+    height var(--resize-dur) var(--resize-ease),
+    width var(--resize-dur) var(--resize-ease);
+}
+
+/* Step rows: the status icon is a four-state stack (p: pending dot,
+   a: spinner, b: check, c: cross) riding the icon-swap tokens, with the
+   incoming icon popping on the bob ease (slight overshoot past 1). The
+   check additionally swings upright and stroke-draws its path (t-check-draw;
+   35 = the calibrated length of the shared check path), and the next step's
+   spinner waits a beat so the landing check reads before the handoff. */
+:root {
+  --step-advance-delay: 120ms;
+}
+
+.t-step-icon {
+  position: relative;
+}
+.t-step-ico {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(var(--icon-swap-start-scale));
+  filter: blur(var(--icon-swap-blur));
+  transition: opacity var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--check-ease-bob),
+    filter var(--icon-swap-dur) var(--icon-swap-ease);
+}
+.t-step-ico[data-ico="b"] {
+  transform: scale(var(--icon-swap-start-scale)) rotate(-80deg);
+}
+.t-step-ico[data-ico="b"] svg path {
+  stroke-dasharray: 35;
+  stroke-dashoffset: 35;
+}
+.t-step-icon[data-state="p"] .t-step-ico[data-ico="p"],
+.t-step-icon[data-state="a"] .t-step-ico[data-ico="a"],
+.t-step-icon[data-state="b"] .t-step-ico[data-ico="b"],
+.t-step-icon[data-state="c"] .t-step-ico[data-ico="c"] {
+  opacity: 1;
+  transform: scale(1);
+  filter: blur(0);
+}
+.t-step-icon[data-state="b"] .t-step-ico[data-ico="b"] {
+  transform: scale(1) rotate(0deg);
+}
+.t-step-icon[data-state="b"] .t-step-ico[data-ico="b"] svg path {
+  animation: t-check-draw var(--check-path-dur) var(--check-ease-path) forwards;
+}
+.t-step-icon[data-state="a"] .t-step-ico[data-ico="a"] {
+  transition-delay: var(--step-advance-delay);
+}
+
+/* Smooths the label's dim ⇄ full-black changes as rows advance. */
+.t-step-label {
+  transition: color var(--icon-swap-dur) var(--icon-swap-ease);
+}
+
+.t-step-active {
+  background-image: linear-gradient(
+    90deg,
+    #000 42%,
+    rgba(0, 0, 0, 0.35) 50%,
+    #000 58%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: t-step-shimmer 1.6s linear infinite;
+}
+
+@keyframes t-step-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-step-ico,
+  .t-step-label {
+    transition: none !important;
+  }
+  .t-step-icon .t-step-ico[data-ico="b"] svg path {
+    animation: none !important;
+    stroke-dashoffset: 0 !important;
+  }
+  .t-step-active {
+    animation: none !important;
+    background-image: none;
+    color: #000;
+  }
+}
+
 /* animate-text — soft-blur-in (banner titles). Per-character blurred rise
    from the spec (900ms, 16px, cubic-bezier(0.22,1,0.36,1)), with blur 12→6
    and stagger 25→15ms per its usage notes for sub-24px copy. The mobile home

--- a/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -10,12 +10,25 @@ import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 // bottom-center pill (transitions.dev toast recipe). The status icon is a
 // three-way icon-swap: pending spinner (a) morphs into the success check
 // (b) or the error cross (c).
+//
+// Multi-stage flows can additionally begin() a step script: the pill then
+// renders as a task-steps card listing every stage upfront (pending dot /
+// spinner / check / cross per row), and each loading() message lights up
+// its step. Success collapses the card back into the plain success pill.
 
 type EarnToastPhase = "error" | "loading" | "success";
 
 type EarnToastDetail = { message: string; phase: EarnToastPhase };
 
+export type EarnFlowId =
+  | "autodeposit-delete"
+  | "autodeposit-setup"
+  | "close-policies"
+  | "deposit"
+  | "withdraw";
+
 type EarnToastListener = {
+  begin: (flow: EarnFlowId) => void;
   settle: () => void;
   show: (detail: EarnToastDetail) => void;
   signed: () => void;
@@ -28,7 +41,46 @@ let listener: EarnToastListener | null = null;
 // the toast when this exact message is showing — keep them in sync.
 export const CONFIRM_IN_WALLET_MESSAGE = "Confirm in wallet";
 
+// Step scripts for the multi-stage Earn flows. Entries are the exact
+// loading() messages use-earn-actions.ts emits, in order — the host maps
+// each message to its index and auto-checks everything before it, so a
+// conditional stage that never runs (e.g. "Waiting for approval" when the
+// deposit needs no approval) still reads as done. A loading message outside
+// the active script drops the toast back to the plain pill.
+const FLOW_STEPS: Record<EarnFlowId, readonly string[]> = {
+  "autodeposit-delete": [
+    "Waiting for approval",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+  "autodeposit-setup": [
+    "Waiting for approval",
+    "Preparing Autodeposit",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+  "close-policies": ["Closing policies", CONFIRM_IN_WALLET_MESSAGE, "Confirming"],
+  deposit: [
+    "Preparing deposit",
+    "Waiting for approval",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+  withdraw: [
+    "Preparing withdrawal",
+    "Waiting for approval",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+};
+
 export const earnToast = {
+  // Arm the step script for the flow that is about to start. The following
+  // loading()/success()/error()/settle() calls need no changes — messages
+  // resolve to steps, terminal calls end the flow.
+  begin(flow: EarnFlowId) {
+    listener?.begin(flow);
+  },
   error(message: string) {
     listener?.show({ message, phase: "error" });
   },
@@ -64,10 +116,18 @@ const ICON_STATE: Record<EarnToastPhase, "a" | "b" | "c"> = {
   success: "b",
 };
 
+const PILL_HEIGHT_PX = 48;
+const STEP_ROW_HEIGHT_PX = 28;
+const CARD_PADDING_Y_PX = 12;
+const CARD_WIDTH_PX = 240;
+
 export function EarnToastHost() {
   const [detail, setDetail] = useState<EarnToastDetail | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [steps, setSteps] = useState<readonly string[] | null>(null);
+  const [stepIndex, setStepIndex] = useState(-1);
   const detailRef = useRef<EarnToastDetail | null>(null);
+  const stepsRef = useRef<readonly string[] | null>(null);
   const timersRef = useRef<{
     clear?: ReturnType<typeof setTimeout>;
     hide?: ReturnType<typeof setTimeout>;
@@ -78,17 +138,34 @@ export function EarnToastHost() {
       clearTimeout(timersRef.current.hide);
       clearTimeout(timersRef.current.clear);
     };
+    const disarm = () => {
+      stepsRef.current = null;
+      setSteps(null);
+      setStepIndex(-1);
+    };
     const close = () => {
       detailRef.current = null;
       setIsOpen(false);
-      timersRef.current.clear = setTimeout(
-        () => setDetail(null),
-        CLEAR_AFTER_CLOSE_MS
-      );
+      timersRef.current.clear = setTimeout(() => {
+        setDetail(null);
+        disarm();
+      }, CLEAR_AFTER_CLOSE_MS);
     };
     const show = (next: EarnToastDetail) => {
       clearTimers();
       detailRef.current = next;
+      if (next.phase === "loading" && stepsRef.current) {
+        const index = stepsRef.current.indexOf(next.message);
+        if (index === -1) {
+          disarm();
+        } else {
+          setStepIndex(index);
+        }
+      } else if (next.phase === "success") {
+        // Collapse the step card into the plain success pill; errors keep
+        // the card so the failed step shows where the flow stopped.
+        disarm();
+      }
       setDetail(next);
       setIsOpen(true);
       if (next.phase !== "loading") {
@@ -99,6 +176,11 @@ export function EarnToastHost() {
       }
     };
     listener = {
+      begin: (flow) => {
+        stepsRef.current = FLOW_STEPS[flow];
+        setSteps(stepsRef.current);
+        setStepIndex(-1);
+      },
       settle: () => {
         if (detailRef.current?.phase === "loading") {
           clearTimers();
@@ -121,6 +203,12 @@ export function EarnToastHost() {
     };
   }, []);
 
+  const isCard =
+    steps !== null &&
+    stepIndex >= 0 &&
+    detail !== null &&
+    detail.phase !== "success";
+
   return (
     <div
       aria-live="polite"
@@ -128,59 +216,89 @@ export function EarnToastHost() {
       role="status"
     >
       <div
-        className={`t-toast flex h-12 items-center gap-2.5 rounded-full bg-white pr-5 pl-4 font-medium text-[14px] text-black leading-5 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] ${
+        className={`t-toast t-toast-resize flex flex-col justify-center overflow-hidden bg-white font-medium text-[14px] text-black leading-5 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] ${
           isOpen ? "is-open" : ""
         }`}
         // Top-anchored, so the pill drops in from above its resting spot
-        // (the recipe's default +16px rises from below).
-        style={{ ["--toast-distance" as never]: "-16px" }}
+        // (the recipe's default +16px rises from below). Height/radius are
+        // inline so the card ⇄ pill morph rides the resize clock, same as
+        // t-earn-banner.
+        style={{
+          ["--toast-distance" as never]: "-16px",
+          borderRadius: PILL_HEIGHT_PX / 2,
+          height: isCard
+            ? CARD_PADDING_Y_PX * 2 + steps.length * STEP_ROW_HEIGHT_PX
+            : PILL_HEIGHT_PX,
+          width: isCard ? CARD_WIDTH_PX : undefined,
+        }}
       >
-        {detail ? (
-          <>
+        {isCard ? (
+          <div className="flex flex-col px-4">
+            {steps.map((label, index) => {
+              const isActive = index === stepIndex;
+              const state =
+                index < stepIndex
+                  ? "b"
+                  : isActive
+                    ? detail.phase === "error"
+                      ? "c"
+                      : "a"
+                    : "p";
+              return (
+                <div className="flex h-7 items-center gap-2.5" key={label}>
+                  <span
+                    aria-hidden="true"
+                    className="t-step-icon size-4 shrink-0"
+                    data-state={state}
+                  >
+                    <span className="t-step-ico" data-ico="p">
+                      <span className="size-1.5 rounded-full bg-black/20" />
+                    </span>
+                    <span className="t-step-ico" data-ico="a">
+                      <SpinnerIcon className="size-4" />
+                    </span>
+                    <span className="t-step-ico" data-ico="b">
+                      <CheckIcon className="size-4" />
+                    </span>
+                    <span className="t-step-ico" data-ico="c">
+                      <CrossIcon className="size-4" />
+                    </span>
+                  </span>
+                  <span
+                    className={`t-step-label min-w-0 truncate ${state === "p" ? "text-black/40" : ""}`}
+                  >
+                    <TextSwap
+                      className={state === "a" ? "t-step-active" : ""}
+                      text={
+                        isActive && detail.phase === "error"
+                          ? detail.message
+                          : label
+                      }
+                    />
+                  </span>
+                </div>
+              );
+            })}
+            <span className="sr-only">
+              {`${steps[stepIndex]}, step ${stepIndex + 1} of ${steps.length}`}
+            </span>
+          </div>
+        ) : detail ? (
+          <div className="flex items-center gap-2.5 pr-5 pl-4">
             <span
               aria-hidden="true"
               className="t-icon-swap size-5"
               data-state={ICON_STATE[detail.phase]}
             >
               <span className="t-icon" data-icon="a">
-                <svg className="size-5" fill="none" viewBox="0 0 64 64">
-                  <circle cx="32" cy="32" fill="#ffb800" r="32" />
-                  <circle
-                    className="t-toast-spinner"
-                    cx="32"
-                    cy="32"
-                    fill="none"
-                    r="14"
-                    stroke="white"
-                    strokeDasharray="40 48"
-                    strokeLinecap="round"
-                    strokeWidth="6"
-                  />
-                </svg>
+                <SpinnerIcon className="size-5" />
               </span>
               {/* Same circle + check pair as ActionSuccessBody's t-success-check. */}
               <span className="t-icon" data-icon="b">
-                <svg className="size-5" fill="none" viewBox="0 0 64 64">
-                  <circle cx="32" cy="32" fill="#34c759" r="32" />
-                  <path
-                    d="M20 33l8 8 16-16"
-                    stroke="white"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="5"
-                  />
-                </svg>
+                <CheckIcon className="size-5" />
               </span>
               <span className="t-icon" data-icon="c">
-                <svg className="size-5" fill="none" viewBox="0 0 64 64">
-                  <circle cx="32" cy="32" fill="#f9363c" r="32" />
-                  <path
-                    d="M23 23l18 18M41 23l-18 18"
-                    stroke="white"
-                    strokeLinecap="round"
-                    strokeWidth="5"
-                  />
-                </svg>
+                <CrossIcon className="size-5" />
               </span>
             </span>
             <span>
@@ -193,9 +311,57 @@ export function EarnToastHost() {
                 </span>
               ) : null}
             </span>
-          </>
+          </div>
         ) : null}
       </div>
     </div>
+  );
+}
+
+function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 64 64">
+      <circle cx="32" cy="32" fill="#ffb800" r="32" />
+      <circle
+        className="t-toast-spinner"
+        cx="32"
+        cy="32"
+        fill="none"
+        r="14"
+        stroke="white"
+        strokeDasharray="40 48"
+        strokeLinecap="round"
+        strokeWidth="6"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 64 64">
+      <circle cx="32" cy="32" fill="#34c759" r="32" />
+      <path
+        d="M20 33l8 8 16-16"
+        stroke="white"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="5"
+      />
+    </svg>
+  );
+}
+
+function CrossIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 64 64">
+      <circle cx="32" cy="32" fill="#f9363c" r="32" />
+      <path
+        d="M23 23l18 18M41 23l-18 18"
+        stroke="white"
+        strokeLinecap="round"
+        strokeWidth="5"
+      />
+    </svg>
   );
 }

--- a/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -977,6 +977,7 @@ export function useEarnActions(deps: {
       });
       setDepositError(null);
       setIsDepositPending(true);
+      earnToast.begin("deposit");
       earnToast.loading("Preparing deposit");
       let phase: "prepare" | "sign" = "prepare";
       const interactionStartedAtMs = getBrowserPerformanceNow();
@@ -1408,6 +1409,7 @@ export function useEarnActions(deps: {
       tracker.start("intent", { cleanupRequired: draft.mode === "full" });
       setWithdrawError(null);
       setIsWithdrawPending(true);
+      earnToast.begin("withdraw");
       earnToast.loading("Preparing withdrawal");
       const interactionStartedAtMs = getBrowserPerformanceNow();
       let previewMetricSent = false;
@@ -1781,6 +1783,7 @@ export function useEarnActions(deps: {
     };
     setWithdrawError(null);
     setIsCleanupPending(true);
+    earnToast.begin("close-policies");
     earnToast.loading("Closing policies");
     try {
       tracker.observe("full_exit_verify", {
@@ -2100,6 +2103,7 @@ export function useEarnActions(deps: {
         symbol: "USDC",
         tokenDecimals: source.decimals,
       };
+      earnToast.begin("autodeposit-setup");
       earnToast.loading("Waiting for approval");
       const approvalPromise = requestApproval(
         buildEarnAutodepositSetupReviewItem({ draft: setupReviewDraft })
@@ -2470,6 +2474,7 @@ export function useEarnActions(deps: {
       walletSubmittedAtMs ??= getBrowserPerformanceNow();
     };
 
+    earnToast.begin("autodeposit-delete");
     earnToast.loading("Waiting for approval");
     const approvalPromise = requestApproval(
       buildEarnAutodepositCloseReviewItem({


### PR DESCRIPTION
Multi-stage Earn flows (deposit, withdraw, close policies, autodeposit setup/delete) now expand the toast pill into a task-steps card showing every stage upfront — pending dot, animated spinner with shimmer label, stroke-drawn check, or error cross per row — collapsing back to the plain pill on success. Single-stage flows and unknown messages keep the existing pill behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)