### PR TITLE
feat(admin): add Earn rebalance observability

### DIFF
--- a/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { formatShortAddress } from "@/components/blockchain/address-link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const USDC_DECIMALS = 6;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const SOURCE_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+] as const;
+
+export type SerializedExecutedEarnRebalanceRow = {
+  amountRaw: string;
+  authority: string;
+  confirmedSlot: string;
+  currentDepositRaw: string;
+  executedAt: string;
+  id: string;
+  sourceReserve: string;
+  targetReserve: string;
+  userRank: number;
+};
+
+export type SerializedExecutedEarnRebalanceHistory = {
+  executions: SerializedExecutedEarnRebalanceRow[];
+  generatedAt: string;
+  status: "available" | "unavailable";
+  userCount: number;
+};
+
+type ChartPoint = SerializedExecutedEarnRebalanceRow & {
+  executedAtMs: number;
+};
+
+type RangeKey = "7d" | "30d" | "all";
+
+function formatUtcTimestamp(value: number | string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatUtcTick(value: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function formatUsdcRaw(raw: string): string {
+  const amount = BigInt(raw);
+  const scale = BigInt(10) ** BigInt(USDC_DECIMALS);
+  const whole = amount / scale;
+  const fractional = amount % scale;
+
+  return `${whole.toLocaleString("en-US")}.${fractional
+    .toString()
+    .padStart(USDC_DECIMALS, "0")
+    .slice(0, 2)} USDC`;
+}
+
+function rangeLabel(range: RangeKey): string {
+  if (range === "7d") {
+    return "Last 7 days";
+  }
+  if (range === "30d") {
+    return "Last 30 days";
+  }
+  return "All history";
+}
+
+function ExecutedRebalanceTooltip({
+  active,
+  payload,
+  reserveLabels,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartPoint }>;
+  reserveLabels: ReadonlyMap<string, string>;
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) {
+    return null;
+  }
+
+  const source =
+    reserveLabels.get(point.sourceReserve) ??
+    formatShortAddress(point.sourceReserve);
+  const target =
+    reserveLabels.get(point.targetReserve) ??
+    formatShortAddress(point.targetReserve);
+
+  return (
+    <div className="grid min-w-[17rem] gap-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium">
+        {formatUtcTimestamp(point.executedAtMs)}
+      </div>
+      <div className="text-muted-foreground">
+        {source} → {target}
+      </div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1">
+        <dt className="text-muted-foreground">Executed</dt>
+        <dd className="text-right font-medium tabular-nums">
+          {formatUsdcRaw(point.amountRaw)}
+        </dd>
+        <dt className="text-muted-foreground">User deposit now</dt>
+        <dd className="text-right font-medium tabular-nums">
+          {formatUsdcRaw(point.currentDepositRaw)}
+        </dd>
+        <dt className="text-muted-foreground">User</dt>
+        <dd className="text-right font-mono">
+          {formatShortAddress(point.authority)} · rank {point.userRank}
+        </dd>
+        <dt className="text-muted-foreground">Decision</dt>
+        <dd className="text-right font-mono">{point.id}</dd>
+        <dt className="text-muted-foreground">Confirmed slot</dt>
+        <dd className="text-right font-mono">{point.confirmedSlot}</dd>
+      </dl>
+    </div>
+  );
+}
+
+export function ExecutedEarnRebalancesChart({
+  data,
+  reserveLabels,
+}: {
+  data: SerializedExecutedEarnRebalanceHistory;
+  reserveLabels: ReadonlyMap<string, string>;
+}) {
+  const [range, setRange] = useState<RangeKey>("all");
+  const [showTable, setShowTable] = useState(false);
+
+  const points = useMemo(
+    () =>
+      data.executions
+        .map((execution) => ({
+          ...execution,
+          executedAtMs: Date.parse(execution.executedAt),
+        }))
+        .filter((execution) => Number.isFinite(execution.executedAtMs)),
+    [data.executions]
+  );
+
+  const filteredPoints = useMemo(() => {
+    if (range === "all" || points.length === 0) {
+      return points;
+    }
+    const latest = points[points.length - 1].executedAtMs;
+    const days = range === "7d" ? 7 : 30;
+    return points.filter(
+      (point) => point.executedAtMs >= latest - days * DAY_MS
+    );
+  }, [points, range]);
+
+  const sourceReserves = useMemo(
+    () => [...new Set(points.map((point) => point.sourceReserve))].sort(),
+    [points]
+  );
+  const sources = sourceReserves.map((reserve, index) => ({
+    color: SOURCE_COLORS[index % SOURCE_COLORS.length],
+    key: `source${index}`,
+    label: reserveLabels.get(reserve) ?? formatShortAddress(reserve),
+    reserve,
+  }));
+  const config = Object.fromEntries(
+    sources.map((source) => [
+      source.key,
+      { color: source.color, label: source.label },
+    ])
+  ) satisfies ChartConfig;
+
+  const userByRank = new Map(
+    points.map((point) => [
+      point.userRank,
+      {
+        authority: point.authority,
+        currentDepositRaw: point.currentDepositRaw,
+      },
+    ])
+  );
+  const yTicks = Array.from(
+    new Set(
+      Array.from(
+        { length: Math.min(7, Math.max(data.userCount, 1)) },
+        (_, index) =>
+          Math.max(
+            1,
+            Math.round(
+              1 +
+                (index * Math.max(data.userCount - 1, 0)) /
+                  Math.max(Math.min(7, data.userCount) - 1, 1)
+            )
+          )
+      )
+    )
+  );
+  const tableRows = [...filteredPoints].reverse().slice(0, 50);
+
+  if (data.status === "unavailable") {
+    return (
+      <Card
+        className="min-w-0"
+        aria-labelledby="executed-earn-rebalances-title"
+      >
+        <CardHeader>
+          <CardTitle id="executed-earn-rebalances-title">
+            Executed Earn rebalances
+          </CardTitle>
+          <CardDescription>
+            Confirmed execution history is temporarily unavailable. The other
+            Earn rebalance monitors remain independent and available.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="min-w-0" aria-labelledby="executed-earn-rebalances-title">
+      <CardHeader className="gap-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle id="executed-earn-rebalances-title">
+              Executed Earn rebalances
+            </CardTitle>
+            <CardDescription>
+              One dot per confirmed reserve-to-reserve decision. Users are
+              ordered by their current Earn deposit, smallest at the bottom and
+              largest at the top. Times are UTC.
+            </CardDescription>
+          </div>
+          <div
+            className="flex flex-wrap gap-1"
+            aria-label="Execution history range"
+          >
+            {(["7d", "30d", "all"] as const).map((value) => (
+              <Button
+                aria-pressed={range === value}
+                key={value}
+                onClick={() => setRange(value)}
+                size="sm"
+                type="button"
+                variant={range === value ? "secondary" : "outline"}
+              >
+                {value === "all" ? "All" : value}
+              </Button>
+            ))}
+            <Button
+              aria-pressed={showTable}
+              onClick={() => setShowTable((value) => !value)}
+              size="sm"
+              type="button"
+              variant={showTable ? "secondary" : "outline"}
+            >
+              Table
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            {data.executions.length.toLocaleString("en-US")} confirmed
+            executions
+          </span>
+          <span>{data.userCount.toLocaleString("en-US")} distinct users</span>
+          <span>
+            {filteredPoints.length.toLocaleString("en-US")} shown ·{" "}
+            {rangeLabel(range)}
+          </span>
+          <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {sources.map((source) => (
+            <span className="inline-flex items-center gap-1.5" key={source.key}>
+              <span
+                aria-hidden
+                className="size-2 rounded-full"
+                style={{ backgroundColor: source.color }}
+              />
+              {source.label}
+            </span>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="min-w-0">
+        {points.length === 0 ? (
+          <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+            No confirmed Earn rebalances are available.
+          </div>
+        ) : showTable ? (
+          <div className="max-h-[420px] overflow-auto rounded-md border">
+            <Table>
+              <TableHeader className="sticky top-0 bg-card">
+                <TableRow>
+                  <TableHead>Executed (UTC)</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Route</TableHead>
+                  <TableHead>Decision</TableHead>
+                  <TableHead className="text-right">Confirmed slot</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead className="text-right">Current deposit</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tableRows.map((point) => (
+                  <TableRow key={point.id}>
+                    <TableCell className="whitespace-nowrap">
+                      {formatUtcTimestamp(point.executedAtMs)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap font-mono">
+                      {formatShortAddress(point.authority)} · {point.userRank}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {reserveLabels.get(point.sourceReserve) ??
+                        formatShortAddress(point.sourceReserve)}{" "}
+                      →{" "}
+                      {reserveLabels.get(point.targetReserve) ??
+                        formatShortAddress(point.targetReserve)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap font-mono">
+                      {point.id}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap font-mono tabular-nums">
+                      {point.confirmedSlot}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap tabular-nums">
+                      {formatUsdcRaw(point.amountRaw)}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap tabular-nums">
+                      {formatUsdcRaw(point.currentDepositRaw)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <ChartContainer
+            className="aspect-auto h-[440px] w-full min-w-0"
+            config={config}
+          >
+            <ScatterChart
+              accessibilityLayer
+              margin={{ bottom: 14, left: 12, right: 12, top: 12 }}
+            >
+              <CartesianGrid />
+              <XAxis
+                axisLine={false}
+                dataKey="executedAtMs"
+                domain={["dataMin", "dataMax"]}
+                name="Execution time"
+                tickFormatter={formatUtcTick}
+                tickLine={false}
+                tickMargin={8}
+                type="number"
+              />
+              <YAxis
+                allowDecimals={false}
+                axisLine={false}
+                dataKey="userRank"
+                domain={[1, Math.max(data.userCount, 1)]}
+                name="User ordered by current deposit"
+                tickFormatter={(rank: number) => {
+                  const user = userByRank.get(rank);
+                  return user ? formatShortAddress(user.authority) : `#${rank}`;
+                }}
+                tickLine={false}
+                ticks={yTicks}
+                type="number"
+                width={78}
+              />
+              <ZAxis range={[18, 18]} />
+              <ChartTooltip
+                content={
+                  <ExecutedRebalanceTooltip reserveLabels={reserveLabels} />
+                }
+                cursor={{ strokeDasharray: "3 3" }}
+              />
+              {sources.map((source) => (
+                <Scatter
+                  data={filteredPoints.filter(
+                    (point) => point.sourceReserve === source.reserve
+                  )}
+                  fill={`var(--color-${source.key})`}
+                  key={source.key}
+                  name={source.label}
+                />
+              ))}
+            </ScatterChart>
+          </ChartContainer>
+        )}
+        {!showTable ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Y-axis labels sample the ordered user ranks; hover a dot for the
+            exact wallet, current deposit, route, amount, decision, and slot.
+          </p>
+        ) : (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Showing the 50 most recent executions in the selected range.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -98,6 +98,24 @@ export type Last30DaysRebalancePoint = {
   terminalAttempts: number;
 };
 
+export type ExecutedEarnRebalanceRow = {
+  amountRaw: bigint;
+  authority: string;
+  confirmedSlot: bigint;
+  currentDepositRaw: bigint;
+  executedAt: string;
+  id: string;
+  sourceReserve: string;
+  targetReserve: string;
+  userRank: number;
+};
+
+export type ExecutedEarnRebalanceHistory = {
+  executions: ExecutedEarnRebalanceRow[];
+  generatedAt: string;
+  userCount: number;
+};
+
 export type RebalanceAuditRow = {
   abandonReason: string | null;
   amountRaw: bigint | null;
@@ -215,6 +233,19 @@ type Last30DaysRebalanceSqlRow = {
   date: string;
   failed: SqlScalar;
   terminal_attempts: SqlScalar;
+};
+
+type ExecutedEarnRebalanceSqlRow = {
+  amount_raw: SqlScalar;
+  authority: string;
+  confirmed_slot: SqlScalar;
+  current_deposit_raw: SqlScalar;
+  executed_at: Date | string;
+  id: string;
+  source_reserve: string;
+  target_reserve: string;
+  user_count: SqlScalar;
+  user_rank: SqlScalar;
 };
 
 type RebalanceAuditSqlRow = {
@@ -1357,6 +1388,146 @@ export async function getLast30DaysRebalanceSeries(): Promise<
     failed: toNumber(row.failed),
     terminalAttempts: toNumber(row.terminal_attempts),
   }));
+}
+
+export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnRebalanceHistory> {
+  const rows = await queryRows<ExecutedEarnRebalanceSqlRow>(
+    `
+      WITH executed AS MATERIALIZED (
+        SELECT
+          decision.id,
+          decision.updated_at AS executed_at,
+          decision.amount_raw,
+          decision.source_reserve,
+          decision.target_reserve,
+          decision.confirmed_slot,
+          policy.authority
+        FROM loyal_yield.rebalance_decisions AS decision
+        INNER JOIN loyal_yield.managed_vaults AS vault
+          ON vault.id = decision.vault_id
+        INNER JOIN loyal_yield.route_policies AS policy
+          ON policy.id = vault.active_policy_id
+        WHERE decision.status = 'confirmed'
+          AND decision.source_reserve IS NOT NULL
+          AND decision.target_reserve IS NOT NULL
+          AND decision.amount_raw IS NOT NULL
+          AND decision.confirmed_slot IS NOT NULL
+      ),
+      executed_users AS MATERIALIZED (
+        SELECT DISTINCT authority FROM executed
+      ),
+      relevant_vaults AS MATERIALIZED (
+        SELECT vault.id AS vault_id, policy.authority
+        FROM loyal_yield.managed_vaults AS vault
+        INNER JOIN loyal_yield.route_policies AS policy
+          ON policy.id = vault.active_policy_id
+        INNER JOIN executed_users
+          ON executed_users.authority = policy.authority
+      ),
+      current_reserve_by_vault AS MATERIALIZED (
+        SELECT
+          position.vault_id,
+          SUM(
+            CASE
+              WHEN COALESCE(
+                position.planning_metadata->>'amountSemantics',
+                position.planning_metadata->>'amount_semantics'
+              ) IN (
+                'kamino_redeemable_liquidity',
+                'redeemable_liquidity_amount'
+              )
+                THEN position.amount_raw
+              WHEN COALESCE(
+                position.planning_metadata->>'amountSemantics',
+                position.planning_metadata->>'amount_semantics'
+              ) = 'kamino_obligation_collateral_deposited_amount'
+                AND COALESCE(
+                  position.planning_metadata->>'redeemable_liquidity_amount_raw',
+                  position.planning_metadata->>'redeemable_source_liquidity_amount_raw'
+                ) ~ '^[0-9]+$'
+                THEN COALESCE(
+                  position.planning_metadata->>'redeemable_liquidity_amount_raw',
+                  position.planning_metadata->>'redeemable_source_liquidity_amount_raw'
+                )::bigint
+              ELSE 0::bigint
+            END
+          )::bigint AS amount_raw
+        FROM relevant_vaults AS relevant
+        INNER JOIN loyal_yield.vault_reserve_positions_current AS position
+          ON position.vault_id = relevant.vault_id
+        WHERE position.has_value = true
+          AND position.amount_raw > 0
+        GROUP BY position.vault_id
+      ),
+      current_idle_by_vault AS MATERIALIZED (
+        SELECT idle.vault_id, SUM(idle.amount_raw)::bigint AS amount_raw
+        FROM relevant_vaults AS relevant
+        INNER JOIN loyal_yield.vault_idle_token_balances_current AS idle
+          ON idle.vault_id = relevant.vault_id
+        WHERE idle.amount_raw > 0
+        GROUP BY idle.vault_id
+      ),
+      current_user_deposits AS MATERIALIZED (
+        SELECT
+          relevant.authority,
+          SUM(
+            COALESCE(reserve.amount_raw, 0::bigint)
+            + COALESCE(idle.amount_raw, 0::bigint)
+          )::bigint AS current_deposit_raw
+        FROM relevant_vaults AS relevant
+        LEFT JOIN current_reserve_by_vault AS reserve
+          ON reserve.vault_id = relevant.vault_id
+        LEFT JOIN current_idle_by_vault AS idle
+          ON idle.vault_id = relevant.vault_id
+        GROUP BY relevant.authority
+      ),
+      ranked_users AS MATERIALIZED (
+        SELECT
+          executed_user.authority,
+          COALESCE(deposit_total.current_deposit_raw, 0::bigint)
+            AS current_deposit_raw,
+          ROW_NUMBER() OVER (
+            ORDER BY
+              COALESCE(deposit_total.current_deposit_raw, 0::bigint) ASC,
+              executed_user.authority ASC
+          )::integer AS user_rank
+        FROM executed_users AS executed_user
+        LEFT JOIN current_user_deposits AS deposit_total
+          ON deposit_total.authority = executed_user.authority
+      )
+      SELECT
+        executed.id::text,
+        executed.executed_at,
+        executed.amount_raw::text,
+        executed.source_reserve,
+        executed.target_reserve,
+        executed.confirmed_slot::text,
+        executed.authority,
+        ranked_users.current_deposit_raw::text,
+        ranked_users.user_rank::text,
+        MAX(ranked_users.user_rank) OVER ()::text AS user_count
+      FROM executed
+      INNER JOIN ranked_users
+        ON ranked_users.authority = executed.authority
+      ORDER BY executed.executed_at ASC, executed.id ASC
+    `
+  );
+
+  return {
+    executions: rows.map((row) => ({
+      amountRaw: toBigInt(row.amount_raw),
+      authority: row.authority,
+      confirmedSlot: toBigInt(row.confirmed_slot),
+      currentDepositRaw: toBigInt(row.current_deposit_raw),
+      executedAt: toIsoString(row.executed_at) ?? "",
+      id: row.id,
+      sourceReserve: row.source_reserve,
+      targetReserve: row.target_reserve,
+      userRank: toNumber(row.user_rank),
+    })),
+    generatedAt: new Date().toISOString(),
+    userCount: rows.length > 0 ? toNumber(rows[0].user_count) : 0,
+  };
 }
 
 export async function getRebalanceAuditSummary(

--- a/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -45,6 +45,10 @@ import {
   AutodepositFailuresChart,
   type SerializedAutodepositFailureRange,
 } from "./autodeposit-failures-chart";
+import {
+  ExecutedEarnRebalancesChart,
+  type SerializedExecutedEarnRebalanceHistory,
+} from "./executed-earn-rebalances-chart";
 import { Last30DaysRebalanceChart } from "./last-30-days-rebalance-chart";
 import { RebalanceActivityChart } from "./rebalance-activity-chart";
 import type {
@@ -92,6 +96,7 @@ type RebalanceApiData = {
   apyData: SafeReserveApyMonitorData;
   autodeposit: SerializedAutodepositFailureRange[];
   decisions: SerializedRebalanceDecisionRow[];
+  executedRebalances: SerializedExecutedEarnRebalanceHistory;
   last30DaysRebalances: Last30DaysRebalancePoint[];
   routes: SerializedActiveReserveRouteRow[];
 };
@@ -1353,6 +1358,10 @@ export function RebalanceMonitorClient() {
         decisionMarkers={toDecisionMarkers(state.data.decisions)}
       />
       <RebalanceActivityChart data={state.data.activity} />
+      <ExecutedEarnRebalancesChart
+        data={state.data.executedRebalances}
+        reserveLabels={reserveLabels}
+      />
       <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />
       <AutodepositFailuresChart data={state.data.autodeposit} />
       <RebalanceAuditCard reserveLabels={reserveLabels} />

--- a/admin/src/app/(admin)/metrics/earn-rebalance-latency-data.ts
+++ b/admin/src/app/(admin)/metrics/earn-rebalance-latency-data.ts
@@ -1,0 +1,346 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
+import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.server";
+
+type SqlScalar = bigint | number | string | null;
+
+export type EarnLatencyStageKey =
+  | "observedToOpportunityMs"
+  | "opportunityToReadyMs"
+  | "readyToDecisionMs"
+  | "decisionToSignedMs"
+  | "signedToSubmittedMs"
+  | "submittedToConfirmedMs";
+
+export type EarnLatencyPoint = {
+  confirmedAt: string;
+  decisionAt: string;
+  decisionId: string;
+  decisionToSignedMs: number;
+  monitorToSubmittedMs: number;
+  observedToOpportunityMs: number;
+  opportunityAt: string;
+  opportunityToReadyMs: number | null;
+  readyAt: string | null;
+  readyToDecisionMs: number | null;
+  signedAt: string;
+  signedToSubmittedMs: number;
+  sourceReserve: string;
+  submittedAt: string;
+  submittedToConfirmedMs: number;
+  targetObservedAt: string;
+  targetReserve: string;
+};
+
+export type EarnLatencyStageSummary = {
+  key: EarnLatencyStageKey;
+  label: string;
+  measuredCount: number;
+  p50Ms: number;
+  p95Ms: number;
+};
+
+export type EarnRebalanceLatencyData = {
+  fetchedAt: string;
+  measuredCount: number;
+  monitorToSubmittedP50Ms: number;
+  monitorToSubmittedP95Ms: number;
+  points: EarnLatencyPoint[];
+  rangeEndedAt: string | null;
+  rangeStartedAt: string | null;
+  stages: EarnLatencyStageSummary[];
+  status: "available" | "unavailable";
+  submittedToConfirmedP50Ms: number;
+  submittedToConfirmedP95Ms: number;
+  totalConfirmed: number;
+};
+
+type EarnLatencySqlRow = {
+  confirmed_at: Date | string;
+  decision_at: Date | string;
+  decision_to_signed_ms: SqlScalar;
+  id: string;
+  monitor_to_submitted_ms: SqlScalar;
+  observed_to_opportunity_ms: SqlScalar;
+  opportunity_at: Date | string;
+  opportunity_to_ready_ms: SqlScalar;
+  ready_at: Date | string | null;
+  ready_to_decision_ms: SqlScalar;
+  signed_at: Date | string;
+  signed_to_submitted_ms: SqlScalar;
+  source_reserve: string;
+  submitted_at: Date | string;
+  submitted_to_confirmed_ms: SqlScalar;
+  target_observed_at: Date | string;
+  target_reserve: string;
+  total_confirmed: SqlScalar;
+};
+
+const STAGES: ReadonlyArray<{
+  key: EarnLatencyStageKey;
+  label: string;
+}> = [
+  {
+    key: "observedToOpportunityMs",
+    label: "Observed → opportunity",
+  },
+  {
+    key: "opportunityToReadyMs",
+    label: "Opportunity → ready",
+  },
+  { key: "readyToDecisionMs", label: "Ready → decision" },
+  { key: "decisionToSignedMs", label: "Decision → signed" },
+  { key: "signedToSubmittedMs", label: "Signed → submitted" },
+  {
+    key: "submittedToConfirmedMs",
+    label: "Submitted → confirmed",
+  },
+];
+
+function toIsoString(value: Date | string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
+}
+
+function toNumber(value: SqlScalar): number {
+  if (value === null) {
+    return 0;
+  }
+  return Number(value);
+}
+
+function toNullableNumber(value: SqlScalar): number | null {
+  if (value === null) {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function percentile(values: readonly number[], level: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const position = (sorted.length - 1) * level;
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.ceil(position);
+  const lower = sorted[lowerIndex];
+  const upper = sorted[upperIndex];
+
+  return lower + (upper - lower) * (position - lowerIndex);
+}
+
+function summarize(
+  points: EarnLatencyPoint[],
+  key: EarnLatencyStageKey,
+  label: string
+): EarnLatencyStageSummary {
+  const values = points.flatMap((point) => {
+    const value = point[key];
+    return typeof value === "number" ? [value] : [];
+  });
+
+  return {
+    key,
+    label,
+    measuredCount: values.length,
+    p50Ms: percentile(values, 0.5),
+    p95Ms: percentile(values, 0.95),
+  };
+}
+
+async function loadEarnRebalanceLatencyData(): Promise<EarnRebalanceLatencyData> {
+  const rows = (await getYieldNeonSql().query(`
+    WITH first_submission AS MATERIALIZED (
+      SELECT
+        submission.decision_id,
+        MIN(submission.created_at) AS signed_at,
+        MIN(submission.submitted_at) FILTER (
+          WHERE submission.submitted_at IS NOT NULL
+        ) AS submitted_at,
+        MIN(submission.confirmed_at) FILTER (
+          WHERE submission.confirmed_at IS NOT NULL
+        ) AS confirmed_at
+      FROM loyal_yield.signed_route_submissions AS submission
+      WHERE submission.decision_id IS NOT NULL
+      GROUP BY submission.decision_id
+    ),
+    linked AS MATERIALIZED (
+      SELECT
+        decision.id,
+        decision.source_reserve,
+        decision.target_reserve,
+        opportunity.created_at AS opportunity_at,
+        opportunity.ready_at,
+        decision.created_at AS decision_at,
+        first_submission.signed_at,
+        first_submission.submitted_at,
+        first_submission.confirmed_at,
+        target_reserve.observed_at AS target_observed_at
+      FROM loyal_yield.rebalance_decisions AS decision
+      INNER JOIN loyal_yield.rebalance_opportunities AS opportunity
+        ON opportunity.decision_id = decision.id
+      INNER JOIN loyal_yield.optimizer_epochs AS epoch
+        ON epoch.id = opportunity.optimizer_epoch_id
+      INNER JOIN LATERAL (
+        SELECT (reserve.value->>'observedAt')::timestamptz AS observed_at
+        FROM jsonb_array_elements(epoch.market_state->'reserves') AS reserve(value)
+        WHERE reserve.value->>'reserve' = decision.target_reserve
+          AND reserve.value->>'observedAt' IS NOT NULL
+        LIMIT 1
+      ) AS target_reserve ON true
+      INNER JOIN first_submission
+        ON first_submission.decision_id = decision.id
+      WHERE decision.status = 'confirmed'
+        AND decision.source_reserve IS NOT NULL
+        AND decision.target_reserve IS NOT NULL
+    ),
+    valid AS MATERIALIZED (
+      SELECT *
+      FROM linked
+      WHERE target_observed_at <= opportunity_at
+        AND opportunity_at <= decision_at
+        AND decision_at <= signed_at
+        AND signed_at <= submitted_at
+        AND submitted_at <= confirmed_at
+    )
+    SELECT
+      valid.id::text,
+      valid.source_reserve,
+      valid.target_reserve,
+      valid.target_observed_at,
+      valid.opportunity_at,
+      valid.ready_at,
+      valid.decision_at,
+      valid.signed_at,
+      valid.submitted_at,
+      valid.confirmed_at,
+      ROUND(EXTRACT(epoch FROM (
+        valid.opportunity_at - valid.target_observed_at
+      ))::numeric * 1000)::bigint::text AS observed_to_opportunity_ms,
+      CASE
+        WHEN valid.ready_at >= valid.opportunity_at
+          AND valid.ready_at <= valid.decision_at
+          THEN ROUND(EXTRACT(epoch FROM (
+            valid.ready_at - valid.opportunity_at
+          ))::numeric * 1000)::bigint::text
+      END AS opportunity_to_ready_ms,
+      CASE
+        WHEN valid.ready_at >= valid.opportunity_at
+          AND valid.ready_at <= valid.decision_at
+          THEN ROUND(EXTRACT(epoch FROM (
+            valid.decision_at - valid.ready_at
+          ))::numeric * 1000)::bigint::text
+      END AS ready_to_decision_ms,
+      ROUND(EXTRACT(epoch FROM (
+        valid.signed_at - valid.decision_at
+      ))::numeric * 1000)::bigint::text AS decision_to_signed_ms,
+      ROUND(EXTRACT(epoch FROM (
+        valid.submitted_at - valid.signed_at
+      ))::numeric * 1000)::bigint::text AS signed_to_submitted_ms,
+      ROUND(EXTRACT(epoch FROM (
+        valid.confirmed_at - valid.submitted_at
+      ))::numeric * 1000)::bigint::text AS submitted_to_confirmed_ms,
+      ROUND(EXTRACT(epoch FROM (
+        valid.submitted_at - valid.target_observed_at
+      ))::numeric * 1000)::bigint::text AS monitor_to_submitted_ms,
+      (
+        SELECT COUNT(*)::integer
+        FROM loyal_yield.rebalance_decisions AS total
+        WHERE total.status = 'confirmed'
+          AND total.source_reserve IS NOT NULL
+          AND total.target_reserve IS NOT NULL
+      )::text AS total_confirmed
+    FROM valid
+    ORDER BY valid.submitted_at ASC, valid.id ASC
+  `)) as unknown as EarnLatencySqlRow[];
+
+  const points = rows.map(
+    (row): EarnLatencyPoint => ({
+      confirmedAt: toIsoString(row.confirmed_at) ?? "",
+      decisionAt: toIsoString(row.decision_at) ?? "",
+      decisionId: row.id,
+      decisionToSignedMs: toNumber(row.decision_to_signed_ms),
+      monitorToSubmittedMs: toNumber(row.monitor_to_submitted_ms),
+      observedToOpportunityMs: toNumber(row.observed_to_opportunity_ms),
+      opportunityAt: toIsoString(row.opportunity_at) ?? "",
+      opportunityToReadyMs: toNullableNumber(row.opportunity_to_ready_ms),
+      readyAt: toIsoString(row.ready_at),
+      readyToDecisionMs: toNullableNumber(row.ready_to_decision_ms),
+      signedAt: toIsoString(row.signed_at) ?? "",
+      signedToSubmittedMs: toNumber(row.signed_to_submitted_ms),
+      sourceReserve: row.source_reserve,
+      submittedAt: toIsoString(row.submitted_at) ?? "",
+      submittedToConfirmedMs: toNumber(row.submitted_to_confirmed_ms),
+      targetObservedAt: toIsoString(row.target_observed_at) ?? "",
+      targetReserve: row.target_reserve,
+    })
+  );
+  const monitorToSubmitted = points.map((point) => point.monitorToSubmittedMs);
+  const submittedToConfirmed = points.map(
+    (point) => point.submittedToConfirmedMs
+  );
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    measuredCount: points.length,
+    monitorToSubmittedP50Ms: percentile(monitorToSubmitted, 0.5),
+    monitorToSubmittedP95Ms: percentile(monitorToSubmitted, 0.95),
+    points,
+    rangeEndedAt: points.at(-1)?.submittedAt ?? null,
+    rangeStartedAt: points[0]?.submittedAt ?? null,
+    stages: STAGES.map(({ key, label }) => summarize(points, key, label)),
+    status: "available",
+    submittedToConfirmedP50Ms: percentile(submittedToConfirmed, 0.5),
+    submittedToConfirmedP95Ms: percentile(submittedToConfirmed, 0.95),
+    totalConfirmed: rows.length > 0 ? toNumber(rows[0].total_confirmed) : 0,
+  };
+}
+
+const getCachedEarnRebalanceLatencyData = unstable_cache(
+  loadEarnRebalanceLatencyData,
+  ["earn-rebalance-latency"],
+  { revalidate: DATA_CACHE_TTL_SECONDS }
+);
+
+export async function getEarnRebalanceLatencyData(): Promise<EarnRebalanceLatencyData> {
+  try {
+    return await getCachedEarnRebalanceLatencyData();
+  } catch (error) {
+    console.error("Earn rebalance latency query failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown database error",
+      errorName: error instanceof Error ? error.name : "Error",
+    });
+
+    return {
+      fetchedAt: new Date().toISOString(),
+      measuredCount: 0,
+      monitorToSubmittedP50Ms: 0,
+      monitorToSubmittedP95Ms: 0,
+      points: [],
+      rangeEndedAt: null,
+      rangeStartedAt: null,
+      stages: STAGES.map(({ key, label }) => ({
+        key,
+        label,
+        measuredCount: 0,
+        p50Ms: 0,
+        p95Ms: 0,
+      })),
+      status: "unavailable",
+      submittedToConfirmedP50Ms: 0,
+      submittedToConfirmedP95Ms: 0,
+      totalConfirmed: 0,
+    };
+  }
+}

--- a/admin/src/app/(admin)/metrics/earn-rebalance-latency.tsx
+++ b/admin/src/app/(admin)/metrics/earn-rebalance-latency.tsx
@@ -1,0 +1,623 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { formatShortAddress } from "@/components/blockchain/address-link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import type {
+  EarnLatencyPoint,
+  EarnLatencyStageKey,
+  EarnLatencyStageSummary,
+  EarnRebalanceLatencyData,
+} from "./earn-rebalance-latency-data";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+type LatencySeriesKey = EarnLatencyStageKey | "monitorToSubmittedMs";
+type RangeKey = "7d" | "30d" | "all";
+
+type ScatterPoint = EarnLatencyPoint & {
+  durationMs: number;
+  seriesLabel: string;
+  submittedAtMs: number;
+};
+
+const SERIES: ReadonlyArray<{
+  color: string;
+  key: LatencySeriesKey;
+  label: string;
+}> = [
+  {
+    color: "var(--chart-1)",
+    key: "monitorToSubmittedMs",
+    label: "Target observed → submitted",
+  },
+  {
+    color: "var(--chart-2)",
+    key: "observedToOpportunityMs",
+    label: "Observed → opportunity",
+  },
+  {
+    color: "var(--chart-3)",
+    key: "opportunityToReadyMs",
+    label: "Opportunity → ready",
+  },
+  {
+    color: "var(--chart-4)",
+    key: "readyToDecisionMs",
+    label: "Ready → decision",
+  },
+  {
+    color: "var(--chart-5)",
+    key: "decisionToSignedMs",
+    label: "Decision → signed",
+  },
+  {
+    color: "var(--metric-2)",
+    key: "signedToSubmittedMs",
+    label: "Signed → submitted",
+  },
+  {
+    color: "var(--metric-4)",
+    key: "submittedToConfirmedMs",
+    label: "Submitted → confirmed",
+  },
+];
+
+const DEFAULT_SERIES: LatencySeriesKey[] = [
+  "monitorToSubmittedMs",
+  "observedToOpportunityMs",
+  "submittedToConfirmedMs",
+];
+
+const chartConfig = Object.fromEntries(
+  SERIES.map((series) => [
+    series.key,
+    { color: series.color, label: series.label },
+  ])
+) satisfies ChartConfig;
+
+const stageChartConfig = {
+  p50Ms: { color: "var(--chart-2)", label: "p50" },
+  p95Ms: { color: "var(--chart-4)", label: "p95" },
+} satisfies ChartConfig;
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "—";
+  }
+  if (ms < 1_000) {
+    return `${Math.round(ms)}ms`;
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1_000).toFixed(ms < 10_000 ? 2 : 1)}s`;
+  }
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function formatUtcTimestamp(value: number | string | null): string {
+  if (value === null) {
+    return "No data";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatUtcTick(value: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function LatencyTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ScatterPoint }>;
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) {
+    return null;
+  }
+
+  return (
+    <div className="grid min-w-[18rem] gap-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium">{point.seriesLabel}</div>
+      <div className="text-lg font-semibold tabular-nums">
+        {formatDuration(point.durationMs)}
+      </div>
+      <div className="text-muted-foreground">
+        Submitted {formatUtcTimestamp(point.submittedAtMs)}
+      </div>
+      <div className="text-muted-foreground">
+        {formatShortAddress(point.sourceReserve)} →{" "}
+        {formatShortAddress(point.targetReserve)}
+      </div>
+      <div className="font-mono text-muted-foreground">
+        Decision {point.decisionId}
+      </div>
+    </div>
+  );
+}
+
+function StageTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: EarnLatencyStageSummary }>;
+}) {
+  const stage = payload?.[0]?.payload;
+  if (!active || !stage) {
+    return null;
+  }
+
+  return (
+    <div className="grid min-w-[13rem] gap-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium">{stage.label}</div>
+      <div className="flex justify-between gap-4">
+        <span className="text-muted-foreground">p50</span>
+        <span className="font-medium tabular-nums">
+          {formatDuration(stage.p50Ms)}
+        </span>
+      </div>
+      <div className="flex justify-between gap-4">
+        <span className="text-muted-foreground">p95</span>
+        <span className="font-medium tabular-nums">
+          {formatDuration(stage.p95Ms)}
+        </span>
+      </div>
+      <div className="text-muted-foreground">
+        {stage.measuredCount.toLocaleString("en-US")} measured executions
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  detail,
+  label,
+  value,
+}: {
+  detail: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <Card className="gap-2 py-4">
+      <CardHeader className="px-4">
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="text-2xl tabular-nums">{value}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 text-xs text-muted-foreground">
+        {detail}
+      </CardContent>
+    </Card>
+  );
+}
+
+function LatencyTable({
+  points,
+  selectedSeries,
+}: {
+  points: EarnLatencyPoint[];
+  selectedSeries: LatencySeriesKey[];
+}) {
+  const rows = [...points].reverse().slice(0, 50);
+
+  return (
+    <div className="max-h-[420px] overflow-auto rounded-md border">
+      <Table>
+        <TableHeader className="sticky top-0 bg-card">
+          <TableRow>
+            <TableHead>Submitted (UTC)</TableHead>
+            <TableHead>Decision</TableHead>
+            <TableHead>Route</TableHead>
+            {selectedSeries.map((key) => (
+              <TableHead className="text-right whitespace-nowrap" key={key}>
+                {SERIES.find((series) => series.key === key)?.label ?? key}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((point) => (
+            <TableRow key={point.decisionId}>
+              <TableCell className="whitespace-nowrap">
+                {formatUtcTimestamp(point.submittedAt)}
+              </TableCell>
+              <TableCell className="font-mono">{point.decisionId}</TableCell>
+              <TableCell className="whitespace-nowrap font-mono">
+                {formatShortAddress(point.sourceReserve)} →{" "}
+                {formatShortAddress(point.targetReserve)}
+              </TableCell>
+              {selectedSeries.map((key) => (
+                <TableCell
+                  className="text-right whitespace-nowrap tabular-nums"
+                  key={key}
+                >
+                  {typeof point[key] === "number"
+                    ? formatDuration(point[key] as number)
+                    : "Not measured"}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function EarnRebalanceLatency({
+  data,
+}: {
+  data: EarnRebalanceLatencyData;
+}) {
+  const [range, setRange] = useState<RangeKey>("all");
+  const [selectedSeries, setSelectedSeries] =
+    useState<LatencySeriesKey[]>(DEFAULT_SERIES);
+  const [showTable, setShowTable] = useState(false);
+
+  const filteredPoints = useMemo(() => {
+    if (range === "all" || data.points.length === 0) {
+      return data.points;
+    }
+    const latest = Date.parse(data.points[data.points.length - 1].submittedAt);
+    const days = range === "7d" ? 7 : 30;
+    return data.points.filter(
+      (point) => Date.parse(point.submittedAt) >= latest - days * DAY_MS
+    );
+  }, [data.points, range]);
+
+  const scatterBySeries = useMemo(
+    () =>
+      new Map(
+        SERIES.map((series) => [
+          series.key,
+          filteredPoints.flatMap((point): ScatterPoint[] => {
+            const duration = point[series.key];
+            if (typeof duration !== "number") {
+              return [];
+            }
+            return [
+              {
+                ...point,
+                durationMs: duration,
+                seriesLabel: series.label,
+                submittedAtMs: Date.parse(point.submittedAt),
+              },
+            ];
+          }),
+        ])
+      ),
+    [filteredPoints]
+  );
+
+  function toggleSeries(key: LatencySeriesKey) {
+    setSelectedSeries((current) => {
+      if (current.includes(key)) {
+        return current.length === 1
+          ? current
+          : current.filter((value) => value !== key);
+      }
+      return [...current, key];
+    });
+  }
+
+  if (data.status === "unavailable") {
+    return (
+      <section aria-labelledby="earn-rebalance-latency-title">
+        <Card>
+          <CardHeader>
+            <CardTitle id="earn-rebalance-latency-title">
+              Earn rebalance latency
+            </CardTitle>
+            <CardDescription>
+              Yield Neon latency data is temporarily unavailable. The ClickStack
+              metrics below remain independent and available.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="earn-rebalance-latency-title"
+      className="space-y-5"
+    >
+      <div>
+        <h2
+          className="text-xl font-semibold tracking-tight"
+          id="earn-rebalance-latency-title"
+        >
+          Earn rebalance latency
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Durable Yield Neon boundaries for confirmed reserve-to-reserve
+          decisions. The monitor boundary is the destination Kamino reserve’s
+          optimizer-epoch observation; all times are UTC.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          detail={`${data.measuredCount.toLocaleString(
+            "en-US"
+          )} of ${data.totalConfirmed.toLocaleString(
+            "en-US"
+          )} confirmed executions`}
+          label="Measured executions"
+          value={`${(
+            (data.measuredCount / Math.max(data.totalConfirmed, 1)) *
+            100
+          ).toFixed(1)}%`}
+        />
+        <SummaryCard
+          detail={`p95 ${formatDuration(data.monitorToSubmittedP95Ms)}`}
+          label="Target monitor → submitted"
+          value={formatDuration(data.monitorToSubmittedP50Ms)}
+        />
+        <SummaryCard
+          detail={`p95 ${formatDuration(data.submittedToConfirmedP95Ms)}`}
+          label="Submitted → confirmed"
+          value={formatDuration(data.submittedToConfirmedP50Ms)}
+        />
+        <SummaryCard
+          detail={`Through ${formatUtcTimestamp(data.rangeEndedAt)}`}
+          label="Measured window"
+          value={
+            data.rangeStartedAt
+              ? new Intl.DateTimeFormat("en-US", {
+                  month: "short",
+                  timeZone: "UTC",
+                  year: "numeric",
+                }).format(new Date(data.rangeStartedAt))
+              : "No data"
+          }
+        />
+      </div>
+
+      <Card className="min-w-0">
+        <CardHeader className="gap-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <CardTitle>Actual rebalance transaction latency</CardTitle>
+              <CardDescription>
+                One dot per measured execution and enabled stage; X is first
+                submission time and Y is elapsed time.
+              </CardDescription>
+            </div>
+            <div
+              className="flex flex-wrap gap-1"
+              aria-label="Latency chart range"
+            >
+              {(["7d", "30d", "all"] as const).map((value) => (
+                <Button
+                  aria-pressed={range === value}
+                  key={value}
+                  onClick={() => setRange(value)}
+                  size="sm"
+                  type="button"
+                  variant={range === value ? "secondary" : "outline"}
+                >
+                  {value === "all" ? "All" : value}
+                </Button>
+              ))}
+              <Button
+                aria-pressed={showTable}
+                onClick={() => setShowTable((value) => !value)}
+                size="sm"
+                type="button"
+                variant={showTable ? "secondary" : "outline"}
+              >
+                Table
+              </Button>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1.5" aria-label="Latency stages">
+            {SERIES.map((series) => {
+              const selected = selectedSeries.includes(series.key);
+              return (
+                <Button
+                  aria-pressed={selected}
+                  className="h-7 gap-1.5 px-2 text-xs"
+                  key={series.key}
+                  onClick={() => toggleSeries(series.key)}
+                  size="sm"
+                  type="button"
+                  variant={selected ? "secondary" : "outline"}
+                >
+                  <span
+                    aria-hidden
+                    className="size-2 rounded-full"
+                    style={{ backgroundColor: series.color }}
+                  />
+                  {series.label}
+                </Button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {filteredPoints.length.toLocaleString("en-US")} executions in the
+            selected range · updated {formatUtcTimestamp(data.fetchedAt)}
+          </p>
+        </CardHeader>
+        <CardContent className="min-w-0">
+          {showTable ? (
+            <LatencyTable
+              points={filteredPoints}
+              selectedSeries={selectedSeries}
+            />
+          ) : (
+            <ChartContainer
+              className="aspect-auto h-[360px] w-full min-w-0"
+              config={chartConfig}
+            >
+              <ScatterChart
+                accessibilityLayer
+                margin={{ bottom: 14, left: 8, right: 16, top: 12 }}
+              >
+                <CartesianGrid />
+                <XAxis
+                  axisLine={false}
+                  dataKey="submittedAtMs"
+                  domain={["dataMin", "dataMax"]}
+                  name="First submission time"
+                  tickFormatter={formatUtcTick}
+                  tickLine={false}
+                  tickMargin={8}
+                  type="number"
+                />
+                <YAxis
+                  axisLine={false}
+                  dataKey="durationMs"
+                  name="Elapsed time"
+                  tickFormatter={formatDuration}
+                  tickLine={false}
+                  width={58}
+                />
+                <ZAxis range={[18, 18]} />
+                <ChartTooltip
+                  content={<LatencyTooltip />}
+                  cursor={{ strokeDasharray: "3 3" }}
+                />
+                {SERIES.filter((series) =>
+                  selectedSeries.includes(series.key)
+                ).map((series) => (
+                  <Scatter
+                    data={scatterBySeries.get(series.key) ?? []}
+                    fill={`var(--color-${series.key})`}
+                    key={series.key}
+                    name={series.label}
+                  />
+                ))}
+              </ScatterChart>
+            </ChartContainer>
+          )}
+          <p className="mt-3 text-xs text-muted-foreground">
+            Missing durable stage timestamps are excluded from that stage’s
+            coverage, never replaced with zero. Historical planner-loop runtime
+            remains in transient Render logs and is not presented here as
+            durable database history.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle>Where confirmed rebalances spend time</CardTitle>
+          <CardDescription>
+            p50 and p95 elapsed time by durable lifecycle stage. Coverage is
+            printed with each stage because historical ready timestamps are
+            incomplete.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="min-w-0 space-y-4">
+          <ChartContainer
+            className="aspect-auto h-[320px] w-full min-w-0"
+            config={stageChartConfig}
+          >
+            <BarChart
+              accessibilityLayer
+              data={data.stages}
+              layout="vertical"
+              margin={{ left: 16, right: 20 }}
+            >
+              <CartesianGrid horizontal={false} />
+              <XAxis
+                axisLine={false}
+                tickFormatter={formatDuration}
+                tickLine={false}
+                type="number"
+              />
+              <YAxis
+                axisLine={false}
+                dataKey="label"
+                tickLine={false}
+                type="category"
+                width={128}
+              />
+              <ChartTooltip content={<StageTooltip />} cursor={false} />
+              <Bar
+                dataKey="p50Ms"
+                fill="var(--color-p50Ms)"
+                radius={[0, 3, 3, 0]}
+              />
+              <Bar
+                dataKey="p95Ms"
+                fill="var(--color-p95Ms)"
+                radius={[0, 3, 3, 0]}
+              />
+            </BarChart>
+          </ChartContainer>
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+            {data.stages.map((stage) => (
+              <div
+                className="rounded-md border px-3 py-2 text-xs"
+                key={stage.key}
+              >
+                <div className="font-medium">{stage.label}</div>
+                <div className="mt-1 flex flex-wrap gap-x-3 text-muted-foreground">
+                  <span>p50 {formatDuration(stage.p50Ms)}</span>
+                  <span>p95 {formatDuration(stage.p95Ms)}</span>
+                  <span>
+                    {stage.measuredCount.toLocaleString("en-US")} measured
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
+++ b/admin/src/app/(admin)/metrics/metrics-dashboard.tsx
@@ -268,7 +268,10 @@ function buildBucketGrid(data: MetricsDashboardData): number[] {
   let earliestSample = Number.POSITIVE_INFINITY;
   for (const points of [data.desktop, data.mobile]) {
     for (const point of points) {
-      earliestSample = Math.min(earliestSample, Date.parse(point.bucketStartedAt));
+      earliestSample = Math.min(
+        earliestSample,
+        Date.parse(point.bucketStartedAt)
+      );
     }
   }
 
@@ -421,7 +424,9 @@ function SeriesSwatch({ spec }: { spec: SeriesSpec }) {
       style={
         isFailure
           ? {
-              backgroundImage: `repeating-linear-gradient(to right, ${slotColor(spec.slot)} 0 4px, transparent 4px 7px)`,
+              backgroundImage: `repeating-linear-gradient(to right, ${slotColor(
+                spec.slot
+              )} 0 4px, transparent 4px 7px)`,
             }
           : { backgroundColor: slotColor(spec.slot) }
       }
@@ -513,11 +518,7 @@ function MetricTooltip({
  * the card, and a tooltip must never be the only way to reach a value, so every
  * measured bucket is readable as text here.
  */
-function MetricTable({
-  chart,
-}: {
-  chart: OperationChart;
-}) {
+function MetricTable({ chart }: { chart: OperationChart }) {
   const rows = chart.data.filter((row) =>
     chart.series.some((spec) => typeof row[spec.key] === "number")
   );
@@ -531,7 +532,10 @@ function MetricTable({
             {chart.series.map((spec) => (
               // No swatch here on purpose: this view exists so identity and
               // value read without colour.
-              <TableHead className="text-right whitespace-nowrap" key={spec.key}>
+              <TableHead
+                className="text-right whitespace-nowrap"
+                key={spec.key}
+              >
                 {spec.label}
               </TableHead>
             ))}
@@ -544,10 +548,7 @@ function MetricTable({
                 {formatUtcTimestamp(row.bucketTime)}
               </TableCell>
               {chart.series.map((spec) => (
-                <TableCell
-                  className="text-right tabular-nums"
-                  key={spec.key}
-                >
+                <TableCell className="text-right tabular-nums" key={spec.key}>
                   {typeof row[spec.key] === "number"
                     ? formatDuration(row[spec.key] as number)
                     : "—"}
@@ -617,9 +618,7 @@ function MetricChartCard({
   const clippedAxis = buildValueAxis(robustMax);
   // Counted against the clipped axis in both states, so the label stays put
   // instead of dropping to "0 above" the moment the outliers are shown.
-  const outlierCount = values.filter(
-    (value) => value > clippedAxis.max
-  ).length;
+  const outlierCount = values.filter((value) => value > clippedAxis.max).length;
   // Measured against the axis that renders, not the raw p95. Comparing the p95
   // would disagree with the count, since niceStep rounds the axis up far enough
   // that it can already contain every point; dropping the ratio entirely would
@@ -685,10 +684,12 @@ function MetricChartCard({
         </div>
         <CardDescription className="tabular-nums">
           {volume
-            ? `${volume.total.toLocaleString()} ${volume.total === 1 ? "sample" : "samples"}`
+            ? `${volume.total.toLocaleString("en-US")} ${
+                volume.total === 1 ? "sample" : "samples"
+              }`
             : "p95 latency"}
           {volume && volume.failed > 0
-            ? ` · ${volume.failed.toLocaleString()} failed`
+            ? ` · ${volume.failed.toLocaleString("en-US")} failed`
             : ""}
           {` · ${chart.bucketCount} of ${bucketGrid.length} buckets`}
         </CardDescription>
@@ -714,7 +715,9 @@ function MetricChartCard({
                 dataKey="bucketTime"
                 domain={[bucketGrid[0], bucketGrid[bucketGrid.length - 1]]}
                 scale="time"
-                tickFormatter={(value: number) => formatUtcTick(value, axisSpan)}
+                tickFormatter={(value: number) =>
+                  formatUtcTick(value, axisSpan)
+                }
                 tickLine={false}
                 tickMargin={8}
                 ticks={buildAxisTicks(bucketGrid)}
@@ -879,7 +882,8 @@ export function MetricsDashboard({ data }: { data: MetricsDashboardData }) {
   const latestSampleAt = getLatestSampleAt(data);
   const bucketGrid = useMemo(() => buildBucketGrid(data), [data]);
   const isTrimmed =
-    bucketGrid[0] - Date.parse(data.rangeStartedAt) > data.bucketMinutes * 60_000;
+    bucketGrid[0] - Date.parse(data.rangeStartedAt) >
+    data.bucketMinutes * 60_000;
 
   return (
     <div className="space-y-8">

--- a/admin/src/app/(admin)/metrics/page.tsx
+++ b/admin/src/app/(admin)/metrics/page.tsx
@@ -1,13 +1,18 @@
 import { PageContainer } from "@/components/layout/page-container";
 import { SectionHeader } from "@/components/layout/section-header";
 
+import { EarnRebalanceLatency } from "./earn-rebalance-latency";
+import { getEarnRebalanceLatencyData } from "./earn-rebalance-latency-data";
 import { getMetricsData } from "./metrics-data";
 import { MetricsDashboard } from "./metrics-dashboard";
 
 export const dynamic = "force-dynamic";
 
 export default async function MetricsPage() {
-  const data = await getMetricsData();
+  const [data, earnRebalanceLatency] = await Promise.all([
+    getMetricsData(),
+    getEarnRebalanceLatencyData(),
+  ]);
 
   return (
     <PageContainer className="max-w-7xl">
@@ -16,7 +21,10 @@ export default async function MetricsPage() {
         breadcrumbs={[{ label: "Metrics" }]}
         subtitle="Production p95 latency in two-hour UTC buckets over the last 7 days, busiest operations first."
       />
-      <MetricsDashboard data={data} />
+      <div className="space-y-10">
+        <EarnRebalanceLatency data={earnRebalanceLatency} />
+        <MetricsDashboard data={data} />
+      </div>
     </PageContainer>
   );
 }

--- a/admin/src/app/api/earn/rebalance/route.ts
+++ b/admin/src/app/api/earn/rebalance/route.ts
@@ -7,6 +7,7 @@ import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
 import {
   getActiveReserveRoutes,
   getAutodepositTimeSeries,
+  getExecutedEarnRebalanceHistory,
   getLast30DaysRebalanceSeries,
   getRebalanceActivity,
   getRecentRebalanceDecisions,
@@ -16,6 +17,22 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 async function loadRebalanceMonitorData() {
+  const executedRebalancesPromise = getExecutedEarnRebalanceHistory()
+    .then((history) => ({ ...history, status: "available" as const }))
+    .catch((error) => {
+      console.error("Executed Earn rebalance history query failed", {
+        errorMessage:
+          error instanceof Error ? error.message : "Unknown database error",
+        errorName: error instanceof Error ? error.name : "Error",
+      });
+
+      return {
+        executions: [],
+        generatedAt: new Date().toISOString(),
+        status: "unavailable" as const,
+        userCount: 0,
+      };
+    });
   const [
     apyData,
     routes,
@@ -23,6 +40,7 @@ async function loadRebalanceMonitorData() {
     activity,
     last30DaysRebalances,
     autodeposit,
+    executedRebalances,
   ] = await Promise.all([
     getSafeReserveApyMonitorData(),
     getActiveReserveRoutes(),
@@ -30,6 +48,7 @@ async function loadRebalanceMonitorData() {
     getRebalanceActivity(),
     getLast30DaysRebalanceSeries(),
     getAutodepositTimeSeries(),
+    executedRebalancesPromise,
   ]);
 
   return {
@@ -54,6 +73,15 @@ async function loadRebalanceMonitorData() {
       amountRaw: decision.amountRaw?.toString() ?? null,
       confirmedSlot: decision.confirmedSlot?.toString() ?? null,
     })),
+    executedRebalances: {
+      ...executedRebalances,
+      executions: executedRebalances.executions.map((execution) => ({
+        ...execution,
+        amountRaw: execution.amountRaw.toString(),
+        confirmedSlot: execution.confirmedSlot.toString(),
+        currentDepositRaw: execution.currentDepositRaw.toString(),
+      })),
+    },
     last30DaysRebalances,
     routes: routes.map((route) => ({
       ...route,


### PR DESCRIPTION
Adds durable Yield Neon-backed Earn observability to admin: confirmed rebalance history ordered by each user's current deposit on `/earn/rebalance`, plus coverage, p50/p95 latency summaries, an execution time series, and lifecycle-stage comparisons on `/metrics`. The existing ClickStack dashboard remains independent, missing durable timestamps reduce reported coverage instead of becoming zero, and deterministic number formatting fixes the metrics-page hydration mismatch exposed during browser verification.

Validated with live read-only database cross-checks (2,920 executions, 690 users, zero rank violations; 1,938 measurable latency records), Prettier, lint, `bunx tsc --noEmit`, production build, desktop/mobile browser checks, and the repository pre-push app/admin/frontend lint-and-build hook.