### PR TITLE
feat(ui): add dark theme with semantic tokens and animated theme toggle

### DIFF
--- a/frontend/public/wallet-workspace/facelift/icon-shield-dark.svg
+++ b/frontend/public/wallet-workspace/facelift/icon-shield-dark.svg
@@ -1,0 +1,9 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="shield-2, safety, privacy">
+<path id="vector" fill-rule="evenodd" clip-rule="evenodd" d="M10.926 1.89094C11.6124 1.59974 12.3876 1.59974 13.074 1.89094L19.324 4.54245C20.3401 4.97352 21 5.97032 21 7.07405V13C21 17.9706 16.9706 22 12 22C7.02944 22 3 17.9706 3 13V7.07405C3 5.97032 3.65991 4.97352 4.67599 4.54245L10.926 1.89094Z" fill="#636067"/>
+<g id="Eye">
+<path id="Vector" d="M12 9C15.0376 9 17.5 11.2386 17.5 14H6.5C6.5 11.2386 8.96243 9 12 9Z" fill="white"/>
+<circle id="Vector_2" cx="12" cy="11.5" r="2.5" fill="black"/>
+</g>
+</g>
+</svg>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -31,6 +31,11 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-positive: var(--positive);
+  --color-tertiary: var(--tertiary);
+  --color-segmented: var(--segmented);
+  --color-accent-selected: var(--accent-selected);
+  --color-accent-active: var(--accent-active);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -49,26 +54,32 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+/* Values from Figma "Color Web" variables (Loyal UI Base Library) */
 :root {
   --radius: 0.65rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
+  --background: oklch(1 0 0); /* Background/Primary #FFFFFF */
+  --foreground: oklch(0 0 0); /* Text/Primary #000000 */
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
+  --card-foreground: oklch(0 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.623 0.214 259.815);
-  --primary-foreground: oklch(0.97 0.014 254.604);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.623 0.214 259.815);
+  --popover-foreground: oklch(0 0 0);
+  --primary: oklch(0.641 0.229 25.29); /* Background/Accent #F9363C */
+  --primary-foreground: oklch(1 0 0); /* Text/Contrast #FFFFFF */
+  --secondary: oklch(0.97 0 0); /* Background/Tertiary #F5F5F5 */
+  --secondary-foreground: oklch(0 0 0);
+  --muted: oklch(0.97 0 0); /* Background/Secondary #F5F5F5 */
+  --muted-foreground: oklch(0.635 0.006 286.23); /* Text/Secondary #8A8A8E */
+  --accent: oklch(0 0 0 / 4%); /* Background States/Hover */
+  --accent-selected: oklch(0 0 0 / 6%); /* Background States/Selected|Pressed */
+  --accent-active: oklch(0 0 0 / 8%); /* Background States/Secondary Alpha Hover */
+  --accent-foreground: oklch(0 0 0);
+  --destructive: oklch(0.641 0.229 25.29); /* Text/Negative #F9363C */
+  --positive: oklch(0.683 0.173 143.395); /* Text/Positive #4BB34B */
+  --tertiary: oklch(0.751 0.009 301.305); /* Text|Icon/Tertiary #AFADB3 */
+  --segmented: oklch(1 0 0); /* Other/Segmented Control #FFFFFF */
+  --border: oklch(0 0 0 / 12%); /* Separator/Non-opaque */
+  --input: oklch(0 0 0 / 12%);
+  --ring: oklch(0.641 0.229 25.29);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -85,71 +96,42 @@
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.546 0.245 262.881);
-  --primary-foreground: oklch(0.379 0.146 265.522);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.488 0.243 264.376);
+  --background: oklch(0.227 0.01 303.714); /* Background/Primary #1D1B20 */
+  --foreground: oklch(0.915 0.005 258.325); /* Text/Primary #E1E3E6 */
+  --card: oklch(0.227 0.01 303.714); /* Background/Primary #1D1B20 — cards share the primary surface */
+  --card-foreground: oklch(0.915 0.005 258.325);
+  --popover: oklch(0.286 0.013 298.633); /* Other/Action Sheet #2B2930 */
+  --popover-foreground: oklch(0.915 0.005 258.325);
+  --primary: oklch(0.676 0.212 24.811); /* Background/Accent #FF5050 */
+  --primary-foreground: oklch(1 0 0); /* Text/Contrast #FFFFFF */
+  --secondary: oklch(0.286 0.013 298.633); /* Background/Tertiary #2B2930 */
+  --secondary-foreground: oklch(0.915 0.005 258.325);
+  --muted: oklch(0.187 0.012 300.422); /* Background/Secondary #141218 — recessed canvas */
+  --muted-foreground: oklch(0.673 0.008 304.183); /* Text/Secondary #97959A */
+  --accent: oklch(1 0 0 / 4%); /* Background States/Hover */
+  --accent-selected: oklch(1 0 0 / 6%); /* Background States/Selected|Pressed */
+  --accent-active: oklch(1 0 0 / 8%); /* Background States/Secondary Alpha Hover */
+  --accent-foreground: oklch(0.915 0.005 258.325);
+  --destructive: oklch(0.676 0.212 24.811); /* Text/Negative #FF5050 */
+  --positive: oklch(0.756 0.208 146.984); /* Text/Positive #30D158 */
+  --tertiary: oklch(0.494 0.012 305.226); /* Text|Icon/Tertiary #636067 */
+  --segmented: oklch(0.41 0.012 298.916); /* Other/Segmented Control #4B4950 */
+  --border: oklch(1 0 0 / 12%); /* Separator/Non-opaque */
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.676 0.212 24.811);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.546 0.245 262.881);
-  --sidebar-primary-foreground: oklch(0.379 0.146 265.522);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.488 0.243 264.376);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.286 0.013 298.633);
+  --sidebar-foreground: oklch(0.915 0.005 258.325);
+  --sidebar-primary: oklch(0.676 0.212 24.811);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(1 0 0 / 4%);
+  --sidebar-accent-foreground: oklch(0.915 0.005 258.325);
+  --sidebar-border: oklch(1 0 0 / 12%);
+  --sidebar-ring: oklch(0.676 0.212 24.811);
 }
 
 @layer base {
@@ -157,7 +139,7 @@
     @apply border-border outline-ring/50;
   }
   html {
-    background-color: white;
+    background-color: var(--background);
     scroll-behavior: smooth;
   }
   body {
@@ -1936,8 +1918,8 @@
 /* transitions.dev — Shimmer text (frontend/transitions/shimmer-text.md) */
 :root {
   --shimmer-dur: 2000ms;
-  --shimmer-base: #7c7c7c;
-  --shimmer-highlight: #0d0d0d;
+  --shimmer-base: var(--muted-foreground);
+  --shimmer-highlight: var(--foreground);
   --shimmer-band: 400%;
   --shimmer-ease: linear;
 }
@@ -1997,10 +1979,10 @@
 :root {
   --tabs-dur: 250ms;
   --tabs-ease: cubic-bezier(0.22, 1, 0.36, 1);
-  --tabs-text-muted: #8a8a8e;
-  --tabs-text-active: #000;
-  --tabs-bar-bg: rgba(0, 0, 0, 0.04);
-  --tabs-pill-bg: #fff;
+  --tabs-text-muted: var(--muted-foreground);
+  --tabs-text-active: var(--foreground);
+  --tabs-bar-bg: var(--accent);
+  --tabs-pill-bg: var(--segmented);
 }
 
 /* The bar is just a flex container with padding for the pill
@@ -2080,8 +2062,8 @@
   --tt-delay: 80ms;
   --tt-in-ease: ease-out;
   --tt-out-ease: ease-out;
-  --tt-bg: #ffffff;
-  --tt-fg: #2f2f2f;
+  --tt-bg: var(--popover);
+  --tt-fg: var(--popover-foreground);
 }
 
 .t-tt-wrap {
@@ -2336,18 +2318,18 @@
 }
 
 .t-flow-node {
-  background: rgba(0, 0, 0, 0.04);
-  color: rgba(60, 60, 67, 0.45);
+  background: var(--accent);
+  color: var(--tertiary);
   transition: background var(--flow-dur) var(--flow-ease),
     color var(--flow-dur) var(--flow-ease),
     transform var(--flow-dur) var(--flow-ease);
   will-change: transform;
 }
 .t-flow-node.is-reached {
-  color: #f9363c;
+  color: var(--primary);
 }
 .t-flow-node.is-active {
-  background: rgba(249, 54, 60, 0.08);
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
   transform: scale(1.08);
 }
 
@@ -2358,14 +2340,14 @@
   min-height: 14px;
   margin: 4px 0;
   border-radius: 9999px;
-  background: rgba(0, 0, 0, 0.08);
+  background: var(--accent-active);
   overflow: hidden;
 }
 .t-flow-fill {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: #f9363c;
+  background: var(--primary);
   transform: scaleY(0);
   transform-origin: top;
   transition: transform var(--flow-fill-dur) var(--flow-ease);
@@ -2413,7 +2395,7 @@
   left: 0;
   height: 3px;
   border-radius: 4px 4px 1px 1px;
-  background: #f9363c;
+  background: var(--primary);
   transition: transform var(--tabs-dur) var(--tabs-ease),
     width var(--tabs-dur) var(--tabs-ease);
   will-change: transform, width;
@@ -2595,6 +2577,42 @@
   --hover-ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Monochrome SVG assets rendered in the current text color: the asset is a
+   mask, the fill comes from currentColor, so icons follow the theme tokens. */
+/* transitions/theme-switch.md — while the theme circle-wipe runs, freeze
+   both root snapshots so the WAAPI clip-path on the new one is the only
+   motion. Scoped by the data attribute so any other view transition keeps
+   the API's default crossfade. */
+:root[data-theme-wipe]::view-transition-old(root),
+:root[data-theme-wipe]::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+/* The old snapshot stacks at z-index 1 by default, which would hide the
+   clip-reveal happening on the new one — put the new snapshot on top. */
+:root[data-theme-wipe]::view-transition-new(root) {
+  z-index: 2;
+}
+
+/* icon-shield.svg is multicolor (white eye on themed body) so it can't go
+   through the currentColor mask — dark mode swaps the whole image for the
+   #636067-body variant (Figma 5200:100388). */
+.dark img[src$="/icon-shield.svg"] {
+  content: url("/wallet-workspace/facelift/icon-shield-dark.svg");
+}
+
+/* In @layer components so display utilities (hidden, max-*:block) can
+   override the inline-block default — unlayered CSS would always win. */
+@layer components {
+  .icon-themed {
+    display: inline-block;
+    flex-shrink: 0;
+    background-color: currentColor;
+    mask: var(--icon) center / contain no-repeat;
+    -webkit-mask: var(--icon) center / contain no-repeat;
+  }
+}
+
 .t-hover {
   transition: background-color var(--hover-dur) var(--hover-ease),
     color var(--hover-dur) var(--hover-ease),
@@ -2673,6 +2691,16 @@ cap-widget {
   --cap-spinner-color: #0a0a0a;
   --cap-spinner-background-color: rgba(0, 0, 0, 0.08);
   --cap-spinner-thickness: 3px;
+}
+
+.dark cap-widget {
+  /* Opaque equivalent of white/[0.04] over Background/Primary #1D1B20. */
+  --cap-background: #262429;
+  --cap-color: #e1e3e6;
+  --cap-checkbox-border: 1px solid rgba(255, 255, 255, 0.29);
+  --cap-checkbox-background: #1d1b20;
+  --cap-spinner-color: #e1e3e6;
+  --cap-spinner-background-color: rgba(255, 255, 255, 0.08);
 }
 
 /* transitions.dev — Page side-by-side (frontend/transitions/page-side-by-side.md).
@@ -3271,9 +3299,9 @@ cap-widget {
 .t-step-active {
   background-image: linear-gradient(
     90deg,
-    #000 42%,
-    rgba(0, 0, 0, 0.35) 50%,
-    #000 58%
+    var(--foreground) 42%,
+    color-mix(in oklab, var(--foreground) 35%, transparent) 50%,
+    var(--foreground) 58%
   );
   background-size: 200% 100%;
   -webkit-background-clip: text;
@@ -3303,7 +3331,7 @@ cap-widget {
   .t-step-active {
     animation: none !important;
     background-image: none;
-    color: #000;
+    color: var(--foreground);
   }
 }
 
@@ -3398,7 +3426,7 @@ cap-widget {
 }
 .milo-tag path {
   fill: none;
-  stroke: #f9363c;
+  stroke: var(--primary);
   stroke-width: 8;
   stroke-linecap: round;
   stroke-linejoin: round;

--- a/frontend/src/app/landing/page.tsx
+++ b/frontend/src/app/landing/page.tsx
@@ -79,24 +79,14 @@ const ChatBotDemo = () => {
     setModel(models[0].value);
   }, [setMessages]);
 
-  // Initialize dark mode: explicit user choice (theme toggle) wins,
-  // otherwise follow system preference.
+  // Light is the default for everyone regardless of system preference;
+  // dark only via the explicit theme toggle (stored "theme" = "dark").
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     let stored: string | null = null;
     try {
       stored = localStorage.getItem("theme");
     } catch {}
-    setDarkMode(stored ? stored === "dark" : mediaQuery.matches);
-
-    const handler = (e: MediaQueryListEvent) => {
-      try {
-        if (localStorage.getItem("theme")) return;
-      } catch {}
-      setDarkMode(e.matches);
-    };
-    mediaQuery.addEventListener("change", handler);
-    return () => mediaQuery.removeEventListener("change", handler);
+    setDarkMode(stored === "dark");
   }, []);
 
   // apply dark mode

--- a/frontend/src/app/landing/page.tsx
+++ b/frontend/src/app/landing/page.tsx
@@ -79,12 +79,22 @@ const ChatBotDemo = () => {
     setModel(models[0].value);
   }, [setMessages]);
 
-  // Initialize dark mode based on system preference
+  // Initialize dark mode: explicit user choice (theme toggle) wins,
+  // otherwise follow system preference.
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    setDarkMode(mediaQuery.matches);
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem("theme");
+    } catch {}
+    setDarkMode(stored ? stored === "dark" : mediaQuery.matches);
 
-    const handler = (e: MediaQueryListEvent) => setDarkMode(e.matches);
+    const handler = (e: MediaQueryListEvent) => {
+      try {
+        if (localStorage.getItem("theme")) return;
+      } catch {}
+      setDarkMode(e.matches);
+    };
     mediaQuery.addEventListener("change", handler);
     return () => mediaQuery.removeEventListener("change", handler);
   }, []);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -141,7 +141,7 @@ export default async function RootLayout({
         {/* Pre-paint theme resolution: explicit choice wins, else OS preference. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"||(!t&&matchMedia("(prefers-color-scheme: dark)").matches))document.documentElement.classList.add("dark")}catch(e){}`,
+            __html: `try{if(localStorage.getItem("theme")==="dark")document.documentElement.classList.add("dark")}catch(e){}`,
           }}
         />
         <script

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -134,10 +134,16 @@ export default async function RootLayout({
   const publicEnv = createPublicEnv(process.env);
 
   return (
-    <html className="dark" lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        {/* Pre-paint theme resolution: explicit choice wins, else OS preference. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"||(!t&&matchMedia("(prefers-color-scheme: dark)").matches))document.documentElement.classList.add("dark")}catch(e){}`,
+          }}
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -47,8 +47,8 @@ const getStatusBadge = (status: ToolUIPart["state"]) => {
   const icons = {
     "input-streaming": <CircleIcon className="size-4" />,
     "input-available": <ClockIcon className="size-4 animate-pulse" />,
-    "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
-    "output-error": <XCircleIcon className="size-4 text-red-600" />,
+    "output-available": <CheckCircleIcon className="size-4 text-positive" />,
+    "output-error": <XCircleIcon className="size-4 text-destructive" />,
   } as const;
 
   return (

--- a/frontend/src/components/auth/sign-in-modal.tsx
+++ b/frontend/src/components/auth/sign-in-modal.tsx
@@ -39,9 +39,9 @@ function ConnectedView() {
 
   return (
     <div className="flex flex-col gap-5 px-6 pb-6">
-      <div className="rounded-[28px] bg-[#f5f5f5] p-4">
+      <div className="rounded-[28px] bg-secondary p-4">
         <div className="flex items-center gap-4">
-          <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl bg-white">
+          <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl bg-card">
             <Image
               alt=""
               className="h-full w-full object-cover"
@@ -49,15 +49,15 @@ function ConnectedView() {
               src="/agents/Agent-03.svg"
               width={64}
             />
-            <span className="-right-1 -bottom-1 absolute flex h-6 w-6 items-center justify-center rounded-full border-2 border-[#f5f5f5] bg-[#24c45a]">
+            <span className="-right-1 -bottom-1 absolute flex h-6 w-6 items-center justify-center rounded-full border-2 border-secondary bg-positive">
               <Check aria-hidden="true" className="h-3.5 w-3.5 text-white" />
             </span>
           </div>
           <div className="min-w-0 flex-1">
-            <p className="font-semibold text-[22px] text-neutral-950 leading-7">
+            <p className="font-semibold text-[22px] text-foreground leading-7">
               {hasWalletConnection ? "Connected" : "Signed in"}
             </p>
-            <p className="mt-1 text-neutral-500 text-sm">
+            <p className="mt-1 text-muted-foreground text-sm">
               Wallet workspace is ready.
             </p>
           </div>
@@ -65,18 +65,18 @@ function ConnectedView() {
 
         {address ? (
           <button
-            className="mt-4 flex w-full items-center gap-2 rounded-full bg-white px-4 py-3 text-left transition hover:bg-neutral-50"
+            className="mt-4 flex w-full items-center gap-2 rounded-full bg-card px-4 py-3 text-left transition hover:bg-card/90"
             onClick={handleCopy}
             title="Copy address"
             type="button"
           >
-            <span className="min-w-0 flex-1 truncate font-mono text-neutral-500 text-sm">
+            <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground text-sm">
               {address}
             </span>
             {copied ? (
-              <Check className="h-4 w-4 shrink-0 text-[#24c45a]" />
+              <Check className="h-4 w-4 shrink-0 text-positive" />
             ) : (
-              <Copy className="h-4 w-4 shrink-0 text-neutral-400" />
+              <Copy className="h-4 w-4 shrink-0 text-tertiary" />
             )}
           </button>
         ) : null}
@@ -86,7 +86,7 @@ function ConnectedView() {
         <div className="flex flex-col gap-2">
           {hasAuthSession ? (
             <button
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-neutral-950 px-4 font-medium text-sm text-white transition hover:bg-neutral-800"
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-4 font-medium text-background text-sm transition hover:bg-foreground/90"
               onClick={async () => {
                 await Promise.allSettled([logout(), disconnect()]);
                 close();
@@ -99,7 +99,7 @@ function ConnectedView() {
           ) : null}
           {hasWalletConnection ? (
             <button
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-[#fde8e9] px-4 font-medium text-[#f9363c] text-sm transition hover:bg-[#fadadb]"
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-destructive/15 px-4 font-medium text-destructive text-sm transition hover:bg-destructive/25"
               onClick={async () => {
                 await disconnect();
                 close();
@@ -139,11 +139,11 @@ export function SignInModal() {
     <Dialog onOpenChange={handleOpenChange} open={isOpen}>
       <DialogPortal>
         <DialogOverlay className="t-modal-overlay" />
-        <DialogPrimitive.Content className="t-modal t-modal-center fixed top-[50%] left-[50%] z-[70] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-[32px] border border-black/10 bg-white text-neutral-950 shadow-[0_24px_70px_rgba(0,0,0,0.2)] outline-none sm:max-w-[480px]">
+        <DialogPrimitive.Content className="t-modal t-modal-center fixed top-[50%] left-[50%] z-[70] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-[32px] border border-border bg-card text-card-foreground shadow-[0_24px_70px_rgba(0,0,0,0.2)] outline-none sm:max-w-[480px]">
           {hasAuthSession ? (
             <>
               <DialogHeader className="px-6 pt-6 pb-5 text-left">
-                <DialogTitle className="font-semibold text-[28px] text-neutral-950 leading-8">
+                <DialogTitle className="font-semibold text-[28px] text-foreground leading-8">
                   Account
                 </DialogTitle>
                 <DialogDescription className="sr-only">
@@ -155,7 +155,7 @@ export function SignInModal() {
           ) : (
             <>
               <DialogHeader className="px-6 pt-6 pb-5 text-left">
-                <DialogTitle className="font-semibold text-[28px] text-neutral-950 leading-8">
+                <DialogTitle className="font-semibold text-[28px] text-foreground leading-8">
                   {cherryRuntime.mode === "cherry_embedded"
                     ? "Verify"
                     : "Connect"}
@@ -169,7 +169,7 @@ export function SignInModal() {
               </div>
             </>
           )}
-          <DialogClose className="absolute top-5 right-5 flex h-11 w-11 items-center justify-center rounded-full bg-black/[0.04] text-neutral-500 transition hover:bg-black/[0.08] hover:text-neutral-900">
+          <DialogClose className="absolute top-5 right-5 flex h-11 w-11 items-center justify-center rounded-full bg-accent text-muted-foreground transition hover:bg-accent-active hover:text-foreground">
             <XIcon className="size-4" />
             <span className="sr-only">Close</span>
           </DialogClose>

--- a/frontend/src/components/auth/wallet-sign-in.tsx
+++ b/frontend/src/components/auth/wallet-sign-in.tsx
@@ -50,7 +50,7 @@ export function WalletSignIn() {
         <div className="t-acc-panel">
           <div className="t-acc-panel-inner">
             <div className="flex flex-col gap-3 pb-4">
-              <p className="text-neutral-500 text-sm">
+              <p className="text-muted-foreground text-sm">
                 Complete verification to continue
               </p>
               <CapWidget key={widgetEpoch} onVerify={setCaptchaToken} />
@@ -58,7 +58,7 @@ export function WalletSignIn() {
           </div>
         </div>
       </div>
-      <p className="pb-4 text-neutral-500 text-sm">
+      <p className="pb-4 text-muted-foreground text-sm">
         Choose your preferred sign-in method.
       </p>
       <WalletTab

--- a/frontend/src/components/auth/wallet-tab.tsx
+++ b/frontend/src/components/auth/wallet-tab.tsx
@@ -44,12 +44,12 @@ function MobileWalletList() {
 
   return (
     <div className="flex flex-col gap-2">
-      <p className="text-neutral-500 text-sm">
+      <p className="text-muted-foreground text-sm">
         Open this page in your wallet&apos;s built-in browser:
       </p>
       {MOBILE_WALLETS.map((wallet) => (
         <TrackedExternalLink
-          className="flex h-14 items-center gap-3 rounded-2xl bg-[#f5f5f5] px-4 text-neutral-900 text-sm transition hover:bg-black/[0.06]"
+          className="flex h-14 items-center gap-3 rounded-2xl bg-secondary px-4 text-foreground text-sm transition hover:bg-accent-selected"
           href={wallet.browseUrl(currentUrl)}
           key={wallet.name}
           linkText={`Open in ${wallet.name}`}
@@ -57,7 +57,7 @@ function MobileWalletList() {
         >
           <img alt={wallet.name} className="h-6 w-6" src={wallet.icon} />
           <span className="min-w-0 flex-1">Open in {wallet.name}</span>
-          <ArrowUpRight className="h-4 w-4 text-neutral-400" />
+          <ArrowUpRight className="h-4 w-4 text-tertiary" />
         </TrackedExternalLink>
       ))}
     </div>
@@ -81,7 +81,7 @@ function LedgerModeToggle({
   // button's own clicks — mouse or Space/Enter — bubble up to it too).
   return (
     <div
-      className={`flex items-start gap-3 rounded-2xl bg-[#f5f5f5] px-4 py-3 text-left text-neutral-900 text-sm ${
+      className={`flex items-start gap-3 rounded-2xl bg-secondary px-4 py-3 text-left text-foreground text-sm ${
         disabled ? "opacity-60" : "cursor-pointer"
       }`}
       onClick={() => {
@@ -94,7 +94,7 @@ function LedgerModeToggle({
         aria-checked={checked}
         aria-describedby={descriptionId}
         aria-labelledby={labelId}
-        className="t-check mt-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] bg-white shadow-[inset_0_0_0_1.5px_#d4d4d4] aria-checked:bg-neutral-950 aria-checked:shadow-[inset_0_0_0_1.5px_#0a0a0a]"
+        className="t-check mt-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] bg-card shadow-[inset_0_0_0_1.5px_var(--border)] aria-checked:bg-foreground aria-checked:shadow-[inset_0_0_0_1.5px_var(--foreground)]"
         disabled={disabled}
         role="checkbox"
         type="button"
@@ -119,7 +119,7 @@ function LedgerModeToggle({
           I use Ledger or hardware wallet
         </span>
         <span
-          className="mt-0.5 block text-neutral-500 text-xs"
+          className="mt-0.5 block text-muted-foreground text-xs"
           id={descriptionId}
         >
           Approves a login verification transaction. Loyal will not broadcast
@@ -205,14 +205,14 @@ export function WalletTab({
         : "Verifying your wallet and preparing your smart account...";
 
     return (
-      <div className="flex flex-col items-center gap-4 rounded-[28px] bg-[#f5f5f5] px-5 py-8 text-center">
+      <div className="flex flex-col items-center gap-4 rounded-[28px] bg-secondary px-5 py-8 text-center">
         <MatrixLoader />
-        <p className="max-w-[320px] text-neutral-500 text-sm">
+        <p className="max-w-[320px] text-muted-foreground text-sm">
           <TextSwap text={statusMessage} />
         </p>
         {isCherryEmbedded ? null : (
           <button
-            className="rounded-full px-4 py-2 font-medium text-neutral-500 text-sm transition hover:bg-black/[0.06] hover:text-neutral-900"
+            className="rounded-full px-4 py-2 font-medium text-muted-foreground text-sm transition hover:bg-accent-selected hover:text-foreground"
             onClick={handleChooseAnotherWallet}
             type="button"
           >
@@ -226,15 +226,15 @@ export function WalletTab({
   if (isErrorState && showError) {
     return (
       <div className="flex flex-col gap-3">
-        <div className="rounded-[24px] bg-[#fff1f2] p-4 text-[#d50012] text-sm">
+        <div className="rounded-[24px] bg-destructive/10 p-4 text-destructive text-sm">
           <div className="flex gap-3">
-            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white">
+            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-card">
               <AlertCircle className="h-4 w-4" />
             </span>
             <div className="min-w-0">
               <p className="font-medium">{state.errorMessage}</p>
               {state.errorDetails.length > 0 && (
-                <ul className="mt-2 list-disc pl-5 text-[#d50012]/80">
+                <ul className="mt-2 list-disc pl-5 text-destructive/80">
                   {state.errorDetails.map((detail) => (
                     <li key={detail}>{detail}</li>
                   ))}
@@ -255,7 +255,7 @@ export function WalletTab({
           />
         )}
         <button
-          className="h-12 rounded-full bg-neutral-950 px-4 font-medium text-sm text-white transition hover:bg-neutral-800"
+          className="h-12 rounded-full bg-foreground px-4 font-medium text-background text-sm transition hover:bg-foreground/90"
           onClick={
             isCherryEmbedded
               ? () => {
@@ -284,7 +284,7 @@ export function WalletTab({
             />
           )}
           <button
-            className="h-12 rounded-full bg-neutral-950 px-4 font-medium text-sm text-white transition hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+            className="h-12 rounded-full bg-foreground px-4 font-medium text-background text-sm transition hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={!isVerified}
             onClick={startConnectedWalletVerification}
             type="button"
@@ -301,7 +301,7 @@ export function WalletTab({
           </button>
           {isCherryEmbedded ? null : (
             <button
-              className="h-12 rounded-full px-4 font-medium text-neutral-500 text-sm transition hover:bg-black/[0.06] hover:text-neutral-900"
+              className="h-12 rounded-full px-4 font-medium text-muted-foreground text-sm transition hover:bg-accent-selected hover:text-foreground"
               onClick={handleChooseAnotherWallet}
               type="button"
             >
@@ -318,7 +318,7 @@ export function WalletTab({
           />
           {installedWallets.map((installedWallet) => (
             <button
-              className="flex h-14 items-center gap-3 rounded-2xl bg-[#f5f5f5] px-4 text-neutral-900 text-sm transition hover:bg-black/[0.06] disabled:cursor-not-allowed disabled:opacity-40"
+              className="flex h-14 items-center gap-3 rounded-2xl bg-secondary px-4 text-foreground text-sm transition hover:bg-accent-selected disabled:cursor-not-allowed disabled:opacity-40"
               disabled={!isVerified}
               key={installedWallet.adapter.name}
               onClick={() => handleConnectWallet(installedWallet.adapter.name)}
@@ -334,12 +334,12 @@ export function WalletTab({
               <span className="min-w-0 flex-1 text-left">
                 {installedWallet.adapter.name}
               </span>
-              <ArrowUpRight className="h-4 w-4 text-neutral-400" />
+              <ArrowUpRight className="h-4 w-4 text-tertiary" />
             </button>
           ))}
           {installedWallets.length === 0 && isMobile && <MobileWalletList />}
           {installedWallets.length === 0 && !isMobile && (
-            <p className="py-4 text-center text-neutral-500 text-sm">
+            <p className="py-4 text-center text-muted-foreground text-sm">
               No wallet extensions detected. Install a Solana wallet extension
               to continue.
             </p>

--- a/frontend/src/components/kibo-ui/ticker/index.tsx
+++ b/frontend/src/components/kibo-ui/ticker/index.tsx
@@ -167,9 +167,7 @@ export const TickerPriceChange = memo(
       <span
         className={cn(
           "flex items-center gap-0.5",
-          isPositiveChange
-            ? "text-green-600 dark:text-green-500"
-            : "text-red-600 dark:text-red-500",
+          isPositiveChange ? "text-positive" : "text-destructive",
           className
         )}
         {...props}

--- a/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
+++ b/frontend/src/components/wallet-sidebar/earn-detail-view.tsx
@@ -55,10 +55,10 @@ import { useEarnForecastApy } from "@/hooks/use-earn-forecast-apy";
 import { useEarnForecastApyHistory } from "@/hooks/use-earn-forecast-apy-history";
 
 const font = "var(--font-geist-sans), sans-serif";
-const secondary = "rgba(60, 60, 67, 0.6)";
-const decimalGray = "rgba(60, 60, 67, 0.4)";
-const POSITIVE_AMOUNT_COLOR = "#34C759";
-const LOYAL_EARN_BRAND_COLOR = "#F9363C";
+const secondary = "var(--muted-foreground)";
+const decimalGray = "var(--tertiary)";
+const POSITIVE_AMOUNT_COLOR = "var(--positive)";
+const LOYAL_EARN_BRAND_COLOR = "var(--primary)";
 // USDC mark badged onto the Main Account icon when a row reflects only the
 // account's USDC balance (deposit/withdraw/autodeposit), so it isn't confused
 // with the account's full multi-token value. Mirrors the shielded-asset badge.
@@ -397,7 +397,7 @@ function forecastMoneySegments(value: number, mutedFraction = false) {
   return [
     { text: `$${whole}` },
     {
-      color: mutedFraction ? "rgba(60, 60, 67, 0.4)" : undefined,
+      color: mutedFraction ? "var(--tertiary)" : undefined,
       text: `.${fraction}`,
     },
   ];
@@ -409,7 +409,7 @@ function formatForecastMoney(value: number, mutedFraction = false) {
     <>
       ${whole}
       <span
-        style={{ color: mutedFraction ? "rgba(60, 60, 67, 0.4)" : "inherit" }}
+        style={{ color: mutedFraction ? "var(--tertiary)" : "inherit" }}
       >
         .{fraction}
       </span>
@@ -1736,10 +1736,10 @@ function EarningsBlock({
                 width: "100%",
               }}
             >
-              <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+              <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
                 {dailyBars[0]?.label ?? ""}
               </span>
-              <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+              <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
                 {dailyBars[dailyBars.length - 1]?.label ?? ""}
               </span>
             </div>
@@ -4737,7 +4737,7 @@ function historicalApyValueSegments(
   return [
     { text: whole },
     {
-      color: mutedFraction ? "rgba(60, 60, 67, 0.4)" : undefined,
+      color: mutedFraction ? "var(--tertiary)" : undefined,
       text: `.${fraction}%`,
     },
   ];
@@ -5033,7 +5033,7 @@ function HydratedHistoricalApyChart({
             >
               <p
                 style={{
-                  color: isPrimary ? "#000" : "#3C3C43",
+                  color: "var(--foreground)",
                   fontFamily: font,
                   fontSize: isPrimary ? "28px" : "20px",
                   fontWeight: 600,
@@ -5071,7 +5071,7 @@ function HydratedHistoricalApyChart({
                 />
                 <span
                   style={{
-                    color: isPrimary ? "#000" : secondary,
+                    color: secondary,
                     fontFamily: font,
                     fontSize: "13px",
                     lineHeight: "16px",
@@ -5099,12 +5099,12 @@ function HydratedHistoricalApyChart({
           width: "100%",
         }}
       >
-        <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+        <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
           {isHovering
             ? HISTORICAL_HOVER_DATE_FORMAT.format(focusSample.observedAtMs)
             : ""}
         </span>
-        <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+        <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
           {`${scaleMax.toFixed(2)}%`}
         </span>
       </div>
@@ -5159,7 +5159,7 @@ function HydratedHistoricalApyChart({
                   style={{ opacity: isHovering ? 1 : 0 }}
                 >
                   <rect
-                    fill="#fff"
+                    fill="var(--card)"
                     fillOpacity={0.6}
                     height={chartHeight}
                     width={Math.max(chartWidth - focusX, 0)}
@@ -5167,7 +5167,7 @@ function HydratedHistoricalApyChart({
                     y={0}
                   />
                   <line
-                    stroke="#000"
+                    stroke="var(--foreground)"
                     strokeDasharray="6 6"
                     strokeLinecap="round"
                     strokeOpacity={0.14}
@@ -5187,7 +5187,7 @@ function HydratedHistoricalApyChart({
                 style={{
                   background: series.color,
                   borderRadius: "9999px",
-                  boxShadow: "0 0 0 2px #fff",
+                  boxShadow: "0 0 0 2px var(--card)",
                   height: "8px",
                   left: `${((focusX / chartWidth) * 100).toFixed(2)}%`,
                   pointerEvents: "none",
@@ -5223,7 +5223,7 @@ function HydratedHistoricalApyChart({
           return (
             <span
               key={index}
-              style={{ color: secondary, whiteSpace: "nowrap" }}
+              style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}
             >
               {HISTORICAL_AXIS_DATE_FORMAT.format(tickMs)}
             </span>
@@ -5489,11 +5489,7 @@ export function ForecastChart({
                 className="forecast-chart-summary-value"
                 data-primary={isPrimary ? "true" : undefined}
                 style={{
-                  color: isBalanceHidden
-                    ? "#BBBBC0"
-                    : isPrimary
-                    ? "#000"
-                    : "#3C3C43",
+                  color: isBalanceHidden ? "var(--tertiary)" : "var(--foreground)",
                   filter: hiddenValueFilter,
                   fontFamily: font,
                   fontSize: isPrimary ? "28px" : "16px",
@@ -5539,7 +5535,7 @@ export function ForecastChart({
                 <span
                   className="forecast-chart-summary-label"
                   style={{
-                    color: isPrimary ? "#000" : secondary,
+                    color: secondary,
                     fontFamily: font,
                     fontSize: "13px",
                     lineHeight: "16px",
@@ -5577,12 +5573,12 @@ export function ForecastChart({
           width: "100%",
         }}
       >
-        <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+        <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
           {isHovering ? focusPoint.date : ""}
         </span>
         <span
           style={{
-            color: secondary,
+            color: "var(--tertiary)",
             filter: hiddenValueFilter,
             whiteSpace: "nowrap",
           }}
@@ -5658,7 +5654,7 @@ export function ForecastChart({
                     />
                   ))}
                   <rect
-                    fill="#fff"
+                    fill="var(--card)"
                     fillOpacity={0.6}
                     height={chartHeight}
                     width={Math.max(chartWidth - focusX, 0)}
@@ -5666,7 +5662,7 @@ export function ForecastChart({
                     y={0}
                   />
                   <line
-                    stroke="#000"
+                    stroke="var(--foreground)"
                     strokeDasharray="6 6"
                     strokeLinecap="round"
                     strokeOpacity={0.14}
@@ -5686,7 +5682,7 @@ export function ForecastChart({
                 style={{
                   background: EARN_SERIES_DISPLAY[series.key].color,
                   borderRadius: "9999px",
-                  boxShadow: "0 0 0 2px #fff",
+                  boxShadow: "0 0 0 2px var(--card)",
                   height: "8px",
                   left: `${((focusX / chartWidth) * 100).toFixed(2)}%`,
                   pointerEvents: "none",
@@ -5717,14 +5713,14 @@ export function ForecastChart({
       >
         <span
           style={{
-            color: secondary,
+            color: "var(--tertiary)",
             filter: isBalanceHidden ? "url(#rs-pixelate-sm)" : "none",
             whiteSpace: "nowrap",
           }}
         >
           {`Today · $${formatMoney(principal)}`}
         </span>
-        <span style={{ color: secondary, whiteSpace: "nowrap" }}>
+        <span style={{ color: "var(--tertiary)", whiteSpace: "nowrap" }}>
           {points[points.length - 1]?.date ?? ""}
         </span>
       </div>
@@ -5921,7 +5917,7 @@ function DepositChart({
               style={{
                 background: series.color,
                 borderRadius: "9999px",
-                boxShadow: "0 0 0 2px #fff",
+                boxShadow: "0 0 0 2px var(--card)",
                 height: "8px",
                 left: `${hoverLeft}%`,
                 pointerEvents: "none",
@@ -6015,7 +6011,7 @@ function DepositChart({
               </span>
               <span
                 style={{
-                  color: isBalanceHidden ? "#BBBBC0" : POSITIVE_AMOUNT_COLOR,
+                  color: isBalanceHidden ? "var(--tertiary)" : POSITIVE_AMOUNT_COLOR,
                   filter: isBalanceHidden ? "url(#rs-pixelate-sm)" : "none",
                   fontFamily: font,
                   fontSize: "13px",

--- a/frontend/src/components/wallet-workspace/earn-transactions-pane.tsx
+++ b/frontend/src/components/wallet-workspace/earn-transactions-pane.tsx
@@ -210,12 +210,12 @@ export function getEarnTransactionAmountColor(args: {
   kind: EarnTransactionItem["kind"];
 }) {
   if (args.isBalanceHidden) {
-    return "#BBBBC0";
+    return "var(--tertiary)";
   }
 
   return args.kind === "deposit" || args.kind === "balance_sweep"
-    ? "#34C759"
-    : "#000";
+    ? "var(--positive)"
+    : "var(--foreground)";
 }
 
 function EarnTransactionsLoadingState() {

--- a/frontend/src/components/wallet-workspace/facelift/action-screens.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/action-screens.tsx
@@ -57,7 +57,7 @@ export function ActionProcessingBody({
     <div className="flex w-full flex-1 flex-col items-center justify-center pb-[68px]">
       <div className="flex w-full flex-col items-center gap-4 p-8">
         <div className="flex items-start">{icons}</div>
-        <p className="text-center font-semibold text-[28px] text-black leading-8 tracking-[-0.28px]">
+        <p className="text-center font-semibold text-[28px] text-foreground leading-8 tracking-[-0.28px]">
           {label}
           <span aria-hidden="true" className="t-loading-dots">
             <span>.</span>
@@ -114,7 +114,7 @@ export function ActionSuccessBody({
           </span>
           <span aria-hidden="true" className="t-success-check" data-state="in">
             <svg className="size-16" fill="none" viewBox="0 0 64 64">
-              <circle cx="32" cy="32" fill="#34c759" r="32" />
+              <circle cx="32" cy="32" fill="var(--positive)" r="32" />
               <path
                 d="M20 33l8 8 16-16"
                 stroke="white"
@@ -125,14 +125,14 @@ export function ActionSuccessBody({
             </svg>
           </span>
         </span>
-        <p className="text-center font-semibold text-[28px] text-black leading-8 tracking-[-0.28px]">
+        <p className="text-center font-semibold text-[28px] text-foreground leading-8 tracking-[-0.28px]">
           {label}
         </p>
       </div>
       <div className="relative flex flex-col items-center gap-3">
         {signature ? (
           <button
-            className="t-hover flex h-12 items-center justify-center rounded-full bg-black/[0.04] px-5 font-medium text-[16px] text-black leading-5 hover:bg-black/[0.08]"
+            className="t-hover flex h-12 items-center justify-center rounded-full bg-accent px-5 font-medium text-[16px] text-foreground leading-5 hover:bg-accent-active"
             onClick={() =>
               openTrackedLink(publicEnv, {
                 href: getExplorerTxUrl(signature),
@@ -146,7 +146,7 @@ export function ActionSuccessBody({
           </button>
         ) : null}
         <button
-          className="t-hover flex h-12 items-center justify-center rounded-full bg-black px-5 font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+          className="t-hover flex h-12 items-center justify-center rounded-full bg-foreground px-5 font-medium text-[16px] text-background leading-5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
           onClick={onDone}
           type="button"
         >
@@ -184,17 +184,17 @@ export function ActionErrorBody({
           className="size-16"
           src={`${ASSET_BASE}/icon-swap-failed.svg`}
         />
-        <p className="text-center font-semibold text-[28px] text-black leading-8 tracking-[-0.28px]">
+        <p className="text-center font-semibold text-[28px] text-foreground leading-8 tracking-[-0.28px]">
           Failed
         </p>
         {message ? (
-          <p className="max-w-[400px] truncate text-center text-[16px] leading-5 tracking-[-0.16px] text-[#f9363c]">
+          <p className="max-w-[400px] truncate text-center text-[16px] leading-5 tracking-[-0.16px] text-destructive">
             {message}
           </p>
         ) : null}
       </div>
       <button
-        className="t-hover relative flex h-12 items-center justify-center rounded-full bg-black px-5 font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+        className="t-hover relative flex h-12 items-center justify-center rounded-full bg-foreground px-5 font-medium text-[16px] text-background leading-5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
         onClick={onBack}
         type="button"
       >

--- a/frontend/src/components/wallet-workspace/facelift/activity-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/activity-page.tsx
@@ -18,6 +18,7 @@ import {
   StaggerLine,
   StaggerReveal,
 } from "@/components/wallet-workspace/facelift/stagger-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { EarnTransactionDetailPane } from "@/components/wallet-workspace/facelift/transaction-detail-pane";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
@@ -171,10 +172,10 @@ export function ActivityPage({
     <>
       <div className="flex h-full min-h-0 min-w-0 flex-1 gap-2 p-2 max-[795px]:gap-0 max-[795px]:p-0">
         <PaneReveal>
-          <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-white max-[795px]:rounded-none">
+          <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-card max-[795px]:rounded-none">
             <header className="flex w-full shrink-0 items-center p-2">
               <div className="flex min-w-0 flex-1 items-center py-2.5 pl-4">
-                <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6 max-[795px]:text-[24px] max-[795px]:leading-7">
+                <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6 max-[795px]:text-[24px] max-[795px]:leading-7">
                   Activity
                 </h1>
               </div>
@@ -186,19 +187,19 @@ export function ActivityPage({
                 <div className="t-skel-rows flex flex-col gap-2 px-2 py-1">
                   {[0, 1, 2].map((index) => (
                     <div
-                      className="h-[66px] w-full rounded-2xl bg-black/[0.04]"
+                      className="h-[66px] w-full rounded-2xl bg-accent"
                       key={index}
                     />
                   ))}
                 </div>
               ) : null}
               {items === null && hasError ? (
-                <p className="px-4 py-3 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <p className="px-4 py-3 text-[13px] leading-4 text-muted-foreground">
                   Failed to load transactions.
                 </p>
               ) : null}
               {items !== null && items.length === 0 ? (
-                <p className="px-4 py-8 text-center text-[14px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <p className="px-4 py-8 text-center text-[14px] leading-5 text-muted-foreground">
                   No activity yet
                 </p>
               ) : null}
@@ -242,7 +243,7 @@ export function ActivityPage({
           </section>
         </PaneReveal>
         {selectedItem ? (
-          <aside className="hidden h-full w-[400px] shrink-0 flex-col overflow-clip rounded-3xl bg-white min-[1204px]:flex">
+          <aside className="hidden h-full w-[400px] shrink-0 flex-col overflow-clip rounded-3xl bg-card min-[1204px]:flex">
             {/* Keyed by tx so switching rows replays the reveal — same as
                 the send flow's per-step PaneReveal. */}
             <PaneReveal key={selectedItem.id}>
@@ -254,16 +255,13 @@ export function ActivityPage({
             </PaneReveal>
           </aside>
         ) : (
-          <aside className="hidden h-full w-[400px] shrink-0 flex-col items-center justify-center overflow-clip rounded-3xl border-2 border-black/10 border-dashed min-[1204px]:flex">
+          <aside className="hidden h-full w-[400px] shrink-0 flex-col items-center justify-center overflow-clip rounded-3xl border-2 border-border border-dashed min-[1204px]:flex">
             <div className="flex w-full flex-col items-center gap-4 px-6">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-11"
+              <ThemedIcon
+                className="size-11 text-tertiary"
                 src={`${ASSET_BASE}/icon-cursor-click.svg`}
               />
-              <p className="text-center text-[16px] leading-5 text-[#8a8a8e] tracking-[-0.176px]">
+              <p className="text-center text-[16px] leading-5 text-muted-foreground tracking-[-0.176px]">
                 Select a transaction to view its details
               </p>
             </div>
@@ -280,7 +278,7 @@ export function ActivityPage({
         isOpen={selectedItem !== null}
         onClose={() => setSelectedItem(null)}
         scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
-        sheetClassName="ml-auto flex h-full w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+        sheetClassName="ml-auto flex h-full w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
       >
         {sheetItem ? (
           <EarnTransactionDetailPane

--- a/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
@@ -21,6 +21,7 @@ import {
   type FlowStep,
 } from "@/components/wallet-workspace/facelift/flow-explainer";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { useStablecoinsUsd } from "@/components/wallet-workspace/facelift/use-stablecoins-usd";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
@@ -159,39 +160,33 @@ export function AutodepositPane({
 
   return (
     <>
-      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-none">
         <header className="flex w-full items-center p-2">
           <div className="pr-3">
             <button
               aria-label="Back"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={handleBack}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-arrow-left.svg`}
               />
             </button>
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2 py-2">
-            <h1 className="truncate font-semibold text-[20px] text-black leading-6">
+            <h1 className="truncate font-semibold text-[20px] text-foreground leading-6">
               Autodeposit
             </h1>
             <button
               aria-label="How Autodeposit works"
-              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] min-[1204px]:hidden"
+              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"
               onClick={() => setIsInfoOpen(true)}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-question.svg`}
               />
             </button>
@@ -199,19 +194,16 @@ export function AutodepositPane({
           {isEdit ? (
             <div className="flex items-start pl-3">
               <button
-                className="t-hover flex items-center justify-center gap-2 rounded-full bg-[rgba(249,54,60,0.08)] p-2.5 enabled:hover:-translate-y-0.5 enabled:hover:bg-[rgba(249,54,60,0.14)] enabled:active:translate-y-0 disabled:opacity-60"
+                className="t-hover flex items-center justify-center gap-2 rounded-full bg-destructive/[0.08] p-2.5 enabled:hover:-translate-y-0.5 enabled:hover:bg-destructive/[0.14] enabled:active:translate-y-0 disabled:opacity-60"
                 disabled={isSaving}
                 onClick={() => void handleDelete()}
                 type="button"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-6"
+                <ThemedIcon
+                  className="size-6 text-destructive"
                   src={`${ASSET_BASE}/icon-trash-red.svg`}
                 />
-                <span className="whitespace-nowrap pr-2.5 font-medium text-[#f9363c] text-[16px] leading-5">
+                <span className="whitespace-nowrap pr-2.5 font-medium text-destructive text-[16px] leading-5">
                   <TextSwap
                     text={isDeleteArmed ? "Confirm delete" : "Delete"}
                   />
@@ -225,16 +217,16 @@ export function AutodepositPane({
           <div className="flex w-full flex-1 flex-col">
             <div className="w-full p-2">
               <label className="flex w-full flex-col gap-0.5 rounded-2xl px-4 py-2">
-                <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                   Deposit anything above
                 </span>
                 <span className="flex h-12 w-full items-baseline">
-                  <span className="font-semibold text-[40px] text-black leading-[48px]">
+                  <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                     $
                   </span>
                   <input
                     autoFocus
-                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                     inputMode="decimal"
                     onChange={(event) => handleAmountChange(event.target.value)}
                     onKeyDown={(event) => {
@@ -257,15 +249,12 @@ export function AutodepositPane({
             <div className="w-full px-2">
               <div className="flex w-full items-start px-4">
                 <div className="flex items-center py-1 pr-2">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-6"
+                  <ThemedIcon
+                    className="size-6 text-primary"
                     src={`${ASSET_BASE}/icon-exclamation-circle.svg`}
                   />
                 </div>
-                <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[#f9363c] text-[13px] leading-4">
+                <p className="min-w-0 max-w-[400px] flex-1 py-2 text-primary text-[13px] leading-4">
                   Any stablecoins above this amount will automatically go to
                   Earn
                 </p>
@@ -285,15 +274,15 @@ export function AutodepositPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                <span className="truncate text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="truncate text-[13px] leading-4 text-muted-foreground">
                   {`from Stablecoins · ${addressLabel}`}
                 </span>
-                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText
                     isHidden={isBalanceHidden}
                     text={stablecoinsBalance.balanceWhole}
                   />
-                  <span className="text-[rgba(60,60,67,0.4)]">
+                  <span className="text-tertiary">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={stablecoinsBalance.balanceFraction}
@@ -314,15 +303,15 @@ export function AutodepositPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   to Earn
                 </span>
-                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText
                     isHidden={isBalanceHidden}
                     text={earnBalance.balanceWhole}
                   />
-                  <span className="text-[rgba(60,60,67,0.4)]">
+                  <span className="text-tertiary">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={earnBalance.balanceFraction}
@@ -332,13 +321,13 @@ export function AutodepositPane({
               </div>
             </div>
 
-            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-[#d9d9d9]" />
+            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-border" />
           </div>
         </div>
 
-        <div className="w-full bg-white px-4 pt-2 pb-4">
+        <div className="w-full bg-card px-4 pt-2 pb-4">
           {actions.autodepositError ? (
-            <p className="px-4 pb-2 text-[13px] leading-4 text-[#f9363c]">
+            <p className="px-4 pb-2 text-[13px] leading-4 text-destructive">
               {actions.autodepositError}
             </p>
           ) : null}
@@ -347,8 +336,8 @@ export function AutodepositPane({
           <button
             className={`t-hover flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 ${
               hasChanges
-                ? "bg-black text-white enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
-                : "bg-black/[0.04] text-[rgba(60,60,67,0.6)]"
+                ? "bg-foreground text-background enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0"
+                : "bg-accent text-muted-foreground"
             }`}
             disabled={!hasChanges || isSaving}
             onClick={() => void handleSave()}

--- a/frontend/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -41,6 +41,7 @@ import {
   SwapPane,
   SwapTokenSelectPane,
 } from "@/components/wallet-workspace/facelift/swap-pane";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { TokenDetailPane } from "@/components/wallet-workspace/facelift/token-detail-pane";
 import { useAuthCapability } from "@/lib/auth/capability";
 import { usePublicEnv } from "@/contexts/public-env-context";
@@ -151,39 +152,36 @@ function ShieldUnlockOverlay({
       isOpen={isOpen}
       onClose={onClose}
       scrimClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/20 p-4 backdrop-blur-[4px]"
-      sheetClassName="flex w-full max-w-[400px] flex-col overflow-clip rounded-3xl bg-white"
+      sheetClassName="flex w-full max-w-[400px] flex-col overflow-clip rounded-3xl bg-card"
     >
       <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
           Shielded balances
         </h2>
         <button
           aria-label="Close"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onClose}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src="/wallet-workspace/facelift/icon-cross.svg"
           />
         </button>
       </header>
-      <p className="px-4 text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+      <p className="px-4 text-[16px] leading-5 text-muted-foreground">
         Signing proves wallet ownership so Loyal can show shielded balances. No
         funds move and no gas is spent.
       </p>
       {error ? (
-        <p className="px-4 pt-2 text-[13px] leading-4 text-[#f9363c]">
+        <p className="px-4 pt-2 text-[13px] leading-4 text-destructive">
           {error}
         </p>
       ) : null}
       <div className="w-full p-4">
         <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 hover:bg-[#171717] disabled:bg-[#cccdcd]"
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 hover:bg-foreground/90 disabled:bg-foreground/20"
           disabled={isUnlocking}
           onClick={onSign}
           type="button"
@@ -939,7 +937,7 @@ export function CryptoPage({
           // pane; both slide out while a submit runs and on result screens.
           <div className="hidden h-full w-[400px] shrink-0 min-[1204px]:block">
             <InlineSheetReveal
-              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white"
+              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card"
               isOpen={sendSelect !== null && isSendFormActive}
             >
               <PaneReveal key={overlaySendSelect}>
@@ -953,7 +951,7 @@ export function CryptoPage({
           // switching sides replays the content reveal on the open panel.
           <div className="hidden h-full w-[400px] shrink-0 min-[1204px]:block">
             <InlineSheetReveal
-              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white"
+              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card"
               isOpen={swapSelectSide !== null}
             >
               <PaneReveal key={overlaySelectSide}>
@@ -982,7 +980,7 @@ export function CryptoPage({
           // screens (the 400px slot stays reserved so the middle never jumps).
           <div className="hidden h-full w-[400px] shrink-0 min-[1204px]:block">
             <InlineSheetReveal
-              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white"
+              className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card"
               isOpen={isShieldFormActive}
             >
               <PaneReveal>
@@ -1000,7 +998,7 @@ export function CryptoPage({
           // switching tokens replays the panel reveal.
           <aside className="hidden h-full w-[400px] shrink-0 min-[1204px]:block">
             <PaneReveal key={detailMint}>
-              <div className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white">
+              <div className="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card">
                 <TokenDetailPane
                   hideChart={page === "stables"}
                   icon={detailBase.icon}
@@ -1019,7 +1017,7 @@ export function CryptoPage({
             </PaneReveal>
           </aside>
         ) : (
-          <aside className="hidden h-full w-[400px] shrink-0 rounded-3xl bg-white min-[1204px]:block" />
+          <aside className="hidden h-full w-[400px] shrink-0 rounded-3xl bg-card min-[1204px]:block" />
         )}
       </div>
       {/* Below 1204px the selector opens as the right-pinned card over the
@@ -1029,7 +1027,7 @@ export function CryptoPage({
         isOpen={isSwapOpen && swapSelectSide !== null}
         onClose={() => setSwapSelectSide(null)}
         scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
-        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
       >
         <PaneReveal key={overlaySelectSide}>
           <SwapTokenSelectPane
@@ -1051,7 +1049,7 @@ export function CryptoPage({
         isOpen={isSendOpen && sendSelect !== null && isSendFormActive}
         onClose={() => setSendSelect(null)}
         scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
-        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
       >
         <PaneReveal key={overlaySendSelect}>
           {renderSendSelectPane()}
@@ -1063,7 +1061,7 @@ export function CryptoPage({
         isOpen={isShieldOpen && isShieldSelectOpen}
         onClose={() => setIsShieldSelectOpen(false)}
         scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
-        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+        sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
       >
         <ShieldAssetPane
           nameByMint={tokenNameByMint}
@@ -1084,7 +1082,7 @@ export function CryptoPage({
           isOpen={isDetailSheetOpen}
           onClose={() => setIsDetailSheetOpen(false)}
           scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8 min-[1204px]:hidden"
-          sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+          sheetClassName="ml-auto flex h-full w-[392px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
         >
           <TokenDetailPane
             hideChart={page === "stables"}

--- a/frontend/src/components/wallet-workspace/facelift/crypto-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/crypto-pane.tsx
@@ -7,6 +7,7 @@ import {
   useBalanceVisibility,
 } from "@/components/wallet-workspace/facelift/balance-visibility";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -35,9 +36,9 @@ export function SplitUsd({
   const whole = dotIndex >= 0 ? value.slice(0, dotIndex) : value;
   const fraction = dotIndex >= 0 ? value.slice(dotIndex) : "";
   return (
-    <p className="whitespace-nowrap text-right font-medium text-[16px] text-black leading-5">
+    <p className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
       <ScrambleText isHidden={isHidden} text={whole} />
-      <span className="text-[#b1b1b4]">
+      <span className="text-tertiary">
         <ScrambleText isHidden={isHidden} text={fraction} />
       </span>
     </p>
@@ -57,12 +58,15 @@ function getPairKey(row: TokenRow): string {
 function HeaderPill({
   hideLabel,
   icon,
+  iconColorClass,
   isBlack,
   label,
   onClick,
 }: {
   hideLabel?: boolean;
   icon: string;
+  /** text-* class rendering the icon as a themed mask; omit = raw img. */
+  iconColorClass?: string;
   isBlack?: boolean;
   label: string;
   onClick: () => void;
@@ -71,22 +75,29 @@ function HeaderPill({
     <button
       className={`t-hover flex items-center justify-center gap-2 rounded-full p-2.5 hover:-translate-y-0.5 active:translate-y-0 ${
         isBlack
-          ? "bg-black hover:bg-[#171717]"
-          : "bg-black/[0.04] hover:bg-black/[0.08]"
+          ? "bg-foreground hover:bg-foreground/90"
+          : "bg-accent hover:bg-accent-active"
       }`}
       onClick={onClick}
       type="button"
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-6"
-        src={`${ASSET_BASE}/${icon}`}
-      />
+      {iconColorClass ? (
+        <ThemedIcon
+          className={`size-6 ${iconColorClass}`}
+          src={`${ASSET_BASE}/${icon}`}
+        />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          alt=""
+          aria-hidden="true"
+          className="size-6"
+          src={`${ASSET_BASE}/${icon}`}
+        />
+      )}
       <span
         className={`whitespace-nowrap pr-2.5 font-medium text-[16px] leading-5 ${
-          isBlack ? "text-white" : "text-black"
+          isBlack ? "text-background" : "text-foreground"
         }${hideLabel ? " max-[999px]:hidden" : ""}`}
       >
         {label}
@@ -98,11 +109,14 @@ function HeaderPill({
 // Hover-revealed row action: label pill wide, icon circle when downsized.
 function RowPill({
   icon,
+  iconColorClass,
   isBlack,
   label,
   onClick,
 }: {
   icon: string;
+  /** text-* class rendering the icon as a themed mask; omit = raw img. */
+  iconColorClass?: string;
   isBlack?: boolean;
   label: string;
   onClick: () => void;
@@ -111,8 +125,8 @@ function RowPill({
     <button
       className={`flex min-w-16 items-center justify-center rounded-[40px] px-4 py-2.5 font-medium text-[13px] leading-4 transition-colors max-[999px]:size-9 max-[999px]:min-w-0 max-[999px]:p-0 ${
         isBlack
-          ? "bg-black text-white hover:bg-[#171717]"
-          : "bg-black/[0.04] text-black hover:bg-black/[0.08]"
+          ? "bg-foreground text-background hover:bg-foreground/90"
+          : "bg-accent text-foreground hover:bg-accent-active"
       }`}
       onClick={(event) => {
         // Don't bubble into the row click — below 1204px that would slide
@@ -123,12 +137,20 @@ function RowPill({
       type="button"
     >
       <span className="max-[999px]:hidden">{label}</span>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        alt={label}
-        className="hidden size-5 max-[999px]:block"
-        src={`${ASSET_BASE}/${icon}`}
-      />
+      {iconColorClass ? (
+        <ThemedIcon
+          className={`hidden size-5 max-[999px]:block ${iconColorClass}`}
+          label={label}
+          src={`${ASSET_BASE}/${icon}`}
+        />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          alt={label}
+          className="hidden size-5 max-[999px]:block"
+          src={`${ASSET_BASE}/${icon}`}
+        />
+      )}
     </button>
   );
 }
@@ -157,13 +179,13 @@ function TokenCell({
     // pills stop propagation (the page's row actions select the token
     // themselves without opening the <1204 detail sheet).
     <div
-      className="group relative flex w-full cursor-pointer items-center rounded-2xl px-4 transition-colors duration-150 hover:bg-black/[0.04]"
+      className="group relative flex w-full cursor-pointer items-center rounded-2xl px-4 transition-colors duration-150 hover:bg-accent"
       onClick={() => actions.onSelect?.(row)}
     >
       {isPairFirst ? (
         <span
           aria-hidden="true"
-          className="-bottom-1.5 absolute left-[37px] z-10 h-3 w-0.5 rounded-full bg-[#d9d9d9]"
+          className="-bottom-1.5 absolute left-[37px] z-10 h-3 w-0.5 rounded-full bg-border"
         />
       ) : null}
       <div className="flex shrink-0 items-center py-2 pr-3">
@@ -185,13 +207,13 @@ function TokenCell({
         </div>
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-        <p className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+        <p className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
           {row.name ?? row.symbol}
           {row.isSecured ? (
-            <span className="text-[#b1b1b4]">{" · Shielded"}</span>
+            <span className="text-tertiary">{" · Shielded"}</span>
           ) : null}
         </p>
-        <p className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
           {isStables ? (
             row.symbol
           ) : (
@@ -201,8 +223,8 @@ function TokenCell({
                 <span
                   className={
                     row.priceChange24h >= 0
-                      ? "text-[#34c759]"
-                      : "text-[#f9363c]"
+                      ? "text-positive"
+                      : "text-destructive"
                   }
                 >
                   {formatChangeLabel(row.priceChange24h)}
@@ -216,7 +238,7 @@ function TokenCell({
         <div className="group-hover:pointer-events-none flex flex-col items-end justify-center gap-0.5 py-[11px] transition-opacity duration-150 group-hover:opacity-0">
           <SplitUsd isHidden={isBalanceHidden} value={row.value} />
           {isStables ? null : (
-            <p className="whitespace-nowrap text-right text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+            <p className="whitespace-nowrap text-right text-[13px] leading-4 text-muted-foreground">
               <ScrambleText
                 isHidden={isBalanceHidden}
                 text={`${row.amount} ${row.symbol}`}
@@ -226,10 +248,11 @@ function TokenCell({
         </div>
         {/* Reveal rides a short delay so quick pointer passes don't flash the
             buttons; un-hover drops the delay and hides immediately. */}
-        <div className="pointer-events-none absolute right-0 flex items-center gap-2 rounded-[40px] bg-[#f5f5f5] opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:delay-100">
+        <div className="pointer-events-none absolute right-0 flex items-center gap-2 rounded-[40px] bg-secondary opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:delay-100">
           {row.isSecured ? (
             <RowPill
               icon="icon-shield-break.svg"
+              iconColorClass="text-muted-foreground"
               label="Unshield"
               onClick={() => actions.onUnshield(row)}
             />
@@ -244,6 +267,7 @@ function TokenCell({
             <>
               <RowPill
                 icon="icon-arrow-up-circle.svg"
+                iconColorClass="text-tertiary"
                 label="Send"
                 onClick={() => actions.onSend(row)}
               />
@@ -252,6 +276,9 @@ function TokenCell({
                   isStables
                     ? "icon-swap-repeat-gray.svg"
                     : "icon-swap-repeat.svg"
+                }
+                iconColorClass={
+                  isStables ? "text-tertiary" : "text-background"
                 }
                 isBlack={!isStables}
                 label="Swap"
@@ -262,6 +289,7 @@ function TokenCell({
           {isStables ? (
             <RowPill
               icon="icon-coins-add.svg"
+              iconColorClass="text-background"
               isBlack
               label="Earn"
               onClick={() => actions.onEarn?.(row)}
@@ -307,28 +335,25 @@ export function CryptoPane({
 
   return (
     <div className="flex h-full min-w-0 flex-1 flex-col">
-      <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-white max-[795px]:rounded-none">
+      <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-card max-[795px]:rounded-none">
         <header className="flex w-full shrink-0 items-center p-2">
           {/* Mobile (Figma 4813:365930 / 4813:366091) — a pushed screen: back
               arrow to the wallet home, no header pills. */}
           <div className="hidden shrink-0 items-center pr-3 max-[795px]:flex">
             <button
               aria-label="Back"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={onBack}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-arrow-left.svg`}
               />
             </button>
           </div>
           <div className="flex min-w-0 flex-1 items-center py-2.5 pl-4 max-[795px]:pl-0">
-            <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+            <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
               {isStables ? "Stablecoins" : "Crypto"}
             </h1>
           </div>
@@ -342,6 +367,7 @@ export function CryptoPane({
             <HeaderPill
               hideLabel
               icon="icon-arrow-up-circle.svg"
+              iconColorClass="text-tertiary"
               label="Send"
               onClick={onSend}
             />
@@ -350,6 +376,7 @@ export function CryptoPane({
               icon={
                 isStables ? "icon-swap-repeat-gray.svg" : "icon-swap-repeat.svg"
               }
+              iconColorClass={isStables ? "text-tertiary" : "text-background"}
               isBlack={!isStables}
               label="Swap"
               onClick={onSwap}
@@ -358,6 +385,7 @@ export function CryptoPane({
               <HeaderPill
                 hideLabel
                 icon="icon-coins-add.svg"
+                iconColorClass="text-background"
                 isBlack
                 label="Earn"
                 onClick={onEarn}
@@ -387,20 +415,20 @@ export function CryptoPane({
               )}
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+              <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                 Balance
               </p>
-              <p className="whitespace-nowrap font-semibold text-[40px] text-black leading-[48px] tracking-[-0.44px]">
+              <p className="whitespace-nowrap font-semibold text-[40px] text-foreground leading-[48px] tracking-[-0.44px]">
                 <SkeletonReveal
                   isRevealed={isBalanceRevealed}
-                  skeletonClassName="rounded-lg bg-black/[0.06]"
+                  skeletonClassName="rounded-lg bg-accent-selected"
                 >
                   {isBalanceRevealed ? (
                     <ScrambledPopDigits
                       isHidden={isBalanceHidden}
                       segments={[
                         { text: balanceWhole },
-                        { color: "#b1b1b4", text: balanceFraction },
+                        { color: "var(--tertiary)", text: balanceFraction },
                       ]}
                     />
                   ) : (
@@ -435,41 +463,35 @@ export function CryptoPane({
 
       {/* Mobile action bar (Figma 4813:366048 / 4813:366180) — the header
           pills' actions pinned under the list; same trio on both variants. */}
-      <div className="hidden w-full shrink-0 gap-2 bg-white px-4 pt-2 pb-4 max-[795px]:flex">
+      <div className="hidden w-full shrink-0 gap-2 bg-card px-4 pt-2 pb-4 max-[795px]:flex">
         <button
-          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-black p-2.5"
+          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-foreground p-2.5"
           onClick={onSwap}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-background"
             src={`${ASSET_BASE}/icon-swap-repeat.svg`}
           />
-          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-white leading-5">
+          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-background leading-5">
             Swap
           </span>
         </button>
         <button
-          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-[#f5f5f5] p-2.5"
+          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-secondary p-2.5"
           onClick={onSend}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-tertiary"
             src={`${ASSET_BASE}/icon-arrow-up-circle.svg`}
           />
-          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
+          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
             Send
           </span>
         </button>
         <button
-          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-black/[0.04] p-2.5"
+          className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-accent p-2.5"
           onClick={onShield}
           type="button"
         >
@@ -480,7 +502,7 @@ export function CryptoPane({
             className="size-6"
             src={`${ASSET_BASE}/icon-shield.svg`}
           />
-          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
+          <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
             Shield
           </span>
         </button>

--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -17,6 +17,7 @@ import {
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { usePublicEnv } from "@/contexts/public-env-context";
@@ -134,54 +135,45 @@ export function DepositPane({
 
   return (
     <>
-      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-none">
         <header className="flex w-full items-center p-2">
           <div className="pr-3">
             <button
               aria-label="Back"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={onBack}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-arrow-left.svg`}
               />
             </button>
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2 py-2">
-            <h1 className="truncate font-semibold text-[20px] text-black leading-6">
+            <h1 className="truncate font-semibold text-[20px] text-foreground leading-6">
               Deposit
             </h1>
             <button
               aria-label="How Deposit works"
-              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] min-[1204px]:hidden"
+              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"
               onClick={() => setIsInfoOpen(true)}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-question.svg`}
               />
             </button>
           </div>
           <button
             aria-label="Open chart"
-            className="t-hover hidden size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] max-[795px]:flex"
+            className="t-hover hidden size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent max-[795px]:flex"
             onClick={onOpenChart}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-chart.svg`}
             />
           </button>
@@ -191,16 +183,16 @@ export function DepositPane({
           <div className="flex w-full flex-1 flex-col">
             <div className="w-full p-2">
               <label className="flex w-full flex-col gap-0.5 rounded-2xl px-4 py-2">
-                <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                   Amount
                 </span>
                 <span className="flex h-12 w-full items-baseline">
-                  <span className="font-semibold text-[40px] text-black leading-[48px]">
+                  <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                     $
                   </span>
                   <input
                     autoFocus
-                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                     inputMode="decimal"
                     onChange={(event) => handleAmountChange(event.target.value)}
                     onKeyDown={(event) => {
@@ -234,7 +226,7 @@ export function DepositPane({
                       src={`${ASSET_BASE}/icon-circle-info.svg`}
                     />
                   </div>
-                  <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-muted-foreground">
                     Your first deposit takes ~0.06 SOL from your wallet for
                     Solana account rent — it is returned when you fully
                     withdraw.
@@ -256,15 +248,15 @@ export function DepositPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   from USDC balance
                 </span>
-                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText
                     isHidden={isBalanceHidden}
                     text={usdcBalance.balanceWhole}
                   />
-                  <span className="text-[rgba(60,60,67,0.4)]">
+                  <span className="text-tertiary">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={usdcBalance.balanceFraction}
@@ -274,7 +266,7 @@ export function DepositPane({
               </div>
               <div className="pl-3">
                 <button
-                  className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                  className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                   onClick={() => {
                     if (usdcUsd > 0) {
                       // Floor to cents so the fill never rounds above the real
@@ -303,7 +295,7 @@ export function DepositPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   to Earn
                 </span>
                 <span className="flex items-center">
@@ -311,9 +303,9 @@ export function DepositPane({
                     + pop — the fallback APY would otherwise flash. */}
                   <SkeletonReveal
                     isRevealed={isApyLoaded}
-                    skeletonClassName="rounded-lg bg-black/[0.06]"
+                    skeletonClassName="rounded-lg bg-accent-selected"
                   >
-                    <span className="inline-flex items-center gap-1 rounded-lg bg-[rgba(52,199,89,0.14)] px-2 py-0.5">
+                    <span className="inline-flex items-center gap-1 rounded-lg bg-positive/[0.14] px-2 py-0.5">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         alt=""
@@ -321,7 +313,7 @@ export function DepositPane({
                         className="h-5 w-3"
                         src="/wallet-workspace/earn-flash.svg"
                       />
-                      <span className="whitespace-nowrap font-medium text-[#34c759] text-[16px] leading-5 tracking-[0.06px]">
+                      <span className="whitespace-nowrap font-medium text-positive text-[16px] leading-5 tracking-[0.06px]">
                         {isApyLoaded ? (
                           <PopDigits
                             segments={[
@@ -338,13 +330,13 @@ export function DepositPane({
               </div>
             </div>
 
-            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-[#d9d9d9]" />
+            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-border" />
           </div>
         </div>
 
-        <div className="w-full bg-white px-4 pt-2 pb-4">
+        <div className="w-full bg-card px-4 pt-2 pb-4">
           {actions.depositError ? (
-            <p className="px-4 pb-2 text-[13px] leading-4 text-[#f9363c]">
+            <p className="px-4 pb-2 text-[13px] leading-4 text-destructive">
               {actions.depositError}
             </p>
           ) : null}
@@ -353,8 +345,8 @@ export function DepositPane({
           <button
             className={`t-hover flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 ${
               isValidAmount
-                ? "bg-black text-white enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
-                : "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+                ? "bg-foreground text-background enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0"
+                : "bg-destructive/[0.08] text-destructive"
             }`}
             disabled={!isValidAmount || isSubmitting}
             onClick={() => void handleSubmit()}

--- a/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
@@ -32,6 +32,7 @@ import {
   shouldShowScheduledSweepsSection,
 } from "@/components/wallet-workspace/earn-transactions-pane";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import type { ActiveEarnPositionHolding } from "@/hooks/use-active-earn-position";
@@ -125,17 +126,14 @@ function RouteLabel({
 }) {
   return (
     <span className="flex items-center justify-end gap-1">
-      <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+      <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
         {source}
       </span>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-4"
+      <ThemedIcon
+        className="size-4 text-tertiary"
         src={`${ASSET_BASE}/icon-arrow-right-circle.svg`}
       />
-      <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+      <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
         {destination}
       </span>
     </span>
@@ -145,7 +143,7 @@ function RouteLabel({
 export function GroupHeader({ label }: { label: string }) {
   return (
     <div className="flex w-full items-start px-4 pt-1">
-      <p className="min-w-0 flex-1 pt-3 pb-2 text-[16px] leading-5 tracking-[-0.176px] text-[rgba(60,60,67,0.6)]">
+      <p className="min-w-0 flex-1 pt-3 pb-2 text-[16px] leading-5 tracking-[-0.176px] text-muted-foreground">
         {label}
       </p>
     </div>
@@ -247,15 +245,15 @@ function ScheduledSweepRow({
         </div>
         <div className="flex min-w-0 flex-1 items-center justify-between">
           <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-            <p className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+            <p className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
               Autodeposit
             </p>
-            <p className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+            <p className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
               {formatScheduledSweepTime(sweep.eligibleAfter)}
             </p>
           </div>
           <div className="flex flex-col items-end gap-0.5 py-[11px] pl-3">
-            <p className="whitespace-nowrap text-[16px] text-black leading-5 text-right">
+            <p className="whitespace-nowrap text-[16px] text-foreground leading-5 text-right">
               <ScrambleText isHidden={isBalanceHidden} text={amountLabel} />
             </p>
             <RouteLabel destination="Earn" source="Main" />
@@ -265,7 +263,7 @@ function ScheduledSweepRow({
       <div className="flex w-full flex-col items-start px-4 pt-1 pb-2">
         <button
           aria-busy={isProgressActive}
-          className="t-hover flex h-9 items-center justify-center rounded-full bg-black/[0.04] px-4 font-medium text-[14px] text-black leading-5 enabled:hover:bg-black/[0.08] disabled:opacity-50"
+          className="t-hover flex h-9 items-center justify-center rounded-full bg-accent px-4 font-medium text-[14px] text-foreground leading-5 enabled:hover:bg-accent-active disabled:opacity-50"
           disabled={isButtonDisabled}
           onClick={() => void executeNow.run(sweep)}
           type="button"
@@ -273,7 +271,7 @@ function ScheduledSweepRow({
           <TextSwap text={buttonLabel} />
         </button>
         {executeNow.error && !isProgressActive ? (
-          <p className="pt-2 text-[13px] leading-4 text-[#f9363c]">
+          <p className="pt-2 text-[13px] leading-4 text-destructive">
             {executeNow.error}
           </p>
         ) : null}
@@ -318,10 +316,10 @@ export function TransactionRow({
         )}
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-        <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+        <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
           {getEarnTransactionRowLabel(item)}
         </span>
-        <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
           {timeLabel}
         </span>
       </span>
@@ -353,7 +351,7 @@ export function TransactionRow({
   return (
     <button
       className={`flex w-full items-center rounded-2xl px-4 text-left transition-colors duration-150 ${
-        isSelected ? "bg-black/[0.04]" : "hover:bg-black/[0.04]"
+        isSelected ? "bg-accent" : "hover:bg-accent"
       }`}
       onClick={onSelect}
       type="button"
@@ -519,14 +517,11 @@ function TransactionsTab({
           <StaggerLine index={0}>
             <div className="flex w-full items-start px-4 pt-1">
               <div className="flex min-w-0 flex-1 items-center gap-1 pt-3 pb-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-5"
+                <ThemedIcon
+                  className="size-5 text-tertiary"
                   src={`${ASSET_BASE}/icon-clock.svg`}
                 />
-                <p className="min-w-0 flex-1 text-[16px] leading-5 tracking-[-0.176px] text-[rgba(60,60,67,0.6)]">
+                <p className="min-w-0 flex-1 text-[16px] leading-5 tracking-[-0.176px] text-muted-foreground">
                   Scheduled
                 </p>
               </div>
@@ -550,7 +545,7 @@ function TransactionsTab({
         <div className="t-skel-rows flex flex-col gap-2 px-4 py-3">
           {[0, 1, 2].map((index) => (
             <div
-              className="h-[60px] w-full rounded-2xl bg-black/[0.04]"
+              className="h-[60px] w-full rounded-2xl bg-accent"
               key={index}
             />
           ))}
@@ -566,19 +561,19 @@ function TransactionsTab({
         <div className="t-skel-rows flex flex-col gap-2 px-4 py-3">
           {pendingRows.map((signature) => (
             <div
-              className="h-[60px] w-full rounded-2xl bg-black/[0.04]"
+              className="h-[60px] w-full rounded-2xl bg-accent"
               key={signature}
             />
           ))}
         </div>
       ) : null}
       {hasError ? (
-        <p className="px-4 py-3 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="px-4 py-3 text-[13px] leading-4 text-muted-foreground">
           Failed to load transactions.
         </p>
       ) : null}
       {items !== null && items.length === 0 && pendingRows.length === 0 ? (
-        <p className="px-4 py-3 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="px-4 py-3 text-[13px] leading-4 text-muted-foreground">
           No transactions yet.
         </p>
       ) : null}
@@ -618,7 +613,7 @@ function TransactionsTab({
                 {renderedGroups}
                 <StaggerLine index={lineIndex}>
                   <button
-                    className="t-hover flex h-11 w-full items-center justify-center rounded-2xl font-medium text-[14px] text-black leading-5 hover:bg-black/[0.04]"
+                    className="t-hover flex h-11 w-full items-center justify-center rounded-2xl font-medium text-[14px] text-foreground leading-5 hover:bg-accent"
                     onClick={onViewAllActivity}
                     type="button"
                   >
@@ -653,7 +648,7 @@ function PositionsTab({
   return (
     <StaggerReveal className="flex w-full flex-col p-2">
       {visibleHoldings.length === 0 ? (
-        <p className="px-4 py-3 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="px-4 py-3 text-[13px] leading-4 text-muted-foreground">
           No positions.
         </p>
       ) : null}
@@ -672,7 +667,7 @@ function PositionsTab({
               holding.reserve ?? holding.market ?? label
             }`}
           >
-            <div className="group t-hover flex w-full items-center rounded-2xl px-4 hover:bg-black/[0.04]">
+            <div className="group t-hover flex w-full items-center rounded-2xl px-4 hover:bg-accent">
               <div className="flex items-center py-2 pr-3">
                 <DualIcon
                   frontSrc={resolveEarnTransactionMarketIcon({
@@ -681,15 +676,15 @@ function PositionsTab({
                 />
               </div>
               <div className="flex h-[60px] min-w-0 flex-1 flex-col gap-0.5 py-[9px]">
-                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   {label}
                 </span>
-                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText
                     isHidden={isBalanceHidden}
                     text={amount.balanceWhole}
                   />
-                  <span className="text-[rgba(60,60,67,0.4)]">
+                  <span className="text-tertiary">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={amount.balanceFraction}
@@ -701,7 +696,7 @@ function PositionsTab({
                   flash the pill; un-hover drops the delay and hides at once. */}
               <div className="pointer-events-none flex pl-3 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:delay-100">
                 <button
-                  className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                  className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                   onClick={() =>
                     onWithdrawSource(getWithdrawSourceKeyForHolding(holding))
                   }
@@ -860,7 +855,7 @@ export function EarnActivityCard({
   return (
     // On mobile the card grows to meet the sticky action bar and drops its
     // bottom rounding (Figma 4693:70498).
-    <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:flex-1 max-[795px]:rounded-b-none">
+    <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:flex-1 max-[795px]:rounded-b-none">
       <div
         className="relative flex w-full items-center px-2 pt-2"
         ref={tabBarRef}
@@ -878,8 +873,8 @@ export function EarnActivityCard({
               aria-selected={isActive}
               className={`t-hover relative flex h-11 items-center justify-center px-4 font-medium text-[16px] leading-5 tracking-[-0.176px] ${
                 isActive
-                  ? "text-black"
-                  : "rounded-3xl text-[rgba(60,60,67,0.6)] hover:bg-black/[0.04] hover:text-black"
+                  ? "text-foreground"
+                  : "rounded-3xl text-muted-foreground hover:bg-accent hover:text-foreground"
               }`}
               key={tab}
               onClick={() => selectTab(tab)}

--- a/frontend/src/components/wallet-workspace/facelift/earn-approval-sheet.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-approval-sheet.tsx
@@ -21,11 +21,11 @@ function ReviewRow({ row }: { row: ApprovalReviewDisplayRow }) {
   const isAddressLike = isAddressLikeValue(row.value);
   return (
     <div className="px-3 py-[9px]">
-      <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+      <p className="text-[13px] leading-4 text-muted-foreground">
         {row.label}
       </p>
       <p
-        className={`mt-0.5 break-words text-black ${
+        className={`mt-0.5 break-words text-foreground ${
           isAddressLike ? "text-[13px] leading-[18px]" : "text-[16px] leading-5"
         }`}
         style={isAddressLike ? { fontFamily: MONO_FONT } : undefined}
@@ -43,18 +43,18 @@ function CollapsibleRows({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className="overflow-hidden rounded-2xl bg-black/[0.04]">
+    <div className="overflow-hidden rounded-2xl bg-accent">
       <button
-        className="flex w-full items-center justify-between gap-2 px-3 py-[13px] text-left font-medium text-[14px] text-black leading-5"
+        className="flex w-full items-center justify-between gap-2 px-3 py-[13px] text-left font-medium text-[14px] text-foreground leading-5"
         onClick={() => setIsOpen((current) => !current)}
         type="button"
       >
         <span>{collapsible.title}</span>
         {isOpen ? (
-          <ChevronUp className="shrink-0 text-[rgba(60,60,67,0.6)]" size={16} />
+          <ChevronUp className="shrink-0 text-muted-foreground" size={16} />
         ) : (
           <ChevronDown
-            className="shrink-0 text-[rgba(60,60,67,0.6)]"
+            className="shrink-0 text-muted-foreground"
             size={16}
           />
         )}
@@ -104,11 +104,11 @@ function ApprovalBody({ approval }: { approval: PendingEarnApproval }) {
       <header className="flex w-full shrink-0 items-center justify-end p-2">
         <button
           aria-label="Close"
-          className="t-hover flex size-11 items-center justify-center rounded-full hover:bg-black/[0.04]"
+          className="t-hover flex size-11 items-center justify-center rounded-full hover:bg-accent"
           onClick={approval.reject}
           type="button"
         >
-          <X className="text-[#3c3c43]" size={24} />
+          <X className="text-foreground" size={24} />
         </button>
       </header>
 
@@ -116,27 +116,27 @@ function ApprovalBody({ approval }: { approval: PendingEarnApproval }) {
         <div className="flex w-full flex-col gap-1 px-2 pt-6 pb-6">
           {page.amount ? (
             <p className="flex items-baseline gap-2 whitespace-nowrap font-semibold">
-              <span className="text-[40px] text-black leading-[48px]">
+              <span className="text-[40px] text-foreground leading-[48px]">
                 {page.amount}
               </span>
               {page.symbol ? (
-                <span className="text-[28px] leading-8 tracking-[0.4px] text-[rgba(60,60,67,0.4)]">
+                <span className="text-[28px] leading-8 tracking-[0.4px] text-tertiary">
                   {page.symbol}
                 </span>
               ) : null}
             </p>
           ) : (
-            <p className="font-semibold text-[24px] text-black leading-[30px]">
+            <p className="font-semibold text-[24px] text-foreground leading-[30px]">
               {page.heading}
             </p>
           )}
           {page.amount && !page.hideAmountHeading ? (
-            <p className="text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+            <p className="text-[16px] leading-5 text-muted-foreground">
               {page.heading}
             </p>
           ) : null}
           {page.subheading ? (
-            <p className="text-[14px] leading-[19px] text-[rgba(60,60,67,0.6)]">
+            <p className="text-[14px] leading-[19px] text-muted-foreground">
               {page.subheading}
             </p>
           ) : null}
@@ -144,7 +144,7 @@ function ApprovalBody({ approval }: { approval: PendingEarnApproval }) {
 
         <div className="flex w-full flex-col gap-2">
           {page.rows && page.rows.length > 0 ? (
-            <div className="flex w-full flex-col rounded-2xl bg-black/[0.04] py-1">
+            <div className="flex w-full flex-col rounded-2xl bg-accent py-1">
               {page.rows.map((row) => (
                 <ReviewRow key={row.label} row={row} />
               ))}
@@ -157,14 +157,14 @@ function ApprovalBody({ approval }: { approval: PendingEarnApproval }) {
       </div>
 
       {page.mascotNote ? (
-        <p className="w-full shrink-0 px-6 pt-3 pb-1 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="w-full shrink-0 px-6 pt-3 pb-1 text-[13px] leading-4 text-muted-foreground">
           {page.mascotNote}
         </p>
       ) : null}
 
       <div className="flex w-full shrink-0 gap-2 px-4 pt-2 pb-4">
         <button
-          className="t-hover flex h-12 flex-1 items-center justify-center rounded-full bg-black/[0.04] font-medium text-[16px] text-black leading-5 hover:bg-black/[0.08]"
+          className="t-hover flex h-12 flex-1 items-center justify-center rounded-full bg-accent font-medium text-[16px] text-foreground leading-5 hover:bg-accent-active"
           onClick={
             isFirst
               ? approval.reject
@@ -175,7 +175,7 @@ function ApprovalBody({ approval }: { approval: PendingEarnApproval }) {
           {isFirst ? secondaryLabel : "Back"}
         </button>
         <button
-          className="t-hover flex h-12 flex-1 items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+          className="t-hover flex h-12 flex-1 items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
           onClick={
             isLast
               ? approval.approve
@@ -211,7 +211,7 @@ export function EarnApprovalSheet({
       isOpen={approval !== null}
       onClose={() => approval?.reject()}
       scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8"
-      sheetClassName="ml-auto flex h-full w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+      sheetClassName="ml-auto flex h-full w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
     >
       {sheetApproval ? <ApprovalBody approval={sheetApproval} /> : null}
     </SheetReveal>

--- a/frontend/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
@@ -18,6 +18,7 @@ import { useBalanceVisibility } from "@/components/wallet-workspace/facelift/bal
 import { readCssDurationMs } from "@/components/wallet-workspace/facelift/css-duration";
 import { EarnedChart } from "@/components/wallet-workspace/facelift/earned-chart";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { useIsNarrowViewport } from "@/components/wallet-workspace/facelift/use-is-narrow-viewport";
@@ -212,7 +213,7 @@ export function EarnChartCard({
         <div className="min-w-0 flex-1">
           {isLoggedOut ? (
             <div className="flex items-center gap-2 py-2.5 pl-4">
-              <h2 className="truncate font-semibold text-[20px] text-black leading-6">
+              <h2 className="truncate font-semibold text-[20px] text-foreground leading-6">
                 APY
               </h2>
               <InfoTooltip
@@ -233,15 +234,12 @@ export function EarnChartCard({
         </div>
         <button
           aria-label={actionAriaLabel}
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onAction}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={actionIconSrc}
           />
         </button>
@@ -389,7 +387,7 @@ function ExpandedChartOverlay({
             footer={
               <div className="w-full px-4 pt-2 pb-4 min-[796px]:hidden">
                 <button
-                  className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-[#f5f5f5] font-medium text-[16px] text-black leading-5 hover:bg-[#ececec]"
+                  className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-secondary font-medium text-[16px] text-foreground leading-5 hover:bg-accent-active"
                   onClick={onClose}
                   type="button"
                 >
@@ -400,7 +398,7 @@ function ExpandedChartOverlay({
             isExpanded
             onAction={onClose}
             onSelectTab={onSelectTab}
-            sectionClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+            sectionClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
             selectedTab={selectedTab}
           />
         </div>
@@ -468,7 +466,7 @@ export function EarnChartPane({
             isLoggedOut={isLoggedOut}
             onAction={() => onExpandedChange(true)}
             onSelectTab={onSelectTab}
-            sectionClassName="flex h-[527px] w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white"
+            sectionClassName="flex h-[527px] w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card"
             selectedTab={selectedTab}
           />
           {statsPanel}

--- a/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
@@ -4,6 +4,7 @@ import { DogLottie } from "@/components/wallet-workspace/facelift/dog-lottie";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import { useSignInModal } from "@/contexts/sign-in-modal-context";
 import { useAuthCapability } from "@/lib/auth/capability";
@@ -52,10 +53,10 @@ export function EarnEmptyPane({
   ];
 
   return (
-    <section className="relative flex h-full min-w-0 flex-1 flex-col items-center rounded-3xl bg-white max-[795px]:overflow-clip max-[795px]:rounded-none">
+    <section className="relative flex h-full min-w-0 flex-1 flex-col items-center rounded-3xl bg-card max-[795px]:overflow-clip max-[795px]:rounded-none">
       <header className="flex w-full items-center p-2">
         <div className="flex min-w-0 flex-1 items-center gap-2 py-2 pl-4">
-          <h1 className="whitespace-nowrap font-semibold text-[24px] text-black leading-7">
+          <h1 className="whitespace-nowrap font-semibold text-[24px] text-foreground leading-7">
             Earn
           </h1>
           {/* ponytail: mock tooltip copy — real copy comes with the wiring pass */}
@@ -67,15 +68,12 @@ export function EarnEmptyPane({
         </div>
         <button
           aria-label="Open chart"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] min-[1204px]:hidden"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"
           onClick={onOpenChart}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={`${ASSET_BASE}/icon-chart.svg`}
           />
         </button>
@@ -89,8 +87,8 @@ export function EarnEmptyPane({
           >
             {headlineWords.map((word, index) => {
               const colorClassName = word.emphasized
-                ? "text-black"
-                : "text-[#8a8a8e]";
+                ? "text-foreground"
+                : "text-muted-foreground";
               if (!word.apyDependent) {
                 return (
                   <span className={colorClassName} key={index}>
@@ -104,7 +102,7 @@ export function EarnEmptyPane({
                 <SkeletonReveal
                   isRevealed={isApyLoaded}
                   key={index}
-                  skeletonClassName="rounded-[8px] bg-black/[0.06]"
+                  skeletonClassName="rounded-[8px] bg-accent-selected"
                 >
                   <span className={colorClassName}>
                     {isApyLoaded ? (
@@ -128,24 +126,21 @@ export function EarnEmptyPane({
           if (!isSignedIn) {
             return (
               <button
-                className="t-hover flex h-14 items-center justify-center rounded-full bg-[#f9363c] px-8 font-medium text-[20px] leading-6 hover:-translate-y-0.5 hover:bg-[#e62f35] active:translate-y-0"
+                className="t-hover flex h-14 items-center justify-center rounded-full bg-foreground px-8 font-medium text-[20px] leading-6 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 onClick={openSignIn}
                 type="button"
               >
-                <span className="text-white">Connect wallet</span>
+                <span className="text-background">Connect wallet</span>
               </button>
             );
           }
           return (
             <button
-              className="t-hover flex h-14 items-center justify-center gap-2 rounded-full bg-black px-6 text-white hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+              className="t-hover flex h-14 items-center justify-center gap-2 rounded-full bg-foreground px-6 text-background hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
               onClick={onDeposit}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
+              <ThemedIcon
                 className="size-6"
                 src={`${ASSET_BASE}/icon-plus.svg`}
               />

--- a/frontend/src/components/wallet-workspace/facelift/earn-modal.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-modal.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 import { useEffect } from "react";
 
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -67,7 +68,7 @@ export function EarnModal({
           ? "items-end justify-end p-2"
           : "items-center justify-center p-4"
       }`}
-      sheetClassName={`flex max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none ${
+      sheetClassName={`flex max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none ${
         withMascot ? "w-[724px]" : "w-[400px]"
       }`}
     >
@@ -76,16 +77,16 @@ export function EarnModal({
           <div className="flex min-h-[300px] w-full flex-col p-2 max-[795px]:min-h-0">
             <div className="flex w-full flex-col gap-6 px-4 pt-4 pb-2">
               {Icon ? (
-                <span className="flex size-16 items-center justify-center rounded-[14.667px] bg-[#f9363c]">
+                <span className="flex size-16 items-center justify-center rounded-[14.667px] bg-primary">
                   <Icon aria-hidden="true" className="size-11 text-white" />
                 </span>
               ) : null}
               <div className="flex w-full flex-col gap-3 pr-4">
-                <h2 className="font-semibold text-[36px] text-black leading-10 tracking-[-0.72px]">
+                <h2 className="font-semibold text-[36px] text-foreground leading-10 tracking-[-0.72px]">
                   {title}
                 </h2>
                 {description ? (
-                  <p className="text-[16px] leading-5 text-[#8a8a8e]">
+                  <p className="text-[16px] leading-5 text-muted-foreground">
                     {description}
                   </p>
                 ) : null}
@@ -98,15 +99,15 @@ export function EarnModal({
                     <span className="flex items-start py-[9px] pr-3">
                       <step.icon
                         aria-hidden="true"
-                        className="size-6 text-[#8a8a8e]"
+                        className="size-6 text-muted-foreground"
                       />
                     </span>
                     <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                      <span className="font-medium text-[16px] text-black leading-5">
+                      <span className="font-medium text-[16px] text-foreground leading-5">
                         {step.title}
                       </span>
                       {step.description ? (
-                        <span className="text-[13px] leading-4 text-[#8a8a8e]">
+                        <span className="text-[13px] leading-4 text-muted-foreground">
                           {step.description}
                         </span>
                       ) : null}
@@ -118,7 +119,7 @@ export function EarnModal({
           </div>
           <div className="w-full px-4 pt-2 pb-4">
             <button
-              className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+              className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
               onClick={onAction}
               type="button"
             >
@@ -144,15 +145,12 @@ export function EarnModal({
         <div className="absolute top-2 right-2">
           <button
             aria-label="Close"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onClose}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-cross.svg`}
             />
           </button>

--- a/frontend/src/components/wallet-workspace/facelift/earn-position-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-position-pane.tsx
@@ -20,6 +20,7 @@ import {
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
 import { ApyRevealText } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { formatEarnApyLabel } from "@/lib/kamino/earn-forecast.shared";
@@ -77,10 +78,10 @@ export function EarnPositionPane({
   return (
     <div className="flex h-full min-w-0 flex-1 flex-col">
       <div className="flex min-h-0 w-full flex-1 flex-col gap-2 overflow-y-auto">
-        <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-t-none">
+        <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-t-none">
           <header className="flex w-full items-center p-2">
             <div className="flex min-w-0 flex-1 items-center gap-2 py-2 pl-4">
-              <h1 className="whitespace-nowrap font-semibold text-[24px] text-black leading-7">
+              <h1 className="whitespace-nowrap font-semibold text-[24px] text-foreground leading-7">
                 Earn
               </h1>
               {/* ponytail: mock tooltip copy — real copy comes with the wiring pass */}
@@ -92,34 +93,28 @@ export function EarnPositionPane({
             </div>
             <div className="flex shrink-0 items-start gap-2 pl-3 max-[795px]:hidden">
               <button
-                className="t-hover flex items-center justify-center gap-2 rounded-full bg-black/[0.04] p-2.5 hover:-translate-y-0.5 hover:bg-black/[0.08] active:translate-y-0"
+                className="t-hover flex items-center justify-center gap-2 rounded-full bg-accent p-2.5 hover:-translate-y-0.5 hover:bg-accent-active active:translate-y-0"
                 onClick={() => onWithdraw()}
                 type="button"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-6"
+                <ThemedIcon
+                  className="size-6 text-muted-foreground"
                   src={`${ASSET_BASE}/icon-withdraw-arrow.svg`}
                 />
-                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
+                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
                   Withdraw
                 </span>
               </button>
               <button
-                className="t-hover flex items-center justify-center gap-2 rounded-full bg-black p-2.5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+                className="t-hover flex items-center justify-center gap-2 rounded-full bg-foreground p-2.5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 onClick={onDeposit}
                 type="button"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-6"
+                <ThemedIcon
+                  className="size-6 text-background"
                   src={`${ASSET_BASE}/icon-plus.svg`}
                 />
-                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-white leading-5">
+                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-background leading-5">
                   Deposit
                 </span>
               </button>
@@ -129,9 +124,9 @@ export function EarnPositionPane({
           <div className="w-full p-2">
             <div className="flex h-[86px] w-full flex-col items-start gap-0.5 rounded-[20px] px-4 py-2">
               <div className="flex items-start gap-1">
-                <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                   {"Balance · "}
-                  <span className="text-[#34c759]">
+                  <span className="text-positive">
                     <ApyRevealText
                       isRevealed={isApyLoaded}
                       segments={[{ text: formatEarnApyLabel(apy.apyBps) }]}
@@ -149,7 +144,9 @@ export function EarnPositionPane({
                   <p
                     className="whitespace-nowrap font-semibold text-[40px] leading-[46px] [font-variant-numeric:tabular-nums] max-[760px]:text-[clamp(30px,9.5vw,40px)] max-[760px]:leading-[1.08]"
                     style={{
-                      color: isBalanceHidden ? "#BBBBC0" : "#000",
+                      color: isBalanceHidden
+                        ? "var(--tertiary)"
+                        : "var(--foreground)",
                     }}
                   >
                     <ScrambledPopDigits
@@ -157,9 +154,7 @@ export function EarnPositionPane({
                       segments={[
                         { text: balance.whole },
                         {
-                          color: isBalanceHidden
-                            ? "#BBBBC0"
-                            : "rgba(60, 60, 67, 0.4)",
+                          color: "var(--tertiary)",
                           text: balance.fraction,
                         },
                       ]}
@@ -182,12 +177,12 @@ export function EarnPositionPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                <p className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+                <p className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
                   Autodeposit
                 </p>
                 {/* No truncate: the setup teaser must wrap on narrow screens
                     instead of clipping mid-word. */}
-                <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <p className="text-[13px] leading-4 text-muted-foreground">
                   {/* Hiding masks the amount-bearing label through TextSwap's
                       own swap animation (churning it would thrash the swap). */}
                   <TextSwap
@@ -203,15 +198,12 @@ export function EarnPositionPane({
                 <div className="flex items-center justify-end gap-1 pl-3">
                   <button
                     aria-label="Autodeposit settings"
-                    className="t-hover flex size-11 items-center justify-center rounded-[20px] hover:bg-black/[0.04]"
+                    className="t-hover flex size-11 items-center justify-center rounded-[20px] hover:bg-accent"
                     onClick={onOpenAutodeposit}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-muted-foreground"
                       src={`${ASSET_BASE}/icon-settings-slider.svg`}
                     />
                   </button>
@@ -235,20 +227,17 @@ export function EarnPositionPane({
                 <div className="flex items-center gap-1 pl-3">
                   <button
                     aria-label="How Autodeposit works"
-                    className="t-hover hidden size-11 items-center justify-center rounded-[20px] hover:bg-black/[0.04] max-[795px]:flex"
+                    className="t-hover hidden size-11 items-center justify-center rounded-[20px] hover:bg-accent max-[795px]:flex"
                     onClick={() => setIsInfoOpen(true)}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
                       src={`${ASSET_BASE}/icon-question.svg`}
                     />
                   </button>
                   <button
-                    className="t-hover min-w-16 rounded-full bg-[#f9363c] px-4 py-2.5 text-center font-medium text-[13px] text-white leading-4 hover:-translate-y-0.5 hover:bg-[#e62f35] active:translate-y-0"
+                    className="t-hover min-w-16 rounded-full bg-primary px-4 py-2.5 text-center font-medium text-[13px] text-white leading-4 hover:-translate-y-0.5 hover:bg-primary/90 active:translate-y-0"
                     onClick={onOpenAutodeposit}
                     type="button"
                   >
@@ -258,7 +247,7 @@ export function EarnPositionPane({
               )}
             </div>
             {data.autodepositToggleError ? (
-              <p className="px-4 pt-1 pb-2 text-[13px] leading-4 text-[#f9363c]">
+              <p className="px-4 pt-1 pb-2 text-[13px] leading-4 text-destructive">
                 {data.autodepositToggleError}
               </p>
             ) : null}
@@ -273,7 +262,7 @@ export function EarnPositionPane({
           earnData={data}
           onAction={onOpenChart}
           onSelectTab={onSelectChartTab}
-          sectionClassName="hidden h-[406px] w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:flex"
+          sectionClassName="hidden h-[406px] w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:flex"
           selectedTab={selectedChartTab}
         />
 
@@ -296,37 +285,31 @@ export function EarnPositionPane({
       </div>
 
       {/* Mobile sticky action bar (Figma 4693:70601). */}
-      <div className="hidden w-full shrink-0 bg-white px-4 py-2 max-[795px]:block">
+      <div className="hidden w-full shrink-0 bg-card px-4 py-2 max-[795px]:block">
         <div className="flex w-full gap-2">
           <button
-            className="t-hover flex h-12 min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-black hover:bg-[#171717]"
+            className="t-hover flex h-12 min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-foreground hover:bg-foreground/90"
             onClick={onDeposit}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-background"
               src={`${ASSET_BASE}/icon-plus.svg`}
             />
-            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-white leading-5">
+            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-background leading-5">
               Deposit
             </span>
           </button>
           <button
-            className="t-hover flex h-12 min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-black/[0.04] hover:bg-black/[0.08]"
+            className="t-hover flex h-12 min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-accent hover:bg-accent-active"
             onClick={() => onWithdraw()}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-withdraw-arrow.svg`}
             />
-            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
+            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
               Withdraw
             </span>
           </button>

--- a/frontend/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
@@ -48,13 +48,13 @@ function StatValue({
   return (
     <div className="flex w-full flex-col gap-0.5 px-4 py-2">
       <div className="flex items-center gap-1">
-        <p className="text-[16px] leading-5 text-[#8a8a8e]">{label}</p>
+        <p className="text-[16px] leading-5 text-muted-foreground">{label}</p>
         <InfoTooltip text={tooltip} />
       </div>
-      <p className="w-full font-semibold text-[40px] text-black leading-[48px]">
+      <p className="w-full font-semibold text-[40px] text-foreground leading-[48px]">
         {value.balanceWhole}
         {value.balanceFraction ? (
-          <span className="text-[#b1b1b4]">{value.balanceFraction}</span>
+          <span className="text-tertiary">{value.balanceFraction}</span>
         ) : null}
       </p>
     </div>
@@ -111,7 +111,7 @@ function AumBarChart({
           }
         }
       `}</style>
-      <div className="flex w-full items-center justify-between px-4 pb-2 text-[13px] leading-4 text-[#8a8a8e]">
+      <div className="flex w-full items-center justify-between px-4 pb-2 text-[13px] leading-4 text-tertiary">
         <p className={hoveredPoint ? "" : "invisible"}>
           {hoveredPoint?.label ?? " "}
         </p>
@@ -134,8 +134,8 @@ function AumBarChart({
                   ["--bar-index" as string]: index,
                   backgroundColor:
                     hoveredIndex === index
-                      ? "rgba(52,199,89,0.6)"
-                      : "rgba(52,199,89,0.4)",
+                      ? "color-mix(in oklab, var(--positive) 60%, transparent)"
+                      : "color-mix(in oklab, var(--positive) 40%, transparent)",
                   height: `${Math.max(
                     MIN_BAR_HEIGHT_PX,
                     Math.round((point.value / maxValue) * CHART_HEIGHT_PX)
@@ -148,7 +148,7 @@ function AumBarChart({
           </div>
         ))}
       </div>
-      <div className="flex w-full items-start justify-between px-4 py-2 text-[13px] leading-4 text-[#8a8a8e]">
+      <div className="flex w-full items-start justify-between px-4 py-2 text-[13px] leading-4 text-tertiary">
         <p>{firstPoint?.label}</p>
         <p>{lastPoint?.label}</p>
       </div>
@@ -209,29 +209,29 @@ export function EarnStatsPanel() {
   }
 
   return (
-    <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white">
+    <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card">
       <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
           Loyal Stats
         </h2>
       </header>
       {stats === null ? (
         <div className="t-skel-rows flex flex-col gap-2 px-6 pt-2 pb-6">
-          <div className="h-[76px] w-full rounded-2xl bg-black/[0.04]" />
-          <div className="h-[240px] w-full rounded-2xl bg-black/[0.04]" />
-          <div className="h-[76px] w-full rounded-2xl bg-black/[0.04]" />
+          <div className="h-[76px] w-full rounded-2xl bg-accent" />
+          <div className="h-[240px] w-full rounded-2xl bg-accent" />
+          <div className="h-[76px] w-full rounded-2xl bg-accent" />
         </div>
       ) : (
         <div className="flex w-full flex-col pb-4">
           <div className="flex w-full flex-col px-2 pt-2">
             <div className="flex w-full flex-col gap-0.5 px-4 py-2">
               <div className="flex items-center gap-1">
-                <p className="text-[16px] leading-5 text-[#8a8a8e]">Earn AUM</p>
+                <p className="text-[16px] leading-5 text-muted-foreground">Earn AUM</p>
                 <InfoTooltip text={AUM_TOOLTIP} />
               </div>
-              <p className="w-full font-semibold text-[40px] text-black leading-[48px]">
+              <p className="w-full font-semibold text-[40px] text-foreground leading-[48px]">
                 {splitUsdBalance(displayedAumUsd).balanceWhole}
-                <span className="text-[#b1b1b4]">
+                <span className="text-tertiary">
                   {splitUsdBalance(displayedAumUsd).balanceFraction}
                 </span>
               </p>
@@ -239,7 +239,10 @@ export function EarnStatsPanel() {
                 <p
                   className="text-[16px] leading-5"
                   style={{
-                    color: displayedAumDeltaUsd > 0 ? "#34c759" : "#f9363c",
+                    color:
+                      displayedAumDeltaUsd > 0
+                        ? "var(--positive)"
+                        : "var(--destructive)",
                   }}
                 >
                   {formatSignedUsd(displayedAumDeltaUsd)} vs prior week

--- a/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -216,7 +216,7 @@ export function EarnToastHost() {
       role="status"
     >
       <div
-        className={`t-toast t-toast-resize flex flex-col justify-center overflow-hidden bg-white font-medium text-[14px] text-black leading-5 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] ${
+        className={`t-toast t-toast-resize flex flex-col justify-center overflow-hidden bg-popover font-medium text-[14px] text-foreground leading-5 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] ${
           isOpen ? "is-open" : ""
         }`}
         // Top-anchored, so the pill drops in from above its resting spot
@@ -252,7 +252,7 @@ export function EarnToastHost() {
                     data-state={state}
                   >
                     <span className="t-step-ico" data-ico="p">
-                      <span className="size-1.5 rounded-full bg-black/20" />
+                      <span className="size-1.5 rounded-full bg-foreground/20" />
                     </span>
                     <span className="t-step-ico" data-ico="a">
                       <SpinnerIcon className="size-4" />
@@ -265,7 +265,7 @@ export function EarnToastHost() {
                     </span>
                   </span>
                   <span
-                    className={`t-step-label min-w-0 truncate ${state === "p" ? "text-black/40" : ""}`}
+                    className={`t-step-label min-w-0 truncate ${state === "p" ? "text-muted-foreground" : ""}`}
                   >
                     <TextSwap
                       className={state === "a" ? "t-step-active" : ""}
@@ -340,7 +340,7 @@ function SpinnerIcon({ className }: { className?: string }) {
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 64 64">
-      <circle cx="32" cy="32" fill="#34c759" r="32" />
+      <circle cx="32" cy="32" fill="var(--positive)" r="32" />
       <path
         d="M20 33l8 8 16-16"
         stroke="white"
@@ -355,7 +355,7 @@ function CheckIcon({ className }: { className?: string }) {
 function CrossIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 64 64">
-      <circle cx="32" cy="32" fill="#f9363c" r="32" />
+      <circle cx="32" cy="32" fill="var(--destructive)" r="32" />
       <path
         d="M23 23l18 18M41 23l-18 18"
         stroke="white"

--- a/frontend/src/components/wallet-workspace/facelift/earned-chart.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earned-chart.tsx
@@ -29,11 +29,11 @@ import { deriveEarnEarningsDisplayAmounts } from "@/lib/yield-optimization/earni
 
 // Figma 4693:67592 (compact) / 4693:68575 (expanded) — bars are flex-1 so the
 // wider expanded pane thickens them without extra layout rules.
-const BAR_COLOR = "rgba(52, 199, 89, 0.4)";
-const BAR_HOVER_COLOR = "rgba(52, 199, 89, 0.16)";
-const TODAY_BAR_BORDER_COLOR = "#34c759";
+const BAR_COLOR = "color-mix(in srgb, var(--positive) 40%, transparent)";
+const BAR_HOVER_COLOR = "color-mix(in srgb, var(--positive) 16%, transparent)";
+const TODAY_BAR_BORDER_COLOR = "var(--positive)";
 const TODAY_BAR_HOVER_FILL =
-  "linear-gradient(180deg, rgba(52, 199, 89, 0.6) 0%, rgba(52, 199, 89, 0) 100%)";
+  "linear-gradient(180deg, color-mix(in srgb, var(--positive) 60%, transparent) 0%, transparent 100%)";
 // Tallest bar tops out at 290/300 of the chart height in the Figma spec.
 const BAR_MAX_FRACTION = 290 / 300;
 const BAR_MIN_HEIGHT_PX = 4;
@@ -173,7 +173,7 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
         /* Full-height column track behind the bar — hover feedback stays
            visible even when the day's bar is tiny or absent. */
         .earned-bar-track {
-          background: rgba(0, 0, 0, 0.04);
+          background: var(--accent);
           border-radius: 4px;
           inset: 0;
           opacity: 0;
@@ -212,10 +212,10 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
       `}</style>
 
       <div className="flex w-full flex-col gap-0.5 pb-2">
-        <p className="truncate text-[16px] leading-5 text-[#8a8a8e]">
+        <p className="truncate text-[16px] leading-5 text-muted-foreground">
           {headerSubtitle}
         </p>
-        <p className="font-semibold text-[40px] text-black leading-[48px]">
+        <p className="font-semibold text-[40px] text-foreground leading-[48px]">
           {earningsUnavailable ? (
             "Unavailable"
           ) : (
@@ -230,7 +230,7 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
                   popOnChange={false}
                   segments={[
                     { text: `$${headerValue.whole}` },
-                    { color: "#b1b1b4", text: `.${headerValue.fraction}` },
+                    { color: "var(--tertiary)", text: `.${headerValue.fraction}` },
                   ]}
                 />
               )}
@@ -239,7 +239,7 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
         </p>
       </div>
 
-      <div className="flex w-full justify-between pb-2 text-[13px] leading-4 text-[#8a8a8e]">
+      <div className="flex w-full justify-between pb-2 text-[13px] leading-4 text-tertiary">
         <span>{hoveredDateRowLabel}</span>
         <span>
           <ScrambleText
@@ -258,10 +258,10 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
         onMouseLeave={() => setHoveredBar(null)}
       >
         {earningsUnavailable ? (
-          <div className="flex h-full flex-1 flex-col items-center justify-center gap-2 text-[13px] leading-4 text-[#8a8a8e]">
+          <div className="flex h-full flex-1 flex-col items-center justify-center gap-2 text-[13px] leading-4 text-muted-foreground">
             <span>Earnings are temporarily unavailable.</span>
             <button
-              className="t-hover rounded-full bg-black/[0.04] px-3 py-1.5 text-black hover:bg-black/[0.08]"
+              className="t-hover rounded-full bg-accent px-3 py-1.5 text-foreground hover:bg-accent-active"
               onClick={refreshEarnings}
               type="button"
             >
@@ -322,13 +322,13 @@ export function EarnedChart({ data }: { data: EarnPositionData }) {
         {dailyBars.length === 0 &&
         !showEarningsLoader &&
         !earningsUnavailable ? (
-          <div className="flex h-full flex-1 items-center justify-center text-[13px] leading-4 text-[#8a8a8e]">
+          <div className="flex h-full flex-1 items-center justify-center text-[13px] leading-4 text-muted-foreground">
             No earnings yet
           </div>
         ) : null}
       </div>
 
-      <div className="flex w-full justify-between pt-2 text-[13px] leading-4 text-[#8a8a8e]">
+      <div className="flex w-full justify-between pt-2 text-[13px] leading-4 text-tertiary">
         <span className="whitespace-nowrap">{dailyBars[0]?.label ?? ""}</span>
         <span className="whitespace-nowrap">
           {dailyBars[dailyBars.length - 1]?.label ?? ""}

--- a/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/flow-explainer.tsx
@@ -9,6 +9,7 @@ import {
   StaggerLine,
   StaggerReveal,
 } from "@/components/wallet-workspace/facelift/stagger-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -113,10 +114,10 @@ export function FlowDiagram({
                   isLast ? "" : "pb-5"
                 }`}
               >
-                <p className="font-medium text-[16px] text-black leading-5">
+                <p className="font-medium text-[16px] text-foreground leading-5">
                   {title}
                 </p>
-                <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <p className="text-[13px] leading-4 text-muted-foreground">
                   {body}
                 </p>
               </div>
@@ -126,7 +127,7 @@ export function FlowDiagram({
       })}
       {footnote ? (
         <StaggerLine index={steps.length}>
-          <p className="pt-5 text-[13px] leading-4 text-[rgba(60,60,67,0.45)]">
+          <p className="pt-5 text-[13px] leading-4 text-tertiary">
             {footnote}
           </p>
         </StaggerLine>
@@ -134,7 +135,7 @@ export function FlowDiagram({
       {docsHref ? (
         <StaggerLine index={steps.length + (footnote ? 1 : 0)}>
           <a
-            className="t-hover mt-5 inline-block font-medium text-[13px] leading-4 text-[rgba(60,60,67,0.6)] hover:text-black"
+            className="t-hover mt-5 inline-block font-medium text-[13px] leading-4 text-muted-foreground hover:text-foreground"
             href={docsHref}
             rel="noreferrer"
             target="_blank"
@@ -160,9 +161,9 @@ export function FlowExplainerAside({
 }) {
   return (
     <aside className="hidden h-full w-[400px] shrink-0 flex-col gap-2 overflow-y-auto [scrollbar-width:none] min-[1204px]:flex [&::-webkit-scrollbar]:hidden">
-      <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-white">
+      <section className="flex w-full shrink-0 flex-col overflow-clip rounded-3xl bg-card">
         <header className="flex w-full items-center p-2">
-          <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+          <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
             {title}
           </h2>
         </header>
@@ -206,23 +207,20 @@ export function FlowExplainerOverlay({
       isOpen={isOpen}
       onClose={onClose}
       scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 pl-[368px] backdrop-blur-[4px] min-[1204px]:hidden max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8"
-      sheetClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+      sheetClassName="flex h-full w-full min-w-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
     >
       <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
           {title}
         </h2>
         <button
           aria-label="Close info"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onClose}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={`${ASSET_BASE}/icon-cross.svg`}
           />
         </button>
@@ -230,7 +228,7 @@ export function FlowExplainerOverlay({
       {children}
       <div className="w-full px-4 pt-2 pb-4 min-[796px]:hidden">
         <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-[#f5f5f5] font-medium text-[16px] text-black leading-5 hover:bg-[#ececec]"
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-secondary font-medium text-[16px] text-foreground leading-5 hover:bg-accent-active"
           onClick={onClose}
           type="button"
         >

--- a/frontend/src/components/wallet-workspace/facelift/info-tooltip.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/info-tooltip.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useId, useLayoutEffect, useRef } from "react";
 
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+
 const ASSET_BASE = "/wallet-workspace/facelift";
 const CLIP_PADDING_PX = 8;
 
@@ -84,11 +86,8 @@ export function InfoTooltip({
         className="t-tt-trigger flex cursor-help items-center justify-center"
         type="button"
       >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          alt=""
-          aria-hidden="true"
-          className={iconClassName}
+        <ThemedIcon
+          className={`${iconClassName} text-tertiary`}
           src={`${ASSET_BASE}/icon-question.svg`}
         />
       </button>

--- a/frontend/src/components/wallet-workspace/facelift/matrix-loader.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/matrix-loader.tsx
@@ -37,6 +37,52 @@ if (typeof window !== "undefined") {
   });
 }
 
+// The lottie's two cell colors are baked for a white surface; in dark the
+// pale cells glare, so the palette remaps at mount (the loader is transient,
+// so a mid-flight theme toggle isn't re-themed until remount).
+const DARK_CELL_REMAP: [from: number[], to: number[]][] = [
+  [
+    [249, 54, 60],
+    [255, 80, 80],
+  ], // brand red -> dark accent #FF5050
+  [
+    [227, 201, 202],
+    [85, 49, 54],
+  ], // pale pink -> #553136, same lift off #2B2930 as the pink has off white
+];
+
+function remapDarkCellColors(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      remapDarkCellColors(item);
+    }
+    return;
+  }
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  const color = record.c as { k?: unknown } | undefined;
+  if (
+    color &&
+    Array.isArray(color.k) &&
+    color.k.length >= 3 &&
+    color.k.every((channel) => typeof channel === "number")
+  ) {
+    const k = color.k as number[];
+    for (const [from, to] of DARK_CELL_REMAP) {
+      if (from.every((value, i) => Math.abs(k[i] * 255 - value) < 2)) {
+        for (let i = 0; i < 3; i++) {
+          k[i] = to[i] / 255;
+        }
+      }
+    }
+  }
+  for (const value of Object.values(record)) {
+    remapDarkCellColors(value);
+  }
+}
+
 // Brand-red "Matrix Loader" lottie. Shared by the sign-in wallet wait and the
 // Earn shell boot loader.
 export function MatrixLoader() {
@@ -55,10 +101,14 @@ export function MatrixLoader() {
         if (cancelled || !el) {
           return;
         }
+        // lottie mutates the data it plays; clone so concurrent/sequential
+        // mounts never share a poisoned object.
+        const data = structuredClone(animationData);
+        if (document.documentElement.classList.contains("dark")) {
+          remapDarkCellColors(data);
+        }
         anim = lottie.loadAnimation({
-          // lottie mutates the data it plays; clone so concurrent/sequential
-          // mounts never share a poisoned object.
-          animationData: structuredClone(animationData),
+          animationData: data,
           autoplay: !prefersReducedMotion,
           container: el,
           loop: true,

--- a/frontend/src/components/wallet-workspace/facelift/mobile-tab-bar.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/mobile-tab-bar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+
 const ASSET_BASE = "/wallet-workspace/facelift";
 
 // Figma 4813:400091 — mobile-only bottom tab bar: Wallet home · Earn (mascot
-// pill) · Activity. Active icons go black, inactive stay #B1B1B4. Shown only
-// on the root views; input screens (deposit/withdraw/autodeposit, send/swap)
-// hide it under the system keyboard.
+// pill) · Activity. Active icons render in the foreground color, inactive in
+// tertiary. Shown only on the root views; input screens (deposit/withdraw/
+// autodeposit, send/swap) hide it under the system keyboard.
 export function MobileTabBar({
   activeTab,
   onSelect,
@@ -16,7 +18,7 @@ export function MobileTabBar({
   showActivityBadge?: boolean;
 }) {
   return (
-    <div className="cherry-mobile-tab-bar w-full shrink-0 bg-white px-4 min-[796px]:hidden">
+    <div className="cherry-mobile-tab-bar w-full shrink-0 bg-card px-4 min-[796px]:hidden">
       <div className="flex w-full items-center gap-4">
         <button
           aria-current={activeTab === "wallet" ? "page" : undefined}
@@ -25,11 +27,10 @@ export function MobileTabBar({
           onClick={() => onSelect("wallet")}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-7"
+          <ThemedIcon
+            className={`size-7 ${
+              activeTab === "wallet" ? "text-foreground" : "text-tertiary"
+            }`}
             src={`${ASSET_BASE}/${
               activeTab === "wallet"
                 ? "icon-tab-wallet-black.svg"
@@ -48,7 +49,7 @@ export function MobileTabBar({
               light-red tint (4813:400091). */}
           <span
             className={`relative mx-auto block h-11 w-full max-w-16 overflow-hidden rounded-full ${
-              activeTab === "earn" ? "bg-black" : "bg-[rgba(249,54,60,0.14)]"
+              activeTab === "earn" ? "bg-foreground" : "bg-primary/[0.14]"
             }`}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -68,11 +69,10 @@ export function MobileTabBar({
           type="button"
         >
           <span className="relative">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-7"
+            <ThemedIcon
+              className={`size-7 ${
+                activeTab === "activity" ? "text-foreground" : "text-tertiary"
+              }`}
               src={`${ASSET_BASE}/${
                 activeTab === "activity"
                   ? "icon-tab-clock-black.svg"
@@ -84,7 +84,7 @@ export function MobileTabBar({
               className="t-badge t-badge-tab"
               data-open={showActivityBadge ? "true" : "false"}
             >
-              <span className="t-badge-dot size-1.5 rounded-full bg-[#f9363c]" />
+              <span className="t-badge-dot size-1.5 rounded-full bg-primary" />
             </span>
           </span>
         </button>

--- a/frontend/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { copyTextToClipboard } from "@/components/wallet-workspace/facelift/copy-text";
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -54,43 +55,40 @@ export function ReceiveSheet({
       isOpen={isOpen}
       onClose={onClose}
       scrimClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:items-end max-[795px]:bg-white/60 max-[795px]:p-0"
-      sheetClassName="flex w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+      sheetClassName="flex w-[400px] min-w-0 flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
     >
       <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
           Receive
         </h2>
         <button
           aria-label="Close receive"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onClose}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={`${ASSET_BASE}/icon-cross.svg`}
           />
         </button>
       </header>
       <div className="flex w-full flex-col items-center gap-6 px-6 pt-2 pb-2">
-        <p className="max-w-[300px] text-center text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
           Use to receive tokens on the Solana network only. Other assets will
           be lost forever.
         </p>
-        <div className="flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-black/[0.08] p-8">
+        <div className="flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-border p-8">
           {walletAddress ? (
             <div className="relative">
               <QRCodeSVG
                 bgColor="transparent"
-                fgColor="#000"
+                fgColor="var(--foreground)"
                 level="M"
                 size={192}
                 value={walletAddress}
               />
-              <span className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 flex h-8 w-10 items-center justify-center rounded bg-white p-0.5">
+              <span className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 flex h-8 w-10 items-center justify-center rounded bg-card p-0.5">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   alt=""
@@ -101,16 +99,16 @@ export function ReceiveSheet({
               </span>
             </div>
           ) : (
-            <div className="size-48 rounded-lg bg-black/[0.04]" />
+            <div className="size-48 rounded-lg bg-accent" />
           )}
-          <p className="break-all text-center text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+          <p className="break-all text-center text-[13px] leading-4 text-muted-foreground">
             {walletAddress ?? "No wallet connected"}
           </p>
         </div>
       </div>
       <div className="w-full px-5 pt-2 pb-4">
         <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0 disabled:opacity-40"
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-40"
           disabled={!walletAddress}
           onClick={handleCopy}
           type="button"

--- a/frontend/src/components/wallet-workspace/facelift/send-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/send-pane.tsx
@@ -24,6 +24,7 @@ import {
 import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transitions";
 import { SplitAmount } from "@/components/wallet-workspace/facelift/sidebar";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { usePrivateSend } from "@/hooks/use-private-send";
 import { useSend } from "@/hooks/use-send";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
@@ -94,8 +95,8 @@ export function useSendRecentRecipients(walletAddress: string | null): {
 // Wallet stash square shared by the "To" cell and the recent-recipient rows.
 function RecipientStashIcon() {
   return (
-    <span className="flex size-11 shrink-0 items-center justify-center rounded-[11px] bg-black/[0.04]">
-      <Wallet className="text-[#8a8a8e]" size={24} strokeWidth={1.8} />
+    <span className="flex size-11 shrink-0 items-center justify-center rounded-[11px] bg-accent">
+      <Wallet className="text-muted-foreground" size={24} strokeWidth={1.8} />
     </span>
   );
 }
@@ -254,7 +255,7 @@ export function SendPane({
         into the shell's 8px gap and sit flush with the viewport bottom (same
         escape the earn empty pane uses); the form keeps the clip. */
     <section
-      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-white max-[795px]:rounded-none ${
+      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-card max-[795px]:rounded-none ${
         step === "success" || step === "error"
           ? "max-[795px]:overflow-clip"
           : "overflow-clip"
@@ -264,21 +265,18 @@ export function SendPane({
         <div className="flex shrink-0 items-center pr-3">
           <button
             aria-label="Back"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onBack}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-arrow-left.svg`}
             />
           </button>
         </div>
         <div className="flex min-w-0 flex-1 items-center py-2">
-          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             Send
           </h1>
         </div>
@@ -290,19 +288,19 @@ export function SendPane({
             <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
               <div className="w-full shrink-0 p-2">
                 <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     Amount
                   </p>
                   <div className="flex w-full items-center">
                     <div className="flex h-12 min-w-0 flex-1 items-baseline">
                       {isUsdInput ? (
-                        <span className="font-semibold text-[40px] text-black leading-[48px]">
+                        <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                           $
                         </span>
                       ) : null}
                       <input
                         autoFocus
-                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                         inputMode="decimal"
                         onChange={(event) =>
                           handleAmountChange(event.target.value)
@@ -315,21 +313,18 @@ export function SendPane({
                     <div className="flex shrink-0 items-center pl-3">
                       <button
                         aria-label="Switch between token and dollar amounts"
-                        className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                        className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
                         onClick={handleToggleCurrency}
                         type="button"
                       >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          alt=""
-                          aria-hidden="true"
-                          className="size-6"
+                        <ThemedIcon
+                          className="size-6 text-tertiary"
                           src={`${ASSET_BASE}/icon-arrow-top-bottom.svg`}
                         />
                       </button>
                     </div>
                   </div>
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     {isUsdInput
                       ? `${formatTokenAmount(tokenAmount)} ${token.symbol}`
                       : `$${formatUsdAmount(usdAmount)}`}
@@ -341,11 +336,11 @@ export function SendPane({
                   ready. The fee matches the OG flow's flat reserve. */}
               {isReady ? (
                 <div className="w-full shrink-0 px-2">
-                  <div className="flex w-full items-center justify-between rounded-xl bg-black/[0.04] px-4 py-2.5">
-                    <span className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <div className="flex w-full items-center justify-between rounded-xl bg-accent px-4 py-2.5">
+                    <span className="text-[13px] leading-4 text-muted-foreground">
                       Network Fee
                     </span>
-                    <span className="text-[13px] text-black leading-4">
+                    <span className="text-[13px] text-foreground leading-4">
                       {SOL_FEE_RESERVE} SOL ~ &lt;$0.01
                     </span>
                   </div>
@@ -357,9 +352,9 @@ export function SendPane({
               <div className="relative mt-auto flex w-full shrink-0 flex-col gap-1 p-2">
                 <span
                   aria-hidden="true"
-                  className="-translate-y-1/2 absolute top-1/2 left-[45px] h-3.5 w-0.5 rounded-full bg-[#d9d9d9]"
+                  className="-translate-y-1/2 absolute top-1/2 left-[45px] h-3.5 w-0.5 rounded-full bg-border"
                 />
-                <div className="t-hover flex w-full items-center rounded-2xl px-4 hover:bg-black/[0.04]">
+                <div className="t-hover flex w-full items-center rounded-2xl px-4 hover:bg-accent">
                   <button
                     className="flex min-w-0 flex-1 items-center text-left"
                     onClick={onOpenAssetSelect}
@@ -386,12 +381,12 @@ export function SendPane({
                     <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
                       <SplitAmount
                         fraction={balanceSplit.balanceFraction}
-                        fractionColor="#b1b1b4"
+                        fractionColor="var(--tertiary)"
                         isHidden={isBalanceHidden}
                         isRevealed
                         whole={balanceSplit.balanceWhole}
                       />
-                      <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                      <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                         <ScrambleText
                           isHidden={isBalanceHidden}
                           text={`${formatTokenAmount(token.balance)} ${
@@ -403,7 +398,7 @@ export function SendPane({
                   </button>
                   <span className="flex shrink-0 items-center pl-3">
                     <button
-                      className="t-hover flex min-w-16 items-center justify-center rounded-full bg-black/[0.04] px-4 py-2.5 font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                      className="t-hover flex min-w-16 items-center justify-center rounded-full bg-accent px-4 py-2.5 font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                       onClick={handleMax}
                       type="button"
                     >
@@ -416,17 +411,14 @@ export function SendPane({
                     onClick={onOpenAssetSelect}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-muted-foreground"
                       src={`${ASSET_BASE}/icon-chevron-grabber.svg`}
                     />
                   </button>
                 </div>
                 <button
-                  className="t-hover flex w-full items-center rounded-2xl px-4 text-left hover:bg-black/[0.04]"
+                  className="t-hover flex w-full items-center rounded-2xl px-4 text-left hover:bg-accent"
                   onClick={onOpenRecipientSelect}
                   type="button"
                 >
@@ -434,12 +426,12 @@ export function SendPane({
                     <RecipientStashIcon />
                   </span>
                   <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                    <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                    <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                       To
                     </span>
                     <span
                       className={`truncate font-medium text-[20px] leading-6 ${
-                        recipient ? "text-black" : "text-[#b1b1b4]"
+                        recipient ? "text-foreground" : "text-tertiary"
                       }`}
                     >
                       {recipient
@@ -448,11 +440,8 @@ export function SendPane({
                     </span>
                   </span>
                   <span className="flex shrink-0 items-center pl-3">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
                       src={`${ASSET_BASE}/icon-chevron-right.svg`}
                     />
                   </span>
@@ -460,14 +449,14 @@ export function SendPane({
               </div>
             </div>
 
-            <div className="w-full shrink-0 bg-white px-4 pt-2 pb-4">
+            <div className="w-full shrink-0 bg-card px-4 pt-2 pb-4">
               <button
                 className={`flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 transition-colors ${
                   isCtaInvalid
-                    ? "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+                    ? "bg-primary/[0.08] text-primary"
                     : ctaDisabled
-                    ? "bg-black text-white opacity-60"
-                    : "t-hover bg-black text-white hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+                    ? "bg-foreground text-background opacity-60"
+                    : "t-hover bg-foreground text-background hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 }`}
                 disabled={ctaDisabled}
                 onClick={() => void handleConfirm()}
@@ -554,7 +543,7 @@ export function SendRecipientPane({
     <div className="flex h-full w-full min-w-0 flex-col">
       <header className="flex w-full shrink-0 items-center p-2">
         <div className="flex min-w-0 flex-1 items-center py-2.5 pl-4 max-[795px]:pl-2">
-          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             Recipient
           </h2>
         </div>
@@ -562,15 +551,12 @@ export function SendRecipientPane({
           <div className="flex shrink-0 items-center pl-3">
             <button
               aria-label="Close"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={onClose}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-cross.svg`}
               />
             </button>
@@ -584,7 +570,7 @@ export function SendRecipientPane({
         <div className="flex w-full items-center">
           <input
             autoFocus
-            className="min-w-0 flex-1 bg-transparent font-medium text-[20px] text-black leading-6 outline-none placeholder:text-[#b1b1b4]"
+            className="min-w-0 flex-1 bg-transparent font-medium text-[20px] text-foreground leading-6 outline-none placeholder:text-tertiary"
             onChange={(event) => commitIfValid(event.target.value)}
             placeholder="Solana address"
             spellCheck={false}
@@ -595,15 +581,15 @@ export function SendRecipientPane({
             {trimmed.length > 0 ? (
               <button
                 aria-label="Clear address"
-                className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
                 onClick={() => setInput("")}
                 type="button"
               >
-                <CircleX className="text-[#b1b1b4]" size={24} />
+                <CircleX className="text-tertiary" size={24} />
               </button>
             ) : (
               <button
-                className="t-hover flex min-w-16 items-center justify-center rounded-full bg-black/[0.04] px-4 py-2.5 font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                className="t-hover flex min-w-16 items-center justify-center rounded-full bg-accent px-4 py-2.5 font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                 onClick={() => void handlePaste()}
                 type="button"
               >
@@ -613,7 +599,7 @@ export function SendRecipientPane({
           </span>
         </div>
         {isInvalid ? (
-          <p className="pt-2 text-[#f9363c] text-[14px] leading-5">
+          <p className="pt-2 text-destructive text-[14px] leading-5">
             Invalid Solana address
           </p>
         ) : null}
@@ -621,12 +607,12 @@ export function SendRecipientPane({
 
       {recents.length > 0 ? (
         <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
-          <p className="px-4 pt-3 pb-2 text-[16px] leading-5 text-[rgba(60,60,67,0.6)] tracking-[-0.176px]">
+          <p className="px-4 pt-3 pb-2 text-[16px] leading-5 text-muted-foreground tracking-[-0.176px]">
             Recently used
           </p>
           {recents.map((entry) => (
             <button
-              className="t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-black/[0.04]"
+              className="t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-accent"
               key={entry.address}
               onClick={() => onSelect(entry.address)}
               type="button"
@@ -635,10 +621,10 @@ export function SendRecipientPane({
                 <RecipientStashIcon />
               </span>
               <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+                <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
                   {truncateAddress(entry.address)}
                 </span>
-                <span className="whitespace-nowrap text-[#8a8a8e] text-[13px] leading-4">
+                <span className="whitespace-nowrap text-muted-foreground text-[13px] leading-4">
                   {entry.count === 1 ? "1 send" : `${entry.count} sends`}
                 </span>
               </span>

--- a/frontend/src/components/wallet-workspace/facelift/shell.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/shell.tsx
@@ -273,7 +273,7 @@ export function WorkspaceFaceliftShell() {
     <BalanceVisibilityProvider>
       {/* facelift-shell marks the workspace for globals.css's sign-in modal
           optical centering (the shell's side rails are asymmetric). */}
-      <div className="cherry-mobile-workspace facelift-shell flex h-dvh w-full overflow-clip bg-[#f5f5f5] text-black">
+      <div className="cherry-mobile-workspace facelift-shell flex h-dvh w-full overflow-clip bg-muted text-foreground">
         <HiddenBalanceFilterDefs />
         {/* Wrong-wallet guard for Earn actions — same prompt the old
             workspace mounts (ensureCanSignAccountAction opens it). */}
@@ -320,7 +320,7 @@ export function WorkspaceFaceliftShell() {
         />
         <div
           className={`flex h-full min-w-0 flex-1 flex-col ${
-            isMobileGrayBackground ? "" : "max-[795px]:bg-white"
+            isMobileGrayBackground ? "" : "max-[795px]:bg-card"
           }`}
         >
           {activePage === "wallet" ? (
@@ -379,7 +379,7 @@ export function WorkspaceFaceliftShell() {
                   }
                 >
                   {isPositionLoading ? (
-                    <section className="flex h-full min-w-0 flex-1 rounded-3xl bg-white max-[795px]:rounded-none" />
+                    <section className="flex h-full min-w-0 flex-1 rounded-3xl bg-card max-[795px]:rounded-none" />
                   ) : earnData.hasPosition ? (
                     <PaneReveal>
                       <EarnPositionPane

--- a/frontend/src/components/wallet-workspace/facelift/shield-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/shield-pane.tsx
@@ -25,6 +25,7 @@ import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transiti
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
 import { SplitAmount } from "@/components/wallet-workspace/facelift/sidebar";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useShield } from "@/hooks/use-shield";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
 import { getTokenIconUrl } from "@/lib/token-icon";
@@ -209,7 +210,7 @@ export function ShieldPane({
         into the shell's 8px gap and sit flush with the viewport bottom (same
         escape the earn empty pane uses); the form keeps the clip. */
     <section
-      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-white max-[795px]:rounded-none ${
+      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-card max-[795px]:rounded-none ${
         step === "success" || step === "error"
           ? "max-[795px]:overflow-clip"
           : "overflow-clip"
@@ -219,34 +220,28 @@ export function ShieldPane({
         <div className="flex shrink-0 items-center pr-3">
           <button
             aria-label="Back"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onBack}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-arrow-left.svg`}
             />
           </button>
         </div>
         <div className="flex min-w-0 flex-1 items-center gap-2 py-2">
-          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             <TextSwap text={direction === "shield" ? "Shield" : "Unshield"} />
           </h1>
           <button
             aria-label="What are Shielded Assets?"
-            className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onOpenInfo}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-tertiary"
               src={`${ASSET_BASE}/icon-question.svg`}
             />
           </button>
@@ -259,19 +254,19 @@ export function ShieldPane({
             <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
               <div className="w-full shrink-0 p-2">
                 <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     Amount
                   </p>
                   <div className="flex w-full items-center">
                     <div className="flex h-12 min-w-0 flex-1 items-baseline">
                       {isUsdInput ? (
-                        <span className="font-semibold text-[40px] text-black leading-[48px]">
+                        <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                           $
                         </span>
                       ) : null}
                       <input
                         autoFocus
-                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                         inputMode="decimal"
                         onChange={(event) =>
                           handleAmountChange(event.target.value)
@@ -284,21 +279,18 @@ export function ShieldPane({
                     <div className="flex shrink-0 items-center pl-3">
                       <button
                         aria-label="Switch between token and dollar amounts"
-                        className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                        className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
                         onClick={handleToggleCurrency}
                         type="button"
                       >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          alt=""
-                          aria-hidden="true"
-                          className="size-6"
+                        <ThemedIcon
+                          className="size-6 text-tertiary"
                           src={`${ASSET_BASE}/icon-arrow-top-bottom.svg`}
                         />
                       </button>
                     </div>
                   </div>
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     {isUsdInput
                       ? `${formatTokenAmount(tokenAmount)} ${token.symbol}`
                       : `$${formatUsdAmount(usdAmount)}`}
@@ -316,7 +308,7 @@ export function ShieldPane({
                       src={`${ASSET_BASE}/icon-circle-info.svg`}
                     />
                   </span>
-                  <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <p className="min-w-0 max-w-[400px] flex-1 py-2 text-[13px] leading-4 text-muted-foreground">
                     <TextSwap text={captionText} />
                   </p>
                 </div>
@@ -352,12 +344,12 @@ export function ShieldPane({
                     <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
                       <SplitAmount
                         fraction={balanceSplit.balanceFraction}
-                        fractionColor="#b1b1b4"
+                        fractionColor="var(--tertiary)"
                         isHidden={isBalanceHidden}
                         isRevealed
                         whole={balanceSplit.balanceWhole}
                       />
-                      <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                      <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                         <ScrambleText
                           isHidden={isBalanceHidden}
                           text={`${formatTokenAmount(token.balance)} ${
@@ -369,7 +361,7 @@ export function ShieldPane({
                   </button>
                   <span className="flex shrink-0 items-center pl-3">
                     <button
-                      className="t-hover flex min-w-16 items-center justify-center rounded-full bg-black/[0.04] px-4 py-2.5 font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                      className="t-hover flex min-w-16 items-center justify-center rounded-full bg-accent px-4 py-2.5 font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                       onClick={handleMax}
                       type="button"
                     >
@@ -380,14 +372,14 @@ export function ShieldPane({
               </div>
             </div>
 
-            <div className="w-full shrink-0 bg-white px-4 pt-2 pb-4">
+            <div className="w-full shrink-0 bg-card px-4 pt-2 pb-4">
               <button
                 className={`flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 transition-colors ${
                   isCtaInvalid
-                    ? "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+                    ? "bg-primary/[0.08] text-primary"
                     : ctaDisabled
-                    ? "bg-black text-white opacity-60"
-                    : "t-hover bg-black text-white hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+                    ? "bg-foreground text-background opacity-60"
+                    : "t-hover bg-foreground text-background hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 }`}
                 disabled={ctaDisabled}
                 onClick={() => void handleConfirm()}
@@ -487,7 +479,7 @@ export function ShieldAssetPane({
     <div className="flex h-full w-full min-w-0 flex-col">
       <header className="flex w-full shrink-0 items-center p-2">
         <div className="flex min-w-0 flex-1 items-center py-2.5 pl-4 max-[795px]:pl-2">
-          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             Select asset
           </h2>
         </div>
@@ -495,15 +487,12 @@ export function ShieldAssetPane({
           <div className="flex shrink-0 items-center pl-3">
             <button
               aria-label="Close"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={onClose}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-cross.svg`}
               />
             </button>
@@ -511,14 +500,14 @@ export function ShieldAssetPane({
         ) : null}
       </header>
       <div className="w-full shrink-0 px-4 pb-2">
-        <div className="flex w-full items-center rounded-full bg-black/[0.04] px-3">
+        <div className="flex w-full items-center rounded-full bg-accent px-3">
           <Search
-            className="mr-3 shrink-0 text-[#8a8a8e]"
+            className="mr-3 shrink-0 text-muted-foreground"
             size={24}
             strokeWidth={2}
           />
           <input
-            className="min-w-0 flex-1 bg-transparent py-3 text-[16px] text-black leading-5 outline-none placeholder:text-[#8a8a8e]"
+            className="min-w-0 flex-1 bg-transparent py-3 text-[16px] text-foreground leading-5 outline-none placeholder:text-muted-foreground"
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search assets"
             type="text"
@@ -528,7 +517,7 @@ export function ShieldAssetPane({
       </div>
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
         {filtered.length === 0 ? (
-          <p className="px-4 py-8 text-center text-[14px] leading-5 text-[rgba(60,60,67,0.6)]">
+          <p className="px-4 py-8 text-center text-[14px] leading-5 text-muted-foreground">
             No assets found
           </p>
         ) : (
@@ -540,7 +529,7 @@ export function ShieldAssetPane({
             return (
               <button
                 className={`t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left ${
-                  isSelected ? "bg-black/[0.04]" : "hover:bg-black/[0.04]"
+                  isSelected ? "bg-accent" : "hover:bg-accent"
                 }`}
                 key={`${token.mint ?? token.symbol}${
                   token.isSecured ? "-secured" : ""
@@ -567,19 +556,19 @@ export function ShieldAssetPane({
                   </span>
                 </span>
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                  <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+                  <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
                     {(token.mint ? nameByMint[token.mint] : undefined) ??
                       token.symbol}
                     {token.isSecured ? (
-                      <span className="text-[#b1b1b4]"> · Shielded</span>
+                      <span className="text-tertiary"> · Shielded</span>
                     ) : null}
                   </span>
-                  <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                     {token.symbol}
                   </span>
                 </span>
                 <span className="flex shrink-0 flex-col items-end gap-0.5 py-[11px] pl-3">
-                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-black leading-5">
+                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
                     {isBalanceHidden ? (
                       <ScrambleText
                         isHidden
@@ -588,13 +577,13 @@ export function ShieldAssetPane({
                     ) : (
                       <>
                         {split.balanceWhole}
-                        <span className="text-[#b1b1b4]">
+                        <span className="text-tertiary">
                           {split.balanceFraction}
                         </span>
                       </>
                     )}
                   </span>
-                  <span className="whitespace-nowrap text-right text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <span className="whitespace-nowrap text-right text-[13px] leading-4 text-muted-foreground">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={formatTokenAmount(token.balance)}
@@ -640,23 +629,20 @@ export function ShieldInfoOverlay({
       isOpen={isOpen}
       onClose={onClose}
       scrimClassName="fixed inset-0 z-50 flex bg-black/20 p-2 backdrop-blur-[4px] max-[795px]:bg-white/60 max-[795px]:p-0 max-[795px]:pt-8"
-      sheetClassName="ml-auto flex h-full w-[400px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-white max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+      sheetClassName="ml-auto flex h-full w-[400px] min-w-0 max-w-full flex-col overflow-clip rounded-3xl bg-card max-[795px]:w-full max-[795px]:rounded-b-none max-[795px]:shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
     >
       <header className="flex w-full items-center p-2">
-        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-black leading-6">
+        <h2 className="min-w-0 flex-1 truncate py-2.5 pl-4 font-semibold text-[20px] text-foreground leading-6">
           What are Shielded Assets?
         </h2>
         <button
           aria-label="Close info"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onClose}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={`${ASSET_BASE}/icon-cross.svg`}
           />
         </button>
@@ -664,13 +650,13 @@ export function ShieldInfoOverlay({
       <div className="flex min-h-0 w-full flex-1 items-center justify-center p-2">
         {/* ponytail: the design's info body is still a placeholder — swap in
             real copy when it lands in Figma. */}
-        <p className="text-center text-[16px] leading-5 text-[#8a8a8e]">
+        <p className="text-center text-[16px] leading-5 text-muted-foreground">
           Content
         </p>
       </div>
       <div className="w-full px-4 pt-2 pb-4 min-[796px]:hidden">
         <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-[#f5f5f5] font-medium text-[16px] text-black leading-5 hover:bg-[#ececec]"
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-secondary font-medium text-[16px] text-foreground leading-5 hover:bg-accent-active"
           onClick={onClose}
           type="button"
         >

--- a/frontend/src/components/wallet-workspace/facelift/sidebar.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/sidebar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useWallet } from "@solana/wallet-adapter-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   ScrambledPopDigits,
@@ -15,6 +16,7 @@ import { ReceiveSheet } from "@/components/wallet-workspace/facelift/receive-she
 import type { WorkspacePage } from "@/components/wallet-workspace/facelift/shell";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { useSignInModal } from "@/contexts/sign-in-modal-context";
@@ -26,6 +28,7 @@ import {
   splitUsdBalance,
   useWalletDesktopData,
 } from "@/hooks/use-wallet-desktop-data";
+import { useTheme } from "@/hooks/use-theme";
 import { formatEarnApyLabel } from "@/lib/kamino/earn-forecast.shared";
 import {
   getStablecoinMintSetForSolanaEnv,
@@ -60,7 +63,7 @@ const SIDEBAR_LINKS = [
 
 export function SplitAmount({
   fraction,
-  fractionColor = "rgba(60, 60, 67, 0.4)",
+  fractionColor = "var(--tertiary)",
   isHidden = false,
   isRevealed,
   whole,
@@ -72,10 +75,10 @@ export function SplitAmount({
   whole: string;
 }) {
   return (
-    <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+    <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
       <SkeletonReveal
         isRevealed={isRevealed}
-        skeletonClassName="rounded-md bg-black/[0.06]"
+        skeletonClassName="rounded-md bg-accent-selected"
       >
         {isRevealed ? (
           <ScrambledPopDigits
@@ -109,8 +112,8 @@ function ShortcutKey({
         isFlashed
           ? // A keypress lands instantly, so its feedback must too — only the
             // fade-out (the unflashed state's transition) is animated.
-            "bg-[#f9363c] text-white opacity-100 transition-none"
-          : "bg-black/[0.06] text-[rgba(60,60,67,0.6)] opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+            "bg-primary text-white opacity-100 transition-none"
+          : "bg-accent-selected text-muted-foreground opacity-0 transition-opacity duration-150 group-hover:opacity-100"
       }`}
     >
       {letter}
@@ -146,6 +149,7 @@ export function FaceliftSidebar({
   const canDisconnect = isAuthenticated || isWalletConnected;
   const { isBalanceHidden, toggleBalanceHidden } = useBalanceVisibility();
   const { open: openSignIn } = useSignInModal();
+  const { isDark, toggleTheme } = useTheme();
   const [isWalletMenuOpen, setIsWalletMenuOpen] = useState(false);
   const [isReceiveOpen, setIsReceiveOpen] = useState(false);
 
@@ -299,10 +303,9 @@ export function FaceliftSidebar({
     <aside className="flex h-full w-[360px] shrink-0 flex-col overflow-clip p-2 max-[795px]:hidden">
       {/* Figma 4768:102489 — logo on top, wallet chip moved to the bottom. */}
       <div className="flex h-[60px] w-full shrink-0 items-center">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          alt="Loyal"
-          className="ml-4 h-6 w-14"
+        <ThemedIcon
+          className="ml-4 h-6 w-14 text-foreground"
+          label="Loyal"
           src={`${ASSET_BASE}/logotype.svg`}
         />
         <div className="flex min-w-0 flex-1 items-center justify-end pl-3">
@@ -315,17 +318,14 @@ export function FaceliftSidebar({
               aria-label="Activity"
               className={`t-hover relative flex size-11 items-center justify-center rounded-3xl ${
                 activePage === "activity"
-                  ? "bg-black/[0.04]"
-                  : "hover:bg-black/[0.04]"
+                  ? "bg-accent"
+                  : "hover:bg-accent"
               }`}
               onClick={() => onSelectPage("activity")}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-clock-history.svg`}
               />
               {/* transitions.dev notification badge: pops in when wallet
@@ -334,7 +334,7 @@ export function FaceliftSidebar({
                 className="t-badge t-badge-activity"
                 data-open={hasUnseenActivity ? "true" : "false"}
               >
-                <span className="t-badge-dot size-1.5 rounded-full bg-[#f9363c]" />
+                <span className="t-badge-dot size-1.5 rounded-full bg-primary" />
               </span>
             </button>
           </span>
@@ -344,17 +344,17 @@ export function FaceliftSidebar({
       <div className="w-full py-2">
         <div className="flex w-full flex-col gap-0.5 px-4 py-2">
           <div className="flex items-center gap-1">
-            <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+            <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
               Total balance
             </p>
             {/* ponytail: mock tooltip copy — real copy comes with the wiring pass */}
             <InfoTooltip text="Wallet and Earn balances combined" />
           </div>
           <div className="flex items-center gap-3">
-            <p className="whitespace-nowrap font-semibold text-[40px] text-black leading-[48px] tracking-[-0.44px]">
+            <p className="whitespace-nowrap font-semibold text-[40px] text-foreground leading-[48px] tracking-[-0.44px]">
               <SkeletonReveal
                 isRevealed={isTotalRevealed}
-                skeletonClassName="rounded-lg bg-black/[0.06]"
+                skeletonClassName="rounded-lg bg-accent-selected"
               >
                 {isTotalRevealed ? (
                   <ScrambledPopDigits
@@ -362,7 +362,7 @@ export function FaceliftSidebar({
                     segments={[
                       { text: totalBalance.balanceWhole },
                       {
-                        color: "rgba(60, 60, 67, 0.4)",
+                        color: "var(--tertiary)",
                         text: totalBalance.balanceFraction,
                       },
                     ]}
@@ -375,15 +375,12 @@ export function FaceliftSidebar({
             </p>
             <button
               aria-label={isBalanceHidden ? "Show balance" : "Hide balance"}
-              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={toggleBalanceHidden}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-eye.svg`}
               />
             </button>
@@ -394,7 +391,7 @@ export function FaceliftSidebar({
       <nav className="flex w-full flex-1 flex-col py-2">
         <button
           className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${
-            activePage === "earn" ? "bg-black/[0.04]" : "hover:bg-black/[0.04]"
+            activePage === "earn" ? "bg-accent" : "hover:bg-accent"
           }`}
           onClick={() => onSelectPage("earn")}
           type="button"
@@ -408,7 +405,7 @@ export function FaceliftSidebar({
           />
           <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
             <span className="flex items-center gap-1">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                 Earn
               </span>
               {/* Skeleton the whole pill until the real APY lands, then
@@ -416,9 +413,9 @@ export function FaceliftSidebar({
                   hardcoded number that would otherwise flash and re-pop). */}
               <SkeletonReveal
                 isRevealed={isApyLoaded}
-                skeletonClassName="rounded-md bg-black/[0.06]"
+                skeletonClassName="rounded-md bg-accent-selected"
               >
-                <span className="inline-flex items-center gap-0.5 rounded-md bg-[rgba(52,199,89,0.14)] px-1 py-px">
+                <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     alt=""
@@ -426,7 +423,7 @@ export function FaceliftSidebar({
                     className="h-3 w-2"
                     src="/wallet-workspace/earn-flash.svg"
                   />
-                  <span className="whitespace-nowrap pt-px font-medium text-[#34c759] text-[11px] leading-[13px] tracking-[0.06px]">
+                  <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
                     {isApyLoaded ? (
                       <PopDigits
                         segments={[
@@ -443,7 +440,7 @@ export function FaceliftSidebar({
             </span>
             <SplitAmount
               fraction={earnBalance.balanceFraction}
-              fractionColor="#b1b1b4"
+              fractionColor="var(--tertiary)"
               isHidden={isBalanceHidden}
               isRevealed={isEarnBalanceRevealed}
               whole={earnBalance.balanceWhole}
@@ -454,8 +451,8 @@ export function FaceliftSidebar({
         <button
           className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${
             activePage === "stables"
-              ? "bg-black/[0.04]"
-              : "hover:bg-black/[0.04]"
+              ? "bg-accent"
+              : "hover:bg-accent"
           }`}
           onClick={() => onSelectPage("stables")}
           type="button"
@@ -469,7 +466,7 @@ export function FaceliftSidebar({
           />
           <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
             <span className="flex items-center gap-1">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                 Stablecoins
               </span>
               <ShortcutKey
@@ -489,8 +486,8 @@ export function FaceliftSidebar({
         <button
           className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${
             activePage === "crypto"
-              ? "bg-black/[0.04]"
-              : "hover:bg-black/[0.04]"
+              ? "bg-accent"
+              : "hover:bg-accent"
           }`}
           onClick={() => onSelectPage("crypto")}
           type="button"
@@ -504,7 +501,7 @@ export function FaceliftSidebar({
           />
           <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
             <span className="flex items-center gap-1">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                 Crypto
               </span>
               <ShortcutKey
@@ -525,22 +522,19 @@ export function FaceliftSidebar({
       <div className="flex w-full flex-col py-2">
         {SIDEBAR_LINKS.map((link) => (
           <a
-            className="t-hover flex w-full items-center rounded-2xl px-4 hover:bg-black/[0.04]"
+            className="t-hover flex w-full items-center rounded-2xl px-4 hover:bg-accent"
             href={link.href}
             key={link.label}
             rel="noreferrer"
             target="_blank"
           >
             <span className="mr-3 flex size-11 shrink-0 items-center justify-center">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/${link.icon}`}
               />
             </span>
-            <span className="py-2 font-medium text-[#8a8a8e] text-[16px] leading-5">
+            <span className="py-2 font-medium text-muted-foreground text-[16px] leading-5">
               {link.label}
             </span>
           </a>
@@ -554,7 +548,7 @@ export function FaceliftSidebar({
       {isHydrated && !isSignedIn ? (
         <div className="flex w-full shrink-0 items-center">
           <button
-            className="t-hover flex h-[60px] items-center rounded-2xl px-4 text-left hover:bg-black/[0.04]"
+            className="t-hover flex h-[60px] items-center rounded-2xl px-4 text-left hover:bg-accent"
             onClick={openSignIn}
             type="button"
           >
@@ -565,7 +559,7 @@ export function FaceliftSidebar({
               className="mr-3 size-11 shrink-0 rounded-[11px]"
               src="/agents/Agent-01.svg"
             />
-            <span className="whitespace-nowrap text-[16px] text-black leading-5">
+            <span className="whitespace-nowrap text-[16px] text-foreground leading-5">
               {cherryRuntime.mode === "cherry_embedded"
                 ? "Verify account"
                 : "Connect account"}
@@ -575,7 +569,7 @@ export function FaceliftSidebar({
       ) : (
         <div className="relative flex w-full shrink-0 items-center">
           <button
-            className="t-hover flex h-[60px] items-center rounded-2xl px-4 text-left hover:bg-black/[0.04]"
+            className="t-hover flex h-[60px] items-center rounded-2xl px-4 text-left hover:bg-accent"
             onClick={() => {
               if (cherryRuntime.mode === "standalone") {
                 setIsWalletMenuOpen((open) => !open);
@@ -591,10 +585,10 @@ export function FaceliftSidebar({
               src="/agents/Agent-01.svg"
             />
             <span className="flex min-w-0 items-center gap-1">
-              <span className="whitespace-nowrap text-[16px] text-black leading-5">
+              <span className="whitespace-nowrap text-[16px] text-foreground leading-5">
                 <SkeletonReveal
                   isRevealed={isAddressRevealed}
-                  skeletonClassName="rounded-md bg-black/[0.06]"
+                  skeletonClassName="rounded-md bg-accent-selected"
                 >
                   <TextSwap text={addressLabel} />
                 </SkeletonReveal>
@@ -608,29 +602,24 @@ export function FaceliftSidebar({
                   handleCopyAddress();
                 }}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt="Copy address"
-                  className="t-icon size-6"
+                <span
+                  className="t-icon icon-themed size-6 text-tertiary"
                   data-icon="a"
-                  src={`${ASSET_BASE}/icon-copy.svg`}
+                  role="img"
+                  aria-label="Copy address"
+                  style={{ "--icon": `url("${ASSET_BASE}/icon-copy.svg")` } as CSSProperties}
                 />
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
+                <span
                   aria-hidden="true"
-                  className="t-icon size-6"
+                  className="t-icon icon-themed size-6 text-tertiary"
                   data-icon="b"
-                  src={`${ASSET_BASE}/icon-check.svg`}
+                  style={{ "--icon": `url("${ASSET_BASE}/icon-check.svg")` } as CSSProperties}
                 />
               </span>
             </span>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             {cherryRuntime.mode === "standalone" ? (
-              <img
-                alt=""
-                aria-hidden="true"
-                className="ml-2 size-6 shrink-0"
+              <ThemedIcon
+                className="ml-2 size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-chevron-down.svg`}
               />
             ) : null}
@@ -638,33 +627,30 @@ export function FaceliftSidebar({
           <div className="flex min-w-0 flex-1 items-center justify-end pl-3">
             <button
               aria-label="Receive"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={() => setIsReceiveOpen(true)}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-qr.svg`}
               />
             </button>
-            {/* ponytail: settings screen doesn't exist yet — disabled until
-              it ships. */}
             <button
-              aria-label="Settings"
-              className="flex size-11 items-center justify-center rounded-3xl opacity-40"
-              disabled
+              aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+              className="t-hover flex size-11 items-center justify-center rounded-3xl text-tertiary hover:bg-accent"
+              onClick={(event) => {
+                // Wipe from the toggle itself (also right for keyboard
+                // activation, where click coords are unreliable).
+                const rect = event.currentTarget.getBoundingClientRect();
+                toggleTheme({
+                  x: rect.left + rect.width / 2,
+                  y: rect.top + rect.height / 2,
+                });
+              }}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
-                src={`${ASSET_BASE}/icon-gear.svg`}
-              />
+              {isDark ? <Sun className="size-6" /> : <Moon className="size-6" />}
             </button>
           </div>
 
@@ -678,12 +664,12 @@ export function FaceliftSidebar({
           ) : null}
           {/* Same frosted sheet treatment as the withdraw source select. */}
           <DropdownReveal
-            className="absolute bottom-[calc(100%+4px)] left-0 z-30 flex w-60 flex-col rounded-2xl bg-white/70 p-2 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] backdrop-blur-[16px]"
+            className="absolute bottom-[calc(100%+4px)] left-0 z-30 flex w-60 flex-col rounded-2xl bg-popover/70 p-2 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] backdrop-blur-[16px]"
             isOpen={cherryRuntime.mode === "standalone" && isWalletMenuOpen}
             origin="bottom-left"
           >
             <button
-              className="t-hover flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left font-medium text-[16px] text-black leading-5 enabled:hover:bg-black/[0.04] disabled:text-[#d8d8d9]"
+              className="t-hover flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left font-medium text-[16px] text-foreground leading-5 enabled:hover:bg-accent disabled:text-tertiary"
               disabled={!canDisconnect}
               onClick={() => {
                 setIsWalletMenuOpen(false);
@@ -691,11 +677,8 @@ export function FaceliftSidebar({
               }}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-5"
+              <ThemedIcon
+                className="size-5 text-tertiary"
                 src={`${ASSET_BASE}/icon-logout.svg`}
               />
               Disconnect

--- a/frontend/src/components/wallet-workspace/facelift/skeleton-reveal.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/skeleton-reveal.tsx
@@ -15,7 +15,7 @@ import {
 export function SkeletonReveal({
   children,
   isRevealed,
-  skeletonClassName = "rounded-[6px] bg-black/[0.06]",
+  skeletonClassName = "rounded-[6px] bg-accent-selected",
 }: {
   children: ReactNode;
   isRevealed: boolean;

--- a/frontend/src/components/wallet-workspace/facelift/swap-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/swap-pane.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/wallet-workspace/facelift/balance-visibility";
 import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transitions";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { useSwap } from "@/hooks/use-swap";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
@@ -89,20 +90,17 @@ function SwapTokenPill({
   return (
     <button
       className={`t-hover flex shrink-0 items-center rounded-full py-1 pl-1 pr-2.5 ${
-        isActive ? "bg-black/[0.08]" : "bg-black/[0.04] hover:bg-black/[0.08]"
+        isActive ? "bg-accent-active" : "bg-accent hover:bg-accent-active"
       }`}
       onClick={onClick}
       type="button"
     >
       <TokenIconSwap src={token.icon || getTokenIconUrl(token.symbol)} />
-      <span className="px-2 font-medium text-[16px] text-black leading-5">
+      <span className="px-2 font-medium text-[16px] text-foreground leading-5">
         <TextSwap text={token.symbol} />
       </span>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-6"
+      <ThemedIcon
+        className="size-6 text-tertiary"
         src={`${ASSET_BASE}/icon-chevron-right.svg`}
       />
     </button>
@@ -356,7 +354,7 @@ export function SwapPane({
         into the shell's 8px gap and sit flush with the viewport bottom (same
         escape the earn empty pane uses); the form keeps the clip. */
     <section
-      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-white max-[795px]:rounded-none ${
+      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-card max-[795px]:rounded-none ${
         step === "success" || step === "error"
           ? "max-[795px]:overflow-clip"
           : "overflow-clip"
@@ -366,21 +364,18 @@ export function SwapPane({
         <div className="flex shrink-0 items-center pr-3">
           <button
             aria-label="Back"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onBack}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-arrow-left.svg`}
             />
           </button>
         </div>
         <div className="flex min-w-0 flex-1 items-center py-2">
-          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             Swap
           </h1>
         </div>
@@ -394,19 +389,19 @@ export function SwapPane({
             <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
               <div className="flex w-full shrink-0 flex-col p-2">
                 <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     You swap
                   </p>
                   <div className="flex w-full items-center">
                     <div className="flex h-12 min-w-0 flex-1 items-baseline">
                       {isUsdInput ? (
-                        <span className="font-semibold text-[40px] text-black leading-[48px]">
+                        <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                           $
                         </span>
                       ) : null}
                       <input
                         autoFocus
-                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                        className="w-full min-w-0 bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                         inputMode="decimal"
                         onChange={(event) =>
                           handleAmountChange(event.target.value)
@@ -431,30 +426,27 @@ export function SwapPane({
                       onClick={handleToggleCurrency}
                       type="button"
                     >
-                      <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                      <span className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                         {isUsdInput
                           ? `${formatTokenAmount(tokenAmount)} ${
                               fromToken.symbol
                             }`
                           : `$${formatUsdAmount(fromUsd)}`}
                       </span>
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        alt=""
-                        aria-hidden="true"
-                        className="size-5"
+                      <ThemedIcon
+                        className="size-5 text-tertiary"
                         src={`${ASSET_BASE}/icon-arrow-rotate.svg`}
                       />
                     </button>
                     <p className="flex items-center gap-1 whitespace-nowrap text-[16px] leading-5">
                       <button
-                        className="t-hover text-black hover:opacity-70"
+                        className="t-hover text-foreground hover:opacity-70"
                         onClick={handleMax}
                         type="button"
                       >
                         MAX
                       </button>
-                      <span className="text-[#8a8a8e]">
+                      <span className="text-muted-foreground">
                         <ScrambleText
                           isHidden={isBalanceHidden}
                           text={formatTokenAmount(fromToken.balance)}
@@ -467,33 +459,30 @@ export function SwapPane({
                 <div className="relative flex h-11 w-full items-center justify-center">
                   <span
                     aria-hidden="true"
-                    className="absolute inset-x-6 top-1/2 h-px bg-black/[0.08]"
+                    className="absolute inset-x-6 top-1/2 h-px bg-border"
                   />
                   <button
                     aria-label="Swap tokens"
-                    className="t-hover relative flex size-11 items-center justify-center rounded-3xl bg-[#f5f5f5] hover:bg-[#ececec]"
+                    className="t-hover relative flex size-11 items-center justify-center rounded-3xl bg-secondary hover:bg-accent-active"
                     onClick={handleFlip}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
                       src={`${ASSET_BASE}/icon-arrow-top-bottom.svg`}
                     />
                   </button>
                 </div>
 
                 <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-                  <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                  <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                     You receive
                   </p>
                   <div className="flex w-full items-center">
                     <div className="flex h-12 min-w-0 flex-1 items-baseline overflow-hidden">
                       <p
                         className={`truncate font-semibold text-[40px] leading-[48px] ${
-                          toAmount > 0 ? "text-black" : "text-[#b1b1b4]"
+                          toAmount > 0 ? "text-foreground" : "text-tertiary"
                         }`}
                       >
                         {toAmount > 0 ? formatTokenAmount(toAmount) : "0"}
@@ -508,10 +497,10 @@ export function SwapPane({
                     </div>
                   </div>
                   <div className="flex w-full items-center justify-between">
-                    <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                    <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                       ~${formatUsdAmount(toUsd)}
                     </p>
-                    <p className="whitespace-nowrap text-[16px] leading-5 text-[#8a8a8e]">
+                    <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                       {"Balance: "}
                       <ScrambleText
                         isHidden={isBalanceHidden}
@@ -523,10 +512,10 @@ export function SwapPane({
               </div>
 
               <div className="w-full shrink-0 p-2">
-                <div className="flex w-full flex-col rounded-2xl bg-black/[0.04]">
+                <div className="flex w-full flex-col rounded-2xl bg-accent">
                   <div className="flex w-full items-center justify-between px-4 py-2.5 text-[13px] leading-4">
-                    <span className="text-[rgba(60,60,67,0.6)]">Rate</span>
-                    <span className="pl-3 text-right text-black">
+                    <span className="text-muted-foreground">Rate</span>
+                    <span className="pl-3 text-right text-foreground">
                       {rate > 0
                         ? `1 ${toToken.symbol} ~ ${
                             rate >= 1
@@ -539,16 +528,16 @@ export function SwapPane({
                     </span>
                   </div>
                   <div className="flex w-full items-center justify-between px-4 py-2.5 text-[13px] leading-4">
-                    <span className="text-[rgba(60,60,67,0.6)]">Slippage</span>
+                    <span className="text-muted-foreground">Slippage</span>
                     {/* Same static figures the OG swap form shows — actual
                   slippage/priority fee are Jupiter-side. */}
-                    <span className="text-black">1%</span>
+                    <span className="text-foreground">1%</span>
                   </div>
                   <div className="flex w-full items-center justify-between px-4 py-2.5 text-[13px] leading-4">
-                    <span className="text-[rgba(60,60,67,0.6)]">
+                    <span className="text-muted-foreground">
                       Network Fee
                     </span>
-                    <span className="pl-3 text-right text-black">
+                    <span className="pl-3 text-right text-foreground">
                       {"0.00005 SOL ~ <$0.01"}
                     </span>
                   </div>
@@ -556,19 +545,19 @@ export function SwapPane({
               </div>
             </div>
 
-            <div className="w-full shrink-0 bg-white px-4 pt-2 pb-4">
+            <div className="w-full shrink-0 bg-card px-4 pt-2 pb-4">
               {visibleError ? (
-                <p className="pb-2 text-[13px] text-[#f9363c] leading-4">
+                <p className="pb-2 text-[13px] text-destructive leading-4">
                   {visibleError}
                 </p>
               ) : null}
               <button
                 className={`flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 transition-colors ${
                   isCtaInvalid
-                    ? "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+                    ? "bg-destructive/[0.08] text-destructive"
                     : ctaDisabled
-                    ? "bg-black text-white opacity-60"
-                    : "t-hover bg-black text-white hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+                    ? "bg-foreground text-background opacity-60"
+                    : "t-hover bg-foreground text-background hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 }`}
                 disabled={ctaDisabled}
                 onClick={() => void handleConfirm()}
@@ -696,36 +685,33 @@ export function SwapTokenSelectPane({
     <div className="flex h-full w-full min-w-0 flex-col">
       <header className="flex w-full shrink-0 items-center p-2">
         <div className="flex min-w-0 flex-1 items-center py-2.5 pl-4 max-[795px]:pl-2">
-          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+          <h2 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
             {title ?? (side === "from" ? "You swap" : "You receive")}
           </h2>
         </div>
         <div className="flex shrink-0 items-center pl-3">
           <button
             aria-label="Close"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onClose}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-cross.svg`}
             />
           </button>
         </div>
       </header>
       <div className="w-full shrink-0 px-4 pb-2">
-        <div className="flex w-full items-center rounded-full bg-black/[0.04] px-3">
+        <div className="flex w-full items-center rounded-full bg-accent px-3">
           <Search
-            className="mr-3 shrink-0 text-[#8a8a8e]"
+            className="mr-3 shrink-0 text-muted-foreground"
             size={24}
             strokeWidth={2}
           />
           <input
-            className="min-w-0 flex-1 bg-transparent py-3 text-[16px] text-black leading-5 outline-none placeholder:text-[#8a8a8e]"
+            className="min-w-0 flex-1 bg-transparent py-3 text-[16px] text-foreground leading-5 outline-none placeholder:text-muted-foreground"
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search assets"
             type="text"
@@ -735,13 +721,13 @@ export function SwapTokenSelectPane({
       </div>
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
         {list.length === 0 ? (
-          <p className="px-4 py-8 text-center text-[14px] leading-5 text-[rgba(60,60,67,0.6)]">
+          <p className="px-4 py-8 text-center text-[14px] leading-5 text-muted-foreground">
             No tokens found
           </p>
         ) : (
           list.map((token) => (
             <button
-              className="t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-black/[0.04]"
+              className="t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-accent"
               key={token.mint ?? token.symbol}
               onClick={() => onSelect(token)}
               type="button"
@@ -755,11 +741,11 @@ export function SwapTokenSelectPane({
                 />
               </span>
               <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                <span className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+                <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
                   {(token.mint ? nameByMint[token.mint] : undefined) ??
                     token.symbol}
                 </span>
-                <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   {token.symbol}
                 </span>
               </span>
@@ -767,12 +753,12 @@ export function SwapTokenSelectPane({
                 // Figma 4852:39653 — the source side lists what you hold:
                 // USD value on top (gray fraction), token amount below.
                 <span className="flex shrink-0 flex-col items-end justify-center gap-0.5 py-[11px] pl-3">
-                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-black leading-5">
+                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={splitUsdBalance(token.balance * token.price).balanceWhole}
                     />
-                    <span className="text-[#b1b1b4]">
+                    <span className="text-tertiary">
                       <ScrambleText
                         isHidden={isBalanceHidden}
                         text={
@@ -782,7 +768,7 @@ export function SwapTokenSelectPane({
                       />
                     </span>
                   </span>
-                  <span className="whitespace-nowrap text-right text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <span className="whitespace-nowrap text-right text-[13px] leading-4 text-muted-foreground">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={formatTokenAmount(token.balance)}
@@ -791,7 +777,7 @@ export function SwapTokenSelectPane({
                 </span>
               ) : (
                 <span className="flex shrink-0 items-center justify-end pl-3">
-                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-black leading-5">
+                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
                     ${formatTokenPrice(token.price)}
                   </span>
                 </span>

--- a/frontend/src/components/wallet-workspace/facelift/themed-icon.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/themed-icon.tsx
@@ -1,0 +1,24 @@
+import type { CSSProperties } from "react";
+
+// Renders a monochrome SVG asset in the current text color via CSS mask
+// (see .icon-themed in globals.css), so baked-in fills follow the theme.
+export function ThemedIcon({
+  className,
+  label,
+  src,
+}: {
+  className?: string;
+  /** Accessible name; omitted = decorative (aria-hidden). */
+  label?: string;
+  src: string;
+}) {
+  return (
+    <span
+      aria-hidden={label ? undefined : true}
+      aria-label={label}
+      className={`icon-themed ${className ?? ""}`}
+      role={label ? "img" : undefined}
+      style={{ "--icon": `url("${src}")` } as CSSProperties}
+    />
+  );
+}

--- a/frontend/src/components/wallet-workspace/facelift/token-detail-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/token-detail-pane.tsx
@@ -15,6 +15,7 @@ import {
 import { SplitUsd } from "@/components/wallet-workspace/facelift/crypto-pane";
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
@@ -195,22 +196,29 @@ function buildChartGeometry(points: ChartPoint[]) {
 
 function CircleActionButton({
   icon,
+  iconColorClass,
   label,
   onClick,
 }: {
   icon: string;
+  /** text-* class rendering the icon as a themed mask; omit = raw img. */
+  iconColorClass?: string;
   label: string;
   onClick: () => void;
 }) {
   return (
     <button
       aria-label={label}
-      className="t-hover flex items-center justify-center rounded-full bg-black/[0.04] p-2.5 hover:-translate-y-0.5 hover:bg-black/[0.08] active:translate-y-0"
+      className="t-hover flex items-center justify-center rounded-full bg-accent p-2.5 hover:-translate-y-0.5 hover:bg-accent-active active:translate-y-0"
       onClick={onClick}
       type="button"
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img alt="" aria-hidden="true" className="size-6" src={icon} />
+      {iconColorClass ? (
+        <ThemedIcon className={`size-6 ${iconColorClass}`} src={icon} />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img alt="" aria-hidden="true" className="size-6" src={icon} />
+      )}
     </button>
   );
 }
@@ -251,10 +259,10 @@ function BalanceRow({
         </span>
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-        <p className="truncate font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+        <p className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
           {title}
         </p>
-        <p className="whitespace-nowrap text-[13px] leading-4 text-[#8a8a8e]">
+        <p className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
           <ScrambleText isHidden={isBalanceHidden} text={amountLabel} />
         </p>
       </div>
@@ -282,19 +290,16 @@ function LinkChip({
 }) {
   return (
     <a
-      className="t-hover flex shrink-0 items-center gap-1 rounded-xl bg-[#f5f5f5] py-2 pr-3 pl-2 hover:bg-black/[0.08]"
+      className="t-hover flex shrink-0 items-center gap-1 rounded-xl bg-secondary py-2 pr-3 pl-2 hover:bg-accent-active"
       href={href}
       rel="noopener noreferrer"
       target="_blank"
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-5"
+      <ThemedIcon
+        className="size-5 text-tertiary"
         src={`${ASSET_BASE}/${icon}`}
       />
-      <span className="whitespace-nowrap font-medium text-[15px] text-black leading-5 tracking-[-0.165px]">
+      <span className="whitespace-nowrap font-medium text-[15px] text-foreground leading-5 tracking-[-0.165px]">
         {label}
       </span>
     </a>
@@ -456,7 +461,7 @@ export function TokenDetailPane({
 
   const priceChange = detail?.market.priceChange24hPercent ?? null;
   const isNegative = priceChange !== null && priceChange < 0;
-  const chartColor = isNegative ? "#f9363c" : "#34c759";
+  const chartColor = isNegative ? "var(--destructive)" : "var(--positive)";
   const displayPrice = detail?.market.priceUsd ?? price;
   const priceParts = splitPrice(hoveredPoint?.priceUsd ?? displayPrice);
   // The pop-in mounts once the real price is known (or the fetch settled),
@@ -566,14 +571,13 @@ export function TokenDetailPane({
           />
         </div>
         <div className="flex min-w-0 flex-1 items-center gap-2 py-2.5">
-          <h2 className="truncate font-semibold text-[20px] text-black leading-6">
+          <h2 className="truncate font-semibold text-[20px] text-foreground leading-6">
             {symbol}
           </h2>
           {detail?.info.gtVerified ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt="Verified"
-              className="size-6 shrink-0"
+            <ThemedIcon
+              className="size-6 shrink-0 text-positive"
+              label="Verified"
               src={`${ASSET_BASE}/icon-verified.svg`}
             />
           ) : null}
@@ -581,15 +585,12 @@ export function TokenDetailPane({
         {onClose ? (
           <button
             aria-label="Close"
-            className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+            className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
             onClick={onClose}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
               src={`${ASSET_BASE}/icon-cross.svg`}
             />
           </button>
@@ -600,14 +601,14 @@ export function TokenDetailPane({
         <div className={`w-full shrink-0 ${isSheet ? "py-2" : "p-2"}`}>
           <div className="flex h-[86px] w-full items-center rounded-[20px] px-4 py-2">
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <p className="truncate text-[16px] leading-5 text-[#8a8a8e]">
+              <p className="truncate text-[16px] leading-5 text-muted-foreground">
                 {name}
               </p>
               <div className="flex items-baseline gap-3">
-                <p className="whitespace-nowrap font-semibold text-[40px] text-black leading-[48px] tracking-[-0.44px]">
+                <p className="whitespace-nowrap font-semibold text-[40px] text-foreground leading-[48px] tracking-[-0.44px]">
                   <SkeletonReveal
                     isRevealed={isPriceRevealed}
-                    skeletonClassName="rounded-lg bg-black/[0.06]"
+                    skeletonClassName="rounded-lg bg-accent-selected"
                   >
                     {isPriceRevealed ? (
                       <PopDigits
@@ -615,7 +616,7 @@ export function TokenDetailPane({
                         segments={[
                           { text: priceParts.whole },
                           {
-                            color: "rgba(60,60,67,0.4)",
+                            color: "var(--tertiary)",
                             text: priceParts.fraction,
                           },
                         ]}
@@ -644,7 +645,7 @@ export function TokenDetailPane({
               {/* Hovered point's datetime rides the chart's top row (the empty
                 space left of the max label), so it can't shift the layout. */}
               <p
-                className={`min-h-4 text-[12px] leading-4 text-[rgba(60,60,67,0.6)] transition-opacity duration-150 ${
+                className={`min-h-4 text-[12px] leading-4 text-muted-foreground transition-opacity duration-150 ${
                   hoveredPoint ? "opacity-100" : "opacity-0"
                 }`}
               >
@@ -652,7 +653,7 @@ export function TokenDetailPane({
                   ? formatPointTime(hoveredPoint.timestamp, activeRange)
                   : " "}
               </p>
-              <p className="min-h-4 text-[12px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <p className="min-h-4 text-[12px] leading-4 text-muted-foreground">
                 {geometry ? formatPrice(geometry.maxPrice) : " "}
               </p>
             </div>
@@ -688,14 +689,14 @@ export function TokenDetailPane({
                     rides the line there (cursor x, or the latest point). */}
                   <span
                     aria-hidden="true"
-                    className="token-chart-trail absolute inset-y-0 right-0 bg-white/60"
+                    className="token-chart-trail absolute inset-y-0 right-0 bg-card/60"
                     style={{
                       left: `${(activeIndex / Math.max(lastIndex, 1)) * 100}%`,
                     }}
                   />
                   <span
                     aria-hidden="true"
-                    className="token-chart-dot -translate-x-1/2 -translate-y-1/2 absolute size-3 rounded-full border-2 border-white"
+                    className="token-chart-dot -translate-x-1/2 -translate-y-1/2 absolute size-3 rounded-full border-2 border-card"
                     style={{
                       backgroundColor: chartColor,
                       left: `${(activeIndex / Math.max(lastIndex, 1)) * 100}%`,
@@ -745,11 +746,11 @@ export function TokenDetailPane({
                 </div>
               ) : hasDetailError && !detail ? (
                 <div className="flex h-full w-full flex-col items-center justify-center gap-3">
-                  <p className="text-[13px] leading-4 text-[#8a8a8e]">
+                  <p className="text-[13px] leading-4 text-muted-foreground">
                     Couldn&apos;t load market data.
                   </p>
                   <button
-                    className="t-hover rounded-full bg-black/[0.04] px-4 py-2.5 font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                    className="t-hover rounded-full bg-accent px-4 py-2.5 font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                     onClick={() => setRetryNonce((nonce) => nonce + 1)}
                     type="button"
                   >
@@ -758,18 +759,18 @@ export function TokenDetailPane({
                 </div>
               ) : chartPoints ? (
                 <div className="flex h-full w-full items-center justify-center">
-                  <p className="text-[13px] leading-4 text-[#8a8a8e]">
+                  <p className="text-[13px] leading-4 text-muted-foreground">
                     No price history yet.
                   </p>
                 </div>
               ) : (
                 <div className="h-full w-full pl-4">
-                  <div className="h-full w-full animate-pulse rounded-2xl bg-black/[0.03]" />
+                  <div className="h-full w-full animate-pulse rounded-2xl bg-accent" />
                 </div>
               )}
             </div>
             <div className="flex w-full items-center justify-end px-4 pt-1">
-              <p className="min-h-4 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <p className="min-h-4 text-[13px] leading-4 text-muted-foreground">
                 {geometry ? formatPrice(geometry.minPrice) : " "}
               </p>
             </div>
@@ -778,8 +779,8 @@ export function TokenDetailPane({
                 <button
                   className={`flex min-w-0 flex-1 items-center justify-center rounded-full px-3 py-2.5 font-medium text-[13px] leading-4 transition-colors ${
                     activeRange === range.label
-                      ? "bg-black/[0.04] text-black"
-                      : "text-[#8a8a8e] hover:text-black"
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
                   }`}
                   key={range.label}
                   onClick={() => setActiveRange(range.label)}
@@ -797,13 +798,13 @@ export function TokenDetailPane({
             <div className="flex w-full gap-2 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {statChips.map((chip) => (
                 <div
-                  className="flex shrink-0 flex-col justify-center rounded-xl bg-[#f5f5f5] px-3 py-2"
+                  className="flex shrink-0 flex-col justify-center rounded-xl bg-secondary px-3 py-2"
                   key={chip.label}
                 >
-                  <p className="text-[13px] leading-4 text-[#8a8a8e]">
+                  <p className="text-[13px] leading-4 text-muted-foreground">
                     {chip.label}
                   </p>
-                  <p className="whitespace-nowrap font-medium text-[16px] text-black leading-5 tracking-[-0.176px]">
+                  <p className="whitespace-nowrap font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
                     {chip.value}
                   </p>
                 </div>
@@ -818,20 +819,20 @@ export function TokenDetailPane({
           }`}
         >
           <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-            <p className="text-[16px] leading-5 text-[#8a8a8e]">Balance</p>
-            <p className="whitespace-nowrap font-semibold text-[32px] text-black leading-9">
+            <p className="text-[16px] leading-5 text-muted-foreground">Balance</p>
+            <p className="whitespace-nowrap font-semibold text-[32px] text-foreground leading-9">
               <ScrambleText
                 isHidden={isBalanceHidden}
                 text={balanceParts.balanceWhole}
               />
-              <span className="text-[#b1b1b4]">
+              <span className="text-tertiary">
                 <ScrambleText
                   isHidden={isBalanceHidden}
                   text={balanceParts.balanceFraction}
                 />
               </span>
             </p>
-            <p className="whitespace-nowrap text-[16px] leading-5 text-[#8a8a8e]">
+            <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
               <ScrambleText
                 isHidden={isBalanceHidden}
                 text={`${formatTokenBalance(
@@ -843,23 +844,21 @@ export function TokenDetailPane({
           {isSheet ? null : (
             <div className="flex w-full items-center gap-2 py-2 pl-3">
               <button
-                className="t-hover flex items-center justify-center gap-2 rounded-full bg-black p-2.5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+                className="t-hover flex items-center justify-center gap-2 rounded-full bg-foreground p-2.5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
                 onClick={onSwap}
                 type="button"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-6"
+                <ThemedIcon
+                  className="size-6 text-background"
                   src={`${ASSET_BASE}/icon-swap-repeat.svg`}
                 />
-                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-white leading-5">
+                <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-background leading-5">
                   Swap
                 </span>
               </button>
               <CircleActionButton
                 icon={`${ASSET_BASE}/icon-arrow-up-circle.svg`}
+                iconColorClass="text-tertiary"
                 label="Send"
                 onClick={onSend}
               />
@@ -871,6 +870,7 @@ export function TokenDetailPane({
               {hasSecured ? (
                 <CircleActionButton
                   icon={`${ASSET_BASE}/icon-shield-break.svg`}
+                  iconColorClass="text-muted-foreground"
                   label="Unshield"
                   onClick={onUnshield}
                 />
@@ -903,7 +903,7 @@ export function TokenDetailPane({
               {hasPublic && hasSecured ? (
                 <span
                   aria-hidden="true"
-                  className="-translate-y-1/2 absolute top-1/2 left-[37px] h-3 w-0.5 rounded-full bg-[#d9d9d9]"
+                  className="-translate-y-1/2 absolute top-1/2 left-[37px] h-3 w-0.5 rounded-full bg-border"
                 />
               ) : null}
             </div>
@@ -914,12 +914,12 @@ export function TokenDetailPane({
           className={`flex w-full shrink-0 flex-col ${isSheet ? "" : "px-2"}`}
         >
           <div className="flex w-full items-start px-4 pt-1">
-            <p className="min-w-0 flex-1 pt-3 pb-2 font-semibold text-[16px] text-black leading-5 tracking-[-0.176px]">
+            <p className="min-w-0 flex-1 pt-3 pb-2 font-semibold text-[16px] text-foreground leading-5 tracking-[-0.176px]">
               About
             </p>
           </div>
           {detail?.info.description ? (
-            <p className="px-4 pb-2 text-[13px] leading-4 text-[#8a8a8e]">
+            <p className="px-4 pb-2 text-[13px] leading-4 text-muted-foreground">
               {detail.info.description}
             </p>
           ) : null}
@@ -939,42 +939,36 @@ export function TokenDetailPane({
       {isSheet ? (
         // Sheet variant pins the actions under the scroll area (Figma
         // 4834:440680): labeled Swap/Send pills, stretched shield circles.
-        <div className="flex w-full shrink-0 items-center gap-2 bg-white px-4 pt-2 pb-4">
+        <div className="flex w-full shrink-0 items-center gap-2 bg-card px-4 pt-2 pb-4">
           <button
-            className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-black p-2.5"
+            className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-foreground p-2.5"
             onClick={onSwap}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-background"
               src={`${ASSET_BASE}/icon-swap-repeat.svg`}
             />
-            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-white leading-5">
+            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-background leading-5">
               Swap
             </span>
           </button>
           <button
-            className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-[#f5f5f5] p-2.5"
+            className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-secondary p-2.5"
             onClick={onSend}
             type="button"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              alt=""
-              aria-hidden="true"
-              className="size-6"
+            <ThemedIcon
+              className="size-6 text-tertiary"
               src={`${ASSET_BASE}/icon-arrow-up-circle.svg`}
             />
-            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-black leading-5">
+            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
               Send
             </span>
           </button>
           <button
             aria-label="Shield"
-            className="flex min-w-0 flex-1 items-center justify-center rounded-full bg-black/[0.04] p-2.5"
+            className="flex min-w-0 flex-1 items-center justify-center rounded-full bg-accent p-2.5"
             onClick={onShield}
             type="button"
           >
@@ -989,15 +983,12 @@ export function TokenDetailPane({
           {hasSecured ? (
             <button
               aria-label="Unshield"
-              className="flex min-w-0 flex-1 items-center justify-center rounded-full bg-black/[0.04] p-2.5"
+              className="flex min-w-0 flex-1 items-center justify-center rounded-full bg-accent p-2.5"
               onClick={onUnshield}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-shield-break.svg`}
               />
             </button>

--- a/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
@@ -14,6 +14,7 @@ import {
   DualIcon,
   UsdcCoinImage,
 } from "@/components/wallet-workspace/facelift/earn-activity-card";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { openTrackedLink } from "@/lib/core/analytics";
 import type { EarnTransactionItem } from "@/lib/yield-optimization/earn-transactions.client";
@@ -43,13 +44,13 @@ function RouteRow({
     <div className="flex h-[60px] w-full items-center rounded-2xl px-4">
       <div className="flex shrink-0 items-center py-2 pr-3">{icon}</div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-2">
-        <p className="text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <p className="text-[13px] leading-4 text-muted-foreground">
           {label}
         </p>
-        <p className="truncate font-medium text-[16px] text-black leading-5">
+        <p className="truncate font-medium text-[16px] text-foreground leading-5">
           {value}
           {valueSuffix ? (
-            <span className="text-[#b1b1b4]"> · {valueSuffix}</span>
+            <span className="text-tertiary"> · {valueSuffix}</span>
           ) : null}
         </p>
       </div>
@@ -94,8 +95,8 @@ function RouteTile({ side }: { side: EarnTransactionItem["source"] }) {
 function DetailCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex w-full flex-col gap-0.5 px-4 py-[11px]">
-      <p className="text-[13px] leading-4 text-[#8a8a8e]">{label}</p>
-      <p className="text-[16px] text-black leading-5 tracking-[-0.176px]">
+      <p className="text-[13px] leading-4 text-muted-foreground">{label}</p>
+      <p className="text-[16px] text-foreground leading-5 tracking-[-0.176px]">
         {value}
       </p>
     </div>
@@ -108,8 +109,8 @@ function SignatureCell({ signature }: { signature: string }) {
   return (
     <div className="flex w-full items-center">
       <div className="flex min-w-0 flex-1 flex-col gap-0.5 px-4 py-[11px]">
-        <p className="text-[13px] leading-4 text-[#8a8a8e]">Signature</p>
-        <p className="truncate text-[16px] text-black leading-5 tracking-[-0.176px]">
+        <p className="text-[13px] leading-4 text-muted-foreground">Signature</p>
+        <p className="truncate text-[16px] text-foreground leading-5 tracking-[-0.176px]">
           {truncateMiddle(signature)}
         </p>
       </div>
@@ -126,11 +127,8 @@ function SignatureCell({ signature }: { signature: string }) {
         }}
         type="button"
       >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          alt=""
-          aria-hidden="true"
-          className="size-6"
+        <ThemedIcon
+          className="size-6 text-tertiary"
           src={`${ASSET_BASE}/${copied ? "icon-check.svg" : "icon-copy.svg"}`}
         />
       </button>
@@ -197,24 +195,21 @@ export function EarnTransactionDetailPane({
           )}
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <h2 className="truncate font-semibold text-[20px] text-black leading-6 tracking-[-0.22px]">
+          <h2 className="truncate font-semibold text-[20px] text-foreground leading-6 tracking-[-0.22px]">
             {title}
           </h2>
-          <p className="truncate text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+          <p className="truncate text-[13px] leading-4 text-muted-foreground">
             {dateLabel}, {timeLabel}
           </p>
         </div>
         <button
           aria-label="Close transaction details"
-          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+          className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
           onClick={onClose}
           type="button"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-muted-foreground"
             src={`${ASSET_BASE}/icon-cross.svg`}
           />
         </button>
@@ -230,11 +225,11 @@ export function EarnTransactionDetailPane({
                 }}
               >
                 {item.amount}{" "}
-                <span className="text-[#b1b1b4] text-[28px] leading-8 tracking-[-0.308px]">
+                <span className="text-tertiary text-[28px] leading-8 tracking-[-0.308px]">
                   USDC
                 </span>
               </p>
-              <p className="text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+              <p className="text-[16px] leading-5 text-muted-foreground">
                 {item.rawAmount}
               </p>
             </div>
@@ -260,19 +255,19 @@ export function EarnTransactionDetailPane({
             }
           />
           {/* Connector between the two 60px route rows. */}
-          <span className="absolute top-[54px] left-[45px] h-3 w-0.5 rounded-xl bg-[#d9d9d9]" />
+          <span className="absolute top-[54px] left-[45px] h-3 w-0.5 rounded-xl bg-border" />
         </div>
         <div className="w-full p-2">
-          <div className="flex w-full flex-col rounded-2xl bg-black/[0.04]">
+          <div className="flex w-full flex-col rounded-2xl bg-accent">
             {hasSignature ? <SignatureCell signature={item.signature} /> : null}
             <DetailCell label="Slot" value={item.confirmedSlot} />
           </div>
         </div>
       </div>
       {hasSignature ? (
-        <div className="w-full shrink-0 bg-white px-5 pt-2 pb-4">
+        <div className="w-full shrink-0 bg-card px-5 pt-2 pb-4">
           <button
-            className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 hover:-translate-y-0.5 hover:bg-[#171717] active:translate-y-0"
+            className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
             onClick={() =>
               openTrackedLink(publicEnv, {
                 href: solscanUrl,

--- a/frontend/src/components/wallet-workspace/facelift/wallet-home-banners.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/wallet-home-banners.tsx
@@ -169,7 +169,7 @@ export function WalletHomeBanners({
         {BANNERS.map((banner, index) => (
           <span
             className={`size-2 rounded-full transition-colors duration-200 ${
-              index === activeIndex ? "bg-[#f9363c]" : "bg-[#f9363c]/10"
+              index === activeIndex ? "bg-primary" : "bg-primary/10"
             }`}
             key={banner.key}
           />

--- a/frontend/src/components/wallet-workspace/facelift/wallet-home-page.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/wallet-home-page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useWallet } from "@solana/wallet-adapter-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import {
   ScrambledPopDigits,
@@ -15,6 +21,7 @@ import type { WorkspacePage } from "@/components/wallet-workspace/facelift/shell
 import { SplitAmount } from "@/components/wallet-workspace/facelift/sidebar";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import { WalletHomeBanners } from "@/components/wallet-workspace/facelift/wallet-home-banners";
 import { useAuthSession } from "@/contexts/auth-session-context";
@@ -139,11 +146,11 @@ export function WalletHomePage({
     <>
       <div className="flex h-full min-h-0 min-w-0 flex-1 gap-2 p-2 max-[795px]:gap-0 max-[795px]:p-0">
         <PaneReveal>
-          <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-white max-[795px]:rounded-none">
+          <section className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto rounded-3xl bg-card max-[795px]:rounded-none">
             <div className="flex w-full shrink-0 items-center gap-2.5 pr-2 pl-1">
               {isHydrated && !isSignedIn ? (
                 <button
-                  className="t-hover flex h-[60px] items-center rounded-2xl px-3 text-left hover:bg-black/[0.04]"
+                  className="t-hover flex h-[60px] items-center rounded-2xl px-3 text-left hover:bg-accent"
                   onClick={openSignIn}
                   type="button"
                 >
@@ -154,7 +161,7 @@ export function WalletHomePage({
                     className="mr-3 size-11 shrink-0 rounded-[11px]"
                     src="/agents/Agent-01.svg"
                   />
-                  <span className="whitespace-nowrap text-[16px] text-black leading-5">
+                  <span className="whitespace-nowrap text-[16px] text-foreground leading-5">
                     {cherryRuntime.mode === "cherry_embedded"
                       ? "Verify account"
                       : "Connect account"}
@@ -171,10 +178,10 @@ export function WalletHomePage({
                     src="/agents/Agent-01.svg"
                   />
                   <span className="flex min-w-0 items-center gap-1">
-                    <span className="whitespace-nowrap text-[16px] text-black leading-5">
+                    <span className="whitespace-nowrap text-[16px] text-foreground leading-5">
                       <SkeletonReveal
                         isRevealed={isAddressRevealed}
-                        skeletonClassName="rounded-md bg-black/[0.06]"
+                        skeletonClassName="rounded-md bg-accent-selected"
                       >
                         <TextSwap text={addressLabel} />
                       </SkeletonReveal>
@@ -184,20 +191,26 @@ export function WalletHomePage({
                       data-state={isCopied ? "b" : "a"}
                       onClick={handleCopyAddress}
                     >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        alt="Copy address"
-                        className="t-icon size-5"
+                      <span
+                        aria-label="Copy address"
+                        className="t-icon icon-themed size-5 text-tertiary"
                         data-icon="a"
-                        src={`${ASSET_BASE}/icon-copy.svg`}
+                        role="img"
+                        style={
+                          {
+                            "--icon": `url("${ASSET_BASE}/icon-copy.svg")`,
+                          } as CSSProperties
+                        }
                       />
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        alt=""
+                      <span
                         aria-hidden="true"
-                        className="t-icon size-5"
+                        className="t-icon icon-themed size-5 text-tertiary"
                         data-icon="b"
-                        src={`${ASSET_BASE}/icon-check.svg`}
+                        style={
+                          {
+                            "--icon": `url("${ASSET_BASE}/icon-check.svg")`,
+                          } as CSSProperties
+                        }
                       />
                     </span>
                   </span>
@@ -208,16 +221,13 @@ export function WalletHomePage({
                 {cherryRuntime.mode === "standalone" ? (
                   <button
                     aria-label="Disconnect wallet"
-                    className="t-hover flex size-11 items-center justify-center rounded-3xl enabled:hover:bg-black/[0.04] disabled:opacity-40"
+                    className="t-hover flex size-11 items-center justify-center rounded-3xl enabled:hover:bg-accent disabled:opacity-40"
                     disabled={!canDisconnect}
                     onClick={handleDisconnect}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
                       src={`${ASSET_BASE}/icon-logout.svg`}
                     />
                   </button>
@@ -227,14 +237,14 @@ export function WalletHomePage({
 
             <div className="w-full shrink-0 py-2">
               <div className="flex w-full flex-col gap-0.5 px-4 py-2">
-                <p className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <p className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                   Total balance
                 </p>
                 <div className="flex items-center gap-3">
-                  <p className="whitespace-nowrap font-semibold text-[40px] text-black leading-[48px] tracking-[-0.44px]">
+                  <p className="whitespace-nowrap font-semibold text-[40px] text-foreground leading-[48px] tracking-[-0.44px]">
                     <SkeletonReveal
                       isRevealed={isTotalRevealed}
-                      skeletonClassName="rounded-lg bg-black/[0.06]"
+                      skeletonClassName="rounded-lg bg-accent-selected"
                     >
                       {isTotalRevealed ? (
                         <ScrambledPopDigits
@@ -242,7 +252,7 @@ export function WalletHomePage({
                           segments={[
                             { text: totalBalance.balanceWhole },
                             {
-                              color: "rgba(60, 60, 67, 0.4)",
+                              color: "var(--tertiary)",
                               text: totalBalance.balanceFraction,
                             },
                           ]}
@@ -256,15 +266,12 @@ export function WalletHomePage({
                     aria-label={
                       isBalanceHidden ? "Show balance" : "Hide balance"
                     }
-                    className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                    className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
                     onClick={toggleBalanceHidden}
                     type="button"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      aria-hidden="true"
-                      className="size-6"
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
                       src={`${ASSET_BASE}/icon-eye.svg`}
                     />
                   </button>
@@ -276,7 +283,7 @@ export function WalletHomePage({
               <div className="grid h-full min-h-[400px] grid-cols-2 grid-rows-[repeat(3,minmax(0,1fr))] gap-2">
                 <WalletHomeBanners onSetUpAutodeposit={onSetUpAutodeposit} />
                 <button
-                  className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-black/[0.03] p-4 text-left hover:bg-black/[0.06]"
+                  className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-accent p-4 text-left hover:bg-accent-selected"
                   onClick={() => onSelectPage("crypto")}
                   type="button"
                 >
@@ -286,7 +293,7 @@ export function WalletHomePage({
                     <span className="absolute top-[13.33px] left-[28.33px] h-5 w-[5px] rounded-[1.667px] bg-white" />
                   </span>
                   <span className="flex w-full flex-col gap-1">
-                    <span className="text-[15px] leading-5 text-[rgba(60,60,67,0.6)]">
+                    <span className="text-[15px] leading-5 text-muted-foreground">
                       Crypto
                     </span>
                     <SplitAmount
@@ -298,7 +305,7 @@ export function WalletHomePage({
                   </span>
                 </button>
                 <button
-                  className="t-hover relative row-span-2 flex flex-col items-start justify-between overflow-clip rounded-3xl bg-black/[0.03] p-4 text-left hover:bg-black/[0.06]"
+                  className="t-hover relative row-span-2 flex flex-col items-start justify-between overflow-clip rounded-3xl bg-accent p-4 text-left hover:bg-accent-selected"
                   onClick={() => onSelectPage("earn")}
                   type="button"
                 >
@@ -309,23 +316,20 @@ export function WalletHomePage({
                     className="size-10 shrink-0"
                     src={`${ASSET_BASE}/earn-icon.svg`}
                   />
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 size-12"
+                  <ThemedIcon
+                    className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 size-12 text-tertiary"
                     src={`${ASSET_BASE}/icon-plus-gray.svg`}
                   />
                   <span className="flex w-full flex-col gap-1">
                     <span className="flex items-center gap-1">
-                      <span className="whitespace-nowrap font-semibold text-[15px] text-black leading-5">
+                      <span className="whitespace-nowrap font-semibold text-[15px] text-foreground leading-5">
                         Earn
                       </span>
                       <SkeletonReveal
                         isRevealed={isApyLoaded}
-                        skeletonClassName="rounded-md bg-black/[0.06]"
+                        skeletonClassName="rounded-md bg-accent-selected"
                       >
-                        <span className="inline-flex items-center gap-0.5 rounded-md bg-[rgba(52,199,89,0.14)] px-1 py-px">
+                        <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
                             alt=""
@@ -333,7 +337,7 @@ export function WalletHomePage({
                             className="h-3 w-2"
                             src="/wallet-workspace/earn-flash.svg"
                           />
-                          <span className="whitespace-nowrap pt-px font-medium text-[#34c759] text-[11px] leading-[13px] tracking-[0.06px]">
+                          <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
                             {isApyLoaded ? (
                               <PopDigits
                                 segments={[
@@ -356,7 +360,7 @@ export function WalletHomePage({
                   </span>
                 </button>
                 <button
-                  className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-black/[0.03] p-4 text-left hover:bg-black/[0.06]"
+                  className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-accent p-4 text-left hover:bg-accent-selected"
                   onClick={() => onSelectPage("stables")}
                   type="button"
                 >
@@ -368,7 +372,7 @@ export function WalletHomePage({
                     src={`${ASSET_BASE}/stash-stablecoins.svg`}
                   />
                   <span className="flex w-full flex-col gap-1">
-                    <span className="text-[15px] leading-5 text-[rgba(60,60,67,0.6)]">
+                    <span className="text-[15px] leading-5 text-muted-foreground">
                       Stablecoins
                     </span>
                     <SplitAmount

--- a/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/wallet-workspace/facelift/flow-explainer";
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
 import { useStablecoinsUsd } from "@/components/wallet-workspace/facelift/use-stablecoins-usd";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
@@ -106,18 +107,18 @@ function SourceOptionRow({
   const { isBalanceHidden } = useBalanceVisibility();
   return (
     <button
-      className={`t-hover flex w-full items-center px-4 text-left hover:bg-black/[0.04] ${rounded}`}
+      className={`t-hover flex w-full items-center px-4 text-left hover:bg-accent ${rounded}`}
       onClick={onSelect}
       type="button"
     >
       <span className="flex items-center py-2 pr-3">{option.icon}</span>
       <span className="flex h-[60px] min-w-0 flex-1 flex-col gap-0.5 py-[9px]">
-        <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+        <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
           {option.label}
         </span>
-        <span className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+        <span className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
           <ScrambleText isHidden={isBalanceHidden} text={amount.balanceWhole} />
-          <span className="text-[rgba(60,60,67,0.4)]">
+          <span className="text-tertiary">
             <ScrambleText
               isHidden={isBalanceHidden}
               text={amount.balanceFraction}
@@ -127,11 +128,8 @@ function SourceOptionRow({
       </span>
       {isSelected ? (
         <span className="flex items-center justify-end pl-3">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="size-6"
+          <ThemedIcon
+            className="size-6 text-primary"
             src={`${ASSET_BASE}/icon-check-red.svg`}
           />
         </span>
@@ -276,39 +274,33 @@ export function WithdrawPane({
 
   return (
     <>
-      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-white max-[795px]:rounded-none">
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-none">
         <header className="flex w-full items-center p-2">
           <div className="pr-3">
             <button
               aria-label="Back"
-              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
               onClick={onBack}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
                 src={`${ASSET_BASE}/icon-arrow-left.svg`}
               />
             </button>
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2 py-2">
-            <h1 className="truncate font-semibold text-[20px] text-black leading-6">
+            <h1 className="truncate font-semibold text-[20px] text-foreground leading-6">
               Withdraw
             </h1>
             <button
               aria-label="How Withdraw works"
-              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04] min-[1204px]:hidden"
+              className="t-hover -m-2.5 flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"
               onClick={() => setIsInfoOpen(true)}
               type="button"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-6"
+              <ThemedIcon
+                className="size-6 text-tertiary"
                 src={`${ASSET_BASE}/icon-question.svg`}
               />
             </button>
@@ -319,16 +311,16 @@ export function WithdrawPane({
           <div className="flex w-full flex-1 flex-col">
             <div className="w-full p-2">
               <label className="flex w-full flex-col gap-0.5 rounded-2xl px-4 py-2">
-                <span className="whitespace-nowrap text-[16px] leading-5 text-[rgba(60,60,67,0.6)]">
+                <span className="whitespace-nowrap text-[16px] leading-5 text-muted-foreground">
                   Amount
                 </span>
                 <span className="flex h-12 w-full items-baseline">
-                  <span className="font-semibold text-[40px] text-black leading-[48px]">
+                  <span className="font-semibold text-[40px] text-foreground leading-[48px]">
                     $
                   </span>
                   <input
                     autoFocus
-                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-black leading-[48px] outline-none placeholder:text-[#b1b1b4]"
+                    className="min-w-0 flex-1 border-none bg-transparent font-semibold text-[40px] text-foreground leading-[48px] outline-none placeholder:text-tertiary"
                     inputMode="decimal"
                     onChange={(event) => handleAmountChange(event.target.value)}
                     onKeyDown={(event) => {
@@ -359,7 +351,7 @@ export function WithdrawPane({
               />
             ) : null}
             <DropdownReveal
-              className="absolute inset-x-2 bottom-full z-20 flex flex-col rounded-2xl bg-white/70 p-2 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] backdrop-blur-[16px] max-[795px]:hidden"
+              className="absolute inset-x-2 bottom-full z-20 flex flex-col rounded-2xl bg-popover/70 p-2 shadow-[0px_0px_2px_0px_rgba(0,0,0,0.08),0px_4px_16px_0px_rgba(0,0,0,0.08)] backdrop-blur-[16px] max-[795px]:hidden"
               isOpen={isSheetOpen}
               origin="bottom-center"
             >
@@ -380,23 +372,20 @@ export function WithdrawPane({
               isOpen={isSheetOpen}
               onClose={() => setIsSheetOpen(false)}
               scrimClassName="fixed inset-0 z-50 hidden flex-col justify-end bg-white/60 pt-8 backdrop-blur-[4px] max-[795px]:flex"
-              sheetClassName="flex w-full flex-col rounded-t-3xl bg-white shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
+              sheetClassName="flex w-full flex-col rounded-t-3xl bg-card shadow-[0px_-10px_40px_-10px_rgba(0,0,0,0.2)]"
             >
               <header className="flex w-full items-center p-2">
-                <h2 className="min-w-0 flex-1 truncate py-2.5 pl-2 font-semibold text-[20px] text-black leading-6">
+                <h2 className="min-w-0 flex-1 truncate py-2.5 pl-2 font-semibold text-[20px] text-foreground leading-6">
                   Positions
                 </h2>
                 <button
                   aria-label="Close position select"
-                  className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                  className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent"
                   onClick={() => setIsSheetOpen(false)}
                   type="button"
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-6"
+                  <ThemedIcon
+                    className="size-6 text-muted-foreground"
                     src={`${ASSET_BASE}/icon-cross.svg`}
                   />
                 </button>
@@ -416,7 +405,7 @@ export function WithdrawPane({
 
             <div
               className={`t-hover flex w-full items-center rounded-2xl px-4 ${
-                isSheetOpen ? "bg-black/[0.04]" : ""
+                isSheetOpen ? "bg-accent" : ""
               }`}
             >
               <button
@@ -437,12 +426,12 @@ export function WithdrawPane({
                   )}
                 </span>
                 <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                  <span className="whitespace-nowrap text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                  <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                     <TextSwap
                       text={`from ${selectedOption?.label ?? "Earn"}`}
                     />
                   </span>
-                  <span className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                  <span className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                     {/* Hiding masks through TextSwap's own swap animation
                         (churning it would thrash the swap). */}
                     <TextSwap
@@ -452,7 +441,7 @@ export function WithdrawPane({
                           : fromBalance.balanceWhole
                       }
                     />
-                    <span className="text-[rgba(60,60,67,0.4)]">
+                    <span className="text-tertiary">
                       <TextSwap
                         text={
                           isBalanceHidden
@@ -469,7 +458,7 @@ export function WithdrawPane({
               </button>
               <div className="pl-3">
                 <button
-                  className="t-hover min-w-16 rounded-full bg-black/[0.04] px-4 py-2.5 text-center font-medium text-[13px] text-black leading-4 hover:bg-black/[0.08]"
+                  className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                   onClick={() => {
                     const usd = selectedOption?.usd ?? 0;
                     if (usd > 0) {
@@ -487,15 +476,12 @@ export function WithdrawPane({
               </div>
               <button
                 aria-label="Select position"
-                className="t-hover -my-2.5 -mr-2.5 ml-0.5 flex size-11 items-center justify-center rounded-3xl hover:bg-black/[0.04]"
+                className="t-hover -my-2.5 -mr-2.5 ml-0.5 flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
                 onClick={() => setIsSheetOpen((open) => !open)}
                 type="button"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="size-6"
+                <ThemedIcon
+                  className="size-6 text-muted-foreground"
                   src={`${ASSET_BASE}/icon-chevron-grabber.svg`}
                 />
               </button>
@@ -512,15 +498,15 @@ export function WithdrawPane({
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-                <span className="truncate text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+                <span className="truncate text-[13px] leading-4 text-muted-foreground">
                   {`to Stablecoins · ${addressLabel}`}
                 </span>
-                <p className="whitespace-nowrap font-semibold text-[20px] text-black leading-6">
+                <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText
                     isHidden={isBalanceHidden}
                     text={stablecoinsBalance.balanceWhole}
                   />
-                  <span className="text-[rgba(60,60,67,0.4)]">
+                  <span className="text-tertiary">
                     <ScrambleText
                       isHidden={isBalanceHidden}
                       text={stablecoinsBalance.balanceFraction}
@@ -530,13 +516,13 @@ export function WithdrawPane({
               </div>
             </div>
 
-            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-[#d9d9d9]" />
+            <div className="-translate-y-1/2 absolute top-[calc(50%-2px)] left-[45px] h-3.5 w-0.5 rounded-xl bg-border" />
           </div>
         </div>
 
-        <div className="w-full bg-white px-4 pt-2 pb-4">
+        <div className="w-full bg-card px-4 pt-2 pb-4">
           {data.actions.withdrawError ? (
-            <p className="px-4 pb-2 text-[13px] leading-4 text-[#f9363c]">
+            <p className="px-4 pb-2 text-[13px] leading-4 text-destructive">
               {data.actions.withdrawError}
             </p>
           ) : null}
@@ -545,12 +531,12 @@ export function WithdrawPane({
               {/* Phase 2 of a full exit (slot-pinned zero proof happens
                   server-side in the prepare): close the empty Earn accounts
                   and reclaim their SOL rent. */}
-              <p className="px-4 pb-2 text-[13px] leading-4 text-[rgba(60,60,67,0.6)]">
+              <p className="px-4 pb-2 text-[13px] leading-4 text-muted-foreground">
                 Your funds are withdrawn. Close the empty Earn accounts to
                 reclaim their SOL rent.
               </p>
               <button
-                className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-black font-medium text-[16px] text-white leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
+                className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0"
                 disabled={data.actions.isCleanupPending}
                 onClick={() => void handleCleanup()}
                 type="button"
@@ -568,8 +554,8 @@ export function WithdrawPane({
             <button
               className={`t-hover flex h-12 w-full items-center justify-center rounded-full font-medium text-[16px] leading-5 ${
                 canWithdraw
-                  ? "bg-black text-white enabled:hover:-translate-y-0.5 enabled:hover:bg-[#171717] enabled:active:translate-y-0"
-                  : "bg-[rgba(249,54,60,0.08)] text-[#f9363c]"
+                  ? "bg-foreground text-background enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0"
+                  : "bg-destructive/[0.08] text-destructive"
               }`}
               disabled={!canWithdraw || isSubmitting}
               onClick={() => void handleSubmit()}

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+// transitions/theme-switch.md — circle-wipe timing. 400ms is above the usual
+// UI band deliberately: the motion spans the whole viewport.
+const WIPE_DURATION_MS = 400;
+const WIPE_EASE = "cubic-bezier(0.23, 1, 0.32, 1)";
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (update: () => void) => {
+    finished: Promise<void>;
+    ready: Promise<void>;
+  };
+};
+
+// The pre-paint script in app/layout.tsx owns initial theme resolution
+// (localStorage "theme", falling back to prefers-color-scheme); this hook
+// only mirrors and mutates the html.dark class it set.
+export function useTheme() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  // transitions/theme-switch.md — the new theme sweeps in as a circle from
+  // `origin` (the toggle control) over a view-transition snapshot. Without
+  // an origin or with reduced motion it falls back to the API's gentle
+  // crossfade; without the API it swaps instantly.
+  const toggleTheme = useCallback((origin?: { x: number; y: number }) => {
+    const root = document.documentElement;
+    const next = !root.classList.contains("dark");
+    const apply = () => {
+      root.classList.toggle("dark", next);
+      try {
+        localStorage.setItem("theme", next ? "dark" : "light");
+      } catch {
+        // storage unavailable (private mode) — theme still applies for the session
+      }
+      setIsDark(next);
+    };
+
+    const doc = document as ViewTransitionDocument;
+    if (!doc.startViewTransition) {
+      apply();
+      return;
+    }
+    const wantsWipe =
+      origin !== undefined &&
+      !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (!wantsWipe) {
+      doc.startViewTransition(apply);
+      return;
+    }
+
+    // The attribute scopes the snapshot freeze in globals.css to this wipe,
+    // so other view transitions keep their default crossfade. A rapid
+    // re-toggle can drop the freeze early (the first transition's cleanup
+    // races the second's run) — the fallback is just a crossfade, fine.
+    root.setAttribute("data-theme-wipe", "");
+    const transition = doc.startViewTransition(apply);
+    transition.ready
+      .then(() => {
+        const radius = Math.hypot(
+          Math.max(origin.x, window.innerWidth - origin.x),
+          Math.max(origin.y, window.innerHeight - origin.y)
+        );
+        root.animate(
+          {
+            clipPath: [
+              `circle(0px at ${origin.x}px ${origin.y}px)`,
+              `circle(${radius}px at ${origin.x}px ${origin.y}px)`,
+            ],
+          },
+          {
+            duration: WIPE_DURATION_MS,
+            easing: WIPE_EASE,
+            pseudoElement: "::view-transition-new(root)",
+          }
+        );
+      })
+      .catch(() => {
+        // snapshot skipped (rapid re-toggle) — the theme applied either way
+      });
+    void transition.finished.finally(() => {
+      root.removeAttribute("data-theme-wipe");
+    });
+  }, []);
+
+  return { isDark, toggleTheme };
+}

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -15,8 +15,9 @@ type ViewTransitionDocument = Document & {
 };
 
 // The pre-paint script in app/layout.tsx owns initial theme resolution
-// (localStorage "theme", falling back to prefers-color-scheme); this hook
-// only mirrors and mutates the html.dark class it set.
+// (light for everyone unless localStorage "theme" is "dark" — system
+// preference is deliberately ignored); this hook only mirrors and mutates
+// the html.dark class it set.
 export function useTheme() {
   const [isDark, setIsDark] = useState(false);
 

--- a/frontend/transitions/theme-switch.md
+++ b/frontend/transitions/theme-switch.md
@@ -1,0 +1,50 @@
+# Theme switch (circle wipe)
+
+## When to use
+
+Light/dark toggle. The new theme sweeps over the old one as a circle growing
+from the toggle control, instead of every element flash-swapping its colors.
+Built on the View Transitions API: the browser snapshots the page before and
+after the class flip and we clip-reveal the "after" snapshot — no per-element
+color transitions, fully GPU-composited.
+
+## Usage
+
+JS lives in `src/hooks/use-theme.ts` (`toggleTheme({ x, y })` — pass the
+toggle's center; omit the origin to get the API's default crossfade). CSS is
+the snapshot freeze in `globals.css`, scoped to `:root[data-theme-wipe]`.
+
+```tsx
+const { isDark, toggleTheme } = useTheme();
+<button
+  onClick={(event) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    toggleTheme({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+  }}
+>
+```
+
+## Tunables
+
+| Constant (use-theme.ts) | Default | Notes |
+| --- | --- | --- |
+| `WIPE_DURATION_MS` | `400` | Above the usual sub-300ms UI band on purpose — the motion spans the whole viewport. Keep ≤ 500. |
+| `WIPE_EASE` | `cubic-bezier(0.23, 1, 0.32, 1)` | Strong ease-out; circle area grows with r² so the coverage still reads brisk at the tail. |
+
+## Degradation ladder
+
+1. No `document.startViewTransition` (old browsers): instant swap — exactly
+   the pre-recipe behavior.
+2. `prefers-reduced-motion: reduce`: default view-transition crossfade
+   (opacity only, no motion).
+3. Rapid double-toggle: the second `startViewTransition` skips the first;
+   the first's cleanup can drop the snapshot freeze early, degrading that
+   one wipe to a crossfade. Harmless.
+
+## Caveats
+
+- Canvas/JS-driven surfaces that recolor asynchronously after the class flip
+  may be captured mid-recolor in the "after" snapshot; they settle the frame
+  the transition ends.
+- Interaction is inert under the transition overlay for the wipe's 400ms —
+  another reason to keep the duration tight.


### PR DESCRIPTION
Adds dark theme support across the wallet facelift: designer token mapping in globals.css, hardcoded-color sweep, mask-based icon theming, and a view-transition circle wipe on the sidebar theme toggle. ASK-2060