### PR TITLE
fix(earn): use wallet confirmation slot for autodeposit and extend slot probe budget

### DIFF
--- a/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -109,6 +109,7 @@ import {
   EARN_DEPOSIT_CONFIRMED_BUT_NOT_RECORDED_MESSAGE,
   EARN_DEPOSIT_POLICY_CONFIRMED_BUT_NOT_RECORDED_MESSAGE,
   getEarnDepositUserErrorMessage,
+  isConfirmedSlotUnavailableError,
   prepareEarnCleanupOnServer,
   type SmartAccountSidebarData,
 } from "@/hooks/use-smart-account-sidebar-data";
@@ -2294,6 +2295,14 @@ export function useEarnActions(deps: {
         );
         if (isWalletCancellation(error)) {
           tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
+        } else if (isConfirmedSlotUnavailableError(error)) {
+          // The transaction landed; only the slot probe timed out. Name the
+          // real stage so alerts don't read as backend persistence failures.
+          tracker.fail("slot_resolve", {
+            chainState: "confirmed",
+            errorCode: "slot_resolution_failed",
+          });
+          earnToast.error("Couldn't save Autodeposit");
         } else {
           tracker.fail("backend_confirm", { errorCode: "unexpected_error" });
           earnToast.error("Couldn't save Autodeposit");

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -115,6 +115,7 @@ export const LIFECYCLE_STAGES = {
     "wallet_approval",
     "create_policy",
     "create_recurring_delegation",
+    "slot_resolve",
     "backend_confirm",
     "bootstrap",
     "ui_commit",

--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -2594,8 +2594,25 @@ function createWalletAdapterBridge(
   };
 }
 
-const CONFIRMED_SIGNATURE_SLOT_ATTEMPTS = 10;
+// Status probes can lag a confirmation by tens of seconds on a busy RPC
+// indexer (a 51s slot_resolve was observed in prod on 2026-08-04), so the
+// backoff budget must run to ~40s — the old 10×350ms gave up at ~3.5s and
+// failed setups whose transaction had already landed (ASK-2005).
+const CONFIRMED_SIGNATURE_SLOT_ATTEMPTS = 12;
 const CONFIRMED_SIGNATURE_SLOT_RETRY_MS = 350;
+const CONFIRMED_SIGNATURE_SLOT_RETRY_MAX_MS = 5000;
+
+const CONFIRMED_SLOT_UNAVAILABLE_MESSAGE =
+  "Confirmed transaction slot is unavailable";
+
+// True when the transaction landed but the RPC never surfaced its slot within
+// the polling budget — chain state is fine, only recording fell behind.
+export function isConfirmedSlotUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(CONFIRMED_SLOT_UNAVAILABLE_MESSAGE)
+  );
+}
 
 function waitForConfirmedSignatureSlotRetry(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -2639,13 +2656,16 @@ async function resolveConfirmedSignatureSlot(args: {
 
     if (attempt < CONFIRMED_SIGNATURE_SLOT_ATTEMPTS - 1) {
       await waitForConfirmedSignatureSlotRetry(
-        CONFIRMED_SIGNATURE_SLOT_RETRY_MS
+        Math.min(
+          CONFIRMED_SIGNATURE_SLOT_RETRY_MS * 2 ** attempt,
+          CONFIRMED_SIGNATURE_SLOT_RETRY_MAX_MS
+        )
       );
     }
   }
 
   throw new Error(
-    `Confirmed transaction slot is unavailable${
+    `${CONFIRMED_SLOT_UNAVAILABLE_MESSAGE}${
       lastStatus ? ` (${lastStatus})` : ""
     }.`
   );
@@ -7131,7 +7151,7 @@ export function useSmartAccountSidebarData(
                     recurringDelegationSent = true;
                   }
                 },
-                onTransactionConfirmed: async ({ index, signature }) => {
+                onTransactionConfirmed: async ({ index, signature, slot }) => {
                   const confirmedSetup = batchPreparedSetups[index];
                   if (!confirmedSetup) {
                     throw new Error(
@@ -7139,10 +7159,13 @@ export function useSmartAccountSidebarData(
                     );
                   }
 
-                  const confirmedSlot = await resolveConfirmedSignatureSlot({
-                    connection,
-                    signature,
-                  });
+                  const confirmedSlot =
+                    slot === undefined
+                      ? await resolveConfirmedSignatureSlot({
+                          connection,
+                          signature,
+                        })
+                      : String(slot);
                   try {
                     const response = await postConfirmedEarnAutodepositSetup({
                       observabilityFlowId: request.observabilityFlowId,
@@ -7258,6 +7281,7 @@ export function useSmartAccountSidebarData(
           return { success: false, error: nativeSolError };
         }
 
+        let walletConfirmedSlot: string | null = null;
         const setupSend = await sendPreparedEarnWithClusterPreflight({
           expectedCluster: expectedEarnCluster,
           operation: "autodeposit setup",
@@ -7268,16 +7292,23 @@ export function useSmartAccountSidebarData(
               wallet: walletBridge,
               prepared: preparedSetup.prepared,
               confirm: true,
+              onTransactionConfirmed: ({ slot }) => {
+                walletConfirmedSlot = slot === undefined ? null : String(slot);
+              },
               onTransactionSent: request.onWalletSubmitted,
             }),
         });
         if (!setupSend.success) {
           return setupSend;
         }
-        const confirmedSlot = await resolveConfirmedSignatureSlot({
-          connection,
-          signature: setupSend.signature,
-        });
+        // The confirmation already carries the slot; the status-probe
+        // fallback only runs when the transport did not report one.
+        const confirmedSlot =
+          walletConfirmedSlot ??
+          (await resolveConfirmedSignatureSlot({
+            connection,
+            signature: setupSend.signature,
+          }));
         let confirmResponse: EarnAutodepositSetupConfirmResponse;
         try {
           confirmResponse = await postConfirmedEarnAutodepositSetup({

--- a/packages/smart-account-vaults/src/types.ts
+++ b/packages/smart-account-vaults/src/types.ts
@@ -207,6 +207,15 @@ export type SendPreparedWithWalletArgs = {
     prepared: PreparedLoyalSmartAccountsOperation<string>;
     signature: string;
   }) => Promise<void> | void;
+  // Fires after the transaction's confirmation resolves. `slot` is the
+  // confirmation context's slot when the transport reported one — callers can
+  // use it instead of re-deriving the slot from a status probe, which can lag
+  // the confirmation by tens of seconds on a busy RPC indexer.
+  onTransactionConfirmed?: (args: {
+    prepared: PreparedLoyalSmartAccountsOperation<string>;
+    signature: string;
+    slot?: number;
+  }) => Promise<void> | void;
 };
 
 export type SendPreparedBatchWithWalletArgs = {
@@ -220,6 +229,9 @@ export type SendPreparedBatchWithWalletArgs = {
     index: number;
     prepared: PreparedLoyalSmartAccountsOperation<string>;
     signature: string;
+    // Confirmation-context slot when the transport reported one; see
+    // SendPreparedWithWalletArgs["onTransactionConfirmed"].
+    slot?: number;
   }) => Promise<void> | void;
   onTransactionSent?: (args: {
     index: number;

--- a/packages/smart-account-vaults/src/wallet.ts
+++ b/packages/smart-account-vaults/src/wallet.ts
@@ -269,12 +269,15 @@ async function sendVersionedTransaction(args: {
   });
 }
 
+// Resolves with the confirmation's slot when the transport reported one —
+// the slot is authoritative here, while status probes can lag the
+// confirmation on a busy RPC indexer.
 async function confirmSubmittedTransaction(args: {
   blockhash: string;
   connection: PreparedConnection;
   lastValidBlockHeight: number;
   signature: string;
-}): Promise<void> {
+}): Promise<number | undefined> {
   try {
     const confirmation = await args.connection.confirmTransaction(
       {
@@ -292,7 +295,7 @@ async function confirmSubmittedTransaction(args: {
         )}`
       );
     }
-    return;
+    return confirmation.context.slot;
   } catch (confirmationError) {
     // Confirmation transports can time out after a transaction has landed.
     // Reconcile the returned signature before reporting failure; callers must
@@ -312,7 +315,7 @@ async function confirmSubmittedTransaction(args: {
         status?.confirmationStatus === "confirmed" ||
         status?.confirmationStatus === "finalized"
       ) {
-        return;
+        return status.slot;
       }
     } catch (statusError) {
       if (
@@ -342,6 +345,7 @@ export async function sendPreparedWithWallet({
   wallet,
   prepared,
   confirm = "if-required",
+  onTransactionConfirmed,
   onTransactionSent,
   sendOptions,
 }: SendPreparedWithWalletArgs): Promise<string> {
@@ -371,12 +375,13 @@ export async function sendPreparedWithWallet({
     confirm === true || (confirm !== false && prepared.requiresConfirmation);
 
   if (shouldConfirm) {
-    await confirmSubmittedTransaction({
+    const slot = await confirmSubmittedTransaction({
       blockhash: latestBlockhash.blockhash,
       connection,
       lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
       signature,
     });
+    await onTransactionConfirmed?.({ prepared, signature, slot });
   }
 
   return signature;
@@ -487,8 +492,9 @@ export async function sendPreparedBatchWithWallet({
 
     const confirmationResults = await Promise.allSettled(
       sentTransactions.map(async (sent) => {
+        let slot: number | undefined;
         if (sent.shouldConfirm) {
-          await confirmSubmittedTransaction({
+          slot = await confirmSubmittedTransaction({
             blockhash: latestBlockhash.blockhash,
             connection,
             lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
@@ -500,6 +506,7 @@ export async function sendPreparedBatchWithWallet({
           index: sent.index,
           prepared: sent.operation,
           signature: sent.signature,
+          slot,
         });
       })
     );
@@ -547,8 +554,9 @@ export async function sendPreparedBatchWithWallet({
     const shouldConfirm =
       confirm === true || (confirm !== false && operation.requiresConfirmation);
 
+    let slot: number | undefined;
     if (shouldConfirm) {
-      await confirmSubmittedTransaction({
+      slot = await confirmSubmittedTransaction({
         blockhash: latestBlockhash.blockhash,
         connection,
         lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
@@ -560,6 +568,7 @@ export async function sendPreparedBatchWithWallet({
       index,
       prepared: operation,
       signature,
+      slot,
     });
   }
 


### PR DESCRIPTION
Fixes ASK-2005: Autodeposit setup failed after its transaction had already landed because the confirmed-slot probe gave up after ~3.5s while the RPC indexer lagged (observed up to 51s in prod). The confirmation transport already knows the slot, so sendPreparedWithWallet/sendPreparedBatchWithWallet now report it via onTransactionConfirmed and the autodeposit paths use it directly, with the status probe (now ~40s exponential backoff) as fallback; slot-probe timeouts are reported as slot_resolve/slot_resolution_failed instead of backend_confirm/unexpected_error.