### PR TITLE
fix(earn): stop reporting wallet denials as transaction simulation failures

### DIFF
--- a/frontend/src/hooks/use-smart-account-sidebar-data.ts
+++ b/frontend/src/hooks/use-smart-account-sidebar-data.ts
@@ -699,6 +699,21 @@ function getDetailedWalletErrorMessage(error: unknown, fallback: string) {
   return `${baseMessage}: ${nested}`;
 }
 
+const WALLET_CANCELLATION_MESSAGE_MARKERS = [
+  "user rejected",
+  "user denied",
+  "declined",
+  "cancelled",
+  "canceled",
+];
+
+export function isWalletCancellationError(error: unknown): boolean {
+  const normalized = getDetailedWalletErrorMessage(error, "").toLowerCase();
+  return WALLET_CANCELLATION_MESSAGE_MARKERS.some((marker) =>
+    normalized.includes(marker)
+  );
+}
+
 export const EARN_DEPOSIT_CONFIRMED_BUT_NOT_RECORDED_MESSAGE =
   "Your USDC deposit is confirmed, but Earn is still updating. Refresh Earn before doing anything else so you do not deposit twice.";
 
@@ -747,11 +762,9 @@ export function getEarnDepositUserErrorMessage(
   }
 
   if (
-    normalized.includes("user rejected") ||
-    normalized.includes("user denied") ||
-    normalized.includes("declined") ||
-    normalized.includes("cancelled") ||
-    normalized.includes("canceled")
+    WALLET_CANCELLATION_MESSAGE_MARKERS.some((marker) =>
+      normalized.includes(marker)
+    )
   ) {
     return "You canceled the wallet request. No USDC was deposited.";
   }
@@ -6428,8 +6441,14 @@ export function useSmartAccountSidebarData(
         };
       } catch (err) {
         const error = getEarnDepositUserErrorMessage(err);
-        captureBrowserError(err, "earn.deposit.execute");
-        console.error("[executeEarnDeposit] failed", err);
+        if (isWalletCancellationError(err)) {
+          // A denial is a user decision, not an app failure — keep it out of
+          // error-level telemetry so it does not trip the errors alert.
+          console.warn("[executeEarnDeposit] canceled in wallet", err);
+        } else {
+          captureBrowserError(err, "earn.deposit.execute");
+          console.error("[executeEarnDeposit] failed", err);
+        }
         const signature = getSubmittedTransactionSignature(err);
         return {
           success: false,

--- a/packages/smart-account-vaults/src/wallet.test.ts
+++ b/packages/smart-account-vaults/src/wallet.test.ts
@@ -149,6 +149,48 @@ describe("wallet prepared sends", () => {
     expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
   });
 
+  test("keeps the wallet rejection when the diagnostic simulation succeeds", async () => {
+    // A user denial leaves a perfectly valid transaction behind, so the
+    // post-failure diagnostic simulation succeeds with clean logs. That must
+    // never be reported as "Transaction simulation failed." in place of the
+    // wallet's own rejection error.
+    const connection = createConnection({
+      simulateTransaction: mock(async () => ({
+        context: { slot: 1 },
+        value: {
+          err: null,
+          logs: [
+            "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG invoke [1]",
+            "Program SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG success",
+          ],
+        },
+      })),
+    });
+    const walletError = new Error("User rejected the request.");
+
+    try {
+      await sendPreparedWithWallet({
+        connection,
+        prepared: createPrepared(),
+        wallet: {
+          publicKey: feePayer,
+          sendTransaction: mock(async () => {
+            throw walletError;
+          }),
+          signTransaction: mock(
+            async <T extends VersionedTransaction>(transaction: T) =>
+              transaction
+          ),
+        },
+      });
+      throw new Error("expected sendPreparedWithWallet to throw");
+    } catch (error) {
+      expect(error).toBe(walletError);
+    }
+
+    expect(connection.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
   test("simulates prepared batch transactions after wallet signing failure", async () => {
     const connection = createConnection({
       logs: [

--- a/packages/smart-account-vaults/src/wallet.ts
+++ b/packages/smart-account-vaults/src/wallet.ts
@@ -33,11 +33,21 @@ function translateSimulationLogs(logs: string[]): Error | null {
     return null;
   }
 
+  const placeholder = Object.assign(
+    new Error("Transaction simulation failed."),
+    { logs }
+  );
   try {
-    translateAndThrowAnchorError(
-      Object.assign(new Error("Transaction simulation failed."), { logs })
-    );
+    translateAndThrowAnchorError(placeholder);
   } catch (error) {
+    // The translator rethrows the placeholder unchanged when the logs carry no
+    // recognizable failure — which is what a clean diagnostic simulation looks
+    // like (e.g. the user rejected in the wallet and the transaction itself is
+    // fine). Surfacing the placeholder there would replace the real error with
+    // a fabricated "Transaction simulation failed.", so keep the original.
+    if (error === placeholder) {
+      return null;
+    }
     return error instanceof Error ? error : null;
   }
 }


### PR DESCRIPTION
A post-failure diagnostic simulation in smart-account-vaults replaced any wallet send error with a fabricated "Transaction simulation failed." whenever the simulation came back clean — which is exactly what a user denial looks like — so denials fired the error alert as unexpected_error and showed the wrong toast. The original wallet error now propagates (denials hit the existing cancel/wallet_rejected branches), and executeEarnDeposit no longer error-captures cancellations. ASK-2031.