### PR TITLE
fix(ci): strip mobile workspace refs from generated mirror

### DIFF
--- a/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
+++ b/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   spawn,
   spawnSync,
@@ -281,10 +281,7 @@ function materializeWorktreePrivateTransactionsEntry(): void {
   if (!existsSync(entryPath) || !lstatSync(entryPath).isSymbolicLink()) return;
 
   const linkTarget = readlinkSync(entryPath);
-  const worktreeEntry = resolve(
-    import.meta.dir,
-    "../../../packages/private-transactions/dist/index.js",
-  );
+  const worktreeEntry = resolve(dirname(entryPath), linkTarget);
   unlinkSync(entryPath);
   copyFileSync(worktreeEntry, entryPath);
   materializedPrivateTransactionsEntry = { entryPath, linkTarget };

--- a/scripts/mirror-repos/file-rewrites.ts
+++ b/scripts/mirror-repos/file-rewrites.ts
@@ -220,8 +220,10 @@ module.exports = nativewindConfig;
   writeText(path.join(root, "metro.config.js"), metroConfig);
 
   const jestConfigPath = path.join(root, "jest.config.js");
+  // Workspace aliases only exist in the monorepo; the mirror resolves
+  // @loyal-labs/* from node_modules, so drop every mapper pointing at packages/.
   const jestConfig = readText(jestConfigPath).replace(
-    `    "^@loyal-labs/shared$": "<rootDir>/../../packages/shared/src/index",\n`,
+    /^[ \t]*"\^@loyal-labs\/[^"]+"\s*:\s*"[^"]*\.\.\/\.\.\/packages[^"]*",[ \t]*\r?\n/gm,
     ""
   );
   writeText(jestConfigPath, jestConfig);


### PR DESCRIPTION
The mobile merge (#646) added jest moduleNameMapper entries and an e2e script path pointing at `../../packages`, which trips the mirror safety check and failed Sync Mirror Repos. Mirror generation now drops every `@loyal-labs` workspace mapper, and the e2e script derives the worktree entry from the symlink target.