### PR TITLE
chore(mobile): add a production-ios submit profile for auto-submit

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -89,6 +89,9 @@
     }
   },
   "submit": {
+    "production-ios": {
+      "extends": "production"
+    },
     "production": {
       "ios": {
         "appleId": "vlad@askloyal.com",


### PR DESCRIPTION
`eas build -p ios --profile production-ios --auto-submit` fails with "Missing submit profile in eas.json: production-ios" — the CLI does not fall back to the `production` submit profile despite the docs saying it does (observed with eas-cli 22, build cdb2699a). Extends `production`, so the Apple values stay in one place.

ASK-2137