### PR TITLE
fix(earn): bind prepare transport fetch receiver

### DIFF
--- a/frontend/src/lib/yield-optimization/earn-prepare-request.client.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-prepare-request.client.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { fetchEarnPrepare } from "./earn-prepare-request.client";
+
+// Regression for ASK-2096: `fetchEarnPrepare` used to invoke the transport as
+// `args.fetchImpl(...)`, calling the native fetch with `this === args`.
+// Browsers reject that with "Failed to execute 'fetch' on 'Window': Illegal
+// invocation", which broke every live web Earn deposit/withdrawal prepare.
+// TypeScript cannot catch the receiver, so this guards the invocation shape.
+describe("fetchEarnPrepare receiver binding", () => {
+  test("invokes the transport without a foreign `this` receiver", async () => {
+    const seenReceivers: unknown[] = [];
+    function receiverSensitiveFetch(this: unknown): Promise<Response> {
+      seenReceivers.push(this);
+      if (this !== undefined && this !== globalThis) {
+        // Mirrors the browser's Illegal invocation TypeError.
+        throw new TypeError(
+          "Failed to execute 'fetch' on 'Window': Illegal invocation"
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }
+
+    const response = await fetchEarnPrepare({
+      body: "{}",
+      fetchImpl: receiverSensitiveFetch as unknown as typeof fetch,
+      url: "https://example.invalid/prepare",
+    });
+
+    expect(response.status).toBe(200);
+    expect(seenReceivers).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-prepare-request.client.ts
+++ b/frontend/src/lib/yield-optimization/earn-prepare-request.client.ts
@@ -1,6 +1,9 @@
 import type { LifecycleErrorDetail } from "@/features/observability/lifecycle-contract";
 
-const EARN_PREPARE_REQUEST_TIMEOUT_MS = 15_000;
+// Prepare routes legitimately run long (Safe reserve selection + Kamino RPC
+// round trips measured at ~10s in production, longer on dev cold compiles),
+// so the bound only guards against a hung connection, not a slow prepare.
+const EARN_PREPARE_REQUEST_TIMEOUT_MS = 45_000;
 
 export class EarnPrepareRequestError extends Error {
   readonly code: string | undefined;
@@ -60,7 +63,10 @@ export async function fetchEarnPrepare(args: {
       controller.abort();
     }, EARN_PREPARE_REQUEST_TIMEOUT_MS);
     try {
-      return await args.fetchImpl(args.url, {
+      // Invoke with an explicit receiver: `args.fetchImpl(...)` would call the
+      // native fetch with `this === args`, which browsers reject with
+      // "Failed to execute 'fetch' on 'Window': Illegal invocation".
+      return await args.fetchImpl.call(globalThis, args.url, {
         body: args.body,
         credentials: "include",
         headers: {
@@ -79,10 +85,15 @@ export async function fetchEarnPrepare(args: {
       if (attempt === 0 && errorDetail) {
         continue;
       }
-      throw new EarnPrepareRequestError("Earn prepare request failed.", {
-        cause: error,
-        errorDetail,
-      });
+      throw new EarnPrepareRequestError(
+        errorDetail === "request_timeout"
+          ? "Earn prepare request timed out."
+          : "Earn prepare request failed.",
+        {
+          cause: error,
+          errorDetail,
+        }
+      );
     } finally {
       clearTimeout(timeout);
     }


### PR DESCRIPTION
Fixes live web Earn deposit/withdrawal prepare, broken in production since 05426163: fetchEarnPrepare called the native fetch with `this === args` (Illegal invocation), and the 15s client bound aborted legitimate ~10-16s prepares. ASK-2096.