### PR TITLE
chore(mobile): add the App Store Connect app id for iOS submits

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -92,6 +92,7 @@
     "production": {
       "ios": {
         "appleId": "vlad@askloyal.com",
+        "ascAppId": "6802734319",
         "appleTeamId": "AP32T55T29"
       }
     }


### PR DESCRIPTION
Fills in the last repo-side Apple value: `ascAppId` for the App Store Connect record created for `com.askloyal.app`.

ASK-2127