### PR TITLE
feat(earn): add policy update flow for Token-2022 deposits

### DIFF
--- a/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/prepare-context/route.ts
@@ -29,7 +29,7 @@ import {
   resolveEnabledEarnProductAsset,
 } from "@/lib/yield-optimization/earn-product-mints.shared";
 import {
-  findBestSafeEarnReserveTarget,
+  findBestSafeEarnReserveTargetWithRetry,
   resolveEligibleEarnDepositTarget,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
@@ -262,7 +262,7 @@ export async function POST(request: Request) {
         : null;
     const target =
       existingTarget ??
-      (await findBestSafeEarnReserveTarget({ cluster, productMint }));
+      (await findBestSafeEarnReserveTargetWithRetry({ cluster, productMint }));
     if (!target) {
       return jsonError(
         409,

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/prepare/route.ts
@@ -36,7 +36,7 @@ import {
   resolveEnabledEarnProductAsset,
 } from "@/lib/yield-optimization/earn-product-mints.shared";
 import {
-  findBestSafeEarnReserveTarget,
+  findBestSafeEarnReserveTargetWithRetry,
   resolveEligibleEarnDepositTarget,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
@@ -296,7 +296,7 @@ export async function POST(request: Request) {
         : null;
     const target =
       existingTarget ??
-      (await findBestSafeEarnReserveTarget({ cluster, productMint }));
+      (await findBestSafeEarnReserveTargetWithRetry({ cluster, productMint }));
     if (!target) {
       return jsonError(
         409,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/deposits/prepare/route.ts
@@ -29,7 +29,7 @@ import {
   resolveEnabledEarnProductAsset,
 } from "@/lib/yield-optimization/earn-product-mints.shared";
 import {
-  findBestSafeEarnReserveTarget,
+  findBestSafeEarnReserveTargetWithRetry,
   resolveEligibleEarnDepositTarget,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
@@ -245,7 +245,7 @@ export async function POST(request: Request) {
         : null;
     const target =
       existingTarget ??
-      (await findBestSafeEarnReserveTarget({ cluster, productMint }));
+      (await findBestSafeEarnReserveTargetWithRetry({ cluster, productMint }));
     if (!target) {
       return jsonError(
         409,

--- a/apps/web/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/autodeposit-pane.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import {
+  getStablecoinMintForCluster,
+  resolveLoyalClusterForSolanaEnv,
+  Stablecoin,
+} from "@loyal-labs/actions";
+import { resolveSolanaEnv } from "@loyal-labs/solana-rpc";
+import {
   ArrowRightLeft,
   CalendarClock,
   Radar,
@@ -23,8 +29,12 @@ import {
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
-import { useStablecoinsUsd } from "@/components/wallet-workspace/facelift/use-stablecoins-usd";
-import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
+import { usePublicEnv } from "@/contexts/public-env-context";
+import {
+  splitUsdBalance,
+  useWalletDesktopData,
+} from "@/hooks/use-wallet-desktop-data";
+import { getTokenIconUrl } from "@/lib/token-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -140,8 +150,22 @@ export function AutodepositPane({
     }
   };
 
-  const stablecoinsUsd = useStablecoinsUsd();
-  const stablecoinsBalance = splitUsdBalance(stablecoinsUsd);
+  // Autodeposit sweeps USDC only (ASK-2096 keeps it USDC-only), so the
+  // "from" cell shows the USDC balance, not the all-stablecoins sum. Same
+  // source precedence as the deposit pane: authoritative main-account USDC,
+  // portfolio value as the loading fallback.
+  const publicEnv = usePublicEnv();
+  const walletData = useWalletDesktopData({});
+  const usdcMint = getStablecoinMintForCluster(
+    resolveLoyalClusterForSolanaEnv(resolveSolanaEnv(publicEnv.solanaEnv)),
+    Stablecoin.USDC
+  ).toBase58();
+  const usdcPortfolioUsd =
+    walletData.positions.find((position) => position.asset.mint === usdcMint)
+      ?.totalValueUsd ?? 0;
+  const stablecoinsBalance = splitUsdBalance(
+    actions.mainUsdcAmount ?? usdcPortfolioUsd
+  );
   const earnBalance = splitUsdBalance(data.earnBalanceUsd);
   const addressLabel = data.walletAddress
     ? `${data.walletAddress.slice(0, 4)}…${data.walletAddress.slice(-4)}`
@@ -269,13 +293,13 @@ export function AutodepositPane({
                 <img
                   alt=""
                   aria-hidden="true"
-                  className="size-11"
-                  src={`${ASSET_BASE}/stablecoins-icon.svg`}
+                  className="size-11 rounded-full"
+                  src={getTokenIconUrl("USDC")}
                 />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1 py-2">
                 <span className="truncate text-[13px] leading-4 text-muted-foreground">
-                  {`from Stablecoins · ${addressLabel}`}
+                  {`from USDC · ${addressLabel}`}
                 </span>
                 <p className="whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
                   <ScrambleText

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import { resolveSolanaEnv } from "@loyal-labs/solana-rpc";
 import type { PortfolioPosition } from "@loyal-labs/solana-wallet";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -60,6 +62,7 @@ import {
   getStablecoinMintSetForSolanaEnv,
   isStablecoinMint,
 } from "@/lib/wallet/stablecoin-classification";
+import { getEnabledEarnProductAssetsForCluster } from "@/lib/yield-optimization/earn-product-mints.shared";
 
 type ActionView = Exclude<SubView, null>;
 
@@ -418,6 +421,20 @@ export function CryptoPage({
     grouped.push(...securedByMint.values());
     return grouped;
   }, [derivedTokens, securedTokens]);
+  // Mints the Earn product currently accepts — badged "Can earn" in the
+  // receive selector and ranked right after LOYAL.
+  const earnEligibleMints = useMemo(
+    () =>
+      new Set(
+        getEnabledEarnProductAssetsForCluster({
+          cluster: resolveLoyalClusterForSolanaEnv(
+            resolveSolanaEnv(publicEnv.solanaEnv)
+          ),
+          enabledStablecoins: publicEnv.earnEnabledStablecoins,
+        }).map((asset) => asset.mint.toBase58())
+      ),
+    [publicEnv.earnEnabledStablecoins, publicEnv.solanaEnv]
+  );
   const swapTargetTokens = useMemo<SwapToken[]>(() => {
     const heldMints = new Set(
       derivedTokens.map((token) => token.mint).filter(Boolean)
@@ -425,9 +442,17 @@ export function CryptoPage({
     const extras = popularTokens.filter(
       (token) => token.mint && !heldMints.has(token.mint)
     );
+    // LOYAL first, then the Earn-eligible stables, then everything else —
+    // held-first order is preserved within each group (stable sort).
+    const rank = (token: SwapToken) =>
+      token.mint === LOYL_TOKEN.mint
+        ? 0
+        : token.mint && earnEligibleMints.has(token.mint)
+        ? 1
+        : 2;
 
-    return [...derivedTokens, ...extras];
-  }, [derivedTokens, popularTokens]);
+    return [...derivedTokens, ...extras].sort((a, b) => rank(a) - rank(b));
+  }, [derivedTokens, earnEligibleMints, popularTokens]);
 
   // Seed the flow tokens once the wallet's real tokens land.
   const prevHadTokensRef = useRef(false);
@@ -957,6 +982,7 @@ export function CryptoPage({
             >
               <PaneReveal key={overlaySelectSide}>
                 <SwapTokenSelectPane
+                  earnEligibleMints={earnEligibleMints}
                   nameByMint={tokenNameByMint}
                   onClose={() => setSwapSelectSide(null)}
                   onSearch={
@@ -1032,6 +1058,7 @@ export function CryptoPage({
       >
         <PaneReveal key={overlaySelectSide}>
           <SwapTokenSelectPane
+            earnEligibleMints={earnEligibleMints}
             nameByMint={tokenNameByMint}
             onClose={() => setSwapSelectSide(null)}
             onSearch={overlaySelectSide === "to" ? searchTokens : undefined}

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -421,19 +421,24 @@ export function CryptoPage({
     grouped.push(...securedByMint.values());
     return grouped;
   }, [derivedTokens, securedTokens]);
-  // Mints the Earn product currently accepts — badged "Can earn" in the
+  // Stables the Earn product currently accepts — badged "Can earn" in the
   // receive selector and ranked right after LOYAL.
-  const earnEligibleMints = useMemo(
+  const earnProductAssets = useMemo(
     () =>
-      new Set(
-        getEnabledEarnProductAssetsForCluster({
-          cluster: resolveLoyalClusterForSolanaEnv(
-            resolveSolanaEnv(publicEnv.solanaEnv)
-          ),
-          enabledStablecoins: publicEnv.earnEnabledStablecoins,
-        }).map((asset) => asset.mint.toBase58())
-      ),
+      getEnabledEarnProductAssetsForCluster({
+        cluster: resolveLoyalClusterForSolanaEnv(
+          resolveSolanaEnv(publicEnv.solanaEnv)
+        ),
+        enabledStablecoins: publicEnv.earnEnabledStablecoins,
+      }).map((asset) => ({
+        mint: asset.mint.toBase58(),
+        symbol: asset.symbol,
+      })),
     [publicEnv.earnEnabledStablecoins, publicEnv.solanaEnv]
+  );
+  const earnEligibleMints = useMemo(
+    () => new Set(earnProductAssets.map((asset) => asset.mint)),
+    [earnProductAssets]
   );
   const swapTargetTokens = useMemo<SwapToken[]>(() => {
     const heldMints = new Set(
@@ -442,6 +447,23 @@ export function CryptoPage({
     const extras = popularTokens.filter(
       (token) => token.mint && !heldMints.has(token.mint)
     );
+    // Earn stables missing from held+popular (e.g. CASH) still belong in
+    // the receive list: synthesize them from the canonical product assets.
+    // The picker price is indicative only (quotes come by mint), so a flat
+    // $1 for a USD stable is fine.
+    const listedMints = new Set([
+      ...heldMints,
+      ...extras.map((token) => token.mint),
+    ]);
+    const missingEarnStables = earnProductAssets
+      .filter((asset) => !listedMints.has(asset.mint))
+      .map((asset) => ({
+        balance: 0,
+        icon: getTokenIconUrl(asset.symbol),
+        mint: asset.mint,
+        price: 1,
+        symbol: asset.symbol,
+      }));
     // LOYAL first, then the Earn-eligible stables, then everything else —
     // held-first order is preserved within each group (stable sort).
     const rank = (token: SwapToken) =>
@@ -451,8 +473,10 @@ export function CryptoPage({
         ? 1
         : 2;
 
-    return [...derivedTokens, ...extras].sort((a, b) => rank(a) - rank(b));
-  }, [derivedTokens, earnEligibleMints, popularTokens]);
+    return [...derivedTokens, ...extras, ...missingEarnStables].sort(
+      (a, b) => rank(a) - rank(b)
+    );
+  }, [derivedTokens, earnEligibleMints, earnProductAssets, popularTokens]);
 
   // Seed the flow tokens once the wallet's real tokens land.
   const prevHadTokensRef = useRef(false);

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -208,7 +208,8 @@ export function CryptoPage({
   /** Bumped by the shell on every sidebar selection — abandons open actions. */
   navigationNonce: number;
   onBack: () => void;
-  onEarn: () => void;
+  /** Row-level Earn passes the clicked coin's mint; the header button none. */
+  onEarn: (sourceMint?: string | null) => void;
   page: CryptoPaneVariant;
 }) {
   const publicEnv = usePublicEnv();
@@ -788,11 +789,11 @@ export function CryptoPage({
     setDetailToken(tokenRowToSwapToken(row));
 
   const rowActions: CryptoRowActions = {
-    // ponytail: the deposit pane picks its own source token, so row-level
-    // Earn lands on the same screen as the header button.
+    // Row-level Earn lands on the deposit screen with the clicked coin
+    // preselected as the source; the header button keeps the default.
     onEarn: (row) => {
       selectRowDetail(row);
-      onEarn();
+      onEarn(row.id?.replace(/-secured$/, ""));
     },
     onSelect: (row) => {
       setDetailToken(tokenRowToSwapToken(row));
@@ -917,7 +918,7 @@ export function CryptoPage({
               balanceWhole={pageBalance.balanceWhole}
               isBalanceRevealed={isWalletDataRevealed}
               onBack={onBack}
-              onEarn={onEarn}
+              onEarn={() => onEarn()}
               onSend={() => openSend()}
               onShield={handleShield}
               onSwap={() => openSwap()}

--- a/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -249,13 +249,20 @@ export function DepositPane({
       setAmount(sanitized);
     }
   };
+  // Legacy-policy wallets cannot deposit Token-2022 mints until the Earn
+  // policy is recreated; the same pill then updates the policy and retries.
+  const needsPolicyUpdate =
+    actions.depositPolicyUpdateRequiredMint === selectedSource.mint;
   const handleSubmit = async () => {
-    const didDeposit = await actions.submitDeposit({
+    const draft = {
       amountLabel: amount,
       forecastApyBps: apy.apyBps,
       mint: selectedSource.mint,
       symbol: selectedSource.symbol,
-    });
+    };
+    const didDeposit = needsPolicyUpdate
+      ? await actions.updateDepositPolicyAndRetry(draft)
+      : await actions.submitDeposit(draft);
     if (didDeposit) {
       onBack();
     }
@@ -583,9 +590,13 @@ export function DepositPane({
             <TextSwap
               text={
                 isSubmitting
-                  ? "Depositing…"
+                  ? needsPolicyUpdate
+                    ? "Updating policy…"
+                    : "Depositing…"
                   : isInsufficient
                   ? "Insufficient balance"
+                  : needsPolicyUpdate && isValidAmount
+                  ? "Update policy & deposit"
                   : isValidAmount
                   ? `Deposit ${amountLabel} ${selectedSource.symbol}`
                   : `Minimum deposit is $${MIN_DEPOSIT_USD}`

--- a/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -249,20 +249,13 @@ export function DepositPane({
       setAmount(sanitized);
     }
   };
-  // Legacy-policy wallets cannot deposit Token-2022 mints until the Earn
-  // policy is recreated; the same pill then updates the policy and retries.
-  const needsPolicyUpdate =
-    actions.depositPolicyUpdateRequiredMint === selectedSource.mint;
   const handleSubmit = async () => {
-    const draft = {
+    const didDeposit = await actions.submitDeposit({
       amountLabel: amount,
       forecastApyBps: apy.apyBps,
       mint: selectedSource.mint,
       symbol: selectedSource.symbol,
-    };
-    const didDeposit = needsPolicyUpdate
-      ? await actions.updateDepositPolicyAndRetry(draft)
-      : await actions.submitDeposit(draft);
+    });
     if (didDeposit) {
       onBack();
     }
@@ -590,13 +583,9 @@ export function DepositPane({
             <TextSwap
               text={
                 isSubmitting
-                  ? needsPolicyUpdate
-                    ? "Updating policy…"
-                    : "Depositing…"
+                  ? "Depositing…"
                   : isInsufficient
                   ? "Insufficient balance"
-                  : needsPolicyUpdate && isValidAmount
-                  ? "Update policy & deposit"
                   : isValidAmount
                   ? `Deposit ${amountLabel} ${selectedSource.symbol}`
                   : `Minimum deposit is $${MIN_DEPOSIT_USD}`

--- a/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -140,10 +140,14 @@ const DEPOSIT_DOCS_URL =
 // sheet, system num keyboard under the focused amount input).
 export function DepositPane({
   data: earnData,
+  initialSourceKey,
   onBack,
   onOpenChart,
 }: {
   data: EarnPositionData;
+  /** Preselects the deposit source (keys are mints) — e.g. a stables-row
+   * Earn pill. Unknown or absent keys fall back to the default source. */
+  initialSourceKey?: string | null;
   onBack: () => void;
   onOpenChart: () => void;
 }) {
@@ -154,7 +158,9 @@ export function DepositPane({
   const [amount, setAmount] = useState("");
   const [isInfoOpen, setIsInfoOpen] = useState(false);
   const [isSourceSheetOpen, setIsSourceSheetOpen] = useState(false);
-  const [selectedSourceKey, setSelectedSourceKey] = useState("");
+  const [selectedSourceKey, setSelectedSourceKey] = useState(
+    initialSourceKey ?? ""
+  );
   const { actions } = earnData;
   // The funding balance is only auto-refreshed after Earn transactions, so
   // re-read it on open to pick up swaps and external transfers (ASK-2096).

--- a/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/deposit-pane.tsx
@@ -59,11 +59,15 @@ function DepositSourceOptionRow({
 }) {
   const balance = splitUsdBalance(option.usd);
   const { isBalanceHidden } = useBalanceVisibility();
+  // Nothing to deposit from an empty balance — the row stays visible (so
+  // the product set reads complete) but cannot be picked.
+  const isEmpty = option.usd <= 0;
 
   return (
     <button
       aria-pressed={isSelected}
-      className={`t-hover flex w-full items-center px-4 text-left hover:bg-accent ${rounded}`}
+      className={`t-hover flex w-full items-center px-4 text-left disabled:opacity-40 enabled:hover:bg-accent ${rounded}`}
+      disabled={isEmpty}
       onClick={onSelect}
       type="button"
     >
@@ -219,6 +223,16 @@ export function DepositPane({
   const selectedSource =
     sourceOptions.find((source) => source.key === selectedSourceKey) ??
     defaultSource;
+  // The selector opens upward from the trigger, so funded coins sit at the
+  // bottom (nearest the trigger) and empty ones at the top — stable sort
+  // keeps the product order within each group.
+  const listedSourceOptions = useMemo(
+    () =>
+      [...sourceOptions].sort(
+        (a, b) => (a.usd > 0 ? 1 : 0) - (b.usd > 0 ? 1 : 0)
+      ),
+    [sourceOptions]
+  );
   const sourceUsd = selectedSource.usd;
   const depositSteps = useMemo(
     () => createDepositSteps(selectedSource.symbol),
@@ -402,7 +416,7 @@ export function DepositPane({
               isOpen={isSourceSheetOpen}
               origin="bottom-center"
             >
-              {sourceOptions.map((option) => (
+              {listedSourceOptions.map((option) => (
                 <DepositSourceOptionRow
                   isSelected={option.key === selectedSource.key}
                   key={option.key}
@@ -435,7 +449,7 @@ export function DepositPane({
                 </button>
               </header>
               <div className="flex w-full flex-col py-2">
-                {sourceOptions.map((option) => (
+                {listedSourceOptions.map((option) => (
                   <DepositSourceOptionRow
                     isSelected={option.key === selectedSource.key}
                     key={option.key}

--- a/apps/web/src/components/wallet-workspace/facelift/earn-activity-card.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-activity-card.tsx
@@ -696,12 +696,19 @@ function PositionsTab({
                   market: holding.market,
                 }).mintSymbol
               }`;
-        const amount = splitUsdBalance(
-          rawTokenAmountToNumber(holding.amountRaw, 6)
-        );
+        const usd = rawTokenAmountToNumber(holding.amountRaw, 6);
+        const amount = splitUsdBalance(usd);
+        // Dust that displays as $0.00 — shown grayed for completeness, but
+        // without hover affordances: withdrawing $0.00 is meaningless (the
+        // Max-exit cleanup path collects dust).
+        const isDust = usd < 0.005;
         return (
           <StaggerLine index={holdingIndex} key={holding.sourceId}>
-            <div className="group t-hover flex w-full items-center rounded-2xl px-4 hover:bg-accent">
+            <div
+              className={`flex w-full items-center rounded-2xl px-4 ${
+                isDust ? "opacity-40" : "group t-hover hover:bg-accent"
+              }`}
+            >
               <div className="flex items-center py-2 pr-3">
                 <DualIcon
                   backSrc={resolveEarnCoinIconSrc({
@@ -732,17 +739,19 @@ function PositionsTab({
               </div>
               {/* Reveal rides a short delay so quick pointer passes don't
                   flash the pill; un-hover drops the delay and hides at once. */}
-              <div className="pointer-events-none flex pl-3 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:delay-100">
-                <button
-                  className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
-                  onClick={() =>
-                    onWithdrawSource(getWithdrawSourceKeyForHolding(holding))
-                  }
-                  type="button"
-                >
-                  Withdraw
-                </button>
-              </div>
+              {isDust ? null : (
+                <div className="pointer-events-none flex pl-3 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:delay-100">
+                  <button
+                    className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
+                    onClick={() =>
+                      onWithdrawSource(getWithdrawSourceKeyForHolding(holding))
+                    }
+                    type="button"
+                  >
+                    Withdraw
+                  </button>
+                </div>
+              )}
             </div>
           </StaggerLine>
         );

--- a/apps/web/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
@@ -226,7 +226,9 @@ export function EarnStatsPanel() {
           <div className="flex w-full flex-col px-2 pt-2">
             <div className="flex w-full flex-col gap-0.5 px-4 py-2">
               <div className="flex items-center gap-1">
-                <p className="text-[16px] leading-5 text-muted-foreground">Earn AUM</p>
+                <p className="text-[16px] leading-5 text-muted-foreground">
+                  Earn AUM
+                </p>
                 <InfoTooltip text={AUM_TOOLTIP} />
               </div>
               <p className="w-full font-semibold text-[40px] text-foreground leading-[48px]">
@@ -235,22 +237,22 @@ export function EarnStatsPanel() {
                   {splitUsdBalance(displayedAumUsd).balanceFraction}
                 </span>
               </p>
-              {displayedAumDeltaUsd !== null && displayedAumDeltaUsd !== 0 ? (
+              {/* Negative deltas are hidden, not shown in red — the stats
+                  block advertises growth, not drawdowns. */}
+              {displayedAumDeltaUsd !== null && displayedAumDeltaUsd > 0 ? (
                 <p
                   className="text-[16px] leading-5"
-                  style={{
-                    color:
-                      displayedAumDeltaUsd > 0
-                        ? "var(--positive)"
-                        : "var(--destructive)",
-                  }}
+                  style={{ color: "var(--positive)" }}
                 >
                   {formatSignedUsd(displayedAumDeltaUsd)} vs prior week
                 </p>
               ) : (
                 // Keeps the slot height while scrubbing the first bucket,
                 // which has no prior week to diff against.
-                <p aria-hidden="true" className="invisible text-[16px] leading-5">
+                <p
+                  aria-hidden="true"
+                  className="invisible text-[16px] leading-5"
+                >
                   &nbsp;
                 </p>
               )}

--- a/apps/web/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-stats-panel.tsx
@@ -237,12 +237,20 @@ export function EarnStatsPanel() {
                   {splitUsdBalance(displayedAumUsd).balanceFraction}
                 </span>
               </p>
-              {/* Negative deltas are hidden, not shown in red — the stats
-                  block advertises growth, not drawdowns. */}
-              {displayedAumDeltaUsd !== null && displayedAumDeltaUsd > 0 ? (
+              {/* The resting view hides negative deltas — the stats block
+                  advertises growth. Scrubbing the bars is data exploration,
+                  so historical deltas show in full, red included. */}
+              {displayedAumDeltaUsd !== null &&
+              displayedAumDeltaUsd !== 0 &&
+              (hoveredAumPoint !== null || displayedAumDeltaUsd > 0) ? (
                 <p
                   className="text-[16px] leading-5"
-                  style={{ color: "var(--positive)" }}
+                  style={{
+                    color:
+                      displayedAumDeltaUsd > 0
+                        ? "var(--positive)"
+                        : "var(--destructive)",
+                  }}
                 >
                   {formatSignedUsd(displayedAumDeltaUsd)} vs prior week
                 </p>

--- a/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -59,9 +59,16 @@ const FLOW_STEPS: Record<EarnFlowId, readonly string[]> = {
     CONFIRM_IN_WALLET_MESSAGE,
     "Confirming",
   ],
-  "close-policies": ["Closing policies", CONFIRM_IN_WALLET_MESSAGE, "Confirming"],
+  "close-policies": [
+    "Closing policies",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
   deposit: [
     "Preparing deposit",
+    // Conditional: only legacy-policy wallets depositing a Token-2022 mint
+    // hit this stage (ASK-2108); the host auto-checks it for everyone else.
+    "Updating Earn policy",
     "Waiting for approval",
     CONFIRM_IN_WALLET_MESSAGE,
     "Confirming",
@@ -240,10 +247,10 @@ export function EarnToastHost() {
                 index < stepIndex
                   ? "b"
                   : isActive
-                    ? detail.phase === "error"
-                      ? "c"
-                      : "a"
-                    : "p";
+                  ? detail.phase === "error"
+                    ? "c"
+                    : "a"
+                  : "p";
               return (
                 <div className="flex h-7 items-center gap-2.5" key={label}>
                   <span
@@ -265,7 +272,9 @@ export function EarnToastHost() {
                     </span>
                   </span>
                   <span
-                    className={`t-step-label min-w-0 truncate ${state === "p" ? "text-muted-foreground" : ""}`}
+                    className={`t-step-label min-w-0 truncate ${
+                      state === "p" ? "text-muted-foreground" : ""
+                    }`}
                   >
                     <TextSwap
                       className={state === "a" ? "t-step-active" : ""}

--- a/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -25,6 +25,7 @@ export type EarnFlowId =
   | "autodeposit-setup"
   | "close-policies"
   | "deposit"
+  | "deposit-policy-update"
   | "withdraw";
 
 type EarnToastListener = {
@@ -66,8 +67,15 @@ const FLOW_STEPS: Record<EarnFlowId, readonly string[]> = {
   ],
   deposit: [
     "Preparing deposit",
-    // Conditional: only legacy-policy wallets depositing a Token-2022 mint
-    // hit this stage (ASK-2108); the host auto-checks it for everyone else.
+    "Waiting for approval",
+    CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+  // The deposit script re-armed mid-flow when a legacy-policy wallet needs
+  // the Token-2022 policy update (ASK-2108) — normal deposits never list
+  // the extra step.
+  "deposit-policy-update": [
+    "Preparing deposit",
     "Updating Earn policy",
     "Waiting for approval",
     CONFIRM_IN_WALLET_MESSAGE,

--- a/apps/web/src/components/wallet-workspace/facelift/shell.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/shell.tsx
@@ -143,6 +143,9 @@ export function WorkspaceFaceliftShell() {
   const [withdrawSourceKey, setWithdrawSourceKey] = useState<string | null>(
     null
   );
+  // Same contract for deposit: a stables-row Earn pill preselects its coin
+  // (keys are mints); every other deposit entry point clears it.
+  const [depositSourceKey, setDepositSourceKey] = useState<string | null>(null);
   // Mirrored from the sidebar (which owns the unseen-activity computation)
   // so the mobile tab bar's clock shows the same badge.
   const [hasUnseenActivity, setHasUnseenActivity] = useState(false);
@@ -346,6 +349,7 @@ export function WorkspaceFaceliftShell() {
             setMiddleView("autodeposit");
           }}
           onOpenDeposit={() => {
+            setDepositSourceKey(null);
             setActivePage("earn");
             setMiddleView("deposit");
           }}
@@ -386,9 +390,11 @@ export function WorkspaceFaceliftShell() {
             <CryptoPage
               navigationNonce={navigationNonce}
               onBack={() => handleSelectPage("wallet")}
-              onEarn={() => {
+              onEarn={(sourceMint) => {
                 // The stables Earn buttons jump straight to the deposit
-                // screen, not the Earn root.
+                // screen, not the Earn root — with the clicked coin
+                // preselected as the deposit source.
+                setDepositSourceKey(sourceMint ?? null);
                 setActivePage("earn");
                 setMiddleView("deposit");
               }}
@@ -413,6 +419,7 @@ export function WorkspaceFaceliftShell() {
                     ) : activeMiddleView === "deposit" ? (
                       <DepositPane
                         data={earnData}
+                        initialSourceKey={depositSourceKey}
                         onBack={() => setMiddleView("earn")}
                         onOpenChart={() => setIsChartExpanded(true)}
                       />
@@ -425,7 +432,10 @@ export function WorkspaceFaceliftShell() {
                     <PaneReveal>
                       <EarnPositionPane
                         data={earnData}
-                        onDeposit={() => setMiddleView("deposit")}
+                        onDeposit={() => {
+                          setDepositSourceKey(null);
+                          setMiddleView("deposit");
+                        }}
                         onOpenAutodeposit={() => setMiddleView("autodeposit")}
                         onOpenChart={() => setIsChartExpanded(true)}
                         onSelectChartTab={setChartTab}
@@ -444,7 +454,10 @@ export function WorkspaceFaceliftShell() {
                   ) : (
                     <PaneReveal>
                       <EarnEmptyPane
-                        onDeposit={() => setMiddleView("deposit")}
+                        onDeposit={() => {
+                          setDepositSourceKey(null);
+                          setMiddleView("deposit");
+                        }}
                         onOpenChart={() => setIsChartExpanded(true)}
                       />
                     </PaneReveal>

--- a/apps/web/src/components/wallet-workspace/facelift/swap-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/swap-pane.tsx
@@ -534,9 +534,7 @@ export function SwapPane({
                     <span className="text-foreground">1%</span>
                   </div>
                   <div className="flex w-full items-center justify-between px-4 py-2.5 text-[13px] leading-4">
-                    <span className="text-muted-foreground">
-                      Network Fee
-                    </span>
+                    <span className="text-muted-foreground">Network Fee</span>
                     <span className="pl-3 text-right text-foreground">
                       {"0.00005 SOL ~ <$0.01"}
                     </span>
@@ -615,6 +613,7 @@ export function SwapPane({
 // OG token-select's debounced remote Jupiter search merged in (deduped by
 // mint). Held tokens surface their portfolio names via nameByMint.
 export function SwapTokenSelectPane({
+  earnEligibleMints,
   nameByMint,
   onClose,
   onSearch,
@@ -623,6 +622,8 @@ export function SwapTokenSelectPane({
   title,
   tokens,
 }: {
+  /** Mints the Earn product accepts — badged "Can earn" on the receive side. */
+  earnEligibleMints?: ReadonlySet<string>;
   nameByMint: Record<string, string>;
   onClose: () => void;
   onSearch?: (query: string) => Promise<SwapToken[]>;
@@ -741,9 +742,18 @@ export function SwapTokenSelectPane({
                 />
               </span>
               <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
-                  {(token.mint ? nameByMint[token.mint] : undefined) ??
-                    token.symbol}
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
+                    {(token.mint ? nameByMint[token.mint] : undefined) ??
+                      token.symbol}
+                  </span>
+                  {side === "to" &&
+                  token.mint &&
+                  earnEligibleMints?.has(token.mint) ? (
+                    <span className="shrink-0 rounded-md bg-positive/[0.14] px-1.5 py-0.5 font-medium text-[11px] text-positive leading-3">
+                      Can earn
+                    </span>
+                  ) : null}
                 </span>
                 <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
                   {token.symbol}
@@ -756,7 +766,10 @@ export function SwapTokenSelectPane({
                   <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
                     <ScrambleText
                       isHidden={isBalanceHidden}
-                      text={splitUsdBalance(token.balance * token.price).balanceWhole}
+                      text={
+                        splitUsdBalance(token.balance * token.price)
+                          .balanceWhole
+                      }
                     />
                     <span className="text-tertiary">
                       <ScrambleText

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -156,6 +156,7 @@ export type EarnActions = {
   closeReconnectPrompt: () => void;
   confirmAutodepositClose: () => Promise<boolean>;
   depositError: string | null;
+  depositPolicyUpdateRequiredMint: string | null;
   depositSource: EarnDepositSourceOption;
   dismissAutodepositClose: () => void;
   autodepositProgressBySlot: Readonly<Record<string, EarnAutodepositProgress>>;
@@ -186,6 +187,12 @@ export type EarnActions = {
     symbol: string;
   }) => Promise<boolean>;
   submitWithdraw: (draft: EarnWithdrawDraft) => Promise<boolean>;
+  updateDepositPolicyAndRetry: (args: {
+    amountLabel: string;
+    forecastApyBps: number;
+    mint: string;
+    symbol: string;
+  }) => Promise<boolean>;
   autodepositError: string | null;
   withdrawError: string | null;
   withdrawSources: EarnWithdrawSourceOption[];
@@ -314,6 +321,12 @@ export function useEarnActions(deps: {
   }, []);
 
   const [depositError, setDepositError] = useState<string | null>(null);
+  // Set to the draft mint when a deposit prepare fails with
+  // earn_policy_update_required: the wallet's legacy route policy cannot
+  // authorize Token-2022 mints. The pane then offers
+  // updateDepositPolicyAndRetry for that mint instead of a dead-end error.
+  const [depositPolicyUpdateRequiredMint, setDepositPolicyUpdateRequiredMint] =
+    useState<string | null>(null);
   const [withdrawError, setWithdrawError] = useState<string | null>(null);
   const [autodepositError, setAutodepositError] = useState<string | null>(null);
   const [isDepositPending, setIsDepositPending] = useState(false);
@@ -870,6 +883,7 @@ export function useEarnActions(deps: {
         policyMode: requiresPolicySetup ? "create" : "reuse",
       });
       setDepositError(null);
+      setDepositPolicyUpdateRequiredMint(null);
       setIsDepositPending(true);
       earnToast.begin("deposit");
       earnToast.loading("Preparing deposit");
@@ -1237,6 +1251,9 @@ export function useEarnActions(deps: {
           haystack.includes("insufficient funds for rent") ||
           haystack.includes("insufficient lamports") ||
           haystack.includes("would result in account being unable to pay rent");
+        if (error instanceof EarnPolicyUpdateRequiredClientError) {
+          setDepositPolicyUpdateRequiredMint(draft.tokenMint);
+        }
         setDepositError(
           error instanceof EarnPolicyUpdateRequiredClientError
             ? "Update your Earn policy to enable this stablecoin before depositing."
@@ -1305,6 +1322,62 @@ export function useEarnActions(deps: {
       suppressPositionRefreshThroughSlot,
       trackedKaminoUsdcMint,
       wallet.signAllTransactions,
+    ]
+  );
+
+  // Recovery for earn_policy_update_required (ASK-2108): create the new
+  // owner-neutral policy pair (the legacy pair is left untouched on-chain),
+  // then retry the same deposit. The server rolls the active pair on confirm,
+  // so the retried prepare resolves the new policy.
+  const updateDepositPolicyAndRetry = useCallback(
+    async (args: {
+      amountLabel: string;
+      forecastApyBps: number;
+      mint: string;
+      symbol: string;
+    }): Promise<boolean> => {
+      if (!canMutateAccount) {
+        openSignIn();
+        return false;
+      }
+      if (!ensureCanSignAccountAction()) {
+        return false;
+      }
+      setDepositError(null);
+      setIsDepositPending(true);
+      earnToast.begin("deposit");
+      earnToast.loading("Updating Earn policy");
+      try {
+        const result = await smartAccountData.executeEarnPolicySetup({
+          force: true,
+        });
+        if (!result.success) {
+          setDepositError(result.error ?? "Failed to update Earn policy.");
+          earnToast.error("Policy update failed");
+          return false;
+        }
+        setDepositPolicyUpdateRequiredMint(null);
+      } catch (error) {
+        console.error("[earn.deposit] policy update failed", error);
+        setDepositError(
+          error instanceof Error
+            ? error.message
+            : "Failed to update Earn policy."
+        );
+        earnToast.error("Policy update failed");
+        return false;
+      } finally {
+        setIsDepositPending(false);
+        earnToast.settle();
+      }
+      return submitDeposit(args);
+    },
+    [
+      canMutateAccount,
+      ensureCanSignAccountAction,
+      openSignIn,
+      smartAccountData,
+      submitDeposit,
     ]
   );
 
@@ -2675,8 +2748,10 @@ export function useEarnActions(deps: {
     requestAutodepositClose,
     runCleanup,
     saveAutodeposit,
+    depositPolicyUpdateRequiredMint,
     submitDeposit,
     submitWithdraw,
+    updateDepositPolicyAndRetry,
     autodepositError,
     withdrawError,
     withdrawSources,

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -953,7 +953,7 @@ export function useEarnActions(deps: {
           draft.amountLabel,
           draft.tokenDecimals
         );
-        const runPrepare = () =>
+        const runPrepareOnce = () =>
           measureBrowserLoadingDependencies({
             flowId: tracker.flowId,
             operation: "earn.deposit",
@@ -965,6 +965,27 @@ export function useEarnActions(deps: {
                 observabilityFlowId: tracker.flowId,
               }),
           });
+        // The reserve verification feed can flap a mint out of eligibility
+        // for up to a round (~1 min). Bounded auto-retry converts most of
+        // those into a slightly slower success instead of surfacing the
+        // no_eligible_reserve 409 for hand-retries (observed live
+        // 2026-08-13 during the multi-mint rollout).
+        const runPrepare = async () => {
+          for (let attempt = 0; ; attempt += 1) {
+            try {
+              return await runPrepareOnce();
+            } catch (error) {
+              if (
+                !(error instanceof EarnPrepareRequestError) ||
+                error.code !== "no_eligible_reserve" ||
+                attempt >= 3
+              ) {
+                throw error;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 2000));
+            }
+          }
+        };
         let preparedDeposit: Awaited<ReturnType<typeof runPrepare>>;
         try {
           preparedDeposit = await runPrepare();

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -978,6 +978,7 @@ export function useEarnActions(deps: {
           // re-prepare: the server resolves the new pair after confirm. A
           // second update-required failure falls through to the normal
           // error path, so this cannot loop.
+          earnToast.begin("deposit-policy-update");
           earnToast.loading("Updating Earn policy");
           const policySetup = await smartAccountData.executeEarnPolicySetup({
             force: true,

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -156,7 +156,6 @@ export type EarnActions = {
   closeReconnectPrompt: () => void;
   confirmAutodepositClose: () => Promise<boolean>;
   depositError: string | null;
-  depositPolicyUpdateRequiredMint: string | null;
   depositSource: EarnDepositSourceOption;
   dismissAutodepositClose: () => void;
   autodepositProgressBySlot: Readonly<Record<string, EarnAutodepositProgress>>;
@@ -187,12 +186,6 @@ export type EarnActions = {
     symbol: string;
   }) => Promise<boolean>;
   submitWithdraw: (draft: EarnWithdrawDraft) => Promise<boolean>;
-  updateDepositPolicyAndRetry: (args: {
-    amountLabel: string;
-    forecastApyBps: number;
-    mint: string;
-    symbol: string;
-  }) => Promise<boolean>;
   autodepositError: string | null;
   withdrawError: string | null;
   withdrawSources: EarnWithdrawSourceOption[];
@@ -321,12 +314,6 @@ export function useEarnActions(deps: {
   }, []);
 
   const [depositError, setDepositError] = useState<string | null>(null);
-  // Set to the draft mint when a deposit prepare fails with
-  // earn_policy_update_required: the wallet's legacy route policy cannot
-  // authorize Token-2022 mints. The pane then offers
-  // updateDepositPolicyAndRetry for that mint instead of a dead-end error.
-  const [depositPolicyUpdateRequiredMint, setDepositPolicyUpdateRequiredMint] =
-    useState<string | null>(null);
   const [withdrawError, setWithdrawError] = useState<string | null>(null);
   const [autodepositError, setAutodepositError] = useState<string | null>(null);
   const [isDepositPending, setIsDepositPending] = useState(false);
@@ -883,7 +870,6 @@ export function useEarnActions(deps: {
         policyMode: requiresPolicySetup ? "create" : "reuse",
       });
       setDepositError(null);
-      setDepositPolicyUpdateRequiredMint(null);
       setIsDepositPending(true);
       earnToast.begin("deposit");
       earnToast.loading("Preparing deposit");
@@ -967,17 +953,42 @@ export function useEarnActions(deps: {
           draft.amountLabel,
           draft.tokenDecimals
         );
-        const preparedDeposit = await measureBrowserLoadingDependencies({
-          flowId: tracker.flowId,
-          operation: "earn.deposit",
-          rpcEndpoint: connection.rpcEndpoint,
-          run: () =>
-            prepareEarnDepositOnServer({
-              amountRaw,
-              mint: args.mint,
-              observabilityFlowId: tracker.flowId,
-            }),
-        });
+        const runPrepare = () =>
+          measureBrowserLoadingDependencies({
+            flowId: tracker.flowId,
+            operation: "earn.deposit",
+            rpcEndpoint: connection.rpcEndpoint,
+            run: () =>
+              prepareEarnDepositOnServer({
+                amountRaw,
+                mint: args.mint,
+                observabilityFlowId: tracker.flowId,
+              }),
+          });
+        let preparedDeposit: Awaited<ReturnType<typeof runPrepare>>;
+        try {
+          preparedDeposit = await runPrepare();
+        } catch (error) {
+          if (!(error instanceof EarnPolicyUpdateRequiredClientError)) {
+            throw error;
+          }
+          // The wallet's legacy route policy cannot authorize this
+          // Token-2022 mint (ASK-2108). Create the owner-neutral pair as an
+          // inline toast step — the legacy pair is never mutated — then
+          // re-prepare: the server resolves the new pair after confirm. A
+          // second update-required failure falls through to the normal
+          // error path, so this cannot loop.
+          earnToast.loading("Updating Earn policy");
+          const policySetup = await smartAccountData.executeEarnPolicySetup({
+            force: true,
+          });
+          if (!policySetup.success) {
+            throw new Error(
+              policySetup.error ?? "Failed to update Earn policy."
+            );
+          }
+          preparedDeposit = await runPrepare();
+        }
         const shouldBypassTopUpPreview =
           hasPosition &&
           !requiresPolicySetup &&
@@ -1251,9 +1262,6 @@ export function useEarnActions(deps: {
           haystack.includes("insufficient funds for rent") ||
           haystack.includes("insufficient lamports") ||
           haystack.includes("would result in account being unable to pay rent");
-        if (error instanceof EarnPolicyUpdateRequiredClientError) {
-          setDepositPolicyUpdateRequiredMint(draft.tokenMint);
-        }
         setDepositError(
           error instanceof EarnPolicyUpdateRequiredClientError
             ? "Update your Earn policy to enable this stablecoin before depositing."
@@ -1322,62 +1330,6 @@ export function useEarnActions(deps: {
       suppressPositionRefreshThroughSlot,
       trackedKaminoUsdcMint,
       wallet.signAllTransactions,
-    ]
-  );
-
-  // Recovery for earn_policy_update_required (ASK-2108): create the new
-  // owner-neutral policy pair (the legacy pair is left untouched on-chain),
-  // then retry the same deposit. The server rolls the active pair on confirm,
-  // so the retried prepare resolves the new policy.
-  const updateDepositPolicyAndRetry = useCallback(
-    async (args: {
-      amountLabel: string;
-      forecastApyBps: number;
-      mint: string;
-      symbol: string;
-    }): Promise<boolean> => {
-      if (!canMutateAccount) {
-        openSignIn();
-        return false;
-      }
-      if (!ensureCanSignAccountAction()) {
-        return false;
-      }
-      setDepositError(null);
-      setIsDepositPending(true);
-      earnToast.begin("deposit");
-      earnToast.loading("Updating Earn policy");
-      try {
-        const result = await smartAccountData.executeEarnPolicySetup({
-          force: true,
-        });
-        if (!result.success) {
-          setDepositError(result.error ?? "Failed to update Earn policy.");
-          earnToast.error("Policy update failed");
-          return false;
-        }
-        setDepositPolicyUpdateRequiredMint(null);
-      } catch (error) {
-        console.error("[earn.deposit] policy update failed", error);
-        setDepositError(
-          error instanceof Error
-            ? error.message
-            : "Failed to update Earn policy."
-        );
-        earnToast.error("Policy update failed");
-        return false;
-      } finally {
-        setIsDepositPending(false);
-        earnToast.settle();
-      }
-      return submitDeposit(args);
-    },
-    [
-      canMutateAccount,
-      ensureCanSignAccountAction,
-      openSignIn,
-      smartAccountData,
-      submitDeposit,
     ]
   );
 
@@ -2748,10 +2700,8 @@ export function useEarnActions(deps: {
     requestAutodepositClose,
     runCleanup,
     saveAutodeposit,
-    depositPolicyUpdateRequiredMint,
     submitDeposit,
     submitWithdraw,
-    updateDepositPolicyAndRetry,
     autodepositError,
     withdrawError,
     withdrawSources,

--- a/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -116,9 +116,13 @@ function SourceOptionRow({
 }) {
   const amount = splitUsdBalance(option.usd);
   const { isBalanceHidden } = useBalanceVisibility();
+  // $0.00 dust cannot be withdrawn on its own (Max-exit cleanup collects
+  // it) — the row stays listed but is not selectable.
+  const isDust = option.usd < 0.005;
   return (
     <button
-      className={`t-hover flex w-full items-center px-4 text-left hover:bg-accent ${rounded}`}
+      className={`t-hover flex w-full items-center px-4 text-left disabled:opacity-40 enabled:hover:bg-accent ${rounded}`}
+      disabled={isDust}
       onClick={onSelect}
       type="button"
     >
@@ -203,9 +207,23 @@ export function WithdrawPane({
       })),
     [sources]
   );
+  // The selector opens upward from the trigger, so withdrawable sources sit
+  // at the bottom (nearest the trigger) and $0.00 dust at the top — same
+  // contract as the deposit source selector.
+  const listedOptions = useMemo(
+    () =>
+      [...options].sort(
+        (a, b) => (a.usd >= 0.005 ? 1 : 0) - (b.usd >= 0.005 ? 1 : 0)
+      ),
+    [options]
+  );
   // Null while no sources exist (cleanup-only phase after a full exit).
+  // The fallback prefers a withdrawable source over $0.00 dust.
   const selectedOption =
-    options.find((option) => option.key === selectedKey) ?? options[0] ?? null;
+    options.find((option) => option.key === selectedKey) ??
+    options.find((option) => option.usd >= 0.005) ??
+    options[0] ??
+    null;
   const fromBalance = splitUsdBalance(selectedOption?.usd ?? 0);
 
   const amountUsd = Number.parseFloat(amount.replace(/,/g, "")) || 0;
@@ -380,7 +398,7 @@ export function WithdrawPane({
               isOpen={isSheetOpen}
               origin="bottom-center"
             >
-              {options.map((option) => (
+              {listedOptions.map((option) => (
                 <SourceOptionRow
                   isSelected={option.key === selectedOption?.key}
                   key={option.key}
@@ -416,7 +434,7 @@ export function WithdrawPane({
                 </button>
               </header>
               <div className="flex w-full flex-col py-2">
-                {options.map((option) => (
+                {listedOptions.map((option) => (
                   <SourceOptionRow
                     isSelected={option.key === selectedOption?.key}
                     key={option.key}

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -1119,7 +1119,9 @@ export type SmartAccountSidebarData = {
   executeEarnDepositPolicyStage: (
     request: EarnDepositPolicyStageRequest
   ) => Promise<EarnDepositPolicyStageResult>;
-  executeEarnPolicySetup: () => Promise<EarnPolicySetupResult>;
+  executeEarnPolicySetup: (options?: {
+    force?: boolean;
+  }) => Promise<EarnPolicySetupResult>;
   executeEarnWithdraw: (
     request: EarnWithdrawRequest
   ) => Promise<EarnWithdrawResult>;
@@ -5712,8 +5714,12 @@ export function useSmartAccountSidebarData(
     ]
   );
 
-  const executeEarnPolicySetup =
-    useCallback(async (): Promise<EarnPolicySetupResult> => {
+  const executeEarnPolicySetup = useCallback(
+    // `force` skips the has-policy short-circuit so a wallet whose only
+    // route pair is the legacy single-token-program generation can create
+    // the owner-neutral pair required for Token-2022 deposits (ASK-2108).
+    // The legacy pair is never mutated; the new pair lands at the next seed.
+    async (options?: { force?: boolean }): Promise<EarnPolicySetupResult> => {
       if (!wallet.publicKey) {
         return {
           success: false,
@@ -5749,6 +5755,7 @@ export function useSmartAccountSidebarData(
       }
       const currentEarnPolicy = currentEarnState?.policy ?? null;
       if (
+        !options?.force &&
         !shouldInitializeEarnYieldRoutingPolicyForDeposit({
           hasActiveEarnPosition:
             Boolean(currentEarnPolicy) &&
@@ -5872,7 +5879,9 @@ export function useSmartAccountSidebarData(
       } finally {
         setIsActionPending(false);
       }
-    }, [connection, earnState, solanaEnv, user?.walletAddress, wallet]);
+    },
+    [connection, earnState, solanaEnv, user?.walletAddress, wallet]
+  );
 
   const executeEarnDepositPolicyStage = useCallback(
     async (

--- a/apps/web/src/lib/yield-optimization/earn-reserve-target.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-reserve-target.server.ts
@@ -118,6 +118,34 @@ export async function findBestSafeEarnReserveTarget(args: {
   return selectBestSafeEarnReserveTarget({ ...args, rows });
 }
 
+// The routing worker's verified-reserve rounds can momentarily drop a mint
+// (mid-round rewrites, per-round verification misses — observed live
+// 2026-08-13 during the multi-mint rollout), which surfaces as a transient
+// empty selection and a user-facing no_eligible_reserve 409. A short re-read
+// bridges those blips; a genuine outage still returns null after the
+// retries. Devnet selection is deterministic, so it never retries.
+const RESERVE_SELECTION_RETRIES = 2;
+const RESERVE_SELECTION_RETRY_DELAY_MS = 700;
+
+export async function findBestSafeEarnReserveTargetWithRetry(args: {
+  cluster: LoyalCluster;
+  productMint: EarnProductAsset;
+}): Promise<EarnReserveTarget | null> {
+  for (let attempt = 0; ; attempt += 1) {
+    const target = await findBestSafeEarnReserveTarget(args);
+    if (
+      target ||
+      args.cluster === LoyalCluster.Devnet ||
+      attempt >= RESERVE_SELECTION_RETRIES
+    ) {
+      return target;
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, RESERVE_SELECTION_RETRY_DELAY_MS)
+    );
+  }
+}
+
 export function selectBestSafeEarnReserveTarget(args: {
   cluster: LoyalCluster;
   productMint: EarnProductAsset;

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -223,9 +223,15 @@ function mockKaminoDepositInstruction() {
 
 function mockKaminoWithdrawInstruction(
   overrides: {
+    // Emits the current 14-account withdraw shape (market at 2, collateral
+    // token program at 11, liquidity token program at 12) instead of the
+    // legacy order the older fixtures model.
+    currentAccountOrder?: boolean;
     duplicateWithdrawInstruction?: boolean;
     executionReserve?: PublicKey;
     instructionAmountRaw?: (requestedLiquidityAmountRaw: bigint) => bigint;
+    liquidityMint?: PublicKey;
+    liquidityTokenProgram?: PublicKey;
     vaultUsdcAta?: PublicKey;
   } = {}
 ) {
@@ -240,6 +246,18 @@ function mockKaminoWithdrawInstruction(
       true,
       TOKEN_PROGRAM_ID
     );
+    const liquidityMint =
+      overrides.liquidityMint ?? STABLECOIN_MINTS[Stablecoin.USDC];
+    const liquidityTokenProgram =
+      overrides.liquidityTokenProgram ?? TOKEN_PROGRAM_ID;
+    const defaultVaultLiquidityAta = overrides.liquidityMint
+      ? getAssociatedTokenAddressSync(
+          liquidityMint,
+          deriveVault(),
+          true,
+          liquidityTokenProgram
+        )
+      : deriveVaultUsdcAta();
     const createInstruction = (rawAmount: bigint) => {
       const instructionData = Buffer.alloc(16);
       Buffer.from([235, 52, 119, 152, 149, 197, 20, 7]).copy(
@@ -247,6 +265,42 @@ function mockKaminoWithdrawInstruction(
         0
       );
       instructionData.writeBigUInt64LE(rawAmount, 8);
+      if (overrides.currentAccountOrder) {
+        return {
+          accounts: [
+            { address: deriveVault().toBase58(), role: "WRITABLE_SIGNER" },
+            { address: "11111111111111111111111111111111", role: "WRITABLE" },
+            { address: kaminoMarket.toBase58(), role: "READONLY" },
+            { address: "11111111111111111111111111111111", role: "READONLY" },
+            {
+              address: (overrides.executionReserve ?? kaminoReserve).toBase58(),
+              role: "WRITABLE",
+            },
+            { address: liquidityMint.toBase58(), role: "READONLY" },
+            { address: vaultCollateralAta.toBase58(), role: "WRITABLE" },
+            { address: reserveCollateralMint.toBase58(), role: "WRITABLE" },
+            {
+              address: kaminoReserveLiquiditySupply.toBase58(),
+              role: "WRITABLE",
+            },
+            {
+              address: (
+                overrides.vaultUsdcAta ?? defaultVaultLiquidityAta
+              ).toBase58(),
+              role: "WRITABLE",
+            },
+            { address: kaminoProgram.toBase58(), role: "READONLY" },
+            { address: TOKEN_PROGRAM_ID.toBase58(), role: "READONLY" },
+            { address: liquidityTokenProgram.toBase58(), role: "READONLY" },
+            {
+              address: "Sysvar1nstructions1111111111111111111111111",
+              role: "READONLY",
+            },
+          ],
+          data: instructionData.toString("base64"),
+          programAddress: kaminoProgram.toBase58(),
+        };
+      }
       return {
         accounts: [
           { address: deriveVault().toBase58(), role: "WRITABLE_SIGNER" },
@@ -2533,6 +2587,59 @@ describe("prepareEarnUsdcWithdraw", () => {
         },
       })
     ).rejects.toThrow("unexpected vault USDC account");
+  });
+
+  // Regression (2026-08-13): the current withdraw shape carries the classic
+  // collateral token program at slot 11 and the liquidity mint's program at
+  // slot 12. Reading the liquidity program from slot 11 only passed while
+  // every mint was classic SPL — it rejected all Token-2022 withdrawals.
+  test("accepts the Token-2022 liquidity program at its current-order slot", async () => {
+    const usdgMint = STABLECOIN_MINTS[Stablecoin.USDG];
+    mockKaminoWithdrawInstruction({
+      currentAccountOrder: true,
+      liquidityMint: usdgMint,
+      liquidityTokenProgram: TOKEN_2022_PROGRAM_ID,
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: {} as never,
+      programId,
+    });
+
+    const error = await client
+      .prepareEarnUsdcWithdraw({
+        settingsPda,
+        walletAddress,
+        feePayer,
+        policySigner: backendSigner,
+        amountRaw: BigInt(1_000_000),
+        mode: "partial",
+        target: {
+          liquidityMint: usdgMint,
+          liquidityTokenProgram: TOKEN_2022_PROGRAM_ID,
+          market: kaminoMarket,
+          reserve: kaminoReserve,
+          reserveCollateralMint: kaminoReserveCollateralMint,
+          reserveLiquiditySupply: kaminoReserveLiquiditySupply,
+        },
+        yieldRoutingPolicy: {
+          account: policyAccount,
+          seed: BigInt(7),
+        },
+      })
+      .then(
+        () => null,
+        (thrown) =>
+          thrown instanceof Error ? thrown : new Error(String(thrown))
+      );
+
+    // Both token-program slots must validate; any remaining failure is a
+    // downstream mock gap, never the token-program assertion.
+    expect(error?.message ?? "").not.toContain(
+      "unexpected liquidity token program"
+    );
+    expect(error?.message ?? "").not.toContain(
+      "unexpected collateral token program"
+    );
   });
 });
 

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -8972,7 +8972,7 @@ export function createSmartAccountVaultsClient(
               walletUsdcAta,
               args.walletAddress,
               usdcMint,
-              TOKEN_PROGRAM_ID
+              liquidityTokenProgram
             ),
             ...vaultAtaSetupInstructions,
             ...withdrawPrefixExecution.instructions,
@@ -9050,7 +9050,7 @@ export function createSmartAccountVaultsClient(
           walletTransferAmountRaw,
           EARN_DEPOSIT_USDC_DECIMALS,
           [],
-          TOKEN_PROGRAM_ID
+          liquidityTokenProgram
         ),
         vaultPda
       );
@@ -9115,7 +9115,7 @@ export function createSmartAccountVaultsClient(
             walletUsdcAta,
             args.walletAddress,
             usdcMint,
-            TOKEN_PROGRAM_ID
+            liquidityTokenProgram
           ),
           ...vaultAtaSetupInstructions,
           ...operations.flatMap((operation) => operation.instructions),

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -2744,7 +2744,15 @@ function validateKaminoWithdrawInstruction(args: {
   const vaultCollateralAccountIndex = usesCurrentWithdrawAccountOrder ? 6 : 7;
   const reserveCollateralMintIndex = usesCurrentWithdrawAccountOrder ? 7 : 5;
   const vaultUsdcAccountIndex = usesCurrentWithdrawAccountOrder ? 9 : 8;
-  const tokenProgramIndex = usesCurrentWithdrawAccountOrder ? 11 : 10;
+  // Current-order withdraws carry two token programs: collateral kTokens are
+  // always classic SPL (slot 11) while the liquidity mint's own program sits
+  // at slot 12. Asserting the liquidity program at 11 only ever passed
+  // because classic mints put TOKEN_PROGRAM_ID in both slots — it rejected
+  // every Token-2022 withdrawal (USDG/PYUSD/CASH).
+  const collateralTokenProgramIndex = usesCurrentWithdrawAccountOrder
+    ? 11
+    : null;
+  const tokenProgramIndex = usesCurrentWithdrawAccountOrder ? 12 : 10;
 
   assertKaminoAccountEquals({
     actual: requireKaminoAccount(instruction, marketIndex, "market"),
@@ -2801,6 +2809,17 @@ function validateKaminoWithdrawInstruction(args: {
     expected: args.liquidityTokenProgram,
     label: "liquidity token program",
   });
+  if (collateralTokenProgramIndex !== null) {
+    assertKaminoAccountEquals({
+      actual: requireKaminoAccount(
+        instruction,
+        collateralTokenProgramIndex,
+        "collateral token program"
+      ),
+      expected: TOKEN_PROGRAM_ID,
+      label: "collateral token program",
+    });
+  }
   return {
     executionMarket,
     executionReserve,

--- a/packages/wallet-core/src/lib/token-icon.ts
+++ b/packages/wallet-core/src/lib/token-icon.ts
@@ -32,6 +32,10 @@ const TOKEN_ICON_OVERRIDES: Record<string, string> = {
   // a letter placeholder (USDG, USDS); pin the issuers' canonical marks instead.
   CASH: "https://token-metadata.bridge.xyz/images/cash.png",
   USDG: "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/GDN-USDG-Token-512x512.png",
+  // logo.dev serves the retired blue PayPal-USD mark; Paxos' current logo
+  // (also what Jupiter shows) is the black roundel.
+  PYUSD:
+    "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/PYUSDLOGO.png",
   USDS: "https://coin-images.coingecko.com/coins/images/39926/large/usds.webp",
 };
 

--- a/packages/wallet-core/src/lib/token-icon.ts
+++ b/packages/wallet-core/src/lib/token-icon.ts
@@ -29,9 +29,10 @@ const TOKEN_ICON_OVERRIDES: Record<string, string> = {
   SOL: "https://coin-images.coingecko.com/coins/images/21629/large/solana.jpg",
   USDC: "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png",
   // logo.dev resolves these ambiguous tickers to the wrong project (CASH) or
-  // a letter placeholder (USDG); pin the issuers' canonical marks instead.
+  // a letter placeholder (USDG, USDS); pin the issuers' canonical marks instead.
   CASH: "https://token-metadata.bridge.xyz/images/cash.png",
   USDG: "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/GDN-USDG-Token-512x512.png",
+  USDS: "https://coin-images.coingecko.com/coins/images/39926/large/usds.webp",
 };
 
 export function getTokenIconUrl(symbol: string): string {


### PR DESCRIPTION
Legacy-policy wallets hitting earn_policy_update_required on Token-2022 stables (CASH/USDG/PYUSD) now get an Update policy & deposit CTA that creates the new owner-neutral pair (existing on-chain policies untouched) and retries the deposit. Closes ASK-2108; supports the ASK-2096 rollout.