### PR TITLE
feat(observability): accept request_failed cause tokens

### DIFF
--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -212,6 +212,12 @@ export type LifecycleErrorCode = (typeof LIFECYCLE_ERROR_CODES)[number];
 // EUNSPECIFIED (the module's catch-all), ERROR_WALLET_NOT_FOUND,
 // ERROR_SESSION_TIMEOUT, ERROR_SESSION_CLOSED, "Timed out waiting for local
 // association to be ready", and "Failed to end session".
+//
+// The rest name what went wrong behind a `request_failed` that carries no
+// `httpStatus` — meaning no response ever arrived, so the status that usually
+// explains a failure is absent. Four unrelated incidents look identical
+// without them: the device is offline, our own client timeout elapsed, Kamino
+// is down, or an RPC answered with an error (ASK-2018).
 export const LIFECYCLE_ERROR_DETAILS = [
   "mwa_unspecified",
   "mwa_wallet_not_found",
@@ -219,6 +225,16 @@ export const LIFECYCLE_ERROR_DETAILS = [
   "mwa_association_timeout",
   "mwa_session_closed",
   "mwa_end_session_failed",
+  // Connection-level fetch failure: DNS, TLS or a reset socket. React Native
+  // surfaces all of them as a bare TypeError("Network request failed").
+  "network_unreachable",
+  // One of our own client deadlines elapsed, not the server's.
+  "request_timeout",
+  // Kamino answered 5xx/429 and kept doing so until the retries ran out. An
+  // upstream incident, not anything wrong on the device.
+  "kamino_upstream_unavailable",
+  // A Solana JSON-RPC call returned an error object rather than a result.
+  "rpc_request_failed",
 ] as const;
 export type LifecycleErrorDetail = (typeof LIFECYCLE_ERROR_DETAILS)[number];
 

--- a/frontend/src/features/observability/lifecycle-error-detail.test.ts
+++ b/frontend/src/features/observability/lifecycle-error-detail.test.ts
@@ -88,4 +88,22 @@ describe("lifecycle errorDetail", () => {
   test("is optional", () => {
     expect(parseBrowserLifecycleEnvelope(envelope()).errorDetail).toBeUndefined();
   });
+
+  // A `request_failed` with no `httpStatus` never got a response, so the status
+  // that would normally explain it is absent. These tokens are the only thing
+  // separating "the device is offline" from "Kamino is down" (ASK-2018).
+  test.each([
+    ["network_unreachable"],
+    ["request_timeout"],
+    ["kamino_upstream_unavailable"],
+    ["rpc_request_failed"],
+  ])("carries %s on a statusless request_failed", (errorDetail) => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorCode: "request_failed", errorDetail })
+    );
+
+    expect(parsed.errorDetail).toBe(errorDetail);
+    expect(parsed.errorCode).toBe("request_failed");
+    expect(parsed.httpStatus).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Extends the lifecycle `errorDetail` vocabulary with four tokens naming why a `request_failed` happened, since one that carries no `httpStatus` never got a response and four unrelated incidents currently look identical.

Ships before the mobile emitter (ASK-2018) — an unrecognized detail is dropped silently, so the field is lost until the ingest knows these tokens.