### PR TITLE
feat(admin): add ClickStack latency dashboard

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -10,6 +10,8 @@ Auth credentials are stored in 1Password (`loyal-admin`).
 
 1. From repo root: `bun i`
 2. Set `DATABASE_URL`, `ADMIN_USER`, and `ADMIN_PASSWORD` in `admin/.env.local`
+   - The Metrics page also needs the server-only `LOYAL_CLICKSTACK_API_KEY`.
+     `HYPERDX_ACCESS_KEY` remains supported as a fallback for existing environments.
 3. Start admin:
    - from root: `bun run admin:dev`
    - or from `admin/`: `bun dev`
@@ -17,6 +19,7 @@ Auth credentials are stored in 1Password (`loyal-admin`).
 ## Database Schema
 
 This workspace uses shared monorepo schema and Neon DB adapter packages:
+
 - `@loyal-labs/db-core/schema`
 - `@loyal-labs/db-adapter-neon`
 
@@ -26,6 +29,12 @@ There is no admin `/schema` UI route; schema is sourced directly from shared pac
 ## Vercel Deploy
 
 For monorepo deploys:
+
 - Repository: `loyal-labs/loyal-app`
 - Root Directory: `admin`
 - Config: `admin/vercel.json`
+
+Configure `LOYAL_CLICKSTACK_API_KEY` in the Vercel project before deploying the
+Metrics page. Keep it server-only; never expose it through a `NEXT_PUBLIC_`
+variable. `LOYAL_CLICKSTACK_API_URL` and `LOYAL_CLICKSTACK_METRICS_SOURCE_ID`
+are optional overrides for a different ClickStack deployment or metrics source.

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -16,6 +16,14 @@ import {
   ChartTooltip,
   type ChartConfig,
 } from "@/components/ui/chart";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 import type {
   MetricPoint,
@@ -492,6 +500,59 @@ function MetricTooltip({
   );
 }
 
+/**
+ * The WCAG-clean twin of the plot. Three light-mode slots sit below 3:1 against
+ * the card, and a tooltip must never be the only way to reach a value, so every
+ * measured bucket is readable as text here.
+ */
+function MetricTable({
+  chart,
+}: {
+  chart: OperationChart;
+}) {
+  const rows = chart.data.filter((row) =>
+    chart.series.some((spec) => typeof row[spec.key] === "number")
+  );
+
+  return (
+    <div className="max-h-[260px] overflow-auto rounded-md border">
+      <Table>
+        <TableHeader className="sticky top-0 bg-card">
+          <TableRow>
+            <TableHead className="whitespace-nowrap">Bucket (UTC)</TableHead>
+            {chart.series.map((spec) => (
+              // No swatch here on purpose: this view exists so identity and
+              // value read without colour.
+              <TableHead className="text-right whitespace-nowrap" key={spec.key}>
+                {spec.label}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={String(row.bucketTime)}>
+              <TableCell className="whitespace-nowrap tabular-nums">
+                {formatUtcTimestamp(row.bucketTime)}
+              </TableCell>
+              {chart.series.map((spec) => (
+                <TableCell
+                  className="text-right tabular-nums"
+                  key={spec.key}
+                >
+                  {typeof row[spec.key] === "number"
+                    ? formatDuration(row[spec.key] as number)
+                    : "—"}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 /** Sparse operations get their numbers directly — a line through 2 points is a lie. */
 function ValueTiles({
   latestByKey,
@@ -529,6 +590,7 @@ function MetricChartCard({
   chart: OperationChart;
 }) {
   const [showOutliers, setShowOutliers] = useState(false);
+  const [showTable, setShowTable] = useState(false);
 
   const values = useMemo(
     () =>
@@ -569,16 +631,30 @@ function MetricChartCard({
       <CardHeader className="gap-1">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <CardTitle>{humanizePath(chart.operation)}</CardTitle>
-          {showTrend && hasOutliers ? (
-            <Button
-              className="h-6 px-2 text-xs"
-              onClick={() => setShowOutliers((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showOutliers ? "secondary" : "outline"}
-            >
-              {showOutliers ? "Clip outliers" : `Show ${clippedCount} above`}
-            </Button>
+          {showTrend ? (
+            <div className="flex items-center gap-1.5">
+              {hasOutliers && !showTable ? (
+                <Button
+                  className="h-6 px-2 text-xs"
+                  onClick={() => setShowOutliers((value) => !value)}
+                  size="sm"
+                  type="button"
+                  variant={showOutliers ? "secondary" : "outline"}
+                >
+                  {showOutliers ? "Clip outliers" : `Show ${clippedCount} above`}
+                </Button>
+              ) : null}
+              <Button
+                aria-pressed={showTable}
+                className="h-6 px-2 text-xs"
+                onClick={() => setShowTable((value) => !value)}
+                size="sm"
+                type="button"
+                variant={showTable ? "secondary" : "outline"}
+              >
+                {showTable ? "Chart" : "Table"}
+              </Button>
+            </div>
           ) : null}
         </div>
         <CardDescription className="tabular-nums">
@@ -592,10 +668,11 @@ function MetricChartCard({
         </CardDescription>
       </CardHeader>
       <CardContent className="min-w-0 space-y-4">
-        {showTrend ? (
+        {showTrend && !showTable ? (
           <ChartLegend latestByKey={chart.latestByKey} series={chart.series} />
         ) : null}
-        {showTrend ? (
+        {showTrend && showTable ? <MetricTable chart={chart} /> : null}
+        {showTrend && !showTable ? (
           <ChartContainer
             className="aspect-auto h-[220px] w-full min-w-0"
             config={config}
@@ -660,7 +737,8 @@ function MetricChartCard({
               ))}
             </LineChart>
           </ChartContainer>
-        ) : (
+        ) : null}
+        {showTrend ? null : (
           <ValueTiles latestByKey={chart.latestByKey} series={chart.series} />
         )}
       </CardContent>

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -606,10 +606,14 @@ function MetricChartCard({
   const fullMax = values.length > 0 ? Math.max(...values) : 0;
   const robustMax = percentile(values, 0.95);
   const hasOutliers = fullMax > robustMax * OUTLIER_RATIO && robustMax > 0;
-  const valueAxis = buildValueAxis(
-    hasOutliers && !showOutliers ? robustMax : fullMax
-  );
-  const clippedCount = values.filter((value) => value > valueAxis.max).length;
+  const clippedAxis = buildValueAxis(robustMax);
+  const valueAxis =
+    hasOutliers && !showOutliers ? clippedAxis : buildValueAxis(fullMax);
+  // Counted against the clipped axis either way, so the label stays put instead
+  // of dropping to "0 above" the moment the outliers are shown.
+  const outlierCount = values.filter(
+    (value) => value > clippedAxis.max
+  ).length;
 
   const config = useMemo(
     () =>
@@ -633,18 +637,27 @@ function MetricChartCard({
           <CardTitle>{humanizePath(chart.operation)}</CardTitle>
           {showTrend ? (
             <div className="flex items-center gap-1.5">
+              {/* Both are toggles, so each keeps a fixed label naming what it
+                  controls and lets aria-pressed carry the on/off state. A label
+                  that flips to the other mode's name would make a pressed
+                  toggle announce the mode it is not in. */}
               {hasOutliers && !showTable ? (
                 <Button
+                  aria-label={`Include ${outlierCount} ${
+                    outlierCount === 1 ? "point" : "points"
+                  } above the axis`}
+                  aria-pressed={showOutliers}
                   className="h-6 px-2 text-xs"
                   onClick={() => setShowOutliers((value) => !value)}
                   size="sm"
                   type="button"
                   variant={showOutliers ? "secondary" : "outline"}
                 >
-                  {showOutliers ? "Clip outliers" : `Show ${clippedCount} above`}
+                  {`${outlierCount} above`}
                 </Button>
               ) : null}
               <Button
+                aria-label="Show measurements as a table"
                 aria-pressed={showTable}
                 className="h-6 px-2 text-xs"
                 onClick={() => setShowTable((value) => !value)}
@@ -652,7 +665,7 @@ function MetricChartCard({
                 type="button"
                 variant={showTable ? "secondary" : "outline"}
               >
-                {showTable ? "Chart" : "Table"}
+                Table
               </Button>
             </div>
           ) : null}

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
-import { CartesianGrid, Label, Line, LineChart, XAxis, YAxis } from "recharts";
+import { useMemo, useState } from "react";
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -13,62 +14,121 @@ import {
 import {
   ChartContainer,
   ChartTooltip,
-  ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
 
-import type { MetricPoint, MetricsDashboardData } from "./metrics-data";
+import type {
+  MetricPoint,
+  MetricsDashboardData,
+  OperationVolume,
+} from "./metrics-data";
 
-const SERIES_COLORS = [
-  "hsl(221 83% 53%)",
-  "hsl(142 71% 45%)",
-  "hsl(25 95% 53%)",
-  "hsl(262 83% 58%)",
-  "hsl(346 77% 50%)",
-  "hsl(188 86% 43%)",
-  "hsl(45 93% 47%)",
-  "hsl(215 16% 47%)",
-];
+/** Fixed slot order; see the --metric-* comment in globals.css. */
+const SERIES_SLOT_COUNT = 6;
+
+/**
+ * Operations with fewer buckets than this cannot show a trend — a line drawn
+ * through two points days apart invents one. They render as value tiles.
+ */
+const MIN_BUCKETS_FOR_TREND = 6;
+
+/** Clamping the axis is only worth the confusion when an outlier really dwarfs the rest. */
+const OUTLIER_RATIO = 1.5;
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+/** Never collapse the axis below this, however short the measured history is. */
+const MIN_WINDOW_MS = DAY_MS;
 
 type Surface = "desktop" | "mobile";
 
+type SeriesSpec = {
+  identity: string;
+  key: string;
+  label: string;
+  outcome: string;
+  slot: number;
+};
+
 type OperationChart = {
-  config: ChartConfig;
-  data: Array<Record<string, number | string>>;
+  bucketCount: number;
+  data: Array<Record<string, number | null>>;
+  latestByKey: Record<string, number>;
   operation: string;
-  series: Array<{ key: string; label: string }>;
+  series: SeriesSpec[];
+  volume: OperationVolume | null;
+};
+
+const ACRONYMS: Record<string, string> = {
+  api: "API",
+  ios: "iOS",
+  rpc: "RPC",
+  ui: "UI",
+  url: "URL",
 };
 
 function humanize(value: string): string {
-  return value.replaceAll("_", " ").replaceAll(".", " · ");
+  return value
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .map((word, index) => {
+      const acronym = ACRONYMS[word.toLowerCase()];
+      if (acronym) {
+        return acronym;
+      }
+      return index === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word;
+    })
+    .join(" ");
 }
 
-function formatTickDate(value: unknown): string {
-  if (typeof value !== "string" && typeof value !== "number") {
-    return String(value ?? "");
-  }
+function humanizePath(value: string): string {
+  return value.split(".").map(humanize).join(" · ");
+}
 
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return String(value);
+/**
+ * Latency spans three orders of magnitude here, so a single unit either hides
+ * sub-second dependencies or turns a two-minute withdrawal into "140000".
+ */
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "—";
   }
+  if (ms < 1_000) {
+    return `${Math.round(ms)}ms`;
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1_000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+  }
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
 
+function formatUtcDay(value: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+/** A multi-day axis reads by date; a one-day axis needs the hour to say anything. */
+function formatUtcTick(value: number, spanMs: number): string {
+  if (spanMs > 2 * DAY_MS) {
+    return formatUtcDay(value);
+  }
   return new Intl.DateTimeFormat("en-US", {
     day: "numeric",
     hour: "2-digit",
     hour12: false,
+    minute: "2-digit",
     month: "short",
-  }).format(date);
+    timeZone: "UTC",
+  }).format(new Date(value));
 }
 
-function formatTooltipDate(value: unknown): string {
-  if (typeof value !== "string" && typeof value !== "number") {
-    return String(value ?? "");
-  }
-
-  const date = new Date(value);
+function formatUtcTimestamp(value: unknown): string {
+  const date = new Date(typeof value === "number" ? value : String(value));
   if (Number.isNaN(date.getTime())) {
-    return String(value);
+    return String(value ?? "");
   }
 
   return new Intl.DateTimeFormat("en-US", {
@@ -77,19 +137,613 @@ function formatTooltipDate(value: unknown): string {
     hour12: false,
     minute: "2-digit",
     month: "short",
+    timeZone: "UTC",
     timeZoneName: "short",
-    year: "numeric",
   }).format(date);
 }
 
-function seriesLabel(point: MetricPoint, surface: Surface): string {
+function percentile(values: readonly number[], level: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round((sorted.length - 1) * level))
+  );
+  return sorted[index];
+}
+
+/**
+ * What a series *is*, separate from how it ended. Outcome rides on the line
+ * style instead of doubling the colour count and repeating "· completed" on
+ * every legend row.
+ */
+function seriesIdentity(point: MetricPoint, surface: Surface): string {
   if (surface === "mobile") {
-    return `${humanize(point.platform)} · ${humanize(point.outcome)}`;
+    return point.platform;
+  }
+  const phase = point.phase ?? "total";
+  return point.dependency ? `${phase}:${point.dependency}` : phase;
+}
+
+function identityLabel(identity: string): string {
+  const [phase, dependency] = identity.split(":");
+  return humanize(dependency ?? phase);
+}
+
+/**
+ * Colour follows the entity, not its position in this card's sorted list, so a
+ * dependency keeps one colour across every chart on the surface.
+ */
+function buildSlotsByIdentity(
+  points: MetricPoint[],
+  surface: Surface
+): Map<string, number> {
+  const identities = [
+    ...new Set(points.map((point) => seriesIdentity(point, surface))),
+  ].sort();
+  // Past the last slot, fall back to the neutral rather than cycling — two
+  // identities wearing the same hue is worse than one wearing none.
+  return new Map(
+    identities.map((identity, index) => [
+      identity,
+      index < SERIES_SLOT_COUNT ? index + 1 : 0,
+    ])
+  );
+}
+
+function slotColor(slot: number): string {
+  return slot === 0 ? "var(--muted-foreground)" : `var(--metric-${slot})`;
+}
+
+const Y_AXIS_INTERVALS = 4;
+
+/** Round up to a step that divides cleanly, so ticks are whole numbers. */
+function niceStep(value: number): number {
+  if (value <= 0) {
+    return 1;
+  }
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const normalized = value / magnitude;
+  const step = [1, 2, 2.5, 3, 4, 5, 6, 8, 10].find(
+    (candidate) => normalized <= candidate
+  );
+  return (step ?? 10) * magnitude;
+}
+
+/** Evenly spaced ticks from a nice step beats whatever Recharts infers from a clamped domain. */
+function buildValueAxis(maxValue: number): { max: number; ticks: number[] } {
+  const step = niceStep(Math.max(maxValue, 1) / Y_AXIS_INTERVALS);
+  return {
+    max: step * Y_AXIS_INTERVALS,
+    ticks: Array.from(
+      { length: Y_AXIS_INTERVALS + 1 },
+      (_, index) => step * index
+    ),
+  };
+}
+
+/** One unit for the whole axis — mixing "50s" and "1.3m" hides even spacing. */
+function formatAxisValue(ms: number, axisMax: number): string {
+  if (axisMax < 1_000) {
+    return `${Math.round(ms)}ms`;
+  }
+  if (axisMax < 300_000) {
+    const seconds = ms / 1_000;
+    return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`;
+  }
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+/**
+ * One shared axis for every card, trimmed to the first bucket that actually
+ * carries a measurement. Instrumentation younger than the window would
+ * otherwise leave most of every plot empty, which reads as a broken chart
+ * rather than as "not collected yet". The grid grows back to the full window
+ * on its own as history accumulates.
+ */
+function buildBucketGrid(data: MetricsDashboardData): number[] {
+  const bucketMs = data.bucketMinutes * 60 * 1_000;
+  const windowStart =
+    Math.floor(Date.parse(data.rangeStartedAt) / bucketMs) * bucketMs;
+  const end = Date.parse(data.rangeEndedAt);
+
+  let earliestSample = Number.POSITIVE_INFINITY;
+  for (const points of [data.desktop, data.mobile]) {
+    for (const point of points) {
+      earliestSample = Math.min(earliestSample, Date.parse(point.bucketStartedAt));
+    }
   }
 
-  const phase = point.phase ? humanize(point.phase) : "total";
-  const dependency = point.dependency ? ` · ${humanize(point.dependency)}` : "";
-  return `${phase}${dependency} · ${humanize(point.outcome)}`;
+  const start = Number.isFinite(earliestSample)
+    ? Math.max(
+        windowStart,
+        // Keep at least a day of context around a single busy afternoon.
+        Math.min(
+          Math.floor(earliestSample / bucketMs) * bucketMs,
+          end - MIN_WINDOW_MS
+        )
+      )
+    : windowStart;
+
+  const buckets: number[] = [];
+  for (let time = start; time <= end; time += bucketMs) {
+    buckets.push(time);
+  }
+
+  return buckets;
+}
+
+/**
+ * Tick step and label format are chosen together: sub-day steps would print
+ * duplicate date-only labels, and day steps on a short window print two ticks.
+ */
+function buildAxisTicks(bucketGrid: number[]): number[] {
+  const span = bucketGrid[bucketGrid.length - 1] - bucketGrid[0];
+  const step =
+    span > 2 * DAY_MS ? DAY_MS : span > DAY_MS ? DAY_MS / 2 : DAY_MS / 4;
+  return bucketGrid.filter((time) => time % step === 0);
+}
+
+function buildOperationCharts({
+  bucketGrid,
+  points,
+  slotsByIdentity,
+  surface,
+  volume,
+}: {
+  bucketGrid: number[];
+  points: MetricPoint[];
+  slotsByIdentity: Map<string, number>;
+  surface: Surface;
+  volume: Record<string, OperationVolume>;
+}): OperationChart[] {
+  const byOperation = new Map<string, MetricPoint[]>();
+  for (const point of points) {
+    const operationPoints = byOperation.get(point.operation) ?? [];
+    operationPoints.push(point);
+    byOperation.set(point.operation, operationPoints);
+  }
+
+  return [...byOperation.entries()]
+    .map(([operation, operationPoints]) => {
+      const specByLabel = new Map<string, SeriesSpec>();
+      for (const point of operationPoints) {
+        const identity = seriesIdentity(point, surface);
+        const label = identityLabel(identity);
+        const seriesLabel =
+          point.outcome === "completed"
+            ? label
+            : `${label} · ${humanize(point.outcome)}`;
+        if (specByLabel.has(seriesLabel)) {
+          continue;
+        }
+        specByLabel.set(seriesLabel, {
+          identity,
+          key: "",
+          label: seriesLabel,
+          outcome: point.outcome,
+          slot: slotsByIdentity.get(identity) ?? 1,
+        });
+      }
+
+      const series = [...specByLabel.values()]
+        .sort(
+          (left, right) =>
+            left.slot - right.slot || left.label.localeCompare(right.label)
+        )
+        .map((spec, index) => ({ ...spec, key: `series${index}` }));
+
+      const keyByLabel = new Map(
+        series.map((spec) => [spec.label, spec.key] as const)
+      );
+      const valuesByBucket = new Map<number, Record<string, number>>();
+
+      for (const point of operationPoints) {
+        const identity = seriesIdentity(point, surface);
+        const label = identityLabel(identity);
+        const seriesLabel =
+          point.outcome === "completed"
+            ? label
+            : `${label} · ${humanize(point.outcome)}`;
+        const key = keyByLabel.get(seriesLabel);
+        const bucketTime = Date.parse(point.bucketStartedAt);
+        if (!key || !Number.isFinite(bucketTime)) {
+          continue;
+        }
+        const bucket = valuesByBucket.get(bucketTime) ?? {};
+        bucket[key] = point.p95Ms;
+        valuesByBucket.set(bucketTime, bucket);
+      }
+
+      // Every bucket in the window gets a row, so gaps stay gaps instead of
+      // being interpolated into a trend that was never measured.
+      const data = bucketGrid.map((bucketTime) => {
+        const bucket = valuesByBucket.get(bucketTime);
+        const row: Record<string, number | null> = { bucketTime };
+        for (const spec of series) {
+          row[spec.key] = bucket?.[spec.key] ?? null;
+        }
+        return row;
+      });
+
+      const latestByKey: Record<string, number> = {};
+      for (const spec of series) {
+        for (let index = data.length - 1; index >= 0; index -= 1) {
+          const value = data[index][spec.key];
+          if (typeof value === "number") {
+            latestByKey[spec.key] = value;
+            break;
+          }
+        }
+      }
+
+      return {
+        bucketCount: valuesByBucket.size,
+        data,
+        latestByKey,
+        operation,
+        series,
+        volume: volume[operation] ?? null,
+      };
+    })
+    .sort(
+      (left, right) =>
+        (right.volume?.total ?? 0) - (left.volume?.total ?? 0) ||
+        right.bucketCount - left.bucketCount ||
+        left.operation.localeCompare(right.operation)
+    );
+}
+
+function SeriesSwatch({ spec }: { spec: SeriesSpec }) {
+  const isFailure = spec.outcome !== "completed";
+  return (
+    <span
+      aria-hidden
+      className="h-0.5 w-4 shrink-0 rounded-full"
+      style={
+        isFailure
+          ? {
+              backgroundImage: `repeating-linear-gradient(to right, ${slotColor(spec.slot)} 0 4px, transparent 4px 7px)`,
+            }
+          : { backgroundColor: slotColor(spec.slot) }
+      }
+    />
+  );
+}
+
+/**
+ * The legend carries each series' latest value, so a reader never depends on
+ * the colour alone or on hovering to read a number.
+ */
+function ChartLegend({
+  latestByKey,
+  series,
+}: {
+  latestByKey: Record<string, number>;
+  series: SeriesSpec[];
+}) {
+  return (
+    <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-xs">
+      {series.map((spec) => (
+        <div className="flex items-center gap-2" key={spec.key}>
+          <SeriesSwatch spec={spec} />
+          <span className="text-muted-foreground">{spec.label}</span>
+          <span className="font-medium text-foreground tabular-nums">
+            {latestByKey[spec.key] === undefined
+              ? "—"
+              : formatDuration(latestByKey[spec.key])}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MetricTooltip({
+  active,
+  label,
+  payload,
+  series,
+}: {
+  active?: boolean;
+  label?: unknown;
+  payload?: Array<{ dataKey?: string | number; value?: number }>;
+  series: SeriesSpec[];
+}) {
+  const specByKey = new Map(series.map((spec) => [spec.key, spec] as const));
+  const rows = (payload ?? []).filter(
+    (item) => typeof item.value === "number"
+  ) as Array<{ dataKey: string; value: number }>;
+
+  if (!active || rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid min-w-[13rem] gap-1.5 rounded-lg border border-border/70 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <div className="font-medium text-foreground">
+        {formatUtcTimestamp(label)}
+      </div>
+      <div className="grid gap-1">
+        {rows.map((row) => {
+          const spec = specByKey.get(row.dataKey);
+          if (!spec) {
+            return null;
+          }
+          return (
+            <div
+              className="flex items-center justify-between gap-3"
+              key={row.dataKey}
+            >
+              <div className="flex items-center gap-2">
+                <SeriesSwatch spec={spec} />
+                <span className="text-muted-foreground">{spec.label}</span>
+              </div>
+              <span className="font-medium text-foreground tabular-nums">
+                {formatDuration(row.value)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Sparse operations get their numbers directly — a line through 2 points is a lie. */
+function ValueTiles({
+  latestByKey,
+  series,
+}: {
+  latestByKey: Record<string, number>;
+  series: SeriesSpec[];
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {series.map((spec) => (
+        <div className="rounded-md border px-3 py-2.5" key={spec.key}>
+          <div className="flex items-center gap-2">
+            <SeriesSwatch spec={spec} />
+            <span className="truncate text-xs text-muted-foreground">
+              {spec.label}
+            </span>
+          </div>
+          <div className="mt-1 text-xl leading-none font-semibold">
+            {latestByKey[spec.key] === undefined
+              ? "—"
+              : formatDuration(latestByKey[spec.key])}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MetricChartCard({
+  bucketGrid,
+  chart,
+}: {
+  bucketGrid: number[];
+  chart: OperationChart;
+}) {
+  const [showOutliers, setShowOutliers] = useState(false);
+
+  const values = useMemo(
+    () =>
+      chart.data.flatMap((row) =>
+        chart.series.flatMap((spec) => {
+          const value = row[spec.key];
+          return typeof value === "number" ? [value] : [];
+        })
+      ),
+    [chart]
+  );
+
+  const fullMax = values.length > 0 ? Math.max(...values) : 0;
+  const robustMax = percentile(values, 0.95);
+  const hasOutliers = fullMax > robustMax * OUTLIER_RATIO && robustMax > 0;
+  const valueAxis = buildValueAxis(
+    hasOutliers && !showOutliers ? robustMax : fullMax
+  );
+  const clippedCount = values.filter((value) => value > valueAxis.max).length;
+
+  const config = useMemo(
+    () =>
+      Object.fromEntries(
+        chart.series.map((spec) => [
+          spec.key,
+          { color: slotColor(spec.slot), label: spec.label },
+        ])
+      ) satisfies ChartConfig,
+    [chart.series]
+  );
+
+  const showTrend = chart.bucketCount >= MIN_BUCKETS_FOR_TREND;
+  const volume = chart.volume;
+  const axisSpan = bucketGrid[bucketGrid.length - 1] - bucketGrid[0];
+
+  return (
+    <Card className="min-w-0 gap-4">
+      <CardHeader className="gap-1">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <CardTitle>{humanizePath(chart.operation)}</CardTitle>
+          {showTrend && hasOutliers ? (
+            <Button
+              className="h-6 px-2 text-xs"
+              onClick={() => setShowOutliers((value) => !value)}
+              size="sm"
+              type="button"
+              variant={showOutliers ? "secondary" : "outline"}
+            >
+              {showOutliers ? "Clip outliers" : `Show ${clippedCount} above`}
+            </Button>
+          ) : null}
+        </div>
+        <CardDescription className="tabular-nums">
+          {volume
+            ? `${volume.total.toLocaleString()} ${volume.total === 1 ? "sample" : "samples"}`
+            : "p95 latency"}
+          {volume && volume.failed > 0
+            ? ` · ${volume.failed.toLocaleString()} failed`
+            : ""}
+          {` · ${chart.bucketCount} of ${bucketGrid.length} buckets`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="min-w-0 space-y-4">
+        {showTrend ? (
+          <ChartLegend latestByKey={chart.latestByKey} series={chart.series} />
+        ) : null}
+        {showTrend ? (
+          <ChartContainer
+            className="aspect-auto h-[220px] w-full min-w-0"
+            config={config}
+          >
+            <LineChart
+              accessibilityLayer
+              data={chart.data}
+              margin={{ bottom: 4, left: 4, right: 12, top: 8 }}
+            >
+              <CartesianGrid vertical={false} />
+              <XAxis
+                axisLine={false}
+                dataKey="bucketTime"
+                domain={[bucketGrid[0], bucketGrid[bucketGrid.length - 1]]}
+                scale="time"
+                tickFormatter={(value: number) => formatUtcTick(value, axisSpan)}
+                tickLine={false}
+                tickMargin={8}
+                ticks={buildAxisTicks(bucketGrid)}
+                type="number"
+              />
+              <YAxis
+                allowDataOverflow
+                axisLine={false}
+                domain={[0, valueAxis.max]}
+                tickFormatter={(value: number) =>
+                  formatAxisValue(value, valueAxis.max)
+                }
+                tickLine={false}
+                ticks={valueAxis.ticks}
+                width={52}
+              />
+              <ChartTooltip
+                content={<MetricTooltip series={chart.series} />}
+                cursor={{ strokeDasharray: "3 3" }}
+              />
+              {chart.series.map((spec) => (
+                <Line
+                  activeDot={{
+                    fill: `var(--color-${spec.key})`,
+                    r: 4,
+                    strokeWidth: 0,
+                  }}
+                  connectNulls={false}
+                  dataKey={spec.key}
+                  // Recharts fills dots with the background by default, which
+                  // makes a bucket with no neighbour — and so no line segment —
+                  // invisible. These carry the sparse points.
+                  dot={{
+                    fill: `var(--color-${spec.key})`,
+                    r: 2,
+                    strokeWidth: 0,
+                  }}
+                  key={spec.key}
+                  stroke={`var(--color-${spec.key})`}
+                  strokeDasharray={
+                    spec.outcome === "completed" ? undefined : "4 3"
+                  }
+                  strokeWidth={2}
+                  type="linear"
+                />
+              ))}
+            </LineChart>
+          </ChartContainer>
+        ) : (
+          <ValueTiles latestByKey={chart.latestByKey} series={chart.series} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyStateCard({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function SurfaceSection({
+  bucketGrid,
+  points,
+  status,
+  surface,
+  volume,
+}: {
+  bucketGrid: number[];
+  points: MetricPoint[];
+  status: "available" | "unavailable";
+  surface: Surface;
+  volume: Record<string, OperationVolume>;
+}) {
+  const charts = useMemo(() => {
+    const slotsByIdentity = buildSlotsByIdentity(points, surface);
+    return buildOperationCharts({
+      bucketGrid,
+      points,
+      slotsByIdentity,
+      surface,
+      volume,
+    });
+  }, [bucketGrid, points, surface, volume]);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h2 className="text-lg font-semibold">
+          {surface === "desktop" ? "Desktop" : "Mobile"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {surface === "desktop"
+            ? "Web app loading and Earn interaction latency."
+            : "iOS and Android app loading and Earn operation latency."}
+        </p>
+      </div>
+      {status === "unavailable" ? (
+        <EmptyStateCard
+          description="ClickStack could not be queried. Check the server-side admin configuration."
+          title="Metrics unavailable"
+        />
+      ) : charts.length === 0 ? (
+        <EmptyStateCard
+          description="No production measurements arrived during this 7-day window."
+          title="No recent metrics"
+        />
+      ) : (
+        <div className="grid items-start gap-5 xl:grid-cols-2">
+          {charts.map((chart) => (
+            <MetricChartCard
+              bucketGrid={bucketGrid}
+              chart={chart}
+              key={chart.operation}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
 }
 
 function getLatestSampleAt(data: MetricsDashboardData): string | null {
@@ -106,222 +760,58 @@ function getLatestSampleAt(data: MetricsDashboardData): string | null {
     : null;
 }
 
-function buildOperationCharts(
-  points: MetricPoint[],
-  surface: Surface
-): OperationChart[] {
-  const byOperation = new Map<string, MetricPoint[]>();
-  for (const point of points) {
-    const operationPoints = byOperation.get(point.operation) ?? [];
-    operationPoints.push(point);
-    byOperation.set(point.operation, operationPoints);
-  }
-
-  return [...byOperation.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([operation, operationPoints]) => {
-      const labels = [
-        ...new Set(operationPoints.map((point) => seriesLabel(point, surface))),
-      ].sort();
-      const series = labels.map((label, index) => ({
-        key: `series${index}`,
-        label,
-      }));
-      const keyByLabel = new Map(series.map((item) => [item.label, item.key]));
-      const config = Object.fromEntries(
-        series.map((item, index) => [
-          item.key,
-          {
-            color: SERIES_COLORS[index % SERIES_COLORS.length],
-            label: item.label,
-          },
-        ])
-      ) satisfies ChartConfig;
-      const rowsByBucket = new Map<string, Record<string, number | string>>();
-
-      for (const point of operationPoints) {
-        const row = rowsByBucket.get(point.bucketStartedAt) ?? {
-          bucketTime: Date.parse(point.bucketStartedAt),
-        };
-        const seriesKey = keyByLabel.get(seriesLabel(point, surface));
-        if (seriesKey) {
-          row[seriesKey] = Math.round((point.p95Ms / 1_000) * 100) / 100;
-        }
-        rowsByBucket.set(point.bucketStartedAt, row);
-      }
-
-      return {
-        config,
-        data: [...rowsByBucket.values()].sort(
-          (left, right) => Number(left.bucketTime) - Number(right.bucketTime)
-        ),
-        operation,
-        series,
-      };
-    });
-}
-
-function MetricChartCard({ chart }: { chart: OperationChart }) {
+function MetaItem({ label, value }: { label: string; value: string }) {
   return (
-    <Card className="min-w-0">
-      <CardHeader>
-        <CardTitle className="capitalize">
-          {humanize(chart.operation)}
-        </CardTitle>
-        <CardDescription>
-          {chart.series.length} series · p95 seconds
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="min-w-0 space-y-4">
-        <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
-          {chart.series.map((item) => (
-            <div key={item.key} className="flex items-center gap-1.5">
-              <span
-                aria-hidden
-                className="size-2.5 rounded-[2px]"
-                style={{ backgroundColor: chart.config[item.key]?.color }}
-              />
-              <span>{item.label}</span>
-            </div>
-          ))}
-        </div>
-        <ChartContainer
-          className="aspect-auto h-[260px] w-full min-w-0"
-          config={chart.config}
-        >
-          <LineChart
-            accessibilityLayer
-            data={chart.data}
-            margin={{ bottom: 22, left: 4, right: 16, top: 8 }}
-          >
-            <CartesianGrid vertical={false} />
-            <XAxis
-              axisLine={false}
-              dataKey="bucketTime"
-              domain={["dataMin", "dataMax"]}
-              minTickGap={42}
-              scale="time"
-              tickFormatter={formatTickDate}
-              tickLine={false}
-              tickMargin={8}
-              type="number"
-            >
-              <Label
-                offset={-16}
-                position="insideBottom"
-                value="Time (your local time)"
-              />
-            </XAxis>
-            <YAxis
-              axisLine={false}
-              domain={[0, "auto"]}
-              tickFormatter={(value: number) => `${value}s`}
-              tickLine={false}
-              width={48}
-            />
-            <ChartTooltip
-              content={
-                <ChartTooltipContent
-                  className="min-w-[220px]"
-                  labelFormatter={formatTooltipDate}
-                />
-              }
-            />
-            {chart.series.map((item) => (
-              <Line
-                key={item.key}
-                connectNulls={false}
-                dataKey={item.key}
-                dot={{ r: 1.5, strokeWidth: 0 }}
-                stroke={`var(--color-${item.key})`}
-                strokeWidth={2}
-                type="linear"
-              />
-            ))}
-          </LineChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
-  );
-}
-
-function SurfaceSection({
-  points,
-  status,
-  surface,
-}: {
-  points: MetricPoint[];
-  status: "available" | "unavailable";
-  surface: Surface;
-}) {
-  const charts = useMemo(
-    () => buildOperationCharts(points, surface),
-    [points, surface]
-  );
-
-  return (
-    <section className="space-y-4">
-      <div>
-        <h2 className="text-xl font-semibold capitalize">{surface}</h2>
-        <p className="text-sm text-muted-foreground">
-          {surface === "desktop"
-            ? "Web app loading and Earn interaction latency."
-            : "iOS and Android app loading and Earn operation latency."}
-        </p>
-      </div>
-      {status === "unavailable" ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>Metrics unavailable</CardTitle>
-            <CardDescription>
-              ClickStack could not be queried. Check the server-side admin
-              configuration.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      ) : charts.length === 0 ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>No recent metrics</CardTitle>
-            <CardDescription>
-              No production measurements arrived during this 7-day window.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      ) : (
-        <div className="grid gap-6 xl:grid-cols-2">
-          {charts.map((chart) => (
-            <MetricChartCard key={chart.operation} chart={chart} />
-          ))}
-        </div>
-      )}
-    </section>
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[0.6875rem] tracking-wide text-muted-foreground uppercase">
+        {label}
+      </span>
+      <span className="text-xs font-medium tabular-nums">{value}</span>
+    </div>
   );
 }
 
 export function MetricsDashboard({ data }: { data: MetricsDashboardData }) {
   const latestSampleAt = getLatestSampleAt(data);
+  const bucketGrid = useMemo(() => buildBucketGrid(data), [data]);
+  const isTrimmed =
+    bucketGrid[0] - Date.parse(data.rangeStartedAt) > data.bucketMinutes * 60_000;
 
   return (
-    <div className="space-y-10">
-      <p className="text-xs text-muted-foreground">
-        Queried {formatTooltipDate(data.fetchedAt)}
-        {latestSampleAt
-          ? ` · latest sample ${formatTooltipDate(latestSampleAt)}`
-          : ""}
-        {
-          " · values are milliseconds in ClickStack and displayed here in seconds."
-        }
-      </p>
+    <div className="space-y-8">
+      <div className="flex flex-wrap gap-x-10 gap-y-3 rounded-lg border bg-card px-4 py-3">
+        <MetaItem
+          label="Plotted window"
+          value={`${formatUtcDay(bucketGrid[0])} – ${formatUtcDay(
+            bucketGrid[bucketGrid.length - 1]
+          )} UTC`}
+        />
+        {isTrimmed ? (
+          <MetaItem
+            label="Queried window"
+            value={`7 days · no samples before ${formatUtcDay(bucketGrid[0])}`}
+          />
+        ) : null}
+        <MetaItem label="Bucket" value={`${data.bucketMinutes / 60}h · p95`} />
+        <MetaItem
+          label="Latest sample"
+          value={latestSampleAt ? formatUtcTimestamp(latestSampleAt) : "—"}
+        />
+        <MetaItem label="Queried" value={formatUtcTimestamp(data.fetchedAt)} />
+      </div>
       <SurfaceSection
+        bucketGrid={bucketGrid}
         points={data.desktop}
         status={data.status.desktop}
         surface="desktop"
+        volume={data.volume.desktop}
       />
       <SurfaceSection
+        bucketGrid={bucketGrid}
         points={data.mobile}
         status={data.status.mobile}
         surface="mobile"
+        volume={data.volume.mobile}
       />
     </div>
   );

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -40,6 +40,14 @@ const SERIES_SLOT_COUNT = 6;
  */
 const MIN_BUCKETS_FOR_TREND = 6;
 
+/**
+ * How far past the clipped axis the tallest point must sit before clipping is
+ * worth a control. Measured against the axis rather than the raw p95: the axis
+ * is what renders, so this also guarantees the hidden count is at least one and
+ * that toggling actually changes the scale.
+ */
+const OUTLIER_RATIO = 1.5;
+
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 /** Never collapse the axis below this, however short the measured history is. */
@@ -612,10 +620,12 @@ function MetricChartCard({
   const outlierCount = values.filter(
     (value) => value > clippedAxis.max
   ).length;
-  // Both conditions read off the axis that actually renders. Comparing the raw
-  // p95 instead would disagree with the count, because niceStep rounds the axis
-  // up far enough that it can already contain every point.
-  const canClip = outlierCount > 0 && clippedAxis.max < fullAxis.max;
+  // Measured against the axis that renders, not the raw p95. Comparing the p95
+  // would disagree with the count, since niceStep rounds the axis up far enough
+  // that it can already contain every point; dropping the ratio entirely would
+  // instead offer the control for ordinary spread, whenever the p95 and the
+  // maximum happen to round to different axes.
+  const canClip = robustMax > 0 && fullMax > clippedAxis.max * OUTLIER_RATIO;
   const valueAxis = canClip && !showOutliers ? clippedAxis : fullAxis;
 
   const config = useMemo(

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -40,9 +40,6 @@ const SERIES_SLOT_COUNT = 6;
  */
 const MIN_BUCKETS_FOR_TREND = 6;
 
-/** Clamping the axis is only worth the confusion when an outlier really dwarfs the rest. */
-const OUTLIER_RATIO = 1.5;
-
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 /** Never collapse the axis below this, however short the measured history is. */
@@ -234,6 +231,9 @@ function buildValueAxis(maxValue: number): { max: number; ticks: number[] } {
 
 /** One unit for the whole axis — mixing "50s" and "1.3m" hides even spacing. */
 function formatAxisValue(ms: number, axisMax: number): string {
+  if (ms === 0) {
+    return "0";
+  }
   if (axisMax < 1_000) {
     return `${Math.round(ms)}ms`;
   }
@@ -605,15 +605,18 @@ function MetricChartCard({
 
   const fullMax = values.length > 0 ? Math.max(...values) : 0;
   const robustMax = percentile(values, 0.95);
-  const hasOutliers = fullMax > robustMax * OUTLIER_RATIO && robustMax > 0;
+  const fullAxis = buildValueAxis(fullMax);
   const clippedAxis = buildValueAxis(robustMax);
-  const valueAxis =
-    hasOutliers && !showOutliers ? clippedAxis : buildValueAxis(fullMax);
-  // Counted against the clipped axis either way, so the label stays put instead
-  // of dropping to "0 above" the moment the outliers are shown.
+  // Counted against the clipped axis in both states, so the label stays put
+  // instead of dropping to "0 above" the moment the outliers are shown.
   const outlierCount = values.filter(
     (value) => value > clippedAxis.max
   ).length;
+  // Both conditions read off the axis that actually renders. Comparing the raw
+  // p95 instead would disagree with the count, because niceStep rounds the axis
+  // up far enough that it can already contain every point.
+  const canClip = outlierCount > 0 && clippedAxis.max < fullAxis.max;
+  const valueAxis = canClip && !showOutliers ? clippedAxis : fullAxis;
 
   const config = useMemo(
     () =>
@@ -641,7 +644,7 @@ function MetricChartCard({
                   controls and lets aria-pressed carry the on/off state. A label
                   that flips to the other mode's name would make a pressed
                   toggle announce the mode it is not in. */}
-              {hasOutliers && !showTable ? (
+              {canClip && !showTable ? (
                 <Button
                   aria-label={`Include ${outlierCount} ${
                     outlierCount === 1 ? "point" : "points"

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useMemo } from "react";
+import { CartesianGrid, Label, Line, LineChart, XAxis, YAxis } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+
+import type { MetricPoint, MetricsDashboardData } from "./metrics-data";
+
+const SERIES_COLORS = [
+  "hsl(221 83% 53%)",
+  "hsl(142 71% 45%)",
+  "hsl(25 95% 53%)",
+  "hsl(262 83% 58%)",
+  "hsl(346 77% 50%)",
+  "hsl(188 86% 43%)",
+  "hsl(45 93% 47%)",
+  "hsl(215 16% 47%)",
+];
+
+type Surface = "desktop" | "mobile";
+
+type OperationChart = {
+  config: ChartConfig;
+  data: Array<Record<string, number | string>>;
+  operation: string;
+  series: Array<{ key: string; label: string }>;
+};
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replaceAll(".", " · ");
+}
+
+function formatTickDate(value: unknown): string {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return String(value ?? "");
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    month: "short",
+  }).format(date);
+}
+
+function formatTooltipDate(value: unknown): string {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return String(value ?? "");
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZoneName: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function seriesLabel(point: MetricPoint, surface: Surface): string {
+  if (surface === "mobile") {
+    return `${humanize(point.platform)} · ${humanize(point.outcome)}`;
+  }
+
+  const phase = point.phase ? humanize(point.phase) : "total";
+  const dependency = point.dependency ? ` · ${humanize(point.dependency)}` : "";
+  return `${phase}${dependency} · ${humanize(point.outcome)}`;
+}
+
+function getLatestSampleAt(data: MetricsDashboardData): string | null {
+  let latestTime = Number.NEGATIVE_INFINITY;
+
+  for (const points of [data.desktop, data.mobile]) {
+    for (const point of points) {
+      latestTime = Math.max(latestTime, Date.parse(point.bucketStartedAt));
+    }
+  }
+
+  return Number.isFinite(latestTime)
+    ? new Date(latestTime).toISOString()
+    : null;
+}
+
+function buildOperationCharts(
+  points: MetricPoint[],
+  surface: Surface
+): OperationChart[] {
+  const byOperation = new Map<string, MetricPoint[]>();
+  for (const point of points) {
+    const operationPoints = byOperation.get(point.operation) ?? [];
+    operationPoints.push(point);
+    byOperation.set(point.operation, operationPoints);
+  }
+
+  return [...byOperation.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([operation, operationPoints]) => {
+      const labels = [
+        ...new Set(operationPoints.map((point) => seriesLabel(point, surface))),
+      ].sort();
+      const series = labels.map((label, index) => ({
+        key: `series${index}`,
+        label,
+      }));
+      const keyByLabel = new Map(series.map((item) => [item.label, item.key]));
+      const config = Object.fromEntries(
+        series.map((item, index) => [
+          item.key,
+          {
+            color: SERIES_COLORS[index % SERIES_COLORS.length],
+            label: item.label,
+          },
+        ])
+      ) satisfies ChartConfig;
+      const rowsByBucket = new Map<string, Record<string, number | string>>();
+
+      for (const point of operationPoints) {
+        const row = rowsByBucket.get(point.bucketStartedAt) ?? {
+          bucketTime: Date.parse(point.bucketStartedAt),
+        };
+        const seriesKey = keyByLabel.get(seriesLabel(point, surface));
+        if (seriesKey) {
+          row[seriesKey] = Math.round((point.p95Ms / 1_000) * 100) / 100;
+        }
+        rowsByBucket.set(point.bucketStartedAt, row);
+      }
+
+      return {
+        config,
+        data: [...rowsByBucket.values()].sort(
+          (left, right) => Number(left.bucketTime) - Number(right.bucketTime)
+        ),
+        operation,
+        series,
+      };
+    });
+}
+
+function MetricChartCard({ chart }: { chart: OperationChart }) {
+  return (
+    <Card className="min-w-0">
+      <CardHeader>
+        <CardTitle className="capitalize">
+          {humanize(chart.operation)}
+        </CardTitle>
+        <CardDescription>
+          {chart.series.length} series · p95 seconds
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="min-w-0 space-y-4">
+        <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+          {chart.series.map((item) => (
+            <div key={item.key} className="flex items-center gap-1.5">
+              <span
+                aria-hidden
+                className="size-2.5 rounded-[2px]"
+                style={{ backgroundColor: chart.config[item.key]?.color }}
+              />
+              <span>{item.label}</span>
+            </div>
+          ))}
+        </div>
+        <ChartContainer
+          className="aspect-auto h-[260px] w-full min-w-0"
+          config={chart.config}
+        >
+          <LineChart
+            accessibilityLayer
+            data={chart.data}
+            margin={{ bottom: 22, left: 4, right: 16, top: 8 }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              axisLine={false}
+              dataKey="bucketTime"
+              domain={["dataMin", "dataMax"]}
+              minTickGap={42}
+              scale="time"
+              tickFormatter={formatTickDate}
+              tickLine={false}
+              tickMargin={8}
+              type="number"
+            >
+              <Label
+                offset={-16}
+                position="insideBottom"
+                value="Time (your local time)"
+              />
+            </XAxis>
+            <YAxis
+              axisLine={false}
+              domain={[0, "auto"]}
+              tickFormatter={(value: number) => `${value}s`}
+              tickLine={false}
+              width={48}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  className="min-w-[220px]"
+                  labelFormatter={formatTooltipDate}
+                />
+              }
+            />
+            {chart.series.map((item) => (
+              <Line
+                key={item.key}
+                connectNulls={false}
+                dataKey={item.key}
+                dot={{ r: 1.5, strokeWidth: 0 }}
+                stroke={`var(--color-${item.key})`}
+                strokeWidth={2}
+                type="linear"
+              />
+            ))}
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SurfaceSection({
+  points,
+  status,
+  surface,
+}: {
+  points: MetricPoint[];
+  status: "available" | "unavailable";
+  surface: Surface;
+}) {
+  const charts = useMemo(
+    () => buildOperationCharts(points, surface),
+    [points, surface]
+  );
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold capitalize">{surface}</h2>
+        <p className="text-sm text-muted-foreground">
+          {surface === "desktop"
+            ? "Web app loading and Earn interaction latency."
+            : "iOS and Android app loading and Earn operation latency."}
+        </p>
+      </div>
+      {status === "unavailable" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Metrics unavailable</CardTitle>
+            <CardDescription>
+              ClickStack could not be queried. Check the server-side admin
+              configuration.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : charts.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No recent metrics</CardTitle>
+            <CardDescription>
+              No production measurements arrived during this 7-day window.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="grid gap-6 xl:grid-cols-2">
+          {charts.map((chart) => (
+            <MetricChartCard key={chart.operation} chart={chart} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function MetricsDashboard({ data }: { data: MetricsDashboardData }) {
+  const latestSampleAt = getLatestSampleAt(data);
+
+  return (
+    <div className="space-y-10">
+      <p className="text-xs text-muted-foreground">
+        Queried {formatTooltipDate(data.fetchedAt)}
+        {latestSampleAt
+          ? ` · latest sample ${formatTooltipDate(latestSampleAt)}`
+          : ""}
+        {
+          " · values are milliseconds in ClickStack and displayed here in seconds."
+        }
+      </p>
+      <SurfaceSection
+        points={data.desktop}
+        status={data.status.desktop}
+        surface="desktop"
+      />
+      <SurfaceSection
+        points={data.mobile}
+        status={data.status.mobile}
+        surface="mobile"
+      />
+    </div>
+  );
+}

--- a/admin/src/app/(admin)/metrics/metrics-data.ts
+++ b/admin/src/app/(admin)/metrics/metrics-data.ts
@@ -11,6 +11,13 @@ const DEFAULT_METRICS_SOURCE_ID = "6a58601284f8f1d4ff4d12ab";
 const RANGE_MS = 7 * 24 * 60 * 60 * 1_000;
 const RESPONSE_SIZE_LIMIT = 5 * 1_024 * 1_024;
 
+// Earn traffic is low enough that 30-minute buckets leave 336 slots holding a
+// handful of samples, so every chart degrades into disconnected single points.
+// Two-hour buckets keep the same 7-day window while giving each p95 a real
+// sample population behind it.
+export const BUCKET_MINUTES = 120;
+const GRANULARITY = "2h";
+
 const OPERATION_FIELD = "arrayElement(Attributes, 'loyal.operation')";
 const PHASE_FIELD = "arrayElement(Attributes, 'loyal.phase')";
 const DEPENDENCY_FIELD = "arrayElement(Attributes, 'loyal.dependency')";
@@ -30,18 +37,30 @@ export type MetricPoint = {
   p95Ms: number;
 };
 
+/** Measurements behind each operation, so a p95 drawn from one sample is obvious. */
+export type OperationVolume = {
+  completed: number;
+  failed: number;
+  total: number;
+};
+
 export type MetricsDashboardData = {
+  bucketMinutes: number;
   desktop: MetricPoint[];
   fetchedAt: string;
   mobile: MetricPoint[];
   rangeEndedAt: string;
   rangeStartedAt: string;
   status: Record<MetricSurface, "available" | "unavailable">;
+  volume: Record<MetricSurface, Record<string, OperationVolume>>;
 };
+
+type QueryKind = "latency" | "volume";
 
 type ClickStackQuery = {
   environment: "prod" | "production";
   groupBy: string[];
+  kind: QueryKind;
   metricName: string;
   serviceName: "loyal-frontend" | "loyal-mobile";
   surface: MetricSurface;
@@ -49,30 +68,47 @@ type ClickStackQuery = {
 
 type RawMetricRow = Record<string, unknown>;
 
+const DESKTOP_SOURCE = {
+  environment: "production",
+  metricName: "loyal.frontend.loading.duration",
+  serviceName: "loyal-frontend",
+  surface: "desktop",
+} as const;
+
+const MOBILE_SOURCE = {
+  environment: "prod",
+  metricName: "loyal.mobile.loading.duration",
+  serviceName: "loyal-mobile",
+  surface: "mobile",
+} as const;
+
+const VOLUME_GROUP_BY = [
+  "Attributes['loyal.operation']",
+  "Attributes['loyal.outcome']",
+];
+
 const QUERIES: ClickStackQuery[] = [
   {
-    environment: "production",
+    ...DESKTOP_SOURCE,
     groupBy: [
       "Attributes['loyal.operation']",
       "Attributes['loyal.phase']",
       "Attributes['loyal.dependency']",
       "Attributes['loyal.outcome']",
     ],
-    metricName: "loyal.frontend.loading.duration",
-    serviceName: "loyal-frontend",
-    surface: "desktop",
+    kind: "latency",
   },
   {
-    environment: "prod",
+    ...MOBILE_SOURCE,
     groupBy: [
       "Attributes['loyal.operation']",
       "Attributes['loyal.outcome']",
       "Attributes['loyal.platform']",
     ],
-    metricName: "loyal.mobile.loading.duration",
-    serviceName: "loyal-mobile",
-    surface: "mobile",
+    kind: "latency",
   },
+  { ...DESKTOP_SOURCE, groupBy: VOLUME_GROUP_BY, kind: "volume" },
+  { ...MOBILE_SOURCE, groupBy: VOLUME_GROUP_BY, kind: "volume" },
 ];
 
 function readDimension(value: unknown): string | null {
@@ -142,7 +178,7 @@ async function queryMetrics(
   query: ClickStackQuery,
   startTime: number,
   endTime: number
-): Promise<MetricPoint[]> {
+): Promise<RawMetricRow[]> {
   const apiKey = serverEnv.clickStackApiKey;
   if (!apiKey) {
     throw new Error("ClickStack API key is not configured");
@@ -151,20 +187,21 @@ async function queryMetrics(
   const response = await fetch(getSeriesUrl(), {
     body: JSON.stringify({
       endTime,
-      granularity: "30m",
+      granularity: GRANULARITY,
       series: [
         {
-          aggFn: "quantile",
           dataSource: "metrics",
           field: "Value",
           groupBy: query.groupBy,
-          level: 0.95,
           metricDataType: "gauge",
           metricName: query.metricName,
           sourceId:
             serverEnv.clickStackMetricsSourceId ?? DEFAULT_METRICS_SOURCE_ID,
           where: `ServiceName = '${query.serviceName}' AND ResourceAttributes['deployment.environment.name'] = '${query.environment}'`,
           whereLanguage: "sql",
+          ...(query.kind === "volume"
+            ? { aggFn: "count" }
+            : { aggFn: "quantile", level: 0.95 }),
         },
       ],
       seriesReturnType: "column",
@@ -198,16 +235,47 @@ async function queryMetrics(
     throw new Error("ClickStack returned an invalid metrics response");
   }
 
-  return parsed.data
-    .filter(
-      (row): row is RawMetricRow =>
-        typeof row === "object" && row !== null && !Array.isArray(row)
-    )
-    .map((row) => normalizeRow(row, query.surface))
+  return parsed.data.filter(
+    (row): row is RawMetricRow =>
+      typeof row === "object" && row !== null && !Array.isArray(row)
+  );
+}
+
+function toLatencyPoints(
+  rows: RawMetricRow[],
+  surface: MetricSurface
+): MetricPoint[] {
+  return rows
+    .map((row) => normalizeRow(row, surface))
     .filter((point): point is MetricPoint => point !== null)
     .sort((left, right) =>
       left.bucketStartedAt.localeCompare(right.bucketStartedAt)
     );
+}
+
+function toVolumeByOperation(
+  rows: RawMetricRow[]
+): Record<string, OperationVolume> {
+  const volume: Record<string, OperationVolume> = {};
+
+  for (const row of rows) {
+    const operation = readDimension(row[OPERATION_FIELD]);
+    const outcome = readDimension(row[OUTCOME_FIELD]) ?? "unknown";
+    const count = Number(row.series_0);
+
+    if (!operation || !Number.isFinite(count) || count <= 0) {
+      continue;
+    }
+
+    const current = volume[operation] ?? { completed: 0, failed: 0, total: 0 };
+    volume[operation] = {
+      completed: current.completed + (outcome === "completed" ? count : 0),
+      failed: current.failed + (outcome === "failed" ? count : 0),
+      total: current.total + count,
+    };
+  }
+
+  return volume;
 }
 
 async function loadMetricsData(): Promise<MetricsDashboardData> {
@@ -220,19 +288,25 @@ async function loadMetricsData(): Promise<MetricsDashboardData> {
   );
 
   const data: MetricsDashboardData = {
+    bucketMinutes: BUCKET_MINUTES,
     desktop: [],
     fetchedAt: new Date().toISOString(),
     mobile: [],
     rangeEndedAt: rangeEndedAt.toISOString(),
     rangeStartedAt: rangeStartedAt.toISOString(),
     status: { desktop: "unavailable", mobile: "unavailable" },
+    volume: { desktop: {}, mobile: {} },
   };
 
   results.forEach((result, index) => {
     const query = QUERIES[index];
     if (result.status === "fulfilled") {
-      data[query.surface] = result.value;
-      data.status[query.surface] = "available";
+      if (query.kind === "latency") {
+        data[query.surface] = toLatencyPoints(result.value, query.surface);
+        data.status[query.surface] = "available";
+      } else {
+        data.volume[query.surface] = toVolumeByOperation(result.value);
+      }
       return;
     }
 
@@ -242,6 +316,7 @@ async function loadMetricsData(): Promise<MetricsDashboardData> {
           ? result.reason.message
           : "Unknown error",
       errorName: result.reason instanceof Error ? result.reason.name : "Error",
+      kind: query.kind,
       surface: query.surface,
     });
   });

--- a/admin/src/app/(admin)/metrics/metrics-data.ts
+++ b/admin/src/app/(admin)/metrics/metrics-data.ts
@@ -1,0 +1,260 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { serverEnv } from "@/lib/core/config/server";
+import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
+
+const DEFAULT_CLICKSTACK_API_URL =
+  "https://loyal-clickstack.onrender.com/api/api/v2";
+const DEFAULT_METRICS_SOURCE_ID = "6a58601284f8f1d4ff4d12ab";
+const RANGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const RESPONSE_SIZE_LIMIT = 5 * 1_024 * 1_024;
+
+const OPERATION_FIELD = "arrayElement(Attributes, 'loyal.operation')";
+const PHASE_FIELD = "arrayElement(Attributes, 'loyal.phase')";
+const DEPENDENCY_FIELD = "arrayElement(Attributes, 'loyal.dependency')";
+const OUTCOME_FIELD = "arrayElement(Attributes, 'loyal.outcome')";
+const PLATFORM_FIELD = "arrayElement(Attributes, 'loyal.platform')";
+const TIME_BUCKET_FIELD = "__hdx_time_bucket";
+
+type MetricSurface = "desktop" | "mobile";
+
+export type MetricPoint = {
+  bucketStartedAt: string;
+  dependency: string | null;
+  operation: string;
+  outcome: string;
+  phase: string | null;
+  platform: "android" | "desktop" | "ios" | "other";
+  p95Ms: number;
+};
+
+export type MetricsDashboardData = {
+  desktop: MetricPoint[];
+  fetchedAt: string;
+  mobile: MetricPoint[];
+  rangeEndedAt: string;
+  rangeStartedAt: string;
+  status: Record<MetricSurface, "available" | "unavailable">;
+};
+
+type ClickStackQuery = {
+  environment: "prod" | "production";
+  groupBy: string[];
+  metricName: string;
+  serviceName: "loyal-frontend" | "loyal-mobile";
+  surface: MetricSurface;
+};
+
+type RawMetricRow = Record<string, unknown>;
+
+const QUERIES: ClickStackQuery[] = [
+  {
+    environment: "production",
+    groupBy: [
+      "Attributes['loyal.operation']",
+      "Attributes['loyal.phase']",
+      "Attributes['loyal.dependency']",
+      "Attributes['loyal.outcome']",
+    ],
+    metricName: "loyal.frontend.loading.duration",
+    serviceName: "loyal-frontend",
+    surface: "desktop",
+  },
+  {
+    environment: "prod",
+    groupBy: [
+      "Attributes['loyal.operation']",
+      "Attributes['loyal.outcome']",
+      "Attributes['loyal.platform']",
+    ],
+    metricName: "loyal.mobile.loading.duration",
+    serviceName: "loyal-mobile",
+    surface: "mobile",
+  },
+];
+
+function readDimension(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    trimmed.length > 120 ||
+    !/^[a-zA-Z0-9._:/ -]+$/.test(trimmed)
+  ) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function readPlatform(value: unknown): MetricPoint["platform"] {
+  const platform = readDimension(value)?.toLowerCase();
+  if (platform === "android" || platform === "ios") {
+    return platform;
+  }
+  return "other";
+}
+
+function normalizeRow(
+  row: RawMetricRow,
+  surface: MetricSurface
+): MetricPoint | null {
+  const operation = readDimension(row[OPERATION_FIELD]);
+  const outcome = readDimension(row[OUTCOME_FIELD]) ?? "unknown";
+  const p95Ms =
+    typeof row.series_0 === "number" ? row.series_0 : Number(row.series_0);
+  const bucketStartedAt = readDimension(row[TIME_BUCKET_FIELD]);
+  const bucketTime = bucketStartedAt ? Date.parse(bucketStartedAt) : Number.NaN;
+
+  if (
+    !operation ||
+    !Number.isFinite(p95Ms) ||
+    p95Ms < 0 ||
+    !bucketStartedAt ||
+    !Number.isFinite(bucketTime)
+  ) {
+    return null;
+  }
+
+  return {
+    bucketStartedAt: new Date(bucketTime).toISOString(),
+    dependency: readDimension(row[DEPENDENCY_FIELD]),
+    operation,
+    outcome,
+    phase: readDimension(row[PHASE_FIELD]),
+    platform:
+      surface === "desktop" ? "desktop" : readPlatform(row[PLATFORM_FIELD]),
+    p95Ms,
+  };
+}
+
+function getSeriesUrl(): string {
+  const apiUrl = serverEnv.clickStackApiUrl ?? DEFAULT_CLICKSTACK_API_URL;
+  return `${apiUrl.replace(/\/$/, "")}/charts/series`;
+}
+
+async function queryMetrics(
+  query: ClickStackQuery,
+  startTime: number,
+  endTime: number
+): Promise<MetricPoint[]> {
+  const apiKey = serverEnv.clickStackApiKey;
+  if (!apiKey) {
+    throw new Error("ClickStack API key is not configured");
+  }
+
+  const response = await fetch(getSeriesUrl(), {
+    body: JSON.stringify({
+      endTime,
+      granularity: "30m",
+      series: [
+        {
+          aggFn: "quantile",
+          dataSource: "metrics",
+          field: "Value",
+          groupBy: query.groupBy,
+          level: 0.95,
+          metricDataType: "gauge",
+          metricName: query.metricName,
+          sourceId:
+            serverEnv.clickStackMetricsSourceId ?? DEFAULT_METRICS_SOURCE_ID,
+          where: `ServiceName = '${query.serviceName}' AND ResourceAttributes['deployment.environment.name'] = '${query.environment}'`,
+          whereLanguage: "sql",
+        },
+      ],
+      seriesReturnType: "column",
+      startTime,
+    }),
+    cache: "no-store",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`ClickStack returned HTTP ${response.status}`);
+  }
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > RESPONSE_SIZE_LIMIT) {
+    throw new Error("ClickStack response exceeded the size limit");
+  }
+
+  const body = await response.text();
+  if (body.length > RESPONSE_SIZE_LIMIT) {
+    throw new Error("ClickStack response exceeded the size limit");
+  }
+
+  const parsed = JSON.parse(body) as { data?: unknown };
+  if (!Array.isArray(parsed.data)) {
+    throw new Error("ClickStack returned an invalid metrics response");
+  }
+
+  return parsed.data
+    .filter(
+      (row): row is RawMetricRow =>
+        typeof row === "object" && row !== null && !Array.isArray(row)
+    )
+    .map((row) => normalizeRow(row, query.surface))
+    .filter((point): point is MetricPoint => point !== null)
+    .sort((left, right) =>
+      left.bucketStartedAt.localeCompare(right.bucketStartedAt)
+    );
+}
+
+async function loadMetricsData(): Promise<MetricsDashboardData> {
+  const rangeEndedAt = new Date();
+  const rangeStartedAt = new Date(rangeEndedAt.getTime() - RANGE_MS);
+  const results = await Promise.allSettled(
+    QUERIES.map((query) =>
+      queryMetrics(query, rangeStartedAt.getTime(), rangeEndedAt.getTime())
+    )
+  );
+
+  const data: MetricsDashboardData = {
+    desktop: [],
+    fetchedAt: new Date().toISOString(),
+    mobile: [],
+    rangeEndedAt: rangeEndedAt.toISOString(),
+    rangeStartedAt: rangeStartedAt.toISOString(),
+    status: { desktop: "unavailable", mobile: "unavailable" },
+  };
+
+  results.forEach((result, index) => {
+    const query = QUERIES[index];
+    if (result.status === "fulfilled") {
+      data[query.surface] = result.value;
+      data.status[query.surface] = "available";
+      return;
+    }
+
+    console.error("ClickStack metrics query failed", {
+      errorMessage:
+        result.reason instanceof Error
+          ? result.reason.message
+          : "Unknown error",
+      errorName: result.reason instanceof Error ? result.reason.name : "Error",
+      surface: query.surface,
+    });
+  });
+
+  return data;
+}
+
+const getCachedMetricsData = unstable_cache(
+  loadMetricsData,
+  ["admin-clickstack-loading-metrics"],
+  { revalidate: DATA_CACHE_TTL_SECONDS }
+);
+
+export async function getMetricsData(): Promise<MetricsDashboardData> {
+  return getCachedMetricsData();
+}

--- a/admin/src/app/(admin)/metrics/page.tsx
+++ b/admin/src/app/(admin)/metrics/page.tsx
@@ -14,7 +14,7 @@ export default async function MetricsPage() {
       <SectionHeader
         title="Metrics"
         breadcrumbs={[{ label: "Metrics" }]}
-        subtitle="Production p95 latency in 30-minute buckets over the last 7 days."
+        subtitle="Production p95 latency in two-hour UTC buckets over the last 7 days, busiest operations first."
       />
       <MetricsDashboard data={data} />
     </PageContainer>

--- a/admin/src/app/(admin)/metrics/page.tsx
+++ b/admin/src/app/(admin)/metrics/page.tsx
@@ -1,0 +1,22 @@
+import { PageContainer } from "@/components/layout/page-container";
+import { SectionHeader } from "@/components/layout/section-header";
+
+import { getMetricsData } from "./metrics-data";
+import { MetricsDashboard } from "./metrics-dashboard";
+
+export const dynamic = "force-dynamic";
+
+export default async function MetricsPage() {
+  const data = await getMetricsData();
+
+  return (
+    <PageContainer className="max-w-7xl">
+      <SectionHeader
+        title="Metrics"
+        breadcrumbs={[{ label: "Metrics" }]}
+        subtitle="Production p95 latency in 30-minute buckets over the last 7 days."
+      />
+      <MetricsDashboard data={data} />
+    </PageContainer>
+  );
+}

--- a/admin/src/app/globals.css
+++ b/admin/src/app/globals.css
@@ -74,6 +74,15 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+  /* Categorical series slots for the metrics dashboard. The slot order is the
+     colour-vision-deficiency safety mechanism, so slots are assigned by series
+     identity and are never reordered or cycled per chart. */
+  --metric-1: #2a78d6;
+  --metric-2: #eb6834;
+  --metric-3: #1baf7a;
+  --metric-4: #eda100;
+  --metric-5: #e87ba4;
+  --metric-6: #008300;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -109,6 +118,13 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  /* Same six hues, re-stepped for the dark card surface — not an automatic flip. */
+  --metric-1: #3987e5;
+  --metric-2: #d95926;
+  --metric-3: #199e70;
+  --metric-4: #c98500;
+  --metric-5: #d55181;
+  --metric-6: #008300;
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/admin/src/components/app-sidebar.tsx
+++ b/admin/src/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   BellRingIcon,
   BookOpenIcon,
   CircleDollarSignIcon,
+  GaugeIcon,
   LayoutDashboardIcon,
   LandmarkIcon,
   LogOutIcon,
@@ -49,6 +50,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Core",
     items: [
       { href: "/overview", icon: LayoutDashboardIcon, label: "Overview" },
+      { href: "/metrics", icon: GaugeIcon, label: "Metrics" },
       { href: "/communities", icon: UsersRoundIcon, label: "Communities" },
       // { href: "/features", icon: ListChecksIcon, label: "Features" },
       // { href: "/flags", icon: FlagIcon, label: "Flags" },

--- a/admin/src/lib/core/config/server.ts
+++ b/admin/src/lib/core/config/server.ts
@@ -36,4 +36,16 @@ export const serverEnv = {
   get solanaMainnetRpcUrl(): string | undefined {
     return getOptionalEnv("SOLANA_MAINNET_RPC_URL");
   },
+  get clickStackApiKey(): string | undefined {
+    return (
+      getOptionalEnv("LOYAL_CLICKSTACK_API_KEY") ??
+      getOptionalEnv("HYPERDX_ACCESS_KEY")
+    );
+  },
+  get clickStackApiUrl(): string | undefined {
+    return getOptionalEnv("LOYAL_CLICKSTACK_API_URL");
+  },
+  get clickStackMetricsSourceId(): string | undefined {
+    return getOptionalEnv("LOYAL_CLICKSTACK_METRICS_SOURCE_ID");
+  },
 } as const;


### PR DESCRIPTION
## Summary

- add an authenticated `/metrics` admin page between Overview and Communities
- query production desktop and mobile ClickStack loading metrics server-side
- show p95 latency in 30-minute buckets over the last 7 days, split by operation and outcome
- preserve partial results when one telemetry surface is unavailable and keep the ClickStack key out of the browser

## Live data verification

Verified against production ClickStack on 2026-08-05:

- desktop: 6 operation charts
- mobile: 8 operation charts
- current mobile coverage includes app load, deposit, refund, withdrawal, and autodeposit operations
- authenticated browser render completed with 14 charts, no console errors, and no Next.js error overlay

## Validation

- `tsc -p admin/tsconfig.json --noEmit --incremental false`
- `cd admin && next lint`
- shared admin schema guard
- `cd admin && next build`
- `git diff --check`
- secret and non-English text scans
- live authenticated browser smoke test

## Deployment

Merge safety: ready for review.

Deployment safety: configure the server-only `LOYAL_CLICKSTACK_API_KEY` in the admin Vercel project for Production and Preview before deploying. `HYPERDX_ACCESS_KEY` is accepted as a compatibility fallback.