### PR TITLE
feat(observability): log the alert text sent to Telegram and Slack

### DIFF
--- a/observability/telegram-relay/README.md
+++ b/observability/telegram-relay/README.md
@@ -252,7 +252,7 @@ search link.
 | `RESTART_GRACE_SECONDS`     | no       | `120`                                     | Hold alerts this long after boot and post one restart recap. `0` disables                                                                                        |
 | `SWEEP_INTERVAL_SECONDS`    | no       | `60`                                      | How often windows are closed and the recap schedule is checked                                                                                                   |
 | `STATE_FILE`                | no       | empty                                     | Path to persist windows across restarts. Needs a mounted disk                                                                                                    |
-| `TRACE_LOGS`                | no       | `false`                                   | Structured request and validation diagnostics                                                                                                                    |
+| `TRACE_LOGS`                | no       | `false`                                   | Structured request and validation diagnostics. Delivered message text is logged unconditionally, not by this flag                                                |
 
 `CLICKSTACK_WEBHOOK_SECRET` uses `generateValue: true` in the Blueprint, so
 Render generates it. Read it from the Render dashboard and paste it into the
@@ -379,11 +379,44 @@ difference between a reality check and an unrepresentative sample.
 Use it before changing any noise-related default. The removal of the per-window
 recap was decided this way.
 
+## Delivered message logging
+
+Every message the relay sends is logged to stdout before it is posted, once per
+destination, so Render logs show what Telegram and Slack actually received:
+
+```json
+{
+  "event": "alert_message_outgoing",
+  "destination": "telegram",
+  "eventId": "dcc4a074d12db8a38065aeeeb8fdf88c674ce2dc",
+  "state": "ALERT",
+  "kind": "new",
+  "chars": 812,
+  "parseMode": "HTML",
+  "silent": false,
+  "text": "<b>Alert for Errors</b>\n..."
+}
+```
+
+This is not behind `TRACE_LOGS`. The cooldown keeps alert volume to a handful of
+messages a day, and the text is most needed exactly when a send fails — which is
+why it is logged before the request rather than after a successful one. A send
+Telegram rejects for bad HTML entities logs twice: the second carries
+`"fallback": true` and the unformatted text that replaced it. Slack lines carry
+the Slack rendering, not the Telegram HTML. Bot tokens and Slack webhook URLs are
+redacted from the text — see [Security notes](#security-notes) — and text past
+4096 characters is cut with `"truncated": true`, though the formatter fits inside
+Telegram's limit, so in practice nothing is cut.
+
+Follow one incident across both destinations by filtering Render logs on its
+`eventId`, which is shared with the `clickstack_webhook` outcome line.
+
 ## Trace logging
 
-Trace logs are disabled by default. Enable them temporarily when diagnosing a
-rejected ClickStack webhook by setting `TRACE_LOGS=true`. Each request then
-emits structured JSON diagnostics:
+Trace logs are disabled by default and cover request validation, not message
+content: enable them temporarily when diagnosing a rejected ClickStack webhook
+by setting `TRACE_LOGS=true`. Each request then emits structured JSON
+diagnostics:
 
 ```json
 {
@@ -413,6 +446,40 @@ for `state`, including `INSUFFICIENT_DATA`, are valid.
   alerting path does not depend on the system it alerts about.
 - Trace logs contain field names, validation reasons, `eventId`, state, and
   timestamps, but never request bodies or authentication values.
+- `alert_message_outgoing` logs do contain the delivered text, which carries
+  whatever the alerted log lines carry — service names, exception messages, and
+  wallet addresses. That is the same content already in ClickStack and in the
+  Telegram and Slack channels.
+- Because that text is other services' output, it is redacted more aggressively
+  than the relay's own error messages: bot tokens are stripped both in their URL
+  form and bare by shape (`<id>:<35-char secret>`), Slack webhook URLs by
+  pattern, and all three of the relay's own credentials — bot token, Slack
+  webhook URL, `CLICKSTACK_WEBHOOK_SECRET` — by exact value, in both their raw
+  and HTML-escaped spellings, since formatted text carries the escaped one. A
+  service that logs its bot token, or dumps its environment into an error,
+  therefore cannot leak it through this relay's logs.
+- There is no minimum secret length. A short or word-like secret makes log lines
+  noisy, because every innocent occurrence of that word is redacted too — that
+  is preferred over a floor that silently leaves the shortest secrets in the
+  logs. If logs look over-redacted, the fix is a longer secret.
+- Occurrences are located against the original text and overlapping ones are
+  merged before anything is rewritten, so no character of a credential survives
+  regardless of credential order or how two of them overlap. Rewriting as it
+  scanned left tails behind (`<redacted>-BBBB`) when one credential ended where
+  another began.
+- That secret set is the same for both destinations on purpose. Telegram and
+  Slack render the same alert text, so a credential redacted from only one
+  sender's log line would still be printed in full by the other's. The redactor
+  lives on `RelayCredentials` (`src/credentials.ts`), which holds all four
+  credentials and the redaction over them as one value. Senders post with
+  `credentials.telegramBotToken` and log through `credentials.redactLogText`, so
+  redaction always covers the credentials actually in use. The class has a
+  private field, which makes it nominal: no object literal and no spread of an
+  instance is assignable to it, so `{ ...config, telegramBotToken: other }` —
+  which would otherwise keep redaction built over the previous token and print
+  the new one in full — does not compile. Changing a credential means
+  constructing a new instance, which rebuilds the secret set from the values it
+  was given.
 
 ## Routes
 

--- a/observability/telegram-relay/src/app.test.ts
+++ b/observability/telegram-relay/src/app.test.ts
@@ -35,6 +35,49 @@ function format(
   return formatTelegramMessage(item, { alertColumns });
 }
 
+/**
+ * Senders are built from a real `loadConfig` result, the way `index.ts` builds
+ * them: `redactLogText` is branded and its constructor is private, so this is
+ * also the only way a test can get one. Tests that care about redaction pass
+ * their fake credentials as env, and the redactor covers all of them.
+ */
+function testConfig(env: Record<string, string> = {}) {
+  return loadConfig({
+    CLICKSTACK_WEBHOOK_SECRET: "test-webhook-secret",
+    TELEGRAM_BOT_TOKEN: "token",
+    TELEGRAM_CHAT_ID: "chat",
+    SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/test",
+    ...env,
+  });
+}
+
+type LogLine = Record<string, unknown>;
+
+/**
+ * The delivered-text logs are the feature, not a side effect, so the tests read
+ * them the way an operator reads Render logs: as parsed JSON lines on stdout.
+ */
+function captureInfoLogs() {
+  const original = console.info;
+  const lines: LogLine[] = [];
+  console.info = (...args: unknown[]) => {
+    try {
+      lines.push(JSON.parse(String(args[0])) as LogLine);
+    } catch {
+      // Non-JSON output is not something this relay emits; ignore it rather
+      // than fail a test on an unrelated log line.
+    }
+  };
+
+  return {
+    restore: () => {
+      console.info = original;
+    },
+    all: (event: string) => lines.filter((line) => line.event === event),
+    find: (event: string) => lines.find((line) => line.event === event),
+  };
+}
+
 function createTestHandler() {
   const sent: ClickStackWebhookPayload[] = [];
   const relay = new AlertRelay(
@@ -51,7 +94,8 @@ function createTestHandler() {
   return {
     sent,
     handler: createRequestHandler(relay, {
-      clickStackWebhookSecret: "test-secret",
+      credentials: testConfig({ CLICKSTACK_WEBHOOK_SECRET: "test-secret" })
+        .credentials,
     }),
   };
 }
@@ -169,6 +213,30 @@ describe("payload and formatting", () => {
     };
     expect(loadConfig(env).traceLogs).toBe(false);
     expect(loadConfig({ ...env, TRACE_LOGS: "true" }).traceLogs).toBe(true);
+  });
+
+  test("builds one log redactor covering every credential it read", () => {
+    // The senders require this redactor, so this is the only place a credential
+    // can be left out of the redaction — adding one to ServerConfig without
+    // adding it here is the regression this guards.
+    const secret = "clickstack-bearer-secret-value";
+    const token = "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw";
+    const webhook =
+      "https://hooks.slack.com/services/T00000/B00000/abcdef123456";
+    const config = loadConfig({
+      CLICKSTACK_WEBHOOK_SECRET: secret,
+      TELEGRAM_BOT_TOKEN: token,
+      TELEGRAM_CHAT_ID: "chat",
+      SLACK_WEBHOOK_URL: webhook,
+    });
+
+    const redacted = config.credentials.redactLogText(
+      `secret=${secret} token=${token} webhook=${webhook}`
+    );
+
+    expect(redacted).not.toContain(secret);
+    expect(redacted).not.toContain(token);
+    expect(redacted).not.toContain("abcdef123456");
   });
 
   test("keeps Telegram messages within the API limit", () => {
@@ -323,11 +391,7 @@ describe("pretty alert formatting", () => {
 });
 
 describe("Telegram sender", () => {
-  const senderConfig = {
-    telegramBotToken: "token",
-    telegramChatId: "chat",
-    alertColumns: defaultColumns,
-  };
+  const senderConfig = testConfig();
   const newAlert: AlertContext = { kind: "new", silent: false };
   const formattedPayload: ClickStackWebhookPayload = {
     ...payload,
@@ -433,6 +497,148 @@ describe("Telegram sender", () => {
     expect(bodies[1]?.parse_mode).toBeUndefined();
     expect(bodies[1]?.text).toContain('"loyal-mobile"');
   });
+
+  test("logs the delivered text, redacted, before posting it", async () => {
+    const logs = captureInfoLogs();
+    const send = createTelegramSender(
+      testConfig({ TELEGRAM_BOT_TOKEN: "123456:AAAA-token" }),
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    try {
+      await send(
+        {
+          ...formattedPayload,
+          body: [
+            "```",
+            '"2026-07-21T19:15:10.807Z","loyal-mobile","error","leaked bot123456:AAAA-token"',
+            "```",
+          ].join("\n"),
+        },
+        { kind: "new", silent: false }
+      );
+    } finally {
+      logs.restore();
+    }
+
+    const line = logs.find("alert_message_outgoing");
+    expect(line?.destination).toBe("telegram");
+    expect(line?.eventId).toBe(payload.eventId);
+    expect(line?.kind).toBe("new");
+    expect(line?.silent).toBe(false);
+    expect(line?.parseMode).toBe("HTML");
+    expect(String(line?.text)).toContain("Alert for Errors");
+    expect(String(line?.text)).toContain("bot<redacted>");
+    expect(String(line?.text)).not.toContain("AAAA-token");
+    expect(line?.chars).toBe(String(line?.text).length);
+    expect(line?.truncated).toBeUndefined();
+  });
+
+  test("redacts a bot token an alerted service logged without the URL prefix", async () => {
+    const logs = captureInfoLogs();
+    // The shape of a real token, carried in the alert text with no `bot` in
+    // front of it: the URL-shaped redaction does not see this one.
+    const leaked = "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw";
+    const send = createTelegramSender(
+      senderConfig,
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    try {
+      await send(
+        {
+          ...payload,
+          body: [
+            "```",
+            `"2026-07-21T19:15:10.807Z","loyal-mobile","error","TELEGRAM_BOT_TOKEN=${leaked}"`,
+            "```",
+          ].join("\n"),
+        },
+        newAlert
+      );
+    } finally {
+      logs.restore();
+    }
+
+    const text = String(logs.find("alert_message_outgoing")?.text);
+    expect(text).not.toContain(leaked);
+    expect(text).not.toContain("AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw");
+    expect(text).toContain("TELEGRAM_BOT_TOKEN=<redacted>");
+  });
+
+  test("redacts configured secrets by value, whatever shape they have", async () => {
+    const logs = captureInfoLogs();
+    const token = "unshaped-but-still-a-secret-value";
+    const webhookSecret = "clickstack-bearer-secret-value";
+    const send = createTelegramSender(
+      testConfig({
+        TELEGRAM_BOT_TOKEN: token,
+        CLICKSTACK_WEBHOOK_SECRET: webhookSecret,
+      }),
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    try {
+      await send(
+        { ...payload, title: `Errors ${token} ${webhookSecret}` },
+        newAlert
+      );
+    } finally {
+      logs.restore();
+    }
+
+    const text = String(logs.find("alert_message_outgoing")?.text);
+    expect(text).not.toContain(token);
+    expect(text).not.toContain(webhookSecret);
+    expect(text).toContain("<redacted>");
+  });
+
+  test("logs the text of a send Telegram rejects, and of its fallback", async () => {
+    const logs = captureInfoLogs();
+    let attempts = 0;
+    const send = createTelegramSender(senderConfig, async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          JSON.stringify({ ok: false, description: "can't parse entities" }),
+          { status: 400 }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    try {
+      await send(formattedPayload, newAlert);
+    } finally {
+      logs.restore();
+    }
+
+    const lines = logs.all("alert_message_outgoing");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.parseMode).toBe("HTML");
+    expect(lines[0]?.fallback).toBeUndefined();
+    expect(lines[1]?.fallback).toBe(true);
+    expect(String(lines[1]?.text)).toContain('"loyal-mobile"');
+  });
+
+  test("logs a failed send's text even though nothing was delivered", async () => {
+    const logs = captureInfoLogs();
+    const send = createTelegramSender(
+      senderConfig,
+      async () =>
+        new Response(JSON.stringify({ ok: false, description: "nope" }), {
+          status: 500,
+        })
+    );
+
+    try {
+      await expect(send(payload, newAlert)).rejects.toThrow("HTTP 500");
+    } finally {
+      logs.restore();
+    }
+
+    expect(logs.all("alert_message_outgoing")).toHaveLength(1);
+  });
 });
 
 describe("Slack sender and fan-out", () => {
@@ -440,19 +646,13 @@ describe("Slack sender and fan-out", () => {
 
   test("posts the formatted alert to the configured Slack webhook", async () => {
     const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
-    const send = createSlackSender(
-      {
-        slackWebhookUrl: "https://hooks.slack.com/services/test",
-        alertColumns: defaultColumns,
-      },
-      async (url, init) => {
-        requests.push({
-          url,
-          body: JSON.parse(String(init.body)) as Record<string, unknown>,
-        });
-        return new Response("ok", { status: 200 });
-      }
-    );
+    const send = createSlackSender(testConfig(), async (url, init) => {
+      requests.push({
+        url,
+        body: JSON.parse(String(init.body)) as Record<string, unknown>,
+      });
+      return new Response("ok", { status: 200 });
+    });
 
     await send(payload, newAlert);
 
@@ -460,6 +660,65 @@ describe("Slack sender and fan-out", () => {
     expect(requests[0]?.url).toBe("https://hooks.slack.com/services/test");
     expect(requests[0]?.body.text).toContain("Alert for Errors");
     expect(requests[0]?.body.text).toContain(payload.link);
+  });
+
+  test("redacts the other destination's credentials from its own log line", async () => {
+    const logs = captureInfoLogs();
+    // Neither value is redactable by shape, and both senders log the same text:
+    // whatever one sender hides, the other must hide too.
+    const telegramToken = "unshaped-but-still-a-secret-value";
+    const webhookSecret = "clickstack-bearer-secret-value";
+    const send = createSlackSender(
+      // The Slack sender never touches the Telegram token, but it logs the
+      // same text, so its redactor has to cover it.
+      testConfig({
+        TELEGRAM_BOT_TOKEN: telegramToken,
+        CLICKSTACK_WEBHOOK_SECRET: webhookSecret,
+      }),
+      async () => new Response("ok", { status: 200 })
+    );
+
+    try {
+      await send(
+        { ...payload, title: `Errors ${telegramToken} ${webhookSecret}` },
+        newAlert
+      );
+    } finally {
+      logs.restore();
+    }
+
+    const text = String(logs.find("alert_message_outgoing")?.text);
+    expect(text).not.toContain(telegramToken);
+    expect(text).not.toContain(webhookSecret);
+  });
+
+  test("logs the Slack rendering rather than the Telegram HTML", async () => {
+    const logs = captureInfoLogs();
+    const send = createSlackSender(
+      testConfig(),
+      async () => new Response("ok", { status: 200 })
+    );
+
+    const rowPayload: ClickStackWebhookPayload = {
+      ...payload,
+      body: [
+        "```",
+        '"2026-07-21T19:15:10.807Z","loyal-mobile","error","boom"',
+        "```",
+      ].join("\n"),
+    };
+
+    try {
+      await send(rowPayload, newAlert);
+    } finally {
+      logs.restore();
+    }
+
+    const line = logs.find("alert_message_outgoing");
+    expect(line?.destination).toBe("slack");
+    expect(line?.parseMode).toBeUndefined();
+    expect(String(line?.text)).toContain("*🚨 Alert for Errors*");
+    expect(String(line?.text)).not.toContain("<b>");
   });
 
   test("does not acknowledge fan-out when either destination fails", async () => {

--- a/observability/telegram-relay/src/app.ts
+++ b/observability/telegram-relay/src/app.ts
@@ -7,9 +7,11 @@ import {
   formatPlainTelegramMessage,
   formatTelegramMessage,
 } from "./format.ts";
+import { RelayCredentials } from "./credentials.ts";
 import { redactBotToken } from "./redact.ts";
 import {
   type AlertAnalyzer,
+  type AlertContext,
   type AlertSender,
   AlertRelay,
   type ClickStackWebhookPayload,
@@ -30,14 +32,23 @@ const TELEGRAM_MAX_RETRY_AFTER_MS = 5_000;
  * truncated for delivery anyway.
  */
 const MAX_BODY_FIELD_LENGTH = 8192;
+/**
+ * Telegram's own per-message ceiling, which the formatter already fits inside,
+ * so a logged message is the whole message rather than a clipped sample. The
+ * Slack rendering is a substitution over the same text and stays within it too.
+ */
+const MAX_LOGGED_TEXT_LENGTH = 4096;
 
 export interface ServerConfig {
   host: string;
   port: number;
-  clickStackWebhookSecret: string;
-  telegramBotToken: string;
-  telegramChatId: string;
-  slackWebhookUrl: string;
+  /**
+   * Every credential, and the redaction built over them, as one inseparable
+   * value. They are deliberately not four loose string fields plus a redactor:
+   * that shape let a caller override one credential while keeping redaction
+   * built over the old set. See `RelayCredentials`.
+   */
+  credentials: RelayCredentials;
   cooldownMs: number;
   idempotencyTtlMs: number;
   maxCacheEntries: number;
@@ -61,10 +72,14 @@ export function loadConfig(
   return {
     host: env.HOST?.trim() || "127.0.0.1",
     port: positiveInteger(env.PORT, 3000, "PORT"),
-    clickStackWebhookSecret: required(env, "CLICKSTACK_WEBHOOK_SECRET"),
-    telegramBotToken: required(env, "TELEGRAM_BOT_TOKEN"),
-    telegramChatId: required(env, "TELEGRAM_CHAT_ID"),
-    slackWebhookUrl: required(env, "SLACK_WEBHOOK_URL"),
+    // Reading all four together is what keeps redaction and the credentials in
+    // use from ever drifting apart.
+    credentials: new RelayCredentials({
+      clickStackWebhookSecret: required(env, "CLICKSTACK_WEBHOOK_SECRET"),
+      telegramBotToken: required(env, "TELEGRAM_BOT_TOKEN"),
+      telegramChatId: required(env, "TELEGRAM_CHAT_ID"),
+      slackWebhookUrl: required(env, "SLACK_WEBHOOK_URL"),
+    }),
     cooldownMs:
       positiveInteger(env.COOLDOWN_SECONDS, 3600, "COOLDOWN_SECONDS") * 1000,
     idempotencyTtlMs:
@@ -139,23 +154,24 @@ function columnList(raw: string | undefined): string[] {
 type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 export function createTelegramSender(
-  config: Pick<
-    ServerConfig,
-    "telegramBotToken" | "telegramChatId" | "alertColumns"
-  > &
+  config: Pick<ServerConfig, "credentials" | "alertColumns"> &
     Partial<Pick<ServerConfig, "cardinalityColumns" | "recapSilent">>,
   fetchImpl: FetchLike = fetch,
   sleep: (ms: number) => Promise<void> = defaultSleep
 ): TelegramSender {
+  const logMessage = createOutgoingMessageLogger(
+    "telegram",
+    config.credentials
+  );
   const post = (message: FormattedMessage, silent: boolean) =>
     fetchImpl(
-      `https://api.telegram.org/bot${config.telegramBotToken}/sendMessage`,
+      `https://api.telegram.org/bot${config.credentials.telegramBotToken}/sendMessage`,
       {
         method: "POST",
         signal: AbortSignal.timeout(TELEGRAM_REQUEST_TIMEOUT_MS),
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          chat_id: config.telegramChatId,
+          chat_id: config.credentials.telegramChatId,
           text: message.text,
           ...(message.parseMode ? { parse_mode: message.parseMode } : {}),
           disable_web_page_preview: true,
@@ -172,6 +188,10 @@ export function createTelegramSender(
       alertColumns: config.alertColumns,
       cardinalityColumns: config.cardinalityColumns,
       context,
+    });
+    logMessage(payload, context, message.text, {
+      parseMode: message.parseMode,
+      silent,
     });
     let response = await post(message, silent);
 
@@ -206,10 +226,9 @@ export function createTelegramSender(
           eventId: payload.eventId,
         })
       );
-      response = await post(
-        { text: formatPlainTelegramMessage(payload) },
-        silent
-      );
+      const plainText = formatPlainTelegramMessage(payload);
+      logMessage(payload, context, plainText, { silent, fallback: true });
+      response = await post({ text: plainText }, silent);
     }
 
     const responseText = await response.text();
@@ -239,21 +258,25 @@ export function createTelegramSender(
 }
 
 export function createSlackSender(
-  config: Pick<ServerConfig, "slackWebhookUrl" | "alertColumns"> &
+  config: Pick<ServerConfig, "credentials" | "alertColumns"> &
     Partial<Pick<ServerConfig, "cardinalityColumns">>,
   fetchImpl: FetchLike = fetch
 ): AlertSender {
+  const logMessage = createOutgoingMessageLogger("slack", config.credentials);
+
   return async (payload, context) => {
     const message = formatTelegramMessage(payload, {
       alertColumns: config.alertColumns,
       cardinalityColumns: config.cardinalityColumns,
       context,
     });
-    const response = await fetchImpl(config.slackWebhookUrl, {
+    const text = telegramHtmlToSlack(message.text);
+    logMessage(payload, context, text);
+    const response = await fetchImpl(config.credentials.slackWebhookUrl, {
       method: "POST",
       signal: AbortSignal.timeout(SLACK_REQUEST_TIMEOUT_MS),
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: telegramHtmlToSlack(message.text) }),
+      body: JSON.stringify({ text }),
     });
     const responseText = await response.text();
 
@@ -286,6 +309,51 @@ export function createFanoutSender(senders: AlertSender[]): AlertSender {
           .join("; ")}`
       );
     }
+  };
+}
+
+/**
+ * Logs the message text before it is handed to the destination, not after,
+ * because the send is exactly what this is for: a rejected message (a bad HTML
+ * entity, a chat that vanished) is the case where the text matters most, and
+ * after a throw there is nothing left to log it from. Unconditional rather than
+ * behind `TRACE_LOGS`: alerts are rate limited to a handful a day by the
+ * cooldown, and an operator reading Render logs should not have to redeploy the
+ * relay to find out what it said.
+ *
+ * Redaction goes through the same `RelayCredentials` the sender posts with, so
+ * it always covers the credentials actually in use — including the other
+ * destination's, since both render the same text. That text is assembled from
+ * other services' log lines, so it can carry anything they logged, including a
+ * bot token with no `bot` prefix in front of it, which the URL-shaped redaction
+ * alone would miss.
+ */
+function createOutgoingMessageLogger(
+  destination: "telegram" | "slack",
+  credentials: RelayCredentials
+) {
+  return (
+    payload: ClickStackWebhookPayload,
+    context: AlertContext,
+    text: string,
+    details: Record<string, unknown> = {}
+  ): void => {
+    const redacted = credentials.redactLogText(text);
+    console.info(
+      JSON.stringify({
+        event: "alert_message_outgoing",
+        destination,
+        eventId: payload.eventId,
+        state: payload.state,
+        kind: context.kind,
+        chars: redacted.length,
+        ...(redacted.length > MAX_LOGGED_TEXT_LENGTH
+          ? { truncated: true }
+          : {}),
+        ...details,
+        text: redacted.slice(0, MAX_LOGGED_TEXT_LENGTH),
+      })
+    );
   };
 }
 
@@ -355,7 +423,7 @@ export function createAlertAnalyzer(
 
 export function createRequestHandler(
   relay: AlertRelay,
-  config: Pick<ServerConfig, "clickStackWebhookSecret"> & {
+  config: Pick<ServerConfig, "credentials"> & {
     traceLogs?: boolean;
   }
 ): (request: Request) => Promise<Response> {
@@ -392,7 +460,9 @@ export function createRequestHandler(
       return jsonResponse({ ok: false, error: "not_found" }, 404);
     }
 
-    if (!hasValidBearerToken(request, config.clickStackWebhookSecret)) {
+    if (
+      !hasValidBearerToken(request, config.credentials.clickStackWebhookSecret)
+    ) {
       trace("request_rejected", { reason: "unauthorized" });
       return jsonResponse({ ok: false, error: "unauthorized" }, 401, {
         "WWW-Authenticate": "Bearer",

--- a/observability/telegram-relay/src/credentials.test.ts
+++ b/observability/telegram-relay/src/credentials.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import { RelayCredentials } from "./credentials.ts";
+
+describe("RelayCredentials", () => {
+  const credentials = new RelayCredentials({
+    clickStackWebhookSecret: "clickstack-bearer-secret-value",
+    telegramBotToken: "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+    telegramChatId: "-1001234567890",
+    slackWebhookUrl: "https://hooks.slack.com/services/T00000/B00000/abcdef123",
+  });
+
+  test("redacts every credential it was constructed with", () => {
+    const redacted = credentials.redactLogText(
+      [
+        "secret=clickstack-bearer-secret-value",
+        "token=123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+        "webhook=https://hooks.slack.com/services/T00000/B00000/abcdef123",
+      ].join(" ")
+    );
+
+    expect(redacted).not.toContain("clickstack-bearer-secret-value");
+    expect(redacted).not.toContain("AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw");
+    expect(redacted).not.toContain("abcdef123");
+  });
+
+  test("redaction follows the credentials, not the first set built", () => {
+    // The invariant the type enforces at compile time, asserted at runtime: a
+    // different token means a redactor that covers that token, because the only
+    // way to change one is to construct a new instance.
+    const rotated = new RelayCredentials({
+      clickStackWebhookSecret: "clickstack-bearer-secret-value",
+      telegramBotToken: "rotated-unshaped-token-value",
+      telegramChatId: "-1001234567890",
+      slackWebhookUrl:
+        "https://hooks.slack.com/services/T00000/B00000/abcdef123",
+    });
+
+    expect(rotated.redactLogText("token=rotated-unshaped-token-value")).toBe(
+      "token=<redacted>"
+    );
+    // The old instance is unchanged and still covers only what it was given.
+    expect(
+      credentials.redactLogText("token=rotated-unshaped-token-value")
+    ).toContain("rotated-unshaped-token-value");
+  });
+
+  test("redacts a secret that reaches the log HTML escaped", () => {
+    // Alert text is escaped before it is logged, so a secret containing `&` or
+    // `<` arrives in escaped form; matching only the raw literal missed it.
+    const awkward = new RelayCredentials({
+      clickStackWebhookSecret: "a&b<c>secret",
+      telegramBotToken: "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+      telegramChatId: "-1001234567890",
+      slackWebhookUrl: "https://hooks.slack.com/services/T00000/B00000/abcdef",
+    });
+
+    expect(awkward.redactLogText("secret=a&amp;b&lt;c&gt;secret")).toBe(
+      "secret=<redacted>"
+    );
+    // And still in its raw spelling, which is what the Slack rendering carries.
+    expect(awkward.redactLogText("secret=a&b<c>secret")).toBe(
+      "secret=<redacted>"
+    );
+  });
+
+  test("redacts a short secret rather than skipping it", () => {
+    // Fails open otherwise: a length floor keeps logs readable by leaving the
+    // shortest secrets in them.
+    const short = new RelayCredentials({
+      clickStackWebhookSecret: "hunter2",
+      telegramBotToken: "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+      telegramChatId: "-1001234567890",
+      slackWebhookUrl: "https://hooks.slack.com/services/T00000/B00000/abcdef",
+    });
+
+    expect(short.redactLogText("bearer=hunter2")).toBe("bearer=<redacted>");
+  });
+
+  test("does not let a short secret chew up another redaction's marker", () => {
+    // `red` is a substring of the marker itself. Replacing in sequence rewrote
+    // markers the earlier passes had written — `bot<<redacted>acted>` — so the
+    // output was corrupted, and differently depending on credential order.
+    const short = new RelayCredentials({
+      clickStackWebhookSecret: "red",
+      telegramBotToken: "123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+      telegramChatId: "-1001234567890",
+      slackWebhookUrl: "https://hooks.slack.com/services/T00000/B00000/abcdef",
+    });
+
+    expect(
+      short.redactLogText(
+        "url=https://api.telegram.org/bot123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw/sendMessage"
+      )
+    ).toBe("url=https://api.telegram.org/bot<redacted>/sendMessage");
+    expect(
+      short.redactLogText(
+        "hook=https://hooks.slack.com/services/T00000/B00000/abcdef"
+      )
+    ).toBe("hook=https://hooks.slack.com/services/<redacted>");
+    // The secret itself is still redacted where it genuinely appears.
+    expect(short.redactLogText("bearer=red")).toBe("bearer=<redacted>");
+  });
+
+  test("leaves no tail behind when two credentials overlap in the text", () => {
+    // One credential ends where the other begins. Replacing left to right
+    // consumed the second one's start and left its tail readable —
+    // `<redacted>-BBBB`. Occurrences are found against the original text and
+    // merged, so the whole run goes.
+    const overlapping = new RelayCredentials({
+      clickStackWebhookSecret: "AAAA-shared-tail",
+      telegramBotToken: "shared-tail-BBBB",
+      telegramChatId: "-1001234567890",
+      slackWebhookUrl: "https://hooks.slack.com/services/T00000/B00000/abcdef",
+    });
+
+    expect(overlapping.redactLogText("x=AAAA-shared-tail-BBBB")).toBe(
+      "x=<redacted>"
+    );
+    expect(overlapping.redactLogText("x=shared-tail-BBBB")).toBe(
+      "x=<redacted>"
+    );
+  });
+
+  test("survives an empty credential without shredding the text", () => {
+    // Splitting on "" would put the marker between every character.
+    const blank = new RelayCredentials({
+      clickStackWebhookSecret: "",
+      telegramBotToken: "",
+      telegramChatId: "",
+      slackWebhookUrl: "",
+    });
+
+    expect(blank.redactLogText("nothing secret here")).toBe(
+      "nothing secret here"
+    );
+  });
+
+  test("leaves the chat id readable", () => {
+    expect(credentials.redactLogText("chat=-1001234567890")).toBe(
+      "chat=-1001234567890"
+    );
+  });
+});

--- a/observability/telegram-relay/src/credentials.ts
+++ b/observability/telegram-relay/src/credentials.ts
@@ -1,0 +1,57 @@
+import { stripSecrets } from "./redact.ts";
+
+export interface CredentialValues {
+  clickStackWebhookSecret: string;
+  telegramBotToken: string;
+  telegramChatId: string;
+  slackWebhookUrl: string;
+}
+
+/**
+ * Every credential the relay holds, together with the redaction built over
+ * them, as one value that cannot be taken apart.
+ *
+ * The binding is the point. A sender posts with `telegramBotToken` and logs
+ * through `redactLogText`, and both come from this same object, so redaction
+ * always covers the credentials actually in use. Holding them as separate
+ * config fields did not: `{ ...config, telegramBotToken: other }` type-checked
+ * and kept redaction built over the previous token, which would then print the
+ * new one in full.
+ *
+ * The private field is what enforces it. It makes the class nominal, so no
+ * object literal and no spread of an existing instance is assignable to
+ * `RelayCredentials` — swapping one credential means constructing a new
+ * instance, which rebuilds the secret set from the values it was given. Every
+ * instance is therefore self-consistent by construction, whoever built it.
+ */
+export class RelayCredentials {
+  readonly #secrets: string[];
+
+  readonly clickStackWebhookSecret: string;
+  readonly telegramBotToken: string;
+  readonly telegramChatId: string;
+  readonly slackWebhookUrl: string;
+
+  constructor(values: CredentialValues) {
+    this.clickStackWebhookSecret = values.clickStackWebhookSecret;
+    this.telegramBotToken = values.telegramBotToken;
+    this.telegramChatId = values.telegramChatId;
+    this.slackWebhookUrl = values.slackWebhookUrl;
+
+    // The chat id is not a secret: it is in the Blueprint and in every alert's
+    // delivery target. Redacting it would only make logs harder to read.
+    this.#secrets = [
+      values.clickStackWebhookSecret,
+      values.telegramBotToken,
+      values.slackWebhookUrl,
+    ];
+  }
+
+  /**
+   * Strips these credentials out of text the relay did not author. Called as a
+   * method, never detached: it reads `#secrets` off `this`.
+   */
+  redactLogText(text: string): string {
+    return stripSecrets(text, this.#secrets);
+  }
+}

--- a/observability/telegram-relay/src/format.ts
+++ b/observability/telegram-relay/src/format.ts
@@ -696,7 +696,12 @@ function formatTimestamp(value: string): string {
   return `${parsed.toISOString().slice(11, 19)} UTC`;
 }
 
-function escapeHtml(value: string): string {
+/**
+ * Exported because redaction has to match it: a secret that reaches the log
+ * through formatted text arrives escaped, so `stripSecrets` strips this form of
+ * every credential as well as the raw one. Two escapers would drift.
+ */
+export function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")

--- a/observability/telegram-relay/src/redact.ts
+++ b/observability/telegram-relay/src/redact.ts
@@ -1,12 +1,181 @@
+import { escapeHtml } from "./format.ts";
+
+const REDACTED = "<redacted>";
+
+/** Matches the token only where it sits in the Telegram API URL. */
+const BOT_TOKEN_URL_SOURCE = String.raw`bot\d+:[\w-]+`;
+const SLACK_WEBHOOK_URL_SOURCE = String.raw`https://hooks\.slack\.com/services/[A-Za-z0-9/_-]+`;
+/**
+ * A bot token is `<numeric id>:<35-character secret>`. Delivered alert text is
+ * other services' log output, which can carry a token with no `bot` prefix in
+ * front of it — a config dump, or a message quoting the raw value — so shape
+ * alone has to be enough there. The length floor keeps ordinary `12:34` text
+ * out of it.
+ */
+const BARE_BOT_TOKEN_SOURCE = String.raw`(?<![\w-])\d{5,16}:[A-Za-z0-9_-]{30,}(?![\w-])`;
+
+const BOT_TOKEN_URL = new RegExp(BOT_TOKEN_URL_SOURCE, "g");
+const SLACK_WEBHOOK_URL = new RegExp(SLACK_WEBHOOK_URL_SOURCE, "g");
+const BARE_BOT_TOKEN = new RegExp(BARE_BOT_TOKEN_SOURCE, "g");
+
 /**
  * The bot token is embedded in the request URL, so any error that quotes the
  * URL - fetch connection errors especially - would carry it into the logs.
  */
 export function redactBotToken(text: string): string {
   return text
-    .replace(/bot\d+:[\w-]+/g, "bot<redacted>")
-    .replace(
-      /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]+/g,
-      "https://hooks.slack.com/services/<redacted>"
-    );
+    .replace(BOT_TOKEN_URL, `bot${REDACTED}`)
+    .replace(SLACK_WEBHOOK_URL, `https://hooks.slack.com/services/${REDACTED}`);
+}
+
+/**
+ * For text this relay did not author: the rendered alert message, assembled
+ * from whatever the alerted services logged. On top of the URL forms it strips
+ * bare bot tokens by shape, and `secrets` by exact value — the shape rules are a
+ * best effort against any token, the literal match is the guarantee that this
+ * relay's own secrets cannot appear in its logs.
+ *
+ * Every occurrence is located against the original text, and overlapping ones
+ * are merged into a single span before anything is rewritten. Rewriting as it
+ * scanned was not enough on two counts. Replacing in sequence let each pass read
+ * the markers earlier passes had written, so a secret as short as `red` turned a
+ * redacted bot token into `bot<<redacted>acted>`. Replacing in one left-to-right
+ * pass fixed that but still consumed the start of an overlapping credential and
+ * left its tail behind: two secrets sharing a boundary redacted as
+ * `<redacted>-BBBB`. Merging spans first means no character of any credential
+ * survives, whatever order the credentials are in and however they overlap.
+ *
+ * The only caller is `RelayCredentials.redactLogText`, which owns the secret
+ * set. Redaction is not offered as a standalone function elsewhere: a caller
+ * choosing its own secret list is how a credential gets left out.
+ */
+export function stripSecrets(text: string, secrets: string[]): string {
+  const spans = [
+    ...patternSpans(text, BOT_TOKEN_URL, `bot${REDACTED}`, 0),
+    ...patternSpans(
+      text,
+      SLACK_WEBHOOK_URL,
+      `https://hooks.slack.com/services/${REDACTED}`,
+      1
+    ),
+    ...patternSpans(text, BARE_BOT_TOKEN, REDACTED, 2),
+    ...literalSpans(text, secrets),
+  ];
+
+  return redactSpans(text, spans);
+}
+
+/**
+ * A stretch of text to remove. `priority` decides which marker a merged span
+ * keeps: the URL forms name what was redacted (`bot<redacted>`), which is worth
+ * preserving when one of them is the outermost match of the merge.
+ */
+interface RedactionSpan {
+  start: number;
+  end: number;
+  marker: string;
+  priority: number;
+}
+
+function patternSpans(
+  text: string,
+  pattern: RegExp,
+  marker: string,
+  priority: number
+): RedactionSpan[] {
+  return [...text.matchAll(pattern)].map((match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+    marker,
+    priority,
+  }));
+}
+
+/**
+ * Every occurrence of every credential, overlapping ones included — the search
+ * advances by one character rather than past the match it just found, so a
+ * secret that overlaps itself is fully covered too.
+ */
+function literalSpans(text: string, secrets: string[]): RedactionSpan[] {
+  const spans: RedactionSpan[] = [];
+
+  for (const form of new Set(secrets.flatMap(secretForms))) {
+    for (let from = 0; from <= text.length - form.length; from += 1) {
+      const at = text.indexOf(form, from);
+      if (at === -1) {
+        break;
+      }
+      spans.push({
+        start: at,
+        end: at + form.length,
+        marker: REDACTED,
+        priority: 3,
+      });
+      from = at;
+    }
+  }
+
+  return spans;
+}
+
+function redactSpans(text: string, spans: RedactionSpan[]): string {
+  if (spans.length === 0) {
+    return text;
+  }
+
+  // Leftmost first; at the same start the widest match leads, and between equals
+  // the more specific pattern does, so a bot-token URL keeps its marker even
+  // though the token literal inside it matches at the same time.
+  const ordered = [...spans].sort(
+    (left, right) =>
+      left.start - right.start ||
+      right.end - left.end ||
+      left.priority - right.priority
+  );
+
+  let result = "";
+  let cursor = 0;
+  let index = 0;
+
+  while (index < ordered.length) {
+    const span = ordered[index];
+    let end = span.end;
+    let next = index + 1;
+
+    // Touching counts as overlapping: contiguous credential material must not be
+    // broken into two markers with a fragment of text conjured between them.
+    while (next < ordered.length && ordered[next].start <= end) {
+      end = Math.max(end, ordered[next].end);
+      next += 1;
+    }
+
+    result += text.slice(cursor, span.start) + span.marker;
+    cursor = end;
+    index = next;
+  }
+
+  return result + text.slice(cursor);
+}
+
+/**
+ * Every spelling of a credential that can reach a log line. Alert text is HTML
+ * escaped before it is logged, so a secret containing `&`, `<` or `>` arrives in
+ * escaped form and the raw literal would miss it entirely. The Slack rendering
+ * reverses that escaping, so both forms have to go.
+ *
+ * There is no minimum length. A short or word-like secret makes log lines noisy
+ * — every innocent occurrence of that word is redacted too — and that is the
+ * intended direction: skipping it to keep logs readable is what turns "every
+ * credential is redacted" into a claim that quietly does not hold. An empty
+ * secret is the one exclusion: it matches at every position, and redacting it
+ * would replace the whole message with markers.
+ */
+function secretForms(secret: string): string[] {
+  const literal = secret.trim();
+  if (literal.length === 0) {
+    return [];
+  }
+
+  const escaped = escapeHtml(literal);
+  return escaped === literal ? [literal] : [literal, escaped];
 }


### PR DESCRIPTION
The telegram-relay now logs each message it sends, per destination, as an `alert_message_outgoing` line before the post, so Render logs show what a relayed alert actually said (`TRACE_LOGS` only covers request validation, never message content). Since that text is other services' log output, redaction is stricter than for the relay's own errors: bare bot tokens by shape plus every credential the process holds by exact value, raw and HTML escaped, with overlapping occurrences merged so no fragment survives — `RelayCredentials` owns the credentials and that redaction as one value, so a redactor can no longer be paired with credentials it does not cover.