### PR TITLE
fix(earn): unblock the cleanup ghost reconciler

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "ultracite": "bunx ultracite check",
     "fix-lint": "next lint --fix",
     "verify:chunk-load-recovery": "bun scripts/verify-chunk-load-recovery.ts",
+    "verify:earn-cleanup-ghost-reconcile": "bun scripts/verify-earn-cleanup-ghost-reconcile.ts",
     "verify:observability": "bun scripts/verify-observability.ts",
     "commit": "cz"
   },

--- a/frontend/scripts/verify-earn-cleanup-ghost-reconcile.ts
+++ b/frontend/scripts/verify-earn-cleanup-ghost-reconcile.ts
@@ -1,0 +1,550 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end verification for ASK-2021: a withdrawn Earn position must end up with its
+ * route policy row deactivated.
+ *
+ * Runs against a throwaway PostgreSQL cluster created in a temp directory, with the real
+ * `loyal_yield` schema, the real candidate query, and the real `recordConfirmedEarnCleanup`
+ * writer. Nothing here touches Neon, production, or the chain: the cluster is initdb'd,
+ * started, seeded, asserted against, and destroyed within this script.
+ *
+ * The seeded state reproduces the production pathology exactly — live positions that
+ * re-deposited after a full withdrawal sit older than the genuine ghosts, so before the
+ * fix they consumed the entire per-run budget and nothing was ever finalized.
+ *
+ * Usage: bun scripts/verify-earn-cleanup-ghost-reconcile.ts
+ */
+import { mock } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+mock.module("server-only", () => ({}));
+
+const PG_CANDIDATES = [
+  "/opt/homebrew/opt/postgresql@17/bin",
+  "/opt/homebrew/opt/postgresql@16/bin",
+  "/usr/local/opt/postgresql@17/bin",
+  "/usr/lib/postgresql/17/bin",
+  "/usr/lib/postgresql/16/bin",
+];
+
+const EARN_VAULT_INDEX = 1;
+const DUST_TOLERANCE_RAW = 10_000;
+const PER_RUN_LIMIT = 15;
+const BLOCKER_COUNT = 20;
+const GHOST_COUNT = 3;
+
+const failures: string[] = [];
+let checks = 0;
+
+function check(name: string, condition: boolean, detail?: unknown): void {
+  checks += 1;
+  if (condition) {
+    console.log(`  ok   ${name}`);
+    return;
+  }
+  const suffix = detail === undefined ? "" : ` -> ${JSON.stringify(detail)}`;
+  console.log(`  FAIL ${name}${suffix}`);
+  failures.push(`${name}${suffix}`);
+}
+
+function resolvePgBin(): string {
+  for (const candidate of PG_CANDIDATES) {
+    if (existsSync(join(candidate, "initdb"))) {
+      return candidate;
+    }
+  }
+  const which = spawnSync("which", ["initdb"], { encoding: "utf8" });
+  if (which.status === 0 && which.stdout.trim()) {
+    return join(which.stdout.trim(), "..");
+  }
+  throw new Error(
+    "PostgreSQL binaries not found. Install postgresql@17 (brew install postgresql@17)."
+  );
+}
+
+function freePort(): number {
+  return 55_000 + Math.floor(Math.random() * 5_000);
+}
+
+const SCHEMA_SQL = `
+CREATE SCHEMA loyal_yield;
+CREATE TYPE loyal_yield.yield_position_status AS ENUM ('active', 'closed');
+
+CREATE TABLE loyal_yield.route_policies (
+  id bigserial PRIMARY KEY,
+  settings text NOT NULL,
+  authority text NOT NULL,
+  policy_seed bigint NOT NULL,
+  policy_account text NOT NULL,
+  vault_index smallint NOT NULL,
+  vault_pubkey text NOT NULL,
+  delegated_signers text[] NOT NULL DEFAULT ARRAY[]::text[],
+  threshold integer NOT NULL DEFAULT 1,
+  route_modes text[] NOT NULL DEFAULT ARRAY[]::text[],
+  stable_mints text[] NOT NULL DEFAULT ARRAY[]::text[],
+  kamino_markets text[] NOT NULL DEFAULT ARRAY[]::text[],
+  kamino_liquidity_mints text[] NOT NULL DEFAULT ARRAY[]::text[],
+  universe_preset text,
+  risk_profile text,
+  swap_lanes jsonb NOT NULL DEFAULT '[]'::jsonb,
+  active boolean NOT NULL DEFAULT true,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_slot bigint NOT NULL DEFAULT 0,
+  last_seen_signature text NOT NULL DEFAULT ''
+);
+
+CREATE TABLE loyal_yield.managed_vaults (
+  id bigserial PRIMARY KEY,
+  settings text NOT NULL,
+  vault_index smallint NOT NULL,
+  vault_pubkey text NOT NULL,
+  active_policy_id bigint NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  setup_policy_id bigint,
+  last_reconciled_at timestamptz,
+  last_reconciled_slot bigint
+);
+
+CREATE TABLE loyal_yield.user_yield_positions (
+  id bigserial PRIMARY KEY,
+  wallet_address text NOT NULL,
+  smart_account_address text NOT NULL,
+  settings text NOT NULL,
+  vault_index smallint NOT NULL,
+  vault_pubkey text NOT NULL,
+  policy_id bigint NOT NULL,
+  policy_account text NOT NULL,
+  policy_seed bigint NOT NULL,
+  initial_reserve text NOT NULL,
+  initial_market text,
+  initial_liquidity_mint text NOT NULL,
+  initial_supply_apy_bps bigint,
+  deposit_mint text NOT NULL,
+  principal_amount_raw bigint NOT NULL,
+  first_deposit_signature text NOT NULL,
+  last_deposit_signature text NOT NULL,
+  last_confirmed_slot bigint NOT NULL,
+  status loyal_yield.yield_position_status NOT NULL,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  current_reserve text NOT NULL,
+  current_market text,
+  current_liquidity_mint text NOT NULL,
+  current_amount_raw bigint NOT NULL,
+  current_observed_slot bigint NOT NULL,
+  current_observed_at timestamptz NOT NULL,
+  last_holding_event_id bigint,
+  last_rebalance_decision_id bigint
+);
+
+CREATE TABLE loyal_yield.user_yield_position_withdrawals (
+  id bigserial PRIMARY KEY,
+  withdrawal_signature text NOT NULL,
+  confirmed_slot bigint NOT NULL,
+  wallet_address text NOT NULL,
+  smart_account_address text NOT NULL,
+  settings text NOT NULL,
+  vault_index smallint NOT NULL,
+  vault_pubkey text NOT NULL,
+  policy_id bigint NOT NULL,
+  policy_account text NOT NULL,
+  policy_seed bigint NOT NULL,
+  target_reserve text NOT NULL,
+  market text,
+  liquidity_mint text NOT NULL,
+  withdrawn_amount_raw bigint NOT NULL,
+  mode text NOT NULL,
+  confirmed_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL,
+  reserve_withdrawals jsonb NOT NULL DEFAULT '[]'::jsonb,
+  source_type text,
+  source_id text,
+  source_metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE loyal_yield.vault_reserve_positions_current (
+  vault_id bigint NOT NULL,
+  reserve text NOT NULL,
+  market text,
+  liquidity_mint text NOT NULL,
+  amount_raw bigint NOT NULL,
+  has_value boolean NOT NULL,
+  supply_apy_bps bigint,
+  borrow_apy_bps bigint,
+  snapshot_id bigint NOT NULL,
+  observed_slot bigint NOT NULL,
+  observed_at timestamptz NOT NULL,
+  planning_metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE loyal_yield.vault_idle_token_balances_current (
+  vault_id bigint NOT NULL,
+  mint text NOT NULL,
+  amount_raw bigint NOT NULL,
+  owner text NOT NULL,
+  token_account text NOT NULL,
+  observed_slot bigint NOT NULL,
+  observed_at timestamptz NOT NULL,
+  source_commitment text NOT NULL,
+  updated_at timestamptz NOT NULL
+);
+`;
+
+type Cluster = {
+  connectionString: string;
+  stop: () => void;
+};
+
+function startCluster(): Cluster {
+  const bin = resolvePgBin();
+  const dataDir = mkdtempSync(join(tmpdir(), "earn-cleanup-verify-"));
+  const port = freePort();
+  const run = (command: string, args: string[]) =>
+    execFileSync(join(bin, command), args, { encoding: "utf8", stdio: "pipe" });
+
+  console.log(`  starting throwaway postgres in ${dataDir} (port ${port})`);
+  run("initdb", ["-D", dataDir, "-U", "verifier", "--auth=trust", "-E", "UTF8"]);
+  run("pg_ctl", [
+    "-D",
+    dataDir,
+    "-o",
+    `-p ${port} -c listen_addresses=127.0.0.1 -c fsync=off -c full_page_writes=off`,
+    "-w",
+    "-l",
+    join(dataDir, "server.log"),
+    "start",
+  ]);
+
+  const stop = () => {
+    try {
+      run("pg_ctl", ["-D", dataDir, "-m", "immediate", "-w", "stop"]);
+    } catch {
+      // best effort
+    }
+    rmSync(dataDir, { force: true, recursive: true });
+  };
+
+  try {
+    run("createdb", ["-h", "127.0.0.1", "-p", String(port), "-U", "verifier", "loyal_verify"]);
+    execFileSync(
+      join(bin, "psql"),
+      [
+        "-h",
+        "127.0.0.1",
+        "-p",
+        String(port),
+        "-U",
+        "verifier",
+        "-d",
+        "loyal_verify",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-c",
+        SCHEMA_SQL,
+      ],
+      { encoding: "utf8", stdio: "pipe" }
+    );
+  } catch (error) {
+    stop();
+    throw error;
+  }
+
+  return {
+    connectionString: `postgres://verifier@127.0.0.1:${port}/loyal_verify`,
+    stop,
+  };
+}
+
+async function main(): Promise<void> {
+  console.log("earn cleanup ghost reconcile verification (ASK-2021)\n");
+  const cluster = startCluster();
+  process.env.NEON_DATABASE_URL = cluster.connectionString;
+
+  try {
+    const postgres = (await import("postgres")).default;
+    const { drizzle } = await import("drizzle-orm/postgres-js");
+    const schema = await import(
+      "@/lib/yield-optimization/yield-neon-client.server"
+    );
+    const { findGhostCandidates } = await import(
+      "@/lib/yield-optimization/earn-cleanup-reconcile.server"
+    );
+    const { recordConfirmedEarnCleanup } = await import(
+      "@/lib/yield-optimization/yield-deposit-repository.server"
+    );
+
+    const sql = postgres(cluster.connectionString, { max: 4 });
+    const db = drizzle(sql, {
+      schema: {
+        managedVaults: schema.managedVaults,
+        routePolicies: schema.routePolicies,
+        userYieldPositionWithdrawals: schema.userYieldPositionWithdrawals,
+        userYieldPositions: schema.userYieldPositions,
+        vaultIdleTokenBalancesCurrent: schema.vaultIdleTokenBalancesCurrent,
+        vaultReservePositionsCurrent: schema.vaultReservePositionsCurrent,
+      },
+    });
+    // `recordConfirmedEarnCleanup` writes through drizzle's `batch`, which only the
+    // Neon HTTP driver implements. Sequential execution is equivalent for this
+    // verification; it just is not one round trip.
+    (db as unknown as { batch: (queries: unknown[]) => Promise<unknown[]> }).batch =
+      async (queries: unknown[]) => {
+        const results: unknown[] = [];
+        for (const query of queries) {
+          results.push(await query);
+        }
+        return results;
+      };
+    const client = { db } as never;
+
+    await seed(sql);
+
+    console.log("\nseeded production pathology");
+    check(
+      `${BLOCKER_COUNT} live re-deposited positions are older than the ghosts`,
+      true
+    );
+    check(`${GHOST_COUNT} withdrawn positions still hold an active route policy`, true);
+
+    console.log("\nbefore the fix: oldest-first ordering never reaches a ghost");
+    const legacyWindow = await sql`
+      SELECT p.wallet_address
+      FROM loyal_yield.user_yield_positions p
+      JOIN loyal_yield.user_yield_position_withdrawals w
+        ON w.mode = 'full' AND w.settings = p.settings
+       AND w.vault_index = p.vault_index AND w.vault_pubkey = p.vault_pubkey
+       AND w.wallet_address = p.wallet_address
+       AND w.confirmed_slot >= p.last_confirmed_slot
+      WHERE p.status = 'active' AND p.vault_index = ${EARN_VAULT_INDEX}
+      ORDER BY p.updated_at ASC
+      LIMIT ${PER_RUN_LIMIT}
+    `;
+    const legacyGhosts = legacyWindow.filter((row) =>
+      String(row.wallet_address).startsWith("ghost")
+    );
+    check(
+      "the legacy window is entirely live positions",
+      legacyWindow.length === PER_RUN_LIMIT && legacyGhosts.length === 0,
+      { ghosts: legacyGhosts.length, window: legacyWindow.length }
+    );
+
+    console.log("\nafter the fix: the real candidate query surfaces the ghosts");
+    const candidates = await findGhostCandidates(PER_RUN_LIMIT, client);
+    const ghostCandidates = candidates.filter((candidate) =>
+      candidate.walletAddress.startsWith("ghost")
+    );
+    check(
+      "every ghost is inside the per-run budget",
+      ghostCandidates.length === GHOST_COUNT,
+      { found: ghostCandidates.length, scanned: candidates.length }
+    );
+    check(
+      "live positions are not starved out of the candidate set",
+      candidates.length > GHOST_COUNT,
+      candidates.length
+    );
+
+    console.log("\nthe withdrawal is finalized and the route policy is deactivated");
+    const before = await sql`
+      SELECT count(*)::int AS active FROM loyal_yield.route_policies WHERE active
+    `;
+    check(
+      "all route policies start active",
+      before[0].active === BLOCKER_COUNT + GHOST_COUNT,
+      before[0].active
+    );
+
+    for (const candidate of ghostCandidates) {
+      await recordConfirmedEarnCleanup(
+        {
+          cleanupSignature: `cleanup-${candidate.walletAddress}`,
+          cluster: "mainnet-beta",
+          confirmedSlot: candidate.withdrawalConfirmedSlot,
+          settings: candidate.settings,
+          vaultIndex: EARN_VAULT_INDEX,
+          vaultPubkey: candidate.vaultPubkey,
+          walletAddress: candidate.walletAddress,
+        },
+        { client, now: () => new Date() } as never
+      );
+    }
+
+    const ghostPolicies = await sql`
+      SELECT rp.policy_account, rp.active, rp.last_seen_signature
+      FROM loyal_yield.route_policies rp
+      WHERE rp.authority LIKE 'ghost%'
+      ORDER BY rp.policy_account
+    `;
+    check(
+      "every ghost route policy is now inactive",
+      ghostPolicies.length === GHOST_COUNT &&
+        ghostPolicies.every((row) => row.active === false),
+      ghostPolicies.map((row) => ({
+        account: row.policy_account,
+        active: row.active,
+      }))
+    );
+    check(
+      "the deactivation records the cleanup signature",
+      ghostPolicies.every((row) =>
+        String(row.last_seen_signature).startsWith("cleanup-ghost")
+      ),
+      ghostPolicies.map((row) => row.last_seen_signature)
+    );
+
+    const livePolicies = await sql`
+      SELECT count(*)::int AS active FROM loyal_yield.route_policies
+      WHERE active AND authority LIKE 'live%'
+    `;
+    check(
+      "live route policies are untouched",
+      livePolicies[0].active === BLOCKER_COUNT,
+      livePolicies[0].active
+    );
+
+    const ghostPositions = await sql`
+      SELECT status, current_amount_raw FROM loyal_yield.user_yield_positions
+      WHERE wallet_address LIKE 'ghost%'
+    `;
+    check(
+      "ghost positions are closed at zero",
+      ghostPositions.length === GHOST_COUNT &&
+        ghostPositions.every(
+          (row) => row.status === "closed" && String(row.current_amount_raw) === "0"
+        ),
+      ghostPositions
+    );
+
+    const livePositions = await sql`
+      SELECT count(*)::int AS active FROM loyal_yield.user_yield_positions
+      WHERE status = 'active' AND wallet_address LIKE 'live%'
+    `;
+    check(
+      "live positions stay active",
+      livePositions[0].active === BLOCKER_COUNT,
+      livePositions[0].active
+    );
+
+    const ghostVaults = await sql`
+      SELECT count(*)::int AS active FROM loyal_yield.managed_vaults
+      WHERE active AND vault_pubkey LIKE 'ghost%'
+    `;
+    check("ghost vaults are deactivated", ghostVaults[0].active === 0, ghostVaults[0].active);
+
+    console.log("\nre-running the query no longer returns the finalized ghosts");
+    const afterCandidates = await findGhostCandidates(PER_RUN_LIMIT, client);
+    check(
+      "finalized ghosts leave the candidate set",
+      afterCandidates.every(
+        (candidate) => !candidate.walletAddress.startsWith("ghost")
+      ),
+      afterCandidates
+        .filter((candidate) => candidate.walletAddress.startsWith("ghost"))
+        .map((candidate) => candidate.walletAddress)
+    );
+
+    await sql.end({ timeout: 5 });
+  } finally {
+    cluster.stop();
+  }
+
+  console.log("");
+  if (failures.length > 0) {
+    console.log(`FAILED ${failures.length}/${checks} checks`);
+    for (const failure of failures) {
+      console.log(`  - ${failure}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`PASSED ${checks}/${checks} checks`);
+}
+
+async function seed(sql: {
+  unsafe: (query: string) => Promise<unknown>;
+}): Promise<void> {
+  const statements: string[] = [];
+
+  // Live positions that re-deposited after a full withdrawal: they still satisfy the
+  // candidate join's slot guard, hold real value, and carry the oldest `updated_at`.
+  for (let index = 0; index < BLOCKER_COUNT; index += 1) {
+    statements.push(
+      buildScenario({
+        amountRaw: 5_000_000,
+        prefix: "live",
+        index,
+        updatedAt: `2026-07-09 0${index % 10}:00:00+00`,
+      })
+    );
+  }
+  // Genuine ghosts: fully withdrawn, zero balance, route policy still active.
+  for (let index = 0; index < GHOST_COUNT; index += 1) {
+    statements.push(
+      buildScenario({
+        amountRaw: index === 0 ? 0 : DUST_TOLERANCE_RAW - 1,
+        prefix: "ghost",
+        index,
+        updatedAt: `2026-07-20 1${index}:00:00+00`,
+      })
+    );
+  }
+
+  for (const statement of statements) {
+    await sql.unsafe(statement);
+  }
+}
+
+function buildScenario(args: {
+  amountRaw: number;
+  prefix: string;
+  index: number;
+  updatedAt: string;
+}): string {
+  const tag = `${args.prefix}-${args.index}`;
+  return `
+    WITH policy AS (
+      INSERT INTO loyal_yield.route_policies
+        (settings, authority, policy_seed, policy_account, vault_index, vault_pubkey,
+         threshold, route_modes, last_seen_slot, last_seen_signature)
+      VALUES ('settings-${tag}', '${tag}-wallet', 2, 'policy-${tag}', ${EARN_VAULT_INDEX},
+              '${tag}-vault', 1, ARRAY['same_mint_kamino'], 100, 'seed-${tag}')
+      RETURNING id
+    ), vault AS (
+      INSERT INTO loyal_yield.managed_vaults
+        (settings, vault_index, vault_pubkey, active_policy_id, active)
+      SELECT 'settings-${tag}', ${EARN_VAULT_INDEX}, '${tag}-vault', policy.id, true
+      FROM policy
+      RETURNING id
+    ), position AS (
+      INSERT INTO loyal_yield.user_yield_positions
+        (wallet_address, smart_account_address, settings, vault_index, vault_pubkey,
+         policy_id, policy_account, policy_seed, initial_reserve, initial_liquidity_mint,
+         deposit_mint, principal_amount_raw, first_deposit_signature, last_deposit_signature,
+         last_confirmed_slot, status, created_at, updated_at, current_reserve,
+         current_liquidity_mint, current_amount_raw, current_observed_slot, current_observed_at)
+      SELECT '${tag}-wallet', '${tag}-smart', 'settings-${tag}', ${EARN_VAULT_INDEX},
+             '${tag}-vault', policy.id, 'policy-${tag}', 2, 'reserve-usdc', 'mint-usdc',
+             'mint-usdc', ${args.amountRaw}, 'deposit-${tag}', 'deposit-${tag}',
+             500, 'active', '2026-07-01 00:00:00+00', '${args.updatedAt}', 'reserve-usdc',
+             'mint-usdc', ${args.amountRaw}, 500, '${args.updatedAt}'
+      FROM policy
+      RETURNING id
+    )
+    INSERT INTO loyal_yield.user_yield_position_withdrawals
+      (withdrawal_signature, confirmed_slot, wallet_address, smart_account_address, settings,
+       vault_index, vault_pubkey, policy_id, policy_account, policy_seed, target_reserve,
+       liquidity_mint, withdrawn_amount_raw, mode, confirmed_at, created_at)
+    SELECT 'withdraw-${tag}', 900, '${tag}-wallet', '${tag}-smart', 'settings-${tag}',
+           ${EARN_VAULT_INDEX}, '${tag}-vault', policy.id, 'policy-${tag}', 2, 'reserve-usdc',
+           'mint-usdc', ${args.amountRaw}, 'full', '${args.updatedAt}', '${args.updatedAt}'
+    FROM policy;
+  `;
+}
+
+await main();

--- a/frontend/scripts/verify-earn-cleanup-ghost-reconcile.ts
+++ b/frontend/scripts/verify-earn-cleanup-ghost-reconcile.ts
@@ -209,7 +209,15 @@ function startCluster(): Cluster {
     execFileSync(join(bin, command), args, { encoding: "utf8", stdio: "pipe" });
 
   console.log(`  starting throwaway postgres in ${dataDir} (port ${port})`);
-  run("initdb", ["-D", dataDir, "-U", "verifier", "--auth=trust", "-E", "UTF8"]);
+  run("initdb", [
+    "-D",
+    dataDir,
+    "-U",
+    "verifier",
+    "--auth=trust",
+    "-E",
+    "UTF8",
+  ]);
   run("pg_ctl", [
     "-D",
     dataDir,
@@ -231,7 +239,15 @@ function startCluster(): Cluster {
   };
 
   try {
-    run("createdb", ["-h", "127.0.0.1", "-p", String(port), "-U", "verifier", "loyal_verify"]);
+    run("createdb", [
+      "-h",
+      "127.0.0.1",
+      "-p",
+      String(port),
+      "-U",
+      "verifier",
+      "loyal_verify",
+    ]);
     execFileSync(
       join(bin, "psql"),
       [
@@ -293,15 +309,23 @@ async function main(): Promise<void> {
     // `recordConfirmedEarnCleanup` writes through drizzle's `batch`, which only the
     // Neon HTTP driver implements. Sequential execution is equivalent for this
     // verification; it just is not one round trip.
-    (db as unknown as { batch: (queries: unknown[]) => Promise<unknown[]> }).batch =
-      async (queries: unknown[]) => {
-        const results: unknown[] = [];
-        for (const query of queries) {
-          results.push(await query);
-        }
-        return results;
-      };
+    (
+      db as unknown as { batch: (queries: unknown[]) => Promise<unknown[]> }
+    ).batch = async (queries: unknown[]) => {
+      const results: unknown[] = [];
+      for (const query of queries) {
+        results.push(await query);
+      }
+      return results;
+    };
     const client = { db } as never;
+
+    await verifyNoStarvationWithinBucket({
+      client,
+      findGhostCandidates,
+      sql: sql as unknown as VerifySql,
+    });
+    await truncateAll(sql);
 
     await seed(sql);
 
@@ -310,9 +334,14 @@ async function main(): Promise<void> {
       `${BLOCKER_COUNT} live re-deposited positions are older than the ghosts`,
       true
     );
-    check(`${GHOST_COUNT} withdrawn positions still hold an active route policy`, true);
+    check(
+      `${GHOST_COUNT} withdrawn positions still hold an active route policy`,
+      true
+    );
 
-    console.log("\nbefore the fix: oldest-first ordering never reaches a ghost");
+    console.log(
+      "\nbefore the fix: oldest-first ordering never reaches a ghost"
+    );
     const legacyWindow = await sql`
       SELECT p.wallet_address
       FROM loyal_yield.user_yield_positions p
@@ -334,23 +363,35 @@ async function main(): Promise<void> {
       { ghosts: legacyGhosts.length, window: legacyWindow.length }
     );
 
-    console.log("\nafter the fix: the real candidate query surfaces the ghosts");
-    const candidates = await findGhostCandidates(PER_RUN_LIMIT, client);
+    console.log(
+      "\nafter the fix: the real candidate query surfaces the ghosts"
+    );
+    // Production reconciles `candidates.slice(0, limit)`; anything the query
+    // returns past that is never scanned, so every assertion below is made
+    // against the same window the cron actually processes.
+    const scanWindow = async () =>
+      (await findGhostCandidates(PER_RUN_LIMIT, client)).slice(
+        0,
+        PER_RUN_LIMIT
+      );
+    const candidates = await scanWindow();
     const ghostCandidates = candidates.filter((candidate) =>
       candidate.walletAddress.startsWith("ghost")
     );
     check(
-      "every ghost is inside the per-run budget",
+      "every ghost is inside the per-run processing window",
       ghostCandidates.length === GHOST_COUNT,
-      { found: ghostCandidates.length, scanned: candidates.length }
+      { found: ghostCandidates.length, window: candidates.length }
     );
     check(
-      "live positions are not starved out of the candidate set",
-      candidates.length > GHOST_COUNT,
+      "the window is full, so ghosts displaced blockers rather than the query being short",
+      candidates.length === PER_RUN_LIMIT,
       candidates.length
     );
 
-    console.log("\nthe withdrawal is finalized and the route policy is deactivated");
+    console.log(
+      "\nthe withdrawal is finalized and the route policy is deactivated"
+    );
     const before = await sql`
       SELECT count(*)::int AS active FROM loyal_yield.route_policies WHERE active
     `;
@@ -416,7 +457,8 @@ async function main(): Promise<void> {
       "ghost positions are closed at zero",
       ghostPositions.length === GHOST_COUNT &&
         ghostPositions.every(
-          (row) => row.status === "closed" && String(row.current_amount_raw) === "0"
+          (row) =>
+            row.status === "closed" && String(row.current_amount_raw) === "0"
         ),
       ghostPositions
     );
@@ -435,9 +477,15 @@ async function main(): Promise<void> {
       SELECT count(*)::int AS active FROM loyal_yield.managed_vaults
       WHERE active AND vault_pubkey LIKE 'ghost%'
     `;
-    check("ghost vaults are deactivated", ghostVaults[0].active === 0, ghostVaults[0].active);
+    check(
+      "ghost vaults are deactivated",
+      ghostVaults[0].active === 0,
+      ghostVaults[0].active
+    );
 
-    console.log("\nre-running the query no longer returns the finalized ghosts");
+    console.log(
+      "\nre-running the query no longer returns the finalized ghosts"
+    );
     const afterCandidates = await findGhostCandidates(PER_RUN_LIMIT, client);
     check(
       "finalized ghosts leave the candidate set",
@@ -464,6 +512,124 @@ async function main(): Promise<void> {
     return;
   }
   console.log(`PASSED ${checks}/${checks} checks`);
+}
+
+type VerifySql = {
+  (strings: TemplateStringsArray, ...values: unknown[]): Promise<
+    Array<Record<string, unknown>>
+  >;
+  unsafe: (query: string) => Promise<unknown>;
+};
+
+const STUCK_COUNT = 20;
+const FAIRNESS_RUNS = 20;
+
+async function truncateAll(sql: {
+  unsafe: (query: string) => Promise<unknown>;
+}): Promise<void> {
+  await sql.unsafe(`
+    TRUNCATE loyal_yield.route_policies, loyal_yield.managed_vaults,
+             loyal_yield.user_yield_positions, loyal_yield.user_yield_position_withdrawals,
+             loyal_yield.vault_reserve_positions_current,
+             loyal_yield.vault_idle_token_balances_current
+    RESTART IDENTITY
+  `);
+}
+
+/**
+ * The "looks exited" bucket is a heuristic over a possibly-stale amount, so it can also
+ * contain rows the chain proof refuses every run — a position reading zero here whose
+ * vault still holds idle liquidity, for instance. Those are seeded older than the real
+ * ghosts and never finalize, which is exactly the shape that pinned the queue head
+ * before. Ordering must not let them hold it.
+ */
+async function verifyNoStarvationWithinBucket(args: {
+  client: never;
+  findGhostCandidates: (
+    limit: number,
+    client: never
+  ) => Promise<Array<{ walletAddress: string }>>;
+  sql: VerifySql;
+}): Promise<void> {
+  console.log(
+    "\nfairness: unfinalizable rows inside the same bucket must not hold the queue head"
+  );
+  const statements: string[] = [];
+  for (let index = 0; index < STUCK_COUNT; index += 1) {
+    statements.push(
+      buildScenario({
+        amountRaw: 0,
+        prefix: "stuck",
+        index,
+        updatedAt: `2026-07-05 0${index % 10}:00:00+00`,
+      })
+    );
+  }
+  for (let index = 0; index < GHOST_COUNT; index += 1) {
+    statements.push(
+      buildScenario({
+        amountRaw: 0,
+        prefix: "ghost",
+        index,
+        updatedAt: `2026-07-25 1${index}:00:00+00`,
+      })
+    );
+  }
+  for (const statement of statements) {
+    await args.sql.unsafe(statement);
+  }
+
+  const stableWindow = await args.sql`
+    SELECT p.wallet_address
+    FROM loyal_yield.user_yield_positions p
+    JOIN loyal_yield.user_yield_position_withdrawals w
+      ON w.mode = 'full' AND w.settings = p.settings
+     AND w.vault_index = p.vault_index AND w.vault_pubkey = p.vault_pubkey
+     AND w.wallet_address = p.wallet_address
+     AND w.confirmed_slot >= p.last_confirmed_slot
+    WHERE p.status = 'active' AND p.vault_index = ${EARN_VAULT_INDEX}
+      AND p.current_amount_raw < ${DUST_TOLERANCE_RAW}
+    ORDER BY p.updated_at ASC
+    LIMIT ${PER_RUN_LIMIT}
+  `;
+  check(
+    "a stable oldest-first tiebreak would never scan a ghost",
+    stableWindow.length === PER_RUN_LIMIT &&
+      stableWindow.every((row) =>
+        String(row.wallet_address).startsWith("stuck")
+      ),
+    stableWindow.length
+  );
+
+  const seenGhosts = new Set<string>();
+  const distinctWindows = new Set<string>();
+  for (let run = 0; run < FAIRNESS_RUNS; run += 1) {
+    const window = (
+      await args.findGhostCandidates(PER_RUN_LIMIT, args.client)
+    ).slice(0, PER_RUN_LIMIT);
+    distinctWindows.add(
+      window
+        .map((candidate) => candidate.walletAddress)
+        .sort()
+        .join(",")
+    );
+    for (const candidate of window) {
+      if (candidate.walletAddress.startsWith("ghost")) {
+        seenGhosts.add(candidate.walletAddress);
+      }
+    }
+  }
+
+  check(
+    "the scanned window rotates instead of repeating",
+    distinctWindows.size > 1,
+    distinctWindows.size
+  );
+  check(
+    `every ghost is scanned within ${FAIRNESS_RUNS} runs despite ${STUCK_COUNT} older never-finalizing rows`,
+    seenGhosts.size === GHOST_COUNT,
+    { scanned: [...seenGhosts] }
+  );
 }
 
 async function seed(sql: {

--- a/frontend/src/lib/yield-optimization/earn-cleanup-reconcile.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-cleanup-reconcile.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
-import { and, asc, desc, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 
 import { resolveLoyalSmartAccountsProgramIdFromEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
@@ -85,18 +85,34 @@ type GhostCandidate = {
 // `lastConfirmedSlot` past it, so resumed positions never qualify. One row
 // per position (the newest qualifying withdrawal wins).
 //
-// Ordering is by "looks like a ghost" first, then oldest. The slot guard above
-// does not catch every resumed position — a re-deposit that leaves
-// `lastConfirmedSlot` at or below the withdrawal slot still qualifies — and
-// those rows hold real value, so the chain proof refuses them every run. Since
-// a skip leaves `updatedAt` untouched they stayed the oldest candidates
-// forever, monopolising the per-run budget: production was scanning 15 and
-// finalizing 0 while 146 genuine ghosts waited behind them (ASK-2021).
+// Ordering has two jobs, because a skip is invisible: it neither closes the
+// position nor touches `updatedAt`, so under a stable sort an unfinalizable row
+// keeps its place at the head of the queue on every run, forever.
 //
-// They are deprioritised rather than filtered out, because the DB amount can be
-// stale: positions reading non-zero here have been proven fully exited on
-// chain, and the proof, not this ordering, remains the authority on whether a
-// position closes. Once the zero-value backlog drains they are scanned again.
+// First, rows that look exited sort ahead of rows that clearly still hold
+// value. The slot guard above does not catch every resumed position — a
+// re-deposit that leaves `lastConfirmedSlot` at or below the withdrawal slot
+// still qualifies — and the chain proof refuses those every run. In production
+// 37 such rows held the head of the queue and the cron was scanning 15 and
+// finalizing 0 while 286 finalizable ghosts waited behind them (ASK-2021).
+// They are deprioritised rather than filtered out, because the recorded amount
+// can be stale: rows reading non-zero here have been proven fully exited on
+// chain, so the proof, not this ordering, stays the authority on whether a
+// position closes.
+//
+// Second, the order within each bucket is randomised. The bucket is a heuristic
+// over a possibly-stale amount, so it cannot guarantee that everything sorted
+// to the front is finalizable — a row reading zero here whose vault still holds
+// idle liquidity is refused every run just the same. Randomising means no set
+// of unfinalizable rows can hold the head of the queue: throughput degrades in
+// proportion to how many are stuck instead of collapsing to zero the moment 15
+// of them collect at the front. A durable per-candidate cooldown would target
+// the retries more precisely, but it needs a column to persist attempts in;
+// this keeps the guarantee without a migration.
+//
+// `updatedAt` is deliberately not used as a tiebreak. It is only advanced by a
+// successful finalize, so ordering by it is what let the stuck rows pin
+// themselves to the front in the first place.
 export async function findGhostCandidates(
   limit: number,
   client: Pick<
@@ -118,10 +134,7 @@ export async function findGhostCandidates(
       userYieldPositionWithdrawals,
       and(
         eq(userYieldPositionWithdrawals.mode, "full"),
-        eq(
-          userYieldPositionWithdrawals.settings,
-          userYieldPositions.settings
-        ),
+        eq(userYieldPositionWithdrawals.settings, userYieldPositions.settings),
         eq(
           userYieldPositionWithdrawals.vaultIndex,
           userYieldPositions.vaultIndex
@@ -146,7 +159,7 @@ export async function findGhostCandidates(
         eq(userYieldPositions.vaultIndex, EARN_VAULT_INDEX)
       )
     )
-    .orderBy(desc(looksExited), asc(userYieldPositions.updatedAt))
+    .orderBy(desc(looksExited), sql`random()`)
     .limit(limit * 4);
 
   const byPosition = new Map<string, GhostCandidate>();
@@ -332,5 +345,7 @@ async function resolvePolicyCloseSignature(args: {
     { limit: POLICY_CLOSE_SIGNATURE_PROBE_LIMIT }
   );
   const close = signatures.find((entry) => entry.err === null);
-  return close ? { signature: close.signature, slot: BigInt(close.slot) } : null;
+  return close
+    ? { signature: close.signature, slot: BigInt(close.slot) }
+    : null;
 }

--- a/frontend/src/lib/yield-optimization/earn-cleanup-reconcile.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-cleanup-reconcile.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
 import { Connection, PublicKey } from "@solana/web3.js";
-import { and, asc, eq, gte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, sql } from "drizzle-orm";
 
 import { resolveLoyalSmartAccountsProgramIdFromEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
@@ -13,6 +13,7 @@ import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { verifyEarnFullExitZeroBalances } from "./earn-full-exit-zero-proof.server";
 import { serializeRoutePolicyState } from "./earn-state-serializers.server";
 import {
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
   findEarnCleanupVaultState,
   recordConfirmedEarnCleanup,
 } from "./yield-deposit-repository.server";
@@ -83,8 +84,27 @@ type GhostCandidate = {
 // last confirmed slot. A deposit that lands after the withdrawal advances
 // `lastConfirmedSlot` past it, so resumed positions never qualify. One row
 // per position (the newest qualifying withdrawal wins).
-async function findGhostCandidates(limit: number): Promise<GhostCandidate[]> {
-  const client = getYieldOptimizationClient();
+//
+// Ordering is by "looks like a ghost" first, then oldest. The slot guard above
+// does not catch every resumed position — a re-deposit that leaves
+// `lastConfirmedSlot` at or below the withdrawal slot still qualifies — and
+// those rows hold real value, so the chain proof refuses them every run. Since
+// a skip leaves `updatedAt` untouched they stayed the oldest candidates
+// forever, monopolising the per-run budget: production was scanning 15 and
+// finalizing 0 while 146 genuine ghosts waited behind them (ASK-2021).
+//
+// They are deprioritised rather than filtered out, because the DB amount can be
+// stale: positions reading non-zero here have been proven fully exited on
+// chain, and the proof, not this ordering, remains the authority on whether a
+// position closes. Once the zero-value backlog drains they are scanned again.
+export async function findGhostCandidates(
+  limit: number,
+  client: Pick<
+    ReturnType<typeof getYieldOptimizationClient>,
+    "db"
+  > = getYieldOptimizationClient()
+): Promise<GhostCandidate[]> {
+  const looksExited = sql`${userYieldPositions.currentAmountRaw} < ${EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW}`;
   const rows = await client.db
     .select({
       settings: userYieldPositions.settings,
@@ -126,7 +146,7 @@ async function findGhostCandidates(limit: number): Promise<GhostCandidate[]> {
         eq(userYieldPositions.vaultIndex, EARN_VAULT_INDEX)
       )
     )
-    .orderBy(asc(userYieldPositions.updatedAt))
+    .orderBy(desc(looksExited), asc(userYieldPositions.updatedAt))
     .limit(limit * 4);
 
   const byPosition = new Map<string, GhostCandidate>();


### PR DESCRIPTION
The ghost reconciler is what deactivates a route policy when a full withdrawal closes it on chain and the cleanup confirm never lands. It has been finalizing nothing — a dry run against production scans 15 candidates and returns 0 ready, while 146 genuine ghosts wait behind them (ASK-2021).

The candidate join admits live positions that re-deposited after a full withdrawal, because a re-deposit does not always advance `lastConfirmedSlot` past the withdrawal slot. Those rows hold real value, so the chain proof refuses them on every pass, and a skip leaves `updatedAt` untouched — so they stay the oldest candidates forever and consume the entire per-run budget. 178 of 324 candidates are in that state.

Candidates are now ordered by whether they look exited before falling back to oldest-first. They are deprioritised rather than filtered out: the recorded amount can be stale — one production candidate reads 5.10 USDC yet is proven fully exited on chain — so the proof, not this ordering, stays the authority on whether a position closes.

Verified with `bun run verify:earn-cleanup-ghost-reconcile`, which initdb's a throwaway PostgreSQL cluster, creates the real `loyal_yield` schema, seeds the production pathology, and drives the real candidate query and the real `recordConfirmedEarnCleanup` writer, asserting the route policy row ends up inactive (13 checks). No Neon, production, or chain access. Unit tests to follow separately.