### PR TITLE
feat(observability): attach wallet provider to sign-in lifecycle failures

### DIFF
--- a/frontend/src/components/auth/use-wallet-proof-auth.ts
+++ b/frontend/src/components/auth/use-wallet-proof-auth.ts
@@ -48,6 +48,7 @@ import {
   type LifecycleFlowStage,
   type LifecycleTracker,
   normalizeLifecycleErrorCode,
+  normalizeLifecycleWalletProvider,
 } from "@/features/observability/lifecycle-contract";
 
 const WALLET_CONNECTION_SETTLE_MS = 2500;
@@ -257,15 +258,22 @@ export function useWalletProofAuth({
             ? error.code
             : classifyWalletAdapterError(error)
         );
+      // Connected-wallet verification never sets selectedWalletNameRef, so
+      // fall back to the adapter the hook currently holds.
+      const walletProvider = normalizeLifecycleWalletProvider(
+        selectedWalletNameRef.current ?? wallet?.adapter.name
+      );
       if (nextError.status === "rejected") {
         // Without an explicit stage this is a proof-flow caller, where a
         // rejection is always the signature prompt.
         lifecycleRef.current?.cancel(options?.stage ?? "wallet_approval", {
           errorCode: "wallet_rejected",
+          walletProvider,
         });
       } else {
         lifecycleRef.current?.fail(options?.stage ?? "completion", {
           errorCode,
+          walletProvider,
         });
       }
       dispatch({
@@ -275,7 +283,7 @@ export function useWalletProofAuth({
         details: nextError.details,
       });
     },
-    [endExplicitWalletConnect]
+    [endExplicitWalletConnect, wallet]
   );
 
   const recoverStaleSelectedWallet = useCallback(

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -204,6 +204,47 @@ export const LIFECYCLE_ERROR_DETAILS = [
 ] as const;
 export type LifecycleErrorDetail = (typeof LIFECYCLE_ERROR_DETAILS)[number];
 
+// The wallet adapter behind a sign-in attempt. Wallet-standard adapters
+// register under arbitrary display names the extension controls, so this is a
+// closed token set for the same reason as `LIFECYCLE_ERROR_DETAILS`: known
+// names map to their token, anything else collapses into `other`, and no
+// string a wallet holds can reach the exported attribute.
+export const LIFECYCLE_WALLET_PROVIDERS = [
+  "backpack",
+  "brave_wallet",
+  "coinbase_wallet",
+  "exodus",
+  "glow",
+  "jupiter",
+  "ledger",
+  "loyal",
+  "magic_eden",
+  "metamask",
+  "nightly",
+  "okx_wallet",
+  "other",
+  "phantom",
+  "solflare",
+  "trust",
+] as const;
+export type LifecycleWalletProvider =
+  (typeof LIFECYCLE_WALLET_PROVIDERS)[number];
+
+// Maps an adapter's display name ("Coinbase Wallet", "Magic Eden") onto its
+// token. Unknown non-empty names become `other` — still counted, bounded
+// cardinality — while a missing name stays unset.
+export function normalizeLifecycleWalletProvider(
+  value: unknown
+): LifecycleWalletProvider | undefined {
+  if (typeof value !== "string") return undefined;
+  const token = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_");
+  if (!token) return undefined;
+  return includes(LIFECYCLE_WALLET_PROVIDERS, token) ? token : "other";
+}
+
 export const EXECUTE_NOW_STATES = [
   "requested",
   "selected",
@@ -280,6 +321,7 @@ export type LifecycleDiagnostics = {
   stageCount?: number;
   stageIndex?: number;
   transactionVersion?: (typeof TRANSACTION_VERSIONS)[number];
+  walletProvider?: LifecycleWalletProvider;
 };
 
 export type BrowserLifecycleEnvelope = LifecycleDiagnostics & {
@@ -423,6 +465,7 @@ export function parseBrowserLifecycleEnvelope(
     "stageIndex",
     "timestamp",
     "transactionVersion",
+    "walletProvider",
   ]);
   if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
     throw new InvalidLifecycleEnvelopeError();
@@ -480,6 +523,15 @@ export function parseBrowserLifecycleEnvelope(
 
   assertOptionalEnum(record.errorCode, LIFECYCLE_ERROR_CODES);
   const errorDetail = normalizeErrorDetail(record.errorDetail);
+  // Exact-token match only: at the ingest boundary an unrecognized value is
+  // dropped, never bucketed into `other` — mapping display names onto tokens
+  // is the emitter's job via normalizeLifecycleWalletProvider.
+  const walletProvider = includes(
+    LIFECYCLE_WALLET_PROVIDERS,
+    record.walletProvider
+  )
+    ? record.walletProvider
+    : undefined;
   assertOptionalEnum(record.executeNowState, EXECUTE_NOW_STATES);
   assertOptionalEnum(record.authProofKind, PROOF_KINDS);
   assertOptionalEnum(record.executionMode, EXECUTION_MODES);
@@ -599,9 +651,14 @@ export function parseBrowserLifecycleEnvelope(
     }
   }
 
-  // `errorDetail` always overwrites the raw value; undefined when it was
-  // absent or normalized away, which downstream treats as "not set".
-  return { ...record, pathname, errorDetail } as BrowserLifecycleEnvelope;
+  // `errorDetail`/`walletProvider` always overwrite the raw value; undefined
+  // when absent or normalized away, which downstream treats as "not set".
+  return {
+    ...record,
+    pathname,
+    errorDetail,
+    walletProvider,
+  } as BrowserLifecycleEnvelope;
 }
 
 const WALLET_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;

--- a/frontend/src/features/observability/lifecycle-wallet-provider.test.ts
+++ b/frontend/src/features/observability/lifecycle-wallet-provider.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeLifecycleWalletProvider,
+  parseBrowserLifecycleEnvelope,
+} from "./lifecycle-contract";
+
+// `walletProvider` names the wallet adapter behind a sign-in attempt. Same
+// invariants as `errorDetail`: a closed token set so no adapter-controlled
+// string reaches the exported attribute, and drop-not-reject at the ingest
+// boundary so a bad annotation never costs the event it describes.
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    durationMs: 10,
+    elapsedMs: 10,
+    errorCode: "wallet_signing_failed",
+    flowId: "6f9619ff-8b86-4d01-b42d-00cf4fc964ff",
+    flowName: "auth.sign_in",
+    flowVariant: "interactive",
+    outcome: "failed",
+    pathname: "/app",
+    runtime: "browser",
+    source: "browser",
+    stage: "completion",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("normalizeLifecycleWalletProvider", () => {
+  test("maps adapter display names to tokens", () => {
+    const cases = [
+      // The Loyal extension's own wallet-standard registration name
+      // (extension/entrypoints/loyal-wallet-provider.content.ts).
+      ["Loyal", "loyal"],
+      ["Phantom", "phantom"],
+      ["Coinbase Wallet", "coinbase_wallet"],
+      ["Magic Eden", "magic_eden"],
+      ["OKX Wallet", "okx_wallet"],
+    ] as const;
+    for (const [name, token] of cases) {
+      expect(normalizeLifecycleWalletProvider(name)).toBe(token);
+    }
+  });
+
+  test("collapses unknown adapter names into other", () => {
+    expect(normalizeLifecycleWalletProvider("SuperWallet 3000")).toBe("other");
+  });
+
+  test.each([
+    ["a non-string value", 42],
+    ["null", null],
+    ["undefined", undefined],
+    ["a blank name", "  "],
+  ])("leaves %s unset", (_label, value) => {
+    expect(normalizeLifecycleWalletProvider(value)).toBeUndefined();
+  });
+});
+
+describe("lifecycle walletProvider", () => {
+  test("is accepted on the envelope", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ walletProvider: "phantom" })
+    );
+
+    expect(parsed.walletProvider).toBe("phantom");
+    expect(parsed.errorCode).toBe("wallet_signing_failed");
+  });
+
+  // The boundary never buckets into `other` — an arbitrary forged string is
+  // dropped, since mapping display names onto tokens is the emitter's job.
+  test.each([
+    ["a raw adapter name", "Coinbase Wallet"],
+    ["a wallet address", "BGtzTW2yczjR7FCpSvKfcjxCw811Rdori8aY96ZJdQ51"],
+    ["a non-string value", 42],
+  ])("drops %s without failing the envelope", (_label, walletProvider) => {
+    const parsed = parseBrowserLifecycleEnvelope(envelope({ walletProvider }));
+
+    expect(parsed.walletProvider).toBeUndefined();
+    expect(parsed.errorCode).toBe("wallet_signing_failed");
+  });
+
+  test("is optional", () => {
+    expect(
+      parseBrowserLifecycleEnvelope(envelope()).walletProvider
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -162,6 +162,7 @@ export function buildOtlpLifecyclePayload(
 
   const strings: Array<[string, string | undefined]> = [
     ["loyal.wallet.address", event.walletAddress],
+    ["loyal.wallet.provider", event.walletProvider],
     ["loyal.error.code", event.errorCode],
     ["loyal.error.detail", event.errorDetail],
     ["loyal.execute_now.state", event.executeNowState],


### PR DESCRIPTION
Failed and cancelled auth.sign_in lifecycle events now carry a `loyal.wallet.provider` attribute so alerts like `wallet_signing_failed` name the wallet adapter involved. Provider names are a closed token set (unknown wallets collapse into `other`, raw adapter strings are dropped at the ingest boundary), including our own extension's `Loyal` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)