### PR TITLE
feat(mobile): back up the wallet key to iCloud

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -170,6 +170,17 @@ const config: ExpoConfig = {
       },
     ],
     [
+      // iCloud Drive wallet backup (ASK-2163). The plugin writes the iCloud
+      // entitlements and derives the container from the bundle identifier
+      // (iCloud.com.askloyal.app / .dev). Backups go to the hidden AppData
+      // scope, so no folder shows up in the Files app despite the plugin's
+      // public-scope Info.plist default.
+      "react-native-cloud-storage",
+      {
+        iCloudContainerEnvironment: "Production",
+      },
+    ],
+    [
       "expo-notifications",
       {
         // Android requires a transparent PNG with a white silhouette for the

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -28,6 +28,11 @@ import { getShowTips, setShowTips } from "@/lib/settings";
 import { mmkv } from "@/lib/storage";
 import { isBiometricAvailable } from "@/lib/wallet/biometrics";
 import {
+  getLastCloudBackupAt,
+  isCloudBackupSupported,
+  writeCloudBackup,
+} from "@/lib/wallet/icloud-backup";
+import {
   isICloudSyncEnabled,
   isICloudSyncSupported,
   setICloudSyncEnabled,
@@ -170,6 +175,8 @@ export default function ProfileScreen() {
   const [showTips, setShowTipsState] = useState(getShowTips);
   const [biometricsAvailable, setBiometricsAvailable] = useState(false);
   const [icloudSyncOn, setICloudSyncOn] = useState(isICloudSyncEnabled);
+  const [lastBackupAt, setLastBackupAt] = useState(getLastCloudBackupAt);
+  const [backingUp, setBackingUp] = useState(false);
   const [showBioPinInput, setShowBioPinInput] = useState(false);
   const [bioPin, setBioPin] = useState("");
   const [bioPinError, setBioPinError] = useState<string | null>(null);
@@ -246,6 +253,35 @@ export default function ProfileScreen() {
     },
     [wallet],
   );
+
+  const handleICloudBackup = useCallback(() => {
+    if (backingUp) return;
+    Alert.alert(
+      "Back Up Wallet to iCloud",
+      "Stores your encrypted wallet in your iCloud. Restoring it on a new phone requires your wallet PIN.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Back Up",
+          onPress: () => {
+            setBackingUp(true);
+            writeCloudBackup()
+              .then((envelope) => {
+                setLastBackupAt(envelope.createdAt);
+                Alert.alert("Backed Up", "Your wallet is backed up to iCloud.");
+              })
+              .catch((error: unknown) => {
+                Alert.alert(
+                  "Backup Failed",
+                  error instanceof Error ? error.message : "Please try again.",
+                );
+              })
+              .finally(() => setBackingUp(false));
+          },
+        },
+      ],
+    );
+  }, [backingUp]);
 
   const handleICloudSyncToggle = useCallback((value: boolean) => {
     if (process.env.EXPO_OS !== "web") {
@@ -460,6 +496,23 @@ export default function ProfileScreen() {
                   value: icloudSyncOn,
                   onValueChange: handleICloudSyncToggle,
                 }}
+              />
+            )}
+
+            {!isVaultBacked && isCloudBackupSupported() && (
+              <ProfileCell
+                icon={
+                  <Cloud size={28} strokeWidth={1.5} color="rgba(0,0,0,0.6)" />
+                }
+                title={backingUp ? "Backing Up..." : "Back Up Wallet to iCloud"}
+                subtitle={
+                  lastBackupAt
+                    ? `Last backup ${new Date(lastBackupAt).toLocaleDateString()}`
+                    : undefined
+                }
+                showChevron
+                disabled={backingUp}
+                onPress={handleICloudBackup}
               />
             )}
 

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -8,6 +8,7 @@ import {
   Bell,
   ChevronRight,
   CircleHelp,
+  Cloud,
   Fingerprint,
   Globe,
   Heart,
@@ -26,6 +27,11 @@ import { PinPadInput } from "@/components/wallet/PinPadInput";
 import { getShowTips, setShowTips } from "@/lib/settings";
 import { mmkv } from "@/lib/storage";
 import { isBiometricAvailable } from "@/lib/wallet/biometrics";
+import {
+  isICloudSyncEnabled,
+  isICloudSyncSupported,
+  setICloudSyncEnabled,
+} from "@/lib/wallet/keypair-storage";
 import { WALLET_PIN_LENGTH } from "@/lib/wallet/pin";
 import { isWalletUnlocked, useWallet } from "@/lib/wallet/wallet-provider";
 import { Pressable, ScrollView, Text, View } from "@/tw";
@@ -163,6 +169,7 @@ export default function ProfileScreen() {
   );
   const [showTips, setShowTipsState] = useState(getShowTips);
   const [biometricsAvailable, setBiometricsAvailable] = useState(false);
+  const [icloudSyncOn, setICloudSyncOn] = useState(isICloudSyncEnabled);
   const [showBioPinInput, setShowBioPinInput] = useState(false);
   const [bioPin, setBioPin] = useState("");
   const [bioPinError, setBioPinError] = useState<string | null>(null);
@@ -239,6 +246,18 @@ export default function ProfileScreen() {
     },
     [wallet],
   );
+
+  const handleICloudSyncToggle = useCallback((value: boolean) => {
+    if (process.env.EXPO_OS !== "web") {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    // Optimistic — the keychain write is fast and failures are logged.
+    setICloudSyncOn(value);
+    setICloudSyncEnabled(value).catch((error) => {
+      console.warn("[settings] iCloud Keychain toggle failed", error);
+      setICloudSyncOn(!value);
+    });
+  }, []);
 
   const handleBioPinSubmit = useCallback(async () => {
     if (bioPin.length !== WALLET_PIN_LENGTH) {
@@ -431,6 +450,17 @@ export default function ProfileScreen() {
                   </View>
                 )}
               </>
+            )}
+
+            {!isVaultBacked && isICloudSyncSupported() && (
+              <ProfileCell
+                icon={<Cloud size={28} strokeWidth={1.5} color="rgba(0,0,0,0.6)" />}
+                title="Sync Wallet to iCloud Keychain"
+                toggle={{
+                  value: icloudSyncOn,
+                  onValueChange: handleICloudSyncToggle,
+                }}
+              />
             )}
 
             {!isVaultBacked && (

--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -72,6 +72,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-cloud-storage": "^3.0.1",
         "react-native-css": "0.0.0-nightly.5ce6396",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "^2.0.0",
@@ -2138,6 +2139,8 @@
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-native": ["react-native@0.81.5", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.5", "@react-native/codegen": "0.81.5", "@react-native/community-cli-plugin": "0.81.5", "@react-native/gradle-plugin": "0.81.5", "@react-native/js-polyfills": "0.81.5", "@react-native/normalize-colors": "0.81.5", "@react-native/virtualized-lists": "0.81.5", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "bin": "cli.js" }, "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw=="],
+
+    "react-native-cloud-storage": ["react-native-cloud-storage@3.0.1", "", { "peerDependencies": { "expo": ">=48.0.0", "react": "*", "react-native": ">=0.76" }, "optionalPeers": ["expo"] }, "sha512-JzkPHXassKeg/yZucoba1WhtTey8ID9WYzsFCK3m3TBb6RhCHr5iY1Z6/odo/zIaNpOw25Yp+wIGleNTe1GHVQ=="],
 
     "react-native-css": ["react-native-css@0.0.0-nightly.5ce6396", "", { "dependencies": { "@expo/metro-runtime": "~6.1.1", "babel-plugin-react-compiler": "^19.1.0-rc.2", "colorjs.io": "0.6.0-alpha.1", "comment-json": "^4.2.5", "debug": "^4.4.1" }, "peerDependencies": { "expo": "54.0.0-preview.6", "lightningcss": ">=1.27.0", "react": "19.1.0", "react-native": "0.81.0" } }, "sha512-jiSNSRpf5h2j1yS5vtOps8iZmZ2+GIM8YYZQrzcZsIaO8QDKdseZSGmxaeZ0cLy2tYCNKJH+1RyHdWMcvSouNg=="],
 

--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -58,6 +58,7 @@
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
+        "expo-synced-keychain": "./modules/expo-synced-keychain",
         "expo-system-ui": "~6.0.9",
         "expo-updates": "~29.0.16",
         "expo-web-browser": "~15.0.10",
@@ -1465,6 +1466,8 @@
     "expo-structured-headers": ["expo-structured-headers@5.0.0", "", {}, "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw=="],
 
     "expo-symbols": ["expo-symbols@1.0.8", "", { "dependencies": { "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-7bNjK350PaQgxBf0owpmSYkdZIpdYYmaPttDBb2WIp6rIKtcEtdzdfmhsc2fTmjBURHYkg36+eCxBFXO25/1hw=="],
+
+    "expo-synced-keychain": ["expo-synced-keychain@file:modules/expo-synced-keychain", {}],
 
     "expo-system-ui": ["expo-system-ui@6.0.9", "", { "dependencies": { "@react-native/normalize-colors": "0.81.5", "debug": "^4.3.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-native-web": "*" } }, "sha512-eQTYGzw1V4RYiYHL9xDLYID3Wsec2aZS+ypEssmF64D38aDrqbDgz1a2MSlHLQp2jHXSs3FvojhZ9FVela1Zcg=="],
 

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
       "<rootDir>/../../packages/wallet-core/src/lib/index",
     "^@loyal-labs/private-transactions$": "<rootDir>/../../packages/private-transactions/index",
     "^expo-seed-vault$": "<rootDir>/modules/expo-seed-vault/src/index",
+    "^expo-synced-keychain$": "<rootDir>/modules/expo-synced-keychain/src/index",
     "\\.(png|jpg|jpeg|gif|webp|svg)$": "<rootDir>/test/fileMock.js",
   },
   transform: {

--- a/apps/mobile/modules/expo-synced-keychain/expo-module.config.json
+++ b/apps/mobile/modules/expo-synced-keychain/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": [
+    "ios"
+  ],
+  "ios": {
+    "modules": [
+      "ExpoSyncedKeychainModule"
+    ]
+  }
+}

--- a/apps/mobile/modules/expo-synced-keychain/ios/ExpoSyncedKeychain.podspec
+++ b/apps/mobile/modules/expo-synced-keychain/ios/ExpoSyncedKeychain.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'ExpoSyncedKeychain'
+  s.version        = '0.1.0'
+  s.summary        = 'iCloud Keychain (kSecAttrSynchronizable) item storage'
+  s.description    = 'Reads and writes generic-password keychain items marked synchronizable, so iCloud Keychain carries them across the user devices. iOS only.'
+  s.author         = ''
+  s.homepage       = 'https://askloyal.com'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = "**/*.{h,m,swift}"
+end

--- a/apps/mobile/modules/expo-synced-keychain/ios/ExpoSyncedKeychainModule.swift
+++ b/apps/mobile/modules/expo-synced-keychain/ios/ExpoSyncedKeychainModule.swift
@@ -1,0 +1,68 @@
+import ExpoModulesCore
+import Security
+
+// Generic-password keychain items with kSecAttrSynchronizable, which iCloud
+// Keychain carries across the user's devices. Deliberately a separate service
+// from expo-secure-store's items: those stay device-only
+// (WHEN_UNLOCKED_THIS_DEVICE_ONLY); a synchronizable item cannot be
+// *_THIS_DEVICE_ONLY, so synced copies live here with WHEN_UNLOCKED.
+public class ExpoSyncedKeychainModule: Module {
+  private let service = "app.askloyal.synced-keychain"
+
+  public func definition() -> ModuleDefinition {
+    Name("ExpoSyncedKeychain")
+
+    AsyncFunction("setItem") { (key: String, value: String) in
+      guard let data = value.data(using: .utf8) else {
+        throw SyncedKeychainException("value is not UTF-8 encodable")
+      }
+      // Delete-then-add keeps this a single code path; SecItemUpdate on a
+      // missing item would need a second branch for the same result.
+      var query = self.baseQuery(key: key)
+      SecItemDelete(query as CFDictionary)
+      query[kSecValueData as String] = data
+      query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+      let status = SecItemAdd(query as CFDictionary, nil)
+      guard status == errSecSuccess else {
+        throw SyncedKeychainException("SecItemAdd failed with status \(status)")
+      }
+    }
+
+    AsyncFunction("getItem") { (key: String) -> String? in
+      var query = self.baseQuery(key: key)
+      query[kSecReturnData as String] = true
+      query[kSecMatchLimit as String] = kSecMatchLimitOne
+      var result: AnyObject?
+      let status = SecItemCopyMatching(query as CFDictionary, &result)
+      if status == errSecItemNotFound {
+        return nil
+      }
+      guard status == errSecSuccess, let data = result as? Data else {
+        throw SyncedKeychainException("SecItemCopyMatching failed with status \(status)")
+      }
+      return String(data: data, encoding: .utf8)
+    }
+
+    AsyncFunction("deleteItem") { (key: String) in
+      let status = SecItemDelete(self.baseQuery(key: key) as CFDictionary)
+      guard status == errSecSuccess || status == errSecItemNotFound else {
+        throw SyncedKeychainException("SecItemDelete failed with status \(status)")
+      }
+    }
+  }
+
+  private func baseQuery(key: String) -> [String: Any] {
+    return [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key,
+      kSecAttrSynchronizable as String: true,
+    ]
+  }
+}
+
+internal final class SyncedKeychainException: GenericException<String> {
+  override var reason: String {
+    "Synced keychain error: \(param)"
+  }
+}

--- a/apps/mobile/modules/expo-synced-keychain/package.json
+++ b/apps/mobile/modules/expo-synced-keychain/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "expo-synced-keychain",
+  "version": "0.1.0",
+  "description": "iCloud Keychain (kSecAttrSynchronizable) storage for the wallet keypair",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true
+}

--- a/apps/mobile/modules/expo-synced-keychain/src/index.ts
+++ b/apps/mobile/modules/expo-synced-keychain/src/index.ts
@@ -1,0 +1,59 @@
+// iCloud Keychain-synced key-value storage. iOS only; every function is a
+// safe no-op elsewhere.
+//
+// The native lookup is lazy and swallows load failures for two reasons:
+// a JS bundle delivered via OTA to a binary that predates this module must
+// degrade to "unavailable" instead of throwing at import time, and Jest's
+// node environment cannot load expo-modules-core/react-native at all —
+// importers of this module must not take test suites down with them.
+
+type NativeSyncedKeychain = {
+  setItem(key: string, value: string): Promise<void>;
+  getItem(key: string): Promise<string | null>;
+  deleteItem(key: string): Promise<void>;
+};
+
+let cached: NativeSyncedKeychain | null | undefined;
+
+function getNative(): NativeSyncedKeychain | null {
+  if (cached !== undefined) return cached;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Platform } = require("react-native") as typeof import("react-native");
+    if (Platform.OS !== "ios") {
+      cached = null;
+      return cached;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { requireOptionalNativeModule } =
+      require("expo-modules-core") as typeof import("expo-modules-core");
+    cached =
+      requireOptionalNativeModule<NativeSyncedKeychain>("ExpoSyncedKeychain");
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/** True when the running binary contains the native module (iOS only). */
+export function isAvailable(): boolean {
+  return getNative() != null;
+}
+
+export async function setItem(key: string, value: string): Promise<void> {
+  const native = getNative();
+  if (!native) return;
+  await native.setItem(key, value);
+}
+
+export async function getItem(key: string): Promise<string | null> {
+  const native = getNative();
+  if (!native) return null;
+  return native.getItem(key);
+}
+
+export async function deleteItem(key: string): Promise<void> {
+  const native = getNative();
+  if (!native) return;
+  await native.deleteItem(key);
+}

--- a/apps/mobile/modules/expo-synced-keychain/tsconfig.json
+++ b/apps/mobile/modules/expo-synced-keychain/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ]
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -79,6 +79,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-cloud-storage": "^3.0.1",
     "react-native-css": "0.0.0-nightly.5ce6396",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "^2.0.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -61,6 +61,7 @@
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-seed-vault": "./modules/expo-seed-vault",
+    "expo-synced-keychain": "./modules/expo-synced-keychain",
     "expo-sharing": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/apps/mobile/src/components/wallet/OnboardingGate.tsx
+++ b/apps/mobile/src/components/wallet/OnboardingGate.tsx
@@ -20,6 +20,11 @@ import {
   type WalletConnectMode,
 } from "@/components/wallet/onboarding-slides";
 import { WalletSetupOnboardingScreen } from "@/components/wallet/WalletSetupOnboardingScreen";
+import {
+  findCloudBackup,
+  restoreCloudBackup,
+  type WalletBackupEnvelope,
+} from "@/lib/wallet/icloud-backup";
 import { connectMwaWallet, isMwaSupported } from "@/lib/wallet/mwa-signer";
 import { WalletRejectedError } from "@/lib/wallet/rejection";
 import { isSeedVaultUserDecline } from "@/lib/wallet/seed-vault-signer";
@@ -56,8 +61,12 @@ const SCREEN_EXITING_ANIMATION = FadeOut.duration(160).easing(
 );
 
 export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
-  const { finalizeSigner, finalizeMwaSigner, finalizeVaultSigner } =
-    useWallet();
+  const {
+    finalizeSigner,
+    finalizeMwaSigner,
+    finalizeVaultSigner,
+    refreshFromStorage,
+  } = useWallet();
 
   const [step, setStep] = useState<Step>(() => getSetupStartStep(mode));
   const [flow, setFlow] = useState<Flow>(null);
@@ -109,6 +118,32 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
     if (isMwaSupported()) return;
     SeedVault.isAvailable().then(setSeedVaultAvailable);
   }, []);
+
+  // iCloud Drive wallet backup, if the user made one on a previous install
+  // (iOS only — findCloudBackup resolves null everywhere else).
+  const [cloudBackup, setCloudBackup] = useState<WalletBackupEnvelope | null>(
+    null,
+  );
+  useEffect(() => {
+    if (mode !== "setup") return;
+    findCloudBackup().then(setCloudBackup);
+  }, [mode]);
+
+  const handleRestoreCloudBackup = useCallback(async () => {
+    if (!cloudBackup) return;
+    setFinalizing(true);
+    try {
+      await restoreCloudBackup(cloudBackup);
+      // Transitions the provider to "locked"; the auth gate swaps this
+      // screen for the PIN lock screen.
+      await refreshFromStorage();
+    } catch (e) {
+      setFinalizing(false);
+      setConnectWalletError(
+        e instanceof Error ? e.message : "Restoring the backup failed",
+      );
+    }
+  }, [cloudBackup, refreshFromStorage]);
 
   useEffect(() => {
     setScreenAnimationsReady(true);
@@ -278,8 +313,12 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
     content = (
       <WalletSetupOnboardingScreen
         connectMode={connectMode}
+        hasCloudBackup={cloudBackup != null}
         connectWalletPending={connectWalletPending}
         connectWalletError={connectWalletError}
+        onRestoreCloudBackup={() => {
+          void handleRestoreCloudBackup();
+        }}
         onConnectWallet={() => {
           setFlow(null);
           void handleConnectWallet();

--- a/apps/mobile/src/components/wallet/WalletSetupOnboardingScreen.tsx
+++ b/apps/mobile/src/components/wallet/WalletSetupOnboardingScreen.tsx
@@ -31,20 +31,24 @@ import { Image } from "@/tw/image";
 
 type Props = {
   connectMode: WalletConnectMode;
+  hasCloudBackup?: boolean;
   connectWalletPending?: boolean;
   connectWalletError?: string | null;
   onConnectWallet: () => void;
   onCreateWallet: () => void;
   onImportWallet: () => void;
+  onRestoreCloudBackup?: () => void;
 };
 
 export function WalletSetupOnboardingScreen({
   connectMode,
+  hasCloudBackup = false,
   connectWalletPending = false,
   connectWalletError = null,
   onConnectWallet,
   onCreateWallet,
   onImportWallet,
+  onRestoreCloudBackup,
 }: Props) {
   const scrollRef = useRef<ScrollView>(null);
   const { bottom } = useSafeAreaInsets();
@@ -55,8 +59,8 @@ export function WalletSetupOnboardingScreen({
   const currentIndex = playbackState.currentIndex;
 
   const actions = useMemo(
-    () => buildWalletSetupActions(connectMode),
-    [connectMode],
+    () => buildWalletSetupActions(connectMode, hasCloudBackup),
+    [connectMode, hasCloudBackup],
   );
   const imageHeight = useMemo(
     () => Math.min(Math.max(height * 0.34, 220), 340),
@@ -71,7 +75,10 @@ export function WalletSetupOnboardingScreen({
   );
 
   const wrapWithEnded = useCallback(
-    (flow: "connect-wallet" | "create" | "import", handler: () => void) =>
+    (
+      flow: "connect-wallet" | "create" | "import" | "restore-icloud",
+      handler: () => void,
+    ) =>
       () => {
         track(ONBOARDING_EVENTS.ended, {
           method: ONBOARDING_COMPLETION_METHODS.completed,
@@ -88,8 +95,18 @@ export function WalletSetupOnboardingScreen({
       "connect-wallet": wrapWithEnded("connect-wallet", onConnectWallet),
       create: wrapWithEnded("create", onCreateWallet),
       import: wrapWithEnded("import", onImportWallet),
+      "restore-icloud": wrapWithEnded(
+        "restore-icloud",
+        onRestoreCloudBackup ?? (() => {}),
+      ),
     }),
-    [onConnectWallet, onCreateWallet, onImportWallet, wrapWithEnded],
+    [
+      onConnectWallet,
+      onCreateWallet,
+      onImportWallet,
+      onRestoreCloudBackup,
+      wrapWithEnded,
+    ],
   );
 
   useEffect(() => {

--- a/apps/mobile/src/components/wallet/onboarding-slides.ts
+++ b/apps/mobile/src/components/wallet/onboarding-slides.ts
@@ -5,7 +5,7 @@ export type OnboardingSlide = {
 };
 
 export type WalletSetupAction = {
-  id: "connect-wallet" | "create" | "import";
+  id: "connect-wallet" | "create" | "import" | "restore-icloud";
   label: string;
   helperText?: string;
 };
@@ -33,7 +33,20 @@ export const ONBOARDING_SLIDES: OnboardingSlide[] = [
 
 export function buildWalletSetupActions(
   connectMode: WalletConnectMode,
+  hasCloudBackup = false,
 ): WalletSetupAction[] {
+  // A found iCloud backup outranks everything: the user already has a wallet
+  // and almost certainly wants it back, so restore renders as the primary.
+  const restore: WalletSetupAction[] = hasCloudBackup
+    ? [
+        {
+          id: "restore-icloud",
+          label: "Restore from iCloud",
+          helperText: "Wallet backup found in your iCloud",
+        },
+      ]
+    : [];
+
   const createAndImport: WalletSetupAction[] = [
     { id: "create", label: "Create New Wallet" },
     { id: "import", label: "Import Existing Wallet" },
@@ -43,9 +56,10 @@ export function buildWalletSetupActions(
   // Adapter). Drop the action entirely rather than rendering a disabled
   // primary CTA — a dead first button that names another mobile platform is
   // both a bad first impression and an App Review flag.
-  if (connectMode === "none") return createAndImport;
+  if (connectMode === "none") return [...restore, ...createAndImport];
 
   return [
+    ...restore,
     connectMode === "seed-vault"
       ? { id: "connect-wallet", label: "Use Seed Vault" }
       : {

--- a/apps/mobile/src/lib/storage.ts
+++ b/apps/mobile/src/lib/storage.ts
@@ -3,8 +3,6 @@
 // (e.g. during Jest tests or web bundle evaluation), so callers never
 // have to branch on environment.
 
-import { MMKV } from "react-native-mmkv";
-
 interface StorageAdapter {
   getString(key: string): string | undefined;
   getNumber(key: string): number | undefined;
@@ -43,6 +41,11 @@ function createInMemoryStorage(): StorageAdapter {
 
 function createMmkvStorage(): StorageAdapter | null {
   try {
+    // Lazy so environments where the import itself throws (Jest's node env
+    // has no react-native runtime) reach the in-memory fallback below instead
+    // of failing at module load — which took every importer down with it.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { MMKV } = require("react-native-mmkv") as typeof import("react-native-mmkv");
     const instance = new MMKV({ id: "loyal-app-storage" });
     return {
       getString: (key) => instance.getString(key),

--- a/apps/mobile/src/lib/wallet/__tests__/icloud-backup-envelope.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/icloud-backup-envelope.test.ts
@@ -1,0 +1,46 @@
+/**
+ * iCloud Drive backup envelope (ASK-2163) — trust-boundary parser tests.
+ * The backup file comes back from iCloud, which can hand over truncated,
+ * stale-format, or foreign content; a bad parse must yield null, never a
+ * half-populated wallet restore.
+ */
+// icloud-backup transitively imports expo-secure-store (ESM, unloadable in
+// jest's node env) via keypair-storage; the parser under test touches neither.
+jest.mock("expo-secure-store", () => ({}));
+jest.mock("expo-synced-keychain", () => ({}));
+
+// eslint-disable-next-line import/first -- mocks above must precede the import
+import { parseBackupEnvelope } from "../icloud-backup";
+
+const valid = {
+  v: 1,
+  createdAt: "2026-08-18T12:00:00.000Z",
+  publicKey: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+  ciphertext: "base64ciphertextblob",
+};
+
+test("accepts a valid envelope and preserves the fields that matter", () => {
+  const parsed = parseBackupEnvelope(JSON.stringify(valid));
+  expect(parsed).not.toBeNull();
+  expect(parsed?.publicKey).toBe(valid.publicKey);
+  expect(parsed?.ciphertext).toBe(valid.ciphertext);
+});
+
+test.each([
+  ["not JSON", "{{{"],
+  ["truncated file", JSON.stringify(valid).slice(0, 40)],
+  ["wrong version", JSON.stringify({ ...valid, v: 2 })],
+  ["missing ciphertext", JSON.stringify({ ...valid, ciphertext: undefined })],
+  ["empty ciphertext", JSON.stringify({ ...valid, ciphertext: "" })],
+  ["missing publicKey", JSON.stringify({ ...valid, publicKey: undefined })],
+  ["non-object", JSON.stringify("hello")],
+  ["null", JSON.stringify(null)],
+])("rejects %s", (_name, raw) => {
+  expect(parseBackupEnvelope(raw)).toBeNull();
+});
+
+test("tolerates a missing createdAt rather than rejecting the wallet", () => {
+  const { createdAt: _omit, ...rest } = valid;
+  const parsed = parseBackupEnvelope(JSON.stringify(rest));
+  expect(parsed?.publicKey).toBe(valid.publicKey);
+});

--- a/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
@@ -1,0 +1,120 @@
+/**
+ * iCloud Keychain mirror (ASK-2162) — storage-boundary contract tests.
+ *
+ * Protects: the synced keychain only ever holds a copy when the user opted
+ * in, reset always removes cloud copies, and a wallet restored from the
+ * synced keychain unlocks with the original PIN (full encrypt/decrypt
+ * round-trip through the real crypto).
+ */
+/* eslint-disable import/first -- the stores must exist before the jest.mock
+   factories run, which happens when the mocked modules are first imported */
+import { Keypair } from "@solana/web3.js";
+
+const localStore = new Map<string, string>();
+const syncedStore = new Map<string, string>();
+
+jest.mock("expo-secure-store", () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  setItemAsync: jest.fn(async (k: string, v: string) => {
+    localStore.set(k, v);
+  }),
+  getItemAsync: jest.fn(async (k: string) => localStore.get(k) ?? null),
+  deleteItemAsync: jest.fn(async (k: string) => {
+    localStore.delete(k);
+  }),
+}));
+
+jest.mock("expo-synced-keychain", () => ({
+  isAvailable: jest.fn(() => true),
+  setItem: jest.fn(async (k: string, v: string) => {
+    syncedStore.set(k, v);
+  }),
+  getItem: jest.fn(async (k: string) => syncedStore.get(k) ?? null),
+  deleteItem: jest.fn(async (k: string) => {
+    syncedStore.delete(k);
+  }),
+}));
+
+import { mmkv } from "@/lib/storage";
+
+import {
+  clearStoredKeypair,
+  getStoredPublicKey,
+  hasStoredKeypair,
+  isICloudSyncEnabled,
+  loadKeypair,
+  restoreFromSyncedKeychain,
+  setICloudSyncEnabled,
+  storeKeypair,
+} from "../keypair-storage";
+
+const PIN = "4821";
+const keypair = Keypair.fromSeed(new Uint8Array(32).fill(7));
+
+beforeEach(async () => {
+  localStore.clear();
+  syncedStore.clear();
+  await setICloudSyncEnabled(false);
+});
+
+test("storeKeypair does not touch the synced keychain when sync is off", async () => {
+  await storeKeypair(keypair, PIN);
+  expect(localStore.size).toBeGreaterThan(0);
+  expect(syncedStore.size).toBe(0);
+});
+
+test("enabling sync mirrors an existing wallet; disabling removes the copies", async () => {
+  await storeKeypair(keypair, PIN);
+  await setICloudSyncEnabled(true);
+  expect(syncedStore.get("wallet_public_key")).toBe(
+    keypair.publicKey.toBase58(),
+  );
+  expect(syncedStore.get("wallet_encrypted_keypair")).toBeTruthy();
+
+  await setICloudSyncEnabled(false);
+  expect(syncedStore.size).toBe(0);
+  // Local wallet must survive the toggle.
+  expect(await hasStoredKeypair()).toBe(true);
+});
+
+test("storeKeypair mirrors when sync is on (PIN change keeps the copy fresh)", async () => {
+  await setICloudSyncEnabled(true);
+  await storeKeypair(keypair, PIN);
+  expect(syncedStore.get("wallet_encrypted_keypair")).toBe(
+    localStore.get("wallet_encrypted_keypair"),
+  );
+});
+
+test("clearStoredKeypair removes the synced copies even when sync is on", async () => {
+  await setICloudSyncEnabled(true);
+  await storeKeypair(keypair, PIN);
+  await clearStoredKeypair();
+  expect(localStore.has("wallet_encrypted_keypair")).toBe(false);
+  expect(syncedStore.size).toBe(0);
+});
+
+test("restore round-trip: synced blob adopts locally and unlocks with the original PIN", async () => {
+  // Device A: wallet exists and syncs.
+  await setICloudSyncEnabled(true);
+  await storeKeypair(keypair, PIN);
+
+  // Device B: fresh install — local empty, flag never set, synced keychain
+  // carried over by iCloud. (Not setICloudSyncEnabled(false) — that is the
+  // explicit opt-out and deletes the cloud copies by design.)
+  localStore.clear();
+  mmkv.delete("settings.icloudKeychainSync");
+  expect(await hasStoredKeypair()).toBe(false);
+
+  const restored = await restoreFromSyncedKeychain();
+  expect(restored).toBe(true);
+  expect(isICloudSyncEnabled()).toBe(true); // stays mirrored on the new device
+  expect(await getStoredPublicKey()).toBe(keypair.publicKey.toBase58());
+
+  const unlocked = await loadKeypair(PIN);
+  expect(unlocked?.publicKey.toBase58()).toBe(keypair.publicKey.toBase58());
+});
+
+test("restore returns false when nothing is synced", async () => {
+  expect(await restoreFromSyncedKeychain()).toBe(false);
+  expect(await hasStoredKeypair()).toBe(false);
+});

--- a/apps/mobile/src/lib/wallet/icloud-backup.ts
+++ b/apps/mobile/src/lib/wallet/icloud-backup.ts
@@ -1,0 +1,173 @@
+// Explicit iCloud Drive wallet backup (ASK-2163). Writes the already
+// PIN-encrypted keypair blob into the app's hidden iCloud container
+// (CloudStorageScope.AppData — no folder appears in the Files app), and
+// restores it on a fresh install. Accepted risk per the Linear issue: the
+// backup keeps the existing PIN-based encryption, no extra password.
+//
+// react-native-cloud-storage is a TurboModule; it is loaded lazily so OTA
+// bundles running on binaries without it (and Jest) degrade to
+// "unsupported" instead of throwing at import time.
+import { mmkv } from "@/lib/storage";
+
+import { adoptEncryptedKeypair, getStoredBackupPayload } from "./keypair-storage";
+
+const BACKUP_PATH = "/loyal-wallet-backup.json";
+const LAST_BACKUP_AT_KEY = "wallet.icloudBackup.lastAt";
+const READ_RETRIES = 3;
+const READ_RETRY_DELAY_MS = 800;
+
+export type WalletBackupEnvelope = {
+  v: 1;
+  createdAt: string;
+  publicKey: string;
+  ciphertext: string;
+};
+
+type CloudLib = typeof import("react-native-cloud-storage");
+
+let cachedLib: CloudLib | null | undefined;
+
+function getCloud(): CloudLib | null {
+  if (cachedLib !== undefined) return cachedLib;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Platform } = require("react-native") as typeof import("react-native");
+    if (Platform.OS !== "ios") {
+      cachedLib = null;
+      return cachedLib;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    cachedLib = require("react-native-cloud-storage") as CloudLib;
+  } catch {
+    cachedLib = null;
+  }
+  return cachedLib;
+}
+
+/** True when this binary can talk to iCloud Drive (iOS builds >= this one). */
+export function isCloudBackupSupported(): boolean {
+  return getCloud() != null;
+}
+
+/**
+ * Validates a raw backup file. The file crosses a trust boundary (any app of
+ * the same team could write into the container, and iCloud may hand back a
+ * truncated file), so nothing is assumed about its shape.
+ */
+export function parseBackupEnvelope(raw: string): WalletBackupEnvelope | null {
+  try {
+    const data = JSON.parse(raw) as unknown;
+    if (typeof data !== "object" || data === null) return null;
+    const d = data as Record<string, unknown>;
+    if (d.v !== 1) return null;
+    if (typeof d.publicKey !== "string" || d.publicKey.length === 0) {
+      return null;
+    }
+    if (typeof d.ciphertext !== "string" || d.ciphertext.length === 0) {
+      return null;
+    }
+    return {
+      v: 1,
+      createdAt: typeof d.createdAt === "string" ? d.createdAt : "",
+      publicKey: d.publicKey,
+      ciphertext: d.ciphertext,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Look for a backup in the iCloud container. An iCloud file can exist
+ * remotely without being downloaded yet, so reads are retried after
+ * triggering a sync.
+ */
+export async function findCloudBackup(): Promise<WalletBackupEnvelope | null> {
+  const cloud = getCloud();
+  if (!cloud) return null;
+  try {
+    const { CloudStorage, CloudStorageScope } = cloud;
+    if (!(await CloudStorage.isCloudAvailable())) return null;
+    if (!(await CloudStorage.exists(BACKUP_PATH, CloudStorageScope.AppData))) {
+      return null;
+    }
+    for (let attempt = 0; attempt < READ_RETRIES; attempt++) {
+      try {
+        const raw = await CloudStorage.readFile(
+          BACKUP_PATH,
+          CloudStorageScope.AppData,
+        );
+        return parseBackupEnvelope(raw);
+      } catch {
+        // Likely not downloaded yet — ask iCloud for it and retry.
+        await CloudStorage.triggerSync(
+          BACKUP_PATH,
+          CloudStorageScope.AppData,
+        ).catch(() => {});
+        await delay(READ_RETRY_DELAY_MS);
+      }
+    }
+    return null;
+  } catch (error) {
+    console.warn("[wallet] iCloud backup lookup failed", error);
+    return null;
+  }
+}
+
+/**
+ * Write the current wallet (already encrypted) into the iCloud container.
+ * Throws when there is no wallet or iCloud is unavailable, so the caller can
+ * show a real error instead of a false success.
+ */
+export async function writeCloudBackup(): Promise<WalletBackupEnvelope> {
+  const cloud = getCloud();
+  if (!cloud) throw new Error("iCloud backup is not supported on this build");
+  const payload = await getStoredBackupPayload();
+  if (!payload) throw new Error("No wallet to back up");
+  const { CloudStorage, CloudStorageScope } = cloud;
+  if (!(await CloudStorage.isCloudAvailable())) {
+    throw new Error("iCloud is not available. Check that you are signed in.");
+  }
+  const envelope: WalletBackupEnvelope = {
+    v: 1,
+    createdAt: new Date().toISOString(),
+    publicKey: payload.publicKey,
+    ciphertext: payload.encrypted,
+  };
+  await CloudStorage.writeFile(
+    BACKUP_PATH,
+    JSON.stringify(envelope),
+    CloudStorageScope.AppData,
+  );
+  mmkv.setString(LAST_BACKUP_AT_KEY, envelope.createdAt);
+  return envelope;
+}
+
+/** Adopt a found backup locally; the user unlocks with the original PIN. */
+export async function restoreCloudBackup(
+  envelope: WalletBackupEnvelope,
+): Promise<void> {
+  await adoptEncryptedKeypair(envelope.ciphertext, envelope.publicKey);
+}
+
+export async function deleteCloudBackup(): Promise<void> {
+  const cloud = getCloud();
+  if (!cloud) return;
+  try {
+    const { CloudStorage, CloudStorageScope } = cloud;
+    if (await CloudStorage.exists(BACKUP_PATH, CloudStorageScope.AppData)) {
+      await CloudStorage.unlink(BACKUP_PATH, CloudStorageScope.AppData);
+    }
+    mmkv.delete(LAST_BACKUP_AT_KEY);
+  } catch (error) {
+    console.warn("[wallet] iCloud backup deletion failed", error);
+  }
+}
+
+export function getLastCloudBackupAt(): string | null {
+  return mmkv.getString(LAST_BACKUP_AT_KEY) ?? null;
+}

--- a/apps/mobile/src/lib/wallet/keypair-storage.ts
+++ b/apps/mobile/src/lib/wallet/keypair-storage.ts
@@ -1,5 +1,8 @@
 import { Keypair } from "@solana/web3.js";
 import * as SecureStore from "expo-secure-store";
+import * as SyncedKeychain from "expo-synced-keychain";
+
+import { mmkv } from "@/lib/storage";
 
 import { decryptSecret, encryptSecret } from "./crypto";
 import { isValidWalletPin } from "./pin";
@@ -16,6 +19,11 @@ const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
 
 const ENCRYPTED_KEYPAIR_KEY = "wallet_encrypted_keypair";
 const WALLET_PUBLIC_KEY = "wallet_public_key";
+
+// Opt-in mirror of the two items above into the iCloud Keychain (ASK-2162).
+// The mirrored copy is the same PIN-encrypted blob — accepted risk, see the
+// Linear issue: "we protect on our level, icloud is user's responsibility."
+const ICLOUD_SYNC_ENABLED_KEY = "settings.icloudKeychainSync";
 const FAILED_ATTEMPTS_KEY = "wallet_failed_attempts";
 const LOCKED_UNTIL_KEY = "wallet_locked_until";
 
@@ -87,6 +95,107 @@ export async function storeKeypair(
     keypair.publicKey.toBase58(),
     KEYCHAIN_OPTIONS,
   );
+  if (isICloudSyncEnabled()) {
+    // Best-effort: a failed mirror must not fail wallet creation/PIN change.
+    try {
+      await mirrorToSyncedKeychain(encrypted, keypair.publicKey.toBase58());
+    } catch (error) {
+      console.warn("[wallet] iCloud Keychain mirror failed", error);
+    }
+  }
+}
+
+/**
+ * Whether the wallet items are mirrored to the iCloud Keychain. Off by
+ * default; toggled from Settings on iOS builds that ship the native module.
+ */
+export function isICloudSyncEnabled(): boolean {
+  return mmkv.getBoolean(ICLOUD_SYNC_ENABLED_KEY) ?? false;
+}
+
+/** True when the running binary can talk to the synced keychain (iOS only). */
+export function isICloudSyncSupported(): boolean {
+  return SyncedKeychain.isAvailable();
+}
+
+async function mirrorToSyncedKeychain(
+  encrypted: string,
+  publicKey: string,
+): Promise<void> {
+  await SyncedKeychain.setItem(ENCRYPTED_KEYPAIR_KEY, encrypted);
+  await SyncedKeychain.setItem(WALLET_PUBLIC_KEY, publicKey);
+}
+
+/**
+ * Toggle the iCloud Keychain mirror. Enabling copies the current items up;
+ * disabling removes the synced copies. The device-local items are untouched
+ * either way.
+ */
+export async function setICloudSyncEnabled(enabled: boolean): Promise<void> {
+  mmkv.setBoolean(ICLOUD_SYNC_ENABLED_KEY, enabled);
+  if (!SyncedKeychain.isAvailable()) return;
+  if (enabled) {
+    const encrypted = await SecureStore.getItemAsync(ENCRYPTED_KEYPAIR_KEY);
+    const publicKey = await SecureStore.getItemAsync(WALLET_PUBLIC_KEY);
+    if (encrypted && publicKey) {
+      await mirrorToSyncedKeychain(encrypted, publicKey);
+    }
+  } else {
+    await SyncedKeychain.deleteItem(ENCRYPTED_KEYPAIR_KEY);
+    await SyncedKeychain.deleteItem(WALLET_PUBLIC_KEY);
+  }
+}
+
+/**
+ * Write an already-encrypted keypair blob into local storage. Shared by the
+ * restore paths (iCloud Keychain, iCloud Drive backup); the caller lands on
+ * the normal locked state and the user unlocks with the original PIN.
+ */
+export async function adoptEncryptedKeypair(
+  encrypted: string,
+  publicKey: string,
+): Promise<void> {
+  await SecureStore.setItemAsync(
+    ENCRYPTED_KEYPAIR_KEY,
+    encrypted,
+    KEYCHAIN_OPTIONS,
+  );
+  await SecureStore.setItemAsync(WALLET_PUBLIC_KEY, publicKey, KEYCHAIN_OPTIONS);
+  await resetAttempts();
+}
+
+/**
+ * On a fresh install, pull the wallet from the iCloud Keychain if the user
+ * synced one from another device. Returns true when a wallet was adopted.
+ */
+export async function restoreFromSyncedKeychain(): Promise<boolean> {
+  if (!SyncedKeychain.isAvailable()) return false;
+  try {
+    const encrypted = await SyncedKeychain.getItem(ENCRYPTED_KEYPAIR_KEY);
+    const publicKey = await SyncedKeychain.getItem(WALLET_PUBLIC_KEY);
+    if (!encrypted || !publicKey) return false;
+    await adoptEncryptedKeypair(encrypted, publicKey);
+    // A synced wallet exists, so keep mirroring PIN changes on this device.
+    mmkv.setBoolean(ICLOUD_SYNC_ENABLED_KEY, true);
+    return true;
+  } catch (error) {
+    console.warn("[wallet] iCloud Keychain restore failed", error);
+    return false;
+  }
+}
+
+/**
+ * The stored (already encrypted) wallet payload, for explicit backups.
+ * Returns null when no wallet exists.
+ */
+export async function getStoredBackupPayload(): Promise<{
+  encrypted: string;
+  publicKey: string;
+} | null> {
+  const encrypted = await SecureStore.getItemAsync(ENCRYPTED_KEYPAIR_KEY);
+  const publicKey = await SecureStore.getItemAsync(WALLET_PUBLIC_KEY);
+  if (!encrypted || !publicKey) return null;
+  return { encrypted, publicKey };
 }
 
 export function generateKeypairInMemory(): Keypair {
@@ -130,6 +239,14 @@ export async function getStoredPublicKey(): Promise<string | null> {
 export async function clearStoredKeypair(): Promise<void> {
   await SecureStore.deleteItemAsync(ENCRYPTED_KEYPAIR_KEY);
   await SecureStore.deleteItemAsync(WALLET_PUBLIC_KEY);
+  // Always clear the synced copies too — a reset must not leave key material
+  // in iCloud regardless of the toggle state at the time.
+  try {
+    await SyncedKeychain.deleteItem(ENCRYPTED_KEYPAIR_KEY);
+    await SyncedKeychain.deleteItem(WALLET_PUBLIC_KEY);
+  } catch (error) {
+    console.warn("[wallet] iCloud Keychain cleanup failed", error);
+  }
   await resetAttempts();
 }
 

--- a/apps/mobile/src/lib/wallet/wallet-provider.tsx
+++ b/apps/mobile/src/lib/wallet/wallet-provider.tsx
@@ -30,6 +30,7 @@ import {
   enableBiometrics,
   isBiometricEnabled,
 } from "./biometrics";
+import { deleteCloudBackup } from "./icloud-backup";
 import {
   clearStoredKeypair,
   generateKeypairInMemory,
@@ -100,6 +101,8 @@ interface WalletContextValue {
   // Management
   changePin: (newPin: string) => Promise<void>;
   resetWallet: () => Promise<void>;
+  /** Re-read storage after an out-of-band restore (e.g. iCloud backup). */
+  refreshFromStorage: () => Promise<void>;
   getSecretKeyHex: () => string | null;
   startOnboardingReplay: () => void;
   finishOnboardingReplay: () => void;
@@ -286,6 +289,16 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     track(WALLET_SETUP_EVENTS.walletCreated, { source: "vault" });
   }, []);
 
+  // After a restore path wrote the encrypted keypair directly to storage,
+  // transition noWallet -> locked so the normal PIN flow takes over.
+  const refreshFromStorage = useCallback(async () => {
+    const exists = await hasStoredKeypair();
+    if (!exists) return;
+    setPublicKey(await getStoredPublicKey());
+    setBiometricEnabledState(await isBiometricEnabled());
+    setState("locked");
+  }, []);
+
   const unlock = useCallback(async (pin: string) => {
     const kp = await loadKeypair(pin);
     if (!kp) throw new Error("Incorrect PIN");
@@ -365,6 +378,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     await clearMwaAccount();
     await clearVaultAccount();
     await clearStoredKeypair();
+    // Reset means gone everywhere we put it — a later fresh install must not
+    // offer to restore a wallet the user deliberately deleted.
+    await deleteCloudBackup();
     await disableBiometrics();
     setSigner(null);
     setPublicKey(null);
@@ -406,6 +422,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       setBiometricEnabled,
       changePin: changePinAction,
       resetWallet,
+      refreshFromStorage,
       getSecretKeyHex,
       startOnboardingReplay,
       finishOnboardingReplay,
@@ -427,6 +444,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       setBiometricEnabled,
       changePinAction,
       resetWallet,
+      refreshFromStorage,
       getSecretKeyHex,
       startOnboardingReplay,
       finishOnboardingReplay,

--- a/apps/mobile/src/lib/wallet/wallet-provider.tsx
+++ b/apps/mobile/src/lib/wallet/wallet-provider.tsx
@@ -37,6 +37,7 @@ import {
   hasStoredKeypair,
   importKeypair,
   loadKeypair,
+  restoreFromSyncedKeychain as restoreFromSyncedKeypair,
   storeKeypair,
   changePin as changeKeypairPin,
 } from "./keypair-storage";
@@ -157,6 +158,11 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setPublicKey(pk);
         const bioEnabled = await isBiometricEnabled();
         setBiometricEnabledState(bioEnabled);
+        setState("locked");
+      } else if (await restoreFromSyncedKeypair()) {
+        // Fresh install, but iCloud Keychain carried a wallet from another
+        // device — land on the lock screen and let the PIN unlock it.
+        setPublicKey(await getStoredPublicKey());
         setState("locked");
       } else {
         setState("noWallet");

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -39,6 +39,9 @@
       ],
       "expo-seed-vault": [
         "./modules/expo-seed-vault/src/index.ts"
+      ],
+      "expo-synced-keychain": [
+        "./modules/expo-synced-keychain/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
Implements both iCloud wallet-recovery routes from the audit follow-up, one commit per issue:

**ASK-2162 — iCloud Keychain sync.** Opt-in Settings toggle mirrors the PIN-encrypted keypair blob + public key into `kSecAttrSynchronizable` keychain items via a new local expo module (`modules/expo-synced-keychain` — expo-secure-store exposes no sync option). A fresh install adopts the synced items and lands on the normal PIN lock screen. Reset always deletes the cloud copies.

**ASK-2163 — explicit iCloud Drive backup.** "Back Up Wallet to iCloud" in Settings writes a versioned envelope into the hidden AppData scope of the app's iCloud container (`react-native-cloud-storage@3.0.1` — 3.1.0 is blocked by the bunfig 7-day supply-chain gate); onboarding offers "Restore from iCloud" as the primary action when a backup exists. Restore requires the original wallet PIN. Wallet reset deletes the backup.

Both routes ship the existing PIN-encrypted blob unchanged — explicit accepted-risk decision recorded on the Linear issues ("we protect on our level, icloud is user's responsibility").

Native lookups are lazy everywhere, so OTA bundles on older binaries and Jest degrade to "unavailable" instead of crashing. Also fixes a latent test-infra bug: `src/lib/storage.ts` now lazy-requires react-native-mmkv so its documented Jest fallback actually works.

Verified: 152/152 tests (10 new: keychain-mirror contract + envelope trust-boundary parser), `expo lint` 0 errors, `tsc --noEmit` 0 errors in apps/mobile, and `expo config --type introspect` confirms the iCloud entitlements land (`iCloud.com.askloyal.app`, CloudDocuments, Production) alongside the existing aps/App Group entitlements.

**Not verifiable off-device:** the Swift module compiles on the next `eas build`; EAS should auto-register the iCloud container capability on the App ID the way it did App Groups; backup/restore + keychain sync need a real signed-in device. Android is untouched (all paths platform-gated; autolinking config unchanged).

Closes ASK-2162, ASK-2163.
