### PR TITLE
feat(earn): animate how-it-works step diagrams on deposit and autodeposit

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2375,8 +2375,10 @@
   transform: scaleY(1);
 }
 /* Loop reset: fills fade out where they stand (the transform snap waits for
-   the fade), nodes ride their normal color/background transition back. */
-.is-flow-resetting .t-flow-fill {
+   the fade), nodes ride their normal color/background transition back. The
+   class sits on each track (not the stagger group, whose is-shown React
+   would wipe on a className change). */
+.t-flow-track.is-resetting .t-flow-fill {
   opacity: 0;
   transform: scaleY(0);
   transition: opacity var(--flow-reset-dur) ease,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2323,6 +2323,73 @@
   }
 }
 
+/* transitions.dev-style — Flow diagram (facelift "How … works" explainers,
+   flow-explainer.tsx): the active node lights up in sequence and the
+   connector fills top-down like funds moving through the pipeline. The loop
+   reset fades the fills in place instead of draining them upward; cycle
+   timing lives in the component. */
+:root {
+  --flow-dur: 500ms;
+  --flow-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --flow-fill-dur: 800ms;
+  --flow-reset-dur: 400ms;
+}
+
+.t-flow-node {
+  background: rgba(0, 0, 0, 0.04);
+  color: rgba(60, 60, 67, 0.45);
+  transition: background var(--flow-dur) var(--flow-ease),
+    color var(--flow-dur) var(--flow-ease),
+    transform var(--flow-dur) var(--flow-ease);
+  will-change: transform;
+}
+.t-flow-node.is-reached {
+  color: #f9363c;
+}
+.t-flow-node.is-active {
+  background: rgba(249, 54, 60, 0.08);
+  transform: scale(1.08);
+}
+
+.t-flow-track {
+  position: relative;
+  flex: 1;
+  width: 2px;
+  min-height: 14px;
+  margin: 4px 0;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+.t-flow-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: #f9363c;
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform var(--flow-fill-dur) var(--flow-ease);
+  will-change: transform;
+}
+.t-flow-track.is-filled .t-flow-fill {
+  transform: scaleY(1);
+}
+/* Loop reset: fills fade out where they stand (the transform snap waits for
+   the fade), nodes ride their normal color/background transition back. */
+.is-flow-resetting .t-flow-fill {
+  opacity: 0;
+  transform: scaleY(0);
+  transition: opacity var(--flow-reset-dur) ease,
+    transform 0s linear var(--flow-reset-dur);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-flow-node,
+  .t-flow-fill {
+    transition: none !important;
+  }
+}
+
 /* Facelift adaptation: flow-layout list skeletons (transaction rows) reuse
    the skeleton recipe's pulse clock without the absolute reveal wrap — the
    reveal side is handled by the texts-reveal stagger on the loaded rows. */

--- a/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import { ArrowRightLeft, Repeat, Undo2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  ArrowRightLeft,
+  CalendarClock,
+  Radar,
+  Undo2,
+  Wallet,
+} from "lucide-react";
+import { useState } from "react";
 
 import { sanitizeBucksAmountInput } from "@/components/wallet-sidebar/earn-detail-view";
 import {
   ScrambleText,
   useBalanceVisibility,
 } from "@/components/wallet-workspace/facelift/balance-visibility";
-import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
+import {
+  FlowDiagram,
+  FlowExplainerAside,
+  FlowExplainerOverlay,
+  type FlowStep,
+} from "@/components/wallet-workspace/facelift/flow-explainer";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { useStablecoinsUsd } from "@/components/wallet-workspace/facelift/use-stablecoins-usd";
@@ -20,48 +31,37 @@ function parseAmountUsd(value: string) {
   return Number.parseFloat(value.replace(/,/g, "")) || 0;
 }
 
-// Same transparency rows the mobile app shows before Autodeposit setup
-// (mobile/src/components/earn/AutodepositInfoSheet.tsx) — what primitive it
-// runs on, what permission it holds, and how it's undone.
-const INFO_ROWS = [
+// The pipeline a sweep travels, told as steps (user-docs/earn/autodeposit.mdx
+// "Execution"), with the trust facts the old flat rows carried — the on-chain
+// primitive, the permission scope, and how it's undone — folded into the
+// step bodies. Mirrors mobile's AutodepositInfoSheet content.
+const AUTODEPOSIT_STEPS: readonly FlowStep[] = [
   {
-    Icon: Repeat,
-    body: "Autodeposit runs on Solana's built-in subscriptions primitive — a standard, auditable on-chain permission.",
-    title: "Native Solana subscriptions",
+    Icon: Wallet,
+    body: "Pick how much of your stablecoins to keep liquid. Everything above that floor is eligible for Earn — change it anytime.",
+    title: "You set the amount to keep",
+  },
+  {
+    Icon: Radar,
+    body: "A native Solana subscription — a standard, auditable on-chain permission — notices when your balance rises above the floor.",
+    title: "Loyal watches your wallet",
+  },
+  {
+    Icon: CalendarClock,
+    body: "The eligible amount is queued while Loyal re-verifies your balance and the on-chain limits. You can also execute it right away.",
+    title: "The surplus gets scheduled",
   },
   {
     Icon: ArrowRightLeft,
-    body: "It lets your smart account move stablecoins above your threshold from your wallet into Kamino reserves — no signing each time.",
-    title: "Deposits happen for you",
+    body: "Your smart account moves the surplus along one approved path into Kamino reserves — no signing each time.",
+    title: "Deposited for you",
   },
   {
     Icon: Undo2,
-    body: "Delete the Autodeposit anytime to revoke its permissions and get back the SOL held as account rent.",
-    title: "Fully reversible",
+    body: "The deposit starts earning immediately. Delete Autodeposit anytime to revoke its permission and get back the SOL held as rent.",
+    title: "Earning — and reversible",
   },
-] as const;
-
-function InfoContent() {
-  return (
-    <div className="flex min-h-0 w-full flex-1 flex-col gap-5 overflow-y-auto px-6 pt-2 pb-6">
-      {INFO_ROWS.map(({ Icon, body, title }) => (
-        <div className="flex w-full gap-3.5" key={title}>
-          <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-black/[0.04]">
-            <Icon className="text-[#f9363c]" size={24} strokeWidth={2} />
-          </span>
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <p className="font-medium text-[16px] text-black leading-5">
-              {title}
-            </p>
-            <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-              {body}
-            </p>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+];
 
 // "How Autodeposit works" as an overlay: card next to the sidebar below
 // 1204px (Figma 4693:69792), bottom sheet on mobile (Figma 4693:71793) —
@@ -74,57 +74,14 @@ export function AutodepositInfoOverlay({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
   return (
-    <SheetReveal
+    <FlowExplainerOverlay
       isOpen={isOpen}
       onClose={onClose}
-      scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 pl-[368px] backdrop-blur-[4px] min-[1204px]:hidden max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8"
-      sheetClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+      title="How Autodeposit works"
     >
-      <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
-          How Autodeposit works
-        </h2>
-        <button
-          aria-label="Close info"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
-          onClick={onClose}
-          type="button"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
-            src={`${ASSET_BASE}/icon-cross.svg`}
-          />
-        </button>
-      </header>
-      <InfoContent />
-      <div className="w-full px-4 pt-2 pb-4 min-[796px]:hidden">
-        <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-[#f5f5f5] font-medium text-[16px] text-black leading-5 hover:bg-[#ececec]"
-          onClick={onClose}
-          type="button"
-        >
-          Close
-        </button>
-      </div>
-    </SheetReveal>
+      <FlowDiagram steps={AUTODEPOSIT_STEPS} />
+    </FlowExplainerOverlay>
   );
 }
 
@@ -414,14 +371,9 @@ export function AutodepositPane({
 
       {/* Info panel: fixed right pane on wide viewports (Figma 4693:69387),
           overlay via the header ? below 1204px (Figma 4693:69792). */}
-      <aside className="hidden h-fit max-h-full w-[400px] shrink-0 flex-col overflow-clip rounded-3xl bg-white min-[1204px]:flex">
-        <header className="flex w-full items-center p-2">
-          <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
-            How Autodeposit works
-          </h2>
-        </header>
-        <InfoContent />
-      </aside>
+      <FlowExplainerAside title="How Autodeposit works">
+        <FlowDiagram steps={AUTODEPOSIT_STEPS} />
+      </FlowExplainerAside>
 
       <AutodepositInfoOverlay
         isOpen={isInfoOpen}

--- a/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
@@ -31,6 +31,8 @@ function parseAmountUsd(value: string) {
   return Number.parseFloat(value.replace(/,/g, "")) || 0;
 }
 
+const AUTODEPOSIT_DOCS_URL = "https://docs.askloyal.com/earn/autodeposit";
+
 // The pipeline a sweep travels, told as steps (user-docs/earn/autodeposit.mdx
 // "Execution"), with the trust facts the old flat rows carried — the on-chain
 // primitive, the permission scope, and how it's undone — folded into the
@@ -80,7 +82,7 @@ export function AutodepositInfoOverlay({
       onClose={onClose}
       title="How Autodeposit works"
     >
-      <FlowDiagram steps={AUTODEPOSIT_STEPS} />
+      <FlowDiagram docsHref={AUTODEPOSIT_DOCS_URL} steps={AUTODEPOSIT_STEPS} />
     </FlowExplainerOverlay>
   );
 }
@@ -372,7 +374,10 @@ export function AutodepositPane({
       {/* Info panel: fixed right pane on wide viewports (Figma 4693:69387),
           overlay via the header ? below 1204px (Figma 4693:69792). */}
       <FlowExplainerAside title="How Autodeposit works">
-        <FlowDiagram steps={AUTODEPOSIT_STEPS} />
+        <FlowDiagram
+          docsHref={AUTODEPOSIT_DOCS_URL}
+          steps={AUTODEPOSIT_STEPS}
+        />
       </FlowExplainerAside>
 
       <AutodepositInfoOverlay

--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CircleDollarSign, Landmark, PenLine, TrendingUp } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { sanitizeBucksAmountInput } from "@/components/wallet-sidebar/earn-detail-view";
@@ -7,6 +8,12 @@ import {
   ScrambleText,
   useBalanceVisibility,
 } from "@/components/wallet-workspace/facelift/balance-visibility";
+import {
+  FlowDiagram,
+  FlowExplainerAside,
+  FlowExplainerOverlay,
+  type FlowStep,
+} from "@/components/wallet-workspace/facelift/flow-explainer";
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
@@ -23,6 +30,36 @@ import { getTokenIconUrl } from "@/lib/token-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 const MIN_DEPOSIT_USD = 1;
+
+// The deposit's path told as steps — amount, one signature, where the USDC
+// actually goes, and what earning/withdrawing look like (user-docs
+// automations/routing-and-yield.mdx: vault → approved lending market, USDC
+// stays USDC; rates are variable).
+const DEPOSIT_STEPS: readonly FlowStep[] = [
+  {
+    Icon: CircleDollarSign,
+    body: `Pick how much USDC to move from your wallet into Earn. The minimum is $${MIN_DEPOSIT_USD}.`,
+    title: "Choose an amount",
+  },
+  {
+    Icon: PenLine,
+    body: "One signature sends the deposit through your own smart account — Loyal never takes custody of your funds.",
+    title: "Approve in your wallet",
+  },
+  {
+    Icon: Landmark,
+    body: "It lands in your Earn vault, then an approved USDC lending market on Kamino. USDC stays USDC — it is never swapped.",
+    title: "Your USDC is lent out",
+  },
+  {
+    Icon: TrendingUp,
+    body: "Interest accrues continuously at a variable rate. Withdraw back to your wallet anytime.",
+    title: "Earning starts right away",
+  },
+];
+
+const DEPOSIT_FOOTNOTE =
+  "Rates are variable, and supplied funds carry the risks of the underlying lending market.";
 
 // Figma 4693:65815 (empty / below minimum) + 4693:65625 (valid amount) +
 // 4693:70280 (mobile: full-bleed, chart button in the header opens the chart
@@ -41,6 +78,7 @@ export function DepositPane({
   const { apy, isLoaded: isApyLoaded } = useEarnForecastApyStatus();
   const { isBalanceHidden } = useBalanceVisibility();
   const [amount, setAmount] = useState("");
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
   const { actions } = earnData;
 
   const positionsUsdcUsd = useMemo(() => {
@@ -81,13 +119,48 @@ export function DepositPane({
   };
 
   return (
-    <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
-      <header className="flex w-full items-center p-2">
-        <div className="pr-3">
+    <>
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
+        <header className="flex w-full items-center p-2">
+          <div className="pr-3">
+            <button
+              aria-label="Back"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              onClick={onBack}
+              type="button"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt=""
+                aria-hidden="true"
+                className="size-6"
+                src={`${ASSET_BASE}/icon-arrow-left.svg`}
+              />
+            </button>
+          </div>
+          <div className="flex min-w-0 flex-1 items-center gap-2 py-2">
+            <h1 className="truncate font-semibold text-[20px] text-black leading-6">
+              Deposit
+            </h1>
+            <button
+              aria-label="How Deposit works"
+              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] min-[1204px]:hidden"
+              onClick={() => setIsInfoOpen(true)}
+              type="button"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt=""
+                aria-hidden="true"
+                className="size-6"
+                src={`${ASSET_BASE}/icon-question.svg`}
+              />
+            </button>
+          </div>
           <button
-            aria-label="Back"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
-            onClick={onBack}
+            aria-label="Open chart"
+            className="t-hover hidden size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] max-[795px]:flex"
+            onClick={onOpenChart}
             type="button"
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -95,212 +168,213 @@ export function DepositPane({
               alt=""
               aria-hidden="true"
               className="size-6"
-              src={`${ASSET_BASE}/icon-arrow-left.svg`}
+              src={`${ASSET_BASE}/icon-chart.svg`}
             />
           </button>
-        </div>
-        <h1 className="min-w-0 flex-1 truncate py-2 font-semibold text-[20px] text-black leading-6">
-          Deposit
-        </h1>
-        <button
-          aria-label="Open chart"
-          className="t-hover hidden size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] max-[795px]:flex"
-          onClick={onOpenChart}
-          type="button"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
-            src={`${ASSET_BASE}/icon-chart.svg`}
-          />
-        </button>
-      </header>
+        </header>
 
-      <div className="flex min-h-0 w-full flex-1 flex-col">
-        <div className="flex w-full flex-1 flex-col">
-          <div className="w-full p-2">
-            <label className="flex w-full flex-col gap-0.5 rounded-2xl px-4 py-2">
-              <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
-                Amount
-              </span>
-              <span className="flex h-12 w-full items-baseline">
-                <span className="font-semibold text-[40px] text-black leading-[48px]">
-                  $
+        <div className="flex min-h-0 w-full flex-1 flex-col">
+          <div className="flex w-full flex-1 flex-col">
+            <div className="w-full p-2">
+              <label className="flex w-full flex-col gap-0.5 rounded-2xl px-4 py-2">
+                <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  Amount
                 </span>
-                <input
-                  autoFocus
-                  className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
-                  inputMode="decimal"
-                  onChange={(event) => handleAmountChange(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" || event.repeat) {
-                      return;
-                    }
-                    event.preventDefault();
-                    if (isValidAmount && !isSubmitting) {
-                      void handleSubmit();
-                    }
-                  }}
-                  placeholder="0"
-                  type="text"
-                  value={amount}
-                />
-              </span>
-            </label>
-          </div>
+                <span className="flex h-12 w-full items-baseline">
+                  <span className="font-semibold text-[40px] text-black leading-[48px]">
+                    $
+                  </span>
+                  <input
+                    autoFocus
+                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                    inputMode="decimal"
+                    onChange={(event) => handleAmountChange(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.repeat) {
+                        return;
+                      }
+                      event.preventDefault();
+                      if (isValidAmount && !isSubmitting) {
+                        void handleSubmit();
+                      }
+                    }}
+                    placeholder="0"
+                    type="text"
+                    value={amount}
+                  />
+                </span>
+              </label>
+            </div>
 
-          {/* Rent disclaimer only concerns the FIRST deposit — an existing
+            {/* Rent disclaimer only concerns the FIRST deposit — an existing
               position's accounts already paid it. */}
-          {earnData.hasPosition ? null : (
-            <div className="w-full px-2">
-              <div className="flex w-full items-start px-4">
-                <div className="flex items-center py-1 pr-2">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-6"
-                    src={`${ASSET_BASE}/icon-circle-info.svg`}
-                  />
-                </div>
-                <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-                  Your first deposit takes ~0.06 SOL from your wallet for Solana
-                  account rent — it is returned when you fully withdraw.
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="relative flex h-36 w-full flex-col gap-1 overflow-clip p-2">
-          <div className="flex w-full items-center rounded-2xl px-4">
-            <div className="py-2 pr-3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-11 rounded-full"
-                src={getTokenIconUrl("USDC")}
-              />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-                from USDC balance
-              </span>
-              <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
-                <ScrambleText
-                  isHidden={isBalanceHidden}
-                  text={usdcBalance.balanceWhole}
-                />
-                <span className="text-[rgba(60,60,67,0.4)]">
-                  <ScrambleText
-                    isHidden={isBalanceHidden}
-                    text={usdcBalance.balanceFraction}
-                  />
-                </span>
-              </p>
-            </div>
-            <div className="pl-3">
-              <button
-                className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
-                onClick={() => {
-                  if (usdcUsd > 0) {
-                    // Floor to cents so the fill never rounds above the real
-                    // balance (toFixed would turn 1.8699 into an
-                    // "insufficient" 1.87), same as the withdraw pane's MAX.
-                    handleAmountChange(
-                      (Math.floor(usdcUsd * 100) / 100).toFixed(2)
-                    );
-                  }
-                }}
-                type="button"
-              >
-                MAX
-              </button>
-            </div>
-          </div>
-
-          <div className="flex w-full items-center rounded-2xl px-4">
-            <div className="py-2 pr-3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-11"
-                src={`${ASSET_BASE}/earn-icon.svg`}
-              />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
-                to Earn
-              </span>
-              <span className="flex items-center">
-                {/* Skeleton the badge until the real APY lands, then reveal
-                    + pop — the fallback APY would otherwise flash. */}
-                <SkeletonReveal
-                  isRevealed={isApyLoaded}
-                  skeletonClassName="rounded-lg bg-black/[0.06]"
-                >
-                  <span className="inline-flex items-center gap-1 rounded-lg bg-[rgba(52,199,89,0.14)] px-2 py-0.5">
+            {earnData.hasPosition ? null : (
+              <div className="w-full px-2">
+                <div className="flex w-full items-start px-4">
+                  <div className="flex items-center py-1 pr-2">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       alt=""
                       aria-hidden="true"
-                      className="h-5 w-3"
-                      src="/wallet-workspace/earn-flash.svg"
+                      className="size-6"
+                      src={`${ASSET_BASE}/icon-circle-info.svg`}
                     />
-                    <span className="whitespace-nowrap font-medium text-[#34c759] text-[16px] leading-5 tracking-[0.06px]">
-                      {isApyLoaded ? (
-                        <PopDigits
-                          segments={[{ text: formatEarnApyLabel(apy.apyBps) }]}
-                        />
-                      ) : (
-                        formatEarnApyLabel(apy.apyBps)
-                      )}
-                    </span>
-                  </span>
-                </SkeletonReveal>
-              </span>
-            </div>
+                  </div>
+                  <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                    Your first deposit takes ~0.06 SOL from your wallet for
+                    Solana account rent — it is returned when you fully
+                    withdraw.
+                  </p>
+                </div>
+              </div>
+            )}
           </div>
 
-          <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-[#d9d9d9]" />
-        </div>
-      </div>
+          <div className="relative flex h-36 w-full flex-col gap-1 overflow-clip p-2">
+            <div className="flex w-full items-center rounded-2xl px-4">
+              <div className="py-2 pr-3">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  className="size-11 rounded-full"
+                  src={getTokenIconUrl("USDC")}
+                />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  from USDC balance
+                </span>
+                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                  <ScrambleText
+                    isHidden={isBalanceHidden}
+                    text={usdcBalance.balanceWhole}
+                  />
+                  <span className="text-[rgba(60,60,67,0.4)]">
+                    <ScrambleText
+                      isHidden={isBalanceHidden}
+                      text={usdcBalance.balanceFraction}
+                    />
+                  </span>
+                </p>
+              </div>
+              <div className="pl-3">
+                <button
+                  className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                  onClick={() => {
+                    if (usdcUsd > 0) {
+                      // Floor to cents so the fill never rounds above the real
+                      // balance (toFixed would turn 1.8699 into an
+                      // "insufficient" 1.87), same as the withdraw pane's MAX.
+                      handleAmountChange(
+                        (Math.floor(usdcUsd * 100) / 100).toFixed(2)
+                      );
+                    }
+                  }}
+                  type="button"
+                >
+                  MAX
+                </button>
+              </div>
+            </div>
 
-      <div className="w-full bg-white px-4 pt-2 pb-4">
-        {actions.depositError ? (
-          <p className="px-4 pb-2 text-[13px] leading-4 text-[#f9363c]">
-            {actions.depositError}
-          </p>
-        ) : null}
-        {/* One persistent pill so the label swaps in place (transitions.dev
+            <div className="flex w-full items-center rounded-2xl px-4">
+              <div className="py-2 pr-3">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  className="size-11"
+                  src={`${ASSET_BASE}/earn-icon.svg`}
+                />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  to Earn
+                </span>
+                <span className="flex items-center">
+                  {/* Skeleton the badge until the real APY lands, then reveal
+                    + pop — the fallback APY would otherwise flash. */}
+                  <SkeletonReveal
+                    isRevealed={isApyLoaded}
+                    skeletonClassName="rounded-lg bg-black/[0.06]"
+                  >
+                    <span className="inline-flex items-center gap-1 rounded-lg bg-[rgba(52,199,89,0.14)] px-2 py-0.5">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        className="h-5 w-3"
+                        src="/wallet-workspace/earn-flash.svg"
+                      />
+                      <span className="whitespace-nowrap font-medium text-[#34c759] text-[16px] leading-5 tracking-[0.06px]">
+                        {isApyLoaded ? (
+                          <PopDigits
+                            segments={[
+                              { text: formatEarnApyLabel(apy.apyBps) },
+                            ]}
+                          />
+                        ) : (
+                          formatEarnApyLabel(apy.apyBps)
+                        )}
+                      </span>
+                    </span>
+                  </SkeletonReveal>
+                </span>
+              </div>
+            </div>
+
+            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-[#d9d9d9]" />
+          </div>
+        </div>
+
+        <div className="w-full bg-white px-4 pt-2 pb-4">
+          {actions.depositError ? (
+            <p className="px-4 pb-2 text-[13px] leading-4 text-[#f9363c]">
+              {actions.depositError}
+            </p>
+          ) : null}
+          {/* One persistent pill so the label swaps in place (transitions.dev
             text states swap); disabled stands in for the old inert div. */}
-        <button
-          className={`t-hover flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 ${
-            isValidAmount
-              ? "bg-black text-white enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
-              : "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
-          }`}
-          disabled={!isValidAmount || isSubmitting}
-          onClick={() => void handleSubmit()}
-          type="button"
-        >
-          <TextSwap
-            text={
-              isSubmitting
-                ? "Depositing…"
-                : isInsufficient
-                ? "Insufficient balance"
-                : isValidAmount
-                ? `Deposit ${amountLabel} USDC`
-                : `Minimum deposit is $${MIN_DEPOSIT_USD}`
-            }
-          />
-        </button>
-      </div>
-    </section>
+          <button
+            className={`t-hover flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 ${
+              isValidAmount
+                ? "bg-black text-white enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
+                : "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+            }`}
+            disabled={!isValidAmount || isSubmitting}
+            onClick={() => void handleSubmit()}
+            type="button"
+          >
+            <TextSwap
+              text={
+                isSubmitting
+                  ? "Depositing…"
+                  : isInsufficient
+                  ? "Insufficient balance"
+                  : isValidAmount
+                  ? `Deposit ${amountLabel} USDC`
+                  : `Minimum deposit is $${MIN_DEPOSIT_USD}`
+              }
+            />
+          </button>
+        </div>
+      </section>
+
+      {/* Explainer: fixed right pane on wide viewports (the slot the chart
+        column vacates for this screen), overlay via the header ? below
+        1204px — same split the Autodeposit screen uses. */}
+      <FlowExplainerAside title="How Deposit works">
+        <FlowDiagram footnote={DEPOSIT_FOOTNOTE} steps={DEPOSIT_STEPS} />
+      </FlowExplainerAside>
+
+      <FlowExplainerOverlay
+        isOpen={isInfoOpen}
+        onClose={() => setIsInfoOpen(false)}
+        title="How Deposit works"
+      >
+        <FlowDiagram footnote={DEPOSIT_FOOTNOTE} steps={DEPOSIT_STEPS} />
+      </FlowExplainerOverlay>
+    </>
   );
 }

--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -61,6 +61,9 @@ const DEPOSIT_STEPS: readonly FlowStep[] = [
 const DEPOSIT_FOOTNOTE =
   "Rates are variable, and supplied funds carry the risks of the underlying lending market.";
 
+const DEPOSIT_DOCS_URL =
+  "https://docs.askloyal.com/automations/routing-and-yield";
+
 // Figma 4693:65815 (empty / below minimum) + 4693:65625 (valid amount) +
 // 4693:70280 (mobile: full-bleed, chart button in the header opens the chart
 // sheet, system num keyboard under the focused amount input).
@@ -365,7 +368,11 @@ export function DepositPane({
         column vacates for this screen), overlay via the header ? below
         1204px — same split the Autodeposit screen uses. */}
       <FlowExplainerAside title="How Deposit works">
-        <FlowDiagram footnote={DEPOSIT_FOOTNOTE} steps={DEPOSIT_STEPS} />
+        <FlowDiagram
+          docsHref={DEPOSIT_DOCS_URL}
+          footnote={DEPOSIT_FOOTNOTE}
+          steps={DEPOSIT_STEPS}
+        />
       </FlowExplainerAside>
 
       <FlowExplainerOverlay
@@ -373,7 +380,11 @@ export function DepositPane({
         onClose={() => setIsInfoOpen(false)}
         title="How Deposit works"
       >
-        <FlowDiagram footnote={DEPOSIT_FOOTNOTE} steps={DEPOSIT_STEPS} />
+        <FlowDiagram
+          docsHref={DEPOSIT_DOCS_URL}
+          footnote={DEPOSIT_FOOTNOTE}
+          steps={DEPOSIT_STEPS}
+        />
       </FlowExplainerOverlay>
     </>
   );

--- a/frontend/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
@@ -456,11 +456,10 @@ export function EarnChartPane({
           420px (Figma 4693:65423); the chart stays reachable via the overlay.
           Every tab shares the Earned hug height (527px, Figma 4693:68847);
           the Stats card scrolls into view below it (Figma 4884:36662). */}
-      {hideAside ? (
-        // Empty reserved slot (same as Send's): the chart column goes away
-        // but the middle pane must keep its usual width.
-        <div className="hidden h-full w-[400px] shrink-0 min-[1204px]:block" />
-      ) : (
+      {/* hideAside (deposit): the action pane brings its own 400px explainer
+          aside in the chart column's place, so no reserved slot is needed —
+          only the expanded overlay below stays mounted. */}
+      {hideAside ? null : (
         <div className="hidden h-full w-[400px] shrink-0 flex-col gap-2 overflow-y-auto [scrollbar-width:none] min-[1204px]:flex [&::-webkit-scrollbar]:hidden">
           <EarnChartCard
             actionAriaLabel="Expand chart"

--- a/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
+import {
+  StaggerLine,
+  StaggerReveal,
+} from "@/components/wallet-workspace/facelift/stagger-reveal";
+
+const ASSET_BASE = "/wallet-workspace/facelift";
+
+export type FlowStep = {
+  Icon: LucideIcon;
+  body: string;
+  title: string;
+};
+
+// Walkthrough clock: the spotlight advances every STEP_MS, dwells on the
+// completed pipeline so it can be read as a whole, then fades back and loops.
+const STEP_MS = 2400;
+const LAST_DWELL_MS = 3600;
+const RESET_MS = 500;
+
+// Animated step diagram for the "How … works" explainer panes: each step is a
+// node on a vertical pipeline, the active node lights up in sequence and the
+// connector fills top-down like funds moving through it (CSS under t-flow in
+// globals.css). Rows enter on the texts-reveal stagger; prefers-reduced-motion
+// pins the finished all-lit state instead of cycling.
+export function FlowDiagram({
+  footnote,
+  steps,
+}: {
+  footnote?: string;
+  steps: readonly FlowStep[];
+}) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isResetting, setIsResetting] = useState(false);
+  const [isStatic, setIsStatic] = useState(false);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setIsStatic(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isStatic) {
+      return;
+    }
+    const timer = window.setTimeout(
+      () => {
+        if (isResetting) {
+          setIsResetting(false);
+          setActiveIndex(0);
+          return;
+        }
+        if (activeIndex >= steps.length - 1) {
+          setIsResetting(true);
+          setActiveIndex(-1);
+          return;
+        }
+        setActiveIndex(activeIndex + 1);
+      },
+      isResetting
+        ? RESET_MS
+        : activeIndex === steps.length - 1
+        ? LAST_DWELL_MS
+        : STEP_MS
+    );
+    return () => window.clearTimeout(timer);
+  }, [activeIndex, isResetting, isStatic, steps.length]);
+
+  return (
+    <StaggerReveal
+      className={`flex min-h-0 w-full flex-1 flex-col overflow-y-auto px-6 pt-2 pb-6 ${
+        isResetting ? "is-flow-resetting" : ""
+      }`}
+    >
+      {steps.map(({ Icon, body, title }, index) => {
+        const isLast = index === steps.length - 1;
+        const isReached = isStatic || index <= activeIndex;
+        const isActive = !isStatic && index === activeIndex;
+        const isFilled = isStatic || index < activeIndex;
+        return (
+          <StaggerLine index={index} key={title}>
+            <div className="flex w-full gap-3.5">
+              <div className="flex shrink-0 flex-col items-center">
+                <span
+                  className={`t-flow-node flex size-11 shrink-0 items-center justify-center rounded-full ${
+                    isReached ? "is-reached" : ""
+                  } ${isActive ? "is-active" : ""}`}
+                >
+                  <Icon size={24} strokeWidth={2} />
+                </span>
+                {isLast ? null : (
+                  <span
+                    aria-hidden="true"
+                    className={`t-flow-track ${isFilled ? "is-filled" : ""}`}
+                  >
+                    <span className="t-flow-fill" />
+                  </span>
+                )}
+              </div>
+              <div
+                className={`flex min-w-0 flex-1 flex-col gap-1 pt-0.5 ${
+                  isLast ? "" : "pb-5"
+                }`}
+              >
+                <p className="font-medium text-[16px] text-black leading-5">
+                  {title}
+                </p>
+                <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  {body}
+                </p>
+              </div>
+            </div>
+          </StaggerLine>
+        );
+      })}
+      {footnote ? (
+        <StaggerLine index={steps.length}>
+          <p className="pt-5 text-[13px] leading-4 text-[rgba(60,60,67,0.45)]">
+            {footnote}
+          </p>
+        </StaggerLine>
+      ) : null}
+    </StaggerReveal>
+  );
+}
+
+// Fixed right pane on wide viewports — same 400px slot and card skin the
+// chart column uses, so the explainer reads as part of the workspace.
+export function FlowExplainerAside({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <aside className="hidden h-fit max-h-full w-[400px] shrink-0 flex-col overflow-clip rounded-3xl bg-white min-[1204px]:flex">
+      <header className="flex w-full items-center p-2">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+          {title}
+        </h2>
+      </header>
+      {children}
+    </aside>
+  );
+}
+
+// Below 1204px the explainer opens from the header "?" as an overlay: card
+// next to the sidebar on desktop widths, bottom sheet on mobile — rising on
+// the panel-reveal clock like a native sheet.
+export function FlowExplainerOverlay({
+  children,
+  isOpen,
+  onClose,
+  title,
+}: {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+}) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  return (
+    <SheetReveal
+      isOpen={isOpen}
+      onClose={onClose}
+      scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 pl-[368px] backdrop-blur-[4px] min-[1204px]:hidden max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8"
+      sheetClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+    >
+      <header className="flex w-full items-center p-2">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+          {title}
+        </h2>
+        <button
+          aria-label="Close info"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          onClick={onClose}
+          type="button"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt=""
+            aria-hidden="true"
+            className="size-6"
+            src={`${ASSET_BASE}/icon-cross.svg`}
+          />
+        </button>
+      </header>
+      {children}
+      <div className="w-full px-4 pt-2 pb-4 min-[796px]:hidden">
+        <button
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-[#f5f5f5] font-medium text-[16px] text-black leading-5 hover:bg-[#ececec]"
+          onClick={onClose}
+          type="button"
+        >
+          Close
+        </button>
+      </div>
+    </SheetReveal>
+  );
+}

--- a/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
@@ -29,9 +29,11 @@ const RESET_MS = 500;
 // globals.css). Rows enter on the texts-reveal stagger; prefers-reduced-motion
 // pins the finished all-lit state instead of cycling.
 export function FlowDiagram({
+  docsHref,
   footnote,
   steps,
 }: {
+  docsHref?: string;
   footnote?: string;
   steps: readonly FlowStep[];
 }) {
@@ -72,12 +74,12 @@ export function FlowDiagram({
     return () => window.clearTimeout(timer);
   }, [activeIndex, isResetting, isStatic, steps.length]);
 
+  // The reset class lives on the per-row tracks, never on StaggerReveal's
+  // className: StaggerReveal adds is-shown imperatively, so a changing
+  // className prop would make React rewrite the attribute and wipe it —
+  // hiding the whole diagram.
   return (
-    <StaggerReveal
-      className={`flex min-h-0 w-full flex-1 flex-col overflow-y-auto px-6 pt-2 pb-6 ${
-        isResetting ? "is-flow-resetting" : ""
-      }`}
-    >
+    <StaggerReveal className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto px-6 pt-2 pb-6">
       {steps.map(({ Icon, body, title }, index) => {
         const isLast = index === steps.length - 1;
         const isReached = isStatic || index <= activeIndex;
@@ -97,7 +99,9 @@ export function FlowDiagram({
                 {isLast ? null : (
                   <span
                     aria-hidden="true"
-                    className={`t-flow-track ${isFilled ? "is-filled" : ""}`}
+                    className={`t-flow-track ${isFilled ? "is-filled" : ""} ${
+                      isResetting ? "is-resetting" : ""
+                    }`}
                   >
                     <span className="t-flow-fill" />
                   </span>
@@ -124,6 +128,18 @@ export function FlowDiagram({
           <p className="pt-5 text-[13px] leading-4 text-[rgba(60,60,67,0.45)]">
             {footnote}
           </p>
+        </StaggerLine>
+      ) : null}
+      {docsHref ? (
+        <StaggerLine index={steps.length + (footnote ? 1 : 0)}>
+          <a
+            className="t-hover mt-5 inline-block font-medium text-[13px] leading-4 text-[rgba(60,60,67,0.6)] hover:text-black"
+            href={docsHref}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Learn more in the docs ↗
+          </a>
         </StaggerLine>
       ) : null}
     </StaggerReveal>

--- a/frontend/src/components/wallet-workspace/facelift/pane-transitions.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/pane-transitions.tsx
@@ -113,9 +113,9 @@ export function MiddlePaneSlide({
     // narrowed mid pane's edge before its exit plays. Pin the exiting page
     // at its open width and lift it over the incoming chart pane (whose
     // transformed innards otherwise paint through); with inset-0 the
-    // explicit width wins and the page stays left-anchored. Single-pane
-    // screens (deposit) keep the chart column mounted, so there the frozen
-    // width matches and this is a no-op.
+    // explicit width wins and the page stays left-anchored. Every action
+    // screen (withdraw/autodeposit/deposit) is two-pane now, so the freeze
+    // always matters.
     const actionPage = actionPageRef.current;
     if (actionPage && actionWidthRef.current !== null) {
       actionPage.style.width = `${actionWidthRef.current}px`;


### PR DESCRIPTION
Replaces the Autodeposit explainer's flat rows with an animated step diagram (nodes light up in sequence while the connector fills top-down, transitions.dev-style with reduced-motion support) and gives the Deposit screen the explanatory right pane it lacked, incl. a "?" overlay below 1204px and docs links for the curious. ASK-2035.