### PR TITLE
fix(earn): sum multi-mint holdings in mobile earn state

### DIFF
--- a/apps/web/src/app/api/smart-accounts/mobile/earn/state/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/state/route.ts
@@ -12,6 +12,8 @@ import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/serv
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getCurrentReserveUpdatesByReserve } from "@/lib/kamino/timescale-reserve-client.server";
 import {
+  findCurrentNonzeroYieldVaultReservePositions,
+  findCurrentYieldVaultIdleTokenBalances,
   findReconciledActiveYieldPositionForVault,
   type UserYieldPositionRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
@@ -65,6 +67,50 @@ function resolveTimescaleReserveForPosition(position: UserYieldPositionRecord) {
     return mainnetEarnTarget.reserve.toBase58();
   }
   return position.currentReserve;
+}
+
+// The wallet can hold one active position row per product mint (ASK-1355), so
+// the headline balance is the sum of the vault's current reserve + idle
+// snapshot rows across every mint — the reconciled single-row read below only
+// covers the mint it points at, which briefly showed a fresh $1 USDG deposit
+// as the whole balance on mobile. Mirrors the session `earn-state` route's
+// `loadCurrentTotalAmountRaw`; falls back to the single row's amount when the
+// snapshots are empty or the read fails.
+async function loadCurrentTotalAmountRaw(args: {
+  cluster: ReturnType<typeof resolveConfiguredCluster>;
+  position: UserYieldPositionRecord;
+  settings: string;
+  walletAddress: string;
+}): Promise<bigint> {
+  try {
+    const [reserveRows, idleRows] = await Promise.all([
+      findCurrentNonzeroYieldVaultReservePositions({
+        cluster: args.cluster,
+        settings: args.settings,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: args.position.vaultPubkey,
+        walletAddress: args.walletAddress,
+      }),
+      findCurrentYieldVaultIdleTokenBalances({
+        cluster: args.cluster,
+        settings: args.settings,
+        vaultIndex: EARN_VAULT_INDEX,
+        vaultPubkey: args.position.vaultPubkey,
+        walletAddress: args.walletAddress,
+      }),
+    ]);
+    const total = [...reserveRows, ...idleRows].reduce(
+      (sum, row) => sum + row.amountRaw,
+      BigInt(0)
+    );
+    return total > BigInt(0) ? total : args.position.currentAmountRaw;
+  } catch (error) {
+    console.warn(
+      "[mobile-earn-state] failed to load current holdings total",
+      error
+    );
+    return args.position.currentAmountRaw;
+  }
 }
 
 // Best-effort: the funded balance is the headline number; APY is supplementary,
@@ -141,11 +187,19 @@ export async function GET(request: Request) {
       });
     }
 
-    const currentSupplyApyBps = await loadCurrentSupplyApyBps(position);
+    const [currentSupplyApyBps, currentTotalAmountRaw] = await Promise.all([
+      loadCurrentSupplyApyBps(position),
+      loadCurrentTotalAmountRaw({
+        cluster,
+        position,
+        settings: account.settingsPda,
+        walletAddress,
+      }),
+    ]);
 
     return NextResponse.json({
       position: {
-        currentAmountRaw: position.currentAmountRaw.toString(),
+        currentAmountRaw: currentTotalAmountRaw.toString(),
         currentSupplyApyBps,
         principalAmountRaw: position.principalAmountRaw.toString(),
         status: position.status,


### PR DESCRIPTION
The mobile /earn/state twin still returned a single reconciled position row, so with one active position per product mint the post-deposit read-model trust window on mobile showed only the freshly deposited mint's balance as the whole Earn total. Mirrors the session earn-state route's loadCurrentTotalAmountRaw: sum current reserve + idle snapshot rows across all mints, falling back to the single row.