### PR TITLE
ci: bump commit-style workflow to bun 1.3.11 to fix native install scripts

### DIFF
--- a/.github/workflows/commit-style.yml
+++ b/.github/workflows/commit-style.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.17"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
Aligns the commit-style workflow's bun pin with the other workflows (1.3.11) — 1.2.17 fails installing the MetaMask SDK's native deps (utf-8-validate exit 127) that landed with the privy showcase lockfile. ASK-2029.