### PR TITLE
fix(earn): hide scheduled autodeposit rows while a sweep executes

### DIFF
--- a/frontend/src/lib/yield-optimization/earn-autodeposit-loaded-state.shared.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-loaded-state.shared.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { getDisplayableEarnAutodepositScheduledSweeps } from "./earn-autodeposit-loaded-state.shared";
+
+describe("getDisplayableEarnAutodepositScheduledSweeps", () => {
+  test("returns nothing while the config is not active", () => {
+    expect(
+      getDisplayableEarnAutodepositScheduledSweeps("paused", [
+        { id: "1", status: "scheduled" },
+      ])
+    ).toEqual([]);
+  });
+
+  test("passes scheduled sweeps through when nothing is executing", () => {
+    const sweeps = [
+      { id: "1", status: "scheduled" },
+      { id: "2", status: "failed" },
+    ];
+    expect(
+      getDisplayableEarnAutodepositScheduledSweeps("active", sweeps)
+    ).toEqual(sweeps);
+  });
+
+  test("hides scheduled siblings while a sweep is executing", () => {
+    // On claim the worker re-points open lots to the next recurring slot, so
+    // a scheduled sibling would show the same funds as the executing sweep.
+    for (const executing of ["requested", "selected"]) {
+      expect(
+        getDisplayableEarnAutodepositScheduledSweeps("created", [
+          { id: "1", status: executing },
+          { id: "2", status: "scheduled" },
+          { id: "3", status: "released" },
+        ])
+      ).toEqual([
+        { id: "1", status: executing },
+        { id: "3", status: "released" },
+      ]);
+    }
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-autodeposit-loaded-state.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-autodeposit-loaded-state.shared.ts
@@ -56,13 +56,26 @@ type EarnAutodepositDisplayStatus =
   | "pausing"
   | "resuming";
 
-export function getDisplayableEarnAutodepositScheduledSweeps<T>(
+const EXECUTING_SWEEP_STATUSES = new Set(["requested", "selected"]);
+
+export function getDisplayableEarnAutodepositScheduledSweeps<
+  T extends { status: string },
+>(
   status: EarnAutodepositDisplayStatus,
   scheduledSweeps: readonly T[] | null | undefined
 ): T[] {
-  return status === "active" || status === "created"
-    ? [...(scheduledSweeps ?? [])]
-    : [];
+  if (status !== "active" && status !== "created") {
+    return [];
+  }
+  const sweeps = [...(scheduledSweeps ?? [])];
+  // On claiming a slot the worker re-points its open surplus lots to the next
+  // recurring slot while the execution is still consuming that same surplus,
+  // so a plain 'scheduled' sibling would double-display the funds. Hide
+  // scheduled rows until the execution settles; they return afterward if
+  // surplus genuinely remains.
+  return sweeps.some((sweep) => EXECUTING_SWEEP_STATUSES.has(sweep.status))
+    ? sweeps.filter((sweep) => sweep.status !== "scheduled")
+    : sweeps;
 }
 
 export function getLoadedScheduledSweepExecuteNowAvailableAtMs(


### PR DESCRIPTION
On claim the worker re-points open surplus lots to the next recurring slot, so a scheduled sibling row double-displayed the same funds as the executing sweep; the shared display filter now hides scheduled rows until the execution settles. ASK-2033.