### PR TITLE
feat(admin): add operational wallet spending charts

### DIFF
--- a/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -4,16 +4,7 @@ import {
   appSmartAccountSponsorshipTransactions,
   gaslessClaimTransactions,
 } from "@loyal-labs/db-core/schema";
-import {
-  and,
-  count,
-  desc,
-  eq,
-  inArray,
-  max,
-  sql as drizzleSql,
-  sum,
-} from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, max } from "drizzle-orm";
 
 import { getDatabase } from "@/lib/core/database";
 import { serverEnv } from "@/lib/core/config/server";
@@ -70,9 +61,34 @@ export type EarnFundingWallet = {
   runwayHours: number | null;
 };
 
+export type OperationalWalletSpendGroup =
+  | "gasless_store"
+  | "gasless_top_up_to_0_01_sol"
+  | "gasless_verify_telegram_init_data"
+  | "lookup_table_close"
+  | "lookup_table_create"
+  | "lookup_table_deactivate"
+  | "lookup_table_extend"
+  | "lookup_table_rollover"
+  | "lookup_table_verify"
+  | "smart_account_sponsorship"
+  | "yield_route_fee";
+
+export type OperationalWalletSpendEvent = {
+  address: string;
+  amountBasis: "compiled_fee" | "confirmed_payer_outflow";
+  group: OperationalWalletSpendGroup;
+  lamports: string;
+  occurredAt: string;
+  signature: string | null;
+};
+
 export type EarnFundingData = {
   wallets: EarnFundingWallet[];
   missingRoles: Array<{ key: FundingRole; label: string; reason: string }>;
+  spendEvents: OperationalWalletSpendEvent[];
+  spendSourceErrors: string[];
+  spendWindow: { endedAt: string; startedAt: string };
   sourceErrors: string[];
   observedAt: string;
 };
@@ -95,20 +111,17 @@ type FeePayerObservationRow = {
   latest_seen_at: string | Date | null;
 };
 
-type SpendObservationRow = {
+type SpendEventObservationRow = {
   address: string | null;
-  lamports_24h: string | number | null;
-  lamports_7d: string | number | null;
-};
-
-type SpendRow = {
-  address: string;
-  lamports24h: bigint;
-  lamports7d: bigint;
+  amount_basis: string | null;
+  group_key: string | null;
+  lamports: string | number | null;
+  occurred_at: string | Date | null;
+  signature: string | null;
 };
 
 type SpendSourceResult = {
-  rows: SpendRow[];
+  events: OperationalWalletSpendEvent[];
   failed: boolean;
 };
 
@@ -381,39 +394,89 @@ function toSpendLamports(value: string | number | null | undefined): bigint {
   return parsed > BigInt(0) ? parsed : BigInt(0);
 }
 
-function toSpendRow(
-  address: string | null | undefined,
-  lamports24h: string | number | null | undefined,
-  lamports7d: string | number | null | undefined
-): SpendRow | null {
-  const normalizedAddress = normalizeAddress(address);
-  if (!normalizedAddress) {
+const OPERATIONAL_WALLET_SPEND_GROUPS = new Set<OperationalWalletSpendGroup>([
+  "gasless_store",
+  "gasless_top_up_to_0_01_sol",
+  "gasless_verify_telegram_init_data",
+  "lookup_table_close",
+  "lookup_table_create",
+  "lookup_table_deactivate",
+  "lookup_table_extend",
+  "lookup_table_rollover",
+  "lookup_table_verify",
+  "smart_account_sponsorship",
+  "yield_route_fee",
+]);
+
+function isOperationalWalletSpendGroup(
+  value: string | null | undefined
+): value is OperationalWalletSpendGroup {
+  return OPERATIONAL_WALLET_SPEND_GROUPS.has(
+    value as OperationalWalletSpendGroup
+  );
+}
+
+function getOperationalWalletSpendWindow(now: Date) {
+  const julyYear =
+    now.getUTCMonth() >= 6 ? now.getUTCFullYear() : now.getUTCFullYear() - 1;
+
+  return {
+    endedAt: now,
+    startedAt: new Date(Date.UTC(julyYear, 6, 1)),
+  };
+}
+
+function toSpendEvent(args: {
+  address: string | null | undefined;
+  amountBasis: string | null | undefined;
+  group: string | null | undefined;
+  lamports: string | number | null | undefined;
+  occurredAt: string | Date | null | undefined;
+  signature: string | null | undefined;
+}): OperationalWalletSpendEvent | null {
+  const normalizedAddress = normalizeAddress(args.address);
+  const occurredAt = toIsoString(args.occurredAt);
+  const lamports = toSpendLamports(args.lamports);
+  if (
+    !normalizedAddress ||
+    !occurredAt ||
+    lamports === BigInt(0) ||
+    !isOperationalWalletSpendGroup(args.group)
+  ) {
     return null;
   }
 
   return {
     address: normalizedAddress,
-    lamports24h: toSpendLamports(lamports24h),
-    lamports7d: toSpendLamports(lamports7d),
+    amountBasis:
+      args.amountBasis === "compiled_fee"
+        ? "compiled_fee"
+        : "confirmed_payer_outflow",
+    group: args.group,
+    lamports: lamports.toString(),
+    occurredAt,
+    signature: normalizeAddress(args.signature),
   };
+}
+
+function gaslessSpendGroup(transactionType: string) {
+  return `gasless_${transactionType}`;
 }
 
 // Sponsored smart-account deployments; rows are written by the app when each
 // sponsored transaction finalizes.
 async function loadSponsorshipSpendRows(
-  addresses: string[]
+  addresses: string[],
+  startedAt: Date
 ): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
     const rows = await db
       .select({
         address: appSmartAccountSponsorshipTransactions.payerAddress,
-        lamports24h: sum(
-          drizzleSql`CASE WHEN ${appSmartAccountSponsorshipTransactions.occurredAt} >= NOW() - INTERVAL '24 hours' THEN ${appSmartAccountSponsorshipTransactions.spentLamports} ELSE 0 END`
-        ),
-        lamports7d: sum(
-          drizzleSql`CASE WHEN ${appSmartAccountSponsorshipTransactions.occurredAt} >= NOW() - INTERVAL '7 days' THEN ${appSmartAccountSponsorshipTransactions.spentLamports} ELSE 0 END`
-        ),
+        lamports: appSmartAccountSponsorshipTransactions.spentLamports,
+        occurredAt: appSmartAccountSponsorshipTransactions.occurredAt,
+        signature: appSmartAccountSponsorshipTransactions.signature,
       })
       .from(appSmartAccountSponsorshipTransactions)
       .where(
@@ -422,63 +485,85 @@ async function loadSponsorshipSpendRows(
           inArray(
             appSmartAccountSponsorshipTransactions.payerAddress,
             addresses
-          )
+          ),
+          gte(appSmartAccountSponsorshipTransactions.occurredAt, startedAt)
         )
-      )
-      .groupBy(appSmartAccountSponsorshipTransactions.payerAddress);
+      );
 
     return {
+      events: rows
+        .map((row) =>
+          toSpendEvent({
+            address: row.address,
+            amountBasis: "confirmed_payer_outflow",
+            group: "smart_account_sponsorship",
+            lamports: row.lamports,
+            occurredAt: row.occurredAt,
+            signature: row.signature,
+          })
+        )
+        .filter((event): event is OperationalWalletSpendEvent =>
+          Boolean(event)
+        ),
       failed: false,
-      rows: rows
-        .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
-        .filter((row): row is SpendRow => Boolean(row)),
     };
   } catch {
-    return { failed: true, rows: [] };
+    return { events: [], failed: true };
   }
 }
 
 // Gasless claim/verification transactions; rows are backfilled by the app's
 // private-transfer-analytics cron.
 async function loadGaslessClaimSpendRows(
-  addresses: string[]
+  addresses: string[],
+  startedAt: Date
 ): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
     const rows = await db
       .select({
         address: gaslessClaimTransactions.payerAddress,
-        lamports24h: sum(
-          drizzleSql`CASE WHEN ${gaslessClaimTransactions.occurredAt} >= NOW() - INTERVAL '24 hours' THEN ${gaslessClaimTransactions.spentLamports} ELSE 0 END`
-        ),
-        lamports7d: sum(
-          drizzleSql`CASE WHEN ${gaslessClaimTransactions.occurredAt} >= NOW() - INTERVAL '7 days' THEN ${gaslessClaimTransactions.spentLamports} ELSE 0 END`
-        ),
+        lamports: gaslessClaimTransactions.spentLamports,
+        occurredAt: gaslessClaimTransactions.occurredAt,
+        signature: gaslessClaimTransactions.signature,
+        transactionType: gaslessClaimTransactions.transactionType,
       })
       .from(gaslessClaimTransactions)
       .where(
         and(
           eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
-          inArray(gaslessClaimTransactions.payerAddress, addresses)
+          inArray(gaslessClaimTransactions.payerAddress, addresses),
+          gte(gaslessClaimTransactions.occurredAt, startedAt)
         )
-      )
-      .groupBy(gaslessClaimTransactions.payerAddress);
+      );
 
     return {
+      events: rows
+        .map((row) =>
+          toSpendEvent({
+            address: row.address,
+            amountBasis: "confirmed_payer_outflow",
+            group: gaslessSpendGroup(row.transactionType),
+            lamports: row.lamports,
+            occurredAt: row.occurredAt,
+            signature: row.signature,
+          })
+        )
+        .filter((event): event is OperationalWalletSpendEvent =>
+          Boolean(event)
+        ),
       failed: false,
-      rows: rows
-        .map((row) => toSpendRow(row.address, row.lamports24h, row.lamports7d))
-        .filter((row): row is SpendRow => Boolean(row)),
     };
   } catch {
-    return { failed: true, rows: [] };
+    return { events: [], failed: true };
   }
 }
 
 // Route execution fees plus lookup-table provisioning fees and unreclaimed
 // rent, both paid by the Earn policy wallet.
 async function loadYieldSpendRows(
-  addresses: string[]
+  addresses: string[],
+  startedAt: Date
 ): Promise<SpendSourceResult> {
   try {
     const sql = getYieldNeonSql();
@@ -487,44 +572,59 @@ async function loadYieldSpendRows(
         `
         SELECT
           fee_payer AS address,
-          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= NOW() - INTERVAL '24 hours'), 0)::text AS lamports_24h,
-          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= NOW() - INTERVAL '7 days'), 0)::text AS lamports_7d
+          'compiled_fee' AS amount_basis,
+          'yield_route_fee' AS group_key,
+          compiled_fee_lamports::text AS lamports,
+          confirmed_at AS occurred_at,
+          transaction_signature AS signature
         FROM loyal_yield.signed_route_submissions
         WHERE cluster = $1
           AND confirmed_at IS NOT NULL
           AND fee_payer = ANY($2::text[])
-        GROUP BY fee_payer
+          AND confirmed_at >= $3::timestamptz
       `,
-        [MAINNET_YIELD_CLUSTER, addresses]
-      ) as unknown as Promise<SpendObservationRow[]>,
+        [MAINNET_YIELD_CLUSTER, addresses, startedAt.toISOString()]
+      ) as unknown as Promise<SpendEventObservationRow[]>,
       sql.query(
         `
         SELECT
           family.payer AS address,
-          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= NOW() - INTERVAL '24 hours'), 0)::text AS lamports_24h,
-          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= NOW() - INTERVAL '7 days'), 0)::text AS lamports_7d
+          'confirmed_payer_outflow' AS amount_basis,
+          'lookup_table_' || operation.operation_kind AS group_key,
+          GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)::text AS lamports,
+          operation.confirmed_at AS occurred_at,
+          operation.transaction_signature AS signature
         FROM loyal_yield.lookup_table_operations AS operation
         JOIN loyal_yield.lookup_table_families AS family
           ON family.id = operation.family_id
         WHERE family.cluster = $1
           AND operation.confirmed_at IS NOT NULL
           AND family.payer = ANY($2::text[])
-        GROUP BY family.payer
+          AND operation.confirmed_at >= $3::timestamptz
       `,
-        [MAINNET_YIELD_CLUSTER, addresses]
-      ) as unknown as Promise<SpendObservationRow[]>,
+        [MAINNET_YIELD_CLUSTER, addresses, startedAt.toISOString()]
+      ) as unknown as Promise<SpendEventObservationRow[]>,
     ]);
 
     return {
-      failed: false,
-      rows: [...routeRows, ...lookupTableRows]
+      events: [...routeRows, ...lookupTableRows]
         .map((row) =>
-          toSpendRow(row.address, row.lamports_24h, row.lamports_7d)
+          toSpendEvent({
+            address: row.address,
+            amountBasis: row.amount_basis,
+            group: row.group_key,
+            lamports: row.lamports,
+            occurredAt: row.occurred_at,
+            signature: row.signature,
+          })
         )
-        .filter((row): row is SpendRow => Boolean(row)),
+        .filter((event): event is OperationalWalletSpendEvent =>
+          Boolean(event)
+        ),
+      failed: false,
     };
   } catch {
-    return { failed: true, rows: [] };
+    return { events: [], failed: true };
   }
 }
 
@@ -534,19 +634,23 @@ async function loadYieldSpendRows(
 // a partial answer unusable — the missing source would understate some wallet's
 // spend and inflate its runway with no way to tell which one. So if any source
 // fails, no wallet reports spend and the failure is surfaced instead.
-async function loadWalletSpend(addresses: string[]): Promise<{
+async function loadWalletSpend(
+  addresses: string[],
+  window: { endedAt: Date; startedAt: Date }
+): Promise<{
+  events: OperationalWalletSpendEvent[];
   spend: Map<string, WalletSpend>;
   sourceErrors: string[];
 }> {
   const sourceErrors: string[] = [];
   if (addresses.length === 0) {
-    return { sourceErrors, spend: new Map() };
+    return { events: [], sourceErrors, spend: new Map() };
   }
 
   const [sponsorship, gasless, yieldSpend] = await Promise.all([
-    loadSponsorshipSpendRows(addresses),
-    loadGaslessClaimSpendRows(addresses),
-    loadYieldSpendRows(addresses),
+    loadSponsorshipSpendRows(addresses, window.startedAt),
+    loadGaslessClaimSpendRows(addresses, window.startedAt),
+    loadYieldSpendRows(addresses, window.startedAt),
   ]);
 
   const sources: Array<{ error: string; result: SpendSourceResult }> = [
@@ -571,8 +675,14 @@ async function loadWalletSpend(addresses: string[]): Promise<{
   }
 
   if (sourceErrors.length > 0) {
-    return { sourceErrors, spend: new Map() };
+    return { events: [], sourceErrors, spend: new Map() };
   }
+
+  const events = sources
+    .flatMap((source) => source.result.events)
+    .sort((left, right) => left.occurredAt.localeCompare(right.occurredAt));
+  const cutoff24h = window.endedAt.getTime() - 24 * 60 * 60 * 1000;
+  const cutoff7d = window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1000;
 
   // Every source answered, so each requested address now has a known spend.
   // Seed them all at zero: an address with no rows anywhere spent nothing,
@@ -583,18 +693,27 @@ async function loadWalletSpend(addresses: string[]): Promise<{
       { lamports24h: BigInt(0), lamports7d: BigInt(0) },
     ])
   );
-  for (const row of sources.flatMap((source) => source.result.rows)) {
-    const existing = totals.get(row.address) ?? {
+  for (const event of events) {
+    const occurredAt = Date.parse(event.occurredAt);
+    const lamports = BigInt(event.lamports);
+    const existing = totals.get(event.address) ?? {
       lamports24h: BigInt(0),
       lamports7d: BigInt(0),
     };
-    totals.set(row.address, {
-      lamports24h: existing.lamports24h + row.lamports24h,
-      lamports7d: existing.lamports7d + row.lamports7d,
+    totals.set(event.address, {
+      lamports24h:
+        occurredAt >= cutoff24h
+          ? existing.lamports24h + lamports
+          : existing.lamports24h,
+      lamports7d:
+        occurredAt >= cutoff7d
+          ? existing.lamports7d + lamports
+          : existing.lamports7d,
     });
   }
 
   return {
+    events,
     sourceErrors,
     spend: new Map(
       Array.from(totals.entries()).map(([address, total]) => [
@@ -998,6 +1117,7 @@ function createWallets(args: {
 }
 
 async function loadFundingData(): Promise<EarnFundingData> {
+  const spendWindow = getOperationalWalletSpendWindow(new Date());
   const configuredSettingsAuthority = serverEnv.earnSettingsAuthorityPublicKey;
   const [appObservations, yieldObservations] = await Promise.all([
     loadAppIdentityObservations(),
@@ -1039,7 +1159,7 @@ async function loadFundingData(): Promise<EarnFundingData> {
         ...definition.observation.observedAddresses.map((row) => row.address),
       ])
   );
-  const spendResult = await loadWalletSpend(spendTrackedAddresses);
+  const spendResult = await loadWalletSpend(spendTrackedAddresses, spendWindow);
   sourceErrors.push(...spendResult.sourceErrors);
 
   const walletResult = createWallets({
@@ -1054,6 +1174,12 @@ async function loadFundingData(): Promise<EarnFundingData> {
   return {
     ...walletResult,
     observedAt: balanceResult.observedAt,
+    spendEvents: spendResult.events,
+    spendSourceErrors: spendResult.sourceErrors,
+    spendWindow: {
+      endedAt: spendWindow.endedAt.toISOString(),
+      startedAt: spendWindow.startedAt.toISOString(),
+    },
     sourceErrors,
   };
 }

--- a/apps/admin/src/app/(admin)/earn/operational-wallet-spending-charts.tsx
+++ b/apps/admin/src/app/(admin)/earn/operational-wallet-spending-charts.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Label,
+  Line,
+  LineChart,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { formatShortAddress } from "@/components/blockchain/address-link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+
+import type {
+  EarnFundingWallet,
+  OperationalWalletSpendEvent,
+  OperationalWalletSpendGroup,
+} from "./earn-funding-data";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+const GROUP_LABELS: Record<OperationalWalletSpendGroup, string> = {
+  gasless_store: "Gasless store",
+  gasless_top_up_to_0_01_sol: "Gasless top-up",
+  gasless_verify_telegram_init_data: "Gasless verification",
+  lookup_table_close: "Lookup close",
+  lookup_table_create: "Lookup create",
+  lookup_table_deactivate: "Lookup deactivate",
+  lookup_table_extend: "Lookup extend",
+  lookup_table_rollover: "Lookup rollover",
+  lookup_table_verify: "Lookup verify",
+  smart_account_sponsorship: "Smart-account sponsorship",
+  yield_route_fee: "Yield route fee",
+};
+
+const GROUP_ORDER = Object.keys(GROUP_LABELS) as OperationalWalletSpendGroup[];
+
+const LINE_STYLES = [
+  { dash: undefined, opacity: 1 },
+  { dash: "7 4", opacity: 0.82 },
+  { dash: "2 4", opacity: 0.68 },
+] as const;
+
+type ScatterPoint = OperationalWalletSpendEvent & {
+  groupIndex: number;
+  lamportsNumber: number;
+  occurredAtMs: number;
+};
+
+type DailySpendPoint = Record<string, number> & { occurredAtMs: number };
+
+type WalletScatterData = {
+  groups: OperationalWalletSpendGroup[];
+  points: ScatterPoint[];
+};
+
+type TooltipPayload<T> = Array<{
+  dataKey?: string | number;
+  payload?: T;
+  value?: number;
+}>;
+
+function getWalletTitle(wallet: EarnFundingWallet) {
+  if (wallet.roles.length === 1) {
+    return wallet.roles[0].label;
+  }
+
+  if (
+    wallet.roles.some((role) => role.key === "policy") &&
+    wallet.roles.some((role) => role.key === "deployment")
+  ) {
+    return "Policy + deployment wallet";
+  }
+
+  return wallet.roles.map((role) => role.label).join(" + ");
+}
+
+function formatUtcDate(value: number | string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function formatUtcTimestamp(value: number | string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatSol(lamports: string) {
+  const amount = BigInt(lamports);
+  const whole = amount / BigInt(1_000_000_000);
+  const fraction = (amount % BigInt(1_000_000_000))
+    .toString()
+    .padStart(9, "0")
+    .replace(/0+$/, "");
+
+  return whole.toLocaleString("en-US") + "." + (fraction || "0") + " SOL";
+}
+
+function SpendEventTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: TooltipPayload<ScatterPoint>;
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) {
+    return null;
+  }
+
+  return (
+    <div className="grid min-w-[17rem] gap-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium">
+        {formatUtcTimestamp(point.occurredAtMs)}
+      </div>
+      <div className="text-muted-foreground">{GROUP_LABELS[point.group]}</div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1">
+        <dt className="text-muted-foreground">Spent</dt>
+        <dd className="text-right font-medium tabular-nums">
+          {formatSol(point.lamports)}
+        </dd>
+        <dt className="text-muted-foreground">Lamports</dt>
+        <dd className="text-right font-mono tabular-nums">
+          {BigInt(point.lamports).toLocaleString("en-US")}
+        </dd>
+        <dt className="text-muted-foreground">Amount basis</dt>
+        <dd className="text-right">
+          {point.amountBasis === "compiled_fee"
+            ? "Confirmed compiled fee"
+            : "Confirmed payer outflow"}
+        </dd>
+        {point.signature ? (
+          <>
+            <dt className="text-muted-foreground">Signature</dt>
+            <dd className="text-right font-mono">
+              {formatShortAddress(point.signature)}
+            </dd>
+          </>
+        ) : null}
+      </dl>
+    </div>
+  );
+}
+
+function DailySpendTooltip({
+  active,
+  payload,
+  wallets,
+}: {
+  active?: boolean;
+  payload?: TooltipPayload<DailySpendPoint>;
+  wallets: EarnFundingWallet[];
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) {
+    return null;
+  }
+
+  return (
+    <div className="grid min-w-[17rem] gap-1.5 rounded-lg border border-border/70 bg-background px-3 py-2 text-xs shadow-xl">
+      <div className="font-medium">{formatUtcDate(point.occurredAtMs)} UTC</div>
+      <div className="grid gap-1">
+        {wallets.map((wallet, index) => (
+          <div
+            className="flex items-center justify-between gap-4"
+            key={wallet.address}
+          >
+            <span className="text-muted-foreground">
+              {getWalletTitle(wallet)}
+            </span>
+            <span className="font-mono font-medium tabular-nums">
+              {(point["wallet_" + index] ?? 0).toLocaleString("en-US", {
+                maximumFractionDigits: 6,
+              })}{" "}
+              SOL
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function buildDailySpendPoints(args: {
+  endedAtMs: number;
+  events: OperationalWalletSpendEvent[];
+  startedAtMs: number;
+  wallets: EarnFundingWallet[];
+}) {
+  const start = new Date(args.startedAtMs);
+  const end = new Date(args.endedAtMs);
+  const firstDay = Date.UTC(
+    start.getUTCFullYear(),
+    start.getUTCMonth(),
+    start.getUTCDate()
+  );
+  const lastDay = Date.UTC(
+    end.getUTCFullYear(),
+    end.getUTCMonth(),
+    end.getUTCDate()
+  );
+  const lamportsByDay = new Map<number, Map<string, bigint>>();
+
+  for (const event of args.events) {
+    const occurredAt = new Date(event.occurredAt);
+    const day = Date.UTC(
+      occurredAt.getUTCFullYear(),
+      occurredAt.getUTCMonth(),
+      occurredAt.getUTCDate()
+    );
+    const walletTotals = lamportsByDay.get(day) ?? new Map<string, bigint>();
+    walletTotals.set(
+      event.address,
+      (walletTotals.get(event.address) ?? BigInt(0)) + BigInt(event.lamports)
+    );
+    lamportsByDay.set(day, walletTotals);
+  }
+
+  const points: DailySpendPoint[] = [];
+  for (let day = firstDay; day <= lastDay; day += DAY_MS) {
+    const walletTotals = lamportsByDay.get(day);
+    const point: DailySpendPoint = { occurredAtMs: day };
+    args.wallets.forEach((wallet, index) => {
+      point["wallet_" + index] =
+        Number(walletTotals?.get(wallet.address) ?? BigInt(0)) / 1_000_000_000;
+    });
+    points.push(point);
+  }
+
+  return points;
+}
+
+export function OperationalWalletSpendingCharts({
+  events,
+  sourceErrors,
+  wallets,
+  window,
+}: {
+  events: OperationalWalletSpendEvent[];
+  sourceErrors: string[];
+  wallets: EarnFundingWallet[];
+  window: { endedAt: string; startedAt: string };
+}) {
+  const primaryWallets = useMemo(
+    () =>
+      wallets.filter((wallet) =>
+        wallet.roles.some((role) => role.key !== "route_fee_payer")
+      ),
+    [wallets]
+  );
+  const startedAtMs = Date.parse(window.startedAt);
+  const endedAtMs = Date.parse(window.endedAt);
+  const visibleEvents = useMemo(() => {
+    const primaryAddresses = new Set(
+      primaryWallets.map((wallet) => wallet.address)
+    );
+    return events.filter((event) => primaryAddresses.has(event.address));
+  }, [events, primaryWallets]);
+  const trackedWallets = useMemo(
+    () =>
+      primaryWallets.filter((wallet) =>
+        wallet.roles.some((role) => role.key !== "settings_authority")
+      ),
+    [primaryWallets]
+  );
+  const scatterByWallet = useMemo(() => {
+    const eventsByWallet = new Map<string, OperationalWalletSpendEvent[]>();
+    for (const event of visibleEvents) {
+      const walletEvents = eventsByWallet.get(event.address) ?? [];
+      walletEvents.push(event);
+      eventsByWallet.set(event.address, walletEvents);
+    }
+
+    return new Map<string, WalletScatterData>(
+      primaryWallets.map((wallet) => {
+        const walletEvents = eventsByWallet.get(wallet.address) ?? [];
+        const groups = GROUP_ORDER.filter((group) =>
+          walletEvents.some((event) => event.group === group)
+        );
+        const groupIndex = new Map(
+          groups.map((group, index) => [group, index])
+        );
+        const points = walletEvents
+          .map((event) => ({
+            ...event,
+            groupIndex: groupIndex.get(event.group) ?? -1,
+            lamportsNumber: Number(event.lamports),
+            occurredAtMs: Date.parse(event.occurredAt),
+          }))
+          .filter(
+            (event) =>
+              event.groupIndex >= 0 &&
+              Number.isFinite(event.lamportsNumber) &&
+              Number.isFinite(event.occurredAtMs)
+          );
+
+        return [wallet.address, { groups, points }];
+      })
+    );
+  }, [primaryWallets, visibleEvents]);
+  const dailySpendPoints = useMemo(
+    () =>
+      buildDailySpendPoints({
+        endedAtMs,
+        events: visibleEvents,
+        startedAtMs,
+        wallets: trackedWallets,
+      }),
+    [endedAtMs, startedAtMs, trackedWallets, visibleEvents]
+  );
+  const lineConfig = Object.fromEntries(
+    trackedWallets.map((wallet, index) => [
+      "wallet_" + index,
+      { color: "var(--foreground)", label: getWalletTitle(wallet) },
+    ])
+  ) satisfies ChartConfig;
+  const scatterConfig = {
+    spend: { color: "var(--foreground)", label: "Transaction spend" },
+  } satisfies ChartConfig;
+  const startLabel = formatUtcDate(startedAtMs);
+
+  if (sourceErrors.length > 0) {
+    return (
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle>Operational wallet spending</CardTitle>
+          <CardDescription>
+            Transaction history is unavailable because at least one required App
+            or Yield spend source could not be read. No partial totals are
+            plotted.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card
+        aria-labelledby="operational-wallet-transactions-title"
+        className="min-w-0"
+      >
+        <CardHeader>
+          <CardTitle id="operational-wallet-transactions-title">
+            Operational wallet transactions
+          </CardTitle>
+          <CardDescription>
+            One dot per recorded transaction since {startLabel}; dot area is
+            proportional to lamports spent. App and lookup-table rows use
+            confirmed payer outflow; route rows use confirmed compiled fees.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="min-w-0 space-y-6">
+          {primaryWallets.map((wallet) => {
+            const walletScatter = scatterByWallet.get(wallet.address);
+            const walletGroups = walletScatter?.groups ?? [];
+            const walletPoints = walletScatter?.points ?? [];
+            const isUntrackedSettingsAuthority = wallet.roles.some(
+              (role) => role.key === "settings_authority"
+            );
+
+            return (
+              <section className="min-w-0 space-y-2" key={wallet.address}>
+                <div className="flex flex-wrap items-baseline justify-between gap-2 px-1">
+                  <div>
+                    <h3 className="text-sm font-medium">
+                      {getWalletTitle(wallet)}
+                    </h3>
+                    <p className="font-mono text-[11px] text-muted-foreground">
+                      {formatShortAddress(wallet.address)}
+                    </p>
+                  </div>
+                  <p className="text-xs text-muted-foreground tabular-nums">
+                    {walletPoints.length.toLocaleString("en-US")} transactions
+                  </p>
+                </div>
+                {walletPoints.length === 0 || walletGroups.length === 0 ? (
+                  <div className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+                    {isUntrackedSettingsAuthority
+                      ? "No App/Yield spend table tracks this settings authority yet; zero rows does not mean zero on-chain fees."
+                      : "No recorded spending since " + startLabel + "."}
+                  </div>
+                ) : (
+                  <ChartContainer
+                    className="aspect-auto w-full min-w-0"
+                    config={scatterConfig}
+                    style={{ height: Math.max(180, walletGroups.length * 42) }}
+                  >
+                    <ScatterChart
+                      accessibilityLayer
+                      margin={{ bottom: 24, left: 8, right: 16, top: 10 }}
+                    >
+                      <CartesianGrid />
+                      <XAxis
+                        axisLine={false}
+                        dataKey="occurredAtMs"
+                        domain={[startedAtMs, endedAtMs]}
+                        minTickGap={40}
+                        tickFormatter={formatUtcDate}
+                        tickLine={false}
+                        tickMargin={8}
+                        type="number"
+                      >
+                        <Label
+                          offset={-16}
+                          position="insideBottom"
+                          value="Time (UTC)"
+                        />
+                      </XAxis>
+                      <YAxis
+                        allowDecimals={false}
+                        axisLine={false}
+                        dataKey="groupIndex"
+                        domain={[
+                          -0.5,
+                          Math.max(walletGroups.length - 0.5, 0.5),
+                        ]}
+                        tickFormatter={(value: number) =>
+                          GROUP_LABELS[walletGroups[value]] ?? ""
+                        }
+                        tickLine={false}
+                        ticks={walletGroups.map((_, index) => index)}
+                        type="number"
+                        width={116}
+                      />
+                      <ZAxis
+                        dataKey="lamportsNumber"
+                        domain={["dataMin", "dataMax"]}
+                        range={[20, 240]}
+                      />
+                      <ChartTooltip
+                        content={<SpendEventTooltip />}
+                        cursor={{ strokeDasharray: "3 3" }}
+                      />
+                      <Scatter
+                        data={walletPoints}
+                        fill="var(--color-spend)"
+                        fillOpacity={0.72}
+                        name="Transaction spend"
+                      />
+                    </ScatterChart>
+                  </ChartContainer>
+                )}
+              </section>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card
+        aria-labelledby="daily-operational-wallet-spending-title"
+        className="min-w-0"
+      >
+        <CardHeader className="gap-3">
+          <div>
+            <CardTitle id="daily-operational-wallet-spending-title">
+              Daily operational wallet spending
+            </CardTitle>
+            <CardDescription>
+              Overlapping UTC daily totals since {startLabel}. A zero is shown
+              only because every required spend source loaded successfully.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            {trackedWallets.map((wallet, index) => {
+              const style = LINE_STYLES[index % LINE_STYLES.length];
+              return (
+                <span
+                  className="inline-flex items-center gap-1.5"
+                  key={wallet.address}
+                >
+                  <svg aria-hidden className="h-2 w-5" viewBox="0 0 20 8">
+                    <line
+                      stroke="currentColor"
+                      strokeDasharray={style.dash}
+                      strokeOpacity={style.opacity}
+                      strokeWidth="2"
+                      x1="0"
+                      x2="20"
+                      y1="4"
+                      y2="4"
+                    />
+                  </svg>
+                  {getWalletTitle(wallet)}
+                </span>
+              );
+            })}
+            {primaryWallets.some((wallet) =>
+              wallet.roles.some((role) => role.key === "settings_authority")
+            ) ? (
+              <span>Settings authority excluded: no spend table coverage</span>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent className="min-w-0">
+          {visibleEvents.length === 0 ? (
+            <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+              No recorded operational-wallet spending since {startLabel}.
+            </div>
+          ) : (
+            <ChartContainer
+              className="aspect-auto h-[320px] w-full min-w-0"
+              config={lineConfig}
+            >
+              <LineChart
+                accessibilityLayer
+                data={dailySpendPoints}
+                margin={{ bottom: 24, left: 8, right: 20, top: 10 }}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  axisLine={false}
+                  dataKey="occurredAtMs"
+                  domain={[startedAtMs, endedAtMs]}
+                  minTickGap={40}
+                  scale="time"
+                  tickFormatter={formatUtcDate}
+                  tickLine={false}
+                  tickMargin={8}
+                  type="number"
+                >
+                  <Label
+                    offset={-16}
+                    position="insideBottom"
+                    value="Time (UTC)"
+                  />
+                </XAxis>
+                <YAxis
+                  axisLine={false}
+                  domain={[0, "auto"]}
+                  tickFormatter={(value: number) =>
+                    value.toLocaleString("en-US", {
+                      maximumFractionDigits: 4,
+                    })
+                  }
+                  tickLine={false}
+                  width={62}
+                >
+                  <Label
+                    angle={-90}
+                    position="insideLeft"
+                    style={{ textAnchor: "middle" }}
+                    value="SOL / day"
+                  />
+                </YAxis>
+                <ChartTooltip
+                  content={<DailySpendTooltip wallets={trackedWallets} />}
+                />
+                {trackedWallets.map((wallet, index) => {
+                  const style = LINE_STYLES[index % LINE_STYLES.length];
+                  return (
+                    <Line
+                      connectNulls
+                      dataKey={"wallet_" + index}
+                      dot={false}
+                      key={wallet.address}
+                      name={getWalletTitle(wallet)}
+                      stroke={"var(--color-wallet_" + index + ")"}
+                      strokeDasharray={style.dash}
+                      strokeOpacity={style.opacity}
+                      strokeWidth={2}
+                      type="linear"
+                    />
+                  );
+                })}
+              </LineChart>
+            </ChartContainer>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/earn/page.tsx
+++ b/apps/admin/src/app/(admin)/earn/page.tsx
@@ -38,6 +38,7 @@ import {
   type EarnFundingWallet,
 } from "./earn-funding-data";
 import { getAdminEarnSnapshot, type AdminEarnSnapshot } from "./earn-snapshot";
+import { OperationalWalletSpendingCharts } from "./operational-wallet-spending-charts";
 import {
   EARN_STABLECOIN_DESCRIPTORS,
   getEarnStablecoinBySymbol,
@@ -447,6 +448,13 @@ function OperationalWallets({ data }: { data: EarnFundingData }) {
           {data.missingRoles.map((role) => role.label).join(", ")}
         </div>
       ) : null}
+
+      <OperationalWalletSpendingCharts
+        events={data.spendEvents}
+        sourceErrors={data.spendSourceErrors}
+        wallets={data.wallets}
+        window={data.spendWindow}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Linear: [ASK-2123](https://linear.app/askloyal/issue/ASK-2123/add-operational-wallet-spending-charts-to-earn-admin)

Adds production-backed operational-wallet spending views below the Earn wallet cards: one grouped dot per recorded transaction from July 1 with area proportional to lamports, plus overlapping UTC daily SOL totals per tracked wallet. The loader combines App sponsorship/gasless payer outflow with Yield lookup-table payer outflow and confirmed compiled route fees, preserves all-or-nothing spend-source error handling, and explicitly labels the settings authority as untracked by current DB spend tables.

Scope is limited to the admin Earn data loader and chart UI; there are no schema, write-path, wallet-key, or deployment changes.

Verification: Prettier, admin ESLint, admin TypeScript, shared-schema guard, commitlint, and a production `apps/admin` build pass. A read-only live data load returned more than 13.5k events from July with no source errors, and system-Chrome checks passed at desktop/mobile widths in light/dark themes with tooltips, proportional dots, overlapping lines, no chart overflow, and no console errors.

Post-merge: confirm the admin Vercel environments expose the three operational-wallet public-address variables so all configured roles appear, then deploy through the normal admin Vercel flow and verify `/earn` against production data.