### PR TITLE
feat(earn): raise default autodeposit balance sweep ceiling from 10k to 100k

### DIFF
--- a/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
+++ b/frontend/src/components/wallet-workspace/app-wallet-workspace.tsx
@@ -664,7 +664,7 @@ function tokenAmountNumberToRaw(
   return parseTokenAmountLabelToRaw(amount.toFixed(decimals), decimals);
 }
 
-const DEFAULT_EARN_AUTODEPOSIT_AMOUNT_LABEL = "10,000";
+const DEFAULT_EARN_AUTODEPOSIT_AMOUNT_LABEL = "100,000";
 const EARN_AUTODEPOSIT_CONFIG_CACHE_VERSION = 1;
 const EARN_AUTODEPOSIT_CONFIG_CACHE_PREFIX = "loyal.earnAutodepositConfig.v1";
 

--- a/frontend/src/components/wallet-workspace/facelift/earn-actions-support.ts
+++ b/frontend/src/components/wallet-workspace/facelift/earn-actions-support.ts
@@ -83,7 +83,7 @@ export const EARN_POLICY_MUTATION_RESOURCES = [
   EARN_SYNC_RESOURCES.state,
 ] as const;
 
-export const DEFAULT_EARN_AUTODEPOSIT_AMOUNT_LABEL = "10,000";
+export const DEFAULT_EARN_AUTODEPOSIT_AMOUNT_LABEL = "100,000";
 
 // app-wallet-workspace.tsx:278-299
 export function resolveEarnMutationSmartAccountPlan(args: {


### PR DESCRIPTION
Raises the default autodeposit delegation amount (the per-period balance sweep cap) from 10,000 to 100,000 USDC for new setups. Existing delegations keep their current cap until re-saved.

ASK-2039