### PR TITLE
feat(observability): add device identity to mobile telemetry envelopes

### DIFF
--- a/frontend/src/features/observability/error-contract.ts
+++ b/frontend/src/features/observability/error-contract.ts
@@ -78,6 +78,14 @@ export const MOBILE_ERROR_OPERATIONS = [
 
 export type MobileErrorOperation = (typeof MOBILE_ERROR_OPERATIONS)[number];
 
+// Same vocabulary as the metrics contract's `platform`; a device identity is
+// useless without knowing which OS fleet it belongs to (ASK-2097).
+export const MOBILE_DEVICE_PLATFORMS = ["android", "ios"] as const;
+export type MobileDevicePlatform = (typeof MOBILE_DEVICE_PLATFORMS)[number];
+
+const DEVICE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
 export type ServerErrorOperation = "next.request.error";
 
 export type ObservabilityRuntime = "browser" | "mobile" | "node";
@@ -105,6 +113,13 @@ export type ParseBrowserErrorEnvelopeOptions = {
 // binary versions and OTA updates, so the server's Vercel release would be
 // meaningless for them.
 export type MobileErrorEnvelope = {
+  /**
+   * Stable per-install UUID, the join key for a device's whole telemetry
+   * trail across sessions and wallets (ASK-2097). Optional: older clients
+   * predate it.
+   */
+  deviceId?: string;
+  devicePlatform?: MobileDevicePlatform;
   environment: string;
   message: string;
   name: string;
@@ -119,6 +134,8 @@ export type NormalizedErrorEvent = {
   browserDiagnostics?: BrowserErrorDiagnostics;
   clientBuildId?: string;
   deploymentEnvironment: string;
+  deviceId?: string;
+  devicePlatform?: MobileDevicePlatform;
   exception: {
     message: string;
     name: string;
@@ -547,6 +564,8 @@ export function parseMobileErrorEnvelope(
 
   const record = value as Record<string, unknown>;
   const allowedKeys = new Set([
+    "deviceId",
+    "devicePlatform",
     "environment",
     "message",
     "name",
@@ -563,9 +582,30 @@ export function parseMobileErrorEnvelope(
   if (!isAllowedMobileOperation(record.operation)) {
     throw new InvalidObservabilityEnvelopeError();
   }
+  if (
+    record.deviceId !== undefined &&
+    (typeof record.deviceId !== "string" ||
+      !DEVICE_ID_PATTERN.test(record.deviceId))
+  ) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
+  if (
+    record.devicePlatform !== undefined &&
+    !MOBILE_DEVICE_PLATFORMS.includes(
+      record.devicePlatform as MobileDevicePlatform
+    )
+  ) {
+    throw new InvalidObservabilityEnvelopeError();
+  }
 
   return {
     ...parseCommonErrorEnvelopeFields(record, now),
+    ...(record.deviceId !== undefined
+      ? { deviceId: record.deviceId as string }
+      : {}),
+    ...(record.devicePlatform !== undefined
+      ? { devicePlatform: record.devicePlatform as MobileDevicePlatform }
+      : {}),
     environment: readResourceValue(
       record,
       "environment",

--- a/frontend/src/features/observability/lifecycle-contract.ts
+++ b/frontend/src/features/observability/lifecycle-contract.ts
@@ -232,6 +232,12 @@ export const LIFECYCLE_CLIENT_PLATFORMS = ["desktop", "mobile"] as const;
 export type LifecycleClientPlatform =
   (typeof LIFECYCLE_CLIENT_PLATFORMS)[number];
 
+// Which OS fleet a mobile device belongs to — same vocabulary as the metrics
+// contract's `platform` (ASK-2097). Distinct from `clientPlatform`, which is
+// a browser form-factor token.
+export const MOBILE_DEVICE_PLATFORMS = ["android", "ios"] as const;
+export type MobileDevicePlatform = (typeof MOBILE_DEVICE_PLATFORMS)[number];
+
 export const LIFECYCLE_ERROR_DETAILS = [
   "mwa_unspecified",
   "mwa_wallet_not_found",
@@ -405,6 +411,13 @@ export type BrowserLifecycleEnvelope = LifecycleDiagnostics & {
 // binary versions and OTA bundles) plus an optional wallet address that the
 // ingest route forwards verbatim, the same way web sessions report theirs.
 export type MobileLifecycleEnvelope = BrowserLifecycleEnvelope & {
+  /**
+   * Stable per-install UUID, the join key for a device's whole telemetry
+   * trail across sessions and wallets (ASK-2097). Optional: older clients
+   * predate it.
+   */
+  deviceId?: string;
+  devicePlatform?: MobileDevicePlatform;
   environment: string;
   release: string;
   walletAddress?: string;
@@ -412,6 +425,8 @@ export type MobileLifecycleEnvelope = BrowserLifecycleEnvelope & {
 
 export type NormalizedLifecycleEvent = BrowserLifecycleEnvelope & {
   deploymentEnvironment: string;
+  deviceId?: string;
+  devicePlatform?: MobileDevicePlatform;
   release: string;
   serviceName: "loyal-frontend" | "loyal-mobile";
   walletAddress?: string;
@@ -760,10 +775,8 @@ export function parseMobileLifecycleEnvelope(
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new InvalidLifecycleEnvelopeError();
   }
-  const { environment, release, walletAddress, ...rest } = value as Record<
-    string,
-    unknown
-  >;
+  const { deviceId, devicePlatform, environment, release, walletAddress, ...rest } =
+    value as Record<string, unknown>;
 
   const normalizedEnvironment =
     typeof environment === "string"
@@ -783,6 +796,18 @@ export function parseMobileLifecycleEnvelope(
   ) {
     throw new InvalidLifecycleEnvelopeError();
   }
+  if (
+    deviceId !== undefined &&
+    (typeof deviceId !== "string" || !UUID_V4_PATTERN.test(deviceId))
+  ) {
+    throw new InvalidLifecycleEnvelopeError();
+  }
+  if (
+    devicePlatform !== undefined &&
+    !includes(MOBILE_DEVICE_PLATFORMS, devicePlatform)
+  ) {
+    throw new InvalidLifecycleEnvelopeError();
+  }
   if (rest.runtime !== "mobile") {
     throw new InvalidLifecycleEnvelopeError();
   }
@@ -792,6 +817,8 @@ export function parseMobileLifecycleEnvelope(
     environment: normalizedEnvironment,
     release: normalizedRelease,
     ...(walletAddress ? { walletAddress } : {}),
+    ...(deviceId !== undefined ? { deviceId } : {}),
+    ...(devicePlatform !== undefined ? { devicePlatform } : {}),
   };
 }
 

--- a/frontend/src/features/observability/metrics-contract.ts
+++ b/frontend/src/features/observability/metrics-contract.ts
@@ -78,6 +78,11 @@ export type MobileLoadingOperation = (typeof MOBILE_LOADING_OPERATIONS)[number];
 
 export type MobileLoadingMetricEnvelope = {
   appSessionId: string;
+  /**
+   * Stable per-install UUID, the join key for a device's whole telemetry
+   * trail (ASK-2097). Optional: older clients predate it.
+   */
+  deviceId?: string;
   durationMs: number;
   environment: string;
   flowId?: string;
@@ -95,6 +100,7 @@ export type NormalizedLoadingMetric = {
   appSessionId?: string;
   dependency?: FrontendLoadingDependency;
   deploymentEnvironment: string;
+  deviceId?: string;
   durationMs: number;
   flowId?: string;
   metricName:
@@ -325,6 +331,7 @@ export function parseMobileLoadingMetricEnvelope(
   const record = value as Record<string, unknown>;
   const allowedKeys = new Set([
     "appSessionId",
+    "deviceId",
     "durationMs",
     "environment",
     "flowId",
@@ -347,7 +354,8 @@ export function parseMobileLoadingMetricEnvelope(
     !includes(["app_ready", "interaction_to_ui"] as const, record.phase) ||
     !includes(["android", "ios"] as const, record.platform) ||
     !isFiniteNumberInRange(record.durationMs, 0, MAX_METRIC_DURATION_MS) ||
-    !isCanonicalUuidV4(record.appSessionId)
+    !isCanonicalUuidV4(record.appSessionId) ||
+    (record.deviceId !== undefined && !isCanonicalUuidV4(record.deviceId))
   ) {
     throw new InvalidMetricsEnvelopeError();
   }

--- a/frontend/src/features/observability/otlp.ts
+++ b/frontend/src/features/observability/otlp.ts
@@ -58,6 +58,14 @@ export function buildOtlpErrorPayload(event: NormalizedErrorEvent): unknown {
       stringAttribute("loyal.page_session.id", event.pageSessionId)
     );
   }
+  if (event.deviceId) {
+    attributes.push(stringAttribute("loyal.device.id", event.deviceId));
+  }
+  if (event.devicePlatform) {
+    attributes.push(
+      stringAttribute("loyal.device.platform", event.devicePlatform)
+    );
+  }
   const diagnostics = event.browserDiagnostics;
   if (diagnostics) {
     attributes.push(stringAttribute("loyal.chunk.url", diagnostics.chunkUrl));
@@ -161,6 +169,8 @@ export function buildOtlpLifecyclePayload(
   ];
 
   const strings: Array<[string, string | undefined]> = [
+    ["loyal.device.id", event.deviceId],
+    ["loyal.device.platform", event.devicePlatform],
     ["loyal.wallet.address", event.walletAddress],
     ["loyal.wallet.provider", event.walletProvider],
     ["loyal.error.code", event.errorCode],
@@ -268,6 +278,9 @@ export function buildOtlpLoadingMetricPayload(
     attributes.push(
       stringAttribute("loyal.app_session.id", event.appSessionId)
     );
+  }
+  if (event.deviceId) {
+    attributes.push(stringAttribute("loyal.device.id", event.deviceId));
   }
   if (event.platform) {
     attributes.push(stringAttribute("loyal.platform", event.platform));

--- a/frontend/src/features/observability/server.ts
+++ b/frontend/src/features/observability/server.ts
@@ -174,6 +174,10 @@ export async function reportMobileErrorEnvelope(
       // The device reports its own release/environment — the app fleet mixes
       // binary versions and OTA updates that Vercel's release can't describe.
       deploymentEnvironment: envelope.environment,
+      ...(envelope.deviceId ? { deviceId: envelope.deviceId } : {}),
+      ...(envelope.devicePlatform
+        ? { devicePlatform: envelope.devicePlatform }
+        : {}),
       exception: {
         message: envelope.message,
         name: envelope.name,


### PR DESCRIPTION
Adds optional deviceId (stable per-install UUID) and devicePlatform (android/ios) to the mobile error, lifecycle, and loading-metric envelope contracts, exported as loyal.device.* OTLP attributes. Gives ClickStack a per-device join key across all mobile telemetry (ASK-2097); must deploy before the mobile client starts sending the fields.