### PR TITLE
feat(push): add automated Earn yield joy pushes

### DIFF
--- a/apps/telegram/drizzle/0028_smiling_union_jack.sql
+++ b/apps/telegram/drizzle/0028_smiling_union_jack.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "earn_yield_push_state" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"wallet_public_key" text NOT NULL,
+	"last_pushed_earned_usd" numeric(20, 6) DEFAULT '0' NOT NULL,
+	"last_pushed_at" timestamp with time zone,
+	"sent_campaigns" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "earn_yield_push_state_wallet_uidx" ON "earn_yield_push_state" USING btree ("wallet_public_key");

--- a/apps/telegram/drizzle/meta/0028_snapshot.json
+++ b/apps/telegram/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,5401 @@
+{
+  "id": "70ad1d2f-97b1-43bc-891a-0bb41143889f",
+  "prevId": "26d3195f-3fd2-46b7-9bbb-2b9a8ad917cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_captcha_keys": {
+      "name": "app_captcha_keys",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_chat_messages": {
+      "name": "app_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chat_messages_chat_client_message_uidx": {
+          "name": "app_chat_messages_chat_client_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"client_message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_role_turn_uidx": {
+          "name": "app_chat_messages_chat_role_turn_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"turn_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_created_idx": {
+          "name": "app_chat_messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chat_messages_chat_id_app_chats_id_fk": {
+          "name": "app_chat_messages_chat_id_app_chats_id_fk",
+          "tableFrom": "app_chat_messages",
+          "tableTo": "app_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_chat_messages_role_check": {
+          "name": "app_chat_messages_role_check",
+          "value": "\"app_chat_messages\".\"role\" IN ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_chats": {
+      "name": "app_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_chat_id": {
+          "name": "client_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chats_user_client_chat_uidx": {
+          "name": "app_chats_user_client_chat_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chats\".\"client_chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chats_user_last_message_idx": {
+          "name": "app_chats_user_last_message_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chats_user_id_app_users_id_fk": {
+          "name": "app_chats_user_id_app_users_id_fk",
+          "tableFrom": "app_chats",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_settings_change_requests": {
+      "name": "app_smart_account_settings_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_address": {
+          "name": "signer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_index": {
+          "name": "transaction_index",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_slot": {
+          "name": "confirmed_slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_settings_change_req_idem_uidx": {
+          "name": "app_smart_account_settings_change_req_idem_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_settings_idx": {
+          "name": "app_smart_account_settings_change_req_settings_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_signer_idx": {
+          "name": "app_smart_account_settings_change_req_signer_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_status_idx": {
+          "name": "app_smart_account_settings_change_req_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_user_idx": {
+          "name": "app_smart_account_settings_change_req_user_idx",
+          "columns": [
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_smart_account_settings_change_requests_requested_by_user_id_app_users_id_fk": {
+          "name": "app_smart_account_settings_change_requests_requested_by_user_id_app_users_id_fk",
+          "tableFrom": "app_smart_account_settings_change_requests",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_settings_change_req_solana_env_check": {
+          "name": "app_smart_account_settings_change_req_solana_env_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_smart_account_settings_change_req_scope_check": {
+          "name": "app_smart_account_settings_change_req_scope_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"scope\" IN ('root_settings')"
+        },
+        "app_smart_account_settings_change_req_action_check": {
+          "name": "app_smart_account_settings_change_req_action_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"action\" IN ('add_root_signer', 'remove_root_signer')"
+        },
+        "app_smart_account_settings_change_req_status_check": {
+          "name": "app_smart_account_settings_change_req_status_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"status\" IN ('draft', 'submitted', 'confirmed', 'failed', 'canceled', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_signers": {
+      "name": "app_smart_account_signers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_address": {
+          "name": "signer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_mask": {
+          "name": "permission_mask",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_signature": {
+          "name": "source_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_slot": {
+          "name": "source_slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_signers_env_settings_scope_signer_uidx": {
+          "name": "app_smart_account_signers_env_settings_scope_signer_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_env_signer_state_idx": {
+          "name": "app_smart_account_signers_env_signer_state_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_settings_idx": {
+          "name": "app_smart_account_signers_settings_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_user_idx": {
+          "name": "app_smart_account_signers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_smart_account_signers_user_id_app_users_id_fk": {
+          "name": "app_smart_account_signers_user_id_app_users_id_fk",
+          "tableFrom": "app_smart_account_signers",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_signers_solana_env_check": {
+          "name": "app_smart_account_signers_solana_env_check",
+          "value": "\"app_smart_account_signers\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_smart_account_signers_scope_check": {
+          "name": "app_smart_account_signers_scope_check",
+          "value": "\"app_smart_account_signers\".\"scope\" IN ('root_settings')"
+        },
+        "app_smart_account_signers_state_check": {
+          "name": "app_smart_account_signers_state_check",
+          "value": "\"app_smart_account_signers\".\"state\" IN ('active', 'removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_sponsorship_transactions": {
+      "name": "app_smart_account_sponsorship_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_sponsorship_tx_env_signature_uidx": {
+          "name": "app_smart_account_sponsorship_tx_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_occurred_at_idx": {
+          "name": "app_smart_account_sponsorship_tx_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_user_address_idx": {
+          "name": "app_smart_account_sponsorship_tx_user_address_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_smart_account_idx": {
+          "name": "app_smart_account_sponsorship_tx_smart_account_idx",
+          "columns": [
+            {
+              "expression": "smart_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_sponsorship_tx_solana_env_check": {
+          "name": "app_smart_account_sponsorship_tx_solana_env_check",
+          "value": "\"app_smart_account_sponsorship_transactions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_smart_accounts": {
+      "name": "app_user_smart_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_signature": {
+          "name": "creation_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_smart_accounts_user_env_uidx": {
+          "name": "app_user_smart_accounts_user_env_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_env_settings_uidx": {
+          "name": "app_user_smart_accounts_env_settings_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_user_id_idx": {
+          "name": "app_user_smart_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_smart_accounts_user_id_app_users_id_fk": {
+          "name": "app_user_smart_accounts_user_id_app_users_id_fk",
+          "tableFrom": "app_user_smart_accounts",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_user_smart_accounts_solana_env_check": {
+          "name": "app_user_smart_accounts_solana_env_check",
+          "value": "\"app_user_smart_accounts\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_user_smart_accounts_state_check": {
+          "name": "app_user_smart_accounts_state_check",
+          "value": "\"app_user_smart_accounts\".\"state\" IN ('provisioning', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_wallets": {
+      "name": "app_user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_wallets_wallet_address_uidx": {
+          "name": "app_user_wallets_wallet_address_uidx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_wallets_user_id_app_users_id_fk": {
+          "name": "app_user_wallets_user_id_app_users_id_fk",
+          "tableFrom": "app_user_wallets",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_users": {
+      "name": "app_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_address": {
+          "name": "subject_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grid_user_id": {
+          "name": "grid_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_settings_pda": {
+          "name": "smart_account_settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_users_provider_subject_uidx": {
+          "name": "app_users_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_users_provider_check": {
+          "name": "app_users_provider_check",
+          "value": "\"app_users\".\"provider\" IN ('solana')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_wallet_auth_completions": {
+      "name": "app_wallet_auth_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_hash": {
+          "name": "challenge_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioning_outcome": {
+          "name": "provisioning_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_wallet_auth_completions_challenge_hash_uidx": {
+          "name": "app_wallet_auth_completions_challenge_hash_uidx",
+          "columns": [
+            {
+              "expression": "challenge_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_wallet_address_idx": {
+          "name": "app_wallet_auth_completions_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_state_idx": {
+          "name": "app_wallet_auth_completions_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_user_id_idx": {
+          "name": "app_wallet_auth_completions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_wallet_auth_completions_user_id_app_users_id_fk": {
+          "name": "app_wallet_auth_completions_user_id_app_users_id_fk",
+          "tableFrom": "app_wallet_auth_completions",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_wallet_auth_completions_solana_env_check": {
+          "name": "app_wallet_auth_completions_solana_env_check",
+          "value": "\"app_wallet_auth_completions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_wallet_auth_completions_state_check": {
+          "name": "app_wallet_auth_completions_state_check",
+          "value": "\"app_wallet_auth_completions\".\"state\" IN ('processing', 'completed', 'failed')"
+        },
+        "app_wallet_auth_completions_provisioning_outcome_check": {
+          "name": "app_wallet_auth_completions_provisioning_outcome_check",
+          "value": "\"app_wallet_auth_completions\".\"provisioning_outcome\" IS NULL OR \"app_wallet_auth_completions\".\"provisioning_outcome\" IN ('existing_ready', 'delegated_root_signer', 'reconciled_ready', 'sponsored_existing_record', 'sponsored_new_record', 'retried_failed_record')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "parser_type": {
+          "name": "parser_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_parser_type_idx": {
+          "name": "communities_is_active_parser_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parser_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_parser_type_check": {
+          "name": "communities_parser_type_check",
+          "value": "\"communities\".\"parser_type\" IN ('bot', 'userbot')"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.earn_yield_push_state": {
+      "name": "earn_yield_push_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pushed_earned_usd": {
+          "name": "last_pushed_earned_usd",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_pushed_at": {
+          "name": "last_pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_campaigns": {
+          "name": "sent_campaigns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "earn_yield_push_state_wallet_uidx": {
+          "name": "earn_yield_push_state_wallet_uidx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_app_statuses": {
+      "name": "feature_app_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_app_statuses_feature_app_idx": {
+          "name": "feature_app_statuses_feature_app_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_app_statuses_feature_id_feature_registry_id_fk": {
+          "name": "feature_app_statuses_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_app_statuses",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_app_statuses_app_check": {
+          "name": "feature_app_statuses_app_check",
+          "value": "\"feature_app_statuses\".\"app\" IN ('telegram_miniapp', 'website', 'mobile', 'extension')"
+        },
+        "feature_app_statuses_status_check": {
+          "name": "feature_app_statuses_status_check",
+          "value": "\"feature_app_statuses\".\"status\" IN ('missing', 'planned', 'in_progress', 'implemented', 'live')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_evidence": {
+      "name": "feature_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_app_status_id": {
+          "name": "feature_app_status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_evidence_feature_app_status_id_idx": {
+          "name": "feature_evidence_feature_app_status_id_idx",
+          "columns": [
+            {
+              "expression": "feature_app_status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk": {
+          "name": "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk",
+          "tableFrom": "feature_evidence",
+          "tableTo": "feature_app_statuses",
+          "columnsFrom": [
+            "feature_app_status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_evidence_type_check": {
+          "name": "feature_evidence_type_check",
+          "value": "\"feature_evidence\".\"type\" IN ('path', 'branch', 'pr', 'linear', 'commit', 'doc')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_flag_links": {
+      "name": "feature_flag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flag_links_unique_idx": {
+          "name": "feature_flag_links_unique_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_flag_links_feature_id_feature_registry_id_fk": {
+          "name": "feature_flag_links_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feature_flag_links_flag_id_runtime_flags_id_fk": {
+          "name": "feature_flag_links_flag_id_runtime_flags_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "runtime_flags",
+          "columnsFrom": [
+            "flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_registry": {
+      "name": "feature_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_registry_key_idx": {
+          "name": "feature_registry_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gasless_claim_transactions": {
+      "name": "gasless_claim_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gasless_claim_transactions_env_signature_uidx": {
+          "name": "gasless_claim_transactions_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_occurred_at_idx": {
+          "name": "gasless_claim_transactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_type_occurred_at_idx": {
+          "name": "gasless_claim_transactions_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_recipient_address_idx": {
+          "name": "gasless_claim_transactions_recipient_address_idx",
+          "columns": [
+            {
+              "expression": "recipient_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gasless_claim_transactions_type_check": {
+          "name": "gasless_claim_transactions_type_check",
+          "value": "\"gasless_claim_transactions\".\"transaction_type\" IN ('store', 'verify_telegram_init_data', 'top_up_to_0_01_sol')"
+        },
+        "gasless_claim_transactions_solana_env_check": {
+          "name": "gasless_claim_transactions_solana_env_check",
+          "value": "\"gasless_claim_transactions\".\"solana_env\" IN ('mainnet', 'devnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_addresses": {
+      "name": "helius_webhook_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhook_addresses_address_unique": {
+          "name": "helius_webhook_addresses_address_unique",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_wallet_idx": {
+          "name": "helius_webhook_addresses_wallet_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_webhook_idx": {
+          "name": "helius_webhook_addresses_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk": {
+          "name": "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk",
+          "tableFrom": "helius_webhook_addresses",
+          "tableTo": "helius_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_deliveries": {
+      "name": "helius_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helius_webhook_deliveries_signature_wallet_public_key_pk": {
+          "name": "helius_webhook_deliveries_signature_wallet_public_key_pk",
+          "columns": [
+            "signature",
+            "wallet_public_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhooks": {
+      "name": "helius_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "helius_webhook_id": {
+          "name": "helius_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "address_count": {
+          "name": "address_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhooks_helius_id_unique": {
+          "name": "helius_webhooks_helius_id_unique",
+          "columns": [
+            {
+              "expression": "helius_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_articles": {
+      "name": "library_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_time": {
+          "name": "read_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_articles_section_order_idx": {
+          "name": "library_articles_section_order_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_articles_featured_idx": {
+          "name": "library_articles_featured_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_articles_section_id_library_sections_id_fk": {
+          "name": "library_articles_section_id_library_sections_id_fk",
+          "tableFrom": "library_articles",
+          "tableTo": "library_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sections": {
+      "name": "library_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sections_active_order_idx": {
+          "name": "library_sections_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loyal_stats_snapshots": {
+      "name": "loyal_stats_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_key": {
+          "name": "snapshot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "total_aum_raw": {
+          "name": "total_aum_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_optimized_volume_raw": {
+          "name": "total_optimized_volume_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_principal_raw": {
+          "name": "active_principal_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "unique_earn_users": {
+          "name": "unique_earn_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_earn_policies": {
+          "name": "unique_earn_policies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_autodeposit_policies": {
+          "name": "active_autodeposit_policies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "earn_aum_series": {
+          "name": "earn_aum_series",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loyal_stats_snapshots_key_uidx": {
+          "name": "loyal_stats_snapshots_key_uidx",
+          "columns": [
+            {
+              "expression": "snapshot_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "loyal_stats_snapshots_current_key_check": {
+          "name": "loyal_stats_snapshots_current_key_check",
+          "value": "\"loyal_stats_snapshots\".\"snapshot_key\" = 'current'"
+        },
+        "loyal_stats_snapshots_nonnegative_check": {
+          "name": "loyal_stats_snapshots_nonnegative_check",
+          "value": "\"loyal_stats_snapshots\".\"total_aum_raw\" >= 0 AND \"loyal_stats_snapshots\".\"total_users\" >= 0 AND \"loyal_stats_snapshots\".\"total_optimized_volume_raw\" >= 0 AND \"loyal_stats_snapshots\".\"active_principal_raw\" >= 0 AND \"loyal_stats_snapshots\".\"unique_earn_users\" >= 0 AND \"loyal_stats_snapshots\".\"unique_earn_policies\" >= 0 AND \"loyal_stats_snapshots\".\"active_autodeposit_policies\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_analytics_sync_state": {
+      "name": "private_transfer_analytics_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_key": {
+          "name": "sync_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backfill_cursor": {
+          "name": "backfill_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_seen_signature": {
+          "name": "latest_seen_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_completed_at": {
+          "name": "backfill_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_started_at": {
+          "name": "last_run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_finished_at": {
+          "name": "last_run_finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_analytics_sync_state_sync_key_uidx": {
+          "name": "private_transfer_analytics_sync_state_sync_key_uidx",
+          "columns": [
+            {
+              "expression": "sync_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_modify_balance_events": {
+      "name": "private_transfer_modify_balance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_index": {
+          "name": "instruction_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_modify_balance_events_signature_instruction_uidx": {
+          "name": "private_transfer_modify_balance_events_signature_instruction_uidx",
+          "columns": [
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instruction_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_token_mint_idx": {
+          "name": "private_transfer_modify_balance_events_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_flow_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_flow_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "flow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_vault_address_idx": {
+          "name": "private_transfer_modify_balance_events_vault_address_idx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "private_transfer_modify_balance_events_flow_check": {
+          "name": "private_transfer_modify_balance_events_flow_check",
+          "value": "\"private_transfer_modify_balance_events\".\"flow\" IN ('shield', 'unshield')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_token_catalog": {
+      "name": "private_transfer_token_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_price_usd": {
+          "name": "last_price_usd",
+          "type": "numeric(30, 12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_token_catalog_token_mint_uidx": {
+          "name": "private_transfer_token_catalog_token_mint_uidx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_vault_holdings": {
+      "name": "private_transfer_vault_holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_account_address": {
+          "name": "token_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_vault_holdings_vault_address_uidx": {
+          "name": "private_transfer_vault_holdings_vault_address_uidx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_account_address_uidx": {
+          "name": "private_transfer_vault_holdings_token_account_address_uidx",
+          "columns": [
+            {
+              "expression": "token_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_mint_idx": {
+          "name": "private_transfer_vault_holdings_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_sends": {
+      "name": "push_notification_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_count": {
+          "name": "requested_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ticket_count": {
+          "name": "ticket_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_ok_count": {
+          "name": "receipt_ok_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_error_count": {
+          "name": "receipt_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_not_registered_count": {
+          "name": "device_not_registered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipts_checked_at": {
+          "name": "receipts_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_sends_created_at_idx": {
+          "name": "push_notification_sends_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_sends_status_idx": {
+          "name": "push_notification_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "push_notification_sends_audience_check": {
+          "name": "push_notification_sends_audience_check",
+          "value": "\"push_notification_sends\".\"audience\" IN ('all', 'platform', 'wallet')"
+        },
+        "push_notification_sends_status_check": {
+          "name": "push_notification_sends_status_check",
+          "value": "\"push_notification_sends\".\"status\" IN ('sending', 'sent', 'receipt_checked', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tickets": {
+      "name": "push_notification_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_status": {
+          "name": "ticket_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_message": {
+          "name": "ticket_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_error": {
+          "name": "ticket_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_status": {
+          "name": "receipt_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_message": {
+          "name": "receipt_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_error": {
+          "name": "receipt_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_tickets_send_id_idx": {
+          "name": "push_notification_tickets_send_id_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_ticket_id_idx": {
+          "name": "push_notification_tickets_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_token_idx": {
+          "name": "push_notification_tickets_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tickets_send_id_push_notification_sends_id_fk": {
+          "name": "push_notification_tickets_send_id_push_notification_sends_id_fk",
+          "tableFrom": "push_notification_tickets",
+          "tableTo": "push_notification_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_telegram_user_id_idx": {
+          "name": "push_tokens_telegram_user_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_wallet_public_key_idx": {
+          "name": "push_tokens_wallet_public_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_flags": {
+      "name": "runtime_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_environments": {
+          "name": "target_environments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"development\",\"preview\",\"production\"]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_flags_key_idx": {
+          "name": "runtime_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_flags_audience_check": {
+          "name": "runtime_flags_audience_check",
+          "value": "\"runtime_flags\".\"audience\" IN ('all', 'public', 'team')"
+        },
+        "runtime_flags_target_environments_check": {
+          "name": "runtime_flags_target_environments_check",
+          "value": "jsonb_typeof(\"runtime_flags\".\"target_environments\") = 'array' AND \"runtime_flags\".\"target_environments\" <@ '[\"development\",\"preview\",\"production\"]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_command_receipts": {
+      "name": "telegram_command_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_update_id": {
+          "name": "telegram_update_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_command_receipts_update_uidx": {
+          "name": "telegram_command_receipts_update_uidx",
+          "columns": [
+            {
+              "expression": "telegram_update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_command_receipts_status_created_idx": {
+          "name": "telegram_command_receipts_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "telegram_command_receipts_status_check": {
+          "name": "telegram_command_receipts_status_check",
+          "value": "\"telegram_command_receipts\".\"status\" IN ('processing', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_helper_message_cleanup": {
+      "name": "telegram_helper_message_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_helper_message_cleanup_delete_after_idx": {
+          "name": "telegram_helper_message_cleanup_delete_after_idx",
+          "columns": [
+            {
+              "expression": "delete_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_helper_message_cleanup_chat_message_uidx": {
+          "name": "telegram_helper_message_cleanup_chat_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trusted_dapps": {
+      "name": "trusted_dapps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trusted_dapps_origin_uidx": {
+          "name": "trusted_dapps_origin_uidx",
+          "columns": [
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_order_idx": {
+          "name": "trusted_dapps_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_category_order_idx": {
+          "name": "trusted_dapps_active_category_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_push_sync_state": {
+      "name": "wallet_push_sync_state",
+      "schema": "",
+      "columns": {
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_signature": {
+          "name": "last_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/telegram/drizzle/meta/_journal.json
+++ b/apps/telegram/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1785737324633,
       "tag": "0027_first_sabra",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1786885799372,
+      "tag": "0028_smiling_union_jack",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/cron/earn-yield-joy/route.ts
+++ b/apps/web/src/app/api/cron/earn-yield-joy/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { runEarnYieldJoy } from "@/lib/yield-optimization/earn-yield-joy.server";
+
+import { validateCronAuthHeader } from "../_shared/auth";
+
+// Daily driver for the Earn "joy" pushes (ASK-2091): first yield, total-earned
+// milestones, the Loyal anniversary, and the self-tuning "+$X earned" digest.
+// A wallet gets at most one of them per run. `?dryRun=1` decides without
+// sending or writing state.
+export const maxDuration = 300;
+
+async function handleCronRequest(request: Request) {
+  const authError = validateCronAuthHeader(request);
+  if (authError) {
+    return authError;
+  }
+
+  const dryRun = new URL(request.url).searchParams.get("dryRun") === "1";
+  try {
+    return NextResponse.json(await runEarnYieldJoy({ dryRun }));
+  } catch (error) {
+    console.error("[cron/earn-yield-joy] failed", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "earn_yield_joy_failed",
+          message: "Failed to run Earn yield joy pushes.",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = handleCronRequest;
+export const POST = handleCronRequest;

--- a/apps/web/src/lib/push-notifications/wallet-push.server.ts
+++ b/apps/web/src/lib/push-notifications/wallet-push.server.ts
@@ -119,6 +119,50 @@ export function autodepositSweepFailedPush(
   return { body, title: "Auto-deposit didn't go through." };
 }
 
+function formatUsd(amountUsd: number): string {
+  return `$${amountUsd.toLocaleString("en-US", {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  })}`;
+}
+
+// Earn "joy" layer (ASK-2091): the pushes that exist to make yield felt.
+// Every one of them carries a real number, because a reminder without an
+// amount is the marketing push these are meant not to be.
+
+export function firstYieldPush(amountUsd: number): WalletPushPayload {
+  return {
+    body: `${formatUsd(amountUsd)} so far, and it keeps going on its own.`,
+    title: "Your USDC just earned its first yield.",
+  };
+}
+
+export function yieldDigestPush(amountUsd: number): WalletPushPayload {
+  return {
+    body: "Your USDC kept working while you were away.",
+    title: `+${formatUsd(amountUsd)} earned.`,
+  };
+}
+
+export function totalEarnedMilestonePush(
+  milestoneUsd: number
+): WalletPushPayload {
+  return {
+    body: "All of it from USDC sitting in Earn.",
+    title: `${formatUsd(milestoneUsd)} earned in total.`,
+  };
+}
+
+export function loyalAnniversaryPush(
+  months: number,
+  amountUsd: number
+): WalletPushPayload {
+  return {
+    body: `${formatUsd(amountUsd)} earned since you joined.`,
+    title: months >= 12 ? "A year with Loyal." : "Six months with Loyal.",
+  };
+}
+
 export function quest1DonePush(): WalletPushPayload {
   return {
     body: "Now flip on auto-deposit for Quest 2 — your USDC starts earning.",

--- a/apps/web/src/lib/push-notifications/wallet-push.server.ts
+++ b/apps/web/src/lib/push-notifications/wallet-push.server.ts
@@ -129,17 +129,22 @@ function formatUsd(amountUsd: number): string {
 // Earn "joy" layer (ASK-2091): the pushes that exist to make yield felt.
 // Every one of them carries a real number, because a reminder without an
 // amount is the marketing push these are meant not to be.
-
+//
+// Deliberately token-neutral, unlike the auto-deposit copy above: auto-deposit
+// sweeps one fixed mint (`getKaminoUsdcEarnTargetForCluster`), but Earn takes
+// any enabled stablecoin and the earnings these report are a USD total across
+// every position a wallet holds. Naming a token here would be wrong for a
+// USDG holder and unanswerable for a wallet holding two.
 export function firstYieldPush(amountUsd: number): WalletPushPayload {
   return {
     body: `${formatUsd(amountUsd)} so far, and it keeps going on its own.`,
-    title: "Your USDC just earned its first yield.",
+    title: "Your first yield just landed.",
   };
 }
 
 export function yieldDigestPush(amountUsd: number): WalletPushPayload {
   return {
-    body: "Your USDC kept working while you were away.",
+    body: "Your Earn balance kept working while you were away.",
     title: `+${formatUsd(amountUsd)} earned.`,
   };
 }
@@ -148,7 +153,7 @@ export function totalEarnedMilestonePush(
   milestoneUsd: number
 ): WalletPushPayload {
   return {
-    body: "All of it from USDC sitting in Earn.",
+    body: "All of it from your balance sitting in Earn.",
     title: `${formatUsd(milestoneUsd)} earned in total.`,
   };
 }

--- a/apps/web/src/lib/yield-optimization/earn-yield-joy.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-yield-joy.server.ts
@@ -1,0 +1,327 @@
+import "server-only";
+
+import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
+import {
+  appUsers,
+  appUserSmartAccounts,
+  earnYieldPushState,
+} from "@loyal-labs/db-core/schema";
+import type { SolanaEnv } from "@loyal-labs/solana-rpc";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getDatabase } from "@/lib/core/database";
+import {
+  firstYieldPush,
+  loyalAnniversaryPush,
+  sendWalletPush,
+  totalEarnedMilestonePush,
+  yieldDigestPush,
+  type WalletPushPayload,
+} from "@/lib/push-notifications/wallet-push.server";
+
+import {
+  EarnEarningsUnavailableError,
+  readEarnEarningsRangeSet,
+} from "./earnings-read-service.server";
+import {
+  selectEarnJoyPush,
+  type EarnJoyPush,
+  type EarnJoyState,
+} from "./earn-yield-joy.shared";
+
+// Daily driver for the Earn "joy" pushes (ASK-2091). Earnings are read through
+// the same service the app reads, so a push can never claim a number the Earn
+// screen would not show.
+const EARN_VAULT_INDEX = 1;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WALLET_CONCURRENCY = 5;
+// Leaves headroom under the route's 300s ceiling for the final state writes.
+const DEFAULT_TIME_BUDGET_MS = 240_000;
+
+export type EarnYieldJoyOutcome = {
+  campaign?: string;
+  amountUsd?: number;
+  status: "pushed" | "seeded" | "quiet" | "unavailable" | "error";
+  wallet: string;
+};
+
+export type EarnYieldJoySummary = {
+  candidates: number;
+  dryRun: boolean;
+  errors: number;
+  processed: number;
+  pushed: EarnYieldJoyOutcome[];
+  quiet: number;
+  seeded: number;
+  truncated: boolean;
+  unavailable: number;
+};
+
+type Candidate = {
+  createdAt: Date;
+  settingsPda: string;
+  walletAddress: string;
+};
+
+function joyPushPayload(push: EarnJoyPush): WalletPushPayload {
+  switch (push.type) {
+    case "first":
+      return firstYieldPush(push.amountUsd);
+    case "milestone":
+      return totalEarnedMilestonePush(push.amountUsd);
+    case "anniversary":
+      return loyalAnniversaryPush(push.months ?? 6, push.amountUsd);
+    case "digest":
+      return yieldDigestPush(push.amountUsd);
+  }
+}
+
+async function listCandidates(solanaEnv: SolanaEnv): Promise<Candidate[]> {
+  const rows = await getDatabase()
+    .select({
+      createdAt: appUsers.createdAt,
+      settingsPda: appUserSmartAccounts.settingsPda,
+      walletAddress: appUsers.subjectAddress,
+    })
+    .from(appUserSmartAccounts)
+    .innerJoin(appUsers, eq(appUserSmartAccounts.userId, appUsers.id))
+    .where(
+      and(
+        eq(appUserSmartAccounts.state, "ready"),
+        eq(appUserSmartAccounts.solanaEnv, solanaEnv)
+      )
+    )
+    .orderBy(desc(appUserSmartAccounts.updatedAt));
+
+  return rows.filter(
+    (row): row is Candidate =>
+      Boolean(row.settingsPda) && Boolean(row.walletAddress)
+  );
+}
+
+async function loadStates(
+  wallets: string[]
+): Promise<Map<string, EarnJoyState>> {
+  const states = new Map<string, EarnJoyState>();
+  if (wallets.length === 0) {
+    return states;
+  }
+  const rows = await getDatabase()
+    .select({
+      lastPushedAt: earnYieldPushState.lastPushedAt,
+      lastPushedEarnedUsd: earnYieldPushState.lastPushedEarnedUsd,
+      sentCampaigns: earnYieldPushState.sentCampaigns,
+      walletPublicKey: earnYieldPushState.walletPublicKey,
+    })
+    .from(earnYieldPushState)
+    .where(inArray(earnYieldPushState.walletPublicKey, wallets));
+
+  for (const row of rows) {
+    states.set(row.walletPublicKey, {
+      lastPushedAt: row.lastPushedAt,
+      lastPushedEarnedUsd: Number(row.lastPushedEarnedUsd),
+      sentCampaigns: row.sentCampaigns ?? [],
+    });
+  }
+  return states;
+}
+
+async function saveState(args: {
+  campaigns: string[];
+  lastPushedAt: Date | null;
+  lifetimeEarnedUsd: number;
+  walletAddress: string;
+}): Promise<void> {
+  const values = {
+    lastPushedAt: args.lastPushedAt,
+    lastPushedEarnedUsd: args.lifetimeEarnedUsd.toFixed(6),
+    sentCampaigns: args.campaigns,
+    updatedAt: new Date(),
+    walletPublicKey: args.walletAddress,
+  };
+  await getDatabase()
+    .insert(earnYieldPushState)
+    .values(values)
+    .onConflictDoUpdate({
+      set: {
+        lastPushedAt: values.lastPushedAt,
+        lastPushedEarnedUsd: values.lastPushedEarnedUsd,
+        sentCampaigns: values.sentCampaigns,
+        updatedAt: values.updatedAt,
+      },
+      target: earnYieldPushState.walletPublicKey,
+    });
+}
+
+async function readLifetimeEarnedUsd(args: {
+  cluster: string;
+  settings: string;
+  walletAddress: string;
+}): Promise<number | null> {
+  try {
+    const earnings = await readEarnEarningsRangeSet({
+      cluster: args.cluster,
+      settings: args.settings,
+      timezone: null,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress: args.walletAddress,
+    });
+    return earnings.ranges.ALL.lifetimeEarnedUsd;
+  } catch (error) {
+    if (error instanceof EarnEarningsUnavailableError) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function processCandidate(args: {
+  candidate: Candidate;
+  cluster: string;
+  dryRun: boolean;
+  now: Date;
+  state: EarnJoyState | null;
+}): Promise<EarnYieldJoyOutcome> {
+  const { candidate } = args;
+  const lifetimeEarnedUsd = await readLifetimeEarnedUsd({
+    cluster: args.cluster,
+    settings: candidate.settingsPda,
+    walletAddress: candidate.walletAddress,
+  });
+  if (lifetimeEarnedUsd === null) {
+    return { status: "unavailable", wallet: candidate.walletAddress };
+  }
+
+  const decision = selectEarnJoyPush({
+    accountAgeDays:
+      (args.now.getTime() - candidate.createdAt.getTime()) / DAY_MS,
+    lifetimeEarnedUsd,
+    now: args.now,
+    state: args.state,
+  });
+
+  if (decision.kind === "none") {
+    return { status: "quiet", wallet: candidate.walletAddress };
+  }
+
+  if (decision.kind === "seed") {
+    if (!args.dryRun) {
+      await saveState({
+        campaigns: decision.campaigns,
+        lastPushedAt: args.now,
+        lifetimeEarnedUsd,
+        walletAddress: candidate.walletAddress,
+      });
+    }
+    return { status: "seeded", wallet: candidate.walletAddress };
+  }
+
+  if (!args.dryRun) {
+    await sendWalletPush(
+      candidate.walletAddress,
+      joyPushPayload(decision.push)
+    );
+    // The digest reports what changed since the user was last told a number,
+    // so every push — not just a digest — rebases the baseline.
+    await saveState({
+      campaigns:
+        decision.push.type === "digest"
+          ? args.state?.sentCampaigns ?? []
+          : [...(args.state?.sentCampaigns ?? []), decision.push.campaign],
+      lastPushedAt: args.now,
+      lifetimeEarnedUsd,
+      walletAddress: candidate.walletAddress,
+    });
+  }
+
+  return {
+    amountUsd: decision.push.amountUsd,
+    campaign: decision.push.campaign,
+    status: "pushed",
+    wallet: candidate.walletAddress,
+  };
+}
+
+export async function runEarnYieldJoy(
+  options: { dryRun?: boolean; timeBudgetMs?: number } = {}
+): Promise<EarnYieldJoySummary> {
+  const dryRun = options.dryRun ?? false;
+  const deadline =
+    Date.now() + (options.timeBudgetMs ?? DEFAULT_TIME_BUDGET_MS);
+  const now = new Date();
+  const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
+  const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
+
+  const candidates = await listCandidates(solanaEnv);
+  const states = await loadStates(
+    candidates.map((candidate) => candidate.walletAddress)
+  );
+
+  const summary: EarnYieldJoySummary = {
+    candidates: candidates.length,
+    dryRun,
+    errors: 0,
+    processed: 0,
+    pushed: [],
+    quiet: 0,
+    seeded: 0,
+    truncated: false,
+    unavailable: 0,
+  };
+
+  const queue = [...candidates];
+  while (queue.length > 0) {
+    if (Date.now() > deadline) {
+      summary.truncated = true;
+      break;
+    }
+    const chunk = queue.splice(0, WALLET_CONCURRENCY);
+    const outcomes = await Promise.all(
+      chunk.map(async (candidate) => {
+        try {
+          return await processCandidate({
+            candidate,
+            cluster,
+            dryRun,
+            now,
+            state: states.get(candidate.walletAddress) ?? null,
+          });
+        } catch (error) {
+          console.warn("[earn-yield-joy] wallet failed", {
+            errorMessage:
+              error instanceof Error ? error.message : "Unknown error.",
+            wallet: candidate.walletAddress,
+          });
+          return {
+            status: "error" as const,
+            wallet: candidate.walletAddress,
+          };
+        }
+      })
+    );
+
+    for (const outcome of outcomes) {
+      summary.processed += 1;
+      switch (outcome.status) {
+        case "pushed":
+          summary.pushed.push(outcome);
+          break;
+        case "seeded":
+          summary.seeded += 1;
+          break;
+        case "quiet":
+          summary.quiet += 1;
+          break;
+        case "unavailable":
+          summary.unavailable += 1;
+          break;
+        case "error":
+          summary.errors += 1;
+          break;
+      }
+    }
+  }
+
+  return summary;
+}

--- a/apps/web/src/lib/yield-optimization/earn-yield-joy.shared.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-yield-joy.shared.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  earnDigestThresholdUsd,
+  selectEarnJoyPush,
+  type EarnJoyState,
+} from "./earn-yield-joy.shared";
+
+const NOW = new Date("2026-08-16T12:00:00.000Z");
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function state(overrides: Partial<EarnJoyState> = {}): EarnJoyState {
+  return {
+    lastPushedAt: daysAgo(1),
+    lastPushedEarnedUsd: 0,
+    sentCampaigns: [],
+    ...overrides,
+  };
+}
+
+describe("earn joy cadence", () => {
+  test("relaxes the bar the longer a wallet has heard nothing", () => {
+    expect(earnDigestThresholdUsd(0)).toBe(1);
+    expect(earnDigestThresholdUsd(6.9)).toBe(1);
+    expect(earnDigestThresholdUsd(7)).toBe(0.1);
+    expect(earnDigestThresholdUsd(30)).toBe(0.01);
+  });
+
+  test("pays out by position size without any per-user configuration", () => {
+    // ~5% APY: $10k earns ~$1.37/day, $1k ~$0.137/day, $10 ~$0.0014/day.
+    const digestAfter = (earnedPerDay: number, days: number) =>
+      selectEarnJoyPush({
+        accountAgeDays: 400,
+        lifetimeEarnedUsd: 5 + earnedPerDay * days,
+        now: NOW,
+        state: state({
+          lastPushedAt: daysAgo(days),
+          lastPushedEarnedUsd: 5,
+          // A wallet past its one-time moments; only the digest is left.
+          sentCampaigns: ["yield-first", "yield-six-months", "yield-one-year"],
+        }),
+      }).kind;
+
+    expect(digestAfter(1.37, 1)).toBe("push"); // $10k: daily
+    expect(digestAfter(0.137, 1)).toBe("none"); // $1k: not yet
+    expect(digestAfter(0.137, 8)).toBe("push"); // $1k: about weekly
+    expect(digestAfter(0.0014, 8)).toBe("none"); // $10: still dust at a week
+    expect(digestAfter(0.0014, 31)).toBe("push"); // $10: monthly note
+    expect(digestAfter(0.00014, 31)).toBe("none"); // dust: never
+  });
+
+  test("adopts an existing wallet silently instead of backdating milestones", () => {
+    const decision = selectEarnJoyPush({
+      accountAgeDays: 400,
+      lifetimeEarnedUsd: 150,
+      now: NOW,
+      state: null,
+    });
+
+    expect(decision).toEqual({
+      kind: "seed",
+      // $10 is passed but never announced: only the highest milestone counts.
+      campaigns: ["yield-first", "yield-total-100", "yield-one-year"],
+    });
+  });
+
+  test("sends the most meaningful moment first, one per run", () => {
+    const decision = selectEarnJoyPush({
+      accountAgeDays: 400,
+      lifetimeEarnedUsd: 120,
+      now: NOW,
+      state: state({ lastPushedEarnedUsd: 90, sentCampaigns: ["yield-first"] }),
+    });
+
+    expect(decision).toEqual({
+      kind: "push",
+      push: { amountUsd: 100, campaign: "yield-total-100", type: "milestone" },
+    });
+  });
+
+  test("never announces an anniversary with nothing to show", () => {
+    expect(
+      selectEarnJoyPush({
+        accountAgeDays: 400,
+        lifetimeEarnedUsd: 0.5,
+        now: NOW,
+        state: state({
+          lastPushedEarnedUsd: 0.5,
+          sentCampaigns: ["yield-first"],
+        }),
+      })
+    ).toEqual({ kind: "none" });
+  });
+});

--- a/apps/web/src/lib/yield-optimization/earn-yield-joy.shared.ts
+++ b/apps/web/src/lib/yield-optimization/earn-yield-joy.shared.ts
@@ -1,0 +1,181 @@
+// Decision layer for the automated Earn "joy" pushes (ASK-2091). Pure so the
+// cadence can be reasoned about (and tested) without a database, an RPC or a
+// push token.
+
+export const EARN_JOY_MILESTONES_USD = [10, 100, 1000] as const;
+
+export const EARN_JOY_ANNIVERSARIES = [
+  { campaign: "yield-one-year", days: 365, months: 12 },
+  { campaign: "yield-six-months", days: 183, months: 6 },
+] as const;
+
+export const FIRST_YIELD_CAMPAIGN = "yield-first";
+
+/** Below a cent there is nothing to report: "+$0.00" is worse than silence. */
+export const EARN_JOY_MIN_REPORTABLE_USD = 0.01;
+
+/** An anniversary push needs an amount worth showing. */
+export const ANNIVERSARY_MIN_EARNED_USD = 1;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How much a wallet must have earned since its last push before it is worth
+ * sending another one.
+ *
+ * The bar decays with silence instead of being fixed per user, which is what
+ * makes one rule fit every size of position. At ~5% APY a $10k position clears
+ * $1 in a day and hears daily; $1k clears it in a week; $100 needs the relaxed
+ * $0.10 bar and lands about every eight days; $10 only ever clears a cent, so
+ * it gets a monthly note; and a dust position never clears anything and stays
+ * quiet forever. No cohorts, no per-user configuration, no "whale" flag.
+ */
+export function earnDigestThresholdUsd(daysSinceLastPush: number): number {
+  if (daysSinceLastPush >= 30) {
+    return EARN_JOY_MIN_REPORTABLE_USD;
+  }
+  if (daysSinceLastPush >= 7) {
+    return 0.1;
+  }
+  return 1;
+}
+
+export type EarnJoyState = {
+  lastPushedEarnedUsd: number;
+  lastPushedAt: Date | null;
+  sentCampaigns: string[];
+};
+
+export type EarnJoyInput = {
+  accountAgeDays: number;
+  lifetimeEarnedUsd: number;
+  now: Date;
+  /** Null the first time this wallet is seen by the cron. */
+  state: EarnJoyState | null;
+};
+
+export type EarnJoyPush = {
+  amountUsd: number;
+  campaign: string;
+  months?: number;
+  type: "anniversary" | "digest" | "first" | "milestone";
+};
+
+export type EarnJoyDecision =
+  /** First sighting: adopt the wallet's current standing without pushing. */
+  | { kind: "seed"; campaigns: string[] }
+  | { kind: "push"; push: EarnJoyPush }
+  | { kind: "none" };
+
+/**
+ * One-time campaigns a wallet already qualifies for right now.
+ *
+ * Only the highest milestone and anniversary count: a wallet sitting at $150
+ * has passed $10 and $100, and telling it about $10 is a worse push than
+ * telling it nothing.
+ */
+export function qualifiedEarnJoyCampaigns(input: {
+  accountAgeDays: number;
+  lifetimeEarnedUsd: number;
+}): string[] {
+  const campaigns: string[] = [];
+  if (input.lifetimeEarnedUsd >= EARN_JOY_MIN_REPORTABLE_USD) {
+    campaigns.push(FIRST_YIELD_CAMPAIGN);
+  }
+  const milestone = [...EARN_JOY_MILESTONES_USD]
+    .reverse()
+    .find((value) => input.lifetimeEarnedUsd >= value);
+  if (milestone !== undefined) {
+    campaigns.push(`yield-total-${milestone}`);
+  }
+  if (input.lifetimeEarnedUsd >= ANNIVERSARY_MIN_EARNED_USD) {
+    const anniversary = EARN_JOY_ANNIVERSARIES.find(
+      (entry) => input.accountAgeDays >= entry.days
+    );
+    if (anniversary) {
+      campaigns.push(anniversary.campaign);
+    }
+  }
+  return campaigns;
+}
+
+/**
+ * At most one push per wallet per run, in the order of how much the moment
+ * means: a first yield beats a milestone, a milestone beats an anniversary,
+ * and anything beats the routine digest. Three pushes in one morning is how a
+ * channel gets muted.
+ */
+export function selectEarnJoyPush(input: EarnJoyInput): EarnJoyDecision {
+  const qualified = qualifiedEarnJoyCampaigns(input);
+
+  // A wallet the cron has never seen may already be months and dollars in.
+  // Adopting its standing silently is what keeps a deploy from turning into a
+  // broadcast of backdated milestones.
+  if (!input.state) {
+    return { kind: "seed", campaigns: qualified };
+  }
+
+  const sent = new Set(input.state.sentCampaigns);
+  const pending = qualified.filter((campaign) => !sent.has(campaign));
+
+  if (pending.includes(FIRST_YIELD_CAMPAIGN)) {
+    return {
+      kind: "push",
+      push: {
+        amountUsd: input.lifetimeEarnedUsd,
+        campaign: FIRST_YIELD_CAMPAIGN,
+        type: "first",
+      },
+    };
+  }
+
+  const milestone = [...EARN_JOY_MILESTONES_USD]
+    .reverse()
+    .find((value) => pending.includes(`yield-total-${value}`));
+  if (milestone !== undefined) {
+    return {
+      kind: "push",
+      push: {
+        amountUsd: milestone,
+        campaign: `yield-total-${milestone}`,
+        type: "milestone",
+      },
+    };
+  }
+
+  const anniversary = EARN_JOY_ANNIVERSARIES.find((entry) =>
+    pending.includes(entry.campaign)
+  );
+  if (anniversary) {
+    return {
+      kind: "push",
+      push: {
+        amountUsd: input.lifetimeEarnedUsd,
+        campaign: anniversary.campaign,
+        months: anniversary.months,
+        type: "anniversary",
+      },
+    };
+  }
+
+  const earnedSinceLastPush =
+    input.lifetimeEarnedUsd - input.state.lastPushedEarnedUsd;
+  const daysSinceLastPush = input.state.lastPushedAt
+    ? (input.now.getTime() - input.state.lastPushedAt.getTime()) / DAY_MS
+    : Number.POSITIVE_INFINITY;
+  if (
+    earnedSinceLastPush >= EARN_JOY_MIN_REPORTABLE_USD &&
+    earnedSinceLastPush >= earnDigestThresholdUsd(daysSinceLastPush)
+  ) {
+    return {
+      kind: "push",
+      push: {
+        amountUsd: earnedSinceLastPush,
+        campaign: "yield-digest",
+        type: "digest",
+      },
+    };
+  }
+
+  return { kind: "none" };
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/cron/earn-cleanup-reconcile",
       "schedule": "7,17,27,37,47,57 * * * *"
+    },
+    {
+      "path": "/api/cron/earn-yield-joy",
+      "schedule": "41 15 * * *"
     }
   ],
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ] || ! git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null; then exit 1; fi; git diff \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD --quiet -- . ../../packages",

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -752,6 +752,36 @@ export const pushTokens = pgTable(
   ]
 );
 
+// Per-wallet bookkeeping for the automated Earn "joy" pushes (ASK-2091).
+// One row per wallet holds both halves of the decision: the lifetime earnings
+// the user was last told about (so a digest reports the delta, not the total)
+// and the one-time pushes already sent. The joy cron is the only writer, so a
+// JSON set is enough and keeps this to a single upsert per wallet.
+export const earnYieldPushState = pgTable(
+  "earn_yield_push_state",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    walletPublicKey: text("wallet_public_key").notNull(),
+    lastPushedEarnedUsd: numeric("last_pushed_earned_usd", {
+      precision: 20,
+      scale: 6,
+    })
+      .notNull()
+      .default("0"),
+    lastPushedAt: timestamp("last_pushed_at", { withTimezone: true }),
+    sentCampaigns: jsonb("sent_campaigns").$type<string[]>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("earn_yield_push_state_wallet_uidx").on(table.walletPublicKey),
+  ]
+);
+
 export const pushNotificationSends = pgTable(
   "push_notification_sends",
   {
@@ -2080,6 +2110,8 @@ export type InsertBotMessage = typeof botMessages.$inferInsert;
 
 export type PushToken = typeof pushTokens.$inferSelect;
 export type InsertPushToken = typeof pushTokens.$inferInsert;
+export type EarnYieldPushState = typeof earnYieldPushState.$inferSelect;
+export type InsertEarnYieldPushState = typeof earnYieldPushState.$inferInsert;
 
 export type PushNotificationSend = typeof pushNotificationSends.$inferSelect;
 export type InsertPushNotificationSend =


### PR DESCRIPTION
Second half of ASK-2091: the Earn "joy" pushes. A daily cron reads lifetime earnings through the same service the Earn screen uses and sends at most one push per wallet — first yield, the highest total-earned milestone ($10/$100/$1000), the 6-month/1-year mark, or the "+$X earned" digest.

Digest cadence self-tunes by decaying the bar with silence: $1 within a week, $0.10 after a week, a cent after a month, never below a cent. At ~5% APY a $10k position hears daily, $1k about weekly, $10 monthly, and dust stays silent — no cohorts or per-user config. Wallets the cron has never seen are adopted silently so the first run cannot broadcast backdated milestones.

**Needs `bun db:migrate` (apps/telegram) for `0028_smiling_union_jack.sql` — the cron 500s until `earn_yield_push_state` exists.**