### PR TITLE
fix(earn): harden Autoswap rollout verification

### DIFF
--- a/apps/web/src/components/auth/cap-widget.tsx
+++ b/apps/web/src/components/auth/cap-widget.tsx
@@ -61,6 +61,20 @@ type CapWidgetContentProps = CapWidgetProps & {
 };
 
 export function CapWidgetContent({ captcha, onVerify }: CapWidgetContentProps) {
+  if (captcha.mode === "bypass") {
+    return (
+      <div className="flex justify-center py-3">
+        <button
+          className="rounded-lg border border-amber-300 border-dashed bg-amber-50 px-4 py-2 font-medium text-amber-900 text-sm transition hover:bg-amber-100"
+          onClick={() => onVerify(captcha.verificationToken)}
+          type="button"
+        >
+          Continue with local verification bypass
+        </button>
+      </div>
+    );
+  }
+
   if (captcha.mode === "misconfigured") {
     return (
       <div className="py-3 text-center text-amber-700 text-sm">

--- a/apps/web/src/components/auth/wallet-auto-reauth.tsx
+++ b/apps/web/src/components/auth/wallet-auto-reauth.tsx
@@ -34,12 +34,10 @@ export function WalletAutoReauth() {
     useWallet();
   const { captcha } = usePublicEnv();
 
-  // Silent re-auth has no captcha UI, so resolve a captcha token for the
-  // gated challenge endpoint without one. Misconfigured envs resolve
-  // immediately; in widget mode there is no token to obtain silently, so we
-  // defer to the interactive sign-in (which renders the widget).
+  // Silent re-auth has no captcha UI. Local development uses the explicit
+  // bypass token; deployed environments defer to interactive sign-in.
   const silentCaptchaToken =
-    captcha.mode === "misconfigured" ? "captcha-skipped" : null;
+    captcha.mode === "bypass" ? captcha.verificationToken : null;
 
   const attemptedAddressRef = useRef<string | null>(null);
   const failedRef = useRef(false);

--- a/apps/web/src/components/auth/wallet-sign-in.tsx
+++ b/apps/web/src/components/auth/wallet-sign-in.tsx
@@ -3,8 +3,6 @@
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useEffect, useState } from "react";
 
-import { usePublicEnv } from "@/contexts/public-env-context";
-
 import { CapWidget } from "./cap-widget";
 import { WalletTab } from "./wallet-tab";
 
@@ -14,8 +12,6 @@ import { WalletTab } from "./wallet-tab";
  * coordination lives in one place.
  */
 export function WalletSignIn() {
-  const publicEnv = usePublicEnv();
-  const captchaMode = publicEnv.captcha.mode;
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   // No installed wallet extension and no connected wallet means sign-in
   // cannot proceed, so asking for captcha verification is pointless noise
@@ -25,15 +21,6 @@ export function WalletSignIn() {
   const hasWalletOption =
     connected ||
     wallets.some((candidate) => candidate.readyState === "Installed");
-
-  // Auto-resolve only for misconfigured environments (no CAP_SECRET); in
-  // widget mode every env — localhost and previews included — runs the real
-  // captcha, since Cap is same-origin with no domain allowlist.
-  useEffect(() => {
-    if (captchaMode === "misconfigured" && captchaToken === null) {
-      setCaptchaToken("captcha-skipped");
-    }
-  }, [captchaToken, captchaMode]);
 
   // Collapse the verification block a beat AFTER solving so the widget's
   // checkmark lands before the accordion folds; a consumed token (sign-in

--- a/apps/web/src/components/wallet-sidebar/index.tsx
+++ b/apps/web/src/components/wallet-sidebar/index.tsx
@@ -94,16 +94,6 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
 
   // Captcha gate for sign-in tab
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const captchaMode = publicEnv.captcha.mode;
-
-  // Auto-resolve only for misconfigured environments (no CAP_SECRET); in
-  // widget mode every env — localhost and previews included — runs the real
-  // captcha, since Cap is same-origin with no domain allowlist.
-  useEffect(() => {
-    if (captchaMode === "misconfigured" && captchaToken === null) {
-      setCaptchaToken("captcha-skipped");
-    }
-  }, [captchaToken, captchaMode]);
 
   // Reset captcha when sidebar closes
   useEffect(() => {

--- a/apps/web/src/features/identity/server/cap-captcha.test.ts
+++ b/apps/web/src/features/identity/server/cap-captcha.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { verifyCaptchaToken } = await import("./cap-captcha");
+
+describe("Cap captcha verification mode", () => {
+  test("allows local authentication without a captcha token", async () => {
+    await expect(
+      verifyCaptchaToken(
+        { token: undefined },
+        {
+          env: {
+            CAP_SECRET: "configured",
+            NEXT_PUBLIC_APP_ENVIRONMENT: "local",
+          },
+        }
+      )
+    ).resolves.toEqual({ ok: true });
+  });
+
+  test("fails closed outside local when Cap is not configured", async () => {
+    await expect(
+      verifyCaptchaToken(
+        { token: undefined },
+        { env: { NEXT_PUBLIC_APP_ENVIRONMENT: "prod" } }
+      )
+    ).resolves.toEqual({
+      ok: false,
+      reason: "captcha_verify_unavailable",
+    });
+  });
+
+  test("requires a token outside local when Cap is configured", async () => {
+    await expect(
+      verifyCaptchaToken(
+        { token: undefined },
+        {
+          env: {
+            CAP_SECRET: "configured",
+            NEXT_PUBLIC_APP_ENVIRONMENT: "dev",
+          },
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: "missing_captcha_token" });
+  });
+});

--- a/apps/web/src/features/identity/server/cap-captcha.ts
+++ b/apps/web/src/features/identity/server/cap-captcha.ts
@@ -10,14 +10,16 @@ import {
   type ValidateChallengeResult,
 } from "capjs-core";
 
-import { getOptionalEnv, type EnvSource } from "@/lib/core/config/shared";
-
 import {
-  consumeCaptchaKey,
-  putCaptchaKey,
-} from "./captcha-key-store";
+  getOptionalEnv,
+  resolveAppEnvironment,
+  type EnvSource,
+} from "@/lib/core/config/shared";
+
+import { consumeCaptchaKey, putCaptchaKey } from "./captcha-key-store";
 
 const CAP_SECRET_ENV_NAME = "CAP_SECRET";
+const APP_ENVIRONMENT_ENV_NAME = "NEXT_PUBLIC_APP_ENVIRONMENT";
 
 /** Binds challenges to the wallet sign-in flow on both generate and validate. */
 const CHALLENGE_SCOPE = "wallet-signin";
@@ -25,9 +27,7 @@ const CHALLENGE_SCOPE = "wallet-signin";
 const NONCE_KEY_PREFIX = "cap-nonce:";
 const TOKEN_KEY_PREFIX = "cap-token:";
 
-export function getCapSecret(
-  env: EnvSource = process.env
-): string | undefined {
+export function getCapSecret(env: EnvSource = process.env): string | undefined {
   return getOptionalEnv(env, CAP_SECRET_ENV_NAME);
 }
 
@@ -66,9 +66,7 @@ export async function redeemCapChallenge(
   return result;
 }
 
-export type CaptchaVerification =
-  | { ok: true }
-  | { ok: false; reason: string };
+export type CaptchaVerification = { ok: true } | { ok: false; reason: string };
 
 /** The default capjs-core redeem token is `id:secret`; the stored key hashes
  *  the secret half so a DB leak alone can't mint valid tokens. */
@@ -77,21 +75,21 @@ function deriveCapTokenKey(token: string): string | null {
   if (!(id && verificationToken)) {
     return null;
   }
-  return `${id}:${createHash("sha256").update(verificationToken).digest("hex")}`;
+  return `${id}:${createHash("sha256")
+    .update(verificationToken)
+    .digest("hex")}`;
 }
 
 /**
  * Server-side enforcement for the Cap captcha. Mirrors the client mode
  * resolution in `lib/core/config/public.ts`:
  *
+ * - local app environment → bypass: local API and UI work can authenticate
+ *   without solving a captcha, matching the previous Turnstile behavior.
  * - `CAP_SECRET` set → enforce: the redeem token is consumed from the
  *   single-use store. Missing, forged, expired, replayed tokens and an
- *   unreachable store all fail closed. Cap runs same-origin with no domain
- *   allowlist, so this holds for localhost and Vercel previews too — there
- *   is no local bypass.
- * - no secret → misconfigured: verification is skipped (parity with the
- *   client, which auto-skips when Cap is not configured), logged loudly so
- *   it is noticed.
+ *   unreachable store all fail closed.
+ * - no secret outside local → misconfigured and fail closed.
  *
  * The mode is resolved from server env only — a client-supplied token can
  * never downgrade it.
@@ -101,10 +99,16 @@ export async function verifyCaptchaToken(
   dependencies: { env?: EnvSource } = {}
 ): Promise<CaptchaVerification> {
   const env = dependencies.env ?? process.env;
+  const appEnvironment = resolveAppEnvironment(
+    getOptionalEnv(env, APP_ENVIRONMENT_ENV_NAME)
+  );
+  if (appEnvironment === "local") {
+    return { ok: true };
+  }
+
   const secret = getCapSecret(env);
   if (!secret) {
-    console.warn("[cap] verification skipped — CAP_SECRET is not set");
-    return { ok: true };
+    return { ok: false, reason: "captcha_verify_unavailable" };
   }
 
   if (!args.token) {

--- a/apps/web/src/lib/core/config/public.test.ts
+++ b/apps/web/src/lib/core/config/public.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { createPublicEnv } from "./public";
+
+describe("captcha public config", () => {
+  test("uses the local bypass even when Cap is configured", () => {
+    expect(
+      createPublicEnv({
+        CAP_SECRET: "configured",
+        NEXT_PUBLIC_APP_ENVIRONMENT: "local",
+      }).captcha
+    ).toEqual({
+      mode: "bypass",
+      verificationToken: "local-bypass",
+    });
+  });
+
+  test("uses the widget outside local when Cap is configured", () => {
+    expect(
+      createPublicEnv({
+        CAP_SECRET: "configured",
+        NEXT_PUBLIC_APP_ENVIRONMENT: "dev",
+      }).captcha
+    ).toEqual({ mode: "widget" });
+  });
+
+  test("reports a missing deployed secret as misconfigured", () => {
+    expect(
+      createPublicEnv({ NEXT_PUBLIC_APP_ENVIRONMENT: "prod" }).captcha
+    ).toEqual({
+      mode: "misconfigured",
+      reason: "The Cap captcha is enabled for prod, but CAP_SECRET is not set.",
+    });
+  });
+});

--- a/apps/web/src/lib/core/config/public.ts
+++ b/apps/web/src/lib/core/config/public.ts
@@ -14,6 +14,7 @@ export type { AppEnvironment } from "./shared";
 const APP_ENVIRONMENT_ENV_NAME = "NEXT_PUBLIC_APP_ENVIRONMENT";
 const APP_URL_ENV_NAME = "NEXT_PUBLIC_APP_URL";
 const CAP_SECRET_ENV_NAME = "CAP_SECRET";
+const LOCAL_CAPTCHA_BYPASS_TOKEN = "local-bypass";
 const FLAGS_MANIFEST_URL_ENV_NAME = "NEXT_PUBLIC_FLAGS_MANIFEST_URL";
 const JUPITER_API_KEY_ENV_NAME = "NEXT_PUBLIC_JUPITER_API_KEY";
 const SKILLS_ENABLED_ENV_NAME = "NEXT_PUBLIC_SKILLS_ENABLED";
@@ -22,6 +23,7 @@ const USERCENTRICS_SETTINGS_ID_ENV_NAME =
   "NEXT_PUBLIC_USERCENTRICS_SETTINGS_ID";
 
 export type CaptchaConfig =
+  | { mode: "bypass"; verificationToken: string }
   | { mode: "widget" }
   | { mode: "misconfigured"; reason: string };
 
@@ -48,15 +50,21 @@ export type PublicEnv = {
 
 const DEFAULT_MIXPANEL_PROXY_PATH = "/ingest";
 
-// Resolved server-side (root layout) and passed down via PublicEnvProvider,
-// so the mode can key off the server-only CAP_SECRET — only the mode string
-// ever reaches the client. Cap runs same-origin with no domain allowlist, so
-// unlike Turnstile the real widget works on localhost and Vercel previews —
-// no local bypass mode needed.
+// Resolved server-side (root layout) and passed down via PublicEnvProvider.
+// Local development follows the old Turnstile contract: authentication stays
+// wired, but the captcha itself is optional. Deployed environments still fail
+// closed when CAP_SECRET is missing.
 function resolveCaptchaConfig(
   env: EnvSource,
   appEnvironment: AppEnvironment
 ): CaptchaConfig {
+  if (appEnvironment === "local") {
+    return {
+      mode: "bypass",
+      verificationToken: LOCAL_CAPTCHA_BYPASS_TOKEN,
+    };
+  }
+
   if (getOptionalEnv(env, CAP_SECRET_ENV_NAME)) {
     return { mode: "widget" };
   }

--- a/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.ts
@@ -235,7 +235,13 @@ export async function setEarnCrossMintEnabled(
     return false;
   }
   if (current.enabled === scope.enabled) {
-    return true;
+    if (
+      current.generation === scope.expectedGeneration ||
+      current.generation === scope.expectedGeneration + BigInt(1)
+    ) {
+      return true;
+    }
+    throw new Error("Autoswap state changed. Refresh and try again.");
   }
   if (current.generation !== scope.expectedGeneration) {
     throw new Error("Autoswap state changed. Refresh and try again.");
@@ -257,7 +263,10 @@ export async function setEarnCrossMintEnabled(
     .returning({ generation: crossMintVaultOptIns.generation });
   if (rows.length !== 1) {
     const latest = await loadEarnCrossMintOptIn(scope);
-    if (latest?.enabled === scope.enabled) {
+    if (
+      latest?.enabled === scope.enabled &&
+      latest.generation === scope.expectedGeneration + BigInt(1)
+    ) {
       return true;
     }
     throw new Error("Autoswap state changed. Refresh and try again.");

--- a/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.test.ts
@@ -340,18 +340,19 @@ describe("yield deposit repository idempotency", () => {
           }),
           query: {
             managedVaults: {
-              findFirst: mock(async () => ({
-                active: true,
-                activePolicyId: BigInt(7),
-                id: BigInt(44),
-                settings: "settings",
-                setupPolicyId: BigInt(8),
-                vaultIndex: 1,
-                vaultPubkey: "vault",
-              })),
+              findFirst: mock(async () => null),
             },
             userYieldPositionWithdrawals: {
-              findFirst: mock(async () => createPersistedWithdrawal()),
+              findFirst: mock(async () =>
+                createPersistedWithdrawal({
+                  sourceId: "reserve:reserve",
+                  sourceMetadata: {
+                    amountRaw: "1000",
+                    requestedWithdrawAmountRaw: "900",
+                  },
+                  sourceType: "reserve",
+                })
+              ),
             },
             userYieldPositions: {
               findFirst: mock(async () => position),
@@ -398,7 +399,12 @@ describe("yield deposit repository idempotency", () => {
     };
 
     const result = await recordConfirmedYieldWithdrawal(
-      createWithdrawalInput(),
+      createWithdrawalInput({
+        requestedWithdrawAmountRaw: BigInt(900),
+        sourceAmountRaw: BigInt(1000),
+        sourceId: "reserve:reserve",
+        sourceType: "reserve",
+      }),
       dependencies as never
     );
 

--- a/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -1760,8 +1760,8 @@ async function findIdempotentWithdrawalPosition(
     }
     if (
       normalizeSourceMetadataForCompare(withdrawal.sourceMetadata ?? {}) !==
-      normalizeSourceMetadataForCompare(
-        buildStoredWithdrawalSourceMetadata({
+      normalizeSourceMetadataForCompare({
+        ...buildStoredWithdrawalSourceMetadata({
           sourceAmountRaw:
             source.sourceAmountRaw ??
             BigInt(
@@ -1772,8 +1772,15 @@ async function findIdempotentWithdrawalPosition(
           sourceMetadata: source.sourceMetadata,
           sourceMint: source.sourceMint,
           sourceTokenAccount: source.sourceTokenAccount,
-        })
-      )
+        }),
+        ...(input.requestedWithdrawAmountRaw !== undefined &&
+        input.requestedWithdrawAmountRaw !== null
+          ? {
+              requestedWithdrawAmountRaw:
+                input.requestedWithdrawAmountRaw.toString(),
+            }
+          : {}),
+      })
     ) {
       throw new Error("Duplicate withdrawal source metadata mismatch.");
     }

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   generated,
   compilePreparedOperation,
+  pda,
   Policy,
   Settings,
 } from "@loyal-labs/loyal-smart-accounts-core";
@@ -1523,6 +1524,123 @@ describe("prepareEarnUsdcDeposit", () => {
         walletAddress: walletAddress.toBase58(),
       });
     }
+  });
+
+  test("reuses a finalized cross-mint policy with materialized spending usage", async () => {
+    const initialClient = createSmartAccountVaultsClient({
+      connection: {
+        getAccountInfo: mock(async (address: PublicKey) =>
+          address.equals(settingsPda)
+            ? createSerializedSettingsAccount(new BN(6))
+            : null
+        ),
+        getProgramAccounts: mock(async () => []),
+      } as never,
+      programId,
+    });
+    const initial = await initialClient.prepareEarnCrossMintSwapPolicies({
+      settingsPda,
+      walletAddress,
+      signer: backendSigner,
+      feePayer,
+      maxSlippageBps: 50,
+      dailySourceMintSpendingCap: BigInt(300_000_000),
+    });
+    const classic = initial.policies[0];
+    const create = decodeGeneratedPolicyCreate(
+      classic.prepared?.instructions[0]
+    );
+    if (create.policyCreationPayload.__kind !== "ProgramInteraction") {
+      throw new Error("Expected ProgramInteraction policy payload.");
+    }
+    const [payload] = create.policyCreationPayload.fields;
+    const runtimeTimestamp = new BN(1_786_936_896);
+    const runtimeState = {
+      __kind: "ProgramInteraction" as const,
+      fields: [
+        {
+          ...payload,
+          spendingLimits: [...payload.spendingLimits]
+            .reverse()
+            .map((limit) => ({
+              ...limit,
+              quantityConstraints: {
+                ...limit.quantityConstraints,
+                enforceExactQuantity: false,
+                maxPerUse: new BN(0),
+              },
+              timeConstraints: {
+                ...limit.timeConstraints,
+                accumulateUnused: false,
+                start: runtimeTimestamp,
+              },
+              usage: {
+                lastReset: runtimeTimestamp,
+                remainingInPeriod: limit.quantityConstraints.maxPerPeriod,
+              },
+            })),
+        },
+      ],
+    };
+    const [, bump] = pda.getPolicyPda({
+      policySeed: Number(classic.policy.seed),
+      programId,
+      settingsPda,
+    });
+    const [data] = Policy.fromArgs({
+      bump,
+      expiration: null,
+      policyState: runtimeState as never,
+      rentCollector: feePayer,
+      seed: new BN(classic.policy.seed.toString()),
+      settings: settingsPda,
+      signers: create.signers,
+      staleTransactionIndex: new BN(0),
+      start: runtimeTimestamp,
+      threshold: create.threshold,
+      timeLock: create.timeLock,
+      transactionIndex: new BN(0),
+    }).serialize();
+    const finalizedClassic = {
+      data,
+      executable: false,
+      lamports: 1,
+      owner: programId,
+      rentEpoch: 0,
+    };
+    const resumedClient = createSmartAccountVaultsClient({
+      connection: {
+        getAccountInfo: mock(async (address: PublicKey) =>
+          address.equals(settingsPda)
+            ? createSerializedSettingsAccount(new BN(7))
+            : null
+        ),
+        getProgramAccounts: mock(async () => [
+          { account: finalizedClassic, pubkey: classic.policy.account },
+        ]),
+      } as never,
+      programId,
+    });
+
+    const resumed = await resumedClient.prepareEarnCrossMintSwapPolicies({
+      settingsPda,
+      walletAddress,
+      signer: backendSigner,
+      feePayer,
+      maxSlippageBps: 50,
+      dailySourceMintSpendingCap: BigInt(300_000_000),
+    });
+
+    expect(
+      resumed.policies.map((entry) => ({
+        existing: entry.existing,
+        seed: entry.policy.seed,
+        shard: entry.sourceShard,
+      }))
+    ).toEqual([
+      { existing: true, seed: BigInt(7), shard: "classic" },
+      { existing: false, seed: BigInt(8), shard: "token_2022" },
+    ]);
   });
 
   test("rejects zero amount deposits", async () => {

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -682,6 +682,53 @@ function generatedValuesEqual(left: unknown, right: unknown): boolean {
   );
 }
 
+function normalizePolicyCreationStateForComparison(value: unknown): unknown {
+  const normalized = normalizeComparableGeneratedValue(value);
+  if (!normalized || typeof normalized !== "object") {
+    return normalized;
+  }
+
+  const state = normalized as {
+    __kind?: string;
+    fields?: Array<{
+      spendingLimits?: Array<{
+        mint?: unknown;
+        quantityConstraints?: Record<string, unknown>;
+        timeConstraints?: Record<string, unknown>;
+        usage?: unknown;
+      }>;
+    }>;
+  };
+  if (state.__kind !== "ProgramInteraction") {
+    return normalized;
+  }
+
+  for (const field of state.fields ?? []) {
+    for (const spendingLimit of field.spendingLimits ?? []) {
+      if (spendingLimit.timeConstraints) {
+        delete spendingLimit.timeConstraints.start;
+        spendingLimit.timeConstraints.accumulateUnused ??= false;
+      }
+      if (spendingLimit.quantityConstraints) {
+        spendingLimit.quantityConstraints.maxPerUse ??= "0";
+        spendingLimit.quantityConstraints.enforceExactQuantity ??= false;
+      }
+      delete spendingLimit.usage;
+    }
+    field.spendingLimits?.sort((left, right) =>
+      JSON.stringify(left.mint).localeCompare(JSON.stringify(right.mint))
+    );
+  }
+  return normalizeComparableGeneratedValue(normalized);
+}
+
+function policyCreationStatesEqual(left: unknown, right: unknown): boolean {
+  return (
+    JSON.stringify(normalizePolicyCreationStateForComparison(left)) ===
+    JSON.stringify(normalizePolicyCreationStateForComparison(right))
+  );
+}
+
 function policyRentSpace(args: {
   feePayer: PublicKey;
   policyPayload: generated.PolicyCreationPayload;
@@ -6109,7 +6156,7 @@ export function createSmartAccountVaultsClient(
       throw new Error(`${args.label} signer permissions are not canonical.`);
     }
     if (
-      !generatedValuesEqual(
+      !policyCreationStatesEqual(
         policy.policyState,
         policyCreationPayloadToState(args.expectedState)
       )
@@ -6161,10 +6208,10 @@ export function createSmartAccountVaultsClient(
       };
       console.error(`[smart-account-vaults] ${args.label} canonical mismatch`);
       collectDiffs(
-        normalizeComparableGeneratedValue(
+        normalizePolicyCreationStateForComparison(
           policyCreationPayloadToState(args.expectedState)
         ),
-        normalizeComparableGeneratedValue(policy.policyState),
+        normalizePolicyCreationStateForComparison(policy.policyState),
         "policyState"
       );
       const describeRawEntry = (value: unknown) => {
@@ -8222,7 +8269,7 @@ export function createSmartAccountVaultsClient(
                 createPolicySigner(args.signer).permissions
               )
           ) &&
-          generatedValuesEqual(policy.policyState, expectedState)
+          policyCreationStatesEqual(policy.policyState, expectedState)
         );
       });
       if (matches.length > 1) {

--- a/scripts/verify-earn-autoswap-flow.ts
+++ b/scripts/verify-earn-autoswap-flow.ts
@@ -194,6 +194,7 @@ const CANARY_GATE_ACTOR = "autoswap-user-rollout-verifier";
 const CANARY_GATE_OWNER = `${CANARY_GATE_ACTOR}:${randomUUID()}`;
 const CANARY_POLL_INTERVAL_MS = 1000;
 const CANARY_TRANSITION_POLL_INTERVAL_MS = 250;
+const POLICY_DISCOVERY_TIMEOUT_MS = 60_000;
 const CANARY_PRODUCTION_DATABASE_HOST_SHA256 =
   "bf4fd3f4262f3de5fa1885a99ab89fb4d2a7e262868af85b44bcd9026ad03092";
 
@@ -493,6 +494,28 @@ async function preparePolicies(
   return prepared;
 }
 
+async function waitForFinalizedPolicyDiscovery(args: {
+  session: Session;
+  sourceShard: "classic" | "token_2022";
+}): Promise<WirePreparedPolicySet> {
+  const deadline = Date.now() + POLICY_DISCOVERY_TIMEOUT_MS;
+  while (true) {
+    const prepared = await preparePolicies(args.session);
+    const policy = prepared.policies.find(
+      (candidate) => candidate.sourceShard === args.sourceShard
+    );
+    if (policy?.existing && !policy.prepared) {
+      return prepared;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Finalized ${args.sourceShard} policy was not discoverable within ${POLICY_DISCOVERY_TIMEOUT_MS}ms.`
+      );
+    }
+    await Bun.sleep(CANARY_POLL_INTERVAL_MS);
+  }
+}
+
 async function simulatePreparedTransaction(args: {
   connection: Connection;
   keypair: Keypair;
@@ -770,6 +793,13 @@ async function verifyReadOnly(args: {
   requireStatus(missingDelete, 404, "off-state delete", "autoswap_not_found");
   return {
     preparedPolicyCount: prepared.policies.length,
+    preparedPolicies: prepared.policies.map((policy) => ({
+      account: policy.policy.account,
+      delegatedSigner: policy.persistence.delegatedSigner,
+      existing: policy.existing,
+      seed: policy.policy.seed,
+      sourceShard: policy.sourceShard,
+    })),
     dependentSimulationLogCounts,
     rejectedMismatchedConfirmation: true,
     simulationLogCounts,
@@ -962,14 +992,19 @@ function requireCanaryDatabaseUrl(): string {
 
 function requireProductionCanaryConfig(): void {
   const baseUrl = new URL(BASE_URL);
-  if (baseUrl.protocol !== "https:" || baseUrl.hostname !== "askloyal.com") {
+  const deployedApi =
+    baseUrl.protocol === "https:" && baseUrl.hostname === "askloyal.com";
+  const localApi =
+    baseUrl.protocol === "http:" &&
+    ["127.0.0.1", "::1", "localhost"].includes(baseUrl.hostname);
+  if (!(deployedApi || localApi)) {
     throw new Error(
-      "Autoswap canaries must use the deployed https://askloyal.com API."
+      "Autoswap canaries must use the deployed API or a loopback-local API."
     );
   }
-  if (EXPECTED_LIVE_POLICY_CREATES !== 2) {
+  if (![1, 2].includes(EXPECTED_LIVE_POLICY_CREATES)) {
     throw new Error(
-      "Autoswap canaries require a clean two-policy installation."
+      "Autoswap canaries require a clean two-policy install or a one-policy interrupted-setup resume."
     );
   }
   requireCanaryDatabaseUrl();
@@ -1905,7 +1940,10 @@ async function verifyLive(args: {
       signature,
     });
 
-    const resumed = await preparePolicies(args.session);
+    const resumed = await waitForFinalizedPolicyDiscovery({
+      session: args.session,
+      sourceShard: firstMissing.sourceShard,
+    });
     const resumedFirst = resumed.policies.find(
       (policy) => policy.sourceShard === firstMissing.sourceShard
     );
@@ -2493,6 +2531,18 @@ async function verifyLocalState(args: {
     ) {
       throw new Error("Blocked deletion did not durably pause Autoswap.");
     }
+    const stalePause = await apiRequest({
+      body: { enabled: false, expectedGeneration: "1" },
+      cookie: args.session.cookie,
+      method: "POST",
+      path: TOGGLE_PATH,
+    });
+    requireStatus(
+      stalePause,
+      409,
+      "ABA-stale Autoswap pause",
+      "autoswap_toggle_failed"
+    );
 
     await database`
       delete from loyal_yield.rebalance_decisions where id = ${movementId}
@@ -2525,6 +2575,7 @@ async function verifyLocalState(args: {
       movementDeletePausedAndBlocked: true,
       pauseGeneration: pause.generation,
       pauseRetryGeneration: pauseRetry.generation,
+      staleGenerationRejectedAfterAba: true,
     };
   } finally {
     if (positionIds.length > 0) {

--- a/scripts/verify-earn-autoswap-flow.ts
+++ b/scripts/verify-earn-autoswap-flow.ts
@@ -44,7 +44,7 @@ function createCanaryDatabase(
 // AUTOSWAP_VERIFY_BASE_URL=http://localhost:3000 bun scripts/verify-earn-autoswap-flow.ts
 //
 // Disposable localhost database state verification (no on-chain writes):
-// AUTOSWAP_VERIFY_MODE=local-state YIELD_OPTIMIZATION_LOCAL_DATABASE_URL=postgresql://localhost/loyal_autoswap_api_verify_<suffix> bun scripts/verify-earn-autoswap-flow.ts
+// AUTOSWAP_VERIFY_MODE=local-state AUTOSWAP_VERIFY_LOCAL_AUTH_ACK=disposable-local-auth YIELD_OPTIMIZATION_LOCAL_DATABASE_URL=postgresql://localhost/loyal_autoswap_api_verify_<suffix> bun scripts/verify-earn-autoswap-flow.ts
 //
 // Explicitly approved mainnet lifecycle:
 // AUTOSWAP_VERIFY_MODE=live AUTOSWAP_VERIFY_BASE_URL=http://localhost:3000 bun scripts/verify-earn-autoswap-flow.ts
@@ -54,6 +54,9 @@ function createCanaryDatabase(
 // Use AUTOSWAP_VERIFY_LIVE_ACTION=canary only for the explicitly acknowledged
 // production run. It installs policies, exercises two bounded movements,
 // proves pause/recovery/delete behavior, and cleans up in one auth session.
+// Use canary-existing to exercise one already-installed mint family and leave
+// the enrollment paused, allowing inventory to be restaged before the other
+// family is verified without reopening the global start gate in between.
 // It requires NEON_DATABASE_URL and:
 // AUTOSWAP_VERIFY_CANARY_ACK=mainnet-production-bounded-autoswap-canaries
 // Set AUTOSWAP_VERIFY_EXPECTED_POLICY_CREATES=1 only to resume a deliberately
@@ -67,6 +70,7 @@ function createCanaryDatabase(
 type VerifyMode = "live" | "local-state" | "read-only";
 type LiveAction =
   | "canary"
+  | "canary-existing"
   | "cleanup"
   | "full"
   | "install"
@@ -189,6 +193,8 @@ const DELETE_CONFIRM_PATH =
 const FAKE_SIGNATURE = "1".repeat(88);
 const SQUADS_MISSING_ACCOUNT_ERROR_CODE = 6024;
 const CANARY_ACKNOWLEDGEMENT = "mainnet-production-bounded-autoswap-canaries";
+const LOCAL_AUTH_ACKNOWLEDGEMENT = "disposable-local-auth";
+const WALLET_SESSION_COOKIE_NAME = "loyal_wallet_session";
 const CANARY_CLUSTER = "mainnet-beta";
 const CANARY_GATE_ACTOR = "autoswap-user-rollout-verifier";
 const CANARY_GATE_OWNER = `${CANARY_GATE_ACTOR}:${randomUUID()}`;
@@ -370,6 +376,71 @@ async function authenticate(keypair: Keypair): Promise<Session> {
     settingsPda,
     smartAccountAddress,
   };
+}
+
+async function authenticateDisposableLocalFixture(
+  keypair: Keypair
+): Promise<Session> {
+  if (
+    process.env.AUTOSWAP_VERIFY_LOCAL_AUTH_ACK?.trim() !==
+    LOCAL_AUTH_ACKNOWLEDGEMENT
+  ) {
+    throw new Error(
+      `Local fixture auth requires AUTOSWAP_VERIFY_LOCAL_AUTH_ACK=${LOCAL_AUTH_ACKNOWLEDGEMENT}.`
+    );
+  }
+
+  const database = postgres(requireDisposableLocalDatabaseUrl(), { max: 1 });
+  try {
+    const rows = await database<{ settings: string }[]>`
+      select distinct settings
+      from loyal_yield.user_yield_positions
+      where wallet_address = ${keypair.publicKey.toBase58()}
+        and status = 'active'
+    `;
+    if (rows.length !== 1) {
+      throw new Error(
+        "Disposable local auth requires exactly one active testing-wallet smart account."
+      );
+    }
+
+    const secret = process.env.AUTH_JWT_SECRET?.trim();
+    if (!secret) {
+      throw new Error("Disposable local auth requires AUTH_JWT_SECRET.");
+    }
+    const [sessionTokenModule, derivationModule, configModule] =
+      await Promise.all([
+        import("../apps/web/src/features/identity/server/session-token.ts"),
+        import("../apps/web/src/features/smart-accounts/derivation.ts"),
+        import("../apps/web/src/lib/core/config/server.ts"),
+      ]);
+    const walletAddress = keypair.publicKey.toBase58();
+    const smartAccountAddress =
+      derivationModule.deriveCanonicalSmartAccountAddress({
+        programId: configModule.getServerEnv().loyalSmartAccounts.programId,
+        settingsPda: rows[0]!.settings,
+      });
+    const token = await sessionTokenModule.issueAuthSessionToken(
+      {
+        authMethod: "wallet",
+        displayAddress: walletAddress,
+        provider: "solana",
+        settingsPda: rows[0]!.settings,
+        smartAccountAddress,
+        subjectAddress: walletAddress,
+        walletAddress,
+      },
+      secret,
+      15 * 60
+    );
+    return {
+      cookie: `${WALLET_SESSION_COOKIE_NAME}=${token}`,
+      settingsPda: rows[0]!.settings,
+      smartAccountAddress,
+    };
+  } finally {
+    await database.end({ timeout: 5 });
+  }
 }
 
 async function getEarnState(session: Session): Promise<EarnState> {
@@ -1858,6 +1929,70 @@ async function verifyProductionCanaries(args: {
   }
 }
 
+async function verifyExistingProductionCanary(args: {
+  connection: Connection;
+  keypair: Keypair;
+  session: Session;
+}): Promise<JsonRecord> {
+  const database = createCanaryDatabase(requireCanaryDatabaseUrl());
+  const gateLease: CanaryGateLease = { generation: null };
+  let baselineVerified = false;
+  try {
+    const initialState = await getEarnState(args.session);
+    const installed = initialState.autoswap;
+    if (installed?.status !== "on") {
+      throw new Error(
+        "Existing Autoswap canary requires an installed on enrollment."
+      );
+    }
+    const vaultId = await assertCanaryProductionBaseline({
+      database,
+      session: args.session,
+      state: installed,
+      vaultPubkey: initialState.vault.pubkey,
+    });
+    baselineVerified = true;
+    const canary = await runProductionCanary({
+      connection: args.connection,
+      controlledPause: true,
+      database,
+      gateLease,
+      keypair: args.keypair,
+      session: args.session,
+      state: installed,
+      vaultId,
+    });
+    await provePausedEnrollmentStartsNothing({
+      database,
+      gateLease,
+      session: args.session,
+      vaultId,
+    });
+    return {
+      action: "canary-existing",
+      canary,
+      finalState: "paused",
+      pausedEnrollmentStartedNewMovements: false,
+    };
+  } catch (error) {
+    await ensureAutoswapEnrollmentFailClosed(args.session);
+    throw error;
+  } finally {
+    let gateError: unknown;
+    if (baselineVerified) {
+      try {
+        await ensureCanaryStartGateClosed(database, gateLease);
+      } catch (error) {
+        gateError = error;
+      }
+    }
+    await database.end({ timeout: 5 });
+    if (gateError) {
+      throw gateError;
+    }
+  }
+}
+
 async function verifyLive(args: {
   action: LiveAction;
   connection: Connection;
@@ -2616,6 +2751,7 @@ async function main(): Promise<void> {
   if (
     MODE === "live" &&
     LIVE_ACTION !== "canary" &&
+    LIVE_ACTION !== "canary-existing" &&
     LIVE_ACTION !== "cleanup" &&
     LIVE_ACTION !== "full" &&
     LIVE_ACTION !== "install" &&
@@ -2623,7 +2759,7 @@ async function main(): Promise<void> {
     LIVE_ACTION !== "resume"
   ) {
     throw new Error(
-      "AUTOSWAP_VERIFY_LIVE_ACTION must be canary, cleanup, full, install, pause, or resume."
+      "AUTOSWAP_VERIFY_LIVE_ACTION must be canary, canary-existing, cleanup, full, install, pause, or resume."
     );
   }
   if (SOLANA_ENV !== "mainnet") {
@@ -2648,13 +2784,19 @@ async function main(): Promise<void> {
       "AUTOSWAP_VERIFY_EXPECTED_POLICY_CREATES must be 1 or 2 in live mode."
     );
   }
-  if (MODE === "live" && LIVE_ACTION === "canary") {
+  if (
+    MODE === "live" &&
+    (LIVE_ACTION === "canary" || LIVE_ACTION === "canary-existing")
+  ) {
     requireProductionCanaryConfig();
   }
 
   const keypair = loadKeypair("SOLANA_TESTING_PK");
   const connection = new Connection(RPC_URL, "confirmed");
-  const session = await authenticate(keypair);
+  const session =
+    MODE === "local-state"
+      ? await authenticateDisposableLocalFixture(keypair)
+      : await authenticate(keypair);
   await verifyRouteBoundaries(session);
   const initialState = await getEarnState(session);
   if (
@@ -2681,6 +2823,12 @@ async function main(): Promise<void> {
             action: LIVE_ACTION,
             connection,
             initialState,
+            keypair,
+            session,
+          })
+        : LIVE_ACTION === "canary-existing"
+        ? await verifyExistingProductionCanary({
+            connection,
             keypair,
             session,
           })

--- a/scripts/verify-earn-autoswap-flow.ts
+++ b/scripts/verify-earn-autoswap-flow.ts
@@ -1363,7 +1363,14 @@ async function waitForNewCanaryMovement(args: {
   database: CanaryDatabase;
   vaultId: string;
 }): Promise<CanaryMovement> {
-  for (let attempt = 0; attempt < 180; attempt += 1) {
+  const maximumAttempts = Number.parseInt(
+    process.env.AUTOSWAP_VERIFY_MOVEMENT_WAIT_ATTEMPTS ?? "180",
+    10
+  );
+  if (!Number.isSafeInteger(maximumAttempts) || maximumAttempts < 1) {
+    throw new Error("AUTOSWAP_VERIFY_MOVEMENT_WAIT_ATTEMPTS must be a positive integer.");
+  }
+  for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
     const [row] = await args.database<{ id: string }[]>`
       select id::text as id
       from loyal_yield.rebalance_decisions

--- a/scripts/verify-earn-mainnet-flow.ts
+++ b/scripts/verify-earn-mainnet-flow.ts
@@ -34,16 +34,16 @@ import {
 import {
   hydratePreparedEarnUsdcDeposit,
   type EarnDepositPrepareResponse,
-} from "../frontend/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts";
+} from "../apps/web/src/lib/yield-optimization/earn-deposit-prepare-contracts.shared.ts";
 import {
   buildEarnDepositConfirmRequestBody,
   buildEarnWithdrawalConfirmRequestBody,
-} from "../frontend/src/lib/yield-optimization/earn-confirm-contracts.shared.ts";
+} from "../apps/web/src/lib/yield-optimization/earn-confirm-contracts.shared.ts";
 import {
   hydratePreparedEarnUsdcWithdraw,
-  type EarnWithdrawPrepareRequestBody,
+  type EarnWithdrawLegacySourceRequest,
   type EarnWithdrawPrepareResponse,
-} from "../frontend/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts";
+} from "../apps/web/src/lib/yield-optimization/earn-withdraw-prepare-contracts.shared.ts";
 import type {
   SmartAccountPreparedEarnUsdcDeposit,
   SmartAccountPreparedEarnUsdcYieldRoutingPolicy,
@@ -208,6 +208,9 @@ const FIRST_DEPOSIT_RAW = parseRawAmount(
 const TOP_UP_DEPOSIT_RAW = parseRawAmount(
   process.env.EARN_TOP_UP_DEPOSIT_RAW ?? "5000"
 );
+const TOP_UP_DEPOSIT_MINT =
+  process.env.EARN_TOP_UP_DEPOSIT_MINT?.trim() || null;
+const TOP_UP_ONLY = process.env.EARN_TOP_UP_ONLY === "1";
 const PARTIAL_WITHDRAW_RAW = parseRawAmount(
   process.env.EARN_PARTIAL_WITHDRAW_RAW ?? "7000"
 );
@@ -582,12 +585,13 @@ async function authenticateFrontendSession(args: {
 
 async function prepareEarnDepositViaFrontend(args: {
   amountRaw: bigint;
+  mint?: PublicKey;
   session: FrontendSession;
 }): Promise<SmartAccountPreparedEarnUsdcDeposit> {
   const response = await frontendPostJson<EarnDepositPrepareResponse>({
     body: {
       amountRaw: args.amountRaw.toString(),
-      mint: EARN_TARGET.liquidityMint.toBase58(),
+      mint: (args.mint ?? EARN_TARGET.liquidityMint).toBase58(),
     },
     cookie: args.session.cookie,
     path: "/api/smart-accounts/yield-optimization/deposits/prepare",
@@ -615,7 +619,7 @@ function buildEarnDepositConfirmFrontendBody(args: {
     setupPolicyConfirmedSlot: args.setupPolicyConfirmedSlot?.toString(),
     setupPolicySignature: args.setupPolicySignature,
     signature: args.signature,
-    smartAccountAddress: args.session.smartAccountAddress,
+    smartAccountAddress: args.prepared.persistence.vaultPubkey,
   });
 }
 
@@ -643,13 +647,14 @@ async function prepareEarnWithdrawViaFrontend(args: {
   amountRaw: bigint;
   mode: "partial" | "full";
   session: FrontendSession;
-  source?: EarnWithdrawPrepareRequestBody["source"];
+  source?: EarnWithdrawLegacySourceRequest;
 }): Promise<SmartAccountPreparedEarnUsdcWithdraw> {
   const response = await frontendPostJson<EarnWithdrawPrepareResponse>({
     body: {
       amountRaw: args.amountRaw.toString(),
-      mode: args.mode,
-      ...(args.source ? { source: args.source } : {}),
+      ...(args.source
+        ? { sourceId: `${args.source.type}:${args.source.id}` }
+        : { mode: args.mode, source: null }),
     },
     cookie: args.session.cookie,
     path: "/api/smart-accounts/yield-optimization/withdrawals/prepare",
@@ -706,7 +711,7 @@ function buildEarnWithdrawConfirmFrontendBody(args: {
     confirmedSlot: args.confirmedSlot.toString(),
     preparedWithdraw: args.prepared,
     signature: args.signature,
-    smartAccountAddress: args.session.smartAccountAddress,
+    smartAccountAddress: args.prepared.persistence.vaultPubkey,
   });
 }
 
@@ -1318,7 +1323,7 @@ function requireSingleEarnHolding(args: {
 
 function withdrawSourceFromHolding(
   holding: EarnSourceHoldingEvidence
-): NonNullable<EarnWithdrawPrepareRequestBody["source"]> {
+): NonNullable<EarnWithdrawLegacySourceRequest> {
   if (holding.kind === "idle") {
     const tokenAccount = getStringField(holding.provenance, "tokenAccount");
     if (!tokenAccount) {
@@ -1351,7 +1356,7 @@ function withdrawSourceFromCurrentRows(args: {
   idleRows: unknown[];
   label: string;
   reserveRows: unknown[];
-}): NonNullable<EarnWithdrawPrepareRequestBody["source"]> {
+}): NonNullable<EarnWithdrawLegacySourceRequest> {
   const activeReserveRows = args.reserveRows.filter(
     (row) => (getRawAmountField(row, "amountRaw") ?? 0n) > 0n
   );
@@ -1434,7 +1439,7 @@ function withdrawSourceFromCurrentRows(args: {
 }
 
 function toClientWithdrawSource(
-  source: NonNullable<EarnWithdrawPrepareRequestBody["source"]>
+  source: NonNullable<EarnWithdrawLegacySourceRequest>
 ): SmartAccountEarnUsdcWithdrawInput["source"] {
   if (source.type === "idle") {
     return {
@@ -1459,7 +1464,7 @@ function toClientWithdrawSource(
 function assertPreparedSourceMetadata(args: {
   label: string;
   prepared: SmartAccountPreparedEarnUsdcWithdraw;
-  source: NonNullable<EarnWithdrawPrepareRequestBody["source"]>;
+  source: NonNullable<EarnWithdrawLegacySourceRequest>;
 }) {
   const persistence = asRecord(args.prepared.persistence);
   if (!persistence) {
@@ -1692,7 +1697,7 @@ function sameMintReserveSwapSetupObligationCommand(args: {
 
 async function loadTopSafeUsdcCandidateEvidence() {
   const { getCurrentBestApyReserveByStablecoin } = await import(
-    "../frontend/src/lib/kamino/timescale-reserve-client.server.ts"
+    "../apps/web/src/lib/kamino/timescale-reserve-client.server.ts"
   );
   const safeMarkets = new Set(EARN_POLICY_UNIVERSE.kaminoMarkets);
   const usdcMint = EARN_TARGET.liquidityMint.toBase58();
@@ -2268,10 +2273,10 @@ async function loadState(args: {
   walletUsdcAta: PublicKey;
   yieldClient: Awaited<
     ReturnType<
-      typeof import("../frontend/src/lib/yield-optimization/yield-neon-client.server.ts")["getYieldOptimizationClient"]
+      typeof import("../apps/web/src/lib/yield-optimization/yield-neon-client.server.ts")["getYieldOptimizationClient"]
     >
   >;
-  schema: typeof import("../frontend/src/lib/yield-optimization/yield-neon-client.server.ts");
+  schema: typeof import("../apps/web/src/lib/yield-optimization/yield-neon-client.server.ts");
 }) {
   const {
     managedVaults,
@@ -2736,7 +2741,7 @@ async function runPolicyResumeReadiness(): Promise<void> {
     };
 
     const schema = await import(
-      "../frontend/src/lib/yield-optimization/yield-neon-client.server.ts"
+      "../apps/web/src/lib/yield-optimization/yield-neon-client.server.ts"
     );
     const yieldClient = schema.getYieldOptimizationClient();
     const vaultPubkey = pda.getSmartAccountPda({
@@ -2947,7 +2952,7 @@ async function runPolicyOnlyReconcileDryRun(): Promise<void> {
       );
     }
     const { reconcileInvisibleEarnDeposits } = await import(
-      "../frontend/src/lib/yield-optimization/earn-deposit-reconcile.server.ts"
+      "../apps/web/src/lib/yield-optimization/earn-deposit-reconcile.server.ts"
     );
     const summary = await reconcileInvisibleEarnDeposits({
       dryRun: true,
@@ -3252,10 +3257,10 @@ async function main() {
     programId: PROGRAM_ID,
   });
   const repository = await import(
-    "../frontend/src/lib/yield-optimization/yield-deposit-repository.server.ts"
+    "../apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts"
   );
   const schema = await import(
-    "../frontend/src/lib/yield-optimization/yield-neon-client.server.ts"
+    "../apps/web/src/lib/yield-optimization/yield-neon-client.server.ts"
   );
   const yieldClient = schema.getYieldOptimizationClient();
   const vaultPubkey = pda.getSmartAccountPda({
@@ -3816,7 +3821,7 @@ async function main() {
       throw new Error("full-withdraw-cleanup requires an active Earn policy.");
     }
 
-    let selectedSource: NonNullable<EarnWithdrawPrepareRequestBody["source"]>;
+    let selectedSource: NonNullable<EarnWithdrawLegacySourceRequest>;
     if (frontendSession) {
       const position = await fetchEarnPositionViaFrontend({
         session: frontendSession,
@@ -5604,6 +5609,9 @@ async function main() {
     const topUp = frontendSession
       ? await prepareEarnDepositViaFrontend({
           amountRaw: TOP_UP_DEPOSIT_RAW,
+          ...(TOP_UP_DEPOSIT_MINT
+            ? { mint: new PublicKey(TOP_UP_DEPOSIT_MINT) }
+            : {}),
           session: frontendSession,
         })
       : await client.prepareEarnUsdcDeposit({
@@ -5715,7 +5723,7 @@ async function main() {
         simulationLogs: topUpSent.simulationLogs.slice(-12),
         status: "success",
       };
-      if (!options.includePartialWithdrawal) {
+      if (!options.includePartialWithdrawal || TOP_UP_ONLY) {
         evidence.verifierFailures = await assertNoVerifierFailures({
           settings: SETTINGS_PDA.toBase58(),
           verifyUserYieldPositions: repository.verifyUserYieldPositions,
@@ -5730,6 +5738,14 @@ async function main() {
           amountRaw: PARTIAL_WITHDRAW_RAW,
           mode: "partial",
           session: frontendSession,
+          source: {
+            amountRaw: before.principalAmountRaw.toString(),
+            id: before.currentReserve,
+            liquidityMint: before.currentLiquidityMint,
+            market: before.currentMarket,
+            reserve: before.currentReserve,
+            type: "reserve",
+          },
         })
       : await client.prepareEarnUsdcWithdraw({
           amountRaw: PARTIAL_WITHDRAW_RAW,

--- a/scripts/verify-earn-mainnet-flow.ts
+++ b/scripts/verify-earn-mainnet-flow.ts
@@ -3396,7 +3396,23 @@ async function main() {
     return Number(row?.count ?? 0);
   }
 
-  async function loadVerifierRowCounts() {
+  function readConfirmSourceSignature(body: unknown): string | null {
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+
+    const record = body as Record<string, unknown>;
+    for (const key of ["depositSignature", "withdrawalSignature"] as const) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+
+    return null;
+  }
+
+  async function loadVerifierRowCounts(sourceSignature?: string | null) {
     const settings = SETTINGS_PDA.toBase58();
     const walletAddress = wallet.publicKey.toBase58();
     const selectedVaultPubkey = vaultPubkey.toBase58();
@@ -3465,7 +3481,15 @@ async function main() {
         where: and(
           eq(schema.userYieldPositionDeposits.settings, settings),
           eq(schema.userYieldPositionDeposits.vaultIndex, 1),
-          eq(schema.userYieldPositionDeposits.walletAddress, walletAddress)
+          eq(schema.userYieldPositionDeposits.walletAddress, walletAddress),
+          ...(sourceSignature
+            ? [
+                eq(
+                  schema.userYieldPositionDeposits.depositSignature,
+                  sourceSignature
+                ),
+              ]
+            : [])
         ),
       }),
       holdingEvents:
@@ -3475,9 +3499,20 @@ async function main() {
               from: schema.userYieldPositionHoldingEvents,
               where: or(
                 ...positionIdList.map((positionId) =>
-                  eq(
-                    schema.userYieldPositionHoldingEvents.positionId,
-                    positionId
+                  and(
+                    eq(
+                      schema.userYieldPositionHoldingEvents.positionId,
+                      positionId
+                    ),
+                    ...(sourceSignature
+                      ? [
+                          eq(
+                            schema.userYieldPositionHoldingEvents
+                              .sourceSignature,
+                            sourceSignature
+                          ),
+                        ]
+                      : [])
                   )
                 )
               ),
@@ -3488,7 +3523,15 @@ async function main() {
         where: and(
           eq(schema.userYieldPositionWithdrawals.settings, settings),
           eq(schema.userYieldPositionWithdrawals.vaultIndex, 1),
-          eq(schema.userYieldPositionWithdrawals.walletAddress, walletAddress)
+          eq(schema.userYieldPositionWithdrawals.walletAddress, walletAddress),
+          ...(sourceSignature
+            ? [
+                eq(
+                  schema.userYieldPositionWithdrawals.withdrawalSignature,
+                  sourceSignature
+                ),
+              ]
+            : [])
         ),
       }),
     };
@@ -3536,7 +3579,8 @@ async function main() {
     path: string;
     session: FrontendSession;
   }) {
-    const before = await loadVerifierRowCounts();
+    const sourceSignature = readConfirmSourceSignature(args.body);
+    const before = await loadVerifierRowCounts(sourceSignature);
     const replay = await frontendPostJsonRaw({
       body: args.body,
       cookie: args.cookie,
@@ -3548,7 +3592,7 @@ async function main() {
         `${args.label} replay failed with ${replay.response.status}: ${replay.text}`
       );
     }
-    const after = await loadVerifierRowCounts();
+    const after = await loadVerifierRowCounts(sourceSignature);
     if (JSON.stringify(before) !== JSON.stringify(after)) {
       throw new Error(
         `${args.label} replay changed row counts: ${JSON.stringify({
@@ -3691,9 +3735,10 @@ async function main() {
     path: string;
     session: FrontendSession;
   }) {
-    const before = await loadVerifierRowCounts();
+    const sourceSignature = readConfirmSourceSignature(args.body);
+    const before = await loadVerifierRowCounts(sourceSignature);
     const failure = await expectFrontendPostFailure(args);
-    const after = await loadVerifierRowCounts();
+    const after = await loadVerifierRowCounts(sourceSignature);
     if (JSON.stringify(before) !== JSON.stringify(after)) {
       throw new Error(
         `${args.label} changed row counts: ${JSON.stringify({
@@ -5835,8 +5880,12 @@ async function main() {
       simulationLogs: partialSent.simulationLogs.slice(-12),
       status: "success",
     };
+    const principalBeforeWithdrawal =
+      before.principalAmountRaw + TOP_UP_DEPOSIT_RAW;
     const expected =
-      before.principalAmountRaw + TOP_UP_DEPOSIT_RAW - PARTIAL_WITHDRAW_RAW;
+      principalBeforeWithdrawal > PARTIAL_WITHDRAW_RAW
+        ? principalBeforeWithdrawal - PARTIAL_WITHDRAW_RAW
+        : BigInt(0);
     const actualPrincipal = readPositionPrincipalAmountRaw(after);
     if (actualPrincipal !== expected) {
       throw new Error(


### PR DESCRIPTION
Hardens the Autoswap policy lifecycle and production verification, and restores the local-only CAPTCHA bypass needed for API/E2E testing. Verified with web lint, Smart Account Vault typecheck, focused CAPTCHA/repository tests, and canonical cross-mint policy tests; the broader vault suite retains nine existing non-Autoswap failures.