### PR TITLE
feat(admin): add vault rebalance frequency chart

### DIFF
--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { formatShortAddress } from "@/components/blockchain/address-link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  getEarnStablecoinSymbol,
+  STABLECOIN_DECIMALS,
+} from "@/lib/earn/stablecoin-monitor.shared";
+import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
+
+const NO_RESERVE_KEY = "__no_current_reserve__";
+const RESERVE_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--foreground)",
+] as const;
+
+export type SerializedEarnVaultRebalanceFrequencyRow = {
+  allCount: number;
+  currentDepositRaw: string;
+  currentReserve: string | null;
+  depositRank: number;
+  last12hCount: number;
+  last2hCount: number;
+  last7dCount: number;
+  liquidityMint: string | null;
+  positionCount: number;
+  vaultId: string;
+  vaultPubkey: string;
+};
+
+export type SerializedEarnVaultRebalanceFrequency = {
+  generatedAt: string;
+  status: "available" | "unavailable";
+  vaultCount: number;
+  vaults: SerializedEarnVaultRebalanceFrequencyRow[];
+};
+
+type RangeKey = "12h" | "2h" | "7d" | "all";
+type CountKey = "allCount" | "last7dCount" | "last12hCount" | "last2hCount";
+
+type ChartPoint = SerializedEarnVaultRebalanceFrequencyRow & {
+  depositRank: number;
+  rebalanceCount: number;
+};
+
+type ReserveSeries = {
+  apyStatus: SafeReserveApyStatusRow | null;
+  color: string;
+  key: string;
+  label: string;
+  reserve: string | null;
+  reserveKey: string;
+};
+
+const RANGE_OPTIONS: ReadonlyArray<{
+  countKey: CountKey;
+  key: RangeKey;
+  label: string;
+  tabLabel: string;
+}> = [
+  { countKey: "allCount", key: "all", label: "All history", tabLabel: "All" },
+  {
+    countKey: "last7dCount",
+    key: "7d",
+    label: "Last 7 days",
+    tabLabel: "7 days",
+  },
+  {
+    countKey: "last12hCount",
+    key: "12h",
+    label: "Last 12 hours",
+    tabLabel: "12 hours",
+  },
+  {
+    countKey: "last2hCount",
+    key: "2h",
+    label: "Last 2 hours",
+    tabLabel: "2 hours",
+  },
+];
+
+function compareRawAmounts(left: string, right: string): number {
+  const leftAmount = BigInt(left);
+  const rightAmount = BigInt(right);
+  return leftAmount < rightAmount ? -1 : leftAmount > rightAmount ? 1 : 0;
+}
+
+function formatApy(value: number | null): string {
+  return value === null ? "APY unavailable" : `${value.toFixed(2)}% APY`;
+}
+
+function formatDeposit(raw: string, liquidityMint: string | null): string {
+  const amount = BigInt(raw);
+  const scale = BigInt(10) ** BigInt(STABLECOIN_DECIMALS);
+  const whole = amount / scale;
+  const fractional = amount % scale;
+  const symbol = getEarnStablecoinSymbol(liquidityMint) ?? "nominal USD";
+
+  return `${whole.toLocaleString("en-US")}.${fractional
+    .toString()
+    .padStart(STABLECOIN_DECIMALS, "0")
+    .slice(0, 2)} ${symbol}`;
+}
+
+function formatCompactDeposit(
+  raw: string,
+  liquidityMint: string | null
+): string {
+  const amount = Number(BigInt(raw)) / 10 ** STABLECOIN_DECIMALS;
+  const symbol = getEarnStablecoinSymbol(liquidityMint) ?? "USD";
+
+  return `${new Intl.NumberFormat("en-US", {
+    compactDisplay: "short",
+    maximumFractionDigits: 2,
+    notation: "compact",
+  }).format(amount)} ${symbol}`;
+}
+
+function formatUtcTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function buildRankTicks(vaultCount: number): number[] {
+  const tickCount = Math.min(7, Math.max(vaultCount, 1));
+  return Array.from(
+    new Set(
+      Array.from({ length: tickCount }, (_, index) =>
+        Math.max(
+          1,
+          Math.round(
+            1 +
+              (index * Math.max(vaultCount - 1, 0)) / Math.max(tickCount - 1, 1)
+          )
+        )
+      )
+    )
+  );
+}
+
+function VaultFrequencyTooltip({
+  active,
+  payload,
+  rangeLabel,
+  reserveSeriesByKey,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartPoint }>;
+  rangeLabel: string;
+  reserveSeriesByKey: ReadonlyMap<string, ReserveSeries>;
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) {
+    return null;
+  }
+
+  const series = reserveSeriesByKey.get(point.currentReserve ?? NO_RESERVE_KEY);
+
+  return (
+    <div className="grid min-w-[18rem] gap-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium font-mono">
+        {formatShortAddress(point.vaultPubkey)}
+      </div>
+      <div className="text-lg font-semibold tabular-nums">
+        {point.rebalanceCount.toLocaleString("en-US")} rebalances
+      </div>
+      <div className="text-muted-foreground">{rangeLabel}</div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1">
+        <dt className="text-muted-foreground">Current deposit</dt>
+        <dd className="text-right font-medium tabular-nums">
+          {formatDeposit(point.currentDepositRaw, point.liquidityMint)}
+        </dd>
+        <dt className="text-muted-foreground">Deposit rank</dt>
+        <dd className="text-right tabular-nums">{point.depositRank}</dd>
+        <dt className="text-muted-foreground">Current reserve</dt>
+        <dd className="text-right">{series?.label ?? "No current reserve"}</dd>
+        <dt className="text-muted-foreground">Current APY</dt>
+        <dd className="text-right tabular-nums">
+          {formatApy(series?.apyStatus?.supplyApyPercent ?? null)}
+        </dd>
+        <dt className="text-muted-foreground">Reserve status</dt>
+        <dd className="text-right">
+          {series?.apyStatus?.status ?? "No reserve position"}
+        </dd>
+        <dt className="text-muted-foreground">Positive positions</dt>
+        <dd className="text-right tabular-nums">{point.positionCount}</dd>
+        <dt className="text-muted-foreground">All / 7d / 12h / 2h</dt>
+        <dd className="text-right tabular-nums">
+          {point.allCount} / {point.last7dCount} / {point.last12hCount} /{" "}
+          {point.last2hCount}
+        </dd>
+        <dt className="text-muted-foreground">Vault id</dt>
+        <dd className="text-right font-mono">{point.vaultId}</dd>
+      </dl>
+    </div>
+  );
+}
+
+export function EarnVaultRebalanceFrequencyChart({
+  data,
+  reserveStatuses,
+}: {
+  data: SerializedEarnVaultRebalanceFrequency;
+  reserveStatuses: SafeReserveApyStatusRow[];
+}) {
+  const [range, setRange] = useState<RangeKey>("all");
+  const [showTable, setShowTable] = useState(false);
+
+  const rangeOption =
+    RANGE_OPTIONS.find((option) => option.key === range) ?? RANGE_OPTIONS[0];
+  const rankedVaults = useMemo(
+    () =>
+      [...data.vaults]
+        .sort((left, right) => {
+          const amountOrder = compareRawAmounts(
+            left.currentDepositRaw,
+            right.currentDepositRaw
+          );
+          return (
+            amountOrder || left.vaultPubkey.localeCompare(right.vaultPubkey)
+          );
+        })
+        .map((vault, index) => ({
+          ...vault,
+          depositRank: index + 1,
+        })),
+    [data.vaults]
+  );
+  const points = useMemo(
+    () =>
+      rankedVaults.map(
+        (vault): ChartPoint => ({
+          ...vault,
+          rebalanceCount: vault[rangeOption.countKey],
+        })
+      ),
+    [rangeOption.countKey, rankedVaults]
+  );
+  const apyByReserve = useMemo(
+    () => new Map(reserveStatuses.map((status) => [status.reserve, status])),
+    [reserveStatuses]
+  );
+  const reserveSeries = useMemo(() => {
+    const reserves = [
+      ...new Set(rankedVaults.map((vault) => vault.currentReserve)),
+    ];
+    return reserves
+      .map((reserve) => {
+        const status =
+          reserve === null ? null : apyByReserve.get(reserve) ?? null;
+        return {
+          apyStatus: status,
+          label:
+            reserve === null
+              ? "No current reserve"
+              : status?.marketName ??
+                status?.market ??
+                formatShortAddress(reserve),
+          reserve,
+          reserveKey: reserve ?? NO_RESERVE_KEY,
+        };
+      })
+      .sort((left, right) => {
+        if (left.reserve === null) {
+          return 1;
+        }
+        if (right.reserve === null) {
+          return -1;
+        }
+        return left.label.localeCompare(right.label);
+      })
+      .map(
+        (series, index): ReserveSeries => ({
+          ...series,
+          color:
+            series.reserve === null
+              ? "var(--muted-foreground)"
+              : RESERVE_COLORS[index % RESERVE_COLORS.length],
+          key: `reserve${index}`,
+        })
+      );
+  }, [apyByReserve, rankedVaults]);
+  const reserveSeriesByKey = useMemo(
+    () => new Map(reserveSeries.map((series) => [series.reserveKey, series])),
+    [reserveSeries]
+  );
+  const config = Object.fromEntries(
+    reserveSeries.map((series) => [
+      series.key,
+      { color: series.color, label: series.label },
+    ])
+  ) satisfies ChartConfig;
+  const vaultByRank = new Map(
+    points.map((point) => [point.depositRank, point])
+  );
+  const rankTicks = buildRankTicks(points.length);
+  const maxCount = points.reduce(
+    (maximum, point) => Math.max(maximum, point.rebalanceCount),
+    0
+  );
+  const rebalancedVaultCount = points.filter(
+    (point) => point.rebalanceCount > 0
+  ).length;
+  const totalRebalances = points.reduce(
+    (total, point) => total + point.rebalanceCount,
+    0
+  );
+  const tableRows = [...points].reverse().slice(0, 100);
+
+  if (data.status === "unavailable") {
+    return (
+      <Card
+        className="min-w-0"
+        aria-labelledby="vault-rebalance-frequency-title"
+      >
+        <CardHeader>
+          <CardTitle id="vault-rebalance-frequency-title">
+            Earn vault rebalance frequency
+          </CardTitle>
+          <CardDescription>
+            Vault-level frequency is temporarily unavailable. The other Earn
+            rebalance monitors remain independent and available.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="min-w-0" aria-labelledby="vault-rebalance-frequency-title">
+      <Tabs
+        value={range}
+        onValueChange={(value) => setRange(value as RangeKey)}
+      >
+        <CardHeader className="gap-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <CardTitle id="vault-rebalance-frequency-title">
+                Earn vault rebalance frequency
+              </CardTitle>
+              <CardDescription>
+                One dot per funded active vault. X orders current deposits from
+                smallest to largest; Y shows confirmed reserve-to-reserve
+                rebalances in the selected window. Dot color is the largest
+                current reserve position.
+              </CardDescription>
+            </div>
+            <Button
+              aria-pressed={showTable}
+              onClick={() => setShowTable((value) => !value)}
+              size="sm"
+              type="button"
+              variant={showTable ? "secondary" : "outline"}
+            >
+              Table
+            </Button>
+          </div>
+          <TabsList
+            aria-label="Vault rebalance frequency window"
+            className="w-fit max-w-full"
+          >
+            {RANGE_OPTIONS.map((option) => (
+              <TabsTrigger key={option.key} value={option.key}>
+                {option.tabLabel}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            <span>{points.length.toLocaleString("en-US")} funded vaults</span>
+            <span>
+              {rebalancedVaultCount.toLocaleString("en-US")} with rebalances
+            </span>
+            <span>
+              {totalRebalances.toLocaleString("en-US")} confirmed executions ·{" "}
+              {rangeOption.label}
+            </span>
+            <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {reserveSeries.map((series) => (
+              <span
+                className="inline-flex items-center gap-1.5"
+                key={series.key}
+              >
+                <span
+                  aria-hidden
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: series.color }}
+                />
+                {series.label} ·{" "}
+                {formatApy(series.apyStatus?.supplyApyPercent ?? null)}
+              </span>
+            ))}
+          </div>
+        </CardHeader>
+        {RANGE_OPTIONS.map((option) => (
+          <TabsContent className="mt-0" key={option.key} value={option.key}>
+            {range === option.key ? (
+              <CardContent className="min-w-0">
+                {points.length === 0 ? (
+                  <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+                    No funded active Earn vaults are available.
+                  </div>
+                ) : showTable ? (
+                  <div className="max-h-[460px] overflow-auto rounded-md border">
+                    <Table>
+                      <TableHeader className="sticky top-0 bg-card">
+                        <TableRow>
+                          <TableHead className="text-right">
+                            Deposit rank
+                          </TableHead>
+                          <TableHead>Vault</TableHead>
+                          <TableHead>Mint</TableHead>
+                          <TableHead>Current reserve</TableHead>
+                          <TableHead className="text-right">
+                            Current APY
+                          </TableHead>
+                          <TableHead className="text-right">
+                            Current deposit
+                          </TableHead>
+                          <TableHead className="text-right">All</TableHead>
+                          <TableHead className="text-right">7d</TableHead>
+                          <TableHead className="text-right">12h</TableHead>
+                          <TableHead className="text-right">2h</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {tableRows.map((point) => {
+                          const series = reserveSeriesByKey.get(
+                            point.currentReserve ?? NO_RESERVE_KEY
+                          );
+                          return (
+                            <TableRow key={point.vaultId}>
+                              <TableCell className="text-right tabular-nums">
+                                {point.depositRank}
+                              </TableCell>
+                              <TableCell className="whitespace-nowrap font-mono">
+                                {formatShortAddress(point.vaultPubkey)}
+                              </TableCell>
+                              <TableCell className="font-medium">
+                                {getEarnStablecoinSymbol(point.liquidityMint) ??
+                                  "Unknown"}
+                              </TableCell>
+                              <TableCell className="whitespace-nowrap">
+                                {series?.label ?? "No current reserve"}
+                              </TableCell>
+                              <TableCell className="text-right whitespace-nowrap tabular-nums">
+                                {formatApy(
+                                  series?.apyStatus?.supplyApyPercent ?? null
+                                )}
+                              </TableCell>
+                              <TableCell className="text-right whitespace-nowrap tabular-nums">
+                                {formatDeposit(
+                                  point.currentDepositRaw,
+                                  point.liquidityMint
+                                )}
+                              </TableCell>
+                              <TableCell className="text-right tabular-nums">
+                                {point.allCount}
+                              </TableCell>
+                              <TableCell className="text-right tabular-nums">
+                                {point.last7dCount}
+                              </TableCell>
+                              <TableCell className="text-right tabular-nums">
+                                {point.last12hCount}
+                              </TableCell>
+                              <TableCell className="text-right tabular-nums">
+                                {point.last2hCount}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                ) : (
+                  <ChartContainer
+                    className="aspect-auto h-[420px] w-full min-w-0"
+                    config={config}
+                  >
+                    <ScatterChart
+                      accessibilityLayer
+                      margin={{ bottom: 16, left: 8, right: 16, top: 12 }}
+                    >
+                      <CartesianGrid />
+                      <XAxis
+                        allowDecimals={false}
+                        axisLine={false}
+                        dataKey="depositRank"
+                        domain={[1, Math.max(points.length, 1)]}
+                        name="Current deposit amount"
+                        tickFormatter={(rank: number) => {
+                          const vault = vaultByRank.get(rank);
+                          return vault
+                            ? formatCompactDeposit(
+                                vault.currentDepositRaw,
+                                vault.liquidityMint
+                              )
+                            : `#${rank}`;
+                        }}
+                        tickLine={false}
+                        tickMargin={8}
+                        ticks={rankTicks}
+                        type="number"
+                      />
+                      <YAxis
+                        allowDecimals={false}
+                        axisLine={false}
+                        dataKey="rebalanceCount"
+                        domain={[0, Math.max(maxCount, 1)]}
+                        name="Confirmed rebalances"
+                        tickLine={false}
+                        width={48}
+                      />
+                      <ZAxis range={[22, 22]} />
+                      <ChartTooltip
+                        content={
+                          <VaultFrequencyTooltip
+                            rangeLabel={rangeOption.label}
+                            reserveSeriesByKey={reserveSeriesByKey}
+                          />
+                        }
+                        cursor={{ strokeDasharray: "3 3" }}
+                      />
+                      {reserveSeries.map((series) => (
+                        <Scatter
+                          data={points.filter(
+                            (point) =>
+                              (point.currentReserve ?? NO_RESERVE_KEY) ===
+                              series.reserveKey
+                          )}
+                          fill={`var(--color-${series.key})`}
+                          key={series.key}
+                          name={series.label}
+                        />
+                      ))}
+                    </ScatterChart>
+                  </ChartContainer>
+                )}
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {maxCount === 0
+                    ? "No confirmed rebalances occurred in this window; every vault is shown at zero."
+                    : "Hover a dot for the exact vault, current deposit, reserve APY, and counts for every window."}
+                  {showTable
+                    ? " The table shows the 100 largest current deposits."
+                    : " Idle-only vaults use the neutral legend color."}
+                </p>
+              </CardContent>
+            ) : null}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </Card>
+  );
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -113,6 +113,16 @@ function formatStablecoinRaw(
     .slice(0, 2)} ${getEarnStablecoinSymbol(liquidityMint) ?? "nominal USD"}`;
 }
 
+function formatCompactStablecoinRaw(raw: string): string {
+  const amount = Number(BigInt(raw)) / 10 ** STABLECOIN_DECIMALS;
+
+  return `$${new Intl.NumberFormat("en-US", {
+    compactDisplay: "short",
+    maximumFractionDigits: 2,
+    notation: "compact",
+  }).format(amount)}`;
+}
+
 function rangeLabel(range: RangeKey): string {
   if (range === "7d") {
     return "Last 7 days";
@@ -227,7 +237,6 @@ export function ExecutedEarnRebalancesChart({
     points.map((point) => [
       point.userRank,
       {
-        authority: point.authority,
         currentDepositRaw: point.currentDepositRaw,
       },
     ])
@@ -420,10 +429,12 @@ export function ExecutedEarnRebalancesChart({
                 axisLine={false}
                 dataKey="userRank"
                 domain={[1, Math.max(data.userCount, 1)]}
-                name="User ordered by current deposit"
+                name="Current deposit amount"
                 tickFormatter={(rank: number) => {
                   const user = userByRank.get(rank);
-                  return user ? formatShortAddress(user.authority) : `#${rank}`;
+                  return user
+                    ? formatCompactStablecoinRaw(user.currentDepositRaw)
+                    : `#${rank}`;
                 }}
                 tickLine={false}
                 ticks={yTicks}
@@ -452,7 +463,7 @@ export function ExecutedEarnRebalancesChart({
         )}
         {!showTable ? (
           <p className="mt-3 text-xs text-muted-foreground">
-            Y-axis labels sample the ordered user ranks; hover a dot for the
+            Y-axis labels sample current deposit amounts; hover a dot for the
             exact wallet, current deposit, route, amount, decision, and slot.
           </p>
         ) : (

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -23,7 +23,36 @@ const chartConfig = {
     color: "var(--chart-2)",
     label: "Confirmed",
   },
+  expiredSubmissions: {
+    color: "var(--muted-foreground)",
+    label: "Expired submissions",
+  },
+  failedDecisions: {
+    color: "var(--chart-5)",
+    label: "Failed decisions",
+  },
+  failedOpportunities: {
+    color: "var(--chart-4)",
+    label: "Failed opportunities",
+  },
+  fleetClaims: {
+    color: "var(--chart-3)",
+    label: "Fleet claims",
+  },
+  terminalAttempts: {
+    color: "var(--chart-1)",
+    label: "Terminal attempts",
+  },
 } satisfies ChartConfig;
+
+const activitySeries = [
+  { key: "confirmed", yAxisId: "events" },
+  { key: "terminalAttempts", yAxisId: "events" },
+  { key: "fleetClaims", yAxisId: "claims" },
+  { key: "failedDecisions", yAxisId: "events" },
+  { key: "failedOpportunities", yAxisId: "events" },
+  { key: "expiredSubmissions", yAxisId: "events" },
+] as const;
 
 function formatTickDate(value: unknown) {
   if (typeof value !== "string") {
@@ -69,28 +98,28 @@ function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
   return (
     <div className="min-w-0 space-y-2">
       <div className="flex flex-wrap items-center justify-between gap-2 px-2 text-xs">
-        <span className="font-medium text-muted-foreground">
-          Confirmed rebalances
-        </span>
+        <span className="font-medium text-muted-foreground">Activity</span>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
-          <span className="flex items-center gap-1.5">
-            <span
-              aria-hidden
-              className="h-0.5 w-3 rounded-full"
-              style={{ backgroundColor: chartConfig.confirmed.color }}
-            />
-            {chartConfig.confirmed.label}
-          </span>
+          {activitySeries.map(({ key }) => (
+            <span className="flex items-center gap-1.5" key={key}>
+              <span
+                aria-hidden
+                className="h-0.5 w-3 rounded-full"
+                style={{ backgroundColor: chartConfig[key].color }}
+              />
+              {chartConfig[key].label}
+            </span>
+          ))}
         </div>
       </div>
       <ChartContainer
-        className="aspect-auto h-[220px] w-full min-w-0 sm:h-[260px]"
+        className="aspect-auto h-[260px] w-full min-w-0 sm:h-[300px]"
         config={chartConfig}
       >
         <LineChart
           accessibilityLayer
           data={data}
-          margin={{ bottom: 20, left: 4, right: 16, top: 8 }}
+          margin={{ bottom: 20, left: 4, right: 4, top: 8 }}
         >
           <CartesianGrid vertical={false} />
           <XAxis
@@ -108,7 +137,17 @@ function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
             axisLine={false}
             domain={[0, (maximum: number) => Math.max(1, maximum)]}
             tickLine={false}
-            width={36}
+            width={40}
+            yAxisId="events"
+          />
+          <YAxis
+            allowDecimals={false}
+            axisLine={false}
+            domain={[0, (maximum: number) => Math.max(1, maximum)]}
+            orientation="right"
+            tickLine={false}
+            width={48}
+            yAxisId="claims"
           />
           <ChartTooltip
             content={
@@ -118,13 +157,17 @@ function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
               />
             }
           />
-          <Line
-            dataKey="confirmed"
-            dot={false}
-            stroke="var(--color-confirmed)"
-            strokeWidth={2}
-            type="linear"
-          />
+          {activitySeries.map(({ key, yAxisId }) => (
+            <Line
+              dataKey={key}
+              dot={false}
+              key={key}
+              stroke={`var(--color-${key})`}
+              strokeWidth={2}
+              type="linear"
+              yAxisId={yAxisId}
+            />
+          ))}
         </LineChart>
       </ChartContainer>
     </div>
@@ -154,8 +197,9 @@ export function RebalanceActivityChart({
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">Rebalance activity</CardTitle>
           <CardDescription>
-            Confirmed executions from the last 72 hours in two-hour UTC buckets
-            from Yield Neon. Render-only errors are not included.
+            Last 72 hours in two-hour UTC buckets from Yield Neon. Fleet claims
+            use the right axis; all other series use the left axis. Render-only
+            errors are not included.
           </CardDescription>
         </div>
         <div className="flex">

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -23,29 +23,7 @@ const chartConfig = {
     color: "var(--chart-2)",
     label: "Confirmed",
   },
-  expiredSubmissions: {
-    color: "var(--muted-foreground)",
-    label: "Expired submissions",
-  },
-  failedDecisions: {
-    color: "var(--chart-2)",
-    label: "Failed decisions",
-  },
-  failedOpportunities: {
-    color: "var(--chart-4)",
-    label: "Failed opportunities",
-  },
-  fleetClaims: {
-    color: "var(--chart-3)",
-    label: "Fleet claims",
-  },
-  terminalAttempts: {
-    color: "var(--chart-1)",
-    label: "Terminal attempts",
-  },
 } satisfies ChartConfig;
-
-type SeriesKey = keyof typeof chartConfig;
 
 function formatTickDate(value: unknown) {
   if (typeof value !== "string") {
@@ -87,34 +65,26 @@ function formatTooltipDate(value: unknown) {
   }).format(date);
 }
 
-function ActivityPanel({
-  data,
-  label,
-  series,
-}: {
-  data: RebalanceActivityPoint[];
-  label: string;
-  series: SeriesKey[];
-}) {
+function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
   return (
     <div className="min-w-0 space-y-2">
       <div className="flex flex-wrap items-center justify-between gap-2 px-2 text-xs">
-        <span className="font-medium text-muted-foreground">{label}</span>
+        <span className="font-medium text-muted-foreground">
+          Confirmed rebalances
+        </span>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
-          {series.map((key) => (
-            <span className="flex items-center gap-1.5" key={key}>
-              <span
-                aria-hidden
-                className="h-0.5 w-3 rounded-full"
-                style={{ backgroundColor: chartConfig[key].color }}
-              />
-              {chartConfig[key].label}
-            </span>
-          ))}
+          <span className="flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="h-0.5 w-3 rounded-full"
+              style={{ backgroundColor: chartConfig.confirmed.color }}
+            />
+            {chartConfig.confirmed.label}
+          </span>
         </div>
       </div>
       <ChartContainer
-        className="aspect-auto h-[150px] w-full min-w-0"
+        className="aspect-auto h-[220px] w-full min-w-0 sm:h-[260px]"
         config={chartConfig}
       >
         <LineChart
@@ -148,16 +118,13 @@ function ActivityPanel({
               />
             }
           />
-          {series.map((key) => (
-            <Line
-              dataKey={key}
-              dot={false}
-              key={key}
-              stroke={`var(--color-${key})`}
-              strokeWidth={2}
-              type="linear"
-            />
-          ))}
+          <Line
+            dataKey="confirmed"
+            dot={false}
+            stroke="var(--color-confirmed)"
+            strokeWidth={2}
+            type="linear"
+          />
         </LineChart>
       </ChartContainer>
     </div>
@@ -187,9 +154,8 @@ export function RebalanceActivityChart({
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">Rebalance activity</CardTitle>
           <CardDescription>
-            Last 72 hours in two-hour UTC buckets from Yield Neon. Failures are
-            persisted states; fleet claims are current attempt counts attributed
-            to opportunity creation time. Render-only errors are not included.
+            Confirmed executions from the last 72 hours in two-hour UTC buckets
+            from Yield Neon. Render-only errors are not included.
           </CardDescription>
         </div>
         <div className="flex">
@@ -209,22 +175,8 @@ export function RebalanceActivityChart({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-5 px-2 pt-6 sm:p-6">
-        <ActivityPanel
-          data={data}
-          label="Outcomes"
-          series={["confirmed", "terminalAttempts"]}
-        />
-        <ActivityPanel data={data} label="Claims" series={["fleetClaims"]} />
-        <ActivityPanel
-          data={data}
-          label="Failures"
-          series={[
-            "failedDecisions",
-            "failedOpportunities",
-            "expiredSubmissions",
-          ]}
-        />
+      <CardContent className="px-2 pt-6 sm:p-6">
+        <ActivityTimeSeries data={data} />
       </CardContent>
     </Card>
   );

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -119,6 +119,26 @@ export type ExecutedEarnRebalanceHistory = {
   userCount: number;
 };
 
+export type EarnVaultRebalanceFrequencyRow = {
+  allCount: number;
+  currentDepositRaw: bigint;
+  currentReserve: string | null;
+  depositRank: number;
+  last12hCount: number;
+  last2hCount: number;
+  last7dCount: number;
+  liquidityMint: string | null;
+  positionCount: number;
+  vaultId: string;
+  vaultPubkey: string;
+};
+
+export type EarnVaultRebalanceFrequency = {
+  generatedAt: string;
+  vaultCount: number;
+  vaults: EarnVaultRebalanceFrequencyRow[];
+};
+
 export type RebalanceAuditRow = {
   abandonReason: string | null;
   amountRaw: bigint | null;
@@ -253,6 +273,21 @@ type ExecutedEarnRebalanceSqlRow = {
   target_reserve: string;
   user_count: SqlScalar;
   user_rank: SqlScalar;
+};
+
+type EarnVaultRebalanceFrequencySqlRow = {
+  all_count: SqlScalar;
+  current_deposit_raw: SqlScalar;
+  current_reserve: string | null;
+  deposit_rank: SqlScalar;
+  last_12h_count: SqlScalar;
+  last_2h_count: SqlScalar;
+  last_7d_count: SqlScalar;
+  liquidity_mint: string | null;
+  position_count: SqlScalar;
+  vault_count: SqlScalar;
+  vault_id: string;
+  vault_pubkey: string;
 };
 
 type RebalanceAuditSqlRow = {
@@ -1548,6 +1583,210 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
     })),
     generatedAt: new Date().toISOString(),
     userCount: rows.length > 0 ? toNumber(rows[0].user_count) : 0,
+  };
+}
+
+export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalanceFrequency> {
+  const rows = await queryRows<EarnVaultRebalanceFrequencySqlRow>(
+    `
+      WITH active_vaults AS MATERIALIZED (
+        SELECT id, vault_pubkey
+        FROM loyal_yield.managed_vaults
+        WHERE active = true
+          AND vault_index = 1
+      ),
+      normalized_positions AS MATERIALIZED (
+        SELECT
+          position.vault_id,
+          position.reserve,
+          position.liquidity_mint,
+          position.observed_at,
+          CASE
+            WHEN COALESCE(
+              position.planning_metadata->>'amountSemantics',
+              position.planning_metadata->>'amount_semantics'
+            ) IN (
+              'kamino_redeemable_liquidity',
+              'redeemable_liquidity_amount'
+            )
+              THEN position.amount_raw
+            WHEN COALESCE(
+              position.planning_metadata->>'amountSemantics',
+              position.planning_metadata->>'amount_semantics'
+            ) = 'kamino_obligation_collateral_deposited_amount'
+              AND COALESCE(
+                position.planning_metadata->>'redeemable_liquidity_amount_raw',
+                position.planning_metadata->>'redeemable_source_liquidity_amount_raw'
+              ) ~ '^[0-9]+$'
+              THEN COALESCE(
+                position.planning_metadata->>'redeemable_liquidity_amount_raw',
+                position.planning_metadata->>'redeemable_source_liquidity_amount_raw'
+              )::bigint
+            ELSE 0::bigint
+          END AS normalized_amount_raw
+        FROM active_vaults AS vault
+        INNER JOIN LATERAL (
+          SELECT position.*
+          FROM loyal_yield.vault_reserve_positions_current AS position
+          WHERE position.vault_id = vault.id
+            AND position.has_value = true
+            AND position.amount_raw > 0
+          OFFSET 0
+        ) AS position ON true
+      ),
+      positive_positions AS MATERIALIZED (
+        SELECT *
+        FROM normalized_positions
+        WHERE normalized_amount_raw > 0
+      ),
+      position_totals AS MATERIALIZED (
+        SELECT
+          vault_id,
+          SUM(normalized_amount_raw)::bigint AS amount_raw,
+          COUNT(*)::integer AS position_count
+        FROM positive_positions
+        GROUP BY vault_id
+      ),
+      primary_positions AS MATERIALIZED (
+        SELECT vault_id, reserve, liquidity_mint
+        FROM (
+          SELECT
+            position.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY position.vault_id
+              ORDER BY
+                position.normalized_amount_raw DESC,
+                position.observed_at DESC NULLS LAST,
+                position.reserve ASC
+            ) AS priority
+          FROM positive_positions AS position
+        ) AS ranked
+        WHERE priority = 1
+      ),
+      positive_idle AS MATERIALIZED (
+        SELECT idle.*
+        FROM active_vaults AS vault
+        INNER JOIN LATERAL (
+          SELECT idle.*
+          FROM loyal_yield.vault_idle_token_balances_current AS idle
+          WHERE idle.vault_id = vault.id
+            AND idle.amount_raw > 0
+          OFFSET 0
+        ) AS idle ON true
+      ),
+      idle_totals AS MATERIALIZED (
+        SELECT vault_id, SUM(amount_raw)::bigint AS amount_raw
+        FROM positive_idle
+        GROUP BY vault_id
+      ),
+      primary_idle AS MATERIALIZED (
+        SELECT vault_id, mint
+        FROM (
+          SELECT
+            idle.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY idle.vault_id
+              ORDER BY
+                idle.amount_raw DESC,
+                idle.observed_at DESC NULLS LAST,
+                idle.mint ASC
+            ) AS priority
+          FROM positive_idle AS idle
+        ) AS ranked
+        WHERE priority = 1
+      ),
+      rebalance_counts AS MATERIALIZED (
+        SELECT
+          decision.vault_id,
+          COUNT(*)::integer AS all_count,
+          COUNT(*) FILTER (
+            WHERE decision.updated_at >= NOW() - INTERVAL '7 days'
+          )::integer AS last_7d_count,
+          COUNT(*) FILTER (
+            WHERE decision.updated_at >= NOW() - INTERVAL '12 hours'
+          )::integer AS last_12h_count,
+          COUNT(*) FILTER (
+            WHERE decision.updated_at >= NOW() - INTERVAL '2 hours'
+          )::integer AS last_2h_count
+        FROM loyal_yield.rebalance_decisions AS decision
+        WHERE decision.status = 'confirmed'
+          AND decision.source_reserve IS NOT NULL
+          AND decision.target_reserve IS NOT NULL
+        GROUP BY decision.vault_id
+      ),
+      current_vaults AS MATERIALIZED (
+        SELECT
+          vault.id,
+          vault.vault_pubkey,
+          primary_position.reserve AS current_reserve,
+          COALESCE(primary_position.liquidity_mint, primary_idle.mint)
+            AS liquidity_mint,
+          COALESCE(position_total.amount_raw, 0::bigint)
+            + COALESCE(idle_total.amount_raw, 0::bigint)
+            AS current_deposit_raw,
+          COALESCE(position_total.position_count, 0) AS position_count,
+          COALESCE(rebalance.all_count, 0) AS all_count,
+          COALESCE(rebalance.last_7d_count, 0) AS last_7d_count,
+          COALESCE(rebalance.last_12h_count, 0) AS last_12h_count,
+          COALESCE(rebalance.last_2h_count, 0) AS last_2h_count
+        FROM active_vaults AS vault
+        LEFT JOIN position_totals AS position_total
+          ON position_total.vault_id = vault.id
+        LEFT JOIN primary_positions AS primary_position
+          ON primary_position.vault_id = vault.id
+        LEFT JOIN idle_totals AS idle_total
+          ON idle_total.vault_id = vault.id
+        LEFT JOIN primary_idle
+          ON primary_idle.vault_id = vault.id
+        LEFT JOIN rebalance_counts AS rebalance
+          ON rebalance.vault_id = vault.id
+        WHERE COALESCE(position_total.amount_raw, 0::bigint)
+          + COALESCE(idle_total.amount_raw, 0::bigint) > 0
+      ),
+      ranked_vaults AS MATERIALIZED (
+        SELECT
+          current_vault.*,
+          ROW_NUMBER() OVER (
+            ORDER BY
+              current_vault.current_deposit_raw ASC,
+              current_vault.vault_pubkey ASC
+          )::integer AS deposit_rank
+        FROM current_vaults AS current_vault
+      )
+      SELECT
+        ranked_vault.id::text AS vault_id,
+        ranked_vault.vault_pubkey,
+        ranked_vault.current_reserve,
+        ranked_vault.liquidity_mint,
+        ranked_vault.current_deposit_raw::text,
+        ranked_vault.position_count::text,
+        ranked_vault.all_count::text,
+        ranked_vault.last_7d_count::text,
+        ranked_vault.last_12h_count::text,
+        ranked_vault.last_2h_count::text,
+        ranked_vault.deposit_rank::text,
+        MAX(ranked_vault.deposit_rank) OVER ()::text AS vault_count
+      FROM ranked_vaults AS ranked_vault
+      ORDER BY ranked_vault.deposit_rank ASC
+    `
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    vaultCount: rows.length > 0 ? toNumber(rows[0].vault_count) : 0,
+    vaults: rows.map((row) => ({
+      allCount: toNumber(row.all_count),
+      currentDepositRaw: toBigInt(row.current_deposit_raw),
+      currentReserve: row.current_reserve,
+      depositRank: toNumber(row.deposit_rank),
+      last12hCount: toNumber(row.last_12h_count),
+      last2hCount: toNumber(row.last_2h_count),
+      last7dCount: toNumber(row.last_7d_count),
+      liquidityMint: row.liquidity_mint,
+      positionCount: toNumber(row.position_count),
+      vaultId: row.vault_id,
+      vaultPubkey: row.vault_pubkey,
+    })),
   };
 }
 

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -51,6 +51,10 @@ import {
   type SerializedAutodepositFailureRange,
 } from "./autodeposit-failures-chart";
 import {
+  EarnVaultRebalanceFrequencyChart,
+  type SerializedEarnVaultRebalanceFrequency,
+} from "./earn-vault-rebalance-frequency-chart";
+import {
   ExecutedEarnRebalancesChart,
   type SerializedExecutedEarnRebalanceHistory,
 } from "./executed-earn-rebalances-chart";
@@ -102,6 +106,7 @@ type RebalanceApiData = {
   executedRebalances: SerializedExecutedEarnRebalanceHistory;
   last30DaysRebalances: Last30DaysRebalancePoint[];
   routes: SerializedActiveReserveRouteRow[];
+  vaultRebalanceFrequency: SerializedEarnVaultRebalanceFrequency;
 };
 
 type LoadState =
@@ -1418,6 +1423,16 @@ export function RebalanceMonitorClient() {
         ),
       }
     : state.data.executedRebalances;
+  const filteredFrequencyVaults = selectedMintAddress
+    ? state.data.vaultRebalanceFrequency.vaults.filter(
+        (vault) => vault.liquidityMint === selectedMintAddress
+      )
+    : state.data.vaultRebalanceFrequency.vaults;
+  const filteredVaultRebalanceFrequency = {
+    ...state.data.vaultRebalanceFrequency,
+    vaultCount: filteredFrequencyVaults.length,
+    vaults: filteredFrequencyVaults,
+  };
 
   return (
     <div className="mx-auto grid w-full max-w-4xl gap-6">
@@ -1425,8 +1440,9 @@ export function RebalanceMonitorClient() {
         <CardHeader>
           <CardTitle className="font-bold">Stablecoin filter</CardTitle>
           <CardDescription>
-            Filters verified reserves and the confirmed execution chart. The
-            aggregate activity and paginated audit sections remain all-mint.
+            Filters verified reserves, confirmed executions, and vault
+            frequency. The aggregate activity and paginated audit sections
+            remain all-mint.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -1457,6 +1473,10 @@ export function RebalanceMonitorClient() {
       <ExecutedEarnRebalancesChart
         data={filteredExecutedRebalances}
         reserveLabels={reserveLabels}
+      />
+      <EarnVaultRebalanceFrequencyChart
+        data={filteredVaultRebalanceFrequency}
+        reserveStatuses={filteredApyData.statuses}
       />
       <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />
       <AutodepositFailuresChart data={state.data.autodeposit} />

--- a/apps/admin/src/app/api/earn/rebalance/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/route.ts
@@ -7,6 +7,7 @@ import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
 import {
   getActiveReserveRoutes,
   getAutodepositTimeSeries,
+  getEarnVaultRebalanceFrequency,
   getExecutedEarnRebalanceHistory,
   getLast30DaysRebalanceSeries,
   getRebalanceActivity,
@@ -17,22 +18,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 async function loadRebalanceMonitorData() {
-  const executedRebalancesPromise = getExecutedEarnRebalanceHistory()
-    .then((history) => ({ ...history, status: "available" as const }))
-    .catch((error) => {
-      console.error("Executed Earn rebalance history query failed", {
-        errorMessage:
-          error instanceof Error ? error.message : "Unknown database error",
-        errorName: error instanceof Error ? error.name : "Error",
-      });
-
-      return {
-        executions: [],
-        generatedAt: new Date().toISOString(),
-        status: "unavailable" as const,
-        userCount: 0,
-      };
-    });
   const [
     apyData,
     routes,
@@ -40,7 +25,6 @@ async function loadRebalanceMonitorData() {
     activity,
     last30DaysRebalances,
     autodeposit,
-    executedRebalances,
   ] = await Promise.all([
     getSafeReserveApyMonitorData(),
     getActiveReserveRoutes(),
@@ -48,7 +32,6 @@ async function loadRebalanceMonitorData() {
     getRebalanceActivity(),
     getLast30DaysRebalanceSeries(),
     getAutodepositTimeSeries(),
-    executedRebalancesPromise,
   ]);
 
   return {
@@ -73,21 +56,70 @@ async function loadRebalanceMonitorData() {
       amountRaw: decision.amountRaw?.toString() ?? null,
       confirmedSlot: decision.confirmedSlot?.toString() ?? null,
     })),
-    executedRebalances: {
-      ...executedRebalances,
-      executions: executedRebalances.executions.map((execution) => ({
-        ...execution,
-        amountRaw: execution.amountRaw.toString(),
-        confirmedSlot: execution.confirmedSlot.toString(),
-        currentDepositRaw: execution.currentDepositRaw.toString(),
-      })),
-    },
     last30DaysRebalances,
     routes: routes.map((route) => ({
       ...route,
       activeAumRaw: route.activeAumRaw.toString(),
     })),
   };
+}
+
+async function loadExecutedRebalances() {
+  try {
+    const history = await getExecutedEarnRebalanceHistory();
+
+    return {
+      ...history,
+      status: "available" as const,
+      executions: history.executions.map((execution) => ({
+        ...execution,
+        amountRaw: execution.amountRaw.toString(),
+        confirmedSlot: execution.confirmedSlot.toString(),
+        currentDepositRaw: execution.currentDepositRaw.toString(),
+      })),
+    };
+  } catch (error) {
+    console.error("Executed Earn rebalance history query failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown database error",
+      errorName: error instanceof Error ? error.name : "Error",
+    });
+
+    return {
+      executions: [],
+      generatedAt: new Date().toISOString(),
+      status: "unavailable" as const,
+      userCount: 0,
+    };
+  }
+}
+
+async function loadVaultRebalanceFrequency() {
+  try {
+    const frequency = await getEarnVaultRebalanceFrequency();
+
+    return {
+      ...frequency,
+      status: "available" as const,
+      vaults: frequency.vaults.map((vault) => ({
+        ...vault,
+        currentDepositRaw: vault.currentDepositRaw.toString(),
+      })),
+    };
+  } catch (error) {
+    console.error("Earn vault rebalance frequency query failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown database error",
+      errorName: error instanceof Error ? error.name : "Error",
+    });
+
+    return {
+      generatedAt: new Date().toISOString(),
+      status: "unavailable" as const,
+      vaultCount: 0,
+      vaults: [],
+    };
+  }
 }
 
 const getCachedRebalanceMonitorData = unstable_cache(
@@ -97,9 +129,19 @@ const getCachedRebalanceMonitorData = unstable_cache(
 );
 
 export async function GET() {
-  return NextResponse.json(await getCachedRebalanceMonitorData(), {
-    headers: {
-      "Cache-Control": "private, no-store",
-    },
-  });
+  const [monitorData, executedRebalances, vaultRebalanceFrequency] =
+    await Promise.all([
+      getCachedRebalanceMonitorData(),
+      loadExecutedRebalances(),
+      loadVaultRebalanceFrequency(),
+    ]);
+
+  return NextResponse.json(
+    { ...monitorData, executedRebalances, vaultRebalanceFrequency },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    }
+  );
 }


### PR DESCRIPTION
## Goal

Give operators a focused view of Earn rebalance health: how often funded vaults are rebalanced, how that activity relates to current deposit size, and when confirmed rebalances were executed.

## Scope and implementation

This only changes the admin Earn rebalance dashboard and its read-only data endpoint; it does not change routing decisions, workers, transactions, or the database schema. We query funded active vaults, order them by current deposit amount, count confirmed rebalances for all time, 7 days, 12 hours, and 2 hours, then show one dot per vault colored by its current reserve with the reserve's live APY in the legend. The Executed Earn rebalances chart keeps users evenly ordered by current deposit and labels its Y axis with compact deposit amounts instead of wallet addresses. Rebalance activity consolidates the previous Outcomes, Claims, and Failures plots into one 72-hour chart containing all six original series: confirmed, terminal attempts, fleet claims, failed decisions, failed opportunities, and expired submissions. Fleet claims uses the right Y axis because its counts are much larger; the other series use the left axis. Large execution-history and vault-frequency datasets are loaded outside the existing Next.js cache entry because browser testing showed that combining them exceeded the 2 MB cache limit and made the endpoint return 500.

## Verification

We checked the queries against live Neon data in read-only mode and verified the dashboard on desktop and mobile. The vault-frequency X axis and execution-history Y axis show deposit amounts without overflow. Rebalance activity renders one chart surface with six lines, two readable Y axes, a complete legend, and no mobile overflow. TypeScript and lint passed, the browser reported no console errors, and the repository's app, admin, and frontend pre-push checks all passed.

## After merge

Wait for the admin deployment to complete, then open `/earn/rebalance` on admin.askloyal.com and check each stablecoin and time-range tab. Confirm Rebalance activity shows all six original series together in one chart, Fleet claims is scaled on the right, both amount-based axes remain readable, the endpoint returns 200, reserve colors and APYs are present, and no cache-size or query errors appear in deployment logs. No database migration or worker deployment is required.

Linear: https://linear.app/askloyal/issue/ASK-2122/add-vault-rebalance-frequency-charts-to-admin