### PR TITLE
fix(mobile): name the cause behind a request_failed withdrawal

### DIFF
--- a/mobile/src/lib/network/connection-failure.ts
+++ b/mobile/src/lib/network/connection-failure.ts
@@ -3,9 +3,20 @@
 // `@/services/observability` would pull the storage/native-module graph into
 // `lib/solana/earn/connection-retry` and break its test suite.
 
+// The two — and only two — TypeErrors RN's fetch rejects with for a
+// connection-level failure, from the whatwg-fetch polyfill's `xhr.onerror` and
+// `xhr.ontimeout` handlers. `xhr.onabort` rejects with a DOMException instead,
+// which `fetchWithTimeout` already turns into a FetchTimeoutError.
+//
+// Matching both matters: keying on "failed" alone would classify every stalled
+// request as a bug in our own code and route it to the sanitized error ingest,
+// which is exactly the flood that ingest is kept clear of.
+const CONNECTION_FAILED = /network request failed/i;
+const CONNECTION_TIMED_OUT = /network request timed out/i;
+
 /**
  * Whether an error is a connection-level fetch failure — DNS, TLS, a reset
- * socket — which React Native surfaces as TypeError("Network request failed").
+ * socket, or a stalled request.
  *
  * The message is matched, not just the type, and that is the whole point: the
  * code paths this guards also run our own transaction-building, where a
@@ -13,7 +24,14 @@
  * on-call looking at connectivity while the real fault sits in our code.
  */
 export function isConnectionFailure(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
   return (
-    error instanceof TypeError && /network request failed/i.test(error.message)
+    CONNECTION_FAILED.test(error.message) ||
+    CONNECTION_TIMED_OUT.test(error.message)
   );
+}
+
+/** The stalled-request half of {@link isConnectionFailure}. */
+export function isConnectionTimeout(error: unknown): boolean {
+  return error instanceof TypeError && CONNECTION_TIMED_OUT.test(error.message);
 }

--- a/mobile/src/lib/network/connection-failure.ts
+++ b/mobile/src/lib/network/connection-failure.ts
@@ -1,0 +1,19 @@
+// Lives in this dependency-free leaf so both the retry helper and the
+// telemetry classifier can share one definition: a value import from
+// `@/services/observability` would pull the storage/native-module graph into
+// `lib/solana/earn/connection-retry` and break its test suite.
+
+/**
+ * Whether an error is a connection-level fetch failure — DNS, TLS, a reset
+ * socket — which React Native surfaces as TypeError("Network request failed").
+ *
+ * The message is matched, not just the type, and that is the whole point: the
+ * code paths this guards also run our own transaction-building, where a
+ * TypeError means a bug in it. Calling that an unreachable network would send
+ * on-call looking at connectivity while the real fault sits in our code.
+ */
+export function isConnectionFailure(error: unknown): boolean {
+  return (
+    error instanceof TypeError && /network request failed/i.test(error.message)
+  );
+}

--- a/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
+++ b/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
@@ -181,4 +181,24 @@ describe("withConnectionRetry", () => {
     // Still no backend code or status: nothing ever answered.
     expect((error as MockEarnApiError).code).toBeUndefined();
   });
+
+  // This helper wraps whole SDK prepare calls, so a TypeError reaching it is
+  // just as likely a bug in our own transaction building as a dead socket.
+  // Retrying one is harmless; calling it a network failure would point on-call
+  // at connectivity while the real fault sits in our code.
+  test("leaves a TypeError that is really a bug unexplained", async () => {
+    const run = jest
+      .fn()
+      .mockRejectedValue(new TypeError("undefined is not a function"));
+
+    const error = await runWithTimers(
+      withConnectionRetry("device prepare", EXHAUSTED, run).then(
+        () => null,
+        (thrown: unknown) => thrown,
+      ),
+    );
+
+    expect((error as MockEarnApiError).detail).toBeUndefined();
+    expect((error as MockEarnApiError).message).toBe(EXHAUSTED);
+  });
 });

--- a/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
+++ b/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
@@ -16,11 +16,13 @@ class MockKaminoUpstreamError extends Error {
 // Jest does not transform.
 class MockEarnApiError extends Error {
   readonly code?: string;
+  readonly detail?: string;
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, code?: string, detail?: string) {
     super(message);
     this.name = "EarnApiError";
     this.code = code;
+    this.detail = detail;
   }
 }
 
@@ -34,6 +36,8 @@ jest.mock(
 
 jest.mock("../earn-api", () => ({
   EarnApiError: MockEarnApiError,
+  earnNetworkError: (message: string, detail?: string) =>
+    new MockEarnApiError(message, undefined, detail),
 }));
 
 // Keep the subject import after mock initialization: this test uses a virtual
@@ -147,5 +151,34 @@ describe("withConnectionRetry", () => {
       runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
     ).rejects.toThrow(EXHAUSTED);
     expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  // The exhausted error replaces the one it was retrying, so without a carried
+  // detail every giving-up looks identical in telemetry — an unexplained
+  // `request_failed` with no httpStatus (ASK-2018).
+  test.each([
+    [
+      "a Kamino outage",
+      () => new MockKaminoUpstreamError(503, "unavailable"),
+      "kamino_upstream_unavailable",
+    ],
+    [
+      "a dead connection",
+      () => new TypeError("Network request failed"),
+      "network_unreachable",
+    ],
+  ])("names %s on the exhausted error", async (_label, makeError, detail) => {
+    const run = jest.fn().mockRejectedValue(makeError());
+
+    const error = await runWithTimers(
+      withConnectionRetry("device prepare", EXHAUSTED, run).then(
+        () => null,
+        (thrown: unknown) => thrown,
+      ),
+    );
+
+    expect((error as MockEarnApiError).detail).toBe(detail);
+    // Still no backend code or status: nothing ever answered.
+    expect((error as MockEarnApiError).code).toBeUndefined();
   });
 });

--- a/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
+++ b/mobile/src/lib/solana/earn/__tests__/connection-retry.test.ts
@@ -109,10 +109,16 @@ describe("withConnectionRetry", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  test("still retries RN connection-level TypeErrors", async () => {
+  // Both messages whatwg-fetch rejects with for a connection-level failure —
+  // `xhr.onerror` and `xhr.ontimeout`. Retrying only the first would strand
+  // every stalled request on its first attempt.
+  test.each([
+    ["a dead socket", "Network request failed"],
+    ["a stalled request", "Network request timed out"],
+  ])("still retries RN's TypeError for %s", async (_label, message) => {
     const run = jest
       .fn()
-      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockRejectedValueOnce(new TypeError(message))
       .mockResolvedValueOnce("prepared");
 
     await expect(
@@ -184,21 +190,17 @@ describe("withConnectionRetry", () => {
 
   // This helper wraps whole SDK prepare calls, so a TypeError reaching it is
   // just as likely a bug in our own transaction building as a dead socket.
-  // Retrying one is harmless; calling it a network failure would point on-call
-  // at connectivity while the real fault sits in our code.
-  test("leaves a TypeError that is really a bug unexplained", async () => {
-    const run = jest
-      .fn()
-      .mockRejectedValue(new TypeError("undefined is not a function"));
+  // Retrying one wasted the budget and then replaced it with a "check your
+  // connection" EarnApiError — telling the user, and on-call, the wrong thing
+  // while the real fault sat in our code (ASK-2018).
+  test("throws a TypeError that is really a bug through untouched", async () => {
+    const error = new TypeError("undefined is not a function");
+    const run = jest.fn().mockRejectedValue(error);
 
-    const error = await runWithTimers(
-      withConnectionRetry("device prepare", EXHAUSTED, run).then(
-        () => null,
-        (thrown: unknown) => thrown,
-      ),
-    );
-
-    expect((error as MockEarnApiError).detail).toBeUndefined();
-    expect((error as MockEarnApiError).message).toBe(EXHAUSTED);
+    await expect(
+      runWithTimers(withConnectionRetry("device prepare", EXHAUSTED, run)),
+    ).rejects.toBe(error);
+    // Not retried, and never rewritten into a network-worded message.
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/lib/solana/earn/connection-retry.ts
+++ b/mobile/src/lib/solana/earn/connection-retry.ts
@@ -1,5 +1,6 @@
 import { KaminoUpstreamError } from "@loyal-labs/smart-account-vaults";
 
+import { isConnectionFailure } from "@/lib/network/connection-failure";
 // Type-only: a value import from `@/services/observability` would pull the
 // storage/native-module graph into this leaf and break its test suite.
 import type { LifecycleErrorDetail } from "@/services/observability";
@@ -54,15 +55,17 @@ function isRetryableNetworkError(error: unknown): error is Error {
 // indistinguishable from a phone with no signal (ASK-2018). Kamino is checked
 // here rather than in the shared classifier because the retryable-status rule
 // lives in this file.
-// Only the two shapes `isRetryableNetworkError` accepts can reach here, since
-// nothing else is ever retried — so this covers every exhausted error.
+//
+// `isConnectionFailure` rather than a bare `instanceof TypeError`: this helper
+// wraps whole SDK prepare calls, not just fetches, so a TypeError reaching it
+// may well be a bug in our own transaction building. Retrying one is harmless,
+// but reporting it as an unreachable network would point on-call at
+// connectivity while the real fault sits in our code. Those stay unnamed.
 function exhaustedErrorDetail(
   lastError: unknown,
 ): LifecycleErrorDetail | undefined {
   if (isKaminoUpstreamError(lastError)) return "kamino_upstream_unavailable";
-  // A TypeError is why this loop retried at all: per `isRetryableNetworkError`
-  // above, fetch rejects with one only for connection-level failures.
-  if (lastError instanceof TypeError) return "network_unreachable";
+  if (isConnectionFailure(lastError)) return "network_unreachable";
   return undefined;
 }
 

--- a/mobile/src/lib/solana/earn/connection-retry.ts
+++ b/mobile/src/lib/solana/earn/connection-retry.ts
@@ -1,6 +1,10 @@
 import { KaminoUpstreamError } from "@loyal-labs/smart-account-vaults";
 
-import { EarnApiError } from "./earn-api";
+// Type-only: a value import from `@/services/observability` would pull the
+// storage/native-module graph into this leaf and break its test suite.
+import type { LifecycleErrorDetail } from "@/services/observability";
+
+import { earnNetworkError } from "./earn-api";
 
 // RN surfaces connection-level fetch failures (DNS/TLS/socket reset) as a bare
 // TypeError("Network request failed") — which used to reach the Earn sheets
@@ -45,6 +49,23 @@ function isRetryableNetworkError(error: unknown): error is Error {
   return isKaminoUpstreamError(error) && isRetryableKaminoStatus(error.status);
 }
 
+// The exhausted error replaces whatever we were retrying, so without this the
+// cause is gone by the time telemetry sees it and a Kamino outage is
+// indistinguishable from a phone with no signal (ASK-2018). Kamino is checked
+// here rather than in the shared classifier because the retryable-status rule
+// lives in this file.
+// Only the two shapes `isRetryableNetworkError` accepts can reach here, since
+// nothing else is ever retried — so this covers every exhausted error.
+function exhaustedErrorDetail(
+  lastError: unknown,
+): LifecycleErrorDetail | undefined {
+  if (isKaminoUpstreamError(lastError)) return "kamino_upstream_unavailable";
+  // A TypeError is why this loop retried at all: per `isRetryableNetworkError`
+  // above, fetch rejects with one only for connection-level failures.
+  if (lastError instanceof TypeError) return "network_unreachable";
+  return undefined;
+}
+
 export async function withConnectionRetry<T>(
   label: string,
   exhaustedMessage: string,
@@ -74,5 +95,5 @@ export async function withConnectionRetry<T>(
     errorMessage:
       lastError instanceof Error ? lastError.message : String(lastError),
   });
-  throw new EarnApiError(exhaustedMessage);
+  throw earnNetworkError(exhaustedMessage, exhaustedErrorDetail(lastError));
 }

--- a/mobile/src/lib/solana/earn/connection-retry.ts
+++ b/mobile/src/lib/solana/earn/connection-retry.ts
@@ -1,6 +1,9 @@
 import { KaminoUpstreamError } from "@loyal-labs/smart-account-vaults";
 
-import { isConnectionFailure } from "@/lib/network/connection-failure";
+import {
+  isConnectionFailure,
+  isConnectionTimeout,
+} from "@/lib/network/connection-failure";
 // Type-only: a value import from `@/services/observability` would pull the
 // storage/native-module graph into this leaf and break its test suite.
 import type { LifecycleErrorDetail } from "@/services/observability";
@@ -42,9 +45,13 @@ function isKaminoUpstreamError(
 }
 
 function isRetryableNetworkError(error: unknown): error is Error {
-  // fetch rejects with TypeError only for connection-level failures;
-  // API rejections are EarnApiError and SDK/build errors are plain Error.
-  if (error instanceof TypeError) {
+  // The message is matched, not just the TypeError type. This helper wraps
+  // whole SDK prepare calls, so a TypeError arriving here is as likely a bug
+  // in our own transaction building as a dead socket — and treating one as a
+  // network blip retried it three times, then replaced it with an
+  // `EarnApiError` telling the user to check their connection while the real
+  // fault sat in our code. A bug now throws straight through, message intact.
+  if (isConnectionFailure(error)) {
     return true;
   }
   return isKaminoUpstreamError(error) && isRetryableKaminoStatus(error.status);
@@ -56,15 +63,15 @@ function isRetryableNetworkError(error: unknown): error is Error {
 // here rather than in the shared classifier because the retryable-status rule
 // lives in this file.
 //
-// `isConnectionFailure` rather than a bare `instanceof TypeError`: this helper
-// wraps whole SDK prepare calls, not just fetches, so a TypeError reaching it
-// may well be a bug in our own transaction building. Retrying one is harmless,
-// but reporting it as an unreachable network would point on-call at
-// connectivity while the real fault sits in our code. Those stay unnamed.
+// Only the two shapes `isRetryableNetworkError` accepts can reach here, since
+// nothing else is ever retried — the undefined return is a safe default, not a
+// reachable case.
 function exhaustedErrorDetail(
   lastError: unknown,
 ): LifecycleErrorDetail | undefined {
   if (isKaminoUpstreamError(lastError)) return "kamino_upstream_unavailable";
+  // Checked before the broader failure test, which also covers timeouts.
+  if (isConnectionTimeout(lastError)) return "request_timeout";
   if (isConnectionFailure(lastError)) return "network_unreachable";
   return undefined;
 }

--- a/mobile/src/lib/solana/earn/deposit.ts
+++ b/mobile/src/lib/solana/earn/deposit.ts
@@ -183,6 +183,12 @@ export async function executeEarnDeposit(args: {
   const flow = startLifecycleFlow({
     flowName: "earn.deposit",
     flowVariant: "initial",
+    // Deposit runs the same SDK prepare through the same retry helper as
+    // withdrawal, so a bug surfaces here the same way: as `unexpected_error`,
+    // whose message and stack only reach the sanitized error ingest when this
+    // is set (ASK-2018). Without it the withdrawal twin was diagnosable and
+    // this was not, for no reason beyond which flow the exception landed in.
+    reportUnexpectedErrors: true,
     walletAddress: args.signer.publicKey.toBase58(),
   });
   flow.start("prepare");

--- a/mobile/src/lib/solana/earn/earn-api.ts
+++ b/mobile/src/lib/solana/earn/earn-api.ts
@@ -3,6 +3,7 @@ import {
   fetchWithTimeout,
   FetchTimeoutError,
 } from "@/lib/network/fetch-with-timeout";
+import type { LifecycleErrorDetail } from "@/services/observability";
 
 import type { WirePreparedOperation } from "./wire";
 
@@ -86,13 +87,37 @@ export function earnHeaders(flowId?: string): Record<string, string> {
 export class EarnApiError extends Error {
   readonly code?: string;
   readonly status?: number;
+  /**
+   * Why the request failed, for the throws that carry no `status` and would
+   * otherwise reach telemetry as an unexplained `request_failed` (ASK-2018).
+   * Set at the throw site, which is the only place that still knows.
+   */
+  readonly detail?: LifecycleErrorDetail;
 
-  constructor(message: string, code?: string, status?: number) {
+  constructor(
+    message: string,
+    code?: string,
+    status?: number,
+    detail?: LifecycleErrorDetail,
+  ) {
     super(message);
     this.name = "EarnApiError";
     this.code = code;
     this.status = status;
+    this.detail = detail;
   }
+}
+
+/**
+ * An Earn failure that never got a response — no backend code, no HTTP status,
+ * just a named cause. Spelling out the two undefineds at every call site would
+ * bury the one argument that carries information.
+ */
+export function earnNetworkError(
+  message: string,
+  detail?: LifecycleErrorDetail,
+): EarnApiError {
+  return new EarnApiError(message, undefined, undefined, detail);
 }
 
 async function throwEarnError(res: Response, fallback: string): Promise<never> {
@@ -154,8 +179,9 @@ export async function fetchEarnDepositPrepareContext(args: {
     );
   } catch (error) {
     if (error instanceof FetchTimeoutError) {
-      throw new EarnApiError(
+      throw earnNetworkError(
         "Setting up your Earn account is taking longer than usual. It finishes in the background — try again in a minute.",
+        "request_timeout",
       );
     }
     throw error;
@@ -192,8 +218,9 @@ export async function prepareEarnDeposit(args: {
     );
   } catch (error) {
     if (error instanceof FetchTimeoutError) {
-      throw new EarnApiError(
+      throw earnNetworkError(
         "Setting up your Earn account is taking longer than usual. It finishes in the background — try again in a minute.",
+        "request_timeout",
       );
     }
     throw error;

--- a/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
@@ -40,6 +40,20 @@ function captureEnvelopes(): Envelope[] {
   return sent;
 }
 
+// Keeps the two ingests apart: lifecycle events carry the outcome, the
+// sanitized error ingest carries the message and stack.
+function capturePostsByPath(): { path: string; body: Envelope }[] {
+  const sent: { path: string; body: Envelope }[] = [];
+  global.fetch = jest.fn(async (url: unknown, init: unknown) => {
+    sent.push({
+      body: JSON.parse((init as { body: string }).body) as Envelope,
+      path: String(url),
+    });
+    return { ok: true, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return sent;
+}
+
 function newFlow() {
   return startLifecycleFlow({
     flowName: "earn.withdrawal",
@@ -190,6 +204,31 @@ describe("errorDetail on the wire", () => {
     expect(sent.find((event) => event.outcome === "failed")?.errorDetail).toBe(
       "request_timeout",
     );
+  });
+
+  // Classifying a bug as `unexpected_error` only helps if the flow forwards it
+  // to the sanitized ingest — that is where the message and stack live.
+  // `request_failed` is deliberately excluded from that ingest, so a bug
+  // misfiled under it was invisible no matter which flow raised it (ASK-2018).
+  test.each([
+    ["reports it when the flow opted in", true, 1],
+    ["stays silent when it did not", false, 0],
+  ])("%s", (_label, reportUnexpectedErrors, expectedReports) => {
+    const posts = capturePostsByPath();
+
+    startLifecycleFlow({
+      flowName: "earn.deposit",
+      flowVariant: "initial",
+      reportUnexpectedErrors,
+    }).failFrom("prepare", new TypeError("undefined is not a function"));
+
+    expect(
+      posts.filter((post) => post.path.includes("/mobile/errors")),
+    ).toHaveLength(expectedReports);
+    // The lifecycle event is emitted either way.
+    expect(
+      posts.filter((post) => post.path.includes("/mobile/events")),
+    ).not.toHaveLength(0);
   });
 
   // A declined prompt is a user decision, not a failure with a cause to name.

--- a/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
@@ -1,0 +1,173 @@
+// Guards the cause token behind `request_failed` (ASK-2018). That code covers
+// four unrelated incidents — the device is offline, our own deadline elapsed,
+// Kamino is down, an RPC answered with an error — and when no response ever
+// arrived there is no `httpStatus` to tell them apart. Nothing in the type
+// system catches a regression, so the emitted envelope is asserted directly.
+//
+// Every token here must also exist in the backend's LIFECYCLE_ERROR_DETAILS
+// (frontend/src/features/observability/lifecycle-contract.ts). The ingest
+// drops an unknown detail silently, so a drift costs the field with no error.
+
+import { WalletRejectedError } from "@/lib/wallet/rejection";
+import {
+  mapLifecycleErrorDetail,
+  startLifecycleFlow,
+} from "../observability";
+
+// Hoisted above the imports by babel-plugin-jest-hoist.
+jest.mock("expo-updates", () => ({
+  channel: "production",
+  runtimeVersion: "1.0.0",
+  updateId: undefined,
+}));
+jest.mock("@/config/env", () => ({
+  env: { earnApiBaseUrl: "https://example.test" },
+}));
+
+type Envelope = {
+  outcome: string;
+  errorCode?: string;
+  errorDetail?: string;
+  httpStatus?: number;
+};
+
+function captureEnvelopes(): Envelope[] {
+  const sent: Envelope[] = [];
+  global.fetch = jest.fn(async (_url: unknown, init: unknown) => {
+    sent.push(JSON.parse((init as { body: string }).body) as Envelope);
+    return { ok: true, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return sent;
+}
+
+function newFlow() {
+  return startLifecycleFlow({
+    flowName: "earn.withdrawal",
+    flowVariant: "full",
+  });
+}
+
+class FetchTimeoutError extends Error {
+  constructor() {
+    super("Fetch to https://example.test timed out after 12000ms");
+    this.name = "FetchTimeoutError";
+  }
+}
+
+// web3.js resolves to more than one module instance under Metro, so the real
+// class is brand-checked by name rather than `instanceof` — mirror that here.
+class SolanaJSONRPCError extends Error {
+  readonly code: number;
+
+  constructor(code: number) {
+    super("failed to get account info");
+    this.name = "SolanaJSONRPCError";
+    this.code = code;
+  }
+}
+
+describe("mapLifecycleErrorDetail", () => {
+  test("reads a detail already classified at the throw site", () => {
+    // What withConnectionRetry attaches: the cause it retried before giving up
+    // is gone from the error that replaces it.
+    const exhausted = Object.assign(new Error("Check your connection."), {
+      name: "EarnApiError",
+      detail: "kamino_upstream_unavailable",
+    });
+
+    expect(mapLifecycleErrorDetail(exhausted)).toBe(
+      "kamino_upstream_unavailable",
+    );
+  });
+
+  test("ignores a detail that is not a declared token", () => {
+    const error = Object.assign(new Error("nope"), {
+      detail: "kamino_is_having_a_bad_day",
+    });
+
+    expect(mapLifecycleErrorDetail(error)).toBeUndefined();
+  });
+
+  test("names our own elapsed deadline", () => {
+    expect(mapLifecycleErrorDetail(new FetchTimeoutError())).toBe(
+      "request_timeout",
+    );
+  });
+
+  test("names a connection-level fetch failure", () => {
+    expect(mapLifecycleErrorDetail(new TypeError("Network request failed"))).toBe(
+      "network_unreachable",
+    );
+  });
+
+  // The reason the message is matched and not just the type: every other
+  // TypeError reaching a flow is a bug in our own code, and calling that a
+  // dead network would send on-call looking at the wrong thing entirely.
+  test("leaves a TypeError that is really a bug unexplained", () => {
+    expect(
+      mapLifecycleErrorDetail(new TypeError("undefined is not a function")),
+    ).toBeUndefined();
+  });
+
+  test("names an RPC that answered with an error", () => {
+    expect(mapLifecycleErrorDetail(new SolanaJSONRPCError(-32603))).toBe(
+      "rpc_request_failed",
+    );
+  });
+
+  test("says nothing when the cause is genuinely unknown", () => {
+    expect(mapLifecycleErrorDetail(new Error("something broke"))).toBeUndefined();
+    expect(mapLifecycleErrorDetail(undefined)).toBeUndefined();
+  });
+});
+
+describe("errorDetail on the wire", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("rides alongside request_failed when no response arrived", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new TypeError("Network request failed"));
+
+    const failed = sent.find((event) => event.outcome === "failed");
+    expect(failed?.errorCode).toBe("request_failed");
+    expect(failed?.errorDetail).toBe("network_unreachable");
+    // Its absence is the signal that nothing ever answered.
+    expect(failed?.httpStatus).toBeUndefined();
+  });
+
+  test("is omitted rather than guessed when the cause is unknown", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new Error("something broke"));
+
+    const failed = sent.find((event) => event.outcome === "failed");
+    expect(failed?.errorCode).toBe("unexpected_error");
+    expect("errorDetail" in (failed ?? {})) .toBe(false);
+  });
+
+  test("a call site's own detail wins over the derived one", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new TypeError("Network request failed"), {
+      errorDetail: "request_timeout",
+    });
+
+    expect(sent.find((event) => event.outcome === "failed")?.errorDetail).toBe(
+      "request_timeout",
+    );
+  });
+
+  // A declined prompt is a user decision, not a failure with a cause to name.
+  test("stays off a wallet rejection", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new WalletRejectedError());
+
+    const terminal = sent.find((event) => event.outcome === "cancelled");
+    expect(terminal?.errorCode).toBe("wallet_rejected");
+    expect(terminal?.errorDetail).toBeUndefined();
+  });
+});

--- a/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-error-detail.test.ts
@@ -100,6 +100,15 @@ describe("mapLifecycleErrorDetail", () => {
     );
   });
 
+  // whatwg-fetch rejects `xhr.ontimeout` with its own TypeError. Missing it
+  // would call every stalled request a bug in our own code and route it to the
+  // sanitized error ingest — the flood that ingest is kept clear of.
+  test("names a stalled request as a timeout, not an unreachable network", () => {
+    expect(
+      mapLifecycleErrorDetail(new TypeError("Network request timed out")),
+    ).toBe("request_timeout");
+  });
+
   // The reason the message is matched and not just the type: every other
   // TypeError reaching a flow is a bug in our own code, and calling that a
   // dead network would send on-call looking at the wrong thing entirely.
@@ -146,6 +155,29 @@ describe("errorDetail on the wire", () => {
     const failed = sent.find((event) => event.outcome === "failed");
     expect(failed?.errorCode).toBe("unexpected_error");
     expect("errorDetail" in (failed ?? {})) .toBe(false);
+  });
+
+  // A bug reported as `request_failed` was invisible twice over: it inflated a
+  // code on-call reads as "the network", and `request_failed` is kept out of
+  // the sanitized error ingest, so its message and stack went nowhere.
+  test("still counts a stalled request as a failed request, not a bug", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new TypeError("Network request timed out"));
+
+    const failed = sent.find((event) => event.outcome === "failed");
+    expect(failed?.errorCode).toBe("request_failed");
+    expect(failed?.errorDetail).toBe("request_timeout");
+  });
+
+  test("reports a TypeError that is really a bug as unexpected_error", () => {
+    const sent = captureEnvelopes();
+
+    newFlow().failFrom("prepare", new TypeError("undefined is not a function"));
+
+    const failed = sent.find((event) => event.outcome === "failed");
+    expect(failed?.errorCode).toBe("unexpected_error");
+    expect(failed?.errorDetail).toBeUndefined();
   });
 
   test("a call site's own detail wins over the derived one", () => {

--- a/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -52,7 +52,11 @@ describe("wallet rejection classification", () => {
 
   it("still maps ordinary and coded failures to their own codes", () => {
     expect(mapLifecycleErrorCode(new Error("boom"))).toBe("unexpected_error");
-    expect(mapLifecycleErrorCode(new TypeError("network"))).toBe("request_failed");
+    // RN's own wording for a connection-level failure — the only TypeError
+    // that is a failed request rather than a bug in our code (ASK-2018).
+    expect(mapLifecycleErrorCode(new TypeError("Network request failed"))).toBe(
+      "request_failed",
+    );
     expect(mapLifecycleErrorCode({ code: "unconfirmed_signature" })).toBe(
       "unconfirmed_signature",
     );

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -331,11 +331,33 @@ type LifecycleErrorCode =
   | "wallet_connection_timeout"
   | "wallet_signing_failed";
 
+// Same contract, same cost on a typo — an unknown detail is dropped rather
+// than failing the envelope, so a mistake here costs the field silently.
+// Mirrors the `request_failed` arm of the backend's LIFECYCLE_ERROR_DETAILS.
+export type LifecycleErrorDetail =
+  | "network_unreachable"
+  | "request_timeout"
+  | "kamino_upstream_unavailable"
+  | "rpc_request_failed";
+
+const LIFECYCLE_ERROR_DETAILS: readonly LifecycleErrorDetail[] = [
+  "network_unreachable",
+  "request_timeout",
+  "kamino_upstream_unavailable",
+  "rpc_request_failed",
+];
+
 export type LifecycleDiagnostics = {
   autodepositCloseRequired?: boolean;
   chainState?: "not_submitted" | "submitted" | "confirmed" | "failed";
   cleanupRequired?: boolean;
   errorCode?: LifecycleErrorCode;
+  /**
+   * Which underlying cause produced a broad `errorCode`. Set automatically by
+   * `failFrom`; only worth passing by hand when a call site knows something
+   * the error shape does not carry.
+   */
+  errorDetail?: LifecycleErrorDetail;
   executeNowState?:
     | "requested"
     | "selected"
@@ -420,6 +442,63 @@ export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
   }
   if (error instanceof TypeError) return "request_failed";
   return "unexpected_error";
+}
+
+function declaredErrorDetail(value: unknown): LifecycleErrorDetail | undefined {
+  return LIFECYCLE_ERROR_DETAILS.includes(value as LifecycleErrorDetail)
+    ? (value as LifecycleErrorDetail)
+    : undefined;
+}
+
+// RN rejects a connection-level failure with TypeError("Network request
+// failed"). Matching the message rather than the type is deliberate: every
+// other TypeError reaching a flow is a bug in our own code, and reporting
+// those as an unreachable network would send on-call looking at the wrong
+// thing entirely.
+function isConnectionFailure(error: unknown): boolean {
+  return (
+    error instanceof TypeError && /network request failed/i.test(error.message)
+  );
+}
+
+// web3.js throws SolanaJSONRPCError with a numeric `code` and no HTTP status,
+// so it lands in `request_failed` looking exactly like a dead connection.
+// Brand-checked by name for the same reason as KaminoUpstreamError: Metro can
+// resolve web3.js to more than one module instance, which would quietly make
+// `instanceof` false.
+function isRpcError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "SolanaJSONRPCError" &&
+    typeof (error as { code?: unknown }).code === "number"
+  );
+}
+
+/**
+ * Name the cause behind a broad `errorCode`. Only a `request_failed` with no
+ * `httpStatus` really needs this — nothing answered, so there is no status to
+ * explain the failure and four unrelated incidents look identical (ASK-2018).
+ *
+ * Returns undefined when the cause is genuinely unknown. That is the honest
+ * answer and a better one than a token that sends on-call somewhere wrong.
+ */
+export function mapLifecycleErrorDetail(
+  error: unknown,
+): LifecycleErrorDetail | undefined {
+  // Already classified at the throw site, which saw the cause this layer
+  // cannot: `withConnectionRetry` knows what it retried before giving up.
+  const carried = declaredErrorDetail(
+    error && typeof error === "object"
+      ? (error as { detail?: unknown }).detail
+      : undefined,
+  );
+  if (carried) return carried;
+  if (error instanceof Error && error.name === "FetchTimeoutError") {
+    return "request_timeout";
+  }
+  if (isConnectionFailure(error)) return "network_unreachable";
+  if (isRpcError(error)) return "rpc_request_failed";
+  return undefined;
 }
 
 /**
@@ -531,9 +610,14 @@ export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
       const cancelled =
         errorCode === "wallet_rejected" && !hasLandedProgress(error);
       const httpStatus = httpStatusOf(error);
+      // An explicit `errorDetail` from the call site wins: it was passed
+      // because the caller knew something the error shape does not carry.
+      const errorDetail =
+        diagnostics?.errorDetail ?? mapLifecycleErrorDetail(error);
       emit(cancelled ? "cancelled" : "failed", stage, {
         ...diagnostics,
         errorCode,
+        ...(errorDetail !== undefined ? { errorDetail } : {}),
         ...(httpStatus !== undefined ? { httpStatus } : {}),
       });
       if (errorCode === "unexpected_error" && args.reportUnexpectedErrors) {

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -12,7 +12,10 @@
 import * as Updates from "expo-updates";
 
 import { env } from "@/config/env";
-import { isConnectionFailure } from "@/lib/network/connection-failure";
+import {
+  isConnectionFailure,
+  isConnectionTimeout,
+} from "@/lib/network/connection-failure";
 import { hasLandedProgress, isWalletRejection } from "@/lib/wallet/rejection";
 import {
   isWalletSessionError,
@@ -441,7 +444,12 @@ export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
     if (code === "unconfirmed_signature") return "unconfirmed_signature";
     return "request_failed";
   }
-  if (error instanceof TypeError) return "request_failed";
+  // Only a connection-level TypeError is a failed request. Every other one is
+  // a bug in our own code, and calling it `request_failed` both inflated that
+  // code and hid the bug: `request_failed` is deliberately kept out of the
+  // sanitized error ingest, so its message and stack were never reported
+  // anywhere. As `unexpected_error` it reaches that ingest and is diagnosable.
+  if (isConnectionFailure(error)) return "request_failed";
   return "unexpected_error";
 }
 
@@ -486,6 +494,8 @@ export function mapLifecycleErrorDetail(
   if (error instanceof Error && error.name === "FetchTimeoutError") {
     return "request_timeout";
   }
+  // Checked before the broader failure test, which also covers timeouts.
+  if (isConnectionTimeout(error)) return "request_timeout";
   if (isConnectionFailure(error)) return "network_unreachable";
   if (isRpcError(error)) return "rpc_request_failed";
   return undefined;

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -12,6 +12,7 @@
 import * as Updates from "expo-updates";
 
 import { env } from "@/config/env";
+import { isConnectionFailure } from "@/lib/network/connection-failure";
 import { hasLandedProgress, isWalletRejection } from "@/lib/wallet/rejection";
 import {
   isWalletSessionError,
@@ -448,17 +449,6 @@ function declaredErrorDetail(value: unknown): LifecycleErrorDetail | undefined {
   return LIFECYCLE_ERROR_DETAILS.includes(value as LifecycleErrorDetail)
     ? (value as LifecycleErrorDetail)
     : undefined;
-}
-
-// RN rejects a connection-level failure with TypeError("Network request
-// failed"). Matching the message rather than the type is deliberate: every
-// other TypeError reaching a flow is a bug in our own code, and reporting
-// those as an unreachable network would send on-call looking at the wrong
-// thing entirely.
-function isConnectionFailure(error: unknown): boolean {
-  return (
-    error instanceof TypeError && /network request failed/i.test(error.message)
-  );
 }
 
 // web3.js throws SolanaJSONRPCError with a numeric `code` and no HTTP status,


### PR DESCRIPTION
Carries the failure cause on `EarnApiError`, classifies it where it is still known, and emits it as the contract's `errorDetail` from every flow failure — `withConnectionRetry` previously replaced the error it was retrying with a bare one, discarding the only evidence of whether Kamino was down or the device was offline.

Depends on #589 being deployed first, which teaches the ingest these tokens.