### PR TITLE
fix(mobile): clear dead wallet authorization when signing is refused

### DIFF
--- a/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -40,6 +40,8 @@ jest.mock("../mwa-account-storage", () => ({
 }));
 
 // eslint-disable-next-line import/first
+import { clearMwaAccount } from "../mwa-account-storage";
+// eslint-disable-next-line import/first
 import { MwaSigner } from "../mwa-signer";
 // eslint-disable-next-line import/first
 import { WalletRejectedError } from "../rejection";
@@ -77,6 +79,11 @@ function failAfterSession(error: unknown) {
       auth_token: authToken,
     }),
     signMessages: async () => {
+      throw error;
+    },
+    // Same session wrapper as `signMessages`, so both privileged calls can be
+    // exercised against an identical rejection.
+    signTransactions: async () => {
       throw error;
     },
   };
@@ -211,6 +218,49 @@ describe("MWA session error classification", () => {
       expect(await failureOf(signer().signMessage(new Uint8Array([1])))).toBe(raw);
     },
   );
+
+  // ERROR_AUTHORIZATION_FAILED is the one numeric code that is NOT our bug: it
+  // means the stored authorization is dead. `reauthorize` recovers when
+  // `authorize` raises it, but a wallet that accepts the reauthorization and
+  // then refuses the privileged method skipped that recovery entirely — the
+  // raw error kept its `code`, telemetry called it `request_failed`, and the
+  // stale token survived. One user retried 41 times over six hours against the
+  // same dead token, with 904 USDC stranded, and never saw a reconnect prompt.
+  describe("authorization revoked mid-session (ERROR_AUTHORIZATION_FAILED)", () => {
+    it("tells the user to reconnect instead of reporting a request failure", async () => {
+      failAfterSession(codedError(-1, "-1/authorization request failed"));
+
+      const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
+      );
+      // A surviving `code` is precisely what routed this to `request_failed`.
+      expect(error).not.toHaveProperty("code");
+    });
+
+    // Without this the app keeps showing a connected wallet that cannot sign,
+    // so every retry repeats the same failure and the user is stuck.
+    it("clears the dead authorization so the next launch can reconnect", async () => {
+      failAfterSession(codedError(-1, "-1/authorization request failed"));
+
+      await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
+    });
+
+    // Signing transactions goes through the same session wrapper, so a fix
+    // that only covered `signMessage` would still strand the send path.
+    it("recovers the same way when signing transactions", async () => {
+      failAfterSession(codedError(-1, "-1/authorization request failed"));
+
+      const error = await failureOf(signer().signAllTransactions([]));
+
+      expect((error as Error).message).toMatch(/reconnect your wallet/);
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
+    });
+  });
 
   // User-facing copy replaces the native message, so the original has to stay
   // reachable or local debugging loses it entirely.

--- a/mobile/src/lib/wallet/mwa-signer.ts
+++ b/mobile/src/lib/wallet/mwa-signer.ts
@@ -360,11 +360,37 @@ export class MwaSigner implements Signer {
         // ERROR_NOT_SIGNED: the user tapped decline in the wallet app.
         throw new WalletRejectedError(SIGNING_DECLINED_MESSAGE);
       }
+      if (hasErrorCode(error, -1)) {
+        // ERROR_AUTHORIZATION_FAILED raised by the signing call rather than by
+        // `authorize`: some wallets accept the reauthorization and only refuse
+        // the privileged method, so `reauthorize`'s recovery never runs. It is
+        // the same dead authorization, so recover it the same way. Left to the
+        // fallback below it kept its raw protocol `code`, which telemetry maps
+        // to `request_failed` — naming an HTTP failure for a call that never
+        // reached the network, and leaving the stale token in place so every
+        // retry failed identically (ASK-1872 follow-up).
+        throw await this.forgetAuthorization();
+      }
       // Only session-layer rejections become wallet-session failures. Protocol
       // errors, `reauthorize`'s reconnect instructions and our signature checks
       // all keep their own identity so they stay alertable.
       throw toWalletSessionError(error, sessionEstablished) ?? error;
     }
+  }
+
+  /**
+   * Drop the stored authorization so the next launch lands in reconnect
+   * onboarding, and return the instruction to show the user. Returns the error
+   * rather than throwing it so call sites keep an explicit `throw` and stay
+   * readable as terminal branches.
+   *
+   * Clearing is the half that matters: without it the app keeps presenting a
+   * connected wallet whose every signature is refused, and the user has no way
+   * to reach the reconnect flow from inside the failing screen.
+   */
+  private async forgetAuthorization(): Promise<Error> {
+    await clearMwaAccount();
+    return new Error(RECONNECT_MESSAGE);
   }
 
   private async reauthorize(wallet: Web3MobileWallet): Promise<void> {
@@ -379,14 +405,12 @@ export class MwaSigner implements Signer {
       // ERROR_AUTHORIZATION_FAILED: the wallet revoked our authorization
       // (the user disconnected this app). Transient session errors rethrow.
       if (!hasErrorCode(error, -1)) throw error;
-      await clearMwaAccount();
-      throw new Error(RECONNECT_MESSAGE);
+      throw await this.forgetAuthorization();
     }
     const base64Address = toBase64Address(this.publicKey);
     if (!result.accounts.some((a) => a.address === base64Address)) {
       // The wallet reauthorized a different account than the one connected.
-      await clearMwaAccount();
-      throw new Error(RECONNECT_MESSAGE);
+      throw await this.forgetAuthorization();
     }
     if (result.auth_token !== this.authToken) {
       this.authToken = result.auth_token;


### PR DESCRIPTION
A wallet that accepts our reauthorization but then rejects the signing call with ERROR_AUTHORIZATION_FAILED (-1) skipped `reauthorize`'s recovery, so the stale auth token survived and every retry failed identically — one user hit this 41 times over six hours with no way to reconnect from inside the app, and telemetry reported it as `request_failed` for a call that never reached the network.

Handles -1 in `withWallet` the same way `reauthorize` already does, via a shared `forgetAuthorization` that drops the stored account and surfaces the reconnect instruction.