### PR TITLE
fix(admin): scale Earn rebalance charts by deposit and eligible vaults

### DIFF
--- a/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+
+export type DepositScale = "linear" | "log";
+
+/**
+ * Log/linear switch for the deposit axis, shared by the Earn rebalance scatter
+ * charts. Both ends are labelled because neither reading is the obvious
+ * default: log is right for the fleet's long dust tail, linear is right when
+ * you care about absolute size.
+ */
+export function DepositScaleSwitch({
+  id,
+  onScaleChange,
+  scale,
+}: {
+  id: string;
+  onScaleChange: (scale: DepositScale) => void;
+  scale: DepositScale;
+}) {
+  const isLog = scale === "log";
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span
+        className={
+          isLog ? "text-muted-foreground" : "font-medium text-foreground"
+        }
+      >
+        Linear scale
+      </span>
+      <Switch
+        aria-label="Use a logarithmic deposit axis"
+        checked={isLog}
+        id={id}
+        onCheckedChange={(checked) => onScaleChange(checked ? "log" : "linear")}
+      />
+      <span
+        className={
+          isLog ? "font-medium text-foreground" : "text-muted-foreground"
+        }
+      >
+        Log scale
+      </span>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.test.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+describe("buildLogTicks", () => {
+  test("keeps the live mainnet deposit range readable", () => {
+    // Mainnet funded deposits currently run from one raw unit (0.000001) to
+    // ~100.3k, which is thirteen decades.
+    const ticks = buildLogTicks(0.000001, 100_322.41);
+
+    expect(ticks.length).toBeLessThanOrEqual(8);
+    expect(ticks[0]).toBeCloseTo(0.000001, 12);
+    expect(ticks[ticks.length - 1]).toBe(10 ** 6);
+  });
+
+  test("covers the whole data range", () => {
+    const min = 0.01;
+    const max = 5_000;
+    const ticks = buildLogTicks(min, max);
+
+    expect(ticks[0]).toBeLessThanOrEqual(min);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(max);
+  });
+
+  test("emits ascending powers of ten", () => {
+    const ticks = buildLogTicks(0.001, 1_000_000);
+
+    for (const tick of ticks) {
+      const exponent = Math.log10(tick);
+      expect(Math.abs(exponent - Math.round(exponent))).toBeLessThan(1e-9);
+    }
+    for (let index = 1; index < ticks.length; index += 1) {
+      expect(ticks[index]).toBeGreaterThan(ticks[index - 1]);
+    }
+  });
+
+  test("handles a single-value range without looping forever", () => {
+    expect(buildLogTicks(100, 100)).toEqual([100]);
+  });
+
+  test("falls back safely on non-positive or infinite input", () => {
+    expect(buildLogTicks(0, 100)).toEqual([1]);
+    expect(buildLogTicks(-5, 100)).toEqual([1]);
+    expect(buildLogTicks(1, Number.POSITIVE_INFINITY)).toEqual([1]);
+  });
+});
+
+describe("formatLogTick", () => {
+  test("compacts large amounts and spells out small ones", () => {
+    expect(formatLogTick(100_000, USDC_MINT)).toBe("100K USDC");
+    expect(formatLogTick(1_000, USDC_MINT)).toBe("1K USDC");
+    expect(formatLogTick(1, USDC_MINT)).toBe("1 USDC");
+    expect(formatLogTick(0.01, USDC_MINT)).toBe("0.01 USDC");
+    expect(formatLogTick(0.000001, USDC_MINT)).toBe("0.000001 USDC");
+  });
+
+  test("falls back to a neutral unit for an unknown mint", () => {
+    expect(formatLogTick(1, null)).toBe("1 USD");
+  });
+});

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.test.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
 
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
@@ -47,16 +47,24 @@ describe("buildLogTicks", () => {
   });
 });
 
-describe("formatLogTick", () => {
+describe("formatDepositTick", () => {
   test("compacts large amounts and spells out small ones", () => {
-    expect(formatLogTick(100_000, USDC_MINT)).toBe("100K USDC");
-    expect(formatLogTick(1_000, USDC_MINT)).toBe("1K USDC");
-    expect(formatLogTick(1, USDC_MINT)).toBe("1 USDC");
-    expect(formatLogTick(0.01, USDC_MINT)).toBe("0.01 USDC");
-    expect(formatLogTick(0.000001, USDC_MINT)).toBe("0.000001 USDC");
+    expect(formatDepositTick(100_000, USDC_MINT)).toBe("100K USDC");
+    expect(formatDepositTick(1_000, USDC_MINT)).toBe("1K USDC");
+    expect(formatDepositTick(1, USDC_MINT)).toBe("1 USDC");
+    expect(formatDepositTick(0.01, USDC_MINT)).toBe("0.01 USDC");
+    expect(formatDepositTick(0.000001, USDC_MINT)).toBe("0.000001 USDC");
   });
 
   test("falls back to a neutral unit for an unknown mint", () => {
-    expect(formatLogTick(1, null)).toBe("1 USD");
+    expect(formatDepositTick(1, null)).toBe("1 USD");
+  });
+
+  test("renders the zero tick a linear axis asks for", () => {
+    // log10(0) is -Infinity, which would throw a RangeError once it reached
+    // maximumFractionDigits. A linear axis always requests a zero tick.
+    expect(() => formatDepositTick(0, USDC_MINT)).not.toThrow();
+    expect(formatDepositTick(0, USDC_MINT)).toBe("0 USDC");
+    expect(formatDepositTick(-1, USDC_MINT)).toBe("0 USDC");
   });
 });

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.ts
@@ -36,11 +36,17 @@ export function buildLogTicks(
   return ticks;
 }
 
-export function formatLogTick(
+export function formatDepositTick(
   value: number,
   liquidityMint: string | null
 ): string {
   const symbol = getEarnStablecoinSymbol(liquidityMint) ?? "USD";
+  // A linear axis puts a tick on zero, and log10(0) is -Infinity, which would
+  // blow up the fraction-digit count below.
+  if (!(value > 0)) {
+    return `0 ${symbol}`;
+  }
+
   const formatted =
     value >= 1000
       ? new Intl.NumberFormat("en-US", {

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.ts
@@ -1,0 +1,56 @@
+import { getEarnStablecoinSymbol } from "@/lib/earn/stablecoin-monitor.shared";
+
+const MAX_LOG_TICKS = 8;
+
+/**
+ * Powers of ten spanning the funded deposits, so the dust decades get the same
+ * width as the whale decade instead of collapsing into the left edge.
+ *
+ * Live deposits run from a single raw unit to six figures, which is thirteen
+ * decades. Labelling every one of them overlaps, so decades are thinned to a
+ * readable stride while the domain still ends on a real power of ten.
+ */
+export function buildLogTicks(
+  minAmount: number,
+  maxAmount: number
+): number[] {
+  if (!(minAmount > 0) || !Number.isFinite(maxAmount)) {
+    return [1];
+  }
+
+  const lowest = Math.floor(Math.log10(minAmount));
+  const highest = Math.ceil(Math.log10(Math.max(maxAmount, minAmount)));
+  const decades = highest - lowest;
+  const stride = Math.max(1, Math.ceil(decades / (MAX_LOG_TICKS - 1)));
+
+  const ticks: number[] = [];
+  for (let exponent = lowest; exponent <= highest; exponent += stride) {
+    ticks.push(10 ** exponent);
+  }
+  // Keep the top of the domain on the axis even when the stride overshoots it.
+  const topTick = 10 ** highest;
+  if (ticks[ticks.length - 1] !== topTick) {
+    ticks.push(topTick);
+  }
+
+  return ticks;
+}
+
+export function formatLogTick(
+  value: number,
+  liquidityMint: string | null
+): string {
+  const symbol = getEarnStablecoinSymbol(liquidityMint) ?? "USD";
+  const formatted =
+    value >= 1000
+      ? new Intl.NumberFormat("en-US", {
+          compactDisplay: "short",
+          maximumFractionDigits: 1,
+          notation: "compact",
+        }).format(value)
+      : value.toLocaleString("en-US", {
+          maximumFractionDigits: Math.max(0, -Math.floor(Math.log10(value))),
+        });
+
+  return `${formatted} ${symbol}`;
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.test.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
+
+import {
+  computeRebalanceEligibilityFloorRaw,
+  summarizeRebalanceEligibility,
+} from "./earn-vault-rebalance-eligibility";
+
+const DECIMALS = 6;
+
+function reserve(
+  reserveAddress: string,
+  supplyApyPercent: number | null
+): SafeReserveApyStatusRow {
+  return {
+    average24hApyPercent: supplyApyPercent,
+    average7dApyPercent: supplyApyPercent,
+    latestObservedAt: "2026-08-18T12:00:00.000Z",
+    liquidityMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    market: `market-${reserveAddress}`,
+    marketName: `Market ${reserveAddress}`,
+    reserve: reserveAddress,
+    status: "eligible",
+    supplyApyPercent,
+    symbol: "USDC",
+    totalSupplyUsdEstimate: 1_000_000,
+  };
+}
+
+describe("computeRebalanceEligibilityFloorRaw", () => {
+  test("matches the planner's economic floor at the live Main-to-OnRe spread", () => {
+    // Main Market 4.05% vs OnRe 6.49% is a 244 bps edge. Over the planner's
+    // 30-day horizon that earns $0.0020055 per dollar, and the gate needs
+    // $0.10 net gain on top of the $0.05 fixed safety margin, so the floor is
+    // $0.15 / 0.0020055 ~= $74.79.
+    const floor = computeRebalanceEligibilityFloorRaw(
+      [reserve("main", 4.05), reserve("onre", 6.49)],
+      DECIMALS
+    );
+
+    expect(floor).not.toBeNull();
+    const floorUsd = Number(floor) / 10 ** DECIMALS;
+    expect(floorUsd).toBeGreaterThan(74);
+    expect(floorUsd).toBeLessThan(75.5);
+  });
+
+  test("widens the floor as the spread narrows", () => {
+    const wide = computeRebalanceEligibilityFloorRaw(
+      [reserve("a", 4), reserve("b", 8)],
+      DECIMALS
+    );
+    const narrow = computeRebalanceEligibilityFloorRaw(
+      [reserve("a", 4), reserve("b", 4.5)],
+      DECIMALS
+    );
+
+    expect(narrow).toBeGreaterThan(wide as bigint);
+  });
+
+  test("never drops below the planner's minimum notional", () => {
+    // A giant spread would imply a sub-dollar floor, but the planner also
+    // refuses anything under $1.00 of notional.
+    const floor = computeRebalanceEligibilityFloorRaw(
+      [reserve("a", 1), reserve("b", 900)],
+      DECIMALS
+    );
+
+    expect(Number(floor) / 10 ** DECIMALS).toBeGreaterThanOrEqual(1);
+  });
+
+  test("ignores reserves the Safe monitor already rejected", () => {
+    // Below-liquidity reserves report 0% APY on mainnet. Counting them would
+    // invent a 6.49% edge and collapse the floor far below what the planner
+    // could ever act on.
+    const withDeadReserve = computeRebalanceEligibilityFloorRaw(
+      [
+        reserve("main", 4.05),
+        reserve("onre", 6.49),
+        { ...reserve("dead", 0), status: "below-liquidity" },
+      ],
+      DECIMALS
+    );
+    const withoutDeadReserve = computeRebalanceEligibilityFloorRaw(
+      [reserve("main", 4.05), reserve("onre", 6.49)],
+      DECIMALS
+    );
+
+    expect(withDeadReserve).toBe(withoutDeadReserve as bigint);
+  });
+
+  test("returns null when the spread cannot be established", () => {
+    expect(
+      computeRebalanceEligibilityFloorRaw([reserve("a", 4.05)], DECIMALS)
+    ).toBeNull();
+    expect(
+      computeRebalanceEligibilityFloorRaw(
+        [reserve("a", null), reserve("b", null)],
+        DECIMALS
+      )
+    ).toBeNull();
+    expect(
+      computeRebalanceEligibilityFloorRaw(
+        [reserve("a", 4.05), reserve("b", 4.05)],
+        DECIMALS
+      )
+    ).toBeNull();
+  });
+});
+
+describe("summarizeRebalanceEligibility", () => {
+  const vaults = [
+    { currentDepositRaw: "7010000", rebalanceCount: 0 },
+    { currentDepositRaw: "100000", rebalanceCount: 0 },
+    { currentDepositRaw: "100000000", rebalanceCount: 12 },
+    { currentDepositRaw: "80000000", rebalanceCount: 0 },
+    { currentDepositRaw: "500000", rebalanceCount: 3 },
+  ];
+
+  test("counts only vaults that clear the floor", () => {
+    const summary = summarizeRebalanceEligibility(vaults, BigInt(74_790_000));
+
+    expect(summary.eligibleCount).toBe(2);
+    expect(summary.eligibleRebalancedCount).toBe(1);
+    expect(summary.ineligibleCount).toBe(3);
+  });
+
+  test("keeps every vault eligible when the floor is unknown", () => {
+    const summary = summarizeRebalanceEligibility(vaults, null);
+
+    expect(summary.eligibleCount).toBe(vaults.length);
+    expect(summary.eligibleRebalancedCount).toBe(2);
+    expect(summary.ineligibleCount).toBe(0);
+  });
+
+  test("treats a vault exactly on the floor as eligible", () => {
+    const summary = summarizeRebalanceEligibility(
+      [{ currentDepositRaw: "74790000", rebalanceCount: 1 }],
+      BigInt(74_790_000)
+    );
+
+    expect(summary.eligibleCount).toBe(1);
+  });
+});

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.test.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.test.ts
@@ -117,12 +117,45 @@ describe("summarizeRebalanceEligibility", () => {
     { currentDepositRaw: "500000", rebalanceCount: 3 },
   ];
 
-  test("counts only vaults that clear the floor", () => {
+  test("counts vaults that clear the floor plus those with recorded activity", () => {
+    // The 0.5 USDC vault is far under the floor but actually rebalanced three
+    // times, so it is demonstrably eligible and must stay in the denominator.
     const summary = summarizeRebalanceEligibility(vaults, BigInt(74_790_000));
 
-    expect(summary.eligibleCount).toBe(2);
-    expect(summary.eligibleRebalancedCount).toBe(1);
-    expect(summary.ineligibleCount).toBe(3);
+    expect(summary.eligibleCount).toBe(3);
+    expect(summary.eligibleRebalancedCount).toBe(2);
+    expect(summary.ineligibleCount).toBe(2);
+  });
+
+  test("keeps a dust vault the planner raised an opportunity for", () => {
+    // This is the case that would otherwise flatter the numbers: a real
+    // opportunity that never converted, on a vault under today's floor.
+    const summary = summarizeRebalanceEligibility(
+      [
+        { currentDepositRaw: "9780000", opportunityCount: 4, rebalanceCount: 0 },
+        { currentDepositRaw: "9780000", opportunityCount: 0, rebalanceCount: 0 },
+      ],
+      BigInt(37_288_959)
+    );
+
+    expect(summary.eligibleCount).toBe(1);
+    expect(summary.eligibleRebalancedCount).toBe(0);
+    expect(summary.ineligibleCount).toBe(1);
+  });
+
+  test("never lets the floor hide a miss", () => {
+    // A vault with opportunities and no rebalances must drag the ratio down,
+    // not vanish from it.
+    const withMiss = summarizeRebalanceEligibility(
+      [
+        { currentDepositRaw: "500000000", opportunityCount: 2, rebalanceCount: 5 },
+        { currentDepositRaw: "1000", opportunityCount: 3, rebalanceCount: 0 },
+      ],
+      BigInt(37_288_959)
+    );
+
+    expect(withMiss.eligibleCount).toBe(2);
+    expect(withMiss.eligibleRebalancedCount).toBe(1);
   });
 
   test("keeps every vault eligible when the floor is unknown", () => {

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.ts
@@ -1,0 +1,110 @@
+import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
+
+/**
+ * Mirrors `EconomicPolicy::default()` from the fleet planner in
+ * `loyal-yield-routing`
+ * (`crates/loyal-yield-store/src/fleet_orchestration/domain.rs`).
+ *
+ * The planner refuses to move a vault unless the expected holding gain clears
+ * `cost_safety_multiplier * execution_cost + fixed_safety_margin`, and the
+ * remaining net gain is at least `minimum_net_gain`. Keep these values in sync
+ * with the Rust defaults; they exist here only so the admin chart can explain
+ * why a vault is sitting at zero.
+ */
+export const REBALANCE_ECONOMIC_POLICY = {
+  fixedSafetyMarginUsdMicros: 50_000,
+  holdingHorizonSeconds: 30 * 24 * 60 * 60,
+  minimumNetGainUsdMicros: 100_000,
+  minimumNotionalUsdMicros: 1_000_000,
+} as const;
+
+const SECONDS_PER_YEAR = 31_536_000;
+const USD_MICROS = 1_000_000;
+
+/**
+ * Smallest deposit that could clear the planner's economic gate, expressed in
+ * raw token units.
+ *
+ * This is a *floor*, not a prediction: it assumes zero execution cost, full
+ * confidence, and the widest spread on the board, so it is the most generous
+ * threshold the planner could ever apply. A vault below it cannot produce a
+ * rebalance no matter how the market moves, which is exactly what makes it a
+ * fair denominator - it can never hide a genuinely stuck vault. Vaults above it
+ * are merely plausible candidates, so the eligible set stays a superset of the
+ * set that actually rebalances.
+ *
+ * Returns `null` when no usable APY spread is available, in which case callers
+ * should fall back to counting every funded vault.
+ */
+export function computeRebalanceEligibilityFloorRaw(
+  reserveStatuses: readonly SafeReserveApyStatusRow[],
+  decimals: number
+): bigint | null {
+  // Only reserves the Safe monitor still considers eligible can anchor a
+  // spread. Stale or below-liquidity reserves routinely report 0%, which would
+  // otherwise invent an enormous edge and collapse the floor to nothing.
+  const apys = reserveStatuses
+    .filter((status) => status.status === "eligible")
+    .map((status) => status.supplyApyPercent)
+    .filter((apy): apy is number => apy !== null && Number.isFinite(apy) && apy > 0);
+  if (apys.length < 2) {
+    return null;
+  }
+
+  const bestEdgeFraction = (Math.max(...apys) - Math.min(...apys)) / 100;
+  if (bestEdgeFraction <= 0) {
+    return null;
+  }
+
+  const horizonFraction =
+    REBALANCE_ECONOMIC_POLICY.holdingHorizonSeconds / SECONDS_PER_YEAR;
+  const requiredGainUsd =
+    (REBALANCE_ECONOMIC_POLICY.minimumNetGainUsdMicros +
+      REBALANCE_ECONOMIC_POLICY.fixedSafetyMarginUsdMicros) /
+    USD_MICROS;
+  const gainFloorUsd = requiredGainUsd / (bestEdgeFraction * horizonFraction);
+  const notionalFloorUsd =
+    REBALANCE_ECONOMIC_POLICY.minimumNotionalUsdMicros / USD_MICROS;
+
+  return toRawAmount(Math.max(gainFloorUsd, notionalFloorUsd), decimals);
+}
+
+function toRawAmount(amount: number, decimals: number): bigint {
+  const scale = 10 ** decimals;
+  return BigInt(Math.ceil(amount * scale));
+}
+
+/**
+ * Splits funded vaults into the set the planner could act on and the dust it
+ * will always decline. `floorRaw` of `null` means the spread is unknown, so
+ * every vault stays eligible rather than being silently hidden.
+ */
+export function summarizeRebalanceEligibility<
+  Vault extends { currentDepositRaw: string; rebalanceCount: number },
+>(
+  vaults: readonly Vault[],
+  floorRaw: bigint | null
+): {
+  eligibleCount: number;
+  eligibleRebalancedCount: number;
+  ineligibleCount: number;
+} {
+  let eligibleCount = 0;
+  let eligibleRebalancedCount = 0;
+
+  for (const vault of vaults) {
+    if (floorRaw !== null && BigInt(vault.currentDepositRaw) < floorRaw) {
+      continue;
+    }
+    eligibleCount += 1;
+    if (vault.rebalanceCount > 0) {
+      eligibleRebalancedCount += 1;
+    }
+  }
+
+  return {
+    eligibleCount,
+    eligibleRebalancedCount,
+    ineligibleCount: vaults.length - eligibleCount,
+  };
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.ts
@@ -78,9 +78,21 @@ function toRawAmount(amount: number, decimals: number): bigint {
  * Splits funded vaults into the set the planner could act on and the dust it
  * will always decline. `floorRaw` of `null` means the spread is unknown, so
  * every vault stays eligible rather than being silently hidden.
+ *
+ * The floor alone is not enough. It is modelled from the spread as it stands
+ * *now*, while the counts are historical, so a vault that was genuinely
+ * actionable last week can sit under today's floor - and dropping it would hide
+ * a real miss and flatter the numbers. Recorded evidence therefore wins over the
+ * model: if the planner actually raised an opportunity for a vault in this
+ * window, or the vault actually rebalanced, it is eligible regardless of what
+ * it holds today.
  */
 export function summarizeRebalanceEligibility<
-  Vault extends { currentDepositRaw: string; rebalanceCount: number },
+  Vault extends {
+    currentDepositRaw: string;
+    opportunityCount?: number;
+    rebalanceCount: number;
+  },
 >(
   vaults: readonly Vault[],
   floorRaw: bigint | null
@@ -93,7 +105,11 @@ export function summarizeRebalanceEligibility<
   let eligibleRebalancedCount = 0;
 
   for (const vault of vaults) {
-    if (floorRaw !== null && BigInt(vault.currentDepositRaw) < floorRaw) {
+    const hasEvidence =
+      vault.rebalanceCount > 0 || (vault.opportunityCount ?? 0) > 0;
+    const clearsFloor =
+      floorRaw === null || BigInt(vault.currentDepositRaw) >= floorRaw;
+    if (!hasEvidence && !clearsFloor) {
       continue;
     }
     eligibleCount += 1;

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -64,6 +64,10 @@ export type SerializedEarnVaultRebalanceFrequencyRow = {
   last2hCount: number;
   last7dCount: number;
   liquidityMint: string | null;
+  opportunity12hCount: number;
+  opportunity2hCount: number;
+  opportunity7dCount: number;
+  opportunityAllCount: number;
   positionCount: number;
   vaultId: string;
   vaultPubkey: string;
@@ -78,11 +82,17 @@ export type SerializedEarnVaultRebalanceFrequency = {
 
 type RangeKey = "12h" | "2h" | "7d" | "all";
 type CountKey = "allCount" | "last7dCount" | "last12hCount" | "last2hCount";
+type OpportunityKey =
+  | "opportunityAllCount"
+  | "opportunity7dCount"
+  | "opportunity12hCount"
+  | "opportunity2hCount";
 type ScaleKey = "linear" | "log";
 
 type ChartPoint = SerializedEarnVaultRebalanceFrequencyRow & {
   depositAmount: number;
   depositRank: number;
+  opportunityCount: number;
   rebalanceCount: number;
 };
 
@@ -99,25 +109,35 @@ const RANGE_OPTIONS: ReadonlyArray<{
   countKey: CountKey;
   key: RangeKey;
   label: string;
+  opportunityKey: OpportunityKey;
   tabLabel: string;
 }> = [
-  { countKey: "allCount", key: "all", label: "All history", tabLabel: "All" },
+  {
+    countKey: "allCount",
+    key: "all",
+    label: "All history",
+    opportunityKey: "opportunityAllCount",
+    tabLabel: "All",
+  },
   {
     countKey: "last7dCount",
     key: "7d",
     label: "Last 7 days",
+    opportunityKey: "opportunity7dCount",
     tabLabel: "7 days",
   },
   {
     countKey: "last12hCount",
     key: "12h",
     label: "Last 12 hours",
+    opportunityKey: "opportunity12hCount",
     tabLabel: "12 hours",
   },
   {
     countKey: "last2hCount",
     key: "2h",
     label: "Last 2 hours",
+    opportunityKey: "opportunity2hCount",
     tabLabel: "2 hours",
   },
 ];
@@ -250,6 +270,10 @@ function VaultFrequencyTooltip({
         <dd className="text-right">
           {series?.apyStatus?.status ?? "No reserve position"}
         </dd>
+        <dt className="text-muted-foreground">Opportunities raised</dt>
+        <dd className="text-right tabular-nums">
+          {point.opportunityCount.toLocaleString("en-US")}
+        </dd>
         <dt className="text-muted-foreground">Positive positions</dt>
         <dd className="text-right tabular-nums">{point.positionCount}</dd>
         <dt className="text-muted-foreground">All / 7d / 12h / 2h</dt>
@@ -301,10 +325,11 @@ export function EarnVaultRebalanceFrequencyChart({
         (vault): ChartPoint => ({
           ...vault,
           depositAmount: toDepositAmount(vault.currentDepositRaw),
+          opportunityCount: vault[rangeOption.opportunityKey],
           rebalanceCount: vault[rangeOption.countKey],
         })
       ),
-    [rangeOption.countKey, rankedVaults]
+    [rangeOption.countKey, rangeOption.opportunityKey, rankedVaults]
   );
   const apyByReserve = useMemo(
     () => new Map(reserveStatuses.map((status) => [status.reserve, status])),

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -39,6 +39,12 @@ import {
 } from "@/lib/earn/stablecoin-monitor.shared";
 import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
+import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+import {
+  computeRebalanceEligibilityFloorRaw,
+  summarizeRebalanceEligibility,
+} from "./earn-vault-rebalance-eligibility";
+
 const NO_RESERVE_KEY = "__no_current_reserve__";
 const RESERVE_COLORS = [
   "var(--chart-1)",
@@ -72,8 +78,10 @@ export type SerializedEarnVaultRebalanceFrequency = {
 
 type RangeKey = "12h" | "2h" | "7d" | "all";
 type CountKey = "allCount" | "last7dCount" | "last12hCount" | "last2hCount";
+type ScaleKey = "linear" | "log";
 
 type ChartPoint = SerializedEarnVaultRebalanceFrequencyRow & {
+  depositAmount: number;
   depositRank: number;
   rebalanceCount: number;
 };
@@ -112,6 +120,14 @@ const RANGE_OPTIONS: ReadonlyArray<{
     label: "Last 2 hours",
     tabLabel: "2 hours",
   },
+];
+
+const SCALE_OPTIONS: ReadonlyArray<{
+  key: ScaleKey;
+  label: string;
+}> = [
+  { key: "log", label: "Log scale" },
+  { key: "linear", label: "As is" },
 ];
 
 function compareRawAmounts(left: string, right: string): number {
@@ -167,6 +183,10 @@ function formatUtcTimestamp(value: string): string {
     timeZoneName: "short",
     year: "numeric",
   }).format(date);
+}
+
+function toDepositAmount(raw: string): number {
+  return Number(BigInt(raw)) / 10 ** STABLECOIN_DECIMALS;
 }
 
 function buildRankTicks(vaultCount: number): number[] {
@@ -252,6 +272,7 @@ export function EarnVaultRebalanceFrequencyChart({
   reserveStatuses: SafeReserveApyStatusRow[];
 }) {
   const [range, setRange] = useState<RangeKey>("all");
+  const [scale, setScale] = useState<ScaleKey>("log");
   const [showTable, setShowTable] = useState(false);
 
   const rangeOption =
@@ -279,6 +300,7 @@ export function EarnVaultRebalanceFrequencyChart({
       rankedVaults.map(
         (vault): ChartPoint => ({
           ...vault,
+          depositAmount: toDepositAmount(vault.currentDepositRaw),
           rebalanceCount: vault[rangeOption.countKey],
         })
       ),
@@ -354,6 +376,26 @@ export function EarnVaultRebalanceFrequencyChart({
     0
   );
   const tableRows = [...points].reverse().slice(0, 100);
+  const primaryLiquidityMint =
+    points.find((point) => point.liquidityMint !== null)?.liquidityMint ?? null;
+  const eligibilityFloorRaw = computeRebalanceEligibilityFloorRaw(
+    reserveStatuses,
+    STABLECOIN_DECIMALS
+  );
+  const { eligibleCount, eligibleRebalancedCount } =
+    summarizeRebalanceEligibility(points, eligibilityFloorRaw);
+  const positiveDeposits = points
+    .map((point) => point.depositAmount)
+    .filter((amount) => amount > 0 && Number.isFinite(amount));
+  const minDepositAmount =
+    positiveDeposits.length > 0 ? Math.min(...positiveDeposits) : 1;
+  const maxDepositAmount =
+    positiveDeposits.length > 0 ? Math.max(...positiveDeposits) : 1;
+  const logTicks = buildLogTicks(minDepositAmount, maxDepositAmount);
+  // A log axis cannot place a zero or rounded-to-zero deposit, so fall back to
+  // the rank axis rather than dropping those vaults from the chart.
+  const useLogScale =
+    scale === "log" && positiveDeposits.length === points.length;
 
   if (data.status === "unavailable") {
     return (
@@ -387,10 +429,12 @@ export function EarnVaultRebalanceFrequencyChart({
                 Earn vault rebalance frequency
               </CardTitle>
               <CardDescription>
-                One dot per funded active vault. X orders current deposits from
-                smallest to largest; Y shows confirmed reserve-to-reserve
-                rebalances in the selected window. Dot color is the largest
-                current reserve position.
+                One dot per funded active vault. X is the current deposit on a
+                log scale, or ordered smallest to largest under &ldquo;As
+                is&rdquo;; Y shows confirmed reserve-to-reserve rebalances in the
+                selected window. Dot color is the largest current reserve
+                position. Vaults below the eligibility floor cannot clear the
+                planner&rsquo;s economic gate, so they sit at zero by design.
               </CardDescription>
             </div>
             <Button
@@ -403,21 +447,64 @@ export function EarnVaultRebalanceFrequencyChart({
               Table
             </Button>
           </div>
-          <TabsList
-            aria-label="Vault rebalance frequency window"
-            className="w-fit max-w-full"
-          >
-            {RANGE_OPTIONS.map((option) => (
-              <TabsTrigger key={option.key} value={option.key}>
-                {option.tabLabel}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+          <div className="flex flex-wrap items-center gap-3">
+            <TabsList
+              aria-label="Vault rebalance frequency window"
+              className="w-fit max-w-full"
+            >
+              {RANGE_OPTIONS.map((option) => (
+                <TabsTrigger key={option.key} value={option.key}>
+                  {option.tabLabel}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            <div
+              aria-label="Deposit axis scale"
+              className="flex w-fit items-center gap-1 rounded-lg bg-muted p-1"
+              role="group"
+            >
+              {SCALE_OPTIONS.map((option) => (
+                <Button
+                  aria-pressed={scale === option.key}
+                  className="h-7 px-3 text-xs"
+                  key={option.key}
+                  onClick={() => setScale(option.key)}
+                  size="sm"
+                  type="button"
+                  variant={scale === option.key ? "secondary" : "ghost"}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </div>
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
-            <span>{points.length.toLocaleString("en-US")} funded vaults</span>
+            {eligibilityFloorRaw === null ? (
+              <span>
+                {rebalancedVaultCount.toLocaleString("en-US")} of{" "}
+                {points.length.toLocaleString("en-US")} funded vaults rebalanced
+              </span>
+            ) : (
+              <span className="text-foreground">
+                {eligibleRebalancedCount.toLocaleString("en-US")} of{" "}
+                {eligibleCount.toLocaleString("en-US")} economically eligible
+                vaults rebalanced
+              </span>
+            )}
             <span>
+              {points.length.toLocaleString("en-US")} funded vaults ·{" "}
               {rebalancedVaultCount.toLocaleString("en-US")} with rebalances
             </span>
+            {eligibilityFloorRaw === null ? null : (
+              <span>
+                Eligible at{" "}
+                {formatDeposit(
+                  eligibilityFloorRaw.toString(),
+                  primaryLiquidityMint
+                )}
+                +
+              </span>
+            )}
             <span>
               {totalRebalances.toLocaleString("en-US")} confirmed executions ·{" "}
               {rangeOption.label}
@@ -531,26 +618,47 @@ export function EarnVaultRebalanceFrequencyChart({
                       margin={{ bottom: 16, left: 8, right: 16, top: 12 }}
                     >
                       <CartesianGrid />
-                      <XAxis
-                        allowDecimals={false}
-                        axisLine={false}
-                        dataKey="depositRank"
-                        domain={[1, Math.max(points.length, 1)]}
-                        name="Current deposit amount"
-                        tickFormatter={(rank: number) => {
-                          const vault = vaultByRank.get(rank);
-                          return vault
-                            ? formatCompactDeposit(
-                                vault.currentDepositRaw,
-                                vault.liquidityMint
-                              )
-                            : `#${rank}`;
-                        }}
-                        tickLine={false}
-                        tickMargin={8}
-                        ticks={rankTicks}
-                        type="number"
-                      />
+                      {useLogScale ? (
+                        <XAxis
+                          allowDataOverflow
+                          axisLine={false}
+                          dataKey="depositAmount"
+                          domain={[
+                            logTicks[0],
+                            logTicks[logTicks.length - 1] ?? 1,
+                          ]}
+                          name="Current deposit amount"
+                          scale="log"
+                          tickFormatter={(amount: number) =>
+                            formatLogTick(amount, primaryLiquidityMint)
+                          }
+                          tickLine={false}
+                          tickMargin={8}
+                          ticks={logTicks}
+                          type="number"
+                        />
+                      ) : (
+                        <XAxis
+                          allowDecimals={false}
+                          axisLine={false}
+                          dataKey="depositRank"
+                          domain={[1, Math.max(points.length, 1)]}
+                          name="Current deposit amount"
+                          tickFormatter={(rank: number) => {
+                            const vault = vaultByRank.get(rank);
+                            return vault
+                              ? formatCompactDeposit(
+                                  vault.currentDepositRaw,
+                                  vault.liquidityMint
+                                )
+                              : `#${rank}`;
+                          }}
+                          tickLine={false}
+                          tickMargin={8}
+                          ticks={rankTicks}
+                          type="number"
+                        />
+                      )}
                       <YAxis
                         allowDecimals={false}
                         axisLine={false}
@@ -592,6 +700,9 @@ export function EarnVaultRebalanceFrequencyChart({
                   {showTable
                     ? " The table shows the 100 largest current deposits."
                     : " Idle-only vaults use the neutral legend color."}
+                  {!showTable && scale === "log" && !useLogScale
+                    ? " Some deposits round to zero, so the log axis fell back to deposit order."
+                    : ""}
                 </p>
               </CardContent>
             ) : null}

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -39,7 +39,11 @@ import {
 } from "@/lib/earn/stablecoin-monitor.shared";
 import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
-import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
+import {
+  DepositScaleSwitch,
+  type DepositScale,
+} from "./deposit-scale-switch";
 import {
   computeRebalanceEligibilityFloorRaw,
   summarizeRebalanceEligibility,
@@ -87,7 +91,6 @@ type OpportunityKey =
   | "opportunity7dCount"
   | "opportunity12hCount"
   | "opportunity2hCount";
-type ScaleKey = "linear" | "log";
 
 type ChartPoint = SerializedEarnVaultRebalanceFrequencyRow & {
   depositAmount: number;
@@ -140,14 +143,6 @@ const RANGE_OPTIONS: ReadonlyArray<{
     opportunityKey: "opportunity2hCount",
     tabLabel: "2 hours",
   },
-];
-
-const SCALE_OPTIONS: ReadonlyArray<{
-  key: ScaleKey;
-  label: string;
-}> = [
-  { key: "log", label: "Log scale" },
-  { key: "linear", label: "As is" },
 ];
 
 function compareRawAmounts(left: string, right: string): number {
@@ -207,23 +202,6 @@ function formatUtcTimestamp(value: string): string {
 
 function toDepositAmount(raw: string): number {
   return Number(BigInt(raw)) / 10 ** STABLECOIN_DECIMALS;
-}
-
-function buildRankTicks(vaultCount: number): number[] {
-  const tickCount = Math.min(7, Math.max(vaultCount, 1));
-  return Array.from(
-    new Set(
-      Array.from({ length: tickCount }, (_, index) =>
-        Math.max(
-          1,
-          Math.round(
-            1 +
-              (index * Math.max(vaultCount - 1, 0)) / Math.max(tickCount - 1, 1)
-          )
-        )
-      )
-    )
-  );
 }
 
 function VaultFrequencyTooltip({
@@ -296,7 +274,7 @@ export function EarnVaultRebalanceFrequencyChart({
   reserveStatuses: SafeReserveApyStatusRow[];
 }) {
   const [range, setRange] = useState<RangeKey>("all");
-  const [scale, setScale] = useState<ScaleKey>("log");
+  const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
 
   const rangeOption =
@@ -385,10 +363,6 @@ export function EarnVaultRebalanceFrequencyChart({
       { color: series.color, label: series.label },
     ])
   ) satisfies ChartConfig;
-  const vaultByRank = new Map(
-    points.map((point) => [point.depositRank, point])
-  );
-  const rankTicks = buildRankTicks(points.length);
   const maxCount = points.reduce(
     (maximum, point) => Math.max(maximum, point.rebalanceCount),
     0
@@ -417,10 +391,16 @@ export function EarnVaultRebalanceFrequencyChart({
   const maxDepositAmount =
     positiveDeposits.length > 0 ? Math.max(...positiveDeposits) : 1;
   const logTicks = buildLogTicks(minDepositAmount, maxDepositAmount);
-  // A log axis cannot place a zero or rounded-to-zero deposit, so fall back to
-  // the rank axis rather than dropping those vaults from the chart.
-  const useLogScale =
-    scale === "log" && positiveDeposits.length === points.length;
+  // A log axis has nowhere to put a deposit that rounds to zero, so pin those
+  // to the bottom decade instead of dropping the vault off the chart.
+  const logFloor = logTicks[0];
+  const useLogScale = scale === "log" && positiveDeposits.length > 0;
+  const zeroDepositCount = points.length - positiveDeposits.length;
+  const scatterPoints = points.map((point) => ({
+    ...point,
+    plottedDeposit:
+      point.depositAmount > 0 ? point.depositAmount : logFloor,
+  }));
 
   if (data.status === "unavailable") {
     return (
@@ -454,12 +434,12 @@ export function EarnVaultRebalanceFrequencyChart({
                 Earn vault rebalance frequency
               </CardTitle>
               <CardDescription>
-                One dot per funded active vault. X is the current deposit on a
-                log scale, or ordered smallest to largest under &ldquo;As
-                is&rdquo;; Y shows confirmed reserve-to-reserve rebalances in the
-                selected window. Dot color is the largest current reserve
-                position. Vaults below the eligibility floor cannot clear the
-                planner&rsquo;s economic gate, so they sit at zero by design.
+                One dot per funded active vault. X is the current deposit, on a
+                log or linear scale; Y shows confirmed reserve-to-reserve
+                rebalances in the selected window. Dot color is the largest
+                current reserve position. Vaults below the eligibility floor
+                cannot clear the planner&rsquo;s economic gate, so they sit at
+                zero by design.
               </CardDescription>
             </div>
             <Button
@@ -483,25 +463,11 @@ export function EarnVaultRebalanceFrequencyChart({
                 </TabsTrigger>
               ))}
             </TabsList>
-            <div
-              aria-label="Deposit axis scale"
-              className="flex w-fit items-center gap-1 rounded-lg bg-muted p-1"
-              role="group"
-            >
-              {SCALE_OPTIONS.map((option) => (
-                <Button
-                  aria-pressed={scale === option.key}
-                  className="h-7 px-3 text-xs"
-                  key={option.key}
-                  onClick={() => setScale(option.key)}
-                  size="sm"
-                  type="button"
-                  variant={scale === option.key ? "secondary" : "ghost"}
-                >
-                  {option.label}
-                </Button>
-              ))}
-            </div>
+            <DepositScaleSwitch
+              id="vault-rebalance-frequency-scale"
+              onScaleChange={setScale}
+              scale={scale}
+            />
           </div>
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
             {eligibilityFloorRaw === null ? (
@@ -647,7 +613,7 @@ export function EarnVaultRebalanceFrequencyChart({
                         <XAxis
                           allowDataOverflow
                           axisLine={false}
-                          dataKey="depositAmount"
+                          dataKey="plottedDeposit"
                           domain={[
                             logTicks[0],
                             logTicks[logTicks.length - 1] ?? 1,
@@ -655,7 +621,7 @@ export function EarnVaultRebalanceFrequencyChart({
                           name="Current deposit amount"
                           scale="log"
                           tickFormatter={(amount: number) =>
-                            formatLogTick(amount, primaryLiquidityMint)
+                            formatDepositTick(amount, primaryLiquidityMint)
                           }
                           tickLine={false}
                           tickMargin={8}
@@ -664,23 +630,15 @@ export function EarnVaultRebalanceFrequencyChart({
                         />
                       ) : (
                         <XAxis
-                          allowDecimals={false}
                           axisLine={false}
-                          dataKey="depositRank"
-                          domain={[1, Math.max(points.length, 1)]}
+                          dataKey="depositAmount"
+                          domain={[0, Math.max(maxDepositAmount, 1)]}
                           name="Current deposit amount"
-                          tickFormatter={(rank: number) => {
-                            const vault = vaultByRank.get(rank);
-                            return vault
-                              ? formatCompactDeposit(
-                                  vault.currentDepositRaw,
-                                  vault.liquidityMint
-                                )
-                              : `#${rank}`;
-                          }}
+                          tickFormatter={(amount: number) =>
+                            formatDepositTick(amount, primaryLiquidityMint)
+                          }
                           tickLine={false}
                           tickMargin={8}
-                          ticks={rankTicks}
                           type="number"
                         />
                       )}
@@ -705,7 +663,7 @@ export function EarnVaultRebalanceFrequencyChart({
                       />
                       {reserveSeries.map((series) => (
                         <Scatter
-                          data={points.filter(
+                          data={scatterPoints.filter(
                             (point) =>
                               (point.currentReserve ?? NO_RESERVE_KEY) ===
                               series.reserveKey
@@ -725,8 +683,10 @@ export function EarnVaultRebalanceFrequencyChart({
                   {showTable
                     ? " The table shows the 100 largest current deposits."
                     : " Idle-only vaults use the neutral legend color."}
-                  {!showTable && scale === "log" && !useLogScale
-                    ? " Some deposits round to zero, so the log axis fell back to deposit order."
+                  {!showTable && useLogScale && zeroDepositCount > 0
+                    ? ` ${zeroDepositCount.toLocaleString("en-US")} vault${
+                        zeroDepositCount === 1 ? "" : "s"
+                      } with a zero deposit sit on the axis floor.`
                     : ""}
                 </p>
               </CardContent>

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -37,6 +37,8 @@ import {
   STABLECOIN_DECIMALS,
 } from "@/lib/earn/stablecoin-monitor.shared";
 
+import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const SOURCE_COLORS = [
   "var(--chart-1)",
@@ -67,10 +69,17 @@ export type SerializedExecutedEarnRebalanceHistory = {
 };
 
 type ChartPoint = SerializedExecutedEarnRebalanceRow & {
+  depositAmount: number;
   executedAtMs: number;
 };
 
 type RangeKey = "7d" | "30d" | "all";
+type ScaleKey = "linear" | "log";
+
+const SCALE_OPTIONS: ReadonlyArray<{ key: ScaleKey; label: string }> = [
+  { key: "log", label: "Log scale" },
+  { key: "linear", label: "As is" },
+];
 
 function formatUtcTimestamp(value: number | string): string {
   const date = new Date(value);
@@ -192,6 +201,7 @@ export function ExecutedEarnRebalancesChart({
   reserveLabels: ReadonlyMap<string, string>;
 }) {
   const [range, setRange] = useState<RangeKey>("all");
+  const [scale, setScale] = useState<ScaleKey>("log");
   const [showTable, setShowTable] = useState(false);
 
   const points = useMemo(
@@ -199,6 +209,9 @@ export function ExecutedEarnRebalancesChart({
       data.executions
         .map((execution) => ({
           ...execution,
+          depositAmount:
+            Number(BigInt(execution.currentDepositRaw)) /
+            10 ** STABLECOIN_DECIMALS,
           executedAtMs: Date.parse(execution.executedAt),
         }))
         .filter((execution) => Number.isFinite(execution.executedAtMs)),
@@ -257,6 +270,26 @@ export function ExecutedEarnRebalancesChart({
       )
     )
   );
+  const positiveDeposits = filteredPoints
+    .map((point) => point.depositAmount)
+    .filter((amount) => amount > 0 && Number.isFinite(amount));
+  const useLogScale = scale === "log" && positiveDeposits.length > 0;
+  // Users who fully withdrew after rebalancing now hold nothing, and a log axis
+  // has no room for zero. Pin them to one decade below the smallest real
+  // deposit so the execution still shows up instead of being dropped.
+  const logFloor = useLogScale
+    ? 10 ** (Math.floor(Math.log10(Math.min(...positiveDeposits))) - 1)
+    : 1;
+  const logTicks = buildLogTicks(
+    logFloor,
+    useLogScale ? Math.max(...positiveDeposits) : 1
+  );
+  const zeroDepositCount = filteredPoints.length - positiveDeposits.length;
+  const scatterPoints = filteredPoints.map((point) => ({
+    ...point,
+    logDepositAmount:
+      point.depositAmount > 0 ? point.depositAmount : logFloor,
+  }));
   const tableRows = [...filteredPoints].reverse().slice(0, 50);
 
   if (data.status === "unavailable") {
@@ -287,9 +320,9 @@ export function ExecutedEarnRebalancesChart({
               Executed Earn rebalances
             </CardTitle>
             <CardDescription>
-              One dot per confirmed reserve-to-reserve decision. Users are
-              ordered by their current Earn deposit, smallest at the bottom and
-              largest at the top. Times are UTC.
+              One dot per confirmed reserve-to-reserve decision. Y is the
+              user&rsquo;s current Earn deposit on a log scale, or ordered
+              smallest to largest under &ldquo;As is&rdquo;. Times are UTC.
             </CardDescription>
           </div>
           <div
@@ -317,6 +350,25 @@ export function ExecutedEarnRebalancesChart({
             >
               Table
             </Button>
+            <div
+              aria-label="Deposit axis scale"
+              className="flex w-fit items-center gap-1 rounded-lg bg-muted p-1"
+              role="group"
+            >
+              {SCALE_OPTIONS.map((option) => (
+                <Button
+                  aria-pressed={scale === option.key}
+                  className="h-7 px-3 text-xs"
+                  key={option.key}
+                  onClick={() => setScale(option.key)}
+                  size="sm"
+                  type="button"
+                  variant={scale === option.key ? "secondary" : "ghost"}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
           </div>
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
@@ -424,23 +476,41 @@ export function ExecutedEarnRebalancesChart({
                 tickMargin={8}
                 type="number"
               />
-              <YAxis
-                allowDecimals={false}
-                axisLine={false}
-                dataKey="userRank"
-                domain={[1, Math.max(data.userCount, 1)]}
-                name="Current deposit amount"
-                tickFormatter={(rank: number) => {
-                  const user = userByRank.get(rank);
-                  return user
-                    ? formatCompactStablecoinRaw(user.currentDepositRaw)
-                    : `#${rank}`;
-                }}
-                tickLine={false}
-                ticks={yTicks}
-                type="number"
-                width={78}
-              />
+              {useLogScale ? (
+                <YAxis
+                  allowDataOverflow
+                  axisLine={false}
+                  dataKey="logDepositAmount"
+                  domain={[logTicks[0], logTicks[logTicks.length - 1] ?? 1]}
+                  name="Current deposit amount"
+                  scale="log"
+                  tickFormatter={(amount: number) =>
+                    formatLogTick(amount, null)
+                  }
+                  tickLine={false}
+                  ticks={logTicks}
+                  type="number"
+                  width={78}
+                />
+              ) : (
+                <YAxis
+                  allowDecimals={false}
+                  axisLine={false}
+                  dataKey="userRank"
+                  domain={[1, Math.max(data.userCount, 1)]}
+                  name="Current deposit amount"
+                  tickFormatter={(rank: number) => {
+                    const user = userByRank.get(rank);
+                    return user
+                      ? formatCompactStablecoinRaw(user.currentDepositRaw)
+                      : `#${rank}`;
+                  }}
+                  tickLine={false}
+                  ticks={yTicks}
+                  type="number"
+                  width={78}
+                />
+              )}
               <ZAxis range={[18, 18]} />
               <ChartTooltip
                 content={
@@ -450,7 +520,7 @@ export function ExecutedEarnRebalancesChart({
               />
               {sources.map((source) => (
                 <Scatter
-                  data={filteredPoints.filter(
+                  data={scatterPoints.filter(
                     (point) => point.sourceReserve === source.reserve
                   )}
                   fill={`var(--color-${source.key})`}
@@ -463,8 +533,16 @@ export function ExecutedEarnRebalancesChart({
         )}
         {!showTable ? (
           <p className="mt-3 text-xs text-muted-foreground">
-            Y-axis labels sample current deposit amounts; hover a dot for the
-            exact wallet, current deposit, route, amount, decision, and slot.
+            {useLogScale
+              ? "Y-axis is a log scale of current deposit amounts"
+              : "Y-axis labels sample current deposit amounts"}
+            ; hover a dot for the exact wallet, current deposit, route, amount,
+            decision, and slot.
+            {useLogScale && zeroDepositCount > 0
+              ? ` ${zeroDepositCount.toLocaleString("en-US")} fully withdrawn ${
+                  zeroDepositCount === 1 ? "execution sits" : "executions sit"
+                } on the axis floor.`
+              : ""}
           </p>
         ) : (
           <p className="mt-3 text-xs text-muted-foreground">

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -37,7 +37,11 @@ import {
   STABLECOIN_DECIMALS,
 } from "@/lib/earn/stablecoin-monitor.shared";
 
-import { buildLogTicks, formatLogTick } from "./earn-vault-rebalance-axis";
+import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
+import {
+  DepositScaleSwitch,
+  type DepositScale,
+} from "./deposit-scale-switch";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const SOURCE_COLORS = [
@@ -74,12 +78,7 @@ type ChartPoint = SerializedExecutedEarnRebalanceRow & {
 };
 
 type RangeKey = "7d" | "30d" | "all";
-type ScaleKey = "linear" | "log";
 
-const SCALE_OPTIONS: ReadonlyArray<{ key: ScaleKey; label: string }> = [
-  { key: "log", label: "Log scale" },
-  { key: "linear", label: "As is" },
-];
 
 function formatUtcTimestamp(value: number | string): string {
   const date = new Date(value);
@@ -201,7 +200,7 @@ export function ExecutedEarnRebalancesChart({
   reserveLabels: ReadonlyMap<string, string>;
 }) {
   const [range, setRange] = useState<RangeKey>("all");
-  const [scale, setScale] = useState<ScaleKey>("log");
+  const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
 
   const points = useMemo(
@@ -285,6 +284,8 @@ export function ExecutedEarnRebalancesChart({
     useLogScale ? Math.max(...positiveDeposits) : 1
   );
   const zeroDepositCount = filteredPoints.length - positiveDeposits.length;
+  const maxDepositAmount =
+    positiveDeposits.length > 0 ? Math.max(...positiveDeposits) : 1;
   const scatterPoints = filteredPoints.map((point) => ({
     ...point,
     logDepositAmount:
@@ -321,8 +322,8 @@ export function ExecutedEarnRebalancesChart({
             </CardTitle>
             <CardDescription>
               One dot per confirmed reserve-to-reserve decision. Y is the
-              user&rsquo;s current Earn deposit on a log scale, or ordered
-              smallest to largest under &ldquo;As is&rdquo;. Times are UTC.
+              user&rsquo;s current Earn deposit, on a log or linear scale. Times
+              are UTC.
             </CardDescription>
           </div>
           <div
@@ -350,25 +351,11 @@ export function ExecutedEarnRebalancesChart({
             >
               Table
             </Button>
-            <div
-              aria-label="Deposit axis scale"
-              className="flex w-fit items-center gap-1 rounded-lg bg-muted p-1"
-              role="group"
-            >
-              {SCALE_OPTIONS.map((option) => (
-                <Button
-                  aria-pressed={scale === option.key}
-                  className="h-7 px-3 text-xs"
-                  key={option.key}
-                  onClick={() => setScale(option.key)}
-                  size="sm"
-                  type="button"
-                  variant={scale === option.key ? "secondary" : "ghost"}
-                >
-                  {option.label}
-                </Button>
-              ))}
-            </div>
+            <DepositScaleSwitch
+              id="executed-earn-rebalances-scale"
+              onScaleChange={setScale}
+              scale={scale}
+            />
           </div>
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
@@ -485,7 +472,7 @@ export function ExecutedEarnRebalancesChart({
                   name="Current deposit amount"
                   scale="log"
                   tickFormatter={(amount: number) =>
-                    formatLogTick(amount, null)
+                    formatDepositTick(amount, null)
                   }
                   tickLine={false}
                   ticks={logTicks}
@@ -494,19 +481,14 @@ export function ExecutedEarnRebalancesChart({
                 />
               ) : (
                 <YAxis
-                  allowDecimals={false}
                   axisLine={false}
-                  dataKey="userRank"
-                  domain={[1, Math.max(data.userCount, 1)]}
+                  dataKey="depositAmount"
+                  domain={[0, Math.max(maxDepositAmount, 1)]}
                   name="Current deposit amount"
-                  tickFormatter={(rank: number) => {
-                    const user = userByRank.get(rank);
-                    return user
-                      ? formatCompactStablecoinRaw(user.currentDepositRaw)
-                      : `#${rank}`;
-                  }}
+                  tickFormatter={(amount: number) =>
+                    formatDepositTick(amount, null)
+                  }
                   tickLine={false}
-                  ticks={yTicks}
                   type="number"
                   width={78}
                 />

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -128,6 +128,10 @@ export type EarnVaultRebalanceFrequencyRow = {
   last2hCount: number;
   last7dCount: number;
   liquidityMint: string | null;
+  opportunity12hCount: number;
+  opportunity2hCount: number;
+  opportunity7dCount: number;
+  opportunityAllCount: number;
   positionCount: number;
   vaultId: string;
   vaultPubkey: string;
@@ -277,6 +281,10 @@ type ExecutedEarnRebalanceSqlRow = {
 
 type EarnVaultRebalanceFrequencySqlRow = {
   all_count: SqlScalar;
+  opportunity_all_count: SqlScalar;
+  opportunity_last_12h_count: SqlScalar;
+  opportunity_last_2h_count: SqlScalar;
+  opportunity_last_7d_count: SqlScalar;
   current_deposit_raw: SqlScalar;
   current_reserve: string | null;
   deposit_rank: SqlScalar;
@@ -1714,6 +1722,22 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           AND decision.target_reserve IS NOT NULL
         GROUP BY decision.vault_id
       ),
+      opportunity_counts AS MATERIALIZED (
+        SELECT
+          opportunity.vault_id,
+          COUNT(*)::integer AS all_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
+          )::integer AS last_7d_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '12 hours'
+          )::integer AS last_12h_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
+          )::integer AS last_2h_count
+        FROM loyal_yield.rebalance_opportunities AS opportunity
+        GROUP BY opportunity.vault_id
+      ),
       current_vaults AS MATERIALIZED (
         SELECT
           vault.id,
@@ -1728,7 +1752,11 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           COALESCE(rebalance.all_count, 0) AS all_count,
           COALESCE(rebalance.last_7d_count, 0) AS last_7d_count,
           COALESCE(rebalance.last_12h_count, 0) AS last_12h_count,
-          COALESCE(rebalance.last_2h_count, 0) AS last_2h_count
+          COALESCE(rebalance.last_2h_count, 0) AS last_2h_count,
+          COALESCE(opportunity.all_count, 0) AS opportunity_all_count,
+          COALESCE(opportunity.last_7d_count, 0) AS opportunity_last_7d_count,
+          COALESCE(opportunity.last_12h_count, 0) AS opportunity_last_12h_count,
+          COALESCE(opportunity.last_2h_count, 0) AS opportunity_last_2h_count
         FROM active_vaults AS vault
         LEFT JOIN position_totals AS position_total
           ON position_total.vault_id = vault.id
@@ -1740,6 +1768,8 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           ON primary_idle.vault_id = vault.id
         LEFT JOIN rebalance_counts AS rebalance
           ON rebalance.vault_id = vault.id
+        LEFT JOIN opportunity_counts AS opportunity
+          ON opportunity.vault_id = vault.id
         WHERE COALESCE(position_total.amount_raw, 0::bigint)
           + COALESCE(idle_total.amount_raw, 0::bigint) > 0
       ),
@@ -1764,6 +1794,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         ranked_vault.last_7d_count::text,
         ranked_vault.last_12h_count::text,
         ranked_vault.last_2h_count::text,
+        ranked_vault.opportunity_all_count::text,
+        ranked_vault.opportunity_last_7d_count::text,
+        ranked_vault.opportunity_last_12h_count::text,
+        ranked_vault.opportunity_last_2h_count::text,
         ranked_vault.deposit_rank::text,
         MAX(ranked_vault.deposit_rank) OVER ()::text AS vault_count
       FROM ranked_vaults AS ranked_vault
@@ -1783,6 +1817,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       last2hCount: toNumber(row.last_2h_count),
       last7dCount: toNumber(row.last_7d_count),
       liquidityMint: row.liquidity_mint,
+      opportunity12hCount: toNumber(row.opportunity_last_12h_count),
+      opportunity2hCount: toNumber(row.opportunity_last_2h_count),
+      opportunity7dCount: toNumber(row.opportunity_last_7d_count),
+      opportunityAllCount: toNumber(row.opportunity_all_count),
       positionCount: toNumber(row.position_count),
       vaultId: row.vault_id,
       vaultPubkey: row.vault_pubkey,

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -1722,6 +1722,12 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           AND decision.target_reserve IS NOT NULL
         GROUP BY decision.vault_id
       ),
+      -- Evidence that a vault was genuinely actionable, used to keep it in the
+      -- eligible denominator even when it now sits under the modelled floor.
+      -- The reserve filter must mirror rebalance_counts above: idle-vault
+      -- deposits carry a NULL source_reserve and can never produce a confirmed
+      -- reserve-to-reserve decision, so counting them would admit vaults the
+      -- numerator is structurally unable to match.
       opportunity_counts AS MATERIALIZED (
         SELECT
           opportunity.vault_id,
@@ -1736,6 +1742,8 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
           )::integer AS last_2h_count
         FROM loyal_yield.rebalance_opportunities AS opportunity
+        WHERE opportunity.source_reserve IS NOT NULL
+          AND opportunity.target_reserve IS NOT NULL
         GROUP BY opportunity.vault_id
       ),
       current_vaults AS MATERIALIZED (


### PR DESCRIPTION
Closes ASK-2160.

## Goal

Make the two Earn rebalance scatter charts in admin tell the truth about the rebalancer. The "Earn vault rebalance frequency" card was reporting **2,080 funded vaults / 122 with rebalances**, which reads as "94% of vaults are broken" and prompted an incident investigation. The rebalancer turned out to be perfectly healthy — the chart was just counting the wrong denominator and squashing the deposit axis.

## What was actually wrong (no alert — this came from reading the chart)

The zeros are the planner's economic gate working as designed:

- The planner observes every funded vault on every cycle. `loyal_yield.fleet_planning_state` showed a full sweep completing with `observed_vault_count = 2087` and `complete_frontier = true` under a second before I queried it, and the last confirmed rebalance was 3 minutes old.
- `evaluate_economics` (`crates/loyal-yield-store/src/fleet_orchestration/domain.rs` in loyal-yield-routing) requires the expected 30-day holding gain to beat `1.25 × execution_cost + $0.05` and still leave `$0.10` of net gain.
- The median funded vault holds **$7.01**. Moving $7 across the live Main Market (4.05%) → OnRe (6.49%) spread earns about **$0.014** over 30 days against a $0.15 floor. Rebalancing it would destroy value.
- Only **314 of 2,081** vaults produced any opportunity in 7 days. The smallest was **$9.78**, and the minimum `expected_net_gain` across 30,648 opportunities was **$0.100014** — sitting exactly on the $0.10 floor.
- Money-weighted, **95.5% of capital** ($546.8k of $572.8k) is in vaults that did rebalance.

So the vaults at zero are dust that the planner is correctly refusing to touch. The chart just had no way to say that.

## How the fix was implemented

Two separate problems, two fixes.

**The denominator.** Rather than hard-coding "ignore small vaults", the chart works out the smallest deposit that *could* clear the planner's gate, and then lets recorded evidence override that model. New `earn-vault-rebalance-eligibility.ts` mirrors the planner's `EconomicPolicy` defaults and inverts the gate: given the widest APY spread currently on the board, how much would a vault need to hold for 30 days of edge to cover the $0.05 safety margin plus the $0.10 minimum net gain? At the live spread that comes out around **$37**. Vaults under it cannot rebalance no matter what the market does, so they don't belong in the denominator.

Two things worth calling out about that number. It's deliberately a *floor*, not a prediction — it assumes zero execution cost, full confidence and the best spread available, so it is the most generous threshold the planner could ever apply. That direction matters: it can never hide a vault that's genuinely stuck, it can only be too generous. And it only counts reserves the Safe monitor still marks `eligible`. That second part was not an academic detail — below-liquidity reserves report **0% APY** on mainnet, and my first version happily used them, inventing a 7.66% spread and dropping the floor to $23.82. There's a test pinning that now.

A modelled floor on its own is not safe, though, and the first version of this got it wrong. The floor comes from the spread as it stands *now*, while the counts are historical — so a vault that was genuinely actionable earlier in the window can sit under today's floor. Filtering the denominator on the floor alone therefore dropped real misses and flattered the ratio. On mainnet it hid **68 vaults that had confirmed opportunities in the last 7 days and never converted**, which pushed the 7-day figure from 37.5% up to 45.8%.

So the query now also returns per-window opportunity counts from `rebalance_opportunities`, and recorded evidence beats the model: if the planner actually raised an opportunity for a vault, or the vault actually rebalanced, it stays in the denominator no matter what it holds today. The floor only decides the vaults with no recorded activity at all. That way the ratio can be dragged down by a miss but never quietly cleaned up by one.

That evidence has to describe the same population as the numerator, which is the second thing I got wrong first time round. The numerator counts confirmed *reserve-to-reserve* decisions, but the opportunity counts were unfiltered — and idle-vault deposits carry a `NULL` source_reserve, so they can never become one. Vaults whose only activity was an idle deposit were being let into the denominator with no route to the numerator, which pushed the ratio the other way (7 vaults, 123/328 instead of 123/321 over 7 days). The error scales with idle-deposit volume, so it would widen after a wave of new deposits. `opportunity_counts` now mirrors the `rebalance_counts` reserve filter exactly, and there's a comment on the CTE saying the two must stay in step. The tooltip shows the opportunity count too, so a dot sitting at zero can be read directly — real opportunity that didn't convert, or simply nothing to do.

The headline reads "123 of 321 economically eligible vaults rebalanced" instead of "123 of 2,081", with the funded total and the floor still shown next to it so nothing is hidden. If the APY spread can't be established, it falls back to the old funded-vault wording rather than showing a made-up number.

**The axis.** Both charts were plotting *rank* and labelling the ticks with deposit *amounts*, so the axis looked like money but spaced like a queue — 1,800 dust vaults got the same room as the whales and everything piled into one edge. Both now default to a real log scale on the deposit amount, with a switch to a linear one. Live deposits span 12 decades (0.000001 to 100.3k USDC), which would mean 13 overlapping labels, so `buildLogTicks` thins the decades to at most 8 while keeping the domain on real powers of ten.

The alternative option started out as "As is", meaning the old rank axis kept verbatim. That name did not say what it showed, and labelling the rank axis "linear" would have repeated the exact mislabelling this PR exists to fix — rank is not a scale of anything. So the second option is now a genuine linear deposit axis, and the two choices are the same quantity on two scales. Be aware that linear is honestly not very readable on this data: one whale at 100.3k flattens the other 2,080 vaults onto the floor. That is what linear actually looks like here, log stays the default, and the rank view is gone. Happy to bring rank back as a third option if it is missed.

The control itself was wrong too. It was a hand-rolled button group using the `ghost` variant with no selected-state styling, so it rendered as two floating labels with no affordance. It is now a small shared component over the Radix `Switch` primitive, reading `Linear scale ─[switch]─ Log scale` with the active side emphasised, used by both charts.

One wrinkle on the executed-rebalances chart: 200 of its 5,465 executions belong to users who have since fully withdrawn, so their current deposit is **0** — and a log axis has nowhere to put zero. Dropping them would have quietly lost 200 executions, and refusing to use log scale whenever a zero exists would have meant the log option never activated at all. They're pinned to one decade below the smallest real deposit, and the footer says how many are sitting there. The frequency chart pins the same way.

Switching to linear also surfaced a latent crash: a linear axis always requests a **zero** tick, and the old tick formatter fed `log10(0)` — negative infinity — straight into `maximumFractionDigits`, which throws a `RangeError`. A log axis never asks for zero so it had never fired. `formatDepositTick` guards it, with a test.

## Verification

- `bun test apps/admin/src/app/(admin)/earn/rebalance/` — 18 tests, all passing, covering the floor math, the below-liquidity trap, the null-spread fallback, the opportunity-evidence override (including the "never let the floor hide a miss" case), tick thinning, tick formatting, the zero tick a linear axis requests, and the degenerate single-value and non-positive ranges.
- Ran the admin app against **live mainnet** data and drove the real API payload through the shipped functions, then cross-checked every window independently in SQL against Neon. Exact match on all three: **123/321 (7d)**, **549/599 (all history)**, **26/253 (12h)**.
- The floor moved from `37.288959` to `37.065509 USDC` between two runs as live APYs shifted, without changing any of the counts — the intended behaviour for a spread-derived threshold.
- Confirmed on real payloads that log scale activates for both charts and produces 8 clean ticks, that the linear axis formats cleanly including its zero tick (`0 USD | 25.1K USD | 50.2K USD | 100.3K USD`), and that the executed chart's 200 zero-deposit rows are pinned rather than dropped.
- Checked the built client bundle actually ships the new control: `Linear scale` ×2, `Log scale` ×2 and the Radix `switch-thumb` are present, with no remaining `As is`. Loading `/earn/rebalance` against live mainnet returned 200 with a clean server log.
- `bun run admin:build` and `bun run admin:lint` both clean. Typecheck shows no new errors in the touched files (the repo has pre-existing `ReactNode` errors in 11 untouched admin files from unbuilt workspace packages).

Headline before and after, same data:

| Window | Before | After |
| --- | --- | --- |
| All history | 549 / 2,081 funded (26.4%) | 549 / 599 eligible (91.7%) |
| 7 days | 123 / 2,081 funded (5.9%) | 123 / 321 eligible (38.3%) |
| 12 hours | 26 / 2,081 funded (1.2%) | 26 / 253 eligible (10.3%) |

## Scope

Admin observability only — `earn-vault-rebalance-frequency-chart.tsx` and `executed-earn-rebalances-chart.tsx`, two new helper modules and their tests, plus additive per-window opportunity counts in the frequency query in `rebalance-data.ts`. **No planner, policy or threshold changes** — the economic gate is behaving correctly and is not touched. The query change is read-only and additive: one extra grouped read of `rebalance_opportunities`, no existing columns or filters altered.

The policy constants are duplicated in TypeScript to explain the Rust planner's behavior, which is a real drift risk — the module carries a comment pointing at the Rust source of truth. Worth a follow-up to serve them from one place if they start changing.

## Post-merge

- Reload `/earn/rebalance` in admin and confirm the frequency card leads with the eligible ratio, both charts open on log scale, and the log/linear switch reads correctly in light and dark.
- The eligibility floor moves with the live APY spread, so expect the eligible count to drift day to day — that's intended, not a regression.
- The denominator now leans on `rebalance_opportunities` retention. If that table is pruned more aggressively than the "All history" window, the all-history denominator will understate. Worth confirming the retention policy.
- Unrelated but found while investigating, both already worth their own tickets: `loyal-fleet-route-executor` is logging `cross-mint continuation failed before signed publication` every ~2 minutes, and `loyal-fleet-route-revalidator` logged `same-mint route worker stopped after a fatal error` four times on 2026-08-18.
