### PR TITLE
fix(earn): refresh activity on failed sweeps and label executor failure codes

### DIFF
--- a/frontend/src/app/api/smart-accounts/yield-optimization/realtime/token/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/realtime/token/route.ts
@@ -42,6 +42,10 @@ export async function POST(request: Request) {
     const serverEnv = getServerEnv();
     const authSecret = serverEnv.earnRealtime.authSecret;
     if (!authSecret) {
+      console.error("[earn-realtime-token] REALTIME_AUTH_SECRET is not set", {
+        settingsPda: principal.settingsPda,
+        walletAddress: principal.walletAddress,
+      });
       return jsonError(
         503,
         "realtime_unavailable",

--- a/frontend/src/features/earn-realtime/invalidation.test.ts
+++ b/frontend/src/features/earn-realtime/invalidation.test.ts
@@ -30,6 +30,22 @@ describe("Earn realtime targeted invalidation", () => {
     });
   });
 
+  test("refreshes activity and position for failed executions (partial pulls)", () => {
+    expect(
+      resolveEarnRealtimeRefreshPlan([
+        {
+          eventType: EARN_REALTIME_EVENT_TYPES.autodeposit,
+          state: "failed",
+        },
+      ])
+    ).toEqual({
+      earnings: false,
+      earnState: true,
+      position: true,
+      transactions: true,
+    });
+  });
+
   test("coalesces mixed events into one targeted refresh plan", () => {
     expect(
       resolveEarnRealtimeRefreshPlan([

--- a/frontend/src/features/earn-realtime/invalidation.ts
+++ b/frontend/src/features/earn-realtime/invalidation.ts
@@ -30,11 +30,14 @@ export function resolveEarnRealtimeRefreshPlan(
         plan.position = true;
         plan.transactions = true;
         plan.earnings = true;
-      } else if (
-        event.state === "failed" ||
-        event.state === "released" ||
-        event.state === "canceled"
-      ) {
+      } else if (event.state === "failed") {
+        // Failed executions can be partial (pull tx landed, top-up blocked),
+        // and the fallback poll may have skipped the intermediate
+        // pull_confirmed state, so refresh transactions and position too.
+        plan.earnState = true;
+        plan.position = true;
+        plan.transactions = true;
+      } else if (event.state === "released" || event.state === "canceled") {
         plan.earnState = true;
       }
     } else if (event.eventType === EARN_REALTIME_EVENT_TYPES.allowance) {

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -187,6 +187,11 @@ export const LIFECYCLE_ERROR_CODES = [
   "no_scheduled_sweeps",
   "request_failed",
   "progress_read_failed",
+  // Terminal sweep failure codes forwarded from the yield backend's bounded
+  // completion_failure_code set. Codes outside this union still collapse to
+  // `unexpected_error` via `normalizeLifecycleErrorCode`.
+  "execution_failed",
+  "kamino_top_up_failed",
   "autodeposit_target_closed",
   "unconfirmed_signature",
   "metadata_mismatch",


### PR DESCRIPTION
Failed autodeposit executions now refresh transactions and position (failures can be partial — the pull tx lands even when the Kamino top-up is blocked), and the known executor failure codes (execution_failed, kamino_top_up_failed) pass through to lifecycle telemetry instead of collapsing to unexpected_error. Also logs when the realtime token route 503s due to missing REALTIME_AUTH_SECRET, which was silently disabling SSE. ASK-2007.