### PR TITLE
fix(earn): support all product mints in confirm and earn UI

### DIFF
--- a/frontend/src/app/api/smart-accounts/earn-transactions/formatter.ts
+++ b/frontend/src/app/api/smart-accounts/earn-transactions/formatter.ts
@@ -39,6 +39,9 @@ export type SerializedEarnTransaction = {
     | "balance_sweep";
   id: string;
   kind: EarnTransactionKind;
+  // Mint of the position the event belongs to; null for autodeposit action
+  // rows (USDC-only flows). Lets the client render per-mint coin icons.
+  liquidityMint: string | null;
   rawAmount: string;
   signature: string;
   sortTimestamp: string;
@@ -190,6 +193,7 @@ function serializeAutodepositActionEvent(
       : "autodeposit_closed",
     id: event.id,
     kind: isBalanceSweep ? "balance_sweep" : "autodeposit_action",
+    liquidityMint: null,
     rawAmount: formatExactUsdcAmount(transactionAmountRaw),
     signature: event.signature,
     sortTimestamp: event.confirmedAt.toISOString(),
@@ -263,6 +267,7 @@ export function serializeEarnTransactionEvent(
     eventType: event.eventType,
     id: `${event.signature}:${event.id.toString()}`,
     kind,
+    liquidityMint: event.liquidityMint,
     rawAmount: formatExactUsdcAmount(transactionAmountRaw),
     signature: event.signature,
     sortTimestamp: event.confirmedAt.toISOString(),

--- a/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -156,6 +156,12 @@ export function DepositPane({
   const [isSourceSheetOpen, setIsSourceSheetOpen] = useState(false);
   const [selectedSourceKey, setSelectedSourceKey] = useState("");
   const { actions } = earnData;
+  // The funding balance is only auto-refreshed after Earn transactions, so
+  // re-read it on open to pick up swaps and external transfers (ASK-2096).
+  const { refreshMainUsdcAmount } = actions;
+  useEffect(() => {
+    void refreshMainUsdcAmount();
+  }, [refreshMainUsdcAmount]);
 
   const sourceOptions = useMemo<DepositSourceOption[]>(() => {
     const cluster = resolveLoyalClusterForSolanaEnv(
@@ -188,10 +194,25 @@ export function DepositPane({
     publicEnv.earnEnabledStablecoins,
     publicEnv.solanaEnv,
   ]);
+  // Default to USDC, but when it has no balance prefer the funded stablecoin
+  // (largest balance) so a fully swapped wallet doesn't open on a $0 source.
+  const defaultSource = useMemo(() => {
+    const usdc = sourceOptions.find(
+      (source) => source.symbol === Stablecoin.USDC
+    );
+    if (usdc && usdc.usd > 0) {
+      return usdc;
+    }
+    const funded = sourceOptions.reduce<DepositSourceOption | null>(
+      (best, source) =>
+        source.usd > 0 && source.usd > (best?.usd ?? 0) ? source : best,
+      null
+    );
+    return funded ?? usdc ?? sourceOptions[0]!;
+  }, [sourceOptions]);
   const selectedSource =
     sourceOptions.find((source) => source.key === selectedSourceKey) ??
-    sourceOptions.find((source) => source.symbol === Stablecoin.USDC) ??
-    sourceOptions[0]!;
+    defaultSource;
   const sourceUsd = selectedSource.usd;
   const depositSteps = useMemo(
     () => createDepositSteps(selectedSource.symbol),

--- a/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/earn-activity-card.tsx
@@ -38,6 +38,7 @@ import { usePublicEnv } from "@/contexts/public-env-context";
 import type { EarnAutodepositProgress } from "@/features/earn-realtime";
 import type { ActiveEarnPositionHolding } from "@/hooks/use-active-earn-position";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
+import { getTokenIconUrl } from "@/lib/token-icon";
 import {
   formatLoadedScheduledSweepAvailableIn,
   getLoadedScheduledSweepExecuteNowAvailableAtMs,
@@ -77,6 +78,16 @@ export function UsdcCoinImage() {
       />
     </>
   );
+}
+
+// Non-USDC holdings show their mint's coin icon in the coin slot; USDC keeps
+// the designed vault art (`UsdcCoinImage`) through the null fallback.
+export function resolveEarnCoinIconSrc(args: {
+  liquidityMint: string;
+  market: string | null;
+}): string | null {
+  const symbol = resolveEarnPositionDisplay(args).mintSymbol;
+  return symbol === "USDC" ? null : getTokenIconUrl(symbol);
 }
 
 // Same fallback rules as the old pane's CompoundIcon, at the redesign's 44px.
@@ -295,10 +306,18 @@ export function TransactionRow({
   const { isBalanceHidden } = useBalanceVisibility();
   const isMovement =
     item.kind === "rebalance" || item.kind === "reconciliation";
+  // Non-USDC events put the mint's coin icon in the coin slot (the slot the
+  // fallbacks would otherwise fill with the USDC vault art).
+  const coinSrc = item.liquidityMint
+    ? resolveEarnCoinIconSrc({
+        liquidityMint: item.liquidityMint,
+        market: null,
+      })
+    : null;
   const backSrc =
-    isMovement || item.kind === "withdraw" ? item.source.icon : null;
+    isMovement || item.kind === "withdraw" ? item.source.icon : coinSrc;
   const frontSrc =
-    isMovement || item.kind === "deposit" ? item.destination.icon : null;
+    isMovement || item.kind === "deposit" ? item.destination.icon : coinSrc;
   const timeLabel =
     formatEarnTransactionTimestamp(item.confirmedAt ?? item.sortTimestamp) ??
     item.timestamp;
@@ -685,6 +704,10 @@ function PositionsTab({
             <div className="group t-hover flex w-full items-center rounded-2xl px-4 hover:bg-accent">
               <div className="flex items-center py-2 pr-3">
                 <DualIcon
+                  backSrc={resolveEarnCoinIconSrc({
+                    liquidityMint: holding.liquidityMint,
+                    market: holding.market,
+                  })}
                   frontSrc={resolveEarnTransactionMarketIcon({
                     market: holding.market,
                   })}

--- a/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/transaction-detail-pane.tsx
@@ -12,12 +12,14 @@ import {
 import { copyTextToClipboard } from "@/components/wallet-workspace/facelift/copy-text";
 import {
   DualIcon,
+  resolveEarnCoinIconSrc,
   UsdcCoinImage,
 } from "@/components/wallet-workspace/facelift/earn-activity-card";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { openTrackedLink } from "@/lib/core/analytics";
 import { getExplorerTxUrl } from "@/lib/solana/explorer";
+import { resolveEarnPositionDisplay } from "@/lib/yield-optimization/earn-position-display";
 import type { EarnTransactionItem } from "@/lib/yield-optimization/earn-transactions.client";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
@@ -63,11 +65,27 @@ function RouteRow({
 // rows use — the API's icon for it is the legacy agent avatar. Market sides
 // carry their own logos; abstract sides (Earn / Autodeposit) fall back to the
 // Earn glyph.
-function RouteTile({ side }: { side: EarnTransactionItem["source"] }) {
+function RouteTile({
+  coinSrc = null,
+  side,
+}: {
+  coinSrc?: string | null;
+  side: EarnTransactionItem["source"];
+}) {
   if (side.label === "Main") {
     return (
       <span className="relative block size-11 overflow-hidden rounded-full">
-        <UsdcCoinImage />
+        {coinSrc ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            alt=""
+            aria-hidden="true"
+            className="size-11 rounded-full object-cover"
+            src={coinSrc}
+          />
+        ) : (
+          <UsdcCoinImage />
+        )}
       </span>
     );
   }
@@ -168,10 +186,22 @@ export function EarnTransactionDetailPane({
   const transactionUrl = getExplorerTxUrl(item.signature);
   // Same art derivation as the activity list's TransactionRow, so the header
   // identity matches the row that opened it.
+  const coinSrc = item.liquidityMint
+    ? resolveEarnCoinIconSrc({
+        liquidityMint: item.liquidityMint,
+        market: null,
+      })
+    : null;
+  const amountSymbol = item.liquidityMint
+    ? resolveEarnPositionDisplay({
+        liquidityMint: item.liquidityMint,
+        market: null,
+      }).mintSymbol
+    : "USDC";
   const backSrc =
-    isMovement || item.kind === "withdraw" ? item.source.icon : null;
+    isMovement || item.kind === "withdraw" ? item.source.icon : coinSrc;
   const frontSrc =
-    isMovement || item.kind === "deposit" ? item.destination.icon : null;
+    isMovement || item.kind === "deposit" ? item.destination.icon : coinSrc;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
@@ -223,7 +253,7 @@ export function EarnTransactionDetailPane({
               >
                 {item.amount}{" "}
                 <span className="text-tertiary text-[28px] leading-8 tracking-[-0.308px]">
-                  USDC
+                  {amountSymbol}
                 </span>
               </p>
               <p className="text-[16px] leading-5 text-muted-foreground">
@@ -234,7 +264,7 @@ export function EarnTransactionDetailPane({
         )}
         <div className="relative w-full px-2 pb-2">
           <RouteRow
-            icon={<RouteTile side={item.source} />}
+            icon={<RouteTile coinSrc={coinSrc} side={item.source} />}
             label="From"
             value={item.source.label}
             valueSuffix={
@@ -242,7 +272,7 @@ export function EarnTransactionDetailPane({
             }
           />
           <RouteRow
-            icon={<RouteTile side={item.destination} />}
+            icon={<RouteTile coinSrc={coinSrc} side={item.destination} />}
             label="To"
             value={item.destination.label}
             valueSuffix={

--- a/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/frontend/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -172,6 +172,7 @@ export type EarnActions = {
   isReconnectPromptOpen: boolean;
   isWithdrawPending: boolean;
   mainUsdcAmount: number | null;
+  refreshMainUsdcAmount: () => Promise<void>;
   pendingApproval: PendingEarnApproval | null;
   pendingTransactionSignatures: string[];
   prefetchDepositPreparation: (amountLabel: string, mint: string) => void;
@@ -209,6 +210,7 @@ export function useEarnActions(deps: {
   hasPosition: boolean;
   mainUsdc: {
     amount: number | null;
+    refresh: (isCurrent?: () => boolean) => Promise<void>;
     setAmountRaw: Dispatch<SetStateAction<bigint | null>>;
   };
   position: ActiveEarnPosition | null;
@@ -351,6 +353,14 @@ export function useEarnActions(deps: {
     [publicEnv.solanaEnv]
   );
   const setMainUsdcAmountRaw = mainUsdc.setAmountRaw;
+  const refreshMainUsdc = mainUsdc.refresh;
+  // Swaps and other non-Earn flows change the wallet's stablecoin balances
+  // without passing through this hook's onAfterTx refresh, so consumers (the
+  // deposit pane) re-read the funding balance on demand.
+  const refreshMainUsdcAmount = useCallback(
+    () => refreshMainUsdc(),
+    [refreshMainUsdc]
+  );
   const debitMainAccountUsdcBalance = useCallback(
     (amountRaw: bigint) => {
       setMainUsdcAmountRaw((current) => {
@@ -2658,6 +2668,7 @@ export function useEarnActions(deps: {
     isReconnectPromptOpen,
     isWithdrawPending,
     mainUsdcAmount: mainUsdc.amount,
+    refreshMainUsdcAmount,
     pendingApproval,
     pendingTransactionSignatures,
     prefetchDepositPreparation,

--- a/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/frontend/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -21,7 +21,10 @@ import {
   useBalanceVisibility,
 } from "@/components/wallet-workspace/facelift/balance-visibility";
 import { DropdownReveal } from "@/components/wallet-workspace/facelift/dropdown-reveal";
-import { DualIcon } from "@/components/wallet-workspace/facelift/earn-activity-card";
+import {
+  DualIcon,
+  resolveEarnCoinIconSrc,
+} from "@/components/wallet-workspace/facelift/earn-activity-card";
 import {
   FlowDiagram,
   FlowExplainerAside,
@@ -184,6 +187,10 @@ export function WithdrawPane({
       sources.map((source) => ({
         icon: (
           <DualIcon
+            backSrc={resolveEarnCoinIconSrc({
+              liquidityMint: source.liquidityMint,
+              market: source.market,
+            })}
             frontSrc={resolveEarnTransactionMarketIcon({
               market: source.market,
             })}

--- a/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-deposit-confirm.server.ts
@@ -16,8 +16,9 @@ import {
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+import { resolveEarnProductAsset } from "@/lib/yield-optimization/earn-product-mints.shared";
 import {
-  assertSafeUsdcEarnReserveMetadata,
+  assertSafeEarnReserveMetadata,
   findEarnReserveTargetIneligibility,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
@@ -205,8 +206,16 @@ function createCanonicalDepositInput(
       requestInput.setupPolicySeed !== null);
   const requiresSetupPolicyMetadata =
     requestInput.policyInitialization === "create" || hasSetupPolicyMetadata;
-  const target = assertSafeUsdcEarnReserveMetadata({
+  // The mint must be one of the supported Earn product mints (throws
+  // otherwise) and the reserve market must sit in the Safe universe — the
+  // same strictness the USDC-only assert enforced, per deposit mint.
+  const productAsset = resolveEarnProductAsset({
     cluster,
+    mint: requestInput.liquidityMint,
+  });
+  const target = assertSafeEarnReserveMetadata({
+    cluster,
+    expectedLiquidityMint: productAsset.mint.toBase58(),
     liquidityMint: requestInput.liquidityMint,
     market: requestInput.market,
     targetReserve: requestInput.targetReserve,
@@ -505,7 +514,7 @@ async function resolveConfirmedDepositTransactionProof(args: {
 
   if (principalAmountRaw <= BigInt(0)) {
     throw new Error(
-      "Confirmed deposit transaction does not debit USDC from the wallet or Earn vault."
+      "Confirmed deposit transaction does not debit the deposit mint from the wallet or Earn vault."
     );
   }
 

--- a/frontend/src/lib/yield-optimization/earn-transactions.client.ts
+++ b/frontend/src/lib/yield-optimization/earn-transactions.client.ts
@@ -27,6 +27,7 @@ export type EarnTransactionItem = {
   signature: string;
   sortTimestamp?: string;
   confirmedSlot: string;
+  liquidityMint?: string | null;
   source: { label: string; icon: string | null };
   destination: { label: string; icon: string | null };
 };

--- a/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.test.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { pda } = await import("@loyal-labs/loyal-smart-accounts");
+const { Keypair } = await import("@solana/web3.js");
+const { createCanonicalWithdrawalInput } = await import(
+  "./earn-withdraw-confirm.server"
+);
+const { EARN_PRODUCT_STABLECOINS } = await import(
+  "./earn-product-mints.shared"
+);
+
+// Multi-mint confirm canonicalization (ASK-2096): the recorder must accept
+// every supported Earn product mint in a Safe-universe market and reject
+// everything else. #624 shipped multi-mint prepare while confirm still
+// asserted USDC, silently stranding confirmed non-USDC deposits off the
+// read model — types can't catch that, only this contract can.
+const USDT_MINT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+const MAIN_MARKET = "7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF";
+const JLP_MARKET = "DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npbDsjzsdA";
+
+function buildInput(overrides: { liquidityMint?: string; market?: string }) {
+  const settings = Keypair.generate().publicKey;
+  const policySeed = BigInt(7);
+  const policyAccount = pda
+    .getPolicyPda({ settingsPda: settings, policySeed: Number(policySeed) })[0]
+    .toBase58();
+  const vault = pda
+    .getSmartAccountPda({ settingsPda: settings, accountIndex: 1 })[0]
+    .toBase58();
+  return {
+    cluster: "mainnet-beta",
+    confirmedSlot: BigInt(1),
+    delegatedSigner: Keypair.generate().publicKey.toBase58(),
+    liquidityMint: overrides.liquidityMint ?? USDT_MINT,
+    market: overrides.market ?? MAIN_MARKET,
+    mode: "partial" as const,
+    policyAccount,
+    policyId: policySeed,
+    policySeed,
+    settings: settings.toBase58(),
+    smartAccountAddress: vault,
+    targetReserve: Keypair.generate().publicKey.toBase58(),
+    vaultIndex: 1,
+    vaultPubkey: vault,
+    walletAddress: Keypair.generate().publicKey.toBase58(),
+    withdrawalSignature: "sig",
+    withdrawnAmountRaw: BigInt(1),
+  };
+}
+
+describe("createCanonicalWithdrawalInput multi-mint support", () => {
+  test("accepts a supported non-USDC mint in a Safe-universe market", () => {
+    const canonical = createCanonicalWithdrawalInput(buildInput({}));
+    expect(canonical.liquidityMint).toBe(USDT_MINT);
+    expect(canonical.market).toBe(MAIN_MARKET);
+  });
+
+  test("rejects a mint outside the Earn product catalog", () => {
+    const rogueMint = Keypair.generate().publicKey.toBase58();
+    expect(() =>
+      createCanonicalWithdrawalInput(buildInput({ liquidityMint: rogueMint }))
+    ).toThrow(/not a supported Earn product mint/);
+  });
+
+  test("rejects a market outside the Safe universe", () => {
+    expect(() =>
+      createCanonicalWithdrawalInput(buildInput({ market: JLP_MARKET }))
+    ).toThrow(/Safe universe/);
+  });
+
+  test("catalog symbols stay in sync with the six planned stables", () => {
+    expect(EARN_PRODUCT_STABLECOINS.map(String)).toEqual([
+      "CASH",
+      "USDG",
+      "PYUSD",
+      "USDC",
+      "USDT",
+      "USDS",
+    ]);
+  });
+});

--- a/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
+++ b/frontend/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
@@ -6,10 +6,7 @@ import {
 } from "@loyal-labs/actions";
 import { pda } from "@loyal-labs/loyal-smart-accounts";
 import type { SolanaEnv } from "@loyal-labs/solana-rpc";
-import {
-  getAssociatedTokenAddressSync,
-  TOKEN_PROGRAM_ID,
-} from "@solana/spl-token";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import {
   Connection,
   PublicKey,
@@ -22,7 +19,8 @@ import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { pollRpcRead } from "@/lib/yield-optimization/earn-deposit-confirm.server";
 import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
-import { assertSafeUsdcEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
+import { resolveEarnProductAsset } from "@/lib/yield-optimization/earn-product-mints.shared";
+import { assertSafeEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
 import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import {
   findEarnCleanupVaultState,
@@ -214,21 +212,28 @@ async function resolveConfirmedWithdrawalTransactionProof(args: {
   }
 
   const liquidityMint = new PublicKey(args.input.liquidityMint);
-  const walletUsdcAta = getAssociatedTokenAddressSync(
+  // ATA addresses depend on the mint's token program (CASH/USDG/PYUSD are
+  // Token-2022); resolving through the product catalog also rejects
+  // unsupported mints before any balance evidence is read.
+  const productAsset = resolveEarnProductAsset({
+    cluster: resolveLoyalClusterForSolanaEnv(args.cluster),
+    mint: liquidityMint,
+  });
+  const walletLiquidityAta = getAssociatedTokenAddressSync(
     liquidityMint,
     new PublicKey(args.input.walletAddress),
     false,
-    TOKEN_PROGRAM_ID
+    productAsset.tokenProgramId
   ).toBase58();
-  const vaultUsdcAta = getAssociatedTokenAddressSync(
+  const vaultLiquidityAta = getAssociatedTokenAddressSync(
     liquidityMint,
     new PublicKey(args.input.vaultPubkey),
     true,
-    TOKEN_PROGRAM_ID
+    productAsset.tokenProgramId
   ).toBase58();
   const walletAtaDeltaRaw = getParsedTokenBalanceDeltaRaw({
     mint: args.input.liquidityMint,
-    tokenAccount: walletUsdcAta,
+    tokenAccount: walletLiquidityAta,
     transaction,
   });
   const walletOwnerDeltaRaw =
@@ -244,17 +249,17 @@ async function resolveConfirmedWithdrawalTransactionProof(args: {
 
   if (walletTransferAmountRaw <= BigInt(0)) {
     throw new Error(
-      "Confirmed withdrawal transaction does not transfer USDC to the authenticated wallet."
+      "Confirmed withdrawal transaction does not transfer the withdrawal mint to the authenticated wallet."
     );
   }
 
-  const vaultUsdcDeltaRaw = getParsedTokenBalanceDeltaRaw({
+  const vaultLiquidityDeltaRaw = getParsedTokenBalanceDeltaRaw({
     mint: args.input.liquidityMint,
-    tokenAccount: vaultUsdcAta,
+    tokenAccount: vaultLiquidityAta,
     transaction,
   });
   const vaultIdleDeltaRaw =
-    vaultUsdcDeltaRaw > BigInt(0) ? vaultUsdcDeltaRaw : BigInt(0);
+    vaultLiquidityDeltaRaw > BigInt(0) ? vaultLiquidityDeltaRaw : BigInt(0);
   const sourceType = args.input.sourceType ?? "reserve";
   const reserveDebitAmountRaw =
     sourceType === "reserve"
@@ -264,7 +269,7 @@ async function resolveConfirmedWithdrawalTransactionProof(args: {
   return {
     reserveDebitAmountRaw,
     vaultIdleDeltaRaw,
-    vaultIdleTokenAccount: vaultUsdcAta,
+    vaultIdleTokenAccount: vaultLiquidityAta,
     walletTransferAmountRaw,
   };
 }
@@ -297,8 +302,15 @@ export function createCanonicalWithdrawalInput(
       requestInput.setupPolicyAccount !== null) ||
     (requestInput.setupPolicySeed !== undefined &&
       requestInput.setupPolicySeed !== null);
-  const target = assertSafeUsdcEarnReserveMetadata({
+  // Same per-mint strictness as the deposit confirm: the mint must be a
+  // supported Earn product mint and the market must be in the Safe universe.
+  const productAsset = resolveEarnProductAsset({
     cluster,
+    mint: requestInput.liquidityMint,
+  });
+  const target = assertSafeEarnReserveMetadata({
+    cluster,
+    expectedLiquidityMint: productAsset.mint.toBase58(),
     liquidityMint: requestInput.liquidityMint,
     market: requestInput.market,
     targetReserve: requestInput.targetReserve,

--- a/packages/wallet-core/src/lib/token-icon.ts
+++ b/packages/wallet-core/src/lib/token-icon.ts
@@ -28,6 +28,10 @@ const GENERIC_TOKEN_ICON = "/hero-new/Wallet-Cover.png";
 const TOKEN_ICON_OVERRIDES: Record<string, string> = {
   SOL: "https://coin-images.coingecko.com/coins/images/21629/large/solana.jpg",
   USDC: "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png",
+  // logo.dev resolves these ambiguous tickers to the wrong project (CASH) or
+  // a letter placeholder (USDG); pin the issuers' canonical marks instead.
+  CASH: "https://token-metadata.bridge.xyz/images/cash.png",
+  USDG: "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/GDN-USDG-Token-512x512.png",
 };
 
 export function getTokenIconUrl(symbol: string): string {


### PR DESCRIPTION
Makes the Earn confirm/persistence chain accept every catalog mint (prepare went multi-mint in #624 but confirm still asserted USDC, stranding confirmed non-USDC deposits/withdrawals off the read model) and fixes the multi-mint UX: per-mint coin icons/symbols in activity, positions and withdraw dropdown, funding-balance refresh on deposit-pane open, funded-stablecoin default source, and canonical CASH/USDG icons. ASK-2096 / ASK-2105.