### PR TITLE
feat(admin): simplify Earn rebalance performance monitoring

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:earn-rebalance-performance": "bun scripts/verify-earn-rebalance-performance.ts",
     "verify:earn-multi-stablecoin": "bun scripts/verify-earn-multi-stablecoin-monitoring.ts",
     "shadcn:init": "bunx shadcn@latest init",
     "shadcn:add": "bunx shadcn@latest add"

--- a/apps/admin/scripts/verify-earn-rebalance-performance.ts
+++ b/apps/admin/scripts/verify-earn-rebalance-performance.ts
@@ -1,0 +1,194 @@
+import { EARN_STABLECOIN_DESCRIPTORS } from "../src/lib/earn/stablecoin-monitor.shared";
+import {
+  buildRebalancePerformancePoints,
+  parseRebalancePerformanceMint,
+  summarizeRebalanceOpportunities,
+  summarizeRebalancePerformance,
+} from "../src/lib/earn/rebalance-performance.shared";
+
+type Check = {
+  detail: string;
+  name: string;
+  passed: boolean;
+};
+
+const checks: Check[] = [];
+
+function check(name: string, passed: boolean, detail: string) {
+  checks.push({ detail, name, passed });
+}
+
+const usdcMint = EARN_STABLECOIN_DESCRIPTORS.find(
+  ({ symbol }) => symbol === "USDC"
+)?.mint;
+if (!usdcMint) {
+  throw new Error("Canonical USDC mint is unavailable.");
+}
+
+const points = buildRebalancePerformancePoints({
+  apyRows: [
+    {
+      bucketStartedAt: "2026-08-17T00:00:00.000Z",
+      reserve: "reserve-a",
+      supplyApyPercent: 4,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:00:00.000Z",
+      reserve: "reserve-b",
+      supplyApyPercent: 8,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:05:00.000Z",
+      reserve: "reserve-a",
+      supplyApyPercent: 9,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:05:00.000Z",
+      reserve: "reserve-b",
+      supplyApyPercent: 5,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:10:00.000Z",
+      reserve: "reserve-a",
+      supplyApyPercent: null,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:15:00.000Z",
+      reserve: "reserve-b",
+      supplyApyPercent: 7,
+    },
+    {
+      bucketStartedAt: "2026-08-17T00:15:00.000Z",
+      reserve: "reserve-a",
+      supplyApyPercent: 7,
+    },
+  ],
+  bucketDurationMs: 5 * 60 * 1000,
+  confirmedRebalances: [
+    {
+      confirmedAt: "2026-08-17T00:06:00.000Z",
+      id: "decision-1",
+    },
+    {
+      confirmedAt: "2026-08-17T00:07:00.000Z",
+      id: "decision-1",
+    },
+  ],
+  fleetAumRows: [
+    {
+      aumRaw: BigInt(75),
+      bucketStartedAt: "2026-08-17T00:00:00.000Z",
+      reserve: "reserve-a",
+    },
+    {
+      aumRaw: BigInt(25),
+      bucketStartedAt: "2026-08-17T00:00:00.000Z",
+      reserve: "reserve-b",
+    },
+    {
+      aumRaw: BigInt(10),
+      bucketStartedAt: "2026-08-17T00:05:00.000Z",
+      reserve: "reserve-a",
+    },
+    {
+      aumRaw: BigInt(30),
+      bucketStartedAt: "2026-08-17T00:05:00.000Z",
+      reserve: "reserve-b",
+    },
+    {
+      aumRaw: BigInt(60),
+      bucketStartedAt: "2026-08-17T00:10:00.000Z",
+      reserve: "reserve-a",
+    },
+  ],
+});
+
+check(
+  "fleet-weighted APY uses reserve AUM",
+  points[0]?.fleetWeightedApyPercent === 5 &&
+    points[1]?.fleetWeightedApyPercent === 6,
+  JSON.stringify(points)
+);
+check(
+  "best-reserve share uses known fleet AUM",
+  points[0]?.bestReserve === "reserve-b" &&
+    points[0]?.fleetShareInBestReservePercent === 25 &&
+    points[1]?.bestReserve === "reserve-a" &&
+    points[1]?.fleetShareInBestReservePercent === 25,
+  JSON.stringify(points)
+);
+check(
+  "confirmed markers are bucketed once",
+  points[0]?.confirmedRebalanceCount === 0 &&
+    points[1]?.confirmedRebalanceCount === 1,
+  JSON.stringify(points)
+);
+check(
+  "missing usable APY stays unavailable",
+  points[2]?.bestObservedApyPercent === null &&
+    points[2]?.fleetWeightedApyPercent === null &&
+    points[2]?.fleetShareInBestReservePercent === null,
+  JSON.stringify(points)
+);
+check(
+  "best reserve ties are deterministic and no-AUM buckets stay unavailable",
+  points[3]?.bestReserve === "reserve-a" &&
+    points[3]?.bestObservedApyPercent === 7 &&
+    points[3]?.knownFleetAumRaw === "0" &&
+    points[3]?.fleetWeightedApyPercent === null &&
+    points[3]?.fleetShareInBestReservePercent === null,
+  JSON.stringify(points)
+);
+
+const performance = summarizeRebalancePerformance(points);
+check(
+  "AUM-time excludes unknown APY coverage",
+  performance.aumTimeInBestReservePercent === 25 &&
+    performance.knownAumTimeRaw === "42000000" &&
+    performance.totalAumTimeRaw === "60000000" &&
+    performance.coveragePercent === 70,
+  JSON.stringify(performance)
+);
+
+const opportunities = summarizeRebalanceOpportunities([
+  { opportunityId: "confirmed", outcome: "pending" },
+  { opportunityId: "confirmed", outcome: "confirmed" },
+  { opportunityId: "confirmed", outcome: "confirmed" },
+  { opportunityId: "failed", outcome: "failed" },
+  { opportunityId: "failed", outcome: "pending" },
+  { opportunityId: "pending", outcome: "pending" },
+]);
+check(
+  "opportunity outcomes are distinct and mutually exclusive",
+  opportunities.qualified === 3 &&
+    opportunities.confirmed === 1 &&
+    opportunities.failed === 1 &&
+    opportunities.pending === 1 &&
+    opportunities.confirmed + opportunities.failed + opportunities.pending ===
+      opportunities.qualified,
+  JSON.stringify(opportunities)
+);
+
+check(
+  "canonical mint validation rejects aggregate and unknown values",
+  parseRebalancePerformanceMint(usdcMint) === usdcMint &&
+    parseRebalancePerformanceMint("all") === null &&
+    parseRebalancePerformanceMint("unknown") === null &&
+    parseRebalancePerformanceMint(null) === null,
+  "only a canonical mint address may pass"
+);
+
+for (const result of checks) {
+  console.log(
+    `${result.passed ? "PASS" : "FAIL"}: ${result.name}${
+      result.passed ? "" : ` - ${result.detail}`
+    }`
+  );
+}
+
+if (checks.some(({ passed }) => !passed)) {
+  console.log("VERDICT: FAIL");
+  process.exit(1);
+}
+
+console.log("VERDICT: PASS");

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-rebalance-performance-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-rebalance-performance-chart.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  Scatter,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  RebalanceOpportunitySummary,
+  RebalancePerformancePoint,
+  RebalancePerformanceSummary,
+} from "@/lib/earn/rebalance-performance.shared";
+
+const chartConfig = {
+  bestObservedApyPercent: {
+    color: "var(--muted-foreground)",
+    label: "Best observed Safe APY",
+  },
+  confirmedRebalanceApyPercent: {
+    color: "var(--foreground)",
+    label: "Confirmed rebalance",
+  },
+  fleetWeightedApyPercent: {
+    color: "var(--foreground)",
+    label: "Fleet-weighted APY",
+  },
+} satisfies ChartConfig;
+
+type SourceStatus = "available" | "unavailable";
+
+function formatPercent(value: number | null, digits = 1) {
+  return value === null || !Number.isFinite(value)
+    ? "Unavailable"
+    : `${value.toFixed(digits)}%`;
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function SummaryMetric({
+  label,
+  note,
+  value,
+}: {
+  label: string;
+  note: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/20 p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{note}</div>
+    </div>
+  );
+}
+
+export function EarnRebalancePerformanceChart({
+  opportunities,
+  points,
+  sources,
+  summary,
+  symbol,
+}: {
+  opportunities: RebalanceOpportunitySummary | null;
+  points: RebalancePerformancePoint[];
+  sources: { fleet: SourceStatus; market: SourceStatus };
+  summary: RebalancePerformanceSummary;
+  symbol: string;
+}) {
+  const chartPoints = useMemo(
+    () =>
+      points.map((point) => ({
+        ...point,
+        confirmedRebalanceApyPercent:
+          point.confirmedRebalanceCount > 0
+            ? point.fleetWeightedApyPercent ?? point.bestObservedApyPercent
+            : null,
+      })),
+    [points]
+  );
+  const hasChartData = chartPoints.some(
+    (point) =>
+      point.bestObservedApyPercent !== null ||
+      point.fleetWeightedApyPercent !== null
+  );
+  const sourceNote =
+    sources.market === "available" && sources.fleet === "available"
+      ? `${formatPercent(
+          summary.coveragePercent
+        )} of fleet AUM-time has matching market observations.`
+      : `Partial data: market ${sources.market}, fleet ${sources.fleet}.`;
+
+  return (
+    <Card className="min-w-0">
+      <CardHeader>
+        <CardTitle className="font-bold">
+          {symbol} rebalance performance
+        </CardTitle>
+        <CardDescription>
+          Best observed Safe APY compared with the AUM-weighted fleet APY over
+          the last seven days. Historical observations are not a claim of
+          point-in-time eligibility.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="min-w-0 space-y-5">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryMetric
+            label="AUM-time in best reserve"
+            note={sourceNote}
+            value={formatPercent(summary.aumTimeInBestReservePercent)}
+          />
+          <SummaryMetric
+            label="Confirmed opportunities"
+            note="Distinct qualified opportunities in this window."
+            value={
+              opportunities
+                ? `${opportunities.confirmed} / ${opportunities.qualified}`
+                : "Unavailable"
+            }
+          />
+          <SummaryMetric
+            label="Failed opportunities"
+            note="Distinct terminal outcomes."
+            value={opportunities ? String(opportunities.failed) : "Unavailable"}
+          />
+          <SummaryMetric
+            label="Pending opportunities"
+            note="Qualified opportunities without a terminal outcome."
+            value={
+              opportunities ? String(opportunities.pending) : "Unavailable"
+            }
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-2">
+            <span className="h-0.5 w-6 bg-foreground" aria-hidden />
+            Fleet-weighted APY
+          </span>
+          <span className="flex items-center gap-2">
+            <span
+              className="h-0.5 w-6 border-t border-dashed border-muted-foreground"
+              aria-hidden
+            />
+            Best observed Safe APY
+          </span>
+          <span className="flex items-center gap-2">
+            <span
+              className="h-2.5 w-2.5 rounded-full bg-foreground"
+              aria-hidden
+            />
+            Confirmed rebalance
+          </span>
+        </div>
+
+        {hasChartData ? (
+          <ChartContainer
+            className="h-[22rem] w-full min-w-0"
+            config={chartConfig}
+          >
+            <ComposedChart accessibilityLayer data={chartPoints}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                axisLine={false}
+                dataKey="bucketStartedAt"
+                minTickGap={40}
+                tickFormatter={formatDateTime}
+                tickLine={false}
+              />
+              <YAxis
+                axisLine={false}
+                domain={["auto", "auto"]}
+                tickFormatter={(value: number) => `${value.toFixed(1)}%`}
+                tickLine={false}
+                width={54}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value) => formatDateTime(String(value))}
+                  />
+                }
+              />
+              <Line
+                connectNulls={false}
+                dataKey="bestObservedApyPercent"
+                dot={false}
+                isAnimationActive={false}
+                stroke="var(--color-bestObservedApyPercent)"
+                strokeDasharray="5 4"
+                strokeWidth={1.5}
+                type="monotone"
+              />
+              <Line
+                connectNulls={false}
+                dataKey="fleetWeightedApyPercent"
+                dot={false}
+                isAnimationActive={false}
+                stroke="var(--color-fleetWeightedApyPercent)"
+                strokeWidth={2}
+                type="monotone"
+              />
+              <Scatter
+                dataKey="confirmedRebalanceApyPercent"
+                fill="var(--color-confirmedRebalanceApyPercent)"
+                isAnimationActive={false}
+              />
+            </ComposedChart>
+          </ChartContainer>
+        ) : (
+          <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No matching fleet and market observations are available for this
+            stablecoin and window.
+          </div>
+        )}
+
+        <details>
+          <summary className="cursor-pointer text-sm font-medium">
+            Accessible performance data
+          </summary>
+          <div className="mt-3 max-h-80 overflow-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Observed at</TableHead>
+                  <TableHead className="text-right">
+                    Best observed APY
+                  </TableHead>
+                  <TableHead className="text-right">Fleet APY</TableHead>
+                  <TableHead className="text-right">Fleet in best</TableHead>
+                  <TableHead className="text-right">Confirmed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {chartPoints.map((point) => (
+                  <TableRow key={point.bucketStartedAt}>
+                    <TableCell>
+                      {formatDateTime(point.bucketStartedAt)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(point.bestObservedApyPercent, 2)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(point.fleetWeightedApyPercent, 2)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(point.fleetShareInBestReservePercent)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {point.confirmedRebalanceCount}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </details>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -1,8 +1,37 @@
 import "server-only";
 
 import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.server";
+import type {
+  ConfirmedRebalanceMarker,
+  RebalanceOpportunitySummary,
+  RebalancePerformanceFleetAumRow,
+} from "@/lib/earn/rebalance-performance.shared";
 
 type SqlScalar = string | number | bigint | null;
+
+type RebalancePerformanceFleetAumSqlRow = {
+  aum_raw: SqlScalar;
+  bucket_started_at: Date | string;
+  reserve: string;
+};
+
+type RebalancePerformanceOpportunitySummarySqlRow = {
+  confirmed: SqlScalar;
+  failed: SqlScalar;
+  pending: SqlScalar;
+  qualified: SqlScalar;
+};
+
+type RebalancePerformanceMarkerSqlRow = {
+  confirmed_at: Date | string;
+  id: SqlScalar;
+};
+
+export type EarnRebalancePerformanceYieldData = {
+  confirmedRebalances: ConfirmedRebalanceMarker[];
+  fleetAumRows: RebalancePerformanceFleetAumRow[];
+  opportunitySummary: RebalanceOpportunitySummary;
+};
 
 export type RebalanceAuditRange = "24h" | "7d" | "30d" | "all";
 export type RebalanceAuditView =
@@ -891,6 +920,184 @@ export async function getRecentRebalanceDecisions(): Promise<
     targetReserve: row.target_reserve,
     updatedAt: toIsoString(row.updated_at) ?? "",
   }));
+}
+
+export async function getEarnRebalancePerformanceYieldData(args: {
+  endedAt: Date;
+  liquidityMint: string;
+  startedAt: Date;
+}): Promise<EarnRebalancePerformanceYieldData> {
+  const liquidityMint = escapeSqlLiteral(args.liquidityMint);
+  const startedAt = escapeSqlLiteral(args.startedAt.toISOString());
+  const endedAt = escapeSqlLiteral(args.endedAt.toISOString());
+  const [fleetRows, opportunitySummaryRows, markerRows] = await Promise.all([
+    queryRows<RebalancePerformanceFleetAumSqlRow>(
+      `
+        WITH bounds AS (
+          SELECT
+            '${startedAt}'::timestamptz AS started_at,
+            '${endedAt}'::timestamptz AS ended_at
+        ),
+        buckets AS (
+          SELECT generate_series(
+            date_bin(
+              interval '5 minutes',
+              (SELECT started_at FROM bounds),
+              timestamptz '1970-01-01 00:00:00+00'
+            ),
+            date_bin(
+              interval '5 minutes',
+              (SELECT ended_at FROM bounds),
+              timestamptz '1970-01-01 00:00:00+00'
+            ),
+            interval '5 minutes'
+          ) AS bucket_started_at
+        ),
+        candidate_positions AS (
+          SELECT position.id
+          FROM loyal_yield.user_yield_positions AS position
+          WHERE position.deposit_mint = '${liquidityMint}'
+            AND position.created_at <= (SELECT ended_at FROM bounds)
+        ),
+        seed_events AS (
+          SELECT DISTINCT ON (event.position_id)
+            event.id,
+            event.position_id,
+            event.reserve,
+            event.liquidity_mint,
+            event.amount_raw,
+            event.observed_slot,
+            event.observed_at
+          FROM loyal_yield.user_yield_position_holding_events AS event
+          INNER JOIN candidate_positions AS position
+            ON position.id = event.position_id
+          WHERE event.observed_at <= (SELECT started_at FROM bounds)
+          ORDER BY
+            event.position_id,
+            event.observed_at DESC,
+            event.observed_slot DESC,
+            event.id DESC
+        ),
+        window_events AS (
+          SELECT
+            event.id,
+            event.position_id,
+            event.reserve,
+            event.liquidity_mint,
+            event.amount_raw,
+            event.observed_slot,
+            event.observed_at
+          FROM loyal_yield.user_yield_position_holding_events AS event
+          INNER JOIN candidate_positions AS position
+            ON position.id = event.position_id
+          WHERE event.observed_at > (SELECT started_at FROM bounds)
+            AND event.observed_at <= (SELECT ended_at FROM bounds)
+        ),
+        holding_intervals AS (
+          SELECT
+            event.position_id,
+            event.reserve,
+            event.liquidity_mint,
+            event.amount_raw,
+            event.observed_at,
+            LEAD(
+              event.observed_at,
+              1,
+              (SELECT ended_at FROM bounds) + interval '5 minutes'
+            ) OVER (
+              PARTITION BY event.position_id
+              ORDER BY event.observed_at, event.observed_slot, event.id
+            ) AS next_observed_at
+          FROM (
+            SELECT * FROM seed_events
+            UNION ALL
+            SELECT * FROM window_events
+          ) AS event
+        )
+        SELECT
+          bucket.bucket_started_at,
+          holding.reserve,
+          SUM(holding.amount_raw)::text AS aum_raw
+        FROM buckets AS bucket
+        INNER JOIN holding_intervals AS holding
+          ON holding.observed_at <= bucket.bucket_started_at
+          AND holding.next_observed_at > bucket.bucket_started_at
+        WHERE holding.liquidity_mint = '${liquidityMint}'
+          AND holding.amount_raw > 0
+        GROUP BY bucket.bucket_started_at, holding.reserve
+        ORDER BY bucket.bucket_started_at, holding.reserve
+      `
+    ),
+    queryRows<RebalancePerformanceOpportunitySummarySqlRow>(
+      `
+        WITH opportunity_outcomes AS (
+          SELECT
+            opportunity.id,
+            CASE
+              WHEN decision.status::text = 'confirmed' THEN 'confirmed'
+              WHEN decision.status::text = 'failed'
+                OR opportunity.opportunity_state IN (
+                  'failed', 'cancelled', 'stale', 'superseded'
+                ) THEN 'failed'
+              ELSE 'pending'
+            END AS outcome
+          FROM loyal_yield.rebalance_opportunities AS opportunity
+          LEFT JOIN loyal_yield.rebalance_decisions AS decision
+            ON decision.id = opportunity.decision_id
+          WHERE opportunity.execution_plan->>'kind' = 'same_mint'
+            AND opportunity.liquidity_mint = '${liquidityMint}'
+            AND opportunity.created_at >= '${startedAt}'::timestamptz
+            AND opportunity.created_at <= '${endedAt}'::timestamptz
+        )
+        SELECT
+          COUNT(DISTINCT id)::text AS qualified,
+          COUNT(DISTINCT id) FILTER (
+            WHERE outcome = 'confirmed'
+          )::text AS confirmed,
+          COUNT(DISTINCT id) FILTER (
+            WHERE outcome = 'failed'
+          )::text AS failed,
+          COUNT(DISTINCT id) FILTER (
+            WHERE outcome = 'pending'
+          )::text AS pending
+        FROM opportunity_outcomes
+      `
+    ),
+    queryRows<RebalancePerformanceMarkerSqlRow>(
+      `
+        SELECT
+          decision.id::text AS id,
+          decision.updated_at AS confirmed_at
+        FROM loyal_yield.rebalance_decisions AS decision
+        WHERE decision.execution_plan->>'kind' = 'same_mint'
+          AND decision.liquidity_mint = '${liquidityMint}'
+          AND decision.status::text = 'confirmed'
+          AND decision.updated_at >= '${startedAt}'::timestamptz
+          AND decision.updated_at <= '${endedAt}'::timestamptz
+        ORDER BY decision.updated_at, decision.id
+      `
+    ),
+  ]);
+
+  const opportunitySummary = opportunitySummaryRows[0];
+
+  return {
+    confirmedRebalances: markerRows.map((row) => ({
+      confirmedAt: toIsoString(row.confirmed_at) ?? "",
+      id: String(row.id),
+    })),
+    fleetAumRows: fleetRows.map((row) => ({
+      aumRaw: toBigInt(row.aum_raw),
+      bucketStartedAt: toIsoString(row.bucket_started_at) ?? "",
+      reserve: row.reserve,
+    })),
+    opportunitySummary: {
+      confirmed: toNumber(opportunitySummary?.confirmed),
+      failed: toNumber(opportunitySummary?.failed),
+      pending: toNumber(opportunitySummary?.pending),
+      qualified: toNumber(opportunitySummary?.qualified),
+    },
+  };
 }
 
 export async function getRebalanceActivity(): Promise<

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -40,31 +40,15 @@ import {
   STABLECOIN_DECIMALS,
 } from "@/lib/earn/stablecoin-monitor.shared";
 import type {
-  SafeReserveApyMonitorData,
-  SafeReserveApyStatusRow,
-  SafeReserveRebalanceDecisionMarker,
-} from "@/lib/kamino/timescale-reserve-monitor.shared";
+  RebalanceOpportunitySummary,
+  RebalancePerformancePoint,
+  RebalancePerformanceSummary,
+} from "@/lib/earn/rebalance-performance.shared";
+import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
-import { SafeReserveApyChart } from "../safe-reserve-apy-chart";
-import {
-  AutodepositFailuresChart,
-  type SerializedAutodepositFailureRange,
-} from "./autodeposit-failures-chart";
-import {
-  EarnVaultRebalanceFrequencyChart,
-  type SerializedEarnVaultRebalanceFrequency,
-} from "./earn-vault-rebalance-frequency-chart";
-import {
-  ExecutedEarnRebalancesChart,
-  type SerializedExecutedEarnRebalanceHistory,
-} from "./executed-earn-rebalances-chart";
-import { Last30DaysRebalanceChart } from "./last-30-days-rebalance-chart";
-import { RebalanceActivityChart } from "./rebalance-activity-chart";
+import { EarnRebalancePerformanceChart } from "./earn-rebalance-performance-chart";
 import type {
   EarnActiveReserveRouteRow,
-  EarnRebalanceDecisionRow,
-  Last30DaysRebalancePoint,
-  RebalanceActivityPoint,
   RebalanceAuditErrorFilter,
   RebalanceAuditLane,
   RebalanceAuditRange,
@@ -81,14 +65,6 @@ type SerializedActiveReserveRouteRow = Omit<
   activeAumRaw: string;
 };
 
-type SerializedRebalanceDecisionRow = Omit<
-  EarnRebalanceDecisionRow,
-  "amountRaw" | "confirmedSlot"
-> & {
-  amountRaw: string | null;
-  confirmedSlot: string | null;
-};
-
 type SerializedRebalanceAuditRow = Omit<
   RebalanceAuditRow,
   "amountRaw" | "confirmedSlot" | "submittedSlot"
@@ -99,14 +75,25 @@ type SerializedRebalanceAuditRow = Omit<
 };
 
 type RebalanceApiData = {
-  activity: RebalanceActivityPoint[];
-  apyData: SafeReserveApyMonitorData;
-  autodeposit: SerializedAutodepositFailureRange[];
-  decisions: SerializedRebalanceDecisionRow[];
-  executedRebalances: SerializedExecutedEarnRebalanceHistory;
-  last30DaysRebalances: Last30DaysRebalancePoint[];
-  routes: SerializedActiveReserveRouteRow[];
-  vaultRebalanceFrequency: SerializedEarnVaultRebalanceFrequency;
+  bucketMinutes: number;
+  current: {
+    routes: SerializedActiveReserveRouteRow[];
+    statuses: SafeReserveApyStatusRow[];
+  };
+  generatedAt: string;
+  liquidityMint: string;
+  opportunities: RebalanceOpportunitySummary | null;
+  points: RebalancePerformancePoint[];
+  sources: {
+    fleet: "available" | "unavailable";
+    market: "available" | "unavailable";
+  };
+  summary: RebalancePerformanceSummary;
+  symbol: string;
+  window: {
+    endedAt: string;
+    startedAt: string;
+  };
 };
 
 type LoadState =
@@ -210,9 +197,9 @@ function formatReason(value: string | null) {
   return value.replaceAll("_", " ");
 }
 
-function createReserveLabelMap(data: SafeReserveApyMonitorData) {
+function createReserveLabelMap(rows: readonly SafeReserveApyStatusRow[]) {
   return new Map(
-    data.statuses.map((row) => [
+    rows.map((row) => [
       row.reserve,
       row.marketName ?? row.market ?? formatShortAddress(row.reserve),
     ])
@@ -228,24 +215,6 @@ function getReserveLabel(
   }
 
   return labels.get(reserve) ?? formatShortAddress(reserve);
-}
-
-function toDecisionMarkers(
-  rows: readonly SerializedRebalanceDecisionRow[]
-): SafeReserveRebalanceDecisionMarker[] {
-  return rows
-    .filter((row) => row.decisionType === "rebalance")
-    .map((row) => ({
-      createdAt: row.createdAt,
-      estimatedEdgeBps: row.estimatedEdgeBps,
-      id: row.id,
-      liquidityMint: row.liquidityMint,
-      sourceApyBps: row.sourceApyBps,
-      sourceReserve: row.sourceReserve,
-      status: row.status,
-      targetApyBps: row.targetApyBps,
-      targetReserve: row.targetReserve,
-    }));
 }
 
 function CurrentReserveApyTable({
@@ -1273,11 +1242,11 @@ function CurrentReserveApyFallback() {
 
 function ApyChartFallback() {
   return (
-    <Card className="mx-auto w-full max-w-4xl">
+    <Card className="mx-auto w-full min-w-0 max-w-4xl">
       <CardHeader className="border-b">
-        <div className="flex flex-col gap-2">
+        <div className="flex min-w-0 flex-col gap-2">
           <Skeleton className="h-5 w-40" />
-          <Skeleton className="h-4 w-96 max-w-full" />
+          <Skeleton className="h-4 w-full max-w-96" />
         </div>
       </CardHeader>
       <CardContent className="px-2 pt-6 sm:p-6">
@@ -1297,7 +1266,7 @@ function RebalanceDecisionAuditFallback() {
     <Card className="min-w-0">
       <CardHeader>
         <Skeleton className="h-5 w-52" />
-        <Skeleton className="h-4 w-96 max-w-full" />
+        <Skeleton className="h-4 w-full max-w-96" />
       </CardHeader>
       <CardContent className="space-y-3">
         {Array.from({ length: 6 }).map((_, index) => (
@@ -1320,12 +1289,9 @@ function RebalanceDecisionAuditFallback() {
 
 function RebalanceMonitorFallback() {
   return (
-    <div className="mx-auto grid w-full max-w-4xl gap-6">
+    <div className="grid min-w-0 gap-6">
       <CurrentReserveApyFallback />
       <ApyChartFallback />
-      <ApyChartFallback />
-      <ApyChartFallback />
-      <RebalanceDecisionAuditFallback />
     </div>
   );
 }
@@ -1333,16 +1299,25 @@ function RebalanceMonitorFallback() {
 export function RebalanceMonitorClient() {
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [selectedMint, setSelectedMint] = useState("USDC");
+  const selectedDescriptor =
+    EARN_STABLECOIN_DESCRIPTORS.find(({ symbol }) => symbol === selectedMint) ??
+    EARN_STABLECOIN_DESCRIPTORS[0];
 
   useEffect(() => {
     const controller = new AbortController();
+    setState({ status: "loading" });
 
     async function loadMonitor() {
       try {
-        const response = await fetch("/api/earn/rebalance", {
-          credentials: "same-origin",
-          signal: controller.signal,
-        });
+        const response = await fetch(
+          `/api/earn/rebalance?mint=${encodeURIComponent(
+            selectedDescriptor.mint
+          )}`,
+          {
+            credentials: "same-origin",
+            signal: controller.signal,
+          }
+        );
 
         if (!response.ok) {
           throw new Error(
@@ -1351,6 +1326,9 @@ export function RebalanceMonitorClient() {
         }
 
         const data = (await response.json()) as RebalanceApiData;
+        if (data.liquidityMint !== selectedDescriptor.mint) {
+          throw new Error("Rebalance monitor returned a different stablecoin.");
+        }
         setState({ data, status: "ready" });
       } catch (error) {
         if (controller.signal.aborted) {
@@ -1370,116 +1348,72 @@ export function RebalanceMonitorClient() {
     void loadMonitor();
 
     return () => controller.abort();
-  }, []);
+  }, [selectedDescriptor.mint]);
 
-  if (state.status === "loading") {
-    return <RebalanceMonitorFallback />;
-  }
+  const currentData =
+    state.status === "ready" &&
+    state.data.liquidityMint === selectedDescriptor.mint
+      ? state.data
+      : null;
+  const reserveLabels = createReserveLabelMap(
+    currentData?.current.statuses ?? []
+  );
 
-  if (state.status === "error") {
-    return (
-      <div className="mx-auto w-full max-w-4xl">
+  return (
+    <div className="mx-auto grid w-full min-w-0 max-w-4xl gap-6">
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle className="font-bold">Stablecoin</CardTitle>
+          <CardDescription>
+            Select one Earn mint. Performance metrics never blend stablecoins.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="min-w-0">
+          <Tabs
+            onValueChange={(value) => {
+              setState({ status: "loading" });
+              setSelectedMint(value);
+            }}
+            value={selectedMint}
+          >
+            <TabsList className="h-auto w-full justify-start overflow-x-auto">
+              {EARN_STABLECOIN_DESCRIPTORS.map(({ mint, symbol }) => (
+                <TabsTrigger key={mint} value={symbol}>
+                  {symbol}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      {state.status === "loading" ? <RebalanceMonitorFallback /> : null}
+      {state.status === "error" ? (
         <Card>
           <CardHeader>
-            <CardTitle className="font-bold">Rebalance monitor</CardTitle>
+            <CardTitle className="font-bold">
+              {selectedMint} rebalance performance
+            </CardTitle>
             <CardDescription>{state.message}</CardDescription>
           </CardHeader>
         </Card>
-      </div>
-    );
-  }
+      ) : null}
+      {currentData ? (
+        <>
+          <CurrentReserveApyCard
+            routes={currentData.current.routes}
+            rows={currentData.current.statuses}
+          />
+          <EarnRebalancePerformanceChart
+            opportunities={currentData.opportunities}
+            points={currentData.points}
+            sources={currentData.sources}
+            summary={currentData.summary}
+            symbol={currentData.symbol}
+          />
+        </>
+      ) : null}
 
-  const reserveLabels = createReserveLabelMap(state.data.apyData);
-  const selectedDescriptor = EARN_STABLECOIN_DESCRIPTORS.find(
-    ({ symbol }) => symbol === selectedMint
-  );
-  const selectedMintAddress = selectedDescriptor?.mint ?? null;
-  const filteredApyData = selectedMintAddress
-    ? {
-        ...state.data.apyData,
-        series: state.data.apyData.series.filter(
-          (series) => series.liquidityMint === selectedMintAddress
-        ),
-        statuses: state.data.apyData.statuses.filter(
-          (status) => status.liquidityMint === selectedMintAddress
-        ),
-      }
-    : state.data.apyData;
-  const filteredRoutes = selectedMintAddress
-    ? state.data.routes.filter(
-        (route) => route.liquidityMint === selectedMintAddress
-      )
-    : state.data.routes;
-  const filteredDecisions = selectedMintAddress
-    ? state.data.decisions.filter(
-        (decision) => decision.liquidityMint === selectedMintAddress
-      )
-    : state.data.decisions;
-  const filteredExecutedRebalances = selectedMintAddress
-    ? {
-        ...state.data.executedRebalances,
-        executions: state.data.executedRebalances.executions.filter(
-          (execution) => execution.liquidityMint === selectedMintAddress
-        ),
-      }
-    : state.data.executedRebalances;
-  const filteredFrequencyVaults = selectedMintAddress
-    ? state.data.vaultRebalanceFrequency.vaults.filter(
-        (vault) => vault.liquidityMint === selectedMintAddress
-      )
-    : state.data.vaultRebalanceFrequency.vaults;
-  const filteredVaultRebalanceFrequency = {
-    ...state.data.vaultRebalanceFrequency,
-    vaultCount: filteredFrequencyVaults.length,
-    vaults: filteredFrequencyVaults,
-  };
-
-  return (
-    <div className="mx-auto grid w-full max-w-4xl gap-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="font-bold">Stablecoin filter</CardTitle>
-          <CardDescription>
-            Filters verified reserves, confirmed executions, and vault
-            frequency. The aggregate activity and paginated audit sections
-            remain all-mint.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Select value={selectedMint} onValueChange={setSelectedMint}>
-            <SelectTrigger className="w-full sm:w-56">
-              <SelectValue placeholder="Select stablecoin" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All stablecoins</SelectItem>
-              {EARN_STABLECOIN_DESCRIPTORS.map(({ mint, symbol }) => (
-                <SelectItem key={mint} value={symbol}>
-                  {symbol}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </CardContent>
-      </Card>
-      <CurrentReserveApyCard
-        routes={filteredRoutes}
-        rows={filteredApyData.statuses}
-      />
-      <SafeReserveApyChart
-        data={filteredApyData}
-        decisionMarkers={toDecisionMarkers(filteredDecisions)}
-      />
-      <RebalanceActivityChart data={state.data.activity} />
-      <ExecutedEarnRebalancesChart
-        data={filteredExecutedRebalances}
-        reserveLabels={reserveLabels}
-      />
-      <EarnVaultRebalanceFrequencyChart
-        data={filteredVaultRebalanceFrequency}
-        reserveStatuses={filteredApyData.statuses}
-      />
-      <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />
-      <AutodepositFailuresChart data={state.data.autodeposit} />
       <RebalanceAuditCard reserveLabels={reserveLabels} />
     </div>
   );

--- a/apps/admin/src/app/api/earn/rebalance/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/route.ts
@@ -1,147 +1,147 @@
 import { unstable_cache } from "next/cache";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
-import { getSafeReserveApyMonitorData } from "@/lib/kamino/timescale-reserve-client.server";
 import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
+import {
+  buildRebalancePerformancePoints,
+  parseRebalancePerformanceMint,
+  summarizeRebalancePerformance,
+} from "@/lib/earn/rebalance-performance.shared";
+import { getEarnStablecoinSymbol } from "@/lib/earn/stablecoin-monitor.shared";
+import { getSafeReserveApyMonitorData } from "@/lib/kamino/timescale-reserve-client.server";
 
 import {
   getActiveReserveRoutes,
-  getAutodepositTimeSeries,
-  getEarnVaultRebalanceFrequency,
-  getExecutedEarnRebalanceHistory,
-  getLast30DaysRebalanceSeries,
-  getRebalanceActivity,
-  getRecentRebalanceDecisions,
+  getEarnRebalancePerformanceYieldData,
 } from "../../../(admin)/earn/rebalance/rebalance-data";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-async function loadRebalanceMonitorData() {
-  const [
-    apyData,
-    routes,
-    decisions,
-    activity,
-    last30DaysRebalances,
-    autodeposit,
-  ] = await Promise.all([
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const BUCKET_DURATION_MS = 5 * 60 * 1000;
+
+function logUnavailableSource(source: string, error: unknown) {
+  console.error("Earn rebalance performance source unavailable", {
+    errorMessage:
+      error instanceof Error ? error.message : "Unknown database error",
+    errorName: error instanceof Error ? error.name : "Error",
+    source,
+  });
+}
+
+async function loadRebalancePerformance(liquidityMint: string) {
+  const endedAt = new Date();
+  const startedAt = new Date(endedAt.getTime() - WINDOW_MS);
+  const [marketResult, yieldResult, routesResult] = await Promise.allSettled([
     getSafeReserveApyMonitorData(),
+    getEarnRebalancePerformanceYieldData({
+      endedAt,
+      liquidityMint,
+      startedAt,
+    }),
     getActiveReserveRoutes(),
-    getRecentRebalanceDecisions(),
-    getRebalanceActivity(),
-    getLast30DaysRebalanceSeries(),
-    getAutodepositTimeSeries(),
   ]);
 
+  if (marketResult.status === "rejected") {
+    logUnavailableSource("kamino_timescale", marketResult.reason);
+  }
+  if (yieldResult.status === "rejected") {
+    logUnavailableSource("yield_neon", yieldResult.reason);
+  }
+  if (routesResult.status === "rejected") {
+    logUnavailableSource("yield_current_routes", routesResult.reason);
+  }
+
+  const selectedSeries =
+    marketResult.status === "fulfilled"
+      ? marketResult.value.series.filter(
+          (series) => series.liquidityMint === liquidityMint
+        )
+      : [];
+  const apyRows =
+    marketResult.status === "fulfilled"
+      ? marketResult.value.chartPoints.flatMap((point) =>
+          selectedSeries.map((series) => ({
+            bucketStartedAt: point.observedAt,
+            reserve: series.reserve,
+            supplyApyPercent:
+              typeof point[series.key] === "number"
+                ? (point[series.key] as number)
+                : null,
+          }))
+        )
+      : [];
+  const points = buildRebalancePerformancePoints({
+    apyRows,
+    bucketDurationMs: BUCKET_DURATION_MS,
+    confirmedRebalances:
+      yieldResult.status === "fulfilled"
+        ? yieldResult.value.confirmedRebalances
+        : [],
+    fleetAumRows:
+      yieldResult.status === "fulfilled" ? yieldResult.value.fleetAumRows : [],
+  });
+
   return {
-    activity,
-    apyData,
-    autodeposit: autodeposit.map((range) => ({
-      bucketHours: range.bucketHours,
-      key: range.key,
-      points: range.points.map((point) => ({
-        accountNotFound: point.accountNotFound,
-        bucketStartedAt: point.bucketStartedAt,
-        confirmationOrTimeout: point.confirmationOrTimeout,
-        insufficientRent: point.insufficientRent,
-        missingTokenDelegate: point.missingTokenDelegate,
-        noLinkedError: point.noLinkedError,
-        otherPrePull: point.otherPrePull,
-        postPullKaminoTopUp: point.postPullKaminoTopUp,
-      })),
-    })),
-    decisions: decisions.map((decision) => ({
-      ...decision,
-      amountRaw: decision.amountRaw?.toString() ?? null,
-      confirmedSlot: decision.confirmedSlot?.toString() ?? null,
-    })),
-    last30DaysRebalances,
-    routes: routes.map((route) => ({
-      ...route,
-      activeAumRaw: route.activeAumRaw.toString(),
-    })),
+    bucketMinutes: BUCKET_DURATION_MS / 60_000,
+    current: {
+      routes:
+        routesResult.status === "fulfilled"
+          ? routesResult.value
+              .filter((route) => route.liquidityMint === liquidityMint)
+              .map((route) => ({
+                ...route,
+                activeAumRaw: route.activeAumRaw.toString(),
+              }))
+          : [],
+      statuses:
+        marketResult.status === "fulfilled"
+          ? marketResult.value.statuses.filter(
+              (status) => status.liquidityMint === liquidityMint
+            )
+          : [],
+    },
+    generatedAt: endedAt.toISOString(),
+    liquidityMint,
+    opportunities:
+      yieldResult.status === "fulfilled"
+        ? yieldResult.value.opportunitySummary
+        : null,
+    points,
+    sources: {
+      fleet: yieldResult.status === "fulfilled" ? "available" : "unavailable",
+      market: marketResult.status === "fulfilled" ? "available" : "unavailable",
+    },
+    summary: summarizeRebalancePerformance(points),
+    symbol: getEarnStablecoinSymbol(liquidityMint) ?? "Unknown",
+    window: {
+      endedAt: endedAt.toISOString(),
+      startedAt: startedAt.toISOString(),
+    },
   };
 }
 
-async function loadExecutedRebalances() {
-  try {
-    const history = await getExecutedEarnRebalanceHistory();
-
-    return {
-      ...history,
-      status: "available" as const,
-      executions: history.executions.map((execution) => ({
-        ...execution,
-        amountRaw: execution.amountRaw.toString(),
-        confirmedSlot: execution.confirmedSlot.toString(),
-        currentDepositRaw: execution.currentDepositRaw.toString(),
-      })),
-    };
-  } catch (error) {
-    console.error("Executed Earn rebalance history query failed", {
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown database error",
-      errorName: error instanceof Error ? error.name : "Error",
-    });
-
-    return {
-      executions: [],
-      generatedAt: new Date().toISOString(),
-      status: "unavailable" as const,
-      userCount: 0,
-    };
-  }
-}
-
-async function loadVaultRebalanceFrequency() {
-  try {
-    const frequency = await getEarnVaultRebalanceFrequency();
-
-    return {
-      ...frequency,
-      status: "available" as const,
-      vaults: frequency.vaults.map((vault) => ({
-        ...vault,
-        currentDepositRaw: vault.currentDepositRaw.toString(),
-      })),
-    };
-  } catch (error) {
-    console.error("Earn vault rebalance frequency query failed", {
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown database error",
-      errorName: error instanceof Error ? error.name : "Error",
-    });
-
-    return {
-      generatedAt: new Date().toISOString(),
-      status: "unavailable" as const,
-      vaultCount: 0,
-      vaults: [],
-    };
-  }
-}
-
-const getCachedRebalanceMonitorData = unstable_cache(
-  loadRebalanceMonitorData,
-  ["earn-rebalance-monitor"],
+const getCachedRebalancePerformance = unstable_cache(
+  loadRebalancePerformance,
+  ["earn-rebalance-performance"],
   { revalidate: DATA_CACHE_TTL_SECONDS }
 );
 
-export async function GET() {
-  const [monitorData, executedRebalances, vaultRebalanceFrequency] =
-    await Promise.all([
-      getCachedRebalanceMonitorData(),
-      loadExecutedRebalances(),
-      loadVaultRebalanceFrequency(),
-    ]);
-
-  return NextResponse.json(
-    { ...monitorData, executedRebalances, vaultRebalanceFrequency },
-    {
-      headers: {
-        "Cache-Control": "private, no-store",
-      },
-    }
+export async function GET(request: NextRequest) {
+  const liquidityMint = parseRebalancePerformanceMint(
+    request.nextUrl.searchParams.get("mint")
   );
+  if (!liquidityMint) {
+    return NextResponse.json(
+      { error: "A canonical Earn stablecoin mint is required." },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(await getCachedRebalancePerformance(liquidityMint), {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
 }

--- a/apps/admin/src/lib/earn/rebalance-performance.shared.ts
+++ b/apps/admin/src/lib/earn/rebalance-performance.shared.ts
@@ -1,0 +1,251 @@
+import { EARN_STABLECOIN_DESCRIPTORS } from "./stablecoin-monitor.shared";
+
+export type RebalancePerformanceApyRow = {
+  bucketStartedAt: string;
+  reserve: string;
+  supplyApyPercent: number | null;
+};
+
+export type RebalancePerformanceFleetAumRow = {
+  aumRaw: bigint;
+  bucketStartedAt: string;
+  reserve: string;
+};
+
+export type ConfirmedRebalanceMarker = {
+  confirmedAt: string;
+  id: string;
+};
+
+export type RebalancePerformancePoint = {
+  bestObservedApyPercent: number | null;
+  bestReserve: string | null;
+  bestReserveAumRaw: string | null;
+  bucketDurationMs: number;
+  bucketStartedAt: string;
+  confirmedRebalanceCount: number;
+  fleetShareInBestReservePercent: number | null;
+  fleetWeightedApyPercent: number | null;
+  knownFleetAumRaw: string;
+};
+
+export type RebalancePerformanceSummary = {
+  aumTimeInBestReservePercent: number | null;
+  coveragePercent: number | null;
+  knownAumTimeRaw: string;
+  totalAumTimeRaw: string;
+};
+
+export type RebalanceOpportunityOutcome = "confirmed" | "failed" | "pending";
+
+export type RebalanceOpportunityRow = {
+  opportunityId: string;
+  outcome: RebalanceOpportunityOutcome;
+};
+
+export type RebalanceOpportunitySummary = {
+  confirmed: number;
+  failed: number;
+  pending: number;
+  qualified: number;
+};
+
+function isFiniteNumber(value: number | null): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function toBucketStartedAt(value: string, bucketDurationMs: number) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  return new Date(
+    Math.floor(timestamp / bucketDurationMs) * bucketDurationMs
+  ).toISOString();
+}
+
+export function parseRebalancePerformanceMint(value: string | null) {
+  return (
+    EARN_STABLECOIN_DESCRIPTORS.find(({ mint }) => mint === value)?.mint ?? null
+  );
+}
+
+export function buildRebalancePerformancePoints(args: {
+  apyRows: readonly RebalancePerformanceApyRow[];
+  bucketDurationMs: number;
+  confirmedRebalances: readonly ConfirmedRebalanceMarker[];
+  fleetAumRows: readonly RebalancePerformanceFleetAumRow[];
+}): RebalancePerformancePoint[] {
+  const bucketKeys = new Set<string>();
+  const apyByBucket = new Map<string, Map<string, number>>();
+  const aumByBucket = new Map<string, Map<string, bigint>>();
+  const confirmedIdsByBucket = new Map<string, Set<string>>();
+
+  for (const row of args.apyRows) {
+    const bucketStartedAt = toBucketStartedAt(
+      row.bucketStartedAt,
+      args.bucketDurationMs
+    );
+    if (!bucketStartedAt || !isFiniteNumber(row.supplyApyPercent)) {
+      if (bucketStartedAt) {
+        bucketKeys.add(bucketStartedAt);
+      }
+      continue;
+    }
+
+    bucketKeys.add(bucketStartedAt);
+    const bucket = apyByBucket.get(bucketStartedAt) ?? new Map();
+    bucket.set(row.reserve, row.supplyApyPercent);
+    apyByBucket.set(bucketStartedAt, bucket);
+  }
+
+  for (const row of args.fleetAumRows) {
+    const bucketStartedAt = toBucketStartedAt(
+      row.bucketStartedAt,
+      args.bucketDurationMs
+    );
+    if (!bucketStartedAt || row.aumRaw < BigInt(0)) {
+      continue;
+    }
+
+    bucketKeys.add(bucketStartedAt);
+    const bucket = aumByBucket.get(bucketStartedAt) ?? new Map();
+    bucket.set(
+      row.reserve,
+      (bucket.get(row.reserve) ?? BigInt(0)) + row.aumRaw
+    );
+    aumByBucket.set(bucketStartedAt, bucket);
+  }
+
+  for (const marker of args.confirmedRebalances) {
+    const bucketStartedAt = toBucketStartedAt(
+      marker.confirmedAt,
+      args.bucketDurationMs
+    );
+    if (!bucketStartedAt) {
+      continue;
+    }
+
+    const bucket = confirmedIdsByBucket.get(bucketStartedAt) ?? new Set();
+    bucket.add(marker.id);
+    confirmedIdsByBucket.set(bucketStartedAt, bucket);
+  }
+
+  return [...bucketKeys]
+    .sort((left, right) => left.localeCompare(right))
+    .map((bucketStartedAt) => {
+      const apyByReserve = apyByBucket.get(bucketStartedAt) ?? new Map();
+      const aumByReserve = aumByBucket.get(bucketStartedAt) ?? new Map();
+      const knownFleetAumRaw = [...aumByReserve.values()].reduce(
+        (sum, value) => sum + value,
+        BigInt(0)
+      );
+      const bestEntry = [...apyByReserve.entries()].sort(
+        ([leftReserve, leftApy], [rightReserve, rightApy]) =>
+          rightApy - leftApy || leftReserve.localeCompare(rightReserve)
+      )[0];
+      const hasCompleteApyCoverage = [...aumByReserve.entries()].every(
+        ([reserve, aumRaw]) => aumRaw === BigInt(0) || apyByReserve.has(reserve)
+      );
+      const bestReserve = bestEntry?.[0] ?? null;
+      const bestReserveAumRaw = bestReserve
+        ? aumByReserve.get(bestReserve) ?? BigInt(0)
+        : null;
+
+      let fleetWeightedApyPercent: number | null = null;
+      if (knownFleetAumRaw > BigInt(0) && bestEntry && hasCompleteApyCoverage) {
+        const weightedTotal = [...aumByReserve.entries()].reduce(
+          (sum, [reserve, aumRaw]) =>
+            sum + Number(aumRaw) * (apyByReserve.get(reserve) ?? 0),
+          0
+        );
+        fleetWeightedApyPercent = weightedTotal / Number(knownFleetAumRaw);
+      }
+
+      return {
+        bestObservedApyPercent: bestEntry?.[1] ?? null,
+        bestReserve,
+        bestReserveAumRaw: bestReserveAumRaw?.toString() ?? null,
+        bucketDurationMs: args.bucketDurationMs,
+        bucketStartedAt,
+        confirmedRebalanceCount:
+          confirmedIdsByBucket.get(bucketStartedAt)?.size ?? 0,
+        fleetShareInBestReservePercent:
+          bestReserveAumRaw !== null &&
+          knownFleetAumRaw > BigInt(0) &&
+          hasCompleteApyCoverage
+            ? (Number(bestReserveAumRaw) / Number(knownFleetAumRaw)) * 100
+            : null,
+        fleetWeightedApyPercent,
+        knownFleetAumRaw: knownFleetAumRaw.toString(),
+      };
+    });
+}
+
+export function summarizeRebalancePerformance(
+  points: readonly RebalancePerformancePoint[]
+): RebalancePerformanceSummary {
+  let bestReserveAumTimeRaw = BigInt(0);
+  let knownAumTimeRaw = BigInt(0);
+  let totalAumTimeRaw = BigInt(0);
+
+  for (const point of points) {
+    const duration = BigInt(point.bucketDurationMs);
+    const fleetAumRaw = BigInt(point.knownFleetAumRaw);
+    totalAumTimeRaw += fleetAumRaw * duration;
+
+    if (
+      point.bestReserveAumRaw === null ||
+      point.fleetWeightedApyPercent === null
+    ) {
+      continue;
+    }
+
+    knownAumTimeRaw += fleetAumRaw * duration;
+    bestReserveAumTimeRaw += BigInt(point.bestReserveAumRaw) * duration;
+  }
+
+  return {
+    aumTimeInBestReservePercent:
+      knownAumTimeRaw > BigInt(0)
+        ? (Number(bestReserveAumTimeRaw) / Number(knownAumTimeRaw)) * 100
+        : null,
+    coveragePercent:
+      totalAumTimeRaw > BigInt(0)
+        ? (Number(knownAumTimeRaw) / Number(totalAumTimeRaw)) * 100
+        : null,
+    knownAumTimeRaw: knownAumTimeRaw.toString(),
+    totalAumTimeRaw: totalAumTimeRaw.toString(),
+  };
+}
+
+export function summarizeRebalanceOpportunities(
+  rows: readonly RebalanceOpportunityRow[]
+): RebalanceOpportunitySummary {
+  const outcomeById = new Map<string, RebalanceOpportunityOutcome>();
+  const rank: Record<RebalanceOpportunityOutcome, number> = {
+    confirmed: 2,
+    failed: 1,
+    pending: 0,
+  };
+
+  for (const row of rows) {
+    const current = outcomeById.get(row.opportunityId);
+    if (!current || rank[row.outcome] > rank[current]) {
+      outcomeById.set(row.opportunityId, row.outcome);
+    }
+  }
+
+  const summary: RebalanceOpportunitySummary = {
+    confirmed: 0,
+    failed: 0,
+    pending: 0,
+    qualified: outcomeById.size,
+  };
+  for (const outcome of outcomeById.values()) {
+    summary[outcome] += 1;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## Goal

Give operators one trustworthy view of Earn rebalance performance: for one stablecoin at a time, show how the fleet APY compares with the best Safe reserve APY we observed and whether confirmed rebalances followed those opportunities. The page should be useful without implying that historical APY observations prove point-in-time eligibility.

## What changed

- Replaced the aggregate stablecoin selector with the six canonical Earn mint tabs, defaulting to USDC. The API now requires one canonical mint, so performance data cannot be mixed across stablecoins.
- Replaced the old multi-reserve APY and destination charts with one seven-day performance view. It compares best observed Safe APY with fleet AUM-weighted APY, marks confirmed rebalances, and summarizes AUM-time in the best reserve plus confirmed, failed, and pending opportunity outcomes.
- Added bounded server-side aggregation. Yield holding history is reduced to five-minute reserve AUM buckets, then joined with Timescale APY observations in typed server code. The browser receives only compact, serializable chart points and summaries.
- Kept the movement audit table for detailed diagnosis and made partial or unavailable source data explicit instead of presenting a misleading zero.
- Added a focused adversarial verifier for the metric math, distinct outcome counting, missing-data behavior, and canonical mint validation.

## Scope

This is limited to the admin Earn rebalance monitor and its API/data helpers. It does not add schemas or migrations, change cross-mint routing behavior, or modify the customer-facing frontend.

## Verification

- `bun run --cwd apps/admin verify:earn-rebalance-performance`
- `bun run guard:admin-shared-schema`
- `bun run admin:lint`
- `bunx tsc --noEmit -p apps/admin/tsconfig.json`
- `bun run admin:build`
- Desktop and narrow mobile browser smoke checks, including keyboard tab navigation, selected-mint loading, responsive layout, and console/hydration errors
- `git diff --check`

## Post-merge

1. Deploy the admin app through the normal release path.
2. Open `/earn/rebalance` and confirm each stablecoin tab loads its own current reserve table and seven-day performance view after one cache refresh.
3. Spot-check the USDC summary and confirmed markers against the Yield audit data and Timescale observations.
4. Watch server logs for unavailable-source errors or unexpectedly slow aggregation, and use the retained movement audit table when a metric needs investigation.
