### PR TITLE
feat(dashboard): add public /api/earn/vaults endpoint for DefiLlama TVL

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -18,6 +18,18 @@ op run --env-file=../.env.mainnet.1password --env-file=../../loyal-yield-routing
 
 Keep real values in 1Password. Do not write plaintext secrets into local env files, source code, logs, command arguments, or chat.
 
+## Public API
+
+### GET /api/earn/vaults
+
+Public list of active Loyal Earn vault pubkeys (Squads smart accounts), plus the treasury autonomous vault.
+
+Production: https://stats.askloyal.com/api/earn/vaults
+
+200 response: JSON object with `vaults` (base58 pubkeys), `count`, and `updatedAt`.
+
+Source: active rows in `loyal_yield.user_yield_positions`, plus treasury vault `F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e` if it is not already in that result.
+
 ## Deployment
 
 Use `dashboard` as the Vercel Root Directory. The local `vercel.json` installs from the monorepo root with Bun and builds this workspace.

--- a/apps/dashboard/src/app/api/earn/vaults/route.ts
+++ b/apps/dashboard/src/app/api/earn/vaults/route.ts
@@ -1,0 +1,66 @@
+import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.server";
+
+export const revalidate = 300; // 5 minutes
+
+const MAX_VAULTS = 50_000;
+
+// Loyal treasury autonomous vault — not in user_yield_positions.
+// Same pubkey as admin MANIFEST.vault in
+// admin/src/app/(admin)/earn/autonomous-vault/autonomous-vault-data.ts
+const TREASURY_VAULTS = [
+  "F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e",
+] as const;
+
+type VaultRow = { vault_pubkey: string };
+
+export async function GET() {
+  try {
+    const sql = getYieldNeonSql();
+    const result = await sql`
+      SELECT DISTINCT vault_pubkey
+      FROM loyal_yield.user_yield_positions
+      WHERE status = 'active'
+        AND vault_pubkey IS NOT NULL
+        AND length(vault_pubkey) BETWEEN 32 AND 44
+      ORDER BY vault_pubkey
+      LIMIT ${MAX_VAULTS}
+    `;
+
+    if (!Array.isArray(result)) {
+      throw new Error("unexpected neon result shape");
+    }
+
+    const fromDb = (result as VaultRow[]).map((r) => r.vault_pubkey);
+    const seen = new Set(fromDb);
+    const vaults = fromDb.concat(
+      TREASURY_VAULTS.filter((vault) => !seen.has(vault)),
+    );
+
+    return Response.json(
+      {
+        vaults,
+        count: vaults.length,
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control":
+            "public, s-maxage=300, stale-while-revalidate=60, max-age=60",
+          "CDN-Cache-Control": "public, s-maxage=300",
+          "X-Content-Type-Options": "nosniff",
+        },
+      },
+    );
+  } catch {
+    return Response.json(
+      { error: "vault list unavailable" },
+      {
+        status: 503,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds a public, cache-friendly endpoint that returns the list of **active Loyal Earn vault pubkeys** (Squads smart accounts).

In production this is served at **https://stats.askloyal.com/api/earn/vaults**.

Loyal has no single central TVL contract. Each user has a Squads smart account; Earn capital is routed into Kamino Lend across the five `RiskBasket.Safe` markets. External indexers (starting with DefiLlama) need a stable list of those vault addresses so they can verify balances on-chain. See [DefiLlama SDK adapter docs](https://docs.llama.fi/list-your-project/how-to-write-an-sdk-adapter).

## Endpoint

`GET /api/earn/vaults`  
Public URL: `https://stats.askloyal.com/api/earn/vaults`

**200 response**
```json
{
  "vaults": ["Base58Pubkey1", "Base58Pubkey2", "..."],
  "count": 1234,
  "updatedAt": "2026-08-09T16:00:00.000Z"
}
```

| Detail | Value |
|--------|--------|
| Source | `loyal_yield.user_yield_positions` where `status = 'active'`, plus treasury vault `F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e` (same address as admin `MANIFEST.vault`; not stored in that table; we only add it if it is not already in the query result) |
| Filters | non-null `vault_pubkey`, length 32–44 |
| Cap | 50_000 rows |
| Cache | `revalidate = 300` + `s-maxage=300` / SWR headers |
| Errors | `503` + `{ "error": "vault list unavailable" }` when Neon is unreachable |

No balances, user IDs, or private data are returned. Consumers must verify TVL on-chain.

## Files

- `dashboard/src/app/api/earn/vaults/route.ts` — new route
- `dashboard/README.md` — public API docs

Uses existing `getYieldNeonSql()` / `NEON_DATABASE_URL`.

## Companion DefiLlama adapter (for joint testing)

Branch / fork for the adapter side:

https://github.com/86doteth/DefiLlama-Adapters/tree/loyal-tvl-adapter

The adapter:

1. Fetches this vault list from the stats API  
2. Derives vanilla Kamino obligations (`tag = 0`, `id = 0`) for each vault × the five Safe markets  
3. Sums redeemable USDC from obligation collateral shares (not stale marketValueSf), plus idle vault USDC. USDC-only. Treasury is also hardcoded in the adapter until this endpoint is live in prod.

Safe markets (from `packages/loyal-actions/src/constants.ts`):

- Main `7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF`
- Figure `CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA`
- Maple `6WEGfej9B9wjxRs6t4BYpb9iCXd8CpTpJ8fVSNzHCC5y`
- OnRe `47tfyEG9SsdEnUm9cw5kY9BXngQGqu3LBoop9j5uTAv8`
- Ethena `BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF`

## How to test (reviewers with Neon / deploy access)

1. Deploy or preview this branch (dashboard root → stats host).  
2. Hit `GET /api/earn/vaults` and confirm a non-empty `vaults` array + sensible `count`.  
3. Point the companion adapter’s `VAULTS_API` at that preview URL if production `stats.askloyal.com` is not live yet.  
4. Run:
   ```bash
   node test.js projects/loyal/index.js
   ```
5. Compare the printed Solana TVL to **Earn AUM** on the public dashboard. They should be in the same ballpark (adapter is pure on-chain obligation value; dashboard AUM may differ slightly on timing / refresh).

## Notes

- CORS left unset (server-side consumers only for now).  
- `timetravel: false` on the DefiLlama side because the vault set comes from a live API.  
- Idle USDC on vaults is included. Non-USDC stables are omitted for now.
