### PR TITLE
fix(auth): route brave wallet away from the unsignable ledger proof transaction

### DIFF
--- a/frontend/src/components/auth/wallet-tab.tsx
+++ b/frontend/src/components/auth/wallet-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useWallet } from "@solana/wallet-adapter-react";
 import { AlertCircle, ArrowUpRight } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useState } from "react";
 
@@ -141,8 +142,15 @@ export function WalletTab({
 }) {
   const cherryRuntime = useCherryRuntime();
   const isCherryEmbedded = cherryRuntime.mode === "cherry_embedded";
+  const { wallet } = useWallet();
   const [useLedgerProof, setUseLedgerProof] = useState(false);
   const [showWalletSelection, setShowWalletSelection] = useState(false);
+  // Brave Wallet validates `recentBlockhash` against the chain before
+  // signing, so it can never sign the non-broadcastable Ledger proof
+  // transaction (ASK-2049). Hide the toggle for it — and mask the flag too,
+  // because the toggle can be checked before a wallet is chosen.
+  const supportsLedgerProof = wallet?.adapter.name !== "Brave Wallet";
+  const ledgerProofActive = useLedgerProof && supportsLedgerProof;
   const {
     connected,
     publicKey,
@@ -155,7 +163,7 @@ export function WalletTab({
     captchaToken: captchaToken ?? undefined,
     onCaptchaConsumed,
     onFlowStart,
-    useLedgerProof,
+    useLedgerProof: ledgerProofActive,
   });
 
   const isVerified = Boolean(captchaToken);
@@ -199,7 +207,7 @@ export function WalletTab({
       state.status === "connecting"
         ? "Connecting your wallet..."
         : state.status === "awaiting_signature"
-        ? useLedgerProof
+        ? ledgerProofActive
           ? "Approve the Ledger verification transaction..."
           : "Approve sign-in in your wallet..."
         : "Verifying your wallet and preparing your smart account...";
@@ -247,7 +255,7 @@ export function WalletTab({
             lands here as an opaque wallet error. Keep the Ledger escape hatch
             visible so those users can self-serve — but not after a deliberate
             cancellation, which is not a capability problem. */}
-        {state.status !== "rejected" && !isCherryEmbedded && (
+        {state.status !== "rejected" && !isCherryEmbedded && supportsLedgerProof && (
           <LedgerModeToggle
             checked={useLedgerProof}
             disabled={!isVerified}
@@ -276,7 +284,7 @@ export function WalletTab({
     <div className="flex flex-col gap-4">
       {connected && publicKey && !showWalletSelection ? (
         <div className="flex flex-col gap-2">
-          {isCherryEmbedded ? null : (
+          {isCherryEmbedded || !supportsLedgerProof ? null : (
             <LedgerModeToggle
               checked={useLedgerProof}
               disabled={!isVerified}
@@ -293,7 +301,7 @@ export function WalletTab({
               text={
                 isCherryEmbedded
                   ? "Verify Cherry Wallet"
-                  : useLedgerProof
+                  : ledgerProofActive
                   ? "Verify Ledger Wallet"
                   : "Verify Connected Wallet"
               }

--- a/frontend/src/lib/auth/wallet-proof-signer.test.ts
+++ b/frontend/src/lib/auth/wallet-proof-signer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+
+import {
+  signWalletProofTransaction,
+  WalletProofSignerError,
+} from "./wallet-proof-signer";
+
+function buildChallengeTransactionBase64(feePayer: PublicKey): string {
+  const transaction = new Transaction({
+    feePayer,
+    recentBlockhash: "11111111111111111111111111111111",
+  }).add(
+    new TransactionInstruction({
+      keys: [{ isSigner: true, isWritable: false, pubkey: feePayer }],
+      programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+      data: Buffer.from("loyal login proof", "utf8"),
+    })
+  );
+
+  return transaction
+    .serialize({ requireAllSignatures: false, verifySignatures: false })
+    .toString("base64");
+}
+
+// Brave Wallet refuses to sign the non-broadcastable proof transaction after
+// pre-validating its placeholder blockhash on-chain (ASK-2049). That refusal
+// must classify as `wallet_signing_unsupported` with a self-serve message, not
+// bubble as an opaque signing failure.
+describe("signWalletProofTransaction", () => {
+  const transaction = buildChallengeTransactionBase64(
+    Keypair.generate().publicKey
+  );
+
+  test("classifies a wallet blockhash-validation refusal as unsupported", async () => {
+    const promise = signWalletProofTransaction({
+      signTransaction: () =>
+        Promise.reject(
+          new Error("Blockhash is invalid or can not be validated")
+        ),
+      transaction,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(WalletProofSignerError);
+    await promise.catch((error: WalletProofSignerError) => {
+      expect(error.code).toBe("wallet_signing_unsupported");
+      expect(error.message).toContain("I use Ledger or hardware wallet");
+    });
+  });
+
+  test("still classifies an explicit user rejection as rejected", async () => {
+    const promise = signWalletProofTransaction({
+      signTransaction: () =>
+        Promise.reject(new Error("User rejected the request.")),
+      transaction,
+    });
+
+    await promise.catch((error: WalletProofSignerError) => {
+      expect(error).toBeInstanceOf(WalletProofSignerError);
+      expect(error.code).toBe("wallet_signature_rejected");
+    });
+  });
+});

--- a/frontend/src/lib/auth/wallet-proof-signer.ts
+++ b/frontend/src/lib/auth/wallet-proof-signer.ts
@@ -232,6 +232,20 @@ export async function signWalletProofTransaction(args: {
       );
     }
 
+    // Some wallets (Brave Wallet) validate `recentBlockhash` against the
+    // chain before signing, so they refuse the deliberately non-broadcastable
+    // proof transaction outright (ASK-2049). A capability gap, not a signing
+    // failure — tell the user the way out instead of surfacing wallet jargon.
+    if (
+      error instanceof Error &&
+      error.message.toLowerCase().includes("blockhash")
+    ) {
+      throw new WalletProofSignerError(
+        "This wallet cannot sign the Ledger verification transaction. Turn off “I use Ledger or hardware wallet” and sign in normally.",
+        "wallet_signing_unsupported"
+      );
+    }
+
     throw error;
   }
 }


### PR DESCRIPTION
Brave Wallet pre-validates `recentBlockhash` and refuses to sign the non-broadcastable Ledger proof transaction, so the Ledger toggle is now hidden/masked for Brave (falls back to SIWS) and a blockhash-validation refusal from any wallet classifies as `wallet_signing_unsupported` with a self-serve message instead of `wallet_signing_failed`.

ASK-2064