### PR TITLE
feat(mobile): join loading metrics to the lifecycle flows they wrap

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -603,7 +603,7 @@ export default function EarnScreen() {
         if (!signer || !isWalletUnlocked(state)) {
           throw new Error("Unlock your wallet to deposit.");
         }
-        await executeEarnDeposit({ signer, amountUsd });
+        await executeEarnDeposit({ signer, amountUsd, flowId: metric.flowId });
         // Trust the read-model for the next reads — confirmEarnDeposit (inside
         // executeEarnDeposit, just awaited) wrote it with the deposited total, so
         // the next `/state` read is correct immediately while live `/holdings` lags.
@@ -709,6 +709,7 @@ export default function EarnScreen() {
         await executeEarnWithdraw({
           signer,
           amountUsd,
+          flowId: metric.flowId,
           mode,
           source: source ? toWithdrawPrepareSource(source) : null,
         });
@@ -812,9 +813,14 @@ export default function EarnScreen() {
             policyAccount: autodeposit.policyAccount,
             recurringDelegation: autodeposit.recurringDelegation,
             vaultIndex: autodeposit.vaultIndex,
+            flowId: metric.flowId,
           });
         } else {
-          await executeEarnAutodepositSetup({ signer, thresholdUsd });
+          await executeEarnAutodepositSetup({
+            signer,
+            thresholdUsd,
+            flowId: metric.flowId,
+          });
         }
         try {
           const fresh = await refreshAutodeposit({ throwOnError: true });
@@ -874,6 +880,7 @@ export default function EarnScreen() {
         signer,
         policy: autodeposit.policyAccount,
         recurringDelegation: autodeposit.recurringDelegation,
+        flowId: metric.flowId,
       });
       try {
         await refreshAutodeposit({ throwOnError: true });

--- a/mobile/src/features/activity/model/ActivityProvider.tsx
+++ b/mobile/src/features/activity/model/ActivityProvider.tsx
@@ -388,6 +388,7 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
     try {
       const execution = await executeEarnAutodepositScheduledSweep({
         signer,
+        flowId: pendingSweepMetricRef.current.flowId,
       });
       if (attemptId !== sweepAttemptIdRef.current) {
         execution.flow.fail("ui_commit", { executeNowState: "failed" });

--- a/mobile/src/hooks/wallet/useEarnAutodepositToggle.ts
+++ b/mobile/src/hooks/wallet/useEarnAutodepositToggle.ts
@@ -74,13 +74,14 @@ export function useEarnAutodepositToggle(args: {
     const controllerTargetKey = targetKey;
     return createAutodepositToggleController({
       debounceMs: AUTODEPOSIT_TOGGLE_DEBOUNCE_MS,
-      submit: (nextActive) =>
+      submit: (nextActive, flowId) =>
         setEarnAutodepositActive({
           signer,
           active: nextActive,
           policyAccount,
           recurringDelegation,
           vaultIndex,
+          flowId,
         }),
       refresh: async () => {
         const refreshed = await refreshAutodeposit({ throwOnError: true });
@@ -96,6 +97,7 @@ export function useEarnAutodepositToggle(args: {
         return {
           complete: metric.completeAfterPaint,
           fail: metric.failAfterPaint,
+          flowId: metric.flowId,
         };
       },
       onOptimisticActive: (nextActive) => {

--- a/mobile/src/lib/solana/earn/autodeposit-toggle-controller.ts
+++ b/mobile/src/lib/solana/earn/autodeposit-toggle-controller.ts
@@ -4,11 +4,14 @@ export type AutodepositToggleController = {
 
 export type AutodepositToggleControllerOptions = {
   debounceMs?: number;
-  submit(active: boolean): Promise<void>;
+  // `flowId` comes from the submission handle below, so the loading metric for
+  // this press and the lifecycle flow the submit starts share one id.
+  submit(active: boolean, flowId?: string): Promise<void>;
   refresh(): Promise<boolean | null>;
   onSubmissionStart?(active: boolean): {
     complete(): void;
     fail(): void;
+    flowId?: string;
   };
   onOptimisticActive(active: boolean): void;
   onReconciledActive(active: boolean): void;
@@ -57,7 +60,7 @@ export function createAutodepositToggleController(
       const submission = options.onSubmissionStart?.(submittedActive);
       let submitSucceeded = false;
       try {
-        await options.submit(submittedActive);
+        await options.submit(submittedActive, submission?.flowId);
         submitSucceeded = true;
         hasTerminalError = false;
         terminalError = undefined;

--- a/mobile/src/lib/solana/earn/autodeposit.ts
+++ b/mobile/src/lib/solana/earn/autodeposit.ts
@@ -168,8 +168,12 @@ async function loadAutodepositPrepareContext(walletAddress: string): Promise<{
 export async function executeEarnAutodepositSetup(args: {
   signer: Signer;
   thresholdUsd: number;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
 }): Promise<void> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.autodeposit.configuration",
     flowVariant: "setup",
     walletAddress: args.signer.publicKey.toBase58(),
@@ -381,8 +385,12 @@ export async function updateEarnAutodepositThreshold(args: {
   policyAccount: string;
   recurringDelegation: string;
   vaultIndex: number;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
 }): Promise<void> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.autodeposit.configuration",
     flowVariant: "floor_update",
     walletAddress: args.signer.publicKey.toBase58(),
@@ -416,8 +424,12 @@ export async function setEarnAutodepositActive(args: {
   policyAccount: string;
   recurringDelegation: string;
   vaultIndex: number;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
 }): Promise<void> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.autodeposit.configuration",
     flowVariant: args.active ? "resume" : "pause",
     walletAddress: args.signer.publicKey.toBase58(),
@@ -465,6 +477,10 @@ export async function executeEarnAutodepositClose(args: {
   policy: string;
   recurringDelegation: string;
   source?: "deleted" | "withdraw";
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`. Ignored for the nested withdrawal close,
+  // which emits no flow of its own.
+  flowId?: string;
 }): Promise<void> {
   // A close nested inside a withdrawal is already traced as that flow's
   // `autodeposit_close` stage — only a standalone delete gets its own flow.
@@ -472,6 +488,7 @@ export async function executeEarnAutodepositClose(args: {
     args.source === "withdraw"
       ? null
       : startLifecycleFlow({
+          ...(args.flowId ? { flowId: args.flowId } : {}),
           flowName: "earn.autodeposit.configuration" as const,
           flowVariant: "close",
           walletAddress: args.signer.publicKey.toBase58(),
@@ -630,11 +647,15 @@ async function runEarnAutodepositClose(
 // the flow's elapsedMs captures the true request→done duration.
 export async function executeEarnAutodepositScheduledSweep(args: {
   signer: Signer;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
 }): Promise<{
   flow: LifecycleFlow<"earn.autodeposit.execute_now">;
   scheduledSlotId: string;
 }> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.autodeposit.execute_now",
     flowVariant: "execute_now",
     walletAddress: args.signer.publicKey.toBase58(),

--- a/mobile/src/lib/solana/earn/deposit.ts
+++ b/mobile/src/lib/solana/earn/deposit.ts
@@ -179,8 +179,12 @@ function hydrateWireStages(
 export async function executeEarnDeposit(args: {
   signer: Signer;
   amountUsd: number;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
 }): Promise<EarnDepositResult> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.deposit",
     flowVariant: "initial",
     // Deposit runs the same SDK prepare through the same retry helper as

--- a/mobile/src/lib/solana/earn/withdraw.ts
+++ b/mobile/src/lib/solana/earn/withdraw.ts
@@ -379,6 +379,9 @@ async function signSendAndConfirmWithdraw(args: {
 export async function executeEarnWithdraw(args: {
   signer: Signer;
   amountUsd: number;
+  // The caller's loading-metric flow id, so the metric point and this flow's
+  // events share one `loyal.flow.id`.
+  flowId?: string;
   mode: EarnWithdrawMode;
   // The chosen source. Omitted/null lets the backend auto-select when there's
   // exactly one source; required (from the picker) when the position spans
@@ -386,6 +389,7 @@ export async function executeEarnWithdraw(args: {
   source?: EarnWithdrawSource | null;
 }): Promise<EarnWithdrawResult> {
   const flow = startLifecycleFlow({
+    ...(args.flowId ? { flowId: args.flowId } : {}),
     flowName: "earn.withdrawal",
     flowVariant: args.mode === "full" ? "full" : "partial",
     reportUnexpectedErrors: true,

--- a/mobile/src/services/__tests__/lifecycle-flow-id.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-flow-id.test.ts
@@ -1,0 +1,81 @@
+// Guards the join between the two telemetry streams (ASK-1949). A loading
+// metric is started in the UI; the lifecycle flow it wraps is started deeper,
+// inside the earn module. When each mints its own id the streams share a
+// `loyal.flow.id` attribute name but not an id space, so a failed point on the
+// metrics dashboard cannot be traced to the error that caused it. Nothing in
+// the type system catches that — both ids are valid uuids — so the emitted
+// envelope is asserted directly against the id the caller handed down.
+
+import { startLifecycleFlow } from "../observability";
+
+// Hoisted above the imports by babel-plugin-jest-hoist.
+jest.mock("expo-updates", () => ({
+  channel: "production",
+  runtimeVersion: "1.0.0",
+  updateId: undefined,
+}));
+jest.mock("@/config/env", () => ({
+  env: { earnApiBaseUrl: "https://example.test" },
+}));
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const METRIC_FLOW_ID = "3f29ecc4-cbf6-4795-bf42-2fb4850e8cb8";
+
+function captureEnvelopes(): { flowId: string }[] {
+  const sent: { flowId: string }[] = [];
+  global.fetch = jest.fn(async (_url: unknown, init: unknown) => {
+    sent.push(JSON.parse((init as { body: string }).body) as { flowId: string });
+    return { ok: true, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return sent;
+}
+
+describe("lifecycle flow id adoption", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("emits every stage under the flow id the caller handed down", () => {
+    const sent = captureEnvelopes();
+    const flow = startLifecycleFlow({
+      flowId: METRIC_FLOW_ID,
+      flowName: "earn.withdrawal",
+      flowVariant: "full",
+    });
+    flow.start("prepare");
+    flow.fail("prepare");
+
+    expect(flow.flowId).toBe(METRIC_FLOW_ID);
+    expect(sent).toHaveLength(2);
+    expect(sent.every((envelope) => envelope.flowId === METRIC_FLOW_ID)).toBe(
+      true,
+    );
+  });
+
+  it("mints its own id when the caller supplies none", () => {
+    const sent = captureEnvelopes();
+    const flow = startLifecycleFlow({
+      flowName: "earn.withdrawal",
+      flowVariant: "full",
+    });
+    flow.start("prepare");
+
+    expect(flow.flowId).toMatch(UUID_V4_PATTERN);
+    expect(sent[0].flowId).toBe(flow.flowId);
+  });
+
+  // The ingest drops any envelope whose flowId isn't a canonical v4. Falling
+  // back keeps a malformed id from costing the whole flow's events — losing the
+  // join is survivable, losing the trace is not.
+  it("falls back to a generated id when the supplied one is malformed", () => {
+    const sent = captureEnvelopes();
+    const flow = startLifecycleFlow({
+      flowId: "not-a-uuid",
+      flowName: "earn.withdrawal",
+      flowVariant: "full",
+    });
+    flow.start("prepare");
+
+    expect(flow.flowId).toMatch(UUID_V4_PATTERN);
+    expect(sent[0].flowId).toMatch(UUID_V4_PATTERN);
+  });
+});

--- a/mobile/src/services/loading-metrics.ts
+++ b/mobile/src/services/loading-metrics.ts
@@ -14,9 +14,16 @@ import {
 
 export type { MobileLoadingOperation } from "./loading-metrics-contract";
 
-type MobileLoadingAttempt = {
+export type MobileLoadingAttempt = {
   completeAfterPaint: () => void;
   failAfterPaint: () => void;
+  /**
+   * Pass to `startLifecycleFlow` so this attempt's metric point and the
+   * lifecycle events it wraps share one `loyal.flow.id`. Without that the two
+   * live in disjoint id spaces and a failed point on the metrics dashboard
+   * cannot be traced to the error that caused it.
+   */
+  flowId: string;
 };
 
 declare global {
@@ -116,6 +123,7 @@ export function startMobileLoadingMetric(
   return {
     completeAfterPaint: () => finish("completed"),
     failAfterPaint: () => finish("failed"),
+    flowId,
   };
 }
 

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -546,15 +546,30 @@ function generateFlowId(): string {
 // The ingest drops any envelope whose walletAddress isn't base58 — guard here
 // so one bad address never costs the whole event.
 const WALLET_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+// The lifecycle ingest drops any envelope whose flowId isn't a canonical v4,
+// so an adopted id is checked before it can cost the whole flow's events.
+const FLOW_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function startLifecycleFlow<F extends LifecycleFlowName>(args: {
+  /**
+   * Adopt the caller's id instead of minting one. The UI starts its loading
+   * metric before this flow exists, so handing that metric's id down here is
+   * what lets a latency point on the metrics dashboard join back to the
+   * lifecycle events and error records that explain it. A malformed id is
+   * ignored rather than propagated: telemetry never breaks the flow it traces.
+   */
+  flowId?: string;
   flowName: F;
   flowVariant: LifecycleVariantMap[F];
   /** Emit a correlated exception record when failFrom maps to unexpected_error. */
   reportUnexpectedErrors?: boolean;
   walletAddress?: string;
 }): LifecycleFlow<F> {
-  const flowId = generateFlowId();
+  const flowId =
+    args.flowId && FLOW_ID_PATTERN.test(args.flowId)
+      ? args.flowId
+      : generateFlowId();
   const startedAt = Date.now();
   let lastAt = startedAt;
   let variant: LifecycleVariantMap[F] = args.flowVariant;


### PR DESCRIPTION
Mobile loading metrics and lifecycle events both publish `loyal.flow.id`, but each minted its own uuid — 0 of 790 metric rows matched any lifecycle log flow id over the last 7 days, so a failed point on the admin metrics dashboard could not be traced to the events or exception record explaining it.

This exposes the loading attempt's id and threads it through the earn entry points into `startLifecycleFlow`, which now adopts a caller-supplied id and falls back to generating one when it is absent or malformed.

## Validation

- `npx tsc --noEmit -p mobile/tsconfig.json`
- `npx jest` in `mobile/` — 274 passed, including 3 new cases covering adoption, the generated fallback, and a malformed id
- `npx expo lint` — 0 errors (9 pre-existing warnings in untouched files)
- 2 suites (`api.test.ts`, `fetch-token-holdings.test.ts`) fail to load on an unbuilt `@loyal-labs/solana-rpc` workspace link; verified identical on the base commit