### PR TITLE
fix(earn): restore legacy mobile prepare request compat

### DIFF
--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint;
-  let mint: string;
+  let mint: string | null;
   try {
     ({ amountRaw, mint } = parseEarnDepositPrepareRequestBody(body));
   } catch (error) {
@@ -155,6 +155,9 @@ export async function POST(request: Request) {
       error instanceof Error ? error.message : "Unsupported Earn mint."
     );
   }
+  // Legacy bodies omit the mint (ASK-2099); from here on use the resolved
+  // product mint, which defaults those to USDC.
+  mint = productMint.mint.toBase58();
 
   // Resolve (provisioning if needed) the canonical smart account for this
   // wallet — same gate as `../prepare`: the first-ever provisioning is

--- a/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
@@ -129,7 +129,7 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint;
-  let mint: string;
+  let mint: string | null;
   try {
     ({ amountRaw, mint } = parseEarnDepositPrepareRequestBody(body));
   } catch (error) {
@@ -161,6 +161,9 @@ export async function POST(request: Request) {
       error instanceof Error ? error.message : "Unsupported Earn mint."
     );
   }
+  // Legacy bodies omit the mint (ASK-2099); from here on use the resolved
+  // product mint, which defaults those to USDC.
+  mint = productMint.mint.toBase58();
 
   // Resolve (provisioning if needed) the canonical smart account for this
   // wallet — the same account the web flow uses, so Earn is one position

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts
@@ -18,7 +18,10 @@ import {
   resolveEarnUsdcWithdrawInput,
   serializeEarnUsdcWithdrawInput,
 } from "@/lib/yield-optimization/earn-withdraw-input-resolution.server";
-import { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+import {
+  type EarnWithdrawLegacyPrepareRequest,
+  parseEarnWithdrawPrepareRequestBody,
+} from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 
 // Context twin of `../prepare` for ON-DEVICE withdraw prepare: same auth and
 // source-selection/reconcile logic (shared via
@@ -82,9 +85,11 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint | "max";
-  let sourceId: string;
+  let sourceId: string | null;
+  let legacy: EarnWithdrawLegacyPrepareRequest | null;
   try {
-    ({ amountRaw, sourceId } = parseEarnWithdrawPrepareRequestBody(body));
+    ({ amountRaw, sourceId, legacy } =
+      parseEarnWithdrawPrepareRequestBody(body));
   } catch (error) {
     return jsonError(
       400,
@@ -147,6 +152,7 @@ export async function POST(request: Request) {
       cluster,
       connection: getConnection(solanaEnv),
       earnVaultPda,
+      legacyRequest: legacy,
       logTag: "mobile-earn-withdraw-prepare-context",
       requestedAmountRaw: amountRaw,
       policySigner: getDeploymentPolicySignerPublicKey(),

--- a/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/mobile/earn/withdraw/prepare/route.ts
@@ -19,6 +19,7 @@ import {
   resolveEarnUsdcWithdrawInput,
 } from "@/lib/yield-optimization/earn-withdraw-input-resolution.server";
 import {
+  type EarnWithdrawLegacyPrepareRequest,
   parseEarnWithdrawPrepareRequestBody,
   serializePreparedEarnUsdcWithdraw,
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
@@ -86,9 +87,11 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint | "max";
-  let sourceId: string;
+  let sourceId: string | null;
+  let legacy: EarnWithdrawLegacyPrepareRequest | null;
   try {
-    ({ amountRaw, sourceId } = parseEarnWithdrawPrepareRequestBody(body));
+    ({ amountRaw, sourceId, legacy } =
+      parseEarnWithdrawPrepareRequestBody(body));
   } catch (error) {
     return jsonError(
       400,
@@ -152,6 +155,7 @@ export async function POST(request: Request) {
       cluster,
       connection,
       earnVaultPda,
+      legacyRequest: legacy,
       logTag: "mobile-earn-withdraw-prepare",
       requestedAmountRaw: amountRaw,
       policySigner: getDeploymentPolicySignerPublicKey(),

--- a/frontend/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
@@ -80,7 +80,7 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint;
-  let mint: string;
+  let mint: string | null;
   try {
     ({ amountRaw, mint } = parseEarnDepositPrepareRequestBody(
       await request.json()
@@ -113,6 +113,9 @@ export async function POST(request: Request) {
       error instanceof Error ? error.message : "Unsupported Earn mint."
     );
   }
+  // Legacy bodies omit the mint (ASK-2099); from here on use the resolved
+  // product mint, which defaults those to USDC.
+  mint = productMint.mint.toBase58();
   let policy: RoutePolicyRecord | null = null;
   let setupPolicy: RoutePolicyRecord | null = null;
   let resumeRouteOnly = false;

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -169,10 +169,16 @@ mock.module(
   () => ({
     parseEarnWithdrawPrepareRequestBody: (body: {
       amountRaw: string;
-      sourceId: string;
+      sourceId?: string;
+      mode?: "partial" | "full";
+      source?: Record<string, unknown> | null;
     }) => ({
       amountRaw: body.amountRaw === "max" ? "max" : BigInt(body.amountRaw),
-      sourceId: body.sourceId,
+      sourceId: body.sourceId ?? null,
+      legacy:
+        body.sourceId === undefined && body.mode
+          ? { mode: body.mode, source: body.source ?? null }
+          : null,
     }),
     serializePreparedEarnUsdcWithdraw: () => ({ ok: true }),
   })
@@ -196,6 +202,9 @@ mock.module("@loyal-labs/smart-account-vaults", () => ({
       return { prepared: true, input };
     },
   }),
+  // The input-resolution module imports this too; an incomplete module mock
+  // fails the whole suite at import time.
+  isEarnWithdrawRequiredAccountMissingError: () => false,
 }));
 
 function createRequest(body: Record<string, unknown>): Request {
@@ -369,5 +378,93 @@ describe("Earn withdrawal prepare route", () => {
     expect(response.status).toBe(409);
     expect(payload.error.code).toBe("earn_withdraw_source_changed");
     expect(prepareCalls).toHaveLength(0);
+  });
+
+  // Legacy `{ amountRaw, mode, source }` bodies — the shape every shipped
+  // mobile binary/OTA still sends (ASK-2099).
+  test("resolves a legacy partial body by raw reserve id (ASK-2099)", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "300000",
+        mode: "partial",
+        source: {
+          id: secondReserve,
+          reserve: secondReserve,
+          type: "reserve",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(300_000));
+    expect(prepareCalls[0]?.mode).toBe("partial");
+    expect(prepareCalls[0]?.source).toMatchObject({
+      id: secondReserve,
+      type: "reserve",
+    });
+    expect(prepareCalls[0]?.fullWithdrawalTargets).toBeUndefined();
+  });
+
+  test("resolves a legacy partial body holding a new-format source id (ASK-2099)", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "300000",
+        mode: "partial",
+        source: { id: `reserve:${secondReserve}`, type: "reserve" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.source).toMatchObject({
+      id: secondReserve,
+      type: "reserve",
+    });
+  });
+
+  test("legacy full exit aggregates every source (ASK-2099)", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "1010000",
+        mode: "full",
+        source: null,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.mode).toBe("full");
+    // 600000 + 400000 + 10000 — every source, not just the largest.
+    expect(prepareCalls[0]?.amountRaw).toBe(BigInt(1_010_000));
+    expect(prepareCalls[0]?.fullWithdrawalTargets).toHaveLength(2);
+    expect(prepareCalls[0]?.source).toMatchObject({
+      id: activePosition.currentReserve,
+      type: "reserve",
+    });
+  });
+
+  test("legacy idle withdrawal keeps a reserve routing target (ASK-2099)", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "10000",
+        mode: "partial",
+        source: { id: idleTokenAccount, type: "idle" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prepareCalls[0]?.source).toMatchObject({
+      id: idleTokenAccount,
+      type: "idle",
+    });
+    expect(prepareCalls[0]?.target).toMatchObject({
+      reserve: new PublicKey(activePosition.currentReserve),
+    });
   });
 });

--- a/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/frontend/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -20,6 +20,7 @@ import {
   resolveEarnUsdcWithdrawInput,
 } from "@/lib/yield-optimization/earn-withdraw-input-resolution.server";
 import {
+  type EarnWithdrawLegacyPrepareRequest,
   parseEarnWithdrawPrepareRequestBody,
   serializePreparedEarnUsdcWithdraw,
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
@@ -66,9 +67,10 @@ export async function POST(request: Request) {
   }
 
   let amountRaw: bigint | "max";
-  let sourceId: string;
+  let sourceId: string | null;
+  let legacy: EarnWithdrawLegacyPrepareRequest | null;
   try {
-    ({ amountRaw, sourceId } = parseEarnWithdrawPrepareRequestBody(
+    ({ amountRaw, sourceId, legacy } = parseEarnWithdrawPrepareRequestBody(
       await request.json()
     ));
   } catch (error) {
@@ -104,6 +106,7 @@ export async function POST(request: Request) {
       cluster,
       connection,
       earnVaultPda,
+      legacyRequest: legacy,
       logTag: "earn-withdraw-prepare",
       requestedAmountRaw: amountRaw,
       policySigner: getDeploymentPolicySignerPublicKey(),

--- a/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts
@@ -82,7 +82,9 @@ function readUnsignedIntegerString(
 
 export function parseEarnDepositPrepareRequestBody(body: unknown): {
   amountRaw: bigint;
-  mint: string;
+  // null = legacy client that predates mint selection; those bodies always
+  // meant USDC and the product-asset resolver defaults accordingly (ASK-2099).
+  mint: string | null;
 } {
   const record = assertRequestObject(body);
   const amountRaw = BigInt(readUnsignedIntegerString(record, "amountRaw"));
@@ -92,6 +94,9 @@ export function parseEarnDepositPrepareRequestBody(body: unknown): {
   }
 
   const mintValue = record.mint;
+  if (mintValue === undefined) {
+    return { amountRaw, mint: null };
+  }
   if (typeof mintValue !== "string") {
     throw new Error("mint must be a mint public key.");
   }

--- a/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseEarnDepositPrepareRequestBody } from "./earn-deposit-prepare-contracts.shared";
+
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+describe("Earn deposit prepare request parsing", () => {
+  test("parses a body with an explicit mint", () => {
+    expect(
+      parseEarnDepositPrepareRequestBody({
+        amountRaw: "5000000",
+        mint: USDC_MINT,
+      })
+    ).toEqual({ amountRaw: BigInt(5_000_000), mint: USDC_MINT });
+  });
+
+  test("accepts a legacy body without a mint (ASK-2099)", () => {
+    // Pre-mint-selection mobile clients send only the amount; requiring the
+    // field silently 400'd every mobile deposit.
+    expect(
+      parseEarnDepositPrepareRequestBody({ amountRaw: "5000000" })
+    ).toEqual({ amountRaw: BigInt(5_000_000), mint: null });
+  });
+
+  test("still rejects a non-string mint", () => {
+    expect(() =>
+      parseEarnDepositPrepareRequestBody({ amountRaw: "5000000", mint: 5 })
+    ).toThrow("mint must be a mint public key.");
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-product-mints.shared.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-product-mints.shared.test.ts
@@ -55,10 +55,17 @@ describe("Earn asset registry and public deposit intent", () => {
     }
   });
 
-  test("rejects missing and unsupported mints before construction", () => {
-    expect(() =>
-      parseEarnDepositPrepareRequestBody({ amountRaw: "1" })
-    ).toThrow("mint must be a mint public key");
+  test("treats a missing mint as legacy USDC and rejects unsupported mints", () => {
+    // Legacy mobile deposit bodies predate mint selection and always meant
+    // USDC; requiring the field silently 400'd every mobile deposit (ASK-2099).
+    expect(parseEarnDepositPrepareRequestBody({ amountRaw: "1" })).toEqual({
+      amountRaw: BigInt(1),
+      mint: null,
+    });
+    expect(
+      resolveEarnProductAsset({ cluster: LoyalCluster.MainnetBeta, mint: null })
+        .symbol
+    ).toBe(Stablecoin.USDC);
     expect(() =>
       resolveEarnProductAsset({
         cluster: LoyalCluster.MainnetBeta,

--- a/frontend/src/lib/yield-optimization/earn-product-mints.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-product-mints.shared.ts
@@ -106,10 +106,16 @@ export function getEnabledEarnProductAssetsForCluster(args: {
 
 export function resolveEarnProductAsset(args: {
   cluster: LoyalCluster;
-  mint: string | PublicKey;
+  // null = legacy deposit body that predates mint selection; those clients
+  // always meant USDC (ASK-2099).
+  mint: string | PublicKey | null;
 }): EarnProductAsset {
   const mint =
-    typeof args.mint === "string" ? new PublicKey(args.mint) : args.mint;
+    args.mint === null
+      ? getStablecoinMintForCluster(args.cluster, Stablecoin.USDC)
+      : typeof args.mint === "string"
+        ? new PublicKey(args.mint)
+        : args.mint;
   const asset = getEarnProductAssetsForCluster(args.cluster).find((candidate) =>
     candidate.mint.equals(mint)
   );
@@ -122,7 +128,7 @@ export function resolveEarnProductAsset(args: {
 export function resolveEnabledEarnProductAsset(args: {
   cluster: LoyalCluster;
   enabledStablecoins: readonly EarnProductStablecoin[];
-  mint: string | PublicKey;
+  mint: string | PublicKey | null;
 }): EarnProductAsset {
   const asset = resolveEarnProductAsset(args);
   if (!args.enabledStablecoins.includes(asset.stablecoin)) {

--- a/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -8,13 +8,20 @@ import {
 import { type Connection, PublicKey } from "@solana/web3.js";
 
 import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
-import type { EarnUsdcReserveTarget } from "@/lib/yield-optimization/earn-reserve-target.server";
+import {
+  earnReserveTargetFromActivePosition,
+  type EarnUsdcReserveTarget,
+} from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
   type EarnRpcHolding,
   fetchEarnRpcHoldingsSnapshot,
 } from "@/lib/yield-optimization/earn-rpc-holdings.client";
 import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
-import type { parseEarnWithdrawPrepareRequestBody } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
+import type {
+  EarnWithdrawLegacyPrepareRequest,
+  EarnWithdrawLegacySourceRequest,
+  parseEarnWithdrawPrepareRequestBody,
+} from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import {
   findActiveYieldRoutePolicyPair,
   findReconciledActiveYieldPositionForVault,
@@ -137,6 +144,190 @@ function selectRequestedEarnWithdrawSource(
   return selected;
 }
 
+// ---------------------------------------------------------------------------
+// Legacy request compatibility (ASK-2099). Mobile binaries and OTAs that
+// predate the sourceId contract still send `{ amountRaw, mode, source }`;
+// these are the selection/matching rules that contract shipped with, applied
+// to the same snapshot sources. Delete once the mobile fleet speaks sourceId.
+
+function isNonEmptyString(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// Legacy clients that refreshed their source list after the contract change
+// hold new-format ids ("reserve:<pubkey>" / "idle:<tokenAccount>") — strip
+// the prefix so they still match the raw identifiers below.
+function stripSourceIdPrefix(value: string): string {
+  return value.replace(/^(?:reserve|idle):/, "");
+}
+
+function legacySourceMatchesDirectIdentifier(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawLegacySourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [request.id, request.reserve, request.tokenAccount]
+    .filter(isNonEmptyString)
+    .map(stripSourceIdPrefix);
+
+  if (identifiers.includes(source.id)) {
+    return true;
+  }
+
+  return source.type === "reserve" && identifiers.includes(source.reserve);
+}
+
+function legacySourceMatchesStableMint(
+  source: SelectedEarnWithdrawSource,
+  request: NonNullable<EarnWithdrawLegacySourceRequest>
+): boolean {
+  if (source.type !== request.type) {
+    return false;
+  }
+
+  const identifiers = [request.id, request.liquidityMint, request.mint].filter(
+    isNonEmptyString
+  );
+
+  return source.type === "reserve"
+    ? identifiers.includes(source.liquidityMint)
+    : identifiers.includes(source.mint);
+}
+
+function selectLegacyEarnWithdrawSource(
+  sources: SelectedEarnWithdrawSource[],
+  request: EarnWithdrawLegacySourceRequest
+): SelectedEarnWithdrawSource | null {
+  if (!request) {
+    return sources.length === 1 ? (sources[0] ?? null) : null;
+  }
+
+  const directMatch = sources.find((source) =>
+    legacySourceMatchesDirectIdentifier(source, request)
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const stableMintMatches = sources.filter((source) =>
+    legacySourceMatchesStableMint(source, request)
+  );
+  if (stableMintMatches.length === 1) {
+    return stableMintMatches[0] ?? null;
+  }
+
+  const amountMatchedStableMintMatches = stableMintMatches.filter(
+    (source) => request.amountRaw === source.amountRaw.toString()
+  );
+
+  return amountMatchedStableMintMatches.length === 1
+    ? (amountMatchedStableMintMatches[0] ?? null)
+    : null;
+}
+
+function publicKeyFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  keys: string[]
+): PublicKey | null {
+  if (!metadata) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      continue;
+    }
+    try {
+      return new PublicKey(value);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+// Reserve target the legacy contract attached to idle-source withdrawals so
+// the device SDK always had a routing venue.
+function snapshotReserveTarget(
+  holdings: EarnRpcHolding[]
+): EarnUsdcReserveTarget | null {
+  const kamino = holdings.find(
+    (holding) => holding.kind === "kamino" && holding.reserve && holding.market
+  );
+  if (!(kamino?.reserve && kamino.market)) {
+    return null;
+  }
+  let supplyApyBps: bigint | null = null;
+  if (kamino.supplyApyBps) {
+    try {
+      supplyApyBps = BigInt(kamino.supplyApyBps);
+    } catch {
+      supplyApyBps = null;
+    }
+  }
+  return {
+    liquidityMint: new PublicKey(kamino.liquidityMint),
+    liquidityTokenProgram: new PublicKey(kamino.tokenProgramId),
+    market: new PublicKey(kamino.market),
+    reserve: new PublicKey(kamino.reserve),
+    supplyApyBps,
+  };
+}
+
+// Legacy full exit unwinds EVERY market the wallet holds; the aggregate target
+// list drives the SDK's multi-market full-withdrawal build.
+function snapshotFullWithdrawalTargets(holdings: EarnRpcHolding[]): {
+  amountRaw: bigint;
+  liquidityMint: PublicKey;
+  market: PublicKey;
+  reserve: PublicKey;
+  reserveCollateralMint?: PublicKey;
+  supplyApyBps: bigint | null;
+}[] {
+  const targets = [];
+  for (const holding of holdings) {
+    if (holding.kind !== "kamino" || !holding.reserve || !holding.market) {
+      continue;
+    }
+    let amountRaw: bigint;
+    try {
+      amountRaw = BigInt(holding.amountRaw);
+    } catch {
+      continue;
+    }
+    if (amountRaw <= BigInt(0)) {
+      continue;
+    }
+    let supplyApyBps: bigint | null = null;
+    if (holding.supplyApyBps) {
+      try {
+        supplyApyBps = BigInt(holding.supplyApyBps);
+      } catch {
+        supplyApyBps = null;
+      }
+    }
+    const reserveCollateralMint = publicKeyFromMetadata(holding.provenance, [
+      "reserveCollateralMint",
+    ]);
+    targets.push({
+      amountRaw,
+      liquidityMint: new PublicKey(holding.liquidityMint),
+      market: new PublicKey(holding.market),
+      reserve: new PublicKey(holding.reserve),
+      ...(reserveCollateralMint ? { reserveCollateralMint } : {}),
+      supplyApyBps,
+    });
+  }
+  return targets;
+}
+
+// ---------------------------------------------------------------------------
+
 // Build withdrawal sources from the live on-chain holdings snapshot. The DB
 // read-model cannot follow a cross-market rebalance. Drop entries missing the
 // identifiers a withdrawal needs to match or build.
@@ -204,6 +395,9 @@ export async function resolveEarnUsdcWithdrawInput(args: {
   earnVaultPda: PublicKey;
   requestedAmountRaw: bigint | "max";
   sourceId: EarnWithdrawSourceId;
+  // Set for legacy `{ amountRaw, mode, source }` bodies (ASK-2099); resolved
+  // with the legacy matcher instead of an exact sourceId match.
+  legacyRequest?: EarnWithdrawLegacyPrepareRequest | null;
   // Route-specific log prefix so on-call greps keep working per endpoint.
   logTag: string;
 }): Promise<ResolvedEarnUsdcWithdraw> {
@@ -292,31 +486,97 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     );
   }
 
-  const selectedSource = selectRequestedEarnWithdrawSource(
-    snapshotSources,
-    args.sourceId
-  );
-  const effectiveAmountRaw =
-    requestedAmountRaw === "max"
-      ? selectedSource.amountRaw
-      : requestedAmountRaw;
-  if (effectiveAmountRaw > selectedSource.amountRaw) {
-    throw new EarnWithdrawResolveError(
-      409,
-      "earn_withdraw_amount_exceeds_source",
-      "Withdrawal exceeds the selected Earn source amount."
+  const legacyRequest = args.legacyRequest ?? null;
+  let selectedSource: SelectedEarnWithdrawSource;
+  let effectiveAmountRaw: bigint;
+  let mode: "partial" | "full" = "partial";
+  let fullWithdrawalTargets: ReturnType<typeof snapshotFullWithdrawalTargets> =
+    [];
+  let withdrawTarget: EarnUsdcReserveTarget | undefined;
+
+  if (legacyRequest && legacyRequest.mode === "full") {
+    // Legacy full exit: aggregate every source and let the SDK unwind each
+    // market; the client's amountRaw is display-precision and ignored.
+    const largestReserveSource = snapshotSources.reduce<Extract<
+      SelectedEarnWithdrawSource,
+      { type: "reserve" }
+    > | null>((largest, source) => {
+      if (source.type !== "reserve") {
+        return largest;
+      }
+      return !largest || source.amountRaw > largest.amountRaw
+        ? source
+        : largest;
+    }, null);
+    selectedSource =
+      largestReserveSource ??
+      snapshotSources.find((source) => source.type === "idle")!;
+    effectiveAmountRaw = snapshotSources.reduce(
+      (total, source) => total + source.amountRaw,
+      BigInt(0)
     );
+    mode = "full";
+    fullWithdrawalTargets = snapshotFullWithdrawalTargets(snapshot.holdings);
+    withdrawTarget =
+      selectedSource.type === "reserve"
+        ? reserveSourceWithdrawTarget(selectedSource)
+        : (snapshotReserveTarget(snapshot.holdings) ??
+          earnReserveTargetFromActivePosition(position, cluster));
+  } else if (legacyRequest) {
+    const selected = selectLegacyEarnWithdrawSource(
+      snapshotSources,
+      legacyRequest.source
+    );
+    if (!selected) {
+      throw new EarnWithdrawResolveError(
+        400,
+        "earn_withdraw_source_required",
+        "Select an Earn source before withdrawing."
+      );
+    }
+    selectedSource = selected;
+    effectiveAmountRaw =
+      requestedAmountRaw === "max" ? selected.amountRaw : requestedAmountRaw;
+    if (effectiveAmountRaw > selected.amountRaw) {
+      throw new EarnWithdrawResolveError(
+        409,
+        "earn_withdraw_amount_exceeds_source",
+        "Withdrawal exceeds the selected Earn source amount."
+      );
+    }
+    withdrawTarget =
+      selected.type === "reserve"
+        ? reserveSourceWithdrawTarget(selected)
+        : (snapshotReserveTarget(snapshot.holdings) ??
+          earnReserveTargetFromActivePosition(position, cluster));
+  } else {
+    if (args.sourceId === null) {
+      throw new EarnWithdrawResolveError(
+        400,
+        "earn_withdraw_source_required",
+        "Select an Earn source before withdrawing."
+      );
+    }
+    selectedSource = selectRequestedEarnWithdrawSource(
+      snapshotSources,
+      args.sourceId
+    );
+    effectiveAmountRaw =
+      requestedAmountRaw === "max"
+        ? selectedSource.amountRaw
+        : requestedAmountRaw;
+    if (effectiveAmountRaw > selectedSource.amountRaw) {
+      throw new EarnWithdrawResolveError(
+        409,
+        "earn_withdraw_amount_exceeds_source",
+        "Withdrawal exceeds the selected Earn source amount."
+      );
+    }
+    withdrawTarget =
+      selectedSource.type === "reserve"
+        ? reserveSourceWithdrawTarget(selectedSource)
+        : undefined;
   }
-  const withdrawTarget: EarnUsdcReserveTarget | undefined =
-    selectedSource.type === "reserve"
-      ? {
-          liquidityMint: new PublicKey(selectedSource.liquidityMint),
-          liquidityTokenProgram: new PublicKey(selectedSource.tokenProgramId),
-          market: new PublicKey(selectedSource.market),
-          reserve: new PublicKey(selectedSource.reserve),
-          supplyApyBps: null,
-        }
-      : undefined;
 
   const yieldRoutingPolicy = {
     account: new PublicKey(policy.policyAccount),
@@ -337,6 +597,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     policySigner: args.policySigner,
     settingsPda: settingsPdaKey,
     target: withdrawTarget,
+    ...(fullWithdrawalTargets.length > 0 ? { fullWithdrawalTargets } : {}),
     // Full withdrawal and policy close are intentionally separate phases.
     closePoliciesOnFullWithdrawal: false,
     source:
@@ -363,10 +624,22 @@ export async function resolveEarnUsdcWithdrawInput(args: {
 
   const input: SmartAccountEarnUsdcWithdrawInput = {
     ...withdrawInput,
-    mode: "partial",
+    mode,
   };
 
   return { input, policy, effectiveAmountRaw };
+}
+
+function reserveSourceWithdrawTarget(
+  source: Extract<SelectedEarnWithdrawSource, { type: "reserve" }>
+): EarnUsdcReserveTarget {
+  return {
+    liquidityMint: new PublicKey(source.liquidityMint),
+    liquidityTokenProgram: new PublicKey(source.tokenProgramId),
+    market: new PublicKey(source.market),
+    reserve: new PublicKey(source.reserve),
+    supplyApyBps: null,
+  };
 }
 
 // Wire form of the resolved SDK input, served by `withdraw/prepare-context`

--- a/frontend/src/lib/yield-optimization/earn-withdraw-intent.shared.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-intent.shared.test.ts
@@ -3,28 +3,44 @@ import { describe, expect, test } from "bun:test";
 import { parseEarnWithdrawPrepareRequestBody } from "./earn-withdraw-prepare-contracts.shared";
 
 describe("Earn withdrawal intent", () => {
-  test("accepts only exact source identity plus raw amount or max", () => {
+  test("accepts exact source identity plus raw amount or max", () => {
     expect(
       parseEarnWithdrawPrepareRequestBody({
         amountRaw: "20",
         sourceId: "reserve:reserve-a",
       })
-    ).toEqual({ amountRaw: BigInt(20), sourceId: "reserve:reserve-a" });
+    ).toEqual({
+      amountRaw: BigInt(20),
+      sourceId: "reserve:reserve-a",
+      legacy: null,
+    });
     expect(
       parseEarnWithdrawPrepareRequestBody({
         amountRaw: "max",
         sourceId: "idle:pyusd-ata",
       })
-    ).toEqual({ amountRaw: "max", sourceId: "idle:pyusd-ata" });
+    ).toEqual({ amountRaw: "max", sourceId: "idle:pyusd-ata", legacy: null });
   });
 
-  test("rejects legacy fuzzy source objects", () => {
+  test("keeps accepting legacy source objects the mobile fleet still sends", () => {
+    // Rejecting these silently 400'd every shipped mobile withdrawal
+    // (ASK-2099). Resolution matches them with the legacy matcher, which
+    // refuses ambiguous fuzzy matches instead of guessing.
+    const parsed = parseEarnWithdrawPrepareRequestBody({
+      amountRaw: "20",
+      mode: "partial",
+      source: { id: "PYUSD", type: "idle" },
+    });
+    expect(parsed.sourceId).toBeNull();
+    expect(parsed.legacy).toMatchObject({
+      mode: "partial",
+      source: { id: "PYUSD", type: "idle" },
+    });
+  });
+
+  test("rejects a body with neither sourceId nor mode", () => {
     expect(() =>
-      parseEarnWithdrawPrepareRequestBody({
-        amountRaw: "20",
-        mode: "partial",
-        source: { id: "PYUSD", type: "idle" },
-      })
+      parseEarnWithdrawPrepareRequestBody({ amountRaw: "20" })
     ).toThrow("sourceId must be a non-empty string");
   });
 });

--- a/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts
@@ -20,6 +20,27 @@ export type EarnWithdrawPrepareRequestBody = {
   sourceId: string;
 };
 
+// Legacy wire shape: `{ amountRaw, mode, source }`. Every mobile binary and
+// OTA shipped before the sourceId contract still sends it, and the change
+// silently 400'd the whole mobile withdraw fleet (ASK-2099) — so the parser
+// accepts both shapes and resolution maps legacy requests with the matcher
+// that contract used. Delete once the mobile fleet speaks sourceId.
+export type EarnWithdrawLegacySourceRequest = {
+  amountRaw?: string;
+  id: string;
+  liquidityMint?: string;
+  market?: string | null;
+  mint?: string;
+  reserve?: string;
+  tokenAccount?: string;
+  type: "reserve" | "idle";
+} | null;
+
+export type EarnWithdrawLegacyPrepareRequest = {
+  mode: "partial" | "full";
+  source: EarnWithdrawLegacySourceRequest;
+};
+
 export type WireSmartAccountPreparedEarnUsdcWithdraw = {
   amountRaw: string;
   autodepositClosePrepared?: WireSmartAccountPreparedEarnUsdcAutodepositClose | null;
@@ -103,7 +124,8 @@ function readUnsignedIntegerString(
 
 export function parseEarnWithdrawPrepareRequestBody(body: unknown): {
   amountRaw: bigint | "max";
-  sourceId: string;
+  sourceId: string | null;
+  legacy: EarnWithdrawLegacyPrepareRequest | null;
 } {
   const record = assertRequestObject(body);
   const amountValue = record.amountRaw;
@@ -115,6 +137,21 @@ export function parseEarnWithdrawPrepareRequestBody(body: unknown): {
   if (amountRaw !== "max" && amountRaw <= BigInt(0)) {
     throw new Error("amountRaw must be greater than 0.");
   }
+
+  if (
+    record.sourceId === undefined &&
+    (record.mode === "partial" || record.mode === "full")
+  ) {
+    if (amountRaw === "max") {
+      throw new Error("amountRaw must be an unsigned integer string.");
+    }
+    return {
+      amountRaw,
+      sourceId: null,
+      legacy: { mode: record.mode, source: readLegacyWithdrawSource(record) },
+    };
+  }
+
   const sourceId = record.sourceId;
   if (typeof sourceId !== "string" || sourceId.trim().length === 0) {
     throw new Error("sourceId must be a non-empty string.");
@@ -123,6 +160,54 @@ export function parseEarnWithdrawPrepareRequestBody(body: unknown): {
   return {
     amountRaw,
     sourceId: sourceId.trim(),
+    legacy: null,
+  };
+}
+
+function readLegacyWithdrawSource(
+  body: EarnWithdrawPrepareRecord
+): EarnWithdrawLegacySourceRequest {
+  const value = body.source;
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "object") {
+    throw new Error("source must be an object when provided.");
+  }
+  const source = value as EarnWithdrawPrepareRecord;
+  const type = source.type;
+  if (type !== "reserve" && type !== "idle") {
+    throw new Error("source.type must be reserve or idle.");
+  }
+  const id = source.id;
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error("source.id must be a non-empty string.");
+  }
+
+  return {
+    amountRaw:
+      typeof source.amountRaw === "string" && /^\d+$/.test(source.amountRaw)
+        ? source.amountRaw
+        : undefined,
+    id: id.trim(),
+    liquidityMint:
+      typeof source.liquidityMint === "string"
+        ? source.liquidityMint.trim()
+        : undefined,
+    market:
+      typeof source.market === "string"
+        ? source.market.trim()
+        : source.market === null
+          ? null
+          : undefined,
+    mint: typeof source.mint === "string" ? source.mint.trim() : undefined,
+    reserve:
+      typeof source.reserve === "string" ? source.reserve.trim() : undefined,
+    tokenAccount:
+      typeof source.tokenAccount === "string"
+        ? source.tokenAccount.trim()
+        : undefined,
+    type,
   };
 }
 

--- a/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseEarnWithdrawPrepareRequestBody } from "./earn-withdraw-prepare-contracts.shared";
+
+// The parser accepts two wire shapes: the current `{ amountRaw, sourceId }`
+// and the legacy `{ amountRaw, mode, source }` every shipped mobile client
+// still sends. Rejecting the legacy shape silently 400'd the whole mobile
+// withdraw fleet (ASK-2099).
+describe("Earn withdraw prepare request parsing", () => {
+  test("parses the current sourceId body", () => {
+    expect(
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "300000",
+        sourceId: "reserve:abc",
+      })
+    ).toEqual({
+      amountRaw: BigInt(300_000),
+      sourceId: "reserve:abc",
+      legacy: null,
+    });
+  });
+
+  test("parses a max sourceId body", () => {
+    expect(
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "max",
+        sourceId: "idle:abc",
+      })
+    ).toEqual({ amountRaw: "max", sourceId: "idle:abc", legacy: null });
+  });
+
+  test("parses a legacy partial body with a source object (ASK-2099)", () => {
+    expect(
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "300000",
+        mode: "partial",
+        source: {
+          amountRaw: "400000",
+          id: "reserve-pubkey",
+          reserve: "reserve-pubkey",
+          type: "reserve",
+        },
+      })
+    ).toEqual({
+      amountRaw: BigInt(300_000),
+      sourceId: null,
+      legacy: {
+        mode: "partial",
+        source: {
+          amountRaw: "400000",
+          id: "reserve-pubkey",
+          liquidityMint: undefined,
+          market: undefined,
+          mint: undefined,
+          reserve: "reserve-pubkey",
+          tokenAccount: undefined,
+          type: "reserve",
+        },
+      },
+    });
+  });
+
+  test("parses a legacy full body with a null source (ASK-2099)", () => {
+    expect(
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "1000000",
+        mode: "full",
+        source: null,
+      })
+    ).toEqual({
+      amountRaw: BigInt(1_000_000),
+      sourceId: null,
+      legacy: { mode: "full", source: null },
+    });
+  });
+
+  test("still rejects a body with neither sourceId nor mode", () => {
+    expect(() =>
+      parseEarnWithdrawPrepareRequestBody({ amountRaw: "1000" })
+    ).toThrow("sourceId must be a non-empty string.");
+  });
+
+  test("rejects a legacy body with a max amount", () => {
+    expect(() =>
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "max",
+        mode: "full",
+        source: null,
+      })
+    ).toThrow("amountRaw must be an unsigned integer string.");
+  });
+
+  test("rejects a legacy body with a malformed source", () => {
+    expect(() =>
+      parseEarnWithdrawPrepareRequestBody({
+        amountRaw: "1000",
+        mode: "partial",
+        source: { id: "", type: "reserve" },
+      })
+    ).toThrow("source.id must be a non-empty string.");
+  });
+});


### PR DESCRIPTION
PR #624's sourceId/mint request contracts silently 400'd every shipped mobile Earn withdrawal and deposit (ASK-2099). The prepare parsers now accept the legacy mobile wire shapes again and resolve them with the pre-#624 source matcher, including true full-exit semantics.