### PR TITLE
feat(observability): accept mobile loading metrics

### DIFF
--- a/frontend/docs/loading-metrics.md
+++ b/frontend/docs/loading-metrics.md
@@ -49,3 +49,33 @@ vendor response is accepted by the metric envelope.
 
 Loading telemetry is best-effort. A rejected, timed-out, or unavailable metrics
 relay never blocks a user action.
+
+## Mobile loading metrics
+
+The Expo app reports the gauge `loyal.mobile.loading.duration` to the native-only
+`POST /api/observability/mobile/metrics` relay. The relay accepts no browser
+origin headers, validates the same strict contract as the app, and exports the
+observation with `service.name=loyal-mobile`. Device-provided environment and
+release values describe the installed binary or OTA release rather than the
+Vercel relay deployment.
+
+| Attribute              | Values                                                                                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `loyal.operation`      | `app_load`, `earn.deposit`, `earn.withdrawal`, `earn.refund`, and Autodeposit `setup`, `floor_update`, `pause`, `resume`, `close`, or `execute_now` |
+| `loyal.phase`          | `app_ready` for app startup; `interaction_to_ui` for an Earn action                                                                                 |
+| `loyal.outcome`        | `completed`, `failed`                                                                                                                               |
+| `loyal.flow.id`        | Random per-attempt UUID for Earn actions                                                                                                            |
+| `loyal.app_session.id` | Random per-process UUID                                                                                                                             |
+| `loyal.platform`       | `android`, `ios`                                                                                                                                    |
+| `url.path`             | Normalized Expo Router pathname without a query or fragment                                                                                         |
+
+`app_load` starts in `mobile/index.js`, before Expo Router is imported, and
+ends after authentication, account address, wallet holdings, Earn position, and
+Autodeposit state have resolved and the final screen has painted. Earn actions
+start at the user's submit or confirm interaction and end after the confirmed
+chain result is refreshed and painted. Failed terminal attempts are observed
+once; retry attempts receive a new flow ID.
+
+The mobile envelope rejects wallet addresses, token amounts, transaction
+signatures, request bodies, and extra attributes. Telemetry remains best-effort
+and cannot make a user action fail.

--- a/frontend/scripts/verify-observability.ts
+++ b/frontend/scripts/verify-observability.ts
@@ -7,7 +7,11 @@ import {
   createErrorDeduplicator,
   parseBrowserErrorEnvelope,
 } from "../src/features/observability/error-contract";
-import { buildOtlpErrorPayload } from "../src/features/observability/otlp";
+import { parseMobileLoadingMetricEnvelope } from "../src/features/observability/metrics-contract";
+import {
+  buildOtlpErrorPayload,
+  buildOtlpLoadingMetricPayload,
+} from "../src/features/observability/otlp";
 
 const frontendRoot = fileURLToPath(new URL("..", import.meta.url));
 
@@ -145,6 +149,69 @@ pass(
   "OTLP payload contains fixed resource/error fields and no forbidden markers"
 );
 
+const mobileLoadingEnvelope = parseMobileLoadingMetricEnvelope(
+  {
+    appSessionId: "31e33790-3c9c-4ead-b40b-f4bb542cbd86",
+    durationMs: 1234.567,
+    environment: "prod",
+    flowId: "0dcc877d-f6c9-4fa2-9a93-a36fdb712a1b",
+    metricName: "loyal.mobile.loading.duration",
+    operation: "earn.autodeposit.execute_now",
+    outcome: "completed",
+    pathname: "/activity",
+    phase: "interaction_to_ui",
+    platform: "android",
+    release: "1.0.0_abcdef1",
+    timestamp: now.toISOString(),
+  },
+  now.getTime()
+);
+assert.throws(() =>
+  parseMobileLoadingMetricEnvelope(
+    { ...mobileLoadingEnvelope, walletAddress: forbidden.wallet },
+    now.getTime()
+  )
+);
+assert.throws(() =>
+  parseMobileLoadingMetricEnvelope(
+    { ...mobileLoadingEnvelope, flowId: undefined },
+    now.getTime()
+  )
+);
+const {
+  environment: mobileEnvironment,
+  release: mobileRelease,
+  ...mobileLoadingEvent
+} = mobileLoadingEnvelope;
+const mobileLoadingPayload = buildOtlpLoadingMetricPayload({
+  ...mobileLoadingEvent,
+  deploymentEnvironment: mobileEnvironment,
+  release: mobileRelease,
+  serviceName: "loyal-mobile",
+});
+const serializedMobileLoadingPayload = JSON.stringify(mobileLoadingPayload);
+for (const required of [
+  "loyal.mobile.loading.duration",
+  "loyal.operation",
+  "loyal.phase",
+  "loyal.outcome",
+  "loyal.flow.id",
+  "loyal.app_session.id",
+  "loyal.platform",
+  "service.name",
+  "service.version",
+  "deployment.environment.name",
+]) {
+  assert.ok(
+    serializedMobileLoadingPayload.includes(required),
+    `mobile loading OTLP payload lacks ${required}`
+  );
+}
+assert.ok(!serializedMobileLoadingPayload.includes(forbidden.wallet));
+pass(
+  "mobile loading contract and OTLP payload preserve strict safe dimensions"
+);
+
 const listeners = new Map<string, (event: unknown) => void>();
 let fetchAttempts = 0;
 const verifierWindow = {
@@ -192,6 +259,9 @@ pass(
 const clientSource = read("src/features/observability/client.ts");
 const serverSource = read("src/features/observability/server.ts");
 const routeSource = read("src/app/api/observability/errors/route.ts");
+const mobileMetricsRouteSource = read(
+  "src/app/api/observability/mobile/metrics/route.ts"
+);
 const rateLimitSource = read("src/features/observability/rate-limit.server.ts");
 const serverInstrumentation = read("src/instrumentation.ts");
 const clientInstrumentation = read("src/instrumentation-client.ts");
@@ -234,6 +304,20 @@ pass(
   "same-origin relay enforces JSON, actual bytes, bounded hashed-source rate limiting, and 202 fail-open semantics"
 );
 
+assert.match(mobileMetricsRouteSource, /isNativeAppRequest/);
+assert.match(mobileMetricsRouteSource, /!request\.headers\.get\("origin"\)/);
+assert.match(mobileMetricsRouteSource, /application\/json/);
+assert.match(mobileMetricsRouteSource, /body\.byteLength/);
+assert.match(mobileMetricsRouteSource, /consumeBrowserMetricsRateLimit/);
+assert.match(mobileMetricsRouteSource, /reportMobileLoadingMetricEnvelope/);
+assert.doesNotMatch(
+  mobileMetricsRouteSource,
+  /OBSERVABILITY_INGESTION_API_KEY|NEXT_PUBLIC_[A-Z_]*(?:KEY|TOKEN)/
+);
+pass(
+  "native loading relay is bounded, rate limited, and keeps ingestion credentials server-only"
+);
+
 assert.match(serverInstrumentation, /reportServerError/);
 assert.match(serverInstrumentation, /context\.routePath \?\? request\.path/);
 assert.doesNotMatch(serverInstrumentation, /request\.(?:headers|body|cookies)/);
@@ -251,6 +335,7 @@ const changedObservabilitySources = [
   clientSource,
   serverSource,
   routeSource,
+  mobileMetricsRouteSource,
   rateLimitSource,
   serverInstrumentation,
   clientInstrumentation,

--- a/frontend/src/app/api/observability/mobile/metrics/route.ts
+++ b/frontend/src/app/api/observability/mobile/metrics/route.ts
@@ -1,0 +1,85 @@
+import {
+  InvalidMetricsEnvelopeError,
+  MAX_METRICS_REQUEST_BYTES,
+  parseMobileLoadingMetricEnvelope,
+} from "@/features/observability/metrics-contract";
+import { consumeBrowserMetricsRateLimit } from "@/features/observability/rate-limit.server";
+import { reportMobileLoadingMetricEnvelope } from "@/features/observability/server";
+
+export const runtime = "nodejs";
+
+const NO_STORE_HEADERS = { "cache-control": "no-store" } as const;
+
+function jsonResponse(
+  body: Readonly<Record<string, boolean | string>>,
+  status: number
+): Response {
+  return Response.json(body, { headers: NO_STORE_HEADERS, status });
+}
+
+// Native fetch does not send browser origin metadata. Rejecting either header
+// keeps web pages from using this public, unauthenticated mobile relay.
+function isNativeAppRequest(request: Request): boolean {
+  return (
+    !request.headers.get("origin") && !request.headers.get("sec-fetch-site")
+  );
+}
+
+function isJsonRequest(request: Request): boolean {
+  return (
+    request.headers.get("content-type")?.split(";", 1)[0]?.trim() ===
+    "application/json"
+  );
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isInteger(parsedLength) || parsedLength < 0) {
+      throw new InvalidMetricsEnvelopeError();
+    }
+    if (parsedLength > MAX_METRICS_REQUEST_BYTES) {
+      throw new RangeError("Observability request is too large.");
+    }
+  }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength === 0) throw new InvalidMetricsEnvelopeError();
+  if (body.byteLength > MAX_METRICS_REQUEST_BYTES) {
+    throw new RangeError("Observability request is too large.");
+  }
+
+  try {
+    return JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(body)
+    ) as unknown;
+  } catch {
+    throw new InvalidMetricsEnvelopeError();
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isNativeAppRequest(request)) {
+    return jsonResponse({ error: "forbidden" }, 403);
+  }
+  if (!isJsonRequest(request)) {
+    return jsonResponse({ error: "invalid_content_type" }, 415);
+  }
+  if (!consumeBrowserMetricsRateLimit(request)) {
+    return jsonResponse({ error: "rate_limited" }, 429);
+  }
+
+  try {
+    const envelope = parseMobileLoadingMetricEnvelope(
+      await readJsonBody(request)
+    );
+    await reportMobileLoadingMetricEnvelope(envelope);
+    return jsonResponse({ accepted: true }, 202);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return jsonResponse({ error: "payload_too_large" }, 413);
+    }
+    return jsonResponse({ error: "invalid_request" }, 400);
+  }
+}

--- a/frontend/src/features/observability/metrics-contract.ts
+++ b/frontend/src/features/observability/metrics-contract.ts
@@ -1,6 +1,9 @@
 import { isBrowserPageSessionId } from "./chunk-load-contract";
 import { isCanonicalUuidV4 } from "./lifecycle-contract";
-import { normalizeTelemetryPathname } from "./error-contract";
+import {
+  normalizeResourceValue,
+  normalizeTelemetryPathname,
+} from "./error-contract";
 
 export const OBSERVABILITY_METRICS_ENDPOINT = "/api/observability/metrics";
 export const MAX_METRICS_REQUEST_BYTES = 16 * 1024;
@@ -57,10 +60,57 @@ export type BrowserLoadingMetricEnvelope = {
   timestamp: string;
 };
 
-export type NormalizedLoadingMetric = BrowserLoadingMetricEnvelope & {
-  deploymentEnvironment: string;
+export const MOBILE_LOADING_METRIC_NAME =
+  "loyal.mobile.loading.duration" as const;
+export const MOBILE_LOADING_OPERATIONS = [
+  "app_load",
+  "earn.deposit",
+  "earn.withdrawal",
+  "earn.refund",
+  "earn.autodeposit.setup",
+  "earn.autodeposit.floor_update",
+  "earn.autodeposit.pause",
+  "earn.autodeposit.resume",
+  "earn.autodeposit.close",
+  "earn.autodeposit.execute_now",
+] as const;
+export type MobileLoadingOperation = (typeof MOBILE_LOADING_OPERATIONS)[number];
+
+export type MobileLoadingMetricEnvelope = {
+  appSessionId: string;
+  durationMs: number;
+  environment: string;
+  flowId?: string;
+  metricName: typeof MOBILE_LOADING_METRIC_NAME;
+  operation: MobileLoadingOperation;
+  outcome: FrontendLoadingOutcome;
+  pathname: string;
+  phase: "app_ready" | "interaction_to_ui";
+  platform: "android" | "ios";
   release: string;
-  serviceName: "loyal-frontend";
+  timestamp: string;
+};
+
+export type NormalizedLoadingMetric = {
+  appSessionId?: string;
+  dependency?: FrontendLoadingDependency;
+  deploymentEnvironment: string;
+  durationMs: number;
+  flowId?: string;
+  metricName:
+    | typeof FRONTEND_LOADING_METRIC_NAME
+    | typeof MOBILE_LOADING_METRIC_NAME;
+  operation: FrontendLoadingOperation | MobileLoadingOperation;
+  outcome: FrontendLoadingOutcome;
+  pageSessionId?: string;
+  pathname: string;
+  phase: FrontendLoadingPhase | "app_ready" | "interaction_to_ui";
+  platform?: "android" | "ios";
+  presentation?: FrontendLoadingPresentation;
+  release: string;
+  requestCount?: number;
+  serviceName: "loyal-frontend" | "loyal-mobile";
+  timestamp: string;
 };
 
 export function resolveBrowserLoadingFailurePhase(args: {
@@ -263,4 +313,87 @@ export function createBrowserLoadingMetricEnvelope(
     },
     now
   );
+}
+
+export function parseMobileLoadingMetricEnvelope(
+  value: unknown,
+  now = Date.now()
+): MobileLoadingMetricEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "appSessionId",
+    "durationMs",
+    "environment",
+    "flowId",
+    "metricName",
+    "operation",
+    "outcome",
+    "pathname",
+    "phase",
+    "platform",
+    "release",
+    "timestamp",
+  ]);
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  if (
+    record.metricName !== MOBILE_LOADING_METRIC_NAME ||
+    !includes(MOBILE_LOADING_OPERATIONS, record.operation) ||
+    !includes(FRONTEND_LOADING_OUTCOMES, record.outcome) ||
+    !includes(["app_ready", "interaction_to_ui"] as const, record.phase) ||
+    !includes(["android", "ios"] as const, record.platform) ||
+    !isFiniteNumberInRange(record.durationMs, 0, MAX_METRIC_DURATION_MS) ||
+    !isCanonicalUuidV4(record.appSessionId)
+  ) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  if (
+    typeof record.pathname !== "string" ||
+    !record.pathname.startsWith("/") ||
+    record.pathname.length > 256 ||
+    record.pathname.includes("?") ||
+    record.pathname.includes("#")
+  ) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  const isAppLoad = record.operation === "app_load";
+  if (
+    (isAppLoad &&
+      (record.phase !== "app_ready" || record.flowId !== undefined)) ||
+    (!isAppLoad &&
+      (record.phase !== "interaction_to_ui" ||
+        !isCanonicalUuidV4(record.flowId)))
+  ) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  if (
+    typeof record.environment !== "string" ||
+    normalizeResourceValue(record.environment, 32) !== record.environment ||
+    typeof record.release !== "string" ||
+    normalizeResourceValue(record.release, 80) !== record.release
+  ) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+  const timestampMs =
+    typeof record.timestamp === "string"
+      ? Date.parse(record.timestamp)
+      : Number.NaN;
+  if (
+    typeof record.timestamp !== "string" ||
+    !Number.isFinite(timestampMs) ||
+    new Date(timestampMs).toISOString() !== record.timestamp ||
+    timestampMs < now - MAX_EVENT_AGE_MS ||
+    timestampMs > now + MAX_EVENT_CLOCK_SKEW_MS
+  ) {
+    throw new InvalidMetricsEnvelopeError();
+  }
+
+  return {
+    ...(record as MobileLoadingMetricEnvelope),
+    durationMs: Math.round(record.durationMs * 1000) / 1000,
+  };
 }

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -261,6 +261,14 @@ export function buildOtlpLoadingMetricPayload(
       stringAttribute("loyal.page_session.id", event.pageSessionId)
     );
   }
+  if (event.appSessionId) {
+    attributes.push(
+      stringAttribute("loyal.app_session.id", event.appSessionId)
+    );
+  }
+  if (event.platform) {
+    attributes.push(stringAttribute("loyal.platform", event.platform));
+  }
   if (event.dependency) {
     attributes.push(stringAttribute("loyal.dependency", event.dependency));
   }
@@ -289,7 +297,9 @@ export function buildOtlpLoadingMetricPayload(
             metrics: [
               {
                 description:
-                  "Browser loading latency from a user-visible Loyal flow boundary.",
+                  event.serviceName === "loyal-mobile"
+                    ? "Mobile loading latency from a user-visible Loyal flow boundary."
+                    : "Browser loading latency from a user-visible Loyal flow boundary.",
                 gauge: {
                   dataPoints: [
                     {
@@ -303,7 +313,13 @@ export function buildOtlpLoadingMetricPayload(
                 unit: "ms",
               },
             ],
-            scope: { name: "loyal.frontend.loading", version: "1" },
+            scope: {
+              name:
+                event.serviceName === "loyal-mobile"
+                  ? "loyal.mobile.loading"
+                  : "loyal.frontend.loading",
+              version: "1",
+            },
           },
         ],
       },

--- a/frontend/src/features/observability/server.ts
+++ b/frontend/src/features/observability/server.ts
@@ -14,7 +14,11 @@ import type {
   MobileLifecycleEnvelope,
   NormalizedLifecycleEvent,
 } from "./lifecycle-contract";
-import type { BrowserLoadingMetricEnvelope } from "./metrics-contract";
+import type {
+  BrowserLoadingMetricEnvelope,
+  MobileLoadingMetricEnvelope,
+  NormalizedLoadingMetric,
+} from "./metrics-contract";
 import {
   buildOtlpErrorPayload,
   buildOtlpLifecyclePayload,
@@ -142,17 +146,9 @@ async function exportLifecycleEvent(
 }
 
 async function exportLoadingMetric(
-  event: BrowserLoadingMetricEnvelope
+  event: NormalizedLoadingMetric
 ): Promise<boolean> {
-  return exportOtlpPayload(
-    buildOtlpLoadingMetricPayload({
-      ...event,
-      deploymentEnvironment: getObservabilityDeploymentEnvironment(),
-      release: getObservabilityRelease(),
-      serviceName: "loyal-frontend",
-    }),
-    "metrics"
-  );
+  return exportOtlpPayload(buildOtlpLoadingMetricPayload(event), "metrics");
 }
 
 export async function reportBrowserErrorEnvelope(
@@ -257,7 +253,28 @@ export async function reportBrowserLoadingMetricEnvelope(
   envelope: BrowserLoadingMetricEnvelope
 ): Promise<boolean> {
   try {
-    return await exportLoadingMetric(envelope);
+    return await exportLoadingMetric({
+      ...envelope,
+      deploymentEnvironment: getObservabilityDeploymentEnvironment(),
+      release: getObservabilityRelease(),
+      serviceName: "loyal-frontend",
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function reportMobileLoadingMetricEnvelope(
+  envelope: MobileLoadingMetricEnvelope
+): Promise<boolean> {
+  try {
+    const { environment, release, ...event } = envelope;
+    return await exportLoadingMetric({
+      ...event,
+      deploymentEnvironment: environment,
+      release,
+      serviceName: "loyal-mobile",
+    });
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- add the native mobile loading-metrics relay at `POST /api/observability/mobile/metrics`
- validate a strict privacy-safe mobile envelope and export it as `loyal.mobile.loading.duration` with `service.name=loyal-mobile`
- extend the observability verifier and loading-metrics documentation for the mobile contract

## Why

The mobile instrumentation in #570 sends loading and Earn-flow metrics to this route. Production currently returns 404, so this main-based backend change must be deployed before the mobile OTA is released.

The endpoint is best-effort, bounded, rate-limited, rejects browser-originated requests, and does not accept wallet addresses, amounts, signatures, request bodies, or arbitrary attributes.

## Validation

- `cd frontend && bun run verify:observability`
- focused Prettier check for all changed files
- `git diff --check origin/main...HEAD`

The repository-wide frontend typecheck was also attempted but remains blocked by existing unrelated errors in `src/lib/yield-optimization/earn-public-stats.server.ts` on the current main-derived checkout.

## Deployment order

1. Merge and deploy this PR to `askloyal.com`.
2. Confirm an invalid mobile envelope returns 400, a valid envelope returns 202, and the metric persists in ClickStack.
3. Release the mobile OTA from #570.
