### PR TITLE
feat(analytics): serve onboarding popup copy from mixpanel feature flags

### DIFF
--- a/frontend/src/app/ingest/[...path]/route.ts
+++ b/frontend/src/app/ingest/[...path]/route.ts
@@ -2,6 +2,8 @@ const MIXPANEL_API_ORIGIN = "https://api-js.mixpanel.com";
 const FORWARDED_REQUEST_HEADERS = [
   "accept",
   "accept-language",
+  // The feature-flags fetch authenticates via `Authorization: Basic <token>`.
+  "authorization",
   "cf-connecting-ip",
   "content-type",
   "forwarded",

--- a/frontend/src/components/wallet-workspace/facelift/lifecycle-onboarding.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/lifecycle-onboarding.tsx
@@ -22,6 +22,7 @@ import {
 import { usePublicEnv } from "@/contexts/public-env-context";
 import {
   FRONTEND_ANALYTICS_EVENTS,
+  getFlagVariant,
   trackFrontendAnalyticsEvent,
 } from "@/lib/core/analytics";
 
@@ -92,6 +93,64 @@ type StepContent = {
   steps: EarnModalStep[];
   title: string;
 };
+
+// Mixpanel dynamic-config flags serving each step's copy (ASK-1972 A/B
+// plumbing). The variant payload overrides the STEP_CONTENT text below;
+// icons and layout stay in code. Copy is editable in Mixpanel without a
+// deploy once the flag is enabled; a disabled/missing flag (or no network)
+// falls back to STEP_CONTENT with variant "fallback".
+const STEP_FLAG_KEYS: Record<OnboardingStepId, string> = {
+  autodeposit: "onboarding_popup_autodeposit",
+  deposit: "onboarding_popup_deposit",
+  welcome: "onboarding_popup_welcome",
+};
+
+// The flags SDK resolves its fallback on fetch errors; this bound only
+// covers a hung fetch so a popup can't be silently swallowed.
+const FLAG_TIMEOUT_MS = 2000;
+
+type StepContentOverride = {
+  buttonLabel?: unknown;
+  description?: unknown;
+  steps?: unknown;
+  title?: unknown;
+};
+
+function mergeStepContent(base: StepContent, payload: unknown): StepContent {
+  if (typeof payload !== "object" || payload === null) {
+    return base;
+  }
+  const override = payload as StepContentOverride;
+  const overrideSteps = Array.isArray(override.steps) ? override.steps : [];
+  return {
+    ...base,
+    buttonLabel:
+      typeof override.buttonLabel === "string"
+        ? override.buttonLabel
+        : base.buttonLabel,
+    description:
+      typeof override.description === "string"
+        ? override.description
+        : base.description,
+    title: typeof override.title === "string" ? override.title : base.title,
+    steps: base.steps.map((step, index) => {
+      const stepOverride = overrideSteps[index] as
+        | { description?: unknown; title?: unknown }
+        | undefined;
+      return {
+        ...step,
+        description:
+          typeof stepOverride?.description === "string"
+            ? stepOverride.description
+            : step.description,
+        title:
+          typeof stepOverride?.title === "string"
+            ? stepOverride.title
+            : step.title,
+      };
+    }),
+  };
+}
 
 const STEP_CONTENT: Record<OnboardingStepId, StepContent> = {
   autodeposit: {
@@ -189,7 +248,11 @@ export function LifecycleOnboardingHost({
   walletAddress: string | null;
 }) {
   const publicEnv = usePublicEnv();
-  const [visibleStep, setVisibleStep] = useState<OnboardingStepId | null>(null);
+  const [presented, setPresented] = useState<{
+    content: StepContent;
+    step: OnboardingStepId;
+    variant: string;
+  } | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   // Bumped whenever a signal writes storage so the presenter effect re-runs.
   const [stateVersion, setStateVersion] = useState(0);
@@ -270,7 +333,9 @@ export function LifecycleOnboardingHost({
   }, [hasAutodeposit, hasPosition, isReady, walletAddress]);
 
   // Presenter: on the Earn root with nothing open, show the furthest
-  // pending step, remember it (and everything before it) as done.
+  // pending step, remember it (and everything before it) as done. The
+  // Mixpanel flag variant is resolved first so the modal renders its copy
+  // in one pass; storage only flips to "done" once the popup really shows.
   useEffect(() => {
     if (!(isReady && walletAddress && isAtEarnRoot) || isOpen) {
       return;
@@ -282,28 +347,50 @@ export function LifecycleOnboardingHost({
     if (!step) {
       return;
     }
-    for (const id of STEP_ORDER) {
-      if (state[id] === "pending") {
-        state[id] = "done";
+    let cancelled = false;
+    void (async () => {
+      const flagVariant = await Promise.race([
+        getFlagVariant(publicEnv, STEP_FLAG_KEYS[step], null),
+        new Promise<{ key: string; value: unknown }>((resolve) =>
+          setTimeout(
+            () => resolve({ key: "fallback", value: null }),
+            FLAG_TIMEOUT_MS
+          )
+        ),
+      ]);
+      if (cancelled) {
+        return;
       }
-      if (id === step) {
-        break;
+      for (const id of STEP_ORDER) {
+        if (state[id] === "pending") {
+          state[id] = "done";
+        }
+        if (id === step) {
+          break;
+        }
       }
-    }
-    writeState(walletAddress, state);
-    trackFrontendAnalyticsEvent(
-      publicEnv,
-      FRONTEND_ANALYTICS_EVENTS.onboardingPopupShown,
-      { step }
-    );
-    setVisibleStep(step);
-    setIsOpen(true);
+      writeState(walletAddress, state);
+      trackFrontendAnalyticsEvent(
+        publicEnv,
+        FRONTEND_ANALYTICS_EVENTS.onboardingPopupShown,
+        { step, variant: flagVariant.key }
+      );
+      setPresented({
+        content: mergeStepContent(STEP_CONTENT[step], flagVariant.value),
+        step,
+        variant: flagVariant.key,
+      });
+      setIsOpen(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [isAtEarnRoot, isOpen, isReady, publicEnv, stateVersion, walletAddress]);
 
-  if (visibleStep === null) {
+  if (presented === null) {
     return null;
   }
-  const content = STEP_CONTENT[visibleStep];
+  const { content, step, variant } = presented;
   return (
     <EarnModal
       buttonLabel={content.buttonLabel}
@@ -314,12 +401,12 @@ export function LifecycleOnboardingHost({
         trackFrontendAnalyticsEvent(
           publicEnv,
           FRONTEND_ANALYTICS_EVENTS.onboardingPopupCtaClicked,
-          { step: visibleStep }
+          { step, variant }
         );
         setIsOpen(false);
-        if (visibleStep === "welcome") {
+        if (step === "welcome") {
           onOpenDeposit();
-        } else if (visibleStep === "deposit") {
+        } else if (step === "deposit") {
           onOpenAutodeposit();
         }
       }}
@@ -327,7 +414,7 @@ export function LifecycleOnboardingHost({
         trackFrontendAnalyticsEvent(
           publicEnv,
           FRONTEND_ANALYTICS_EVENTS.onboardingPopupDismissed,
-          { step: visibleStep }
+          { step, variant }
         );
         setIsOpen(false);
       }}

--- a/frontend/src/lib/core/analytics.ts
+++ b/frontend/src/lib/core/analytics.ts
@@ -6,6 +6,7 @@ import type { AnalyticsProperties } from "@loyal-labs/shared/analytics";
 import type { PublicEnv } from "@/lib/core/config/public";
 
 export {
+  getFlagVariant,
   identifyAuthenticatedUser,
   initAnalytics,
   resetAuthenticatedUser,

--- a/frontend/src/lib/core/analytics/client.ts
+++ b/frontend/src/lib/core/analytics/client.ts
@@ -3,6 +3,7 @@
 import type { AuthSessionUser } from "@loyal-labs/auth-core";
 import {
   type AnalyticsClient,
+  type AnalyticsFlagVariant,
   type AnalyticsProperties,
   createMixpanelBrowserClient,
   createWorkspaceProfileUpdate,
@@ -75,6 +76,7 @@ function getAnalyticsClient(publicEnv: PublicEnv): AnalyticsClient {
     apiHost: getApiHost(publicEnv),
     debug: publicEnv.appEnvironment !== "prod",
     persistence: "localStorage",
+    flags: true,
     defaultEventProperties: {
       workspace: WEBSITE_WORKSPACE,
     },
@@ -157,6 +159,18 @@ export function trackFrontendAnalyticsEvent(
 
 export function trackPageView(publicEnv: PublicEnv, pathname: string): void {
   track(publicEnv, getFrontendPageViewEventName(pathname), { path: pathname });
+}
+
+// Resolves a Mixpanel feature-flag variant ({ key, value }); resolves the
+// fallback (key "fallback") when flags are unavailable or the flag is
+// missing/disabled. Calling this counts as an experiment exposure, so only
+// call it when the flagged surface is actually about to show.
+export function getFlagVariant(
+  publicEnv: PublicEnv,
+  flagKey: string,
+  fallbackValue: unknown
+): Promise<AnalyticsFlagVariant> {
+  return getAnalyticsClient(publicEnv).getFlagVariant(flagKey, fallbackValue);
 }
 
 export function identifyAuthenticatedUser(

--- a/packages/shared/src/analytics.ts
+++ b/packages/shared/src/analytics.ts
@@ -26,6 +26,12 @@ export type AnalyticsConfig = {
   persistence?: Persistence;
   defaultEventProperties?: AnalyticsProperties;
   registerProperties?: AnalyticsProperties;
+  flags?: boolean;
+};
+
+export type AnalyticsFlagVariant = {
+  key: string;
+  value: unknown;
 };
 
 export type AnalyticsClient = {
@@ -38,6 +44,10 @@ export type AnalyticsClient = {
   setUserProfile: (properties: AnalyticsProperties) => void;
   setUserProfileOnce: (properties: AnalyticsProperties) => void;
   unionUserProfile: (properties: AnalyticsProfileUnionProperties) => void;
+  getFlagVariant: (
+    flagKey: string,
+    fallbackValue: unknown
+  ) => Promise<AnalyticsFlagVariant>;
   __resetForTests: () => void;
 };
 
@@ -98,6 +108,7 @@ export function createMixpanelBrowserClient(
           debug: config.debug ?? false,
           track_pageview: false,
           persistence: config.persistence,
+          flags: config.flags ?? false,
         });
 
         if (config.registerProperties) {
@@ -236,6 +247,33 @@ export function createMixpanelBrowserClient(
     });
   }
 
+  async function getFlagVariant(
+    flagKey: string,
+    fallbackValue: unknown
+  ): Promise<AnalyticsFlagVariant> {
+    const fallback: AnalyticsFlagVariant = {
+      key: "fallback",
+      value: fallbackValue,
+    };
+
+    if (!canTrack()) {
+      return fallback;
+    }
+
+    try {
+      await init();
+      if (!isInitialized || !mixpanel) {
+        return fallback;
+      }
+
+      const variant = await mixpanel.flags.get_variant(flagKey, fallback);
+      return { key: variant.key, value: variant.value };
+    } catch (error) {
+      console.error("Failed to get Mixpanel flag variant", error);
+      return fallback;
+    }
+  }
+
   function resetForTests(): void {
     mixpanel = null;
     isInitialized = false;
@@ -253,6 +291,7 @@ export function createMixpanelBrowserClient(
     setUserProfile,
     setUserProfileOnce,
     unionUserProfile,
+    getFlagVariant,
     __resetForTests: resetForTests,
   };
 }


### PR DESCRIPTION
Lifecycle onboarding pop-ups now resolve their copy from Mixpanel dynamic-config flags (onboarding_popup_welcome/deposit/autodeposit) at show time, falling back to the code defaults, and stamp the served variant on the shown/CTA/dismiss events for A/B readouts. Also forwards the authorization header through the Mixpanel ingest proxy so the SDK's flag fetch authenticates. ASK-2056