### PR TITLE
fix(cherry): allow Lighthouse and Memo injection and name injected programs in message diff

### DIFF
--- a/frontend/src/features/cherry/client/wallet-adapter.test.ts
+++ b/frontend/src/features/cherry/client/wallet-adapter.test.ts
@@ -10,6 +10,7 @@ import type { SendTransactionOptions } from "@solana/wallet-adapter-base";
 import {
   ComputeBudgetProgram,
   Keypair,
+  PublicKey,
   SystemProgram,
   Transaction,
   TransactionInstruction,
@@ -50,6 +51,12 @@ const RECIPIENT_A = keypair(3).publicKey;
 const RECIPIENT_B = keypair(4).publicKey;
 const BLOCKHASH = keypair(5).publicKey.toBase58();
 const OTHER_BLOCKHASH = keypair(6).publicKey.toBase58();
+const LIGHTHOUSE_PROGRAM = new PublicKey(
+  "L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95"
+);
+const MEMO_PROGRAM = new PublicKey(
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+);
 const RPC_SIGNATURE = "deterministic-rpc-signature";
 
 const messageListeners = new Set<MessageListener>();
@@ -297,6 +304,48 @@ describe("Loyal Cherry wallet adapter", () => {
     ).toBe(true);
   });
 
+  test("accepts a Seeker-style guard and fee injection without a blockhash change", async () => {
+    activeHost = approvedHost({
+      signVersioned: seekerVaultStyleSigner({
+        inject: [
+          {
+            data: new Uint8Array(
+              ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }).data
+            ),
+            programId: ComputeBudgetProgram.programId,
+          },
+          {
+            data: new Uint8Array(
+              ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1000 })
+                .data
+            ),
+            programId: ComputeBudgetProgram.programId,
+          },
+          { data: new Uint8Array([4, 0, 0]), programId: LIGHTHOUSE_PROGRAM },
+          { data: new Uint8Array([109, 101, 109, 111]), programId: MEMO_PROGRAM },
+        ],
+        replaceBlockhash: false,
+      }),
+    });
+    const adapter = await connectedAdapter();
+    const transaction = versionedTransaction(RECIPIENT_A);
+    const rpc = recordingConnection();
+
+    await expect(
+      adapter.sendTransaction(transaction, rpc.connection)
+    ).resolves.toBe(RPC_SIGNATURE);
+
+    expect(rpc.calls).toHaveLength(1);
+    const sent = VersionedTransaction.deserialize(rpc.calls[0]!.raw);
+    expect(sent.message.recentBlockhash).toBe(BLOCKHASH);
+    expect(sent.message.compiledInstructions).toHaveLength(5);
+    expect(
+      sent.message.staticAccountKeys.some((key) =>
+        key.equals(LIGHTHOUSE_PROGRAM)
+      )
+    ).toBe(true);
+  });
+
   test("rejects a benign-looking modification when the transaction carried a prior signature", async () => {
     activeHost = approvedHost({
       signVersioned: seekerVaultStyleSigner(),
@@ -334,7 +383,9 @@ describe("Loyal Cherry wallet adapter", () => {
 
     await expect(
       adapter.sendTransaction(transaction, rpc.connection)
-    ).rejects.toThrow("different message");
+    ).rejects.toThrow(
+      `instructions inserted: ${SystemProgram.programId.toBase58()}`
+    );
     expect(rpc.calls).toHaveLength(0);
   });
 
@@ -431,21 +482,42 @@ describe("Loyal Cherry wallet adapter", () => {
 });
 
 // Mirrors how an MWA device wallet (Seeker Vault) patches a transaction in
-// place before signing: fresh blockhash, compute-budget program appended to
-// the static keys, and a priority-fee instruction prepended.
-function seekerVaultStyleSigner() {
-  return (transaction: VersionedTransaction): VersionedTransaction => {
-    const message = transaction.message;
-    message.recentBlockhash = OTHER_BLOCKHASH;
-    message.staticAccountKeys.push(ComputeBudgetProgram.programId);
-    message.header.numReadonlyUnsignedAccounts += 1;
-    message.compiledInstructions.unshift({
-      accountKeyIndexes: [],
+// place before signing: injected programs appended to the static keys and
+// their instructions prepended, optionally with a fresh blockhash.
+function seekerVaultStyleSigner(
+  options: {
+    inject?: Array<{ data: Uint8Array; programId: PublicKey }>;
+    replaceBlockhash?: boolean;
+  } = {}
+) {
+  const inject = options.inject ?? [
+    {
       data: new Uint8Array(
         ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1000 }).data
       ),
-      programIdIndex: message.staticAccountKeys.length - 1,
-    });
+      programId: ComputeBudgetProgram.programId,
+    },
+  ];
+  return (transaction: VersionedTransaction): VersionedTransaction => {
+    const message = transaction.message;
+    if (options.replaceBlockhash ?? true) {
+      message.recentBlockhash = OTHER_BLOCKHASH;
+    }
+    for (const { data, programId } of inject) {
+      let programIdIndex = message.staticAccountKeys.findIndex((key) =>
+        key.equals(programId)
+      );
+      if (programIdIndex < 0) {
+        message.staticAccountKeys.push(programId);
+        message.header.numReadonlyUnsignedAccounts += 1;
+        programIdIndex = message.staticAccountKeys.length - 1;
+      }
+      message.compiledInstructions.unshift({
+        accountKeyIndexes: [],
+        data,
+        programIdIndex,
+      });
+    }
     const patched = new VersionedTransaction(message);
     patched.sign([WALLET]);
     return patched;

--- a/frontend/src/features/cherry/client/wallet-adapter.ts
+++ b/frontend/src/features/cherry/client/wallet-adapter.ts
@@ -7,12 +7,12 @@ import {
 } from "@solana/wallet-adapter-base";
 import {
   ComputeBudgetProgram,
+  PublicKey,
   Transaction,
   VersionedTransaction,
   type Connection,
   type MessageAddressTableLookup,
   type MessageCompiledInstruction,
-  type PublicKey,
   type Signer,
   type VersionedMessage,
 } from "@solana/web3.js";
@@ -339,12 +339,29 @@ function messageOf(transaction: SupportedTransaction): VersionedMessage {
     : transaction.compileMessage();
 }
 
+// Programs an MWA wallet may inject without being able to touch user assets:
+// compute-budget (priority fees), Lighthouse (assertion-only guard — its
+// instructions can abort a transaction but never move funds), and Memo
+// (inert data). The Seeker vault injects guard/fee instructions on signing.
+const BENIGN_INJECTED_PROGRAM_IDS: readonly PublicKey[] = [
+  ComputeBudgetProgram.programId,
+  new PublicKey("L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95"),
+  new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+];
+
+function isBenignInjectedProgram(key: PublicKey | undefined): boolean {
+  return Boolean(
+    key && BENIGN_INJECTED_PROGRAM_IDS.some((program) => program.equals(key))
+  );
+}
+
 /**
  * True when the returned message differs from the sent one only in ways an
  * MWA wallet is allowed to introduce: a replaced recent blockhash and/or
- * inserted compute-budget instructions (with the compute-budget program
- * appended to the static keys). Everything else — fee payer, signer set,
- * lookup tables, and every original instruction byte — must be unchanged.
+ * inserted instructions from the benign program allowlist (with those
+ * programs appended to the static keys). Everything else — fee payer, signer
+ * set, lookup tables, and every original instruction byte — must be
+ * unchanged.
  */
 function isBenignWalletModification(
   original: VersionedMessage,
@@ -363,7 +380,7 @@ function isBenignWalletModification(
     return false;
   }
   const addedKeys = signedKeys.slice(originalKeys.length);
-  if (!addedKeys.every((key) => key.equals(ComputeBudgetProgram.programId))) {
+  if (!addedKeys.every((key) => isBenignInjectedProgram(key))) {
     return false;
   }
 
@@ -395,8 +412,7 @@ function isBenignWalletModification(
       cursor += 1;
       continue;
     }
-    const program = signedKeys[instruction.programIdIndex];
-    if (!program?.equals(ComputeBudgetProgram.programId)) {
+    if (!isBenignInjectedProgram(signedKeys[instruction.programIdIndex])) {
       return false;
     }
   }
@@ -418,17 +434,55 @@ function describeMessageChange(
   if (original.recentBlockhash !== signed.recentBlockhash) {
     parts.push("blockhash changed");
   }
-  if (original.staticAccountKeys.length !== signed.staticAccountKeys.length) {
+  const originalKeySet = new Set(
+    original.staticAccountKeys.map((key) => key.toBase58())
+  );
+  const signedKeySet = new Set(
+    signed.staticAccountKeys.map((key) => key.toBase58())
+  );
+  const addedKeys = signed.staticAccountKeys.filter(
+    (key) => !originalKeySet.has(key.toBase58())
+  );
+  const removedKeys = original.staticAccountKeys.filter(
+    (key) => !signedKeySet.has(key.toBase58())
+  );
+  if (addedKeys.length > 0) {
     parts.push(
-      `static keys ${original.staticAccountKeys.length}->${signed.staticAccountKeys.length}`
+      `static keys added: ${addedKeys.map((key) => key.toBase58()).join(", ")}`
+    );
+  }
+  if (removedKeys.length > 0) {
+    parts.push(
+      `static keys removed: ${removedKeys
+        .map((key) => key.toBase58())
+        .join(", ")}`
     );
   }
   if (
-    original.compiledInstructions.length !== signed.compiledInstructions.length
+    !original.staticAccountKeys.every((key, index) =>
+      signed.staticAccountKeys[index]?.equals(key)
+    )
   ) {
-    parts.push(
-      `instructions ${original.compiledInstructions.length}->${signed.compiledInstructions.length}`
+    parts.push("static key order changed");
+  }
+  const insertedPrograms: string[] = [];
+  let cursor = 0;
+  for (const instruction of signed.compiledInstructions) {
+    const expected = original.compiledInstructions[cursor];
+    if (expected && compiledInstructionsEqual(instruction, expected)) {
+      cursor += 1;
+      continue;
+    }
+    insertedPrograms.push(
+      signed.staticAccountKeys[instruction.programIdIndex]?.toBase58() ??
+        `key#${instruction.programIdIndex}`
     );
+  }
+  if (insertedPrograms.length > 0) {
+    parts.push(`instructions inserted: ${insertedPrograms.join(", ")}`);
+  }
+  if (cursor !== original.compiledInstructions.length) {
+    parts.push("original instructions rewritten");
   }
   if (
     !addressTableLookupsEqual(


### PR DESCRIPTION
Round 2 of the Seeker vault fix: the wallet injects guard/fee instructions beyond compute-budget, so the benign allowlist now also covers Lighthouse (assertion-only) and Memo, and any remaining MESSAGE_CHANGED rejection lists the added static keys and inserted program IDs instead of bare counts. ASK-2036.