### PR TITLE
fix(earn): tolerate legacy prepared wires in Earn confirm hydration

### DIFF
--- a/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts
@@ -3,6 +3,7 @@ import type {
   SmartAccountNativeSolRequirement,
   SmartAccountPreparedEarnUsdcDeposit,
 } from "@loyal-labs/smart-account-vaults";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 
 import {
@@ -39,7 +40,8 @@ export type WireSmartAccountPreparedEarnUsdcDeposit = {
   prepared: WirePreparedLoyalSmartAccountsOperation;
   targetReserve: {
     liquidityMint: string;
-    liquidityTokenProgram: string;
+    // Absent on legacy mobile wires (pre-token-2022, always USDC — ASK-2099).
+    liquidityTokenProgram?: string;
     market: string;
     obligation: string;
     reserve: string;
@@ -195,9 +197,11 @@ export function hydratePreparedEarnUsdcDeposit(
     prepared: hydratePreparedOperation(wire.prepared),
     targetReserve: {
       liquidityMint: new PublicKey(wire.targetReserve.liquidityMint),
-      liquidityTokenProgram: new PublicKey(
-        wire.targetReserve.liquidityTokenProgram
-      ),
+      // Legacy mobile wires predate token-2022 mints and omit the field; they
+      // are always classic-token USDC (ASK-2099).
+      liquidityTokenProgram: wire.targetReserve.liquidityTokenProgram
+        ? new PublicKey(wire.targetReserve.liquidityTokenProgram)
+        : TOKEN_PROGRAM_ID,
       market: new PublicKey(wire.targetReserve.market),
       obligation: new PublicKey(wire.targetReserve.obligation),
       reserve: new PublicKey(wire.targetReserve.reserve),

--- a/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
-import { parseEarnDepositPrepareRequestBody } from "./earn-deposit-prepare-contracts.shared";
+import {
+  hydratePreparedEarnUsdcDeposit,
+  parseEarnDepositPrepareRequestBody,
+  type WireSmartAccountPreparedEarnUsdcDeposit,
+} from "./earn-deposit-prepare-contracts.shared";
 
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
@@ -26,5 +31,52 @@ describe("Earn deposit prepare request parsing", () => {
     expect(() =>
       parseEarnDepositPrepareRequestBody({ amountRaw: "5000000", mint: 5 })
     ).toThrow("mint must be a mint public key.");
+  });
+});
+
+describe("Earn deposit prepared-wire hydration", () => {
+  test("defaults a legacy wire without liquidityTokenProgram to the classic token program (ASK-2099)", () => {
+    // Shipped mobile apps serialize targetReserve without the field; blindly
+    // constructing a PublicKey from it 400'd every mobile deposit confirm.
+    const wire: WireSmartAccountPreparedEarnUsdcDeposit = {
+      kaminoSetupAccountCount: 0,
+      kaminoSetupRentLamports: "0",
+      kaminoSetupRequired: false,
+      nativeSolRequirement: {} as never,
+      persistence: {} as never,
+      policy: {
+        account: "11111111111111111111111111111112",
+        id: "7",
+        sameMintInstructionConstraintIndexes: [0, 1],
+        seed: "7",
+      },
+      prepared: {
+        instructions: [],
+        lookupTableAccounts: [],
+        operation: "earn-deposit",
+        payer: "11111111111111111111111111111113",
+        programId: "11111111111111111111111111111114",
+        requiresConfirmation: true,
+      },
+      targetReserve: {
+        liquidityMint: USDC_MINT,
+        market: "11111111111111111111111111111115",
+        obligation: "11111111111111111111111111111116",
+        reserve: "11111111111111111111111111111117",
+        supplyApyBps: null,
+      },
+      vault: {
+        accountIndex: 1,
+        collateralAta: null,
+        pubkey: "11111111111111111111111111111118",
+        usdcAta: "11111111111111111111111111111119",
+      },
+    };
+
+    const hydrated = hydratePreparedEarnUsdcDeposit(wire);
+    expect(
+      hydrated.targetReserve.liquidityTokenProgram.equals(TOKEN_PROGRAM_ID)
+    ).toBe(true);
+    expect(hydrated.targetReserve.liquidityMint.toBase58()).toBe(USDC_MINT);
   });
 });

--- a/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts
@@ -2,6 +2,7 @@ import type {
   SmartAccountEarnUsdcWithdrawMetadata,
   SmartAccountPreparedEarnUsdcWithdraw,
 } from "@loyal-labs/smart-account-vaults";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 
 import {
@@ -82,7 +83,8 @@ export type WireSmartAccountPreparedEarnUsdcWithdraw = {
   }>;
   targetReserve: {
     liquidityMint: string;
-    liquidityTokenProgram: string;
+    // Absent on legacy mobile wires (pre-token-2022, always USDC — ASK-2099).
+    liquidityTokenProgram?: string;
     market: string;
     obligation: string;
     reserve: string;
@@ -375,9 +377,11 @@ export function hydratePreparedEarnUsdcWithdraw(
     targetReserve: wire.targetReserve
       ? {
           liquidityMint: new PublicKey(wire.targetReserve.liquidityMint),
-          liquidityTokenProgram: new PublicKey(
-            wire.targetReserve.liquidityTokenProgram
-          ),
+          // Legacy mobile wires predate token-2022 mints and omit the field;
+          // they are always classic-token USDC (ASK-2099).
+          liquidityTokenProgram: wire.targetReserve.liquidityTokenProgram
+            ? new PublicKey(wire.targetReserve.liquidityTokenProgram)
+            : TOKEN_PROGRAM_ID,
           market: new PublicKey(wire.targetReserve.market),
           obligation: new PublicKey(wire.targetReserve.obligation),
           reserve: new PublicKey(wire.targetReserve.reserve),

--- a/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
-import { parseEarnWithdrawPrepareRequestBody } from "./earn-withdraw-prepare-contracts.shared";
+import {
+  hydratePreparedEarnUsdcWithdraw,
+  parseEarnWithdrawPrepareRequestBody,
+  type WireSmartAccountPreparedEarnUsdcWithdraw,
+} from "./earn-withdraw-prepare-contracts.shared";
 
 // The parser accepts two wire shapes: the current `{ amountRaw, sourceId }`
 // and the legacy `{ amountRaw, mode, source }` every shipped mobile client
@@ -98,5 +103,49 @@ describe("Earn withdraw prepare request parsing", () => {
         source: { id: "", type: "reserve" },
       })
     ).toThrow("source.id must be a non-empty string.");
+  });
+});
+
+describe("Earn withdraw prepared-wire hydration", () => {
+  test("defaults a legacy wire without liquidityTokenProgram to the classic token program (ASK-2099)", () => {
+    // Shipped mobile apps serialize targetReserve without the field; blindly
+    // constructing a PublicKey from it 400'd every mobile withdraw confirm.
+    const wire: WireSmartAccountPreparedEarnUsdcWithdraw = {
+      amountRaw: "1000000",
+      mode: "partial",
+      persistence: {} as never,
+      policy: {
+        account: "11111111111111111111111111111112",
+        id: "7",
+        sameMintInstructionConstraintIndexes: [0, 1],
+        seed: "7",
+        withdrawInstructionConstraintIndex: 0,
+      },
+      prepared: {
+        instructions: [],
+        lookupTableAccounts: [],
+        operation: "earn-withdraw",
+        payer: "11111111111111111111111111111113",
+        programId: "11111111111111111111111111111114",
+        requiresConfirmation: true,
+      },
+      targetReserve: {
+        liquidityMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        market: "11111111111111111111111111111115",
+        obligation: "11111111111111111111111111111116",
+        reserve: "11111111111111111111111111111117",
+      },
+      vault: {
+        accountIndex: 1,
+        collateralAta: null,
+        pubkey: "11111111111111111111111111111118",
+        usdcAta: "11111111111111111111111111111119",
+      },
+    };
+
+    const hydrated = hydratePreparedEarnUsdcWithdraw(wire);
+    expect(
+      hydrated.targetReserve?.liquidityTokenProgram.equals(TOKEN_PROGRAM_ID)
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Shipped mobile apps echo prepared objects without the #624-added targetReserve.liquidityTokenProgram, so every mobile Earn confirm died on new PublicKey(undefined) and on-chain transactions went unrecorded (ASK-2099 leg 2). The hydrators now default the missing field to the classic token program, which is what legacy pre-token-2022 USDC wires always meant.