### PR TITLE
fix(frontend): swallow skipped ViewTransition rejection when tab is hidden

### DIFF
--- a/frontend/src/components/app-transition/app-transition-bridge.tsx
+++ b/frontend/src/components/app-transition/app-transition-bridge.tsx
@@ -130,9 +130,15 @@ export function AppTransitionBridge() {
     // Removing the white overlay inside the VT callback is the DOM mutation VT
     // animates: old snapshot = white + logo, new snapshot = the loaded app. The
     // CSS in globals.css fades the white off and flies the logo at the viewer.
-    doc.startViewTransition(() => {
+    const transition = doc.startViewTransition(() => {
       flushSync(clearOverlay);
     });
+    // A hidden tab skips the transition and rejects these promises with
+    // InvalidStateError ("Skipped ViewTransition due to document being
+    // hidden"). The overlay is still cleared by the callback, so this is
+    // expected — swallow it instead of surfacing an unhandled rejection.
+    transition.ready.catch(() => {});
+    transition.finished.catch(() => {});
   }, [clearOverlay]);
 
   // Warm the app route so the client nav is instant.


### PR DESCRIPTION
Backgrounding the tab during the landing→app splash reveal makes the browser skip the view transition and reject its ready/finished promises with InvalidStateError, which surfaced as unhandled-rejection noise in production error tracking. The overlay is still cleared by the VT callback, so the rejection is expected — catch and ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)