### PR TITLE
feat(earn): polish autoswap setup UX and add lifecycle observability

### DIFF
--- a/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/delete/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/delete/prepare/route.ts
@@ -182,7 +182,10 @@ export async function POST(request: Request) {
       return jsonError(error.status, error.code, error.message);
     }
     console.error("[earn-cross-mint-delete-prepare] prepare failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown error.",
       errorName: error instanceof Error ? error.name : "UnknownError",
+      stack: error instanceof Error ? error.stack : undefined,
     });
     return jsonError(
       409,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/policies/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/policies/confirm/route.ts
@@ -247,7 +247,10 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[earn-cross-mint-policy-confirm] confirm failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown error.",
       errorName: error instanceof Error ? error.name : "UnknownError",
+      stack: error instanceof Error ? error.stack : undefined,
     });
     return jsonError(
       409,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/policies/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/policies/prepare/route.ts
@@ -158,7 +158,10 @@ export async function POST(request: Request) {
       return jsonError(error.status, error.code, error.message);
     }
     console.error("[earn-cross-mint-policy-prepare] prepare failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown error.",
       errorName: error instanceof Error ? error.name : "UnknownError",
+      stack: error instanceof Error ? error.stack : undefined,
     });
     return jsonError(
       500,

--- a/apps/web/src/components/wallet-sidebar/earn-detail-view.tsx
+++ b/apps/web/src/components/wallet-sidebar/earn-detail-view.tsx
@@ -1776,7 +1776,7 @@ export function AutodepositToggle({
       aria-label={
         ariaLabel ?? (isOn ? "Pause Autodeposit" : "Resume Autodeposit")
       }
-      className={`t-toggle${isInit ? "is-init" : ""}`}
+      className={`t-toggle${isInit ? " is-init" : ""}`}
       data-on={isOn}
       disabled={disabled}
       onClick={onToggle}

--- a/apps/web/src/components/wallet-workspace/facelift/autoswap-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/autoswap-pane.tsx
@@ -1,7 +1,14 @@
 "use client";
 
+import { ArrowRightLeft, Gauge, Radar, ShieldCheck, Undo2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import {
+  FlowDiagram,
+  FlowExplainerAside,
+  FlowExplainerOverlay,
+  type FlowStep,
+} from "@/components/wallet-workspace/facelift/flow-explainer";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
@@ -12,6 +19,37 @@ import {
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 const STABLECOIN_DECIMALS = 6;
+
+// The pipeline a cross-mint move travels, told as steps like the Autodeposit
+// explainer — the on-chain limit, the two scoped policies, and how it's
+// undone are folded into the step bodies.
+const AUTOSWAP_STEPS: readonly FlowStep[] = [
+  {
+    Icon: Gauge,
+    body: "Choose how much Autoswap may move per stablecoin each day. The cap is enforced on-chain and stays fixed until you delete Autoswap.",
+    title: "You set a daily limit",
+  },
+  {
+    Icon: ShieldCheck,
+    body: "Two wallet approvals create scoped on-chain permissions — one per token standard — so the same safety limits cover every supported stablecoin.",
+    title: "You approve it once",
+  },
+  {
+    Icon: Radar,
+    body: "Loyal monitors the supported stablecoin markets and only acts when another route pays more than the one your funds are in.",
+    title: "Loyal watches the rates",
+  },
+  {
+    Icon: ArrowRightLeft,
+    body: "Your smart account withdraws, swaps through Jupiter inside a fixed 0.5% maximum slippage, and redeposits — no signing each time.",
+    title: "Funds move on one approved path",
+  },
+  {
+    Icon: Undo2,
+    body: "Pause Autoswap to stop new moves, or delete it anytime to revoke both permissions on-chain.",
+    title: "Paused or removed anytime",
+  },
+];
 
 function formatDailyCap(raw: string): string {
   const amount = BigInt(raw);
@@ -53,6 +91,7 @@ export function AutoswapPane({
   onBack: () => void;
 }) {
   const current = data.autoswapConfig;
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
   const [dailyCap, setDailyCap] = useState(() =>
     current ? formatDailyCap(current.dailySourceMintSpendingCap) : "100"
   );
@@ -92,134 +131,164 @@ export function AutoswapPane({
   };
 
   return (
-    <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-none">
-      <header className="flex w-full items-center p-2">
-        <div className="pr-3">
+    <>
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-clip rounded-3xl bg-card max-[795px]:rounded-none">
+        <header className="flex w-full items-center p-2">
+          <div className="pr-3">
+            <button
+              aria-label="Back"
+              className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
+              onClick={onBack}
+              type="button"
+            >
+              <ThemedIcon
+                className="size-6 text-muted-foreground"
+                src={`${ASSET_BASE}/icon-arrow-left.svg`}
+              />
+            </button>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col py-2">
+            <h1 className="truncate font-semibold text-[20px] text-foreground leading-6">
+              Autoswap
+            </h1>
+            <p className="text-[13px] leading-4 text-muted-foreground">
+              Move Earn funds when another stablecoin route pays more
+            </p>
+          </div>
           <button
-            aria-label="Back"
-            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
-            onClick={onBack}
+            aria-label="How Autoswap works"
+            className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"
+            onClick={() => setIsInfoOpen(true)}
             type="button"
           >
             <ThemedIcon
-              className="size-6 text-muted-foreground"
-              src={`${ASSET_BASE}/icon-arrow-left.svg`}
+              className="size-6 text-tertiary"
+              src={`${ASSET_BASE}/icon-question.svg`}
             />
           </button>
-        </div>
-        <div className="flex min-w-0 flex-1 flex-col py-2">
-          <h1 className="truncate font-semibold text-[20px] text-foreground leading-6">
-            Autoswap
-          </h1>
-          <p className="text-[13px] leading-4 text-muted-foreground">
-            Move Earn funds when another stablecoin route pays more
-          </p>
-        </div>
-      </header>
+        </header>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-4">
-        <div className="rounded-2xl bg-accent/60 p-4">
-          <p className="text-[13px] leading-5 text-muted-foreground">
-            Loyal can withdraw, swap through Jupiter, and redeposit across the
-            supported stablecoins. Every move must stay inside the on-chain
-            daily spending limit you approve and Loyal&apos;s fixed 0.5% maximum
-            slippage.
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-4">
+          <div className="rounded-2xl bg-accent/60 p-4">
+            <p className="text-[13px] leading-5 text-muted-foreground">
+              Loyal can withdraw, swap through Jupiter, and redeposit across the
+              supported stablecoins. Every move must stay inside the on-chain
+              daily spending limit you approve and Loyal&apos;s fixed 0.5%
+              maximum slippage.
+            </p>
+            {!current ? (
+              <p className="mt-2 text-[13px] leading-5 text-muted-foreground">
+                A fresh setup uses two wallet approvals so these same safety
+                limits can cover every supported stablecoin. If setup is
+                interrupted, retrying continues with the remaining approval.
+              </p>
+            ) : null}
+          </div>
+
+          <label className="mt-5 flex flex-col gap-2">
+            <span className="font-medium text-[14px] text-foreground leading-5">
+              Daily swap limit per stablecoin
+            </span>
+            <div className="flex h-14 items-center rounded-2xl bg-accent px-4">
+              <span className="font-semibold text-[24px] text-foreground">
+                $
+              </span>
+              <input
+                className="min-w-0 flex-1 bg-transparent pl-1 font-semibold text-[24px] text-foreground outline-none disabled:opacity-60"
+                disabled={Boolean(current)}
+                inputMode="decimal"
+                onChange={(event) => {
+                  const next = sanitizeUsdInput(event.target.value);
+                  if (next !== null) {
+                    setDailyCap(next);
+                  }
+                }}
+                value={dailyCap}
+              />
+            </div>
+          </label>
+
+          {!current && dailyCapRaw && !isDailyCapValid ? (
+            <p className="mt-2 text-[13px] leading-5 text-destructive">
+              Choose a daily limit between $1 and $1,000.
+            </p>
+          ) : null}
+
+          <p className="mt-4 text-[13px] leading-5 text-muted-foreground">
+            This limit is immutable while Autoswap is installed. To change it,
+            delete Autoswap and set it up again.
           </p>
-          {!current ? (
-            <p className="mt-2 text-[13px] leading-5 text-muted-foreground">
-              A fresh setup uses two wallet approvals so these same safety
-              limits can cover every supported stablecoin. If setup is
-              interrupted, retrying continues with the remaining approval.
+
+          {isFinalizing ? (
+            <p className="mt-4 rounded-2xl bg-primary/10 px-4 py-3 text-[13px] leading-5 text-primary">
+              The policies are finalized on-chain. Loyal is verifying both
+              permissions before routing can begin.
+            </p>
+          ) : null}
+          {isPaused ? (
+            <p className="mt-4 rounded-2xl bg-accent px-4 py-3 text-[13px] leading-5 text-muted-foreground">
+              Autoswap is paused. Loyal will not start a new cross-mint move,
+              but it can still finish or safely recover a move already in
+              progress.
+            </p>
+          ) : null}
+          {data.autoswapError ? (
+            <p className="mt-4 text-[13px] leading-5 text-destructive">
+              {data.autoswapError}
             </p>
           ) : null}
         </div>
 
-        <label className="mt-5 flex flex-col gap-2">
-          <span className="font-medium text-[14px] text-foreground leading-5">
-            Daily swap limit per stablecoin
-          </span>
-          <div className="flex h-14 items-center rounded-2xl bg-accent px-4">
-            <span className="font-semibold text-[24px] text-foreground">$</span>
-            <input
-              className="min-w-0 flex-1 bg-transparent pl-1 font-semibold text-[24px] text-foreground outline-none disabled:opacity-60"
-              disabled={Boolean(current)}
-              inputMode="decimal"
-              onChange={(event) => {
-                const next = sanitizeUsdInput(event.target.value);
-                if (next !== null) {
-                  setDailyCap(next);
+        <div className="flex w-full flex-col gap-2 px-4 pt-2 pb-4">
+          {current ? (
+            <button
+              className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-destructive/[0.08] font-medium text-[16px] text-destructive enabled:hover:bg-destructive/[0.14] disabled:opacity-60"
+              disabled={isPending}
+              onClick={() => void handleDelete()}
+              type="button"
+            >
+              <TextSwap
+                text={
+                  isPending
+                    ? "Removing · takes ~1 minute…"
+                    : isDeleteArmed
+                    ? "Confirm delete"
+                    : "Delete Autoswap"
                 }
-              }}
-              value={dailyCap}
-            />
-          </div>
-        </label>
+              />
+            </button>
+          ) : (
+            <button
+              className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-60"
+              disabled={!isDailyCapValid || isPending}
+              onClick={() => void handlePrimaryAction()}
+              type="button"
+            >
+              <TextSwap
+                text={
+                  isPending
+                    ? "Setting up · takes ~2 minutes…"
+                    : "Continue · up to 2 approvals"
+                }
+              />
+            </button>
+          )}
+        </div>
+      </section>
 
-        {!current && dailyCapRaw && !isDailyCapValid ? (
-          <p className="mt-2 text-[13px] leading-5 text-destructive">
-            Choose a daily limit between $1 and $1,000.
-          </p>
-        ) : null}
+      {/* Info panel: fixed right pane on wide viewports, overlay via the
+          header ? below 1204px — same composition as Autodeposit. */}
+      <FlowExplainerAside title="How Autoswap works">
+        <FlowDiagram steps={AUTOSWAP_STEPS} />
+      </FlowExplainerAside>
 
-        <p className="mt-4 text-[13px] leading-5 text-muted-foreground">
-          This limit is immutable while Autoswap is installed. To change it,
-          delete Autoswap and set it up again.
-        </p>
-
-        {isFinalizing ? (
-          <p className="mt-4 rounded-2xl bg-primary/10 px-4 py-3 text-[13px] leading-5 text-primary">
-            The policies are finalized on-chain. Loyal is verifying both
-            permissions before routing can begin.
-          </p>
-        ) : null}
-        {isPaused ? (
-          <p className="mt-4 rounded-2xl bg-accent px-4 py-3 text-[13px] leading-5 text-muted-foreground">
-            Autoswap is paused. Loyal will not start a new cross-mint move, but
-            it can still finish or safely recover a move already in progress.
-          </p>
-        ) : null}
-        {data.autoswapError ? (
-          <p className="mt-4 text-[13px] leading-5 text-destructive">
-            {data.autoswapError}
-          </p>
-        ) : null}
-      </div>
-
-      <div className="flex w-full flex-col gap-2 px-4 pt-2 pb-4">
-        {current ? (
-          <button
-            className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-destructive/[0.08] font-medium text-[16px] text-destructive enabled:hover:bg-destructive/[0.14] disabled:opacity-60"
-            disabled={isPending}
-            onClick={() => void handleDelete()}
-            type="button"
-          >
-            <TextSwap
-              text={
-                isPending
-                  ? "Waiting for wallet…"
-                  : isDeleteArmed
-                  ? "Confirm delete"
-                  : "Delete Autoswap"
-              }
-            />
-          </button>
-        ) : (
-          <button
-            className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-60"
-            disabled={!isDailyCapValid || isPending}
-            onClick={() => void handlePrimaryAction()}
-            type="button"
-          >
-            <TextSwap
-              text={
-                isPending
-                  ? "Waiting for wallet…"
-                  : "Continue · up to 2 approvals"
-              }
-            />
-          </button>
-        )}
-      </div>
-    </section>
+      <FlowExplainerOverlay
+        isOpen={isInfoOpen}
+        onClose={() => setIsInfoOpen(false)}
+        title="How Autoswap works"
+      >
+        <FlowDiagram steps={AUTOSWAP_STEPS} />
+      </FlowExplainerOverlay>
+    </>
   );
 }

--- a/apps/web/src/components/wallet-workspace/facelift/earn-position-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-position-pane.tsx
@@ -18,7 +18,10 @@ import {
   type ChartTab,
 } from "@/components/wallet-workspace/facelift/earn-chart-pane";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
-import { ApyRevealText } from "@/components/wallet-workspace/facelift/skeleton-reveal";
+import {
+  ApyRevealText,
+  SkeletonReveal,
+} from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
@@ -84,6 +87,10 @@ export function EarnPositionPane({
   );
   const isAutoswapToggling =
     autoswap?.status === "pausing" || autoswap?.status === "resuming";
+  // Unknown until the first Earn state lands; the row shows as a skeleton
+  // instead of popping in after Autodeposit.
+  const isAutoswapResolved =
+    data.autoswapAvailable !== null || autoswap !== null;
   const autoswapLabel = autoswap
     ? autoswap.status === "on"
       ? `Up to $${(
@@ -278,7 +285,7 @@ export function EarnPositionPane({
                 {data.autodepositToggleError}
               </p>
             ) : null}
-            {data.autoswapAvailable || autoswap ? (
+            {data.autoswapAvailable !== false || autoswap ? (
               <>
                 <div className="flex w-full items-center rounded-2xl px-4">
                   <div className="py-2 pr-3">
@@ -295,7 +302,9 @@ export function EarnPositionPane({
                       Autoswap
                     </p>
                     <p className="text-[13px] leading-4 text-muted-foreground">
-                      <TextSwap text={autoswapLabel} />
+                      <SkeletonReveal isRevealed={isAutoswapResolved}>
+                        <TextSwap text={autoswapLabel} />
+                      </SkeletonReveal>
                     </p>
                   </div>
                   {autoswap ? (
@@ -336,13 +345,19 @@ export function EarnPositionPane({
                     </div>
                   ) : (
                     <div className="flex items-center pl-3">
-                      <button
-                        className="t-hover min-w-16 rounded-full bg-primary px-4 py-2.5 text-center font-medium text-[13px] text-white leading-4 hover:-translate-y-0.5 hover:bg-primary/90 active:translate-y-0"
-                        onClick={onOpenAutoswap}
-                        type="button"
+                      <SkeletonReveal
+                        isRevealed={isAutoswapResolved}
+                        skeletonClassName="rounded-full bg-accent-selected"
                       >
-                        Set up
-                      </button>
+                        <button
+                          className="t-hover min-w-16 rounded-full bg-primary px-4 py-2.5 text-center font-medium text-[13px] text-white leading-4 enabled:hover:-translate-y-0.5 enabled:hover:bg-primary/90 enabled:active:translate-y-0 disabled:pointer-events-none"
+                          disabled={!isAutoswapResolved}
+                          onClick={onOpenAutoswap}
+                          type="button"
+                        >
+                          Set up
+                        </button>
+                      </SkeletonReveal>
                     </div>
                   )}
                 </div>

--- a/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-toast.tsx
@@ -23,6 +23,8 @@ type EarnToastDetail = { message: string; phase: EarnToastPhase };
 export type EarnFlowId =
   | "autodeposit-delete"
   | "autodeposit-setup"
+  | "autoswap-delete"
+  | "autoswap-setup"
   | "close-policies"
   | "deposit"
   | "deposit-policy-update"
@@ -58,6 +60,23 @@ const FLOW_STEPS: Record<EarnFlowId, readonly string[]> = {
     "Waiting for approval",
     "Preparing Autodeposit",
     CONFIRM_IN_WALLET_MESSAGE,
+    "Confirming",
+  ],
+  // Autoswap scripts avoid CONFIRM_IN_WALLET_MESSAGE on purpose: the wallet
+  // bridge's signed() shortcut would jump the card straight to "Confirming"
+  // and skip the finalization steps, so the flow drives every step itself.
+  "autoswap-delete": [
+    "Preparing removal",
+    "Confirm removal in wallet",
+    "Finalizing removal",
+    "Confirming",
+  ],
+  "autoswap-setup": [
+    "Preparing Autoswap",
+    "Confirm policy 1 of 2",
+    "Finalizing policy 1 of 2",
+    "Confirm policy 2 of 2",
+    "Finalizing policy 2 of 2",
     "Confirming",
   ],
   "close-policies": [

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-position-data.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-position-data.ts
@@ -45,7 +45,7 @@ export type EarnPositionData = {
   actions: EarnActions;
   autodepositConfig: EarnAutodepositConfigView | null;
   autodepositToggleError: string | null;
-  autoswapAvailable: boolean;
+  autoswapAvailable: boolean | null;
   autoswapConfig: EarnAutoswapConfigView | null;
   autoswapError: string | null;
   deleteAutoswap: () => Promise<boolean>;
@@ -260,6 +260,12 @@ export function useEarnPositionData(): EarnPositionData {
       return;
     }
     const nextEnabled = config.status === "paused";
+    const tracker = createBrowserLifecycleTracker({
+      flowName: "earn.autoswap.configuration",
+      flowVariant: nextEnabled ? "resume" : "pause",
+    });
+    tracker.start("intent");
+    tracker.observe("backend_confirm", { persistenceState: "not_started" });
     setAutoswapError(null);
     autoswapMutationInFlightRef.current = true;
     setAutoswapOverride({
@@ -271,9 +277,14 @@ export function useEarnPositionData(): EarnPositionData {
     const result = await executeAutoswapToggle({
       enabled: nextEnabled,
       expectedGeneration: config.generation,
+      observabilityFlowId: tracker.flowId,
     });
     autoswapMutationInFlightRef.current = false;
     if (!(result.success && result.generation && result.status)) {
+      tracker.fail("backend_confirm", {
+        errorCode: "record_failed",
+        persistenceState: "failed",
+      });
       setAutoswapOverride(null);
       setAutoswapError(result.error ?? "Autoswap update failed.");
       await refreshEarnState().catch(() => undefined);
@@ -287,6 +298,7 @@ export function useEarnPositionData(): EarnPositionData {
         status: result.status,
       },
     });
+    tracker.complete("ui_commit", { persistenceState: "recorded" });
     await refreshEarnState().catch(() => undefined);
   }, [autoswapConfig, executeAutoswapToggle, refreshEarnState]);
   const deleteAutoswap = useCallback(async () => {

--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -16,6 +16,7 @@ export const LIFECYCLE_FLOW_NAMES = [
   "earn.withdrawal",
   "earn.autodeposit.configuration",
   "earn.autodeposit.execute_now",
+  "earn.autoswap.configuration",
   "wallet.swap",
 ] as const;
 
@@ -61,6 +62,7 @@ export const LIFECYCLE_VARIANTS = {
     "close",
   ],
   "earn.autodeposit.execute_now": ["execute_now"],
+  "earn.autoswap.configuration": ["setup", "pause", "resume", "delete"],
   // Direct wallet-adapter signing vs the smart-account execution context.
   "wallet.swap": ["wallet_adapter", "smart_account"],
 } as const satisfies Record<LifecycleFlowName, readonly string[]>;
@@ -128,6 +130,17 @@ export const LIFECYCLE_STAGES = {
     "intent",
     "request",
     "state_observed",
+    "ui_commit",
+  ],
+  // Setup/delete sign wallet transactions (two shard policies on setup, one
+  // revocation on delete); pause/resume are backend-only generation bumps.
+  "earn.autoswap.configuration": [
+    "intent",
+    "prepare",
+    "wallet_approval",
+    "create_policy",
+    "slot_resolve",
+    "backend_confirm",
     "ui_commit",
   ],
   "wallet.swap": [
@@ -691,7 +704,9 @@ export function parseBrowserLifecycleEnvelope(
   const isMoneyFlow =
     flowName === "earn.deposit" || flowName === "earn.withdrawal";
   const isTransactionFlow =
-    isMoneyFlow || flowName === "earn.autodeposit.configuration";
+    isMoneyFlow ||
+    flowName === "earn.autodeposit.configuration" ||
+    flowName === "earn.autoswap.configuration";
   if (
     (record.chainState !== undefined ||
       record.persistenceState !== undefined ||

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -58,7 +58,10 @@ import type {
 import { earnToast } from "@/components/wallet-workspace/facelift/earn-toast";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
-import { captureBrowserError } from "@/features/observability/client";
+import {
+  captureBrowserError,
+  createBrowserLifecycleTracker,
+} from "@/features/observability/client";
 import type { BrowserErrorOperation } from "@/features/observability/error-contract";
 import {
   resolveSmartAccountMutationRefreshPlan,
@@ -1040,7 +1043,8 @@ export type SmartAccountSidebarData = {
   overview: SmartAccountOverview | null;
   earnAutodeposit: EarnStateResponse["autodeposit"];
   earnAutoswap: EarnStateResponse["autoswap"];
-  earnAutoswapAvailable: boolean;
+  /** null while the Earn state is still loading — lets the UI skeleton the row. */
+  earnAutoswapAvailable: boolean | null;
   earnOnboarding: EarnStateResponse["onboarding"] | null;
   earnPolicy: EarnStateResponse["policy"];
   earnPolicySignerPublicKey: string | null;
@@ -1209,6 +1213,7 @@ export type SmartAccountSidebarData = {
   executeEarnAutoswapToggle: (request: {
     enabled: boolean;
     expectedGeneration: string;
+    observabilityFlowId?: string;
   }) => Promise<EarnAutoswapToggleResult>;
   executeEarnAutoswapDelete: (request: {
     expectedGeneration: string;
@@ -1988,12 +1993,13 @@ async function prepareEarnPolicyOnServer(): Promise<SmartAccountPreparedEarnUsdc
 
 async function prepareEarnAutoswapOnServer(args: {
   dailySourceMintSpendingCap: bigint;
+  observabilityFlowId?: string;
 }) {
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/cross-mint/policies/prepare",
     {
       credentials: "include",
-      headers: { "Content-Type": "application/json" },
+      headers: observabilityJsonHeaders(args.observabilityFlowId),
       method: "POST",
       body: JSON.stringify({
         maxSlippageBps: DEFAULT_AUTOSWAP_MAX_SLIPPAGE_BPS,
@@ -2032,15 +2038,17 @@ async function postConfirmedEarnAutoswap(args: {
       sourceShard: "classic" | "token_2022";
     }
   ];
+  observabilityFlowId?: string;
 }) {
+  const { observabilityFlowId, ...body } = args;
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/cross-mint/policies/confirm",
     {
       credentials: "include",
-      headers: { "Content-Type": "application/json" },
+      headers: observabilityJsonHeaders(observabilityFlowId),
       method: "POST",
       body: JSON.stringify({
-        ...args,
+        ...body,
         dailySourceMintSpendingCap: args.dailySourceMintSpendingCap.toString(),
       }),
     }
@@ -2058,13 +2066,15 @@ async function postConfirmedEarnAutoswap(args: {
 async function postEarnAutoswapToggle(args: {
   enabled: boolean;
   expectedGeneration: string;
+  observabilityFlowId?: string;
 }): Promise<EarnCrossMintToggleResponse> {
+  const { observabilityFlowId, ...body } = args;
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/cross-mint/toggle",
     {
-      body: JSON.stringify(args),
+      body: JSON.stringify(body),
       credentials: "include",
-      headers: { "Content-Type": "application/json" },
+      headers: observabilityJsonHeaders(observabilityFlowId),
       method: "POST",
     }
   );
@@ -2079,13 +2089,15 @@ async function postEarnAutoswapToggle(args: {
 
 async function prepareEarnAutoswapDeleteOnServer(args: {
   expectedGeneration: string;
+  observabilityFlowId?: string;
 }) {
+  const { observabilityFlowId, ...body } = args;
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/cross-mint/delete/prepare",
     {
-      body: JSON.stringify(args),
+      body: JSON.stringify(body),
       credentials: "include",
-      headers: { "Content-Type": "application/json" },
+      headers: observabilityJsonHeaders(observabilityFlowId),
       method: "POST",
     }
   );
@@ -2111,16 +2123,18 @@ async function prepareEarnAutoswapDeleteOnServer(args: {
 async function postConfirmedEarnAutoswapDelete(args: {
   expectedGeneration: string;
   finalizedSlot: string;
+  observabilityFlowId?: string;
   policies: readonly [string, string];
   signature: string;
 }) {
+  const { observabilityFlowId, ...body } = args;
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/cross-mint/delete/confirm",
     {
       credentials: "include",
-      headers: { "Content-Type": "application/json" },
+      headers: observabilityJsonHeaders(observabilityFlowId),
       method: "POST",
-      body: JSON.stringify(args),
+      body: JSON.stringify(body),
     }
   );
   if (!response.ok) {
@@ -6157,11 +6171,24 @@ export function useSmartAccountSidebarData(
         };
       }
 
+      const tracker = createBrowserLifecycleTracker({
+        flowName: "earn.autoswap.configuration",
+        flowVariant: "setup",
+      });
+      tracker.start("intent");
+      let trackerStage: "prepare" | "create_policy" | "slot_resolve" | "backend_confirm" =
+        "prepare";
       setIsActionPending(true);
       let completedPolicies = 0;
       try {
         const expectedCluster = resolveEarnLoyalCluster(solanaEnv);
-        let preparedSet = await prepareEarnAutoswapOnServer(request);
+        earnToast.begin("autoswap-setup");
+        earnToast.loading("Preparing Autoswap");
+        tracker.observe("prepare");
+        let preparedSet = await prepareEarnAutoswapOnServer({
+          ...request,
+          observabilityFlowId: tracker.flowId,
+        });
         const evidence = new Map<
           "classic" | "token_2022",
           {
@@ -6207,12 +6234,26 @@ export function useSmartAccountSidebarData(
             );
           }
 
+          const policyNumber = Math.min(evidence.size + 1, 2);
+          trackerStage = "create_policy";
+          tracker.observe("create_policy", {
+            chainState: "not_submitted",
+            stageCount: 2,
+            stageIndex: policyNumber - 1,
+          });
+          tracker.observe("wallet_approval", {
+            chainState: "submitted",
+            executionMode: "sequential",
+          });
+          earnToast.loading(`Confirm policy ${policyNumber} of 2`);
           const signature = await sendPreparedWithWallet({
             connection,
             wallet: walletBridge,
             prepared: nextPolicy.prepared,
             confirm: true,
           });
+          earnToast.loading(`Finalizing policy ${policyNumber} of 2`);
+          trackerStage = "slot_resolve";
           const finalizedSlot = await resolveFinalizedSignatureSlot({
             connection,
             signature,
@@ -6225,7 +6266,11 @@ export function useSmartAccountSidebarData(
             sourceShard: nextPolicy.sourceShard,
           });
           completedPolicies = evidence.size;
-          preparedSet = await prepareEarnAutoswapOnServer(request);
+          trackerStage = "prepare";
+          preparedSet = await prepareEarnAutoswapOnServer({
+            ...request,
+            observabilityFlowId: tracker.flowId,
+          });
         }
 
         const classic = evidence.get("classic");
@@ -6236,12 +6281,26 @@ export function useSmartAccountSidebarData(
         const confirmedPolicies: Parameters<
           typeof postConfirmedEarnAutoswap
         >[0]["policies"] = [classic, token2022];
+        earnToast.loading("Confirming");
+        trackerStage = "backend_confirm";
         await postConfirmedEarnAutoswap({
           dailySourceMintSpendingCap: request.dailySourceMintSpendingCap,
           maxSlippageBps: DEFAULT_AUTOSWAP_MAX_SLIPPAGE_BPS,
+          observabilityFlowId: tracker.flowId,
           policies: confirmedPolicies,
         });
+        tracker.observe("backend_confirm", {
+          chainState: "confirmed",
+          persistenceState: "recorded",
+        });
         await refreshEarnState();
+        earnToast.success("Autoswap enabled");
+        tracker.complete("ui_commit", {
+          chainState: "confirmed",
+          persistenceState: "recorded",
+          stageCount: 2,
+          stageIndex: completedPolicies,
+        });
         return { success: true, completedPolicies };
       } catch (err) {
         const error =
@@ -6251,9 +6310,37 @@ export function useSmartAccountSidebarData(
           "earn.autoswap_setup.execute",
           err
         );
+        if (isWalletCancellationError(err)) {
+          tracker.cancel("wallet_approval", {
+            errorCode: "wallet_rejected",
+            stageCount: 2,
+            stageIndex: completedPolicies,
+          });
+        } else if (trackerStage === "backend_confirm") {
+          tracker.fail("backend_confirm", {
+            chainState: "confirmed",
+            errorCode: "record_failed",
+            persistenceState: "failed",
+            stageCount: 2,
+            stageIndex: completedPolicies,
+          });
+        } else {
+          tracker.fail(trackerStage, {
+            errorCode:
+              trackerStage === "slot_resolve"
+                ? "slot_resolution_failed"
+                : "unexpected_error",
+            stageCount: 2,
+            stageIndex: completedPolicies,
+          });
+        }
+        if (!isWalletCancellationError(err)) {
+          earnToast.error("Autoswap setup failed");
+        }
         return { success: false, completedPolicies, error };
       } finally {
         setIsActionPending(false);
+        earnToast.settle();
       }
     },
     [connection, refreshEarnState, solanaEnv, user?.walletAddress, wallet]
@@ -6263,6 +6350,7 @@ export function useSmartAccountSidebarData(
     async (request: {
       enabled: boolean;
       expectedGeneration: string;
+      observabilityFlowId?: string;
     }): Promise<EarnAutoswapToggleResult> => {
       setIsActionPending(true);
       try {
@@ -6310,13 +6398,28 @@ export function useSmartAccountSidebarData(
         };
       }
 
+      const tracker = createBrowserLifecycleTracker({
+        flowName: "earn.autoswap.configuration",
+        flowVariant: "delete",
+      });
+      tracker.start("intent");
+      let trackerStage: "prepare" | "wallet_approval" | "slot_resolve" | "backend_confirm" =
+        "prepare";
       setIsActionPending(true);
       try {
+        earnToast.begin("autoswap-delete");
+        earnToast.loading("Preparing removal");
+        tracker.observe("prepare");
         // The prepare endpoint disables orchestration before returning this
         // revocation transaction, so a canceled wallet prompt remains safe.
-        const removal = await prepareEarnAutoswapDeleteOnServer(request);
+        const removal = await prepareEarnAutoswapDeleteOnServer({
+          ...request,
+          observabilityFlowId: tracker.flowId,
+        });
         if (removal.status === "off") {
           await refreshEarnState();
+          earnToast.success("Autoswap removed");
+          tracker.complete("ui_commit", { persistenceState: "recorded" });
           return { success: true };
         }
         if (!removal.prepared) {
@@ -6324,23 +6427,43 @@ export function useSmartAccountSidebarData(
             "Autoswap deletion did not return a revocation transaction."
           );
         }
+        earnToast.loading("Confirm removal in wallet");
+        trackerStage = "wallet_approval";
+        tracker.observe("wallet_approval", {
+          chainState: "submitted",
+          executionMode: "single",
+        });
         const signature = await sendPreparedWithWallet({
           connection,
           wallet: walletBridge,
           prepared: removal.prepared,
           confirm: true,
         });
+        earnToast.loading("Finalizing removal");
+        trackerStage = "slot_resolve";
         const finalizedSlot = await resolveFinalizedSignatureSlot({
           connection,
           signature,
         });
+        earnToast.loading("Confirming");
+        trackerStage = "backend_confirm";
         await postConfirmedEarnAutoswapDelete({
           expectedGeneration: removal.expectedGeneration,
           finalizedSlot,
+          observabilityFlowId: tracker.flowId,
           policies: removal.policies,
           signature,
         });
+        tracker.observe("backend_confirm", {
+          chainState: "confirmed",
+          persistenceState: "recorded",
+        });
         await refreshEarnState();
+        earnToast.success("Autoswap removed");
+        tracker.complete("ui_commit", {
+          chainState: "confirmed",
+          persistenceState: "recorded",
+        });
         return { success: true };
       } catch (err) {
         await refreshEarnState().catch(() => undefined);
@@ -6351,9 +6474,29 @@ export function useSmartAccountSidebarData(
           "earn.autoswap_delete.execute",
           err
         );
+        if (isWalletCancellationError(err)) {
+          tracker.cancel("wallet_approval", { errorCode: "wallet_rejected" });
+        } else if (trackerStage === "backend_confirm") {
+          tracker.fail("backend_confirm", {
+            chainState: "confirmed",
+            errorCode: "record_failed",
+            persistenceState: "failed",
+          });
+        } else {
+          tracker.fail(trackerStage, {
+            errorCode:
+              trackerStage === "slot_resolve"
+                ? "slot_resolution_failed"
+                : "unexpected_error",
+          });
+        }
+        if (!isWalletCancellationError(err)) {
+          earnToast.error("Autoswap removal failed");
+        }
         return { success: false, error };
       } finally {
         setIsActionPending(false);
+        earnToast.settle();
       }
     },
     [connection, refreshEarnState, user?.walletAddress, wallet]
@@ -8305,7 +8448,7 @@ export function useSmartAccountSidebarData(
     overview,
     earnAutodeposit: earnState?.autodeposit ?? null,
     earnAutoswap: earnState?.autoswap ?? null,
-    earnAutoswapAvailable: earnState?.autoswapAvailable ?? false,
+    earnAutoswapAvailable: earnState ? earnState.autoswapAvailable : null,
     earnOnboarding: earnState?.onboarding ?? null,
     earnPolicy,
     earnPolicySignerPublicKey: earnState?.policySignerPublicKey ?? null,

--- a/apps/web/src/lib/solana/rpc-rate-limit.ts
+++ b/apps/web/src/lib/solana/rpc-rate-limit.ts
@@ -19,6 +19,7 @@ const RECENTLY_CACHEABLE_RPC_METHODS = new Set([
   "getLatestBlockhash",
   "getMultipleAccounts",
   "getProgramAccounts",
+  "getProgramAccountsV2",
   "getTokenAccountsByOwner",
 ]);
 

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -3792,6 +3792,87 @@ function createSettingsTransactionFilters(
   ];
 }
 
+type ProgramAccountsV2Page = {
+  accounts?: {
+    pubkey: string;
+    account: {
+      data: [string, string];
+      executable: boolean;
+      lamports: number;
+      owner: string;
+      rentEpoch?: number;
+    };
+  }[];
+  paginationKey?: string | null;
+};
+
+const GET_PROGRAM_ACCOUNTS_V2_PAGE_LIMIT = 1_000;
+const JSON_RPC_METHOD_NOT_FOUND = -32601;
+
+// Helius deprioritizes plain getProgramAccounts on account-heavy programs and
+// requires getProgramAccountsV2 with pagination, so prefer V2 when the
+// connection exposes a raw RPC channel and fall back for RPCs without it
+// (local test validators, mocked connections).
+async function getProgramAccountsCompat(
+  connection: Connection,
+  programId: PublicKey,
+  config: {
+    commitment: "confirmed";
+    filters: GetProgramAccountsFilter[];
+  }
+): Promise<readonly { pubkey: PublicKey; account: AccountInfo<Buffer> }[]> {
+  const rpcRequest = (
+    connection as Connection & {
+      _rpcRequest?: (methodName: string, args: unknown[]) => Promise<unknown>;
+    }
+  )._rpcRequest?.bind(connection);
+  if (!rpcRequest) {
+    return connection.getProgramAccounts(programId, config);
+  }
+  const collected: { pubkey: PublicKey; account: AccountInfo<Buffer> }[] = [];
+  let paginationKey: string | null = null;
+  do {
+    const response = (await rpcRequest("getProgramAccountsV2", [
+      programId.toBase58(),
+      {
+        commitment: config.commitment,
+        encoding: "base64",
+        filters: config.filters,
+        limit: GET_PROGRAM_ACCOUNTS_V2_PAGE_LIMIT,
+        ...(paginationKey ? { paginationKey } : {}),
+      },
+    ])) as {
+      error?: { code?: number; message?: string };
+      result?: ProgramAccountsV2Page & { value?: ProgramAccountsV2Page };
+    };
+    if (response.error) {
+      if (response.error.code === JSON_RPC_METHOD_NOT_FOUND) {
+        return connection.getProgramAccounts(programId, config);
+      }
+      throw new Error(
+        response.error.message ?? "getProgramAccountsV2 request failed."
+      );
+    }
+    const page = response.result?.accounts
+      ? response.result
+      : response.result?.value;
+    for (const entry of page?.accounts ?? []) {
+      collected.push({
+        pubkey: new PublicKey(entry.pubkey),
+        account: {
+          data: Buffer.from(entry.account.data[0], "base64"),
+          executable: entry.account.executable,
+          lamports: entry.account.lamports,
+          owner: new PublicKey(entry.account.owner),
+          rentEpoch: entry.account.rentEpoch,
+        },
+      });
+    }
+    paginationKey = page?.paginationKey ?? null;
+  } while (paginationKey);
+  return collected;
+}
+
 function createPolicyFilters(
   settingsPda: PublicKey
 ): GetProgramAccountsFilter[] {
@@ -4998,7 +5079,8 @@ export function createSmartAccountVaultsClient(
   async function fetchPolicyAccounts(args: {
     settingsPda: PublicKey;
   }): Promise<DeserializedPolicyAccount[]> {
-    const policyAccounts = await config.connection.getProgramAccounts(
+    const policyAccounts = await getProgramAccountsCompat(
+      config.connection,
       smartAccountsClient.programId,
       {
         commitment: "confirmed",
@@ -5974,7 +6056,8 @@ export function createSmartAccountVaultsClient(
   }
 
   async function listRawPolicies(args: { settingsPda: PublicKey }) {
-    const policyAccounts = await config.connection.getProgramAccounts(
+    const policyAccounts = await getProgramAccountsCompat(
+      config.connection,
       smartAccountsClient.programId,
       {
         commitment: "confirmed",


### PR DESCRIPTION
Fixes the Helius getProgramAccounts 429/deprioritization on Autoswap prepare, adds steps toasts, explainer/stats panes, skeleton reveal and duration hints to the Autoswap flows, repairs the toggle thumb-travel class bug, and instruments earn.autoswap.configuration lifecycle observability mirroring Autodeposit. Part of ASK-2170.