### PR TITLE
fix(cherry): preserve registered Mini App URL

### DIFF
--- a/docs/integrations/cherry-miniapp.md
+++ b/docs/integrations/cherry-miniapp.md
@@ -156,12 +156,12 @@ submitted, a timeout is unresolved and must reconcile before retry.
 
 ## Runtime configuration
 
-| Variable                  | Required | Purpose                                                                                                                     |
-| ------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `CHERRY_MINIAPP_ID`       | Yes      | Expected `app_id` in Cherry launch tokens.                                                                                  |
-| `CHERRY_MINIAPP_ORIGIN`   | Yes      | Exact registered Loyal origin: `https://askloyal.com`. Paths are removed before the SDK compares the signed `origin` claim. |
-| `CHERRY_MINIAPP_ISSUER`   | No       | Defaults to `https://chat.cherry.fun`.                                                                                      |
-| `CHERRY_MINIAPP_JWKS_URL` | No       | Defaults to Cherry's public JWKS endpoint. A local endpoint may be used only by the development harness.                    |
+| Variable                  | Required | Purpose                                                                                                                        |
+| ------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `CHERRY_MINIAPP_ID`       | Yes      | Expected `app_id` in Cherry launch tokens.                                                                                     |
+| `CHERRY_MINIAPP_ORIGIN`   | Yes      | Exact registered Loyal Mini App URL: `https://askloyal.com/app/cherry`. Cherry includes the path in the signed `origin` claim. |
+| `CHERRY_MINIAPP_ISSUER`   | No       | Defaults to `https://chat.cherry.fun`.                                                                                         |
+| `CHERRY_MINIAPP_JWKS_URL` | No       | Defaults to Cherry's public JWKS endpoint. A local endpoint may be used only by the development harness.                       |
 
 The MiniApp ID is public configuration, not a secret. Launch tokens are
 credentials and must never be written to logs, analytics, URLs controlled by
@@ -241,10 +241,10 @@ production build gate; repository rules prohibit a local frontend build.
    <https://chat.cherry.fun>).
 2. Give Cherry the group name and the stable hosted URL
    `https://askloyal.com/app/cherry`.
-3. Receive the staging MiniApp ID, registered exact origin, staging group/test
+3. Receive the staging MiniApp ID, registered exact app URL, staging group/test
    access, and confirmation of issuer/JWKS plus `wallet:connect` permission.
 4. Configure `CHERRY_MINIAPP_ID` and
-   `CHERRY_MINIAPP_ORIGIN=https://askloyal.com` on the deployment; override
+   `CHERRY_MINIAPP_ORIGIN=https://askloyal.com/app/cherry` on the deployment; override
    issuer/JWKS only if Cherry explicitly supplies different values.
 
 ### 3. Fast live ladder — stop at the first failure

--- a/frontend/src/features/cherry/config.test.ts
+++ b/frontend/src/features/cherry/config.test.ts
@@ -10,7 +10,7 @@ describe("createCherryMiniAppConfig", () => {
     });
   });
 
-  test("normalizes the registered app origin and keeps the JWKS path", () => {
+  test("preserves the registered app path and keeps the JWKS path", () => {
     expect(
       createCherryMiniAppConfig({
         CHERRY_MINIAPP_ID: "miniapp_123",
@@ -19,7 +19,7 @@ describe("createCherryMiniAppConfig", () => {
     ).toEqual({
       mode: "enabled",
       appId: "miniapp_123",
-      expectedOrigin: "https://askloyal.com",
+      expectedOrigin: "https://askloyal.com/app/cherry",
       issuer: "https://chat.cherry.fun",
       jwksUrl: "https://chat.cherry.fun/.well-known/jwks.json",
     });
@@ -44,7 +44,7 @@ describe("createCherryMiniAppConfig", () => {
     ).toMatchObject({
       mode: "enabled",
       appId: "miniapp_local",
-      expectedOrigin: "http://127.0.0.1:3000",
+      expectedOrigin: "http://127.0.0.1:3000/app/cherry",
       jwksUrl: "http://localhost:3100/jwks.json?fixture=1",
     });
   });
@@ -65,5 +65,19 @@ describe("createCherryMiniAppConfig", () => {
           "https://chat.cherry.fun/.well-known/jwks.json#ignored",
       })
     ).toThrow("CHERRY_MINIAPP_JWKS_URL must not contain a URL fragment");
+  });
+
+  test("rejects query parameters and fragments in the registered app URL", () => {
+    for (const origin of [
+      "https://askloyal.com/app/cherry?theme=cherry",
+      "https://askloyal.com/app/cherry#embed",
+    ]) {
+      expect(() =>
+        createCherryMiniAppConfig({
+          CHERRY_MINIAPP_ID: "miniapp_123",
+          CHERRY_MINIAPP_ORIGIN: origin,
+        })
+      ).toThrow("CHERRY_MINIAPP_ORIGIN must not contain a query or fragment");
+    }
   });
 });

--- a/frontend/src/features/cherry/config.ts
+++ b/frontend/src/features/cherry/config.ts
@@ -51,6 +51,16 @@ function normalizeEndpointUrl(value: string, name: string): string {
   return `${normalizedOrigin}${url.pathname}${url.search}`;
 }
 
+function normalizeLaunchUrl(value: string, name: string): string {
+  const normalizedOrigin = normalizeUrl(value, name);
+  const url = new URL(value);
+  if (url.search || url.hash) {
+    throw new Error(`${name} must not contain a query or fragment`);
+  }
+
+  return `${normalizedOrigin}${url.pathname === "/" ? "" : url.pathname}`;
+}
+
 export function createCherryMiniAppConfig(env: EnvSource): CherryMiniAppConfig {
   const appId = env[CHERRY_MINIAPP_ID_ENV_NAME]?.trim();
   const expectedOrigin = env[CHERRY_MINIAPP_ORIGIN_ENV_NAME]?.trim();
@@ -65,7 +75,7 @@ export function createCherryMiniAppConfig(env: EnvSource): CherryMiniAppConfig {
   return {
     mode: "enabled",
     appId,
-    expectedOrigin: normalizeUrl(
+    expectedOrigin: normalizeLaunchUrl(
       expectedOrigin,
       CHERRY_MINIAPP_ORIGIN_ENV_NAME
     ),

--- a/frontend/src/features/cherry/server/sdk-launch-token-contract.test.ts
+++ b/frontend/src/features/cherry/server/sdk-launch-token-contract.test.ts
@@ -1,14 +1,16 @@
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { verifyLaunchToken } from "@cherrydotfun/miniapp-sdk";
 import { exportJWK, generateKeyPair, SignJWT, type JWK } from "jose";
 
+mock.module("server-only", () => ({}));
+
 import type { CherryMiniAppConfig } from "@/features/cherry/config";
 
-import { verifyCherryLaunch } from "./launch-token";
+const { verifyCherryLaunch } = await import("./launch-token");
 
 const JWKS_URL = "https://jwks.cherry-contract.invalid/keys";
 const APP_ID = "miniapp_contract_test";
-const ORIGIN = "https://askloyal.com";
+const ORIGIN = "https://askloyal.com/app/cherry";
 const ISSUER = "https://chat.cherry.fun";
 const originalFetch = globalThis.fetch;
 const config: CherryMiniAppConfig = {


### PR DESCRIPTION
Preserve Cherry's full registered Mini App URL when verifying the signed launch-token origin claim. Update the contract fixture and integration documentation to match the production registration.