### PR TITLE
fix(ci): rewrite file deps at any monorepo depth in mirror sync

### DIFF
--- a/scripts/mirror-repos/package-rewrites.ts
+++ b/scripts/mirror-repos/package-rewrites.ts
@@ -79,8 +79,7 @@ export function rewriteInternalDependencyRanges(
     for (const [name, range] of Object.entries(dependencies)) {
       if (
         range === "workspace:*" ||
-        range.startsWith("file:../packages") ||
-        range.startsWith("file:../sdk")
+        /^file:(\.\.\/)+(packages|sdk)\//.test(range)
       ) {
         const version = versions.get(name);
         if (!version) {


### PR DESCRIPTION
Mirror sync failed on main after #633: mobile's internal deps are now `file:../../{packages,sdk}` but the rewrite only matched single-depth `file:../` prefixes. Depth-agnostic regex fixes it; local `--dry-run` generates all 8 mirrors cleanly.