### PR TITLE
feat(admin): add Crossmint rebalance monitoring

### DIFF
--- a/apps/admin/src/app/(admin)/earn/rebalance/autodeposit-failures-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/autodeposit-failures-chart.tsx
@@ -158,7 +158,7 @@ export function AutodepositFailuresChart({
     : "No range available";
 
   return (
-    <Card className="w-full py-4 sm:py-0">
+    <Card className="w-full gap-0 py-0">
       <CardHeader className="flex flex-col items-stretch border-b !p-0 xl:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">Failed attempts by cause</CardTitle>
@@ -188,7 +188,7 @@ export function AutodepositFailuresChart({
           </span>
         </div>
       </CardHeader>
-      <CardContent className="space-y-2 px-2 pt-6 sm:p-6">
+      <CardContent className="space-y-2 p-4 sm:p-6">
         {chartData.length > 0 ? (
           <>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-2 text-xs text-muted-foreground">

--- a/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
@@ -23,7 +23,7 @@ export function DepositScaleSwitch({
   return (
     <div
       aria-label="Deposit axis scale"
-      className="inline-flex shrink-0 items-center rounded-lg bg-muted p-1"
+      className="inline-flex w-fit shrink-0 self-start rounded-lg bg-muted p-1"
       role="group"
     >
       <Button

--- a/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/deposit-scale-switch.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export type DepositScale = "linear" | "log";
 
 /**
- * Log/linear switch for the deposit axis, shared by the Earn rebalance scatter
+ * Log/linear selector for the deposit axis, shared by the Earn rebalance scatter
  * charts. Both ends are labelled because neither reading is the obvious
  * default: log is right for the fleet's long dust tail, linear is right when
  * you care about absolute size.
@@ -19,30 +20,46 @@ export function DepositScaleSwitch({
   onScaleChange: (scale: DepositScale) => void;
   scale: DepositScale;
 }) {
-  const isLog = scale === "log";
-
   return (
-    <div className="flex items-center gap-2 text-xs">
-      <span
-        className={
-          isLog ? "text-muted-foreground" : "font-medium text-foreground"
-        }
+    <div
+      aria-label="Deposit axis scale"
+      className="inline-flex shrink-0 items-center rounded-lg bg-muted p-1"
+      role="group"
+    >
+      <Button
+        aria-label="Use a linear deposit axis"
+        aria-pressed={scale === "linear"}
+        className={cn(
+          "h-7 rounded-md px-2.5 text-xs shadow-none",
+          scale === "linear"
+            ? "bg-background text-foreground shadow-xs hover:bg-background"
+            : "text-muted-foreground"
+        )}
+        id={`${id}-linear`}
+        onClick={() => onScaleChange("linear")}
+        size="sm"
+        type="button"
+        variant="ghost"
       >
-        Linear scale
-      </span>
-      <Switch
+        Linear
+      </Button>
+      <Button
         aria-label="Use a logarithmic deposit axis"
-        checked={isLog}
+        aria-pressed={scale === "log"}
+        className={cn(
+          "h-7 rounded-md px-2.5 text-xs shadow-none",
+          scale === "log"
+            ? "bg-background text-foreground shadow-xs hover:bg-background"
+            : "text-muted-foreground"
+        )}
         id={id}
-        onCheckedChange={(checked) => onScaleChange(checked ? "log" : "linear")}
-      />
-      <span
-        className={
-          isLog ? "font-medium text-foreground" : "text-muted-foreground"
-        }
+        onClick={() => onScaleChange("log")}
+        size="sm"
+        type="button"
+        variant="ghost"
       >
-        Log scale
-      </span>
+        Log
+      </Button>
     </div>
   );
 }

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -446,7 +446,7 @@ export function EarnVaultRebalanceFrequencyChart({
                 zero by design.
               </CardDescription>
             </div>
-            <div className="flex flex-wrap items-center gap-3">
+            <div className="flex shrink-0 flex-wrap items-center gap-3">
               <RouteModeSwitch
                 id="vault-rebalance-frequency-route-mode"
                 mode={routeMode}
@@ -481,7 +481,13 @@ export function EarnVaultRebalanceFrequencyChart({
             />
           </div>
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
-            {eligibilityFloorRaw === null ? (
+            {points.length === 0 ? (
+              <span className="font-medium text-foreground">
+                {routeMode === "cross_mint"
+                  ? "No enabled Crossmint vaults"
+                  : "No funded active Earn vaults"}
+              </span>
+            ) : eligibilityFloorRaw === null ? (
               <span>
                 {rebalancedVaultCount.toLocaleString("en-US")} of{" "}
                 {points.length.toLocaleString("en-US")} funded vaults rebalanced
@@ -493,11 +499,13 @@ export function EarnVaultRebalanceFrequencyChart({
                 vaults rebalanced
               </span>
             )}
-            <span>
-              {points.length.toLocaleString("en-US")} funded vaults ·{" "}
-              {rebalancedVaultCount.toLocaleString("en-US")} with rebalances
-            </span>
-            {eligibilityFloorRaw === null ? null : (
+            {points.length > 0 ? (
+              <span>
+                {points.length.toLocaleString("en-US")} funded vaults ·{" "}
+                {rebalancedVaultCount.toLocaleString("en-US")} with rebalances
+              </span>
+            ) : null}
+            {points.length === 0 || eligibilityFloorRaw === null ? null : (
               <span>
                 Eligible at{" "}
                 {formatDeposit(
@@ -507,10 +515,12 @@ export function EarnVaultRebalanceFrequencyChart({
                 +
               </span>
             )}
-            <span>
-              {totalRebalances.toLocaleString("en-US")} confirmed executions ·{" "}
-              {rangeOption.label}
-            </span>
+            {points.length > 0 ? (
+              <span>
+                {totalRebalances.toLocaleString("en-US")} confirmed executions ·{" "}
+                {rangeOption.label}
+              </span>
+            ) : null}
             <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
@@ -536,7 +546,9 @@ export function EarnVaultRebalanceFrequencyChart({
               <CardContent className="min-w-0">
                 {points.length === 0 ? (
                   <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-                    No funded active Earn vaults are available.
+                    {routeMode === "cross_mint"
+                      ? "Crossmint is not enabled for any active Earn vault."
+                      : "No funded active Earn vaults are available."}
                   </div>
                 ) : showTable ? (
                   <div className="max-h-[460px] overflow-auto rounded-md border">
@@ -687,19 +699,21 @@ export function EarnVaultRebalanceFrequencyChart({
                     </ScatterChart>
                   </ChartContainer>
                 )}
-                <p className="mt-3 text-xs text-muted-foreground">
-                  {maxCount === 0
-                    ? "No confirmed rebalances occurred in this window; every vault is shown at zero."
-                    : "Hover a dot for the exact vault, current deposit, reserve APY, and counts for every window."}
-                  {showTable
-                    ? " The table shows the 100 largest current deposits."
-                    : " Idle-only vaults use the neutral legend color."}
-                  {!showTable && useLogScale && zeroDepositCount > 0
-                    ? ` ${zeroDepositCount.toLocaleString("en-US")} vault${
-                        zeroDepositCount === 1 ? "" : "s"
-                      } with a zero deposit sit on the axis floor.`
-                    : ""}
-                </p>
+                {points.length > 0 ? (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {maxCount === 0
+                      ? "No confirmed rebalances occurred in this window; every vault is shown at zero."
+                      : "Hover a dot for the exact vault, current deposit, reserve APY, and counts for every window."}
+                    {showTable
+                      ? " The table shows the 100 largest current deposits."
+                      : " Idle-only vaults use the neutral legend color."}
+                    {!showTable && useLogScale && zeroDepositCount > 0
+                      ? ` ${zeroDepositCount.toLocaleString("en-US")} vault${
+                          zeroDepositCount === 1 ? "" : "s"
+                        } with a zero deposit sit on the axis floor.`
+                      : ""}
+                  </p>
+                ) : null}
               </CardContent>
             ) : null}
           </TabsContent>

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -451,39 +451,37 @@ export function EarnVaultRebalanceFrequencyChart({
               mode={routeMode}
               onModeChange={setRouteMode}
             />
-            <TabsList
-              aria-label="Vault rebalance frequency window"
-              className="w-fit max-w-full"
-            >
-              {RANGE_OPTIONS.map((option) => (
-                <TabsTrigger key={option.key} value={option.key}>
-                  {option.tabLabel}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            <DepositScaleSwitch
-              id="vault-rebalance-frequency-scale"
-              onScaleChange={setScale}
-              scale={scale}
-            />
-            <Button
-              aria-pressed={showTable}
-              onClick={() => setShowTable((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showTable ? "secondary" : "outline"}
-            >
-              Table
-            </Button>
+            {points.length > 0 ? (
+              <>
+                <TabsList
+                  aria-label="Vault rebalance frequency window"
+                  className="w-fit max-w-full"
+                >
+                  {RANGE_OPTIONS.map((option) => (
+                    <TabsTrigger key={option.key} value={option.key}>
+                      {option.tabLabel}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                <DepositScaleSwitch
+                  id="vault-rebalance-frequency-scale"
+                  onScaleChange={setScale}
+                  scale={scale}
+                />
+                <Button
+                  aria-pressed={showTable}
+                  onClick={() => setShowTable((value) => !value)}
+                  size="sm"
+                  type="button"
+                  variant={showTable ? "secondary" : "outline"}
+                >
+                  Table
+                </Button>
+              </>
+            ) : null}
           </div>
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
-            {points.length === 0 ? (
-              <span className="font-medium text-foreground">
-                {routeMode === "cross_mint"
-                  ? "No enabled Crossmint vaults"
-                  : "No funded active Earn vaults"}
-              </span>
-            ) : eligibilityFloorRaw === null ? (
+            {points.length === 0 ? null : eligibilityFloorRaw === null ? (
               <span>
                 {rebalancedVaultCount.toLocaleString("en-US")} of{" "}
                 {points.length.toLocaleString("en-US")} funded vaults rebalanced
@@ -541,9 +539,9 @@ export function EarnVaultRebalanceFrequencyChart({
             {range === option.key ? (
               <CardContent className="min-w-0">
                 {points.length === 0 ? (
-                  <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+                  <div className="flex min-h-40 items-center justify-center rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
                     {routeMode === "cross_mint"
-                      ? "Crossmint is not enabled for any active Earn vault."
+                      ? "No active Earn vaults have Crossmint enabled."
                       : "No funded active Earn vaults are available."}
                   </div>
                 ) : showTable ? (

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -425,6 +425,7 @@ export function EarnVaultRebalanceFrequencyChart({
   return (
     <Card className="min-w-0" aria-labelledby="vault-rebalance-frequency-title">
       <Tabs
+        className="gap-6"
         value={range}
         onValueChange={(value) => setRange(value as RangeKey)}
       >

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -40,14 +40,13 @@ import {
 import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
 import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
-import {
-  DepositScaleSwitch,
-  type DepositScale,
-} from "./deposit-scale-switch";
+import { DepositScaleSwitch, type DepositScale } from "./deposit-scale-switch";
 import {
   computeRebalanceEligibilityFloorRaw,
   summarizeRebalanceEligibility,
 } from "./earn-vault-rebalance-eligibility";
+import type { RebalanceRouteMode } from "./rebalance-data";
+import { RouteModeSwitch } from "./route-mode-switch";
 
 const NO_RESERVE_KEY = "__no_current_reserve__";
 const RESERVE_COLORS = [
@@ -73,6 +72,7 @@ export type SerializedEarnVaultRebalanceFrequencyRow = {
   opportunity7dCount: number;
   opportunityAllCount: number;
   positionCount: number;
+  routeMode: RebalanceRouteMode;
   vaultId: string;
   vaultPubkey: string;
 };
@@ -274,6 +274,7 @@ export function EarnVaultRebalanceFrequencyChart({
   reserveStatuses: SafeReserveApyStatusRow[];
 }) {
   const [range, setRange] = useState<RangeKey>("all");
+  const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
   const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
 
@@ -282,6 +283,7 @@ export function EarnVaultRebalanceFrequencyChart({
   const rankedVaults = useMemo(
     () =>
       [...data.vaults]
+        .filter((vault) => vault.routeMode === routeMode)
         .sort((left, right) => {
           const amountOrder = compareRawAmounts(
             left.currentDepositRaw,
@@ -295,7 +297,7 @@ export function EarnVaultRebalanceFrequencyChart({
           ...vault,
           depositRank: index + 1,
         })),
-    [data.vaults]
+    [data.vaults, routeMode]
   );
   const points = useMemo(
     () =>
@@ -398,8 +400,7 @@ export function EarnVaultRebalanceFrequencyChart({
   const zeroDepositCount = points.length - positiveDeposits.length;
   const scatterPoints = points.map((point) => ({
     ...point,
-    plottedDeposit:
-      point.depositAmount > 0 ? point.depositAmount : logFloor,
+    plottedDeposit: point.depositAmount > 0 ? point.depositAmount : logFloor,
   }));
 
   if (data.status === "unavailable") {
@@ -434,23 +435,33 @@ export function EarnVaultRebalanceFrequencyChart({
                 Earn vault rebalance frequency
               </CardTitle>
               <CardDescription>
-                One dot per funded active vault. X is the current deposit, on a
-                log or linear scale; Y shows confirmed reserve-to-reserve
+                One dot per funded active{" "}
+                {routeMode === "cross_mint" ? "Crossmint-enrolled" : "Earn"}{" "}
+                vault. X is the current deposit, on a log or linear scale; Y
+                shows confirmed{" "}
+                {routeMode === "cross_mint" ? "Crossmint" : "same-mint"}{" "}
                 rebalances in the selected window. Dot color is the largest
                 current reserve position. Vaults below the eligibility floor
                 cannot clear the planner&rsquo;s economic gate, so they sit at
                 zero by design.
               </CardDescription>
             </div>
-            <Button
-              aria-pressed={showTable}
-              onClick={() => setShowTable((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showTable ? "secondary" : "outline"}
-            >
-              Table
-            </Button>
+            <div className="flex flex-wrap items-center gap-3">
+              <RouteModeSwitch
+                id="vault-rebalance-frequency-route-mode"
+                mode={routeMode}
+                onModeChange={setRouteMode}
+              />
+              <Button
+                aria-pressed={showTable}
+                onClick={() => setShowTable((value) => !value)}
+                size="sm"
+                type="button"
+                variant={showTable ? "secondary" : "outline"}
+              >
+                Table
+              </Button>
+            </div>
           </div>
           <div className="flex flex-wrap items-center gap-3">
             <TabsList

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -430,41 +430,27 @@ export function EarnVaultRebalanceFrequencyChart({
         onValueChange={(value) => setRange(value as RangeKey)}
       >
         <CardHeader className="gap-3">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-            <div>
-              <CardTitle id="vault-rebalance-frequency-title">
-                Earn vault rebalance frequency
-              </CardTitle>
-              <CardDescription>
-                One dot per funded active{" "}
-                {routeMode === "cross_mint" ? "Crossmint-enrolled" : "Earn"}{" "}
-                vault. X is the current deposit, on a log or linear scale; Y
-                shows confirmed{" "}
-                {routeMode === "cross_mint" ? "Crossmint" : "same-mint"}{" "}
-                rebalances in the selected window. Dot color is the largest
-                current reserve position. Vaults below the eligibility floor
-                cannot clear the planner&rsquo;s economic gate, so they sit at
-                zero by design.
-              </CardDescription>
-            </div>
-            <div className="flex shrink-0 flex-wrap items-center gap-3">
-              <RouteModeSwitch
-                id="vault-rebalance-frequency-route-mode"
-                mode={routeMode}
-                onModeChange={setRouteMode}
-              />
-              <Button
-                aria-pressed={showTable}
-                onClick={() => setShowTable((value) => !value)}
-                size="sm"
-                type="button"
-                variant={showTable ? "secondary" : "outline"}
-              >
-                Table
-              </Button>
-            </div>
+          <div>
+            <CardTitle id="vault-rebalance-frequency-title">
+              Earn vault rebalance frequency
+            </CardTitle>
+            <CardDescription>
+              One dot per funded active{" "}
+              {routeMode === "cross_mint" ? "Crossmint-enrolled" : "Earn"}{" "}
+              vault. X is the current deposit, on a log or linear scale; Y shows
+              confirmed {routeMode === "cross_mint" ? "Crossmint" : "same-mint"}{" "}
+              rebalances in the selected window. Dot color is the largest
+              current reserve position. Vaults below the eligibility floor
+              cannot clear the planner&rsquo;s economic gate, so they sit at
+              zero by design.
+            </CardDescription>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <RouteModeSwitch
+              id="vault-rebalance-frequency-route-mode"
+              mode={routeMode}
+              onModeChange={setRouteMode}
+            />
             <TabsList
               aria-label="Vault rebalance frequency window"
               className="w-fit max-w-full"
@@ -480,6 +466,15 @@ export function EarnVaultRebalanceFrequencyChart({
               onScaleChange={setScale}
               scale={scale}
             />
+            <Button
+              aria-pressed={showTable}
+              onClick={() => setShowTable((value) => !value)}
+              size="sm"
+              type="button"
+              variant={showTable ? "secondary" : "outline"}
+            >
+              Table
+            </Button>
           </div>
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
             {points.length === 0 ? (

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -335,41 +335,45 @@ export function ExecutedEarnRebalancesChart({
               deposit, on a log or linear scale. Times are UTC.
             </CardDescription>
           </div>
-          <div
-            className="flex flex-wrap gap-1"
-            aria-label="Execution history range"
-          >
-            {(["7d", "30d", "all"] as const).map((value) => (
+          <div className="flex shrink-0 flex-col gap-2 lg:items-end">
+            <div
+              className="flex flex-wrap gap-1"
+              aria-label="Execution history range"
+            >
+              {(["7d", "30d", "all"] as const).map((value) => (
+                <Button
+                  aria-pressed={range === value}
+                  key={value}
+                  onClick={() => setRange(value)}
+                  size="sm"
+                  type="button"
+                  variant={range === value ? "secondary" : "outline"}
+                >
+                  {value === "all" ? "All" : value}
+                </Button>
+              ))}
               <Button
-                aria-pressed={range === value}
-                key={value}
-                onClick={() => setRange(value)}
+                aria-pressed={showTable}
+                onClick={() => setShowTable((value) => !value)}
                 size="sm"
                 type="button"
-                variant={range === value ? "secondary" : "outline"}
+                variant={showTable ? "secondary" : "outline"}
               >
-                {value === "all" ? "All" : value}
+                Table
               </Button>
-            ))}
-            <Button
-              aria-pressed={showTable}
-              onClick={() => setShowTable((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showTable ? "secondary" : "outline"}
-            >
-              Table
-            </Button>
-            <RouteModeSwitch
-              id="executed-earn-rebalances-route-mode"
-              mode={routeMode}
-              onModeChange={setRouteMode}
-            />
-            <DepositScaleSwitch
-              id="executed-earn-rebalances-scale"
-              onScaleChange={setScale}
-              scale={scale}
-            />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <RouteModeSwitch
+                id="executed-earn-rebalances-route-mode"
+                mode={routeMode}
+                onModeChange={setRouteMode}
+              />
+              <DepositScaleSwitch
+                id="executed-earn-rebalances-scale"
+                onScaleChange={setScale}
+                scale={scale}
+              />
+            </div>
           </div>
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
@@ -406,7 +410,9 @@ export function ExecutedEarnRebalancesChart({
       <CardContent className="min-w-0">
         {points.length === 0 ? (
           <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-            No confirmed Earn rebalances are available.
+            No confirmed{" "}
+            {routeMode === "cross_mint" ? "Crossmint" : "same-mint"} Earn
+            rebalances are available.
           </div>
         ) : showTable ? (
           <div className="max-h-[420px] overflow-auto rounded-md border">

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -335,23 +335,36 @@ export function ExecutedEarnRebalancesChart({
               deposit, on a log or linear scale. Times are UTC.
             </CardDescription>
           </div>
-          <div className="flex shrink-0 flex-col gap-2 lg:items-end">
-            <div
-              className="flex flex-wrap gap-1"
-              aria-label="Execution history range"
-            >
-              {(["7d", "30d", "all"] as const).map((value) => (
-                <Button
-                  aria-pressed={range === value}
-                  key={value}
-                  onClick={() => setRange(value)}
-                  size="sm"
-                  type="button"
-                  variant={range === value ? "secondary" : "outline"}
-                >
-                  {value === "all" ? "All" : value}
-                </Button>
-              ))}
+          <div className="flex shrink-0 flex-col items-start gap-2 lg:items-end">
+            <RouteModeSwitch
+              id="executed-earn-rebalances-route-mode"
+              mode={routeMode}
+              onModeChange={setRouteMode}
+            />
+            <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+              <div
+                aria-label="Execution history range"
+                className="inline-flex items-center rounded-lg bg-muted p-1"
+                role="group"
+              >
+                {(["7d", "30d", "all"] as const).map((value) => (
+                  <Button
+                    aria-pressed={range === value}
+                    className={
+                      range === value
+                        ? "h-7 bg-background px-2.5 text-xs shadow-xs hover:bg-background"
+                        : "h-7 px-2.5 text-xs text-muted-foreground shadow-none"
+                    }
+                    key={value}
+                    onClick={() => setRange(value)}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    {value === "all" ? "All" : value}
+                  </Button>
+                ))}
+              </div>
               <Button
                 aria-pressed={showTable}
                 onClick={() => setShowTable((value) => !value)}
@@ -362,18 +375,13 @@ export function ExecutedEarnRebalancesChart({
                 Table
               </Button>
             </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <RouteModeSwitch
-                id="executed-earn-rebalances-route-mode"
-                mode={routeMode}
-                onModeChange={setRouteMode}
-              />
+            {showTable ? null : (
               <DepositScaleSwitch
                 id="executed-earn-rebalances-scale"
                 onScaleChange={setScale}
                 scale={scale}
               />
-            </div>
+            )}
           </div>
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -38,10 +38,9 @@ import {
 } from "@/lib/earn/stablecoin-monitor.shared";
 
 import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
-import {
-  DepositScaleSwitch,
-  type DepositScale,
-} from "./deposit-scale-switch";
+import { DepositScaleSwitch, type DepositScale } from "./deposit-scale-switch";
+import type { RebalanceRouteMode } from "./rebalance-data";
+import { RouteModeSwitch } from "./route-mode-switch";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const SOURCE_COLORS = [
@@ -60,8 +59,12 @@ export type SerializedExecutedEarnRebalanceRow = {
   executedAt: string;
   id: string;
   liquidityMint: string | null;
+  routeMode: RebalanceRouteMode;
   sourceReserve: string;
+  sourceLiquidityMint: string | null;
+  swapFeeLamports: string;
   targetReserve: string;
+  targetLiquidityMint: string | null;
   userRank: number;
 };
 
@@ -78,7 +81,6 @@ type ChartPoint = SerializedExecutedEarnRebalanceRow & {
 };
 
 type RangeKey = "7d" | "30d" | "all";
-
 
 function formatUtcTimestamp(value: number | string): string {
   const date = new Date(value);
@@ -131,6 +133,10 @@ function formatCompactStablecoinRaw(raw: string): string {
   }).format(amount)}`;
 }
 
+function formatSwapFee(raw: string): string {
+  return `${(Number(BigInt(raw)) / 1_000_000_000).toFixed(6)} SOL`;
+}
+
 function rangeLabel(range: RangeKey): string {
   if (range === "7d") {
     return "Last 7 days";
@@ -173,8 +179,27 @@ function ExecutedRebalanceTooltip({
       <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1">
         <dt className="text-muted-foreground">Executed</dt>
         <dd className="text-right font-medium tabular-nums">
-          {formatStablecoinRaw(point.amountRaw, point.liquidityMint)}
+          {formatStablecoinRaw(
+            point.amountRaw,
+            point.routeMode === "cross_mint"
+              ? point.sourceLiquidityMint
+              : point.liquidityMint
+          )}
         </dd>
+        {point.routeMode === "cross_mint" ? (
+          <>
+            <dt className="text-muted-foreground">Swap pair</dt>
+            <dd className="text-right font-medium">
+              {getEarnStablecoinSymbol(point.sourceLiquidityMint) ?? "Unknown"}{" "}
+              →{" "}
+              {getEarnStablecoinSymbol(point.targetLiquidityMint) ?? "Unknown"}
+            </dd>
+            <dt className="text-muted-foreground">Swap fee</dt>
+            <dd className="text-right font-medium tabular-nums">
+              {formatSwapFee(point.swapFeeLamports)}
+            </dd>
+          </>
+        ) : null}
         <dt className="text-muted-foreground">User deposit now</dt>
         <dd className="text-right font-medium tabular-nums">
           {formatStablecoinRaw(point.currentDepositRaw, null)}
@@ -200,12 +225,14 @@ export function ExecutedEarnRebalancesChart({
   reserveLabels: ReadonlyMap<string, string>;
 }) {
   const [range, setRange] = useState<RangeKey>("all");
+  const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
   const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
 
   const points = useMemo(
     () =>
       data.executions
+        .filter((execution) => execution.routeMode === routeMode)
         .map((execution) => ({
           ...execution,
           depositAmount:
@@ -214,7 +241,7 @@ export function ExecutedEarnRebalancesChart({
           executedAtMs: Date.parse(execution.executedAt),
         }))
         .filter((execution) => Number.isFinite(execution.executedAtMs)),
-    [data.executions]
+    [data.executions, routeMode]
   );
 
   const filteredPoints = useMemo(() => {
@@ -245,30 +272,8 @@ export function ExecutedEarnRebalancesChart({
     ])
   ) satisfies ChartConfig;
 
-  const userByRank = new Map(
-    points.map((point) => [
-      point.userRank,
-      {
-        currentDepositRaw: point.currentDepositRaw,
-      },
-    ])
-  );
-  const yTicks = Array.from(
-    new Set(
-      Array.from(
-        { length: Math.min(7, Math.max(data.userCount, 1)) },
-        (_, index) =>
-          Math.max(
-            1,
-            Math.round(
-              1 +
-                (index * Math.max(data.userCount - 1, 0)) /
-                  Math.max(Math.min(7, data.userCount) - 1, 1)
-            )
-          )
-      )
-    )
-  );
+  const distinctUserCount = new Set(points.map((point) => point.authority))
+    .size;
   const positiveDeposits = filteredPoints
     .map((point) => point.depositAmount)
     .filter((amount) => amount > 0 && Number.isFinite(amount));
@@ -288,10 +293,13 @@ export function ExecutedEarnRebalancesChart({
     positiveDeposits.length > 0 ? Math.max(...positiveDeposits) : 1;
   const scatterPoints = filteredPoints.map((point) => ({
     ...point,
-    logDepositAmount:
-      point.depositAmount > 0 ? point.depositAmount : logFloor,
+    logDepositAmount: point.depositAmount > 0 ? point.depositAmount : logFloor,
   }));
   const tableRows = [...filteredPoints].reverse().slice(0, 50);
+  const swapFeeLamports = points.reduce(
+    (total, point) => total + BigInt(point.swapFeeLamports),
+    BigInt(0)
+  );
 
   if (data.status === "unavailable") {
     return (
@@ -321,9 +329,10 @@ export function ExecutedEarnRebalancesChart({
               Executed Earn rebalances
             </CardTitle>
             <CardDescription>
-              One dot per confirmed reserve-to-reserve decision. Y is the
-              user&rsquo;s current Earn deposit, on a log or linear scale. Times
-              are UTC.
+              One dot per confirmed{" "}
+              {routeMode === "cross_mint" ? "Crossmint" : "same-mint"}{" "}
+              reserve-to-reserve decision. Y is the user&rsquo;s current Earn
+              deposit, on a log or linear scale. Times are UTC.
             </CardDescription>
           </div>
           <div
@@ -351,6 +360,11 @@ export function ExecutedEarnRebalancesChart({
             >
               Table
             </Button>
+            <RouteModeSwitch
+              id="executed-earn-rebalances-route-mode"
+              mode={routeMode}
+              onModeChange={setRouteMode}
+            />
             <DepositScaleSwitch
               id="executed-earn-rebalances-scale"
               onScaleChange={setScale}
@@ -360,15 +374,21 @@ export function ExecutedEarnRebalancesChart({
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
           <span>
-            {data.executions.length.toLocaleString("en-US")} confirmed
-            executions
+            {points.length.toLocaleString("en-US")} confirmed executions
           </span>
-          <span>{data.userCount.toLocaleString("en-US")} distinct users</span>
+          <span>
+            {distinctUserCount.toLocaleString("en-US")} distinct users
+          </span>
           <span>
             {filteredPoints.length.toLocaleString("en-US")} shown ·{" "}
             {rangeLabel(range)}
           </span>
           <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
+          {routeMode === "cross_mint" ? (
+            <span className="font-medium text-foreground">
+              {formatSwapFee(swapFeeLamports.toString())} finalized swap fees
+            </span>
+          ) : null}
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
           {sources.map((source) => (
@@ -395,11 +415,21 @@ export function ExecutedEarnRebalancesChart({
                 <TableRow>
                   <TableHead>Executed (UTC)</TableHead>
                   <TableHead>User</TableHead>
-                  <TableHead>Mint</TableHead>
+                  {routeMode === "cross_mint" ? (
+                    <>
+                      <TableHead>Source mint</TableHead>
+                      <TableHead>Target mint</TableHead>
+                    </>
+                  ) : (
+                    <TableHead>Mint</TableHead>
+                  )}
                   <TableHead>Route</TableHead>
                   <TableHead>Decision</TableHead>
                   <TableHead className="text-right">Confirmed slot</TableHead>
                   <TableHead className="text-right">Amount</TableHead>
+                  {routeMode === "cross_mint" ? (
+                    <TableHead className="text-right">Swap fee</TableHead>
+                  ) : null}
                   <TableHead className="text-right">Current deposit</TableHead>
                 </TableRow>
               </TableHeader>
@@ -412,10 +442,23 @@ export function ExecutedEarnRebalancesChart({
                     <TableCell className="whitespace-nowrap font-mono">
                       {formatShortAddress(point.authority)} · {point.userRank}
                     </TableCell>
-                    <TableCell className="font-medium">
-                      {getEarnStablecoinSymbol(point.liquidityMint) ??
-                        "Unknown"}
-                    </TableCell>
+                    {routeMode === "cross_mint" ? (
+                      <>
+                        <TableCell className="font-medium">
+                          {getEarnStablecoinSymbol(point.sourceLiquidityMint) ??
+                            "Unknown"}
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          {getEarnStablecoinSymbol(point.targetLiquidityMint) ??
+                            "Unknown"}
+                        </TableCell>
+                      </>
+                    ) : (
+                      <TableCell className="font-medium">
+                        {getEarnStablecoinSymbol(point.liquidityMint) ??
+                          "Unknown"}
+                      </TableCell>
+                    )}
                     <TableCell className="whitespace-nowrap">
                       {reserveLabels.get(point.sourceReserve) ??
                         formatShortAddress(point.sourceReserve)}{" "}
@@ -432,9 +475,16 @@ export function ExecutedEarnRebalancesChart({
                     <TableCell className="text-right whitespace-nowrap tabular-nums">
                       {formatStablecoinRaw(
                         point.amountRaw,
-                        point.liquidityMint
+                        point.routeMode === "cross_mint"
+                          ? point.sourceLiquidityMint
+                          : point.liquidityMint
                       )}
                     </TableCell>
+                    {routeMode === "cross_mint" ? (
+                      <TableCell className="text-right whitespace-nowrap tabular-nums">
+                        {formatSwapFee(point.swapFeeLamports)}
+                      </TableCell>
+                    ) : null}
                     <TableCell className="text-right whitespace-nowrap tabular-nums">
                       {formatStablecoinRaw(point.currentDepositRaw, null)}
                     </TableCell>

--- a/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
@@ -83,7 +83,7 @@ export function Last30DaysRebalanceChart({
     { confirmed: 0, failed: 0 }
   );
   return (
-    <Card className="w-full py-4 sm:py-0">
+    <Card className="w-full gap-0 py-0">
       <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">
@@ -116,7 +116,7 @@ export function Last30DaysRebalanceChart({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="px-2 pt-6 sm:p-6">
+      <CardContent className="p-4 sm:p-6">
         <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 px-2 text-xs text-muted-foreground">
           {Object.entries(chartConfig).map(([key, config]) => (
             <span className="flex items-center gap-1.5" key={key}>

--- a/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { CartesianGrid, Label, Line, LineChart, XAxis, YAxis } from "recharts";
 
 import {
@@ -17,6 +18,7 @@ import {
 } from "@/components/ui/chart";
 
 import type { Last30DaysRebalancePoint } from "./rebalance-data";
+import { RouteModeSwitch } from "./route-mode-switch";
 
 const chartConfig = {
   confirmed: {
@@ -70,7 +72,10 @@ export function Last30DaysRebalanceChart({
 }: {
   data: Last30DaysRebalancePoint[];
 }) {
-  const totals = data.reduce(
+  const [routeMode, setRouteMode] =
+    useState<Last30DaysRebalancePoint["routeMode"]>("same_mint");
+  const visibleData = data.filter((point) => point.routeMode === routeMode);
+  const totals = visibleData.reduce(
     (result, point) => ({
       confirmed: result.confirmed + point.confirmed,
       failed: result.failed + point.failed,
@@ -85,10 +90,16 @@ export function Last30DaysRebalanceChart({
             Last 30 days of rebalance outcomes
           </CardTitle>
           <CardDescription>
-            Daily terminal same-mint decisions for the current UTC day and the
-            preceding 29 calendar days. Today is partial. Render-only errors are
-            not included.
+            Daily terminal{" "}
+            {routeMode === "cross_mint" ? "Crossmint" : "same-mint"} decisions
+            for the current UTC day and the preceding 29 calendar days. Today is
+            partial. Render-only errors are not included.
           </CardDescription>
+          <RouteModeSwitch
+            id="last-30-days-rebalance-route-mode"
+            mode={routeMode}
+            onModeChange={setRouteMode}
+          />
         </div>
         <div className="flex">
           <div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-t-0 sm:border-l sm:px-8 sm:py-6">
@@ -124,7 +135,7 @@ export function Last30DaysRebalanceChart({
         >
           <LineChart
             accessibilityLayer
-            data={data}
+            data={visibleData}
             margin={{ bottom: 24, left: 8, right: 16, top: 8 }}
           >
             <CartesianGrid vertical={false} />

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -329,7 +329,7 @@ export function RebalanceActivityChart({
       : BigInt(0);
 
   return (
-    <Card className="w-full py-4 sm:py-0">
+    <Card className="w-full gap-0 py-0">
       <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">Rebalance activity</CardTitle>
@@ -363,7 +363,7 @@ export function RebalanceActivityChart({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="px-2 pt-6 sm:p-6">
+      <CardContent className="p-4 sm:p-6">
         {routeMode === "cross_mint" ? (
           <div className="mb-5 grid gap-3 px-2 text-xs text-muted-foreground sm:grid-cols-3">
             <span>

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -266,6 +266,9 @@ function SwapFeeTimeSeries({
               <ChartTooltipContent
                 className="min-w-[190px]"
                 labelFormatter={formatTooltipDate}
+                valueFormatter={(value) =>
+                  typeof value === "number" ? `${value.toFixed(6)} SOL` : value
+                }
               />
             }
           />

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { CartesianGrid, Label, Line, LineChart, XAxis, YAxis } from "recharts";
 
 import {
@@ -17,6 +18,15 @@ import {
 } from "@/components/ui/chart";
 
 import type { RebalanceActivityPoint } from "./rebalance-data";
+import { RouteModeSwitch } from "./route-mode-switch";
+
+type SerializedRebalanceActivityPoint = Omit<
+  RebalanceActivityPoint,
+  "maxSwapFeeLamports" | "swapFeeLamports"
+> & {
+  maxSwapFeeLamports: string;
+  swapFeeLamports: string;
+};
 
 const chartConfig = {
   confirmed: {
@@ -53,6 +63,21 @@ const activitySeries = [
   { key: "failedOpportunities", yAxisId: "events" },
   { key: "expiredSubmissions", yAxisId: "events" },
 ] as const;
+
+const swapFeeChartConfig = {
+  maxSwapFeeSol: {
+    color: "var(--chart-5)",
+    label: "Largest swap fee",
+  },
+  swapFeeSol: {
+    color: "var(--chart-2)",
+    label: "Total swap fees",
+  },
+} satisfies ChartConfig;
+
+function formatSol(value: bigint) {
+  return `${(Number(value) / 1_000_000_000).toFixed(6)} SOL`;
+}
 
 function formatTickDate(value: unknown) {
   if (typeof value !== "string") {
@@ -94,7 +119,11 @@ function formatTooltipDate(value: unknown) {
   }).format(date);
 }
 
-function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
+function ActivityTimeSeries({
+  data,
+}: {
+  data: SerializedRebalanceActivityPoint[];
+}) {
   return (
     <div className="min-w-0 space-y-2">
       <div className="flex flex-wrap items-center justify-between gap-2 px-2 text-xs">
@@ -174,22 +203,127 @@ function ActivityTimeSeries({ data }: { data: RebalanceActivityPoint[] }) {
   );
 }
 
+function SwapFeeTimeSeries({
+  data,
+}: {
+  data: SerializedRebalanceActivityPoint[];
+}) {
+  const feeData = data.map((point) => ({
+    ...point,
+    maxSwapFeeSol: Number(BigInt(point.maxSwapFeeLamports)) / 1_000_000_000,
+    swapFeeSol: Number(BigInt(point.swapFeeLamports)) / 1_000_000_000,
+  }));
+
+  return (
+    <div className="min-w-0 space-y-2 border-t pt-5">
+      <div className="flex flex-wrap items-center justify-between gap-2 px-2 text-xs">
+        <span className="font-medium text-muted-foreground">
+          Finalized swap fees
+        </span>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
+          {Object.entries(swapFeeChartConfig).map(([key, config]) => (
+            <span className="flex items-center gap-1.5" key={key}>
+              <span
+                aria-hidden
+                className="h-0.5 w-3 rounded-full"
+                style={{ backgroundColor: config.color }}
+              />
+              {config.label}
+            </span>
+          ))}
+        </div>
+      </div>
+      <ChartContainer
+        className="aspect-auto h-[220px] w-full min-w-0"
+        config={swapFeeChartConfig}
+      >
+        <LineChart
+          accessibilityLayer
+          data={feeData}
+          margin={{ bottom: 20, left: 8, right: 12, top: 8 }}
+        >
+          <CartesianGrid vertical={false} />
+          <XAxis
+            axisLine={false}
+            dataKey="bucketStartedAt"
+            minTickGap={36}
+            tickFormatter={formatTickDate}
+            tickLine={false}
+            tickMargin={8}
+          >
+            <Label offset={-14} position="insideBottom" value="Time (UTC)" />
+          </XAxis>
+          <YAxis
+            allowDecimals
+            axisLine={false}
+            domain={[0, (maximum: number) => Math.max(0.000001, maximum)]}
+            tickFormatter={(value: number) => value.toFixed(6)}
+            tickLine={false}
+            width={68}
+          />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                className="min-w-[190px]"
+                labelFormatter={formatTooltipDate}
+              />
+            }
+          />
+          <Line
+            dataKey="swapFeeSol"
+            dot={false}
+            stroke="var(--color-swapFeeSol)"
+            strokeWidth={2}
+            type="linear"
+          />
+          <Line
+            dataKey="maxSwapFeeSol"
+            dot={false}
+            stroke="var(--color-maxSwapFeeSol)"
+            strokeWidth={2}
+            type="linear"
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  );
+}
+
 export function RebalanceActivityChart({
   data,
 }: {
-  data: RebalanceActivityPoint[];
+  data: SerializedRebalanceActivityPoint[];
 }) {
-  const totals = data.reduce(
+  const [routeMode, setRouteMode] =
+    useState<RebalanceActivityPoint["routeMode"]>("same_mint");
+  const visibleData = data.filter((point) => point.routeMode === routeMode);
+  const totals = visibleData.reduce(
     (result, point) => ({
       confirmed: result.confirmed + point.confirmed,
+      finalizedSwapLegs: result.finalizedSwapLegs + point.finalizedSwapLegs,
       failures:
         result.failures +
         point.failedDecisions +
         point.failedOpportunities +
         point.expiredSubmissions,
+      maxSwapFeeLamports:
+        BigInt(point.maxSwapFeeLamports) > result.maxSwapFeeLamports
+          ? BigInt(point.maxSwapFeeLamports)
+          : result.maxSwapFeeLamports,
+      swapFeeLamports: result.swapFeeLamports + BigInt(point.swapFeeLamports),
     }),
-    { confirmed: 0, failures: 0 }
+    {
+      confirmed: 0,
+      finalizedSwapLegs: 0,
+      failures: 0,
+      maxSwapFeeLamports: BigInt(0),
+      swapFeeLamports: BigInt(0),
+    }
   );
+  const averageSwapFeeLamports =
+    totals.finalizedSwapLegs > 0
+      ? totals.swapFeeLamports / BigInt(totals.finalizedSwapLegs)
+      : BigInt(0);
 
   return (
     <Card className="w-full py-4 sm:py-0">
@@ -197,10 +331,17 @@ export function RebalanceActivityChart({
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-4 sm:py-6">
           <CardTitle className="font-bold">Rebalance activity</CardTitle>
           <CardDescription>
-            Last 72 hours in two-hour UTC buckets from Yield Neon. Fleet claims
-            use the right axis; all other series use the left axis. Render-only
+            Last 72 hours of{" "}
+            {routeMode === "cross_mint" ? "Crossmint" : "same-mint"} activity in
+            two-hour UTC buckets from Yield Neon. Fleet claims use the right
+            axis; all other activity series use the left axis. Render-only
             errors are not included.
           </CardDescription>
+          <RouteModeSwitch
+            id="rebalance-activity-route-mode"
+            mode={routeMode}
+            onModeChange={setRouteMode}
+          />
         </div>
         <div className="flex">
           <div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-t-0 sm:border-l sm:px-8 sm:py-6">
@@ -220,7 +361,32 @@ export function RebalanceActivityChart({
         </div>
       </CardHeader>
       <CardContent className="px-2 pt-6 sm:p-6">
-        <ActivityTimeSeries data={data} />
+        {routeMode === "cross_mint" ? (
+          <div className="mb-5 grid gap-3 px-2 text-xs text-muted-foreground sm:grid-cols-3">
+            <span>
+              Swap fees{" "}
+              <strong className="text-foreground">
+                {formatSol(totals.swapFeeLamports)}
+              </strong>
+            </span>
+            <span>
+              Average{" "}
+              <strong className="text-foreground">
+                {formatSol(averageSwapFeeLamports)}
+              </strong>
+            </span>
+            <span>
+              Largest{" "}
+              <strong className="text-foreground">
+                {formatSol(totals.maxSwapFeeLamports)}
+              </strong>
+            </span>
+          </div>
+        ) : null}
+        <ActivityTimeSeries data={visibleData} />
+        {routeMode === "cross_mint" ? (
+          <SwapFeeTimeSeries data={visibleData} />
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -170,6 +170,7 @@ export type RebalanceAuditRow = {
   liquidityMint: string | null;
   movementKind: string | null;
   source: RebalanceAuditSource;
+  sourceLiquidityMint: string | null;
   signature: string | null;
   secondarySignature: string | null;
   sourceApyBps: number | null;
@@ -177,6 +178,7 @@ export type RebalanceAuditRow = {
   status: string;
   submittedSlot: bigint | null;
   targetApyBps: number | null;
+  targetLiquidityMint: string | null;
   targetReserve: string | null;
   updatedAt: string;
   vaultId: string | null;
@@ -205,6 +207,7 @@ export type RebalanceAuditQuery = {
   errorFilter?: RebalanceAuditErrorFilter;
   limit?: number;
   range: RebalanceAuditRange;
+  routeMode: RebalanceRouteMode;
   view: RebalanceAuditView;
 };
 
@@ -212,6 +215,7 @@ export type RebalanceAuditActiveQuery = {
   cursor?: RebalanceAuditCursor | null;
   limit?: number;
   range: RebalanceAuditRange;
+  routeMode: RebalanceRouteMode;
 };
 
 type ActiveReserveRouteSqlRow = {
@@ -345,10 +349,12 @@ type RebalanceAuditSqlRow = {
   sort_id: string | number | bigint;
   sort_source: SqlScalar;
   source_apy_bps: SqlScalar;
+  source_liquidity_mint: string | null;
   source_reserve: string | null;
   status: string;
   submitted_slot: SqlScalar;
   target_apy_bps: SqlScalar;
+  target_liquidity_mint: string | null;
   target_reserve: string | null;
   updated_at: Date | string;
   vault_id: string | number | bigint | null;
@@ -463,6 +469,17 @@ function rangePredicate(range: RebalanceAuditRange): string {
     case "all":
       return "TRUE";
   }
+}
+
+function routeModePredicate(routeMode: RebalanceRouteMode): string {
+  const executionKind =
+    routeMode === "cross_mint" ? "cross_mint_jupiter" : "same_mint";
+
+  return `(
+    audit.record_type <> 'decision'
+    OR audit.movement_source <> 'rebalance'
+    OR audit.execution_kind = '${executionKind}'
+  )`;
 }
 
 function viewPredicate(
@@ -606,6 +623,7 @@ function mapRebalanceAuditRow(row: RebalanceAuditSqlRow): RebalanceAuditRow {
     liquidityMint: row.liquidity_mint,
     movementKind: row.execution_kind,
     source: mapAuditSource(row.movement_source),
+    sourceLiquidityMint: row.source_liquidity_mint,
     signature: row.signature,
     secondarySignature: row.secondary_signature,
     sourceApyBps: toNullableNumber(row.source_apy_bps),
@@ -613,6 +631,7 @@ function mapRebalanceAuditRow(row: RebalanceAuditSqlRow): RebalanceAuditRow {
     status: row.status,
     submittedSlot: toNullableBigInt(row.submitted_slot),
     targetApyBps: toNullableNumber(row.target_apy_bps),
+    targetLiquidityMint: row.target_liquidity_mint,
     targetReserve: row.target_reserve,
     updatedAt: toIsoString(row.updated_at) ?? "",
     vaultId: row.vault_id === null ? null : String(row.vault_id),
@@ -649,6 +668,8 @@ const AUDIT_ROWS_CTE = `
       END::text AS movement_source,
       decision.execution_plan->>'kind' AS execution_kind,
       decision.liquidity_mint,
+      decision.source_liquidity_mint,
+      decision.target_liquidity_mint,
       decision.status::text AS status,
       decision.abandon_reason,
       decision.amount_raw,
@@ -699,6 +720,8 @@ const AUDIT_ROWS_CTE = `
         ELSE 'manual_deposit'
       END::text AS execution_kind,
       deposit.liquidity_mint,
+      NULL::text AS source_liquidity_mint,
+      NULL::text AS target_liquidity_mint,
       'confirmed'::text AS status,
       NULL::text AS abandon_reason,
       deposit.principal_amount_raw AS amount_raw,
@@ -750,6 +773,8 @@ const AUDIT_ROWS_CTE = `
       'autodeposit'::text AS movement_source,
       'autodeposit'::text AS execution_kind,
       execution.token_mint AS liquidity_mint,
+      NULL::text AS source_liquidity_mint,
+      NULL::text AS target_liquidity_mint,
       'failed'::text AS status,
       execution.completion_failure_code AS abandon_reason,
       execution.amount_raw,
@@ -786,11 +811,13 @@ async function getRebalanceAuditPageByPredicate({
   limit: requestedLimit,
   predicate,
   range,
+  routeMode,
 }: {
   cursor?: RebalanceAuditCursor | null;
   limit?: number;
   predicate: string;
   range: RebalanceAuditRange;
+  routeMode: RebalanceRouteMode;
 }): Promise<RebalanceAuditPage> {
   const limit = Math.min(Math.max(requestedLimit ?? 25, 1), 50);
   const rows = await queryRows<RebalanceAuditSqlRow>(
@@ -800,6 +827,7 @@ async function getRebalanceAuditPageByPredicate({
         audit.*
       FROM audit_rows AS audit
       WHERE ${rangePredicate(range)}
+        AND ${routeModePredicate(routeMode)}
         AND ${predicate}
         ${cursorPredicate(cursor)}
       ORDER BY audit.event_at DESC, audit.sort_source DESC, audit.sort_id DESC
@@ -2058,7 +2086,8 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
 }
 
 export async function getRebalanceAuditSummary(
-  range: RebalanceAuditRange
+  range: RebalanceAuditRange,
+  routeMode: RebalanceRouteMode
 ): Promise<RebalanceAuditSummary> {
   const rows = await queryRows<RebalanceAuditSummarySqlRow>(
     `
@@ -2145,6 +2174,7 @@ export async function getRebalanceAuditSummary(
         )::text AS stale_active
       FROM audit_rows AS audit
       WHERE ${rangePredicate(range)}
+        AND ${routeModePredicate(routeMode)}
     `
   );
 
@@ -2170,6 +2200,7 @@ export async function getRebalanceAuditPage(
     limit: query.limit,
     predicate: viewPredicate(query.view, errorFilter),
     range: query.range,
+    routeMode: query.routeMode,
   });
 }
 
@@ -2181,5 +2212,6 @@ export async function getRebalanceAuditActivePage(
     limit: query.limit,
     predicate: activeStatusPredicate,
     range: query.range,
+    routeMode: query.routeMode,
   });
 }

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -4,6 +4,8 @@ import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.serv
 
 type SqlScalar = string | number | bigint | null;
 
+export type RebalanceRouteMode = "same_mint" | "cross_mint";
+
 export type RebalanceAuditRange = "24h" | "7d" | "30d" | "all";
 export type RebalanceAuditView =
   | "completed_rebalances"
@@ -46,11 +48,14 @@ export type EarnRebalanceDecisionRow = {
   estimatedEdgeBps: number | null;
   id: string;
   liquidityMint: string | null;
+  routeMode: RebalanceRouteMode;
   signature: string | null;
+  sourceLiquidityMint: string | null;
   sourceApyBps: number | null;
   sourceReserve: string | null;
   status: string;
   targetApyBps: number | null;
+  targetLiquidityMint: string | null;
   targetReserve: string | null;
   updatedAt: string;
 };
@@ -58,10 +63,14 @@ export type EarnRebalanceDecisionRow = {
 export type RebalanceActivityPoint = {
   bucketStartedAt: string;
   confirmed: number;
+  finalizedSwapLegs: number;
   expiredSubmissions: number;
   failedDecisions: number;
   failedOpportunities: number;
   fleetClaims: number;
+  maxSwapFeeLamports: bigint;
+  routeMode: RebalanceRouteMode;
+  swapFeeLamports: bigint;
   terminalAttempts: number;
 };
 
@@ -97,6 +106,7 @@ export type Last30DaysRebalancePoint = {
   confirmed: number;
   date: string;
   failed: number;
+  routeMode: RebalanceRouteMode;
   terminalAttempts: number;
 };
 
@@ -108,8 +118,12 @@ export type ExecutedEarnRebalanceRow = {
   executedAt: string;
   id: string;
   liquidityMint: string | null;
+  routeMode: RebalanceRouteMode;
   sourceReserve: string;
+  sourceLiquidityMint: string | null;
+  swapFeeLamports: bigint;
   targetReserve: string;
+  targetLiquidityMint: string | null;
   userRank: number;
 };
 
@@ -133,6 +147,7 @@ export type EarnVaultRebalanceFrequencyRow = {
   opportunity7dCount: number;
   opportunityAllCount: number;
   positionCount: number;
+  routeMode: RebalanceRouteMode;
   vaultId: string;
   vaultPubkey: string;
 };
@@ -217,11 +232,14 @@ type RebalanceDecisionSqlRow = {
   execution_kind: string | null;
   id: string | number | bigint;
   liquidity_mint: string | null;
+  route_mode: string;
   signature: string | null;
+  source_liquidity_mint: string | null;
   source_apy_bps: SqlScalar;
   source_reserve: string | null;
   status: string;
   target_apy_bps: SqlScalar;
+  target_liquidity_mint: string | null;
   target_reserve: string | null;
   updated_at: Date | string;
 };
@@ -229,10 +247,14 @@ type RebalanceDecisionSqlRow = {
 type RebalanceActivitySqlRow = {
   bucket_started_at: Date | string;
   confirmed: SqlScalar;
+  finalized_swap_legs: SqlScalar;
   expired_submissions: SqlScalar;
   failed_decisions: SqlScalar;
   failed_opportunities: SqlScalar;
   fleet_claims: SqlScalar;
+  max_swap_fee_lamports: SqlScalar;
+  route_mode: string;
+  swap_fee_lamports: SqlScalar;
   terminal_attempts: SqlScalar;
 };
 
@@ -262,6 +284,7 @@ type Last30DaysRebalanceSqlRow = {
   confirmed: SqlScalar;
   date: string;
   failed: SqlScalar;
+  route_mode: string;
   terminal_attempts: SqlScalar;
 };
 
@@ -273,8 +296,12 @@ type ExecutedEarnRebalanceSqlRow = {
   executed_at: Date | string;
   id: string;
   liquidity_mint: string | null;
+  route_mode: string;
   source_reserve: string;
+  source_liquidity_mint: string | null;
+  swap_fee_lamports: SqlScalar;
   target_reserve: string;
+  target_liquidity_mint: string | null;
   user_count: SqlScalar;
   user_rank: SqlScalar;
 };
@@ -293,6 +320,7 @@ type EarnVaultRebalanceFrequencySqlRow = {
   last_7d_count: SqlScalar;
   liquidity_mint: string | null;
   position_count: SqlScalar;
+  route_mode: string;
   vault_count: SqlScalar;
   vault_id: string;
   vault_pubkey: string;
@@ -389,11 +417,18 @@ function queryRows<T>(query: string): Promise<T[]> {
 function getDecisionType(
   row: Pick<RebalanceDecisionSqlRow, "execution_kind">
 ): EarnRebalanceDecisionRow["decisionType"] {
-  if (row.execution_kind === "same_mint") {
+  if (
+    row.execution_kind === "same_mint" ||
+    row.execution_kind === "cross_mint_jupiter"
+  ) {
     return "rebalance";
   }
 
   return null;
+}
+
+function mapRouteMode(value: string | null): RebalanceRouteMode {
+  return value === "cross_mint_jupiter" ? "cross_mint" : "same_mint";
 }
 
 function mapAuditLane(value: string | null): RebalanceAuditLane {
@@ -597,12 +632,18 @@ const AUDIT_ROWS_CTE = `
       decision.created_at,
       decision.updated_at,
       CASE
-        WHEN decision.execution_plan->>'kind' = 'same_mint' THEN 'rebalance'
+        WHEN decision.execution_plan->>'kind' IN (
+          'same_mint',
+          'cross_mint_jupiter'
+        ) THEN 'rebalance'
         WHEN decision.execution_plan->>'kind' = 'idle_vault_deposit' THEN 'deposit'
         ELSE 'needs_review'
       END::text AS lane,
       CASE
-        WHEN decision.execution_plan->>'kind' = 'same_mint' THEN 'rebalance'
+        WHEN decision.execution_plan->>'kind' IN (
+          'same_mint',
+          'cross_mint_jupiter'
+        ) THEN 'rebalance'
         WHEN decision.execution_plan->>'kind' = 'idle_vault_deposit' THEN 'idle_vault_deposit'
         ELSE 'needs_review'
       END::text AS movement_source,
@@ -857,12 +898,27 @@ export async function getRecentRebalanceDecisions(): Promise<
 > {
   const rows = await queryRows<RebalanceDecisionSqlRow>(
     `
+      WITH ranked_decisions AS MATERIALIZED (
+        SELECT
+          decision.*,
+          ROW_NUMBER() OVER (
+            PARTITION BY decision.execution_plan->>'kind'
+            ORDER BY decision.created_at DESC, decision.id DESC
+          ) AS route_mode_rank
+        FROM loyal_yield.rebalance_decisions AS decision
+        WHERE decision.execution_plan->>'kind' IN (
+          'same_mint',
+          'cross_mint_jupiter'
+        )
+      )
       SELECT
         id::text,
         status::text,
         source_reserve,
         target_reserve,
         liquidity_mint,
+        source_liquidity_mint,
+        target_liquidity_mint,
         amount_raw::text,
         source_apy_bps::text,
         target_apy_bps::text,
@@ -873,11 +929,11 @@ export async function getRecentRebalanceDecisions(): Promise<
         confirmed_slot::text,
         created_at,
         updated_at,
-        execution_plan->>'kind' AS execution_kind
-      FROM loyal_yield.rebalance_decisions
-      WHERE execution_plan->>'kind' = 'same_mint'
+        execution_plan->>'kind' AS execution_kind,
+        execution_plan->>'kind' AS route_mode
+      FROM ranked_decisions
+      WHERE route_mode_rank <= 25
       ORDER BY created_at DESC, id DESC
-      LIMIT 25
     `
   );
 
@@ -891,11 +947,14 @@ export async function getRecentRebalanceDecisions(): Promise<
     estimatedEdgeBps: toNullableNumber(row.estimated_edge_bps),
     id: String(row.id),
     liquidityMint: row.liquidity_mint,
+    routeMode: mapRouteMode(row.route_mode),
     signature: row.signature,
+    sourceLiquidityMint: row.source_liquidity_mint,
     sourceApyBps: toNullableNumber(row.source_apy_bps),
     sourceReserve: row.source_reserve,
     status: row.status,
     targetApyBps: toNullableNumber(row.target_apy_bps),
+    targetLiquidityMint: row.target_liquidity_mint,
     targetReserve: row.target_reserve,
     updatedAt: toIsoString(row.updated_at) ?? "",
   }));
@@ -920,15 +979,23 @@ export async function getRebalanceActivity(): Promise<
             timestamptz '1970-01-01 00:00:00+00'
           ) AS ended_at
       ),
+      route_modes AS (
+        SELECT *
+        FROM (VALUES ('same_mint'), ('cross_mint_jupiter')) AS modes(route_mode)
+      ),
       buckets AS (
-        SELECT generate_series(
-          (SELECT started_at FROM bounds),
-          (SELECT ended_at FROM bounds),
-          interval '2 hours'
-        ) AS bucket_started_at
+        SELECT
+          route_mode.route_mode,
+          generate_series(
+            (SELECT started_at FROM bounds),
+            (SELECT ended_at FROM bounds),
+            interval '2 hours'
+          ) AS bucket_started_at
+        FROM route_modes AS route_mode
       ),
       decision_activity AS (
         SELECT
+          decision.execution_plan->>'kind' AS route_mode,
           date_bin(
             interval '2 hours',
             decision.updated_at,
@@ -944,12 +1011,16 @@ export async function getRebalanceActivity(): Promise<
             WHERE decision.status = 'failed'
           )::bigint AS failed_decisions
         FROM loyal_yield.rebalance_decisions AS decision
-        WHERE decision.execution_plan->>'kind' = 'same_mint'
+        WHERE decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND decision.updated_at >= (SELECT window_started_at FROM bounds)
-        GROUP BY 1
+        GROUP BY 1, 2
       ),
       opportunity_activity AS (
         SELECT
+          opportunity.execution_plan->>'kind' AS route_mode,
           date_bin(
             interval '2 hours',
             opportunity.state_entered_at,
@@ -957,15 +1028,19 @@ export async function getRebalanceActivity(): Promise<
           ) AS bucket_started_at,
           COUNT(*)::bigint AS failed_opportunities
         FROM loyal_yield.rebalance_opportunities AS opportunity
-        WHERE opportunity.execution_plan->>'kind' = 'same_mint'
+        WHERE opportunity.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND opportunity.opportunity_state = 'failed'
           AND opportunity.state_entered_at >= (
             SELECT window_started_at FROM bounds
           )
-        GROUP BY 1
+        GROUP BY 1, 2
       ),
       submission_activity AS (
         SELECT
+          decision.execution_plan->>'kind' AS route_mode,
           date_bin(
             interval '2 hours',
             submission.submission_state_entered_at,
@@ -973,14 +1048,21 @@ export async function getRebalanceActivity(): Promise<
           ) AS bucket_started_at,
           COUNT(*)::bigint AS expired_submissions
         FROM loyal_yield.signed_route_submissions AS submission
+        INNER JOIN loyal_yield.rebalance_decisions AS decision
+          ON decision.id = submission.decision_id
         WHERE submission.submission_state = 'expired'
+          AND decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND submission.submission_state_entered_at >= (
             SELECT window_started_at FROM bounds
           )
-        GROUP BY 1
+        GROUP BY 1, 2
       ),
       opportunity_claims AS (
         SELECT
+          opportunity.execution_plan->>'kind' AS route_mode,
           date_bin(
             interval '2 hours',
             opportunity.created_at,
@@ -988,11 +1070,39 @@ export async function getRebalanceActivity(): Promise<
           ) AS bucket_started_at,
           COALESCE(SUM(opportunity.attempt_count), 0)::bigint AS fleet_claims
         FROM loyal_yield.rebalance_opportunities AS opportunity
-        WHERE opportunity.execution_plan->>'kind' = 'same_mint'
+        WHERE opportunity.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND opportunity.created_at >= (SELECT window_started_at FROM bounds)
-        GROUP BY 1
+        GROUP BY 1, 2
+      ),
+      swap_fee_activity AS (
+        SELECT
+          'cross_mint_jupiter'::text AS route_mode,
+          date_bin(
+            interval '2 hours',
+            submission.finalized_at,
+            timestamptz '1970-01-01 00:00:00+00'
+          ) AS bucket_started_at,
+          COUNT(*)::bigint AS finalized_swap_legs,
+          COALESCE(SUM(submission.compiled_fee_lamports), 0)::bigint
+            AS swap_fee_lamports,
+          COALESCE(MAX(submission.compiled_fee_lamports), 0)::bigint
+            AS max_swap_fee_lamports
+        FROM loyal_yield.signed_route_submissions AS submission
+        INNER JOIN loyal_yield.rebalance_decisions AS decision
+          ON decision.id = submission.decision_id
+        WHERE decision.execution_plan->>'kind' = 'cross_mint_jupiter'
+          AND submission.movement_leg = 'swap'
+          AND submission.finalized_at IS NOT NULL
+          AND submission.finalized_at >= (
+            SELECT window_started_at FROM bounds
+          )
+        GROUP BY 1, 2
       )
       SELECT
+        bucket.route_mode,
         bucket.bucket_started_at,
         COALESCE(decision.confirmed, 0)::text AS confirmed,
         COALESCE(decision.terminal_attempts, 0)::text AS terminal_attempts,
@@ -1001,23 +1111,39 @@ export async function getRebalanceActivity(): Promise<
           AS failed_opportunities,
         COALESCE(submission.expired_submissions, 0)::text
           AS expired_submissions,
-        COALESCE(claim.fleet_claims, 0)::text AS fleet_claims
+        COALESCE(claim.fleet_claims, 0)::text AS fleet_claims,
+        COALESCE(swap_fee.finalized_swap_legs, 0)::text
+          AS finalized_swap_legs,
+        COALESCE(swap_fee.swap_fee_lamports, 0)::text
+          AS swap_fee_lamports,
+        COALESCE(swap_fee.max_swap_fee_lamports, 0)::text
+          AS max_swap_fee_lamports
       FROM buckets AS bucket
-      LEFT JOIN decision_activity AS decision USING (bucket_started_at)
-      LEFT JOIN opportunity_activity AS opportunity USING (bucket_started_at)
-      LEFT JOIN submission_activity AS submission USING (bucket_started_at)
-      LEFT JOIN opportunity_claims AS claim USING (bucket_started_at)
-      ORDER BY bucket.bucket_started_at ASC
+      LEFT JOIN decision_activity AS decision
+        USING (route_mode, bucket_started_at)
+      LEFT JOIN opportunity_activity AS opportunity
+        USING (route_mode, bucket_started_at)
+      LEFT JOIN submission_activity AS submission
+        USING (route_mode, bucket_started_at)
+      LEFT JOIN opportunity_claims AS claim
+        USING (route_mode, bucket_started_at)
+      LEFT JOIN swap_fee_activity AS swap_fee
+        USING (route_mode, bucket_started_at)
+      ORDER BY bucket.route_mode ASC, bucket.bucket_started_at ASC
     `
   );
 
   return rows.map((row) => ({
     bucketStartedAt: toIsoString(row.bucket_started_at) ?? "",
     confirmed: toNumber(row.confirmed),
+    finalizedSwapLegs: toNumber(row.finalized_swap_legs),
     expiredSubmissions: toNumber(row.expired_submissions),
     failedDecisions: toNumber(row.failed_decisions),
     failedOpportunities: toNumber(row.failed_opportunities),
     fleetClaims: toNumber(row.fleet_claims),
+    maxSwapFeeLamports: toBigInt(row.max_swap_fee_lamports),
+    routeMode: mapRouteMode(row.route_mode),
+    swapFeeLamports: toBigInt(row.swap_fee_lamports),
     terminalAttempts: toNumber(row.terminal_attempts),
   }));
 }
@@ -1404,14 +1530,20 @@ export async function getLast30DaysRebalanceSeries(): Promise<
           now() AT TIME ZONE 'UTC' AS ended_at
       ),
       days AS (
-        SELECT generate_series(
-          (SELECT started_at::date FROM bounds),
-          (SELECT ended_at::date FROM bounds),
-          interval '1 day'
-        )::date AS date
+        SELECT
+          route_mode.route_mode,
+          generate_series(
+            (SELECT started_at::date FROM bounds),
+            (SELECT ended_at::date FROM bounds),
+            interval '1 day'
+          )::date AS date
+        FROM (
+          VALUES ('same_mint'), ('cross_mint_jupiter')
+        ) AS route_mode(route_mode)
       ),
       daily AS (
         SELECT
+          decision.execution_plan->>'kind' AS route_mode,
           (decision.updated_at AT TIME ZONE 'UTC')::date AS date,
           COUNT(*) FILTER (
             WHERE decision.status = 'confirmed'
@@ -1420,7 +1552,10 @@ export async function getLast30DaysRebalanceSeries(): Promise<
             WHERE decision.status = 'failed'
           )::bigint AS failed
         FROM loyal_yield.rebalance_decisions AS decision
-        WHERE decision.execution_plan->>'kind' = 'same_mint'
+        WHERE decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND decision.status IN ('confirmed', 'failed')
           AND decision.updated_at >= (
             SELECT started_at AT TIME ZONE 'UTC' FROM bounds
@@ -1428,9 +1563,10 @@ export async function getLast30DaysRebalanceSeries(): Promise<
           AND decision.updated_at < (
             SELECT ended_at AT TIME ZONE 'UTC' FROM bounds
           )
-        GROUP BY 1
+        GROUP BY 1, 2
       )
       SELECT
+        day.route_mode,
         to_char(day.date, 'YYYY-MM-DD') AS date,
         COALESCE(daily.confirmed, 0)::text AS confirmed,
         COALESCE(daily.failed, 0)::text AS failed,
@@ -1438,8 +1574,8 @@ export async function getLast30DaysRebalanceSeries(): Promise<
           COALESCE(daily.confirmed, 0) + COALESCE(daily.failed, 0)
         )::text AS terminal_attempts
       FROM days AS day
-      LEFT JOIN daily USING (date)
-      ORDER BY day.date ASC
+      LEFT JOIN daily USING (route_mode, date)
+      ORDER BY day.route_mode ASC, day.date ASC
     `
   );
 
@@ -1447,6 +1583,7 @@ export async function getLast30DaysRebalanceSeries(): Promise<
     confirmed: toNumber(row.confirmed),
     date: row.date,
     failed: toNumber(row.failed),
+    routeMode: mapRouteMode(row.route_mode),
     terminalAttempts: toNumber(row.terminal_attempts),
   }));
 }
@@ -1462,6 +1599,9 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
           decision.source_reserve,
           decision.target_reserve,
           decision.liquidity_mint,
+          decision.source_liquidity_mint,
+          decision.target_liquidity_mint,
+          decision.execution_plan->>'kind' AS route_mode,
           decision.confirmed_slot,
           policy.authority
         FROM loyal_yield.rebalance_decisions AS decision
@@ -1470,21 +1610,38 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         INNER JOIN loyal_yield.route_policies AS policy
           ON policy.id = vault.active_policy_id
         WHERE decision.status = 'confirmed'
+          AND decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND decision.source_reserve IS NOT NULL
           AND decision.target_reserve IS NOT NULL
           AND decision.amount_raw IS NOT NULL
           AND decision.confirmed_slot IS NOT NULL
       ),
+      swap_fees AS MATERIALIZED (
+        SELECT
+          submission.decision_id,
+          COALESCE(SUM(submission.compiled_fee_lamports), 0)::bigint
+            AS swap_fee_lamports
+        FROM loyal_yield.signed_route_submissions AS submission
+        WHERE submission.movement_leg = 'swap'
+          AND submission.finalized_at IS NOT NULL
+        GROUP BY submission.decision_id
+      ),
       executed_users AS MATERIALIZED (
-        SELECT DISTINCT authority FROM executed
+        SELECT DISTINCT authority, route_mode FROM executed
       ),
       relevant_vaults AS MATERIALIZED (
-        SELECT vault.id AS vault_id, policy.authority
+        SELECT vault.id AS vault_id, policy.authority, executed_user.route_mode
         FROM loyal_yield.managed_vaults AS vault
         INNER JOIN loyal_yield.route_policies AS policy
           ON policy.id = vault.active_policy_id
-        INNER JOIN executed_users
-          ON executed_users.authority = policy.authority
+        INNER JOIN executed_users AS executed_user
+          ON executed_user.authority = policy.authority
+      ),
+      relevant_vault_ids AS MATERIALIZED (
+        SELECT DISTINCT vault_id FROM relevant_vaults
       ),
       current_reserve_by_vault AS MATERIALIZED (
         SELECT
@@ -1514,7 +1671,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
               ELSE 0::bigint
             END
           )::bigint AS amount_raw
-        FROM relevant_vaults AS relevant
+        FROM relevant_vault_ids AS relevant
         INNER JOIN loyal_yield.vault_reserve_positions_current AS position
           ON position.vault_id = relevant.vault_id
         WHERE position.has_value = true
@@ -1523,7 +1680,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
       ),
       current_idle_by_vault AS MATERIALIZED (
         SELECT idle.vault_id, SUM(idle.amount_raw)::bigint AS amount_raw
-        FROM relevant_vaults AS relevant
+        FROM relevant_vault_ids AS relevant
         INNER JOIN loyal_yield.vault_idle_token_balances_current AS idle
           ON idle.vault_id = relevant.vault_id
         WHERE idle.amount_raw > 0
@@ -1532,6 +1689,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
       current_user_deposits AS MATERIALIZED (
         SELECT
           relevant.authority,
+          relevant.route_mode,
           SUM(
             COALESCE(reserve.amount_raw, 0::bigint)
             + COALESCE(idle.amount_raw, 0::bigint)
@@ -1541,14 +1699,16 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
           ON reserve.vault_id = relevant.vault_id
         LEFT JOIN current_idle_by_vault AS idle
           ON idle.vault_id = relevant.vault_id
-        GROUP BY relevant.authority
+        GROUP BY relevant.authority, relevant.route_mode
       ),
       ranked_users AS MATERIALIZED (
         SELECT
           executed_user.authority,
+          executed_user.route_mode,
           COALESCE(deposit_total.current_deposit_raw, 0::bigint)
             AS current_deposit_raw,
           ROW_NUMBER() OVER (
+            PARTITION BY executed_user.route_mode
             ORDER BY
               COALESCE(deposit_total.current_deposit_raw, 0::bigint) ASC,
               executed_user.authority ASC
@@ -1556,6 +1716,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         FROM executed_users AS executed_user
         LEFT JOIN current_user_deposits AS deposit_total
           ON deposit_total.authority = executed_user.authority
+          AND deposit_total.route_mode = executed_user.route_mode
       )
       SELECT
         executed.id::text,
@@ -1564,14 +1725,23 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         executed.source_reserve,
         executed.target_reserve,
         executed.liquidity_mint,
+        executed.source_liquidity_mint,
+        executed.target_liquidity_mint,
+        executed.route_mode,
+        COALESCE(swap_fee.swap_fee_lamports, 0)::text AS swap_fee_lamports,
         executed.confirmed_slot::text,
         executed.authority,
         ranked_users.current_deposit_raw::text,
         ranked_users.user_rank::text,
-        MAX(ranked_users.user_rank) OVER ()::text AS user_count
+        MAX(ranked_users.user_rank) OVER (
+          PARTITION BY executed.route_mode
+        )::text AS user_count
       FROM executed
       INNER JOIN ranked_users
         ON ranked_users.authority = executed.authority
+        AND ranked_users.route_mode = executed.route_mode
+      LEFT JOIN swap_fees AS swap_fee
+        ON swap_fee.decision_id = executed.id
       ORDER BY executed.executed_at ASC, executed.id ASC
     `
   );
@@ -1585,8 +1755,12 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
       executedAt: toIsoString(row.executed_at) ?? "",
       id: row.id,
       liquidityMint: row.liquidity_mint,
+      routeMode: mapRouteMode(row.route_mode),
       sourceReserve: row.source_reserve,
+      sourceLiquidityMint: row.source_liquidity_mint,
+      swapFeeLamports: toBigInt(row.swap_fee_lamports),
       targetReserve: row.target_reserve,
+      targetLiquidityMint: row.target_liquidity_mint,
       userRank: toNumber(row.user_rank),
     })),
     generatedAt: new Date().toISOString(),
@@ -1598,10 +1772,36 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
   const rows = await queryRows<EarnVaultRebalanceFrequencySqlRow>(
     `
       WITH active_vaults AS MATERIALIZED (
-        SELECT id, vault_pubkey
-        FROM loyal_yield.managed_vaults
-        WHERE active = true
-          AND vault_index = 1
+        SELECT
+          vault.id,
+          policy.cluster,
+          vault.settings,
+          vault.vault_index,
+          vault.vault_pubkey
+        FROM loyal_yield.managed_vaults AS vault
+        INNER JOIN loyal_yield.route_policies AS policy
+          ON policy.id = vault.active_policy_id
+        WHERE vault.active = true
+          AND vault.vault_index = 1
+      ),
+      route_modes AS MATERIALIZED (
+        SELECT *
+        FROM (VALUES ('same_mint'), ('cross_mint_jupiter')) AS modes(route_mode)
+      ),
+      monitored_vault_modes AS MATERIALIZED (
+        SELECT vault.*, route_mode.route_mode
+        FROM active_vaults AS vault
+        CROSS JOIN route_modes AS route_mode
+        WHERE route_mode.route_mode = 'same_mint'
+          OR EXISTS (
+            SELECT 1
+            FROM loyal_yield.cross_mint_vault_opt_ins AS opt_in
+            WHERE opt_in.cluster = vault.cluster
+              AND opt_in.settings = vault.settings
+              AND opt_in.vault_index = vault.vault_index
+              AND opt_in.vault_pubkey = vault.vault_pubkey
+              AND opt_in.enabled = true
+          )
       ),
       normalized_positions AS MATERIALIZED (
         SELECT
@@ -1706,6 +1906,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       rebalance_counts AS MATERIALIZED (
         SELECT
           decision.vault_id,
+          decision.execution_plan->>'kind' AS route_mode,
           COUNT(*)::integer AS all_count,
           COUNT(*) FILTER (
             WHERE decision.updated_at >= NOW() - INTERVAL '7 days'
@@ -1718,9 +1919,13 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           )::integer AS last_2h_count
         FROM loyal_yield.rebalance_decisions AS decision
         WHERE decision.status = 'confirmed'
+          AND decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
           AND decision.source_reserve IS NOT NULL
           AND decision.target_reserve IS NOT NULL
-        GROUP BY decision.vault_id
+        GROUP BY decision.vault_id, decision.execution_plan->>'kind'
       ),
       -- Evidence that a vault was genuinely actionable, used to keep it in the
       -- eligible denominator even when it now sits under the modelled floor.
@@ -1731,6 +1936,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       opportunity_counts AS MATERIALIZED (
         SELECT
           opportunity.vault_id,
+          opportunity.execution_plan->>'kind' AS route_mode,
           COUNT(*)::integer AS all_count,
           COUNT(*) FILTER (
             WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
@@ -1744,12 +1950,17 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         FROM loyal_yield.rebalance_opportunities AS opportunity
         WHERE opportunity.source_reserve IS NOT NULL
           AND opportunity.target_reserve IS NOT NULL
-        GROUP BY opportunity.vault_id
+          AND opportunity.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
+        GROUP BY opportunity.vault_id, opportunity.execution_plan->>'kind'
       ),
       current_vaults AS MATERIALIZED (
         SELECT
           vault.id,
           vault.vault_pubkey,
+          vault.route_mode,
           primary_position.reserve AS current_reserve,
           COALESCE(primary_position.liquidity_mint, primary_idle.mint)
             AS liquidity_mint,
@@ -1765,7 +1976,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           COALESCE(opportunity.last_7d_count, 0) AS opportunity_last_7d_count,
           COALESCE(opportunity.last_12h_count, 0) AS opportunity_last_12h_count,
           COALESCE(opportunity.last_2h_count, 0) AS opportunity_last_2h_count
-        FROM active_vaults AS vault
+        FROM monitored_vault_modes AS vault
         LEFT JOIN position_totals AS position_total
           ON position_total.vault_id = vault.id
         LEFT JOIN primary_positions AS primary_position
@@ -1776,8 +1987,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           ON primary_idle.vault_id = vault.id
         LEFT JOIN rebalance_counts AS rebalance
           ON rebalance.vault_id = vault.id
+          AND rebalance.route_mode = vault.route_mode
         LEFT JOIN opportunity_counts AS opportunity
           ON opportunity.vault_id = vault.id
+          AND opportunity.route_mode = vault.route_mode
         WHERE COALESCE(position_total.amount_raw, 0::bigint)
           + COALESCE(idle_total.amount_raw, 0::bigint) > 0
       ),
@@ -1785,6 +1998,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         SELECT
           current_vault.*,
           ROW_NUMBER() OVER (
+            PARTITION BY current_vault.route_mode
             ORDER BY
               current_vault.current_deposit_raw ASC,
               current_vault.vault_pubkey ASC
@@ -1796,6 +2010,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         ranked_vault.vault_pubkey,
         ranked_vault.current_reserve,
         ranked_vault.liquidity_mint,
+        ranked_vault.route_mode,
         ranked_vault.current_deposit_raw::text,
         ranked_vault.position_count::text,
         ranked_vault.all_count::text,
@@ -1807,15 +2022,20 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         ranked_vault.opportunity_last_12h_count::text,
         ranked_vault.opportunity_last_2h_count::text,
         ranked_vault.deposit_rank::text,
-        MAX(ranked_vault.deposit_rank) OVER ()::text AS vault_count
+        MAX(ranked_vault.deposit_rank) OVER (
+          PARTITION BY ranked_vault.route_mode
+        )::text AS vault_count
       FROM ranked_vaults AS ranked_vault
-      ORDER BY ranked_vault.deposit_rank ASC
+      ORDER BY ranked_vault.route_mode ASC, ranked_vault.deposit_rank ASC
     `
   );
 
   return {
     generatedAt: new Date().toISOString(),
-    vaultCount: rows.length > 0 ? toNumber(rows[0].vault_count) : 0,
+    vaultCount: rows.reduce(
+      (maximum, row) => Math.max(maximum, toNumber(row.vault_count)),
+      0
+    ),
     vaults: rows.map((row) => ({
       allCount: toNumber(row.all_count),
       currentDepositRaw: toBigInt(row.current_deposit_raw),
@@ -1830,6 +2050,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       opportunity7dCount: toNumber(row.opportunity_last_7d_count),
       opportunityAllCount: toNumber(row.opportunity_all_count),
       positionCount: toNumber(row.position_count),
+      routeMode: mapRouteMode(row.route_mode),
       vaultId: row.vault_id,
       vaultPubkey: row.vault_pubkey,
     })),

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -229,6 +229,36 @@ function createReserveLabelMap(data: SafeReserveApyMonitorData) {
   );
 }
 
+function getCrossMintApyData(
+  data: SafeReserveApyMonitorData
+): SafeReserveApyMonitorData {
+  const bestReserveByMint = new Map<string, SafeReserveApyStatusRow>();
+
+  for (const status of data.statuses) {
+    if (status.status !== "eligible" || status.supplyApyPercent === null) {
+      continue;
+    }
+
+    const current = bestReserveByMint.get(status.liquidityMint);
+    if (
+      !current ||
+      current.supplyApyPercent === null ||
+      status.supplyApyPercent > current.supplyApyPercent
+    ) {
+      bestReserveByMint.set(status.liquidityMint, status);
+    }
+  }
+
+  const reserveSet = new Set(
+    [...bestReserveByMint.values()].map((status) => status.reserve)
+  );
+
+  return {
+    ...data,
+    series: data.series.filter((series) => reserveSet.has(series.reserve)),
+  };
+}
+
 function getReserveLabel(
   labels: ReadonlyMap<string, string>,
   reserve: string | null
@@ -416,7 +446,21 @@ function formatAuditStatus(row: SerializedRebalanceAuditRow) {
 function formatAuditAmount(row: SerializedRebalanceAuditRow) {
   return row.amountRaw === null
     ? "No amount"
-    : formatCompactStablecoinRaw(row.amountRaw, row.liquidityMint);
+    : formatCompactStablecoinRaw(
+        row.amountRaw,
+        row.liquidityMint ?? row.sourceLiquidityMint
+      );
+}
+
+function formatAuditMint(row: SerializedRebalanceAuditRow) {
+  const source = getEarnStablecoinSymbol(
+    row.sourceLiquidityMint ?? row.liquidityMint
+  );
+  const target = getEarnStablecoinSymbol(row.targetLiquidityMint);
+
+  return source && target && source !== target
+    ? `${source} → ${target}`
+    : source ?? target ?? "Unknown";
 }
 
 function formatDuration(createdAt: string, updatedAt: string) {
@@ -659,7 +703,7 @@ function RebalanceAuditTable({
                 <AuditVault row={row} />
               </TableCell>
               <TableCell className="font-medium">
-                {getEarnStablecoinSymbol(row.liquidityMint) ?? "Unknown"}
+                {formatAuditMint(row)}
               </TableCell>
               {isDeposits ? (
                 <TableCell>
@@ -764,7 +808,7 @@ function ActiveMovementTable({
                   <AuditVault row={row} />
                 </TableCell>
                 <TableCell className="font-medium">
-                  {getEarnStablecoinSymbol(row.liquidityMint) ?? "Unknown"}
+                  {formatAuditMint(row)}
                 </TableCell>
                 <TableCell>{formatAuditRoute(row, reserveLabels)}</TableCell>
                 <TableCell className="text-right tabular-nums">
@@ -812,7 +856,7 @@ function CurrentReserveApyCard({
         <CardTitle className="font-bold">Current Safe reserve APY</CardTitle>
         <CardDescription>
           {routeMode === "cross_mint"
-            ? "All active verified Safe basket targets across supported stablecoins"
+            ? "Best currently eligible Safe reserve for each Crossmint target mint"
             : "Active verified Safe basket reserves for the selected stablecoin"}
         </CardDescription>
         <RouteModeSwitch
@@ -858,12 +902,14 @@ function updateAuditUrl(values: {
   cursor?: string | null;
   errorFilter: RebalanceAuditErrorFilter;
   range: RebalanceAuditRange;
+  routeMode: RebalanceRouteMode;
   view: RebalanceAuditView;
 }) {
   const params = new URLSearchParams(window.location.search);
   params.set("auditView", values.view);
   params.set("auditRange", values.range);
   params.set("auditError", values.errorFilter);
+  params.set("auditRouteMode", values.routeMode);
 
   if (values.cursor !== undefined) {
     if (values.cursor) {
@@ -960,6 +1006,7 @@ function RebalanceAuditCard({
 }) {
   const [view, setView] = useState<RebalanceAuditView>(DEFAULT_AUDIT_VIEW);
   const [range, setRange] = useState<RebalanceAuditRange>(DEFAULT_AUDIT_RANGE);
+  const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
   const [errorFilter, setErrorFilter] =
     useState<RebalanceAuditErrorFilter>(DEFAULT_ERROR_FILTER);
   const [cursor, setCursor] = useState<string | null>(null);
@@ -973,6 +1020,7 @@ function RebalanceAuditCard({
     const nextView = params.get("auditView");
     const nextRange = params.get("auditRange");
     const nextError = params.get("auditError");
+    const nextRouteMode = params.get("auditRouteMode");
 
     if (isAuditView(nextView)) {
       setView(nextView);
@@ -982,6 +1030,9 @@ function RebalanceAuditCard({
     }
     if (isErrorFilter(nextError)) {
       setErrorFilter(nextError);
+    }
+    if (nextRouteMode === "same_mint" || nextRouteMode === "cross_mint") {
+      setRouteMode(nextRouteMode);
     }
     setCursor(params.get("auditCursor"));
     setActiveCursor(params.get("auditActiveCursor"));
@@ -1000,6 +1051,7 @@ function RebalanceAuditCard({
       const params = new URLSearchParams({
         errorFilter,
         range,
+        routeMode,
         view,
       });
       if (cursor) {
@@ -1045,7 +1097,16 @@ function RebalanceAuditCard({
       controller.abort();
       window.clearInterval(interval);
     };
-  }, [activeCursor, cursor, errorFilter, hydrated, range, refreshToken, view]);
+  }, [
+    activeCursor,
+    cursor,
+    errorFilter,
+    hydrated,
+    range,
+    refreshToken,
+    routeMode,
+    view,
+  ]);
 
   function selectView(nextView: RebalanceAuditView) {
     setView(nextView);
@@ -1056,6 +1117,7 @@ function RebalanceAuditCard({
       cursor: null,
       errorFilter,
       range,
+      routeMode,
       view: nextView,
     });
   }
@@ -1069,6 +1131,7 @@ function RebalanceAuditCard({
       cursor: null,
       errorFilter,
       range: nextRange,
+      routeMode,
       view,
     });
   }
@@ -1082,6 +1145,7 @@ function RebalanceAuditCard({
       cursor: null,
       errorFilter: nextErrorFilter,
       range,
+      routeMode,
       view,
     });
   }
@@ -1098,10 +1162,28 @@ function RebalanceAuditCard({
               Confirmed rebalances, user/autodeposits, idle-vault deposits,
               persisted autodeposit failures, and needs-review records. Worker
               failures before a decision or execution is persisted remain
-              outside this view.
+              outside this view. The mode switch filters rebalance records;
+              deposit records remain shared.
             </CardDescription>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            <RouteModeSwitch
+              id="movement-audit-route-mode"
+              mode={routeMode}
+              onModeChange={(nextRouteMode) => {
+                setRouteMode(nextRouteMode);
+                setCursor(null);
+                setActiveCursor(null);
+                updateAuditUrl({
+                  activeCursor: null,
+                  cursor: null,
+                  errorFilter,
+                  range,
+                  routeMode: nextRouteMode,
+                  view,
+                });
+              }}
+            />
             <span className="text-xs text-muted-foreground">Range</span>
             <Select
               value={range}
@@ -1157,6 +1239,7 @@ function RebalanceAuditCard({
                   activeCursor: nextCursor,
                   errorFilter,
                   range,
+                  routeMode,
                   view,
                 });
               }}
@@ -1251,6 +1334,7 @@ function RebalanceAuditCard({
                     updateAuditUrl({
                       errorFilter,
                       range,
+                      routeMode,
                       view,
                       cursor: nextCursor,
                     });
@@ -1437,9 +1521,8 @@ export function RebalanceMonitorClient() {
   const filteredDecisions = selectedMintAddress
     ? state.data.decisions.filter(
         (decision) =>
-          (decision.routeMode === "same_mint"
-            ? decision.liquidityMint
-            : decision.sourceLiquidityMint) === selectedMintAddress
+          decision.routeMode === "cross_mint" ||
+          decision.liquidityMint === selectedMintAddress
       )
     : state.data.decisions;
   const filteredExecutedRebalances = selectedMintAddress
@@ -1447,15 +1530,16 @@ export function RebalanceMonitorClient() {
         ...state.data.executedRebalances,
         executions: state.data.executedRebalances.executions.filter(
           (execution) =>
-            (execution.routeMode === "same_mint"
-              ? execution.liquidityMint
-              : execution.sourceLiquidityMint) === selectedMintAddress
+            execution.routeMode === "cross_mint" ||
+            execution.liquidityMint === selectedMintAddress
         ),
       }
     : state.data.executedRebalances;
   const filteredFrequencyVaults = selectedMintAddress
     ? state.data.vaultRebalanceFrequency.vaults.filter(
-        (vault) => vault.liquidityMint === selectedMintAddress
+        (vault) =>
+          vault.routeMode === "cross_mint" ||
+          vault.liquidityMint === selectedMintAddress
       )
     : state.data.vaultRebalanceFrequency.vaults;
   const filteredVaultRebalanceFrequency = {
@@ -1463,6 +1547,7 @@ export function RebalanceMonitorClient() {
     vaultCount: filteredFrequencyVaults.length,
     vaults: filteredFrequencyVaults,
   };
+  const crossMintApyData = getCrossMintApyData(state.data.apyData);
 
   return (
     <div className="mx-auto grid w-full max-w-4xl gap-6">
@@ -1470,10 +1555,9 @@ export function RebalanceMonitorClient() {
         <CardHeader>
           <CardTitle className="font-bold">Stablecoin filter</CardTitle>
           <CardDescription>
-            Filters verified reserves, confirmed executions, and vault frequency
-            by same-mint or Crossmint source. Crossmint APY views still include
-            every supported target mint for comparison. The aggregate activity
-            and paginated audit sections remain all-mint.
+            Filters same-mint reserves, executions, and vault frequency.
+            Crossmint cards show all Crossmint routes and the best currently
+            eligible Safe reserve for each supported target mint.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -1495,8 +1579,16 @@ export function RebalanceMonitorClient() {
       <CurrentReserveApyCard
         dataByRouteMode={{
           cross_mint: {
-            routes: state.data.routes,
-            rows: state.data.apyData.statuses,
+            routes: state.data.routes.filter((route) =>
+              crossMintApyData.series.some(
+                (series) => series.reserve === route.currentReserve
+              )
+            ),
+            rows: state.data.apyData.statuses.filter((status) =>
+              crossMintApyData.series.some(
+                (series) => series.reserve === status.reserve
+              )
+            ),
           },
           same_mint: {
             routes: filteredRoutes,
@@ -1506,7 +1598,7 @@ export function RebalanceMonitorClient() {
       />
       <SafeReserveApyChart
         dataByRouteMode={{
-          cross_mint: state.data.apyData,
+          cross_mint: crossMintApyData,
           same_mint: filteredApyData,
         }}
         decisionMarkersByRouteMode={{

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1166,7 +1166,7 @@ function RebalanceAuditCard({
               deposit records remain shared.
             </CardDescription>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex shrink-0 flex-col items-start gap-2 lg:items-end">
             <RouteModeSwitch
               id="movement-audit-route-mode"
               mode={routeMode}
@@ -1184,35 +1184,40 @@ function RebalanceAuditCard({
                 });
               }}
             />
-            <span className="text-xs text-muted-foreground">Range</span>
-            <Select
-              value={range}
-              onValueChange={(value) => {
-                if (isAuditRange(value)) {
-                  selectRange(value);
-                }
-              }}
-            >
-              <SelectTrigger className="w-[7.5rem]" size="sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="24h">Last 24 hours</SelectItem>
-                <SelectItem value="7d">Last 7 days</SelectItem>
-                <SelectItem value="30d">Last 30 days</SelectItem>
-                <SelectItem value="all">All time</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button
-              aria-label="Refresh movement audit"
-              onClick={() => setRefreshToken((value) => value + 1)}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <RefreshCwIcon aria-hidden="true" />
-              Refresh
-            </Button>
+            <div className="flex items-center gap-2">
+              <Select
+                value={range}
+                onValueChange={(value) => {
+                  if (isAuditRange(value)) {
+                    selectRange(value);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  aria-label="Movement audit range"
+                  className="w-[9rem]"
+                  size="sm"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="24h">Last 24 hours</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                  <SelectItem value="all">All time</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                aria-label="Refresh movement audit"
+                onClick={() => setRefreshToken((value) => value + 1)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <RefreshCwIcon aria-hidden="true" />
+                Refresh
+              </Button>
+            </div>
           </div>
         </div>
         {state.status === "ready" ? (

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -72,7 +72,9 @@ import type {
   RebalanceAuditSource,
   RebalanceAuditSummary,
   RebalanceAuditView,
+  RebalanceRouteMode,
 } from "./rebalance-data";
+import { RouteModeSwitch } from "./route-mode-switch";
 
 type SerializedActiveReserveRouteRow = Omit<
   EarnActiveReserveRouteRow,
@@ -98,8 +100,16 @@ type SerializedRebalanceAuditRow = Omit<
   submittedSlot: string | null;
 };
 
+type SerializedRebalanceActivityPoint = Omit<
+  RebalanceActivityPoint,
+  "maxSwapFeeLamports" | "swapFeeLamports"
+> & {
+  maxSwapFeeLamports: string;
+  swapFeeLamports: string;
+};
+
 type RebalanceApiData = {
-  activity: RebalanceActivityPoint[];
+  activity: SerializedRebalanceActivityPoint[];
   apyData: SafeReserveApyMonitorData;
   autodeposit: SerializedAutodepositFailureRange[];
   decisions: SerializedRebalanceDecisionRow[];
@@ -783,19 +793,33 @@ function ActiveMovementTable({
 }
 
 function CurrentReserveApyCard({
-  routes,
-  rows,
+  dataByRouteMode,
 }: {
-  routes: SerializedActiveReserveRouteRow[];
-  rows: SafeReserveApyStatusRow[];
+  dataByRouteMode: Record<
+    RebalanceRouteMode,
+    {
+      routes: SerializedActiveReserveRouteRow[];
+      rows: SafeReserveApyStatusRow[];
+    }
+  >;
 }) {
+  const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
+  const { routes, rows } = dataByRouteMode[routeMode];
+
   return (
     <Card className="min-w-0">
       <CardHeader>
         <CardTitle className="font-bold">Current Safe reserve APY</CardTitle>
         <CardDescription>
-          Active verified Safe basket reserves across supported stablecoins
+          {routeMode === "cross_mint"
+            ? "All active verified Safe basket targets across supported stablecoins"
+            : "Active verified Safe basket reserves for the selected stablecoin"}
         </CardDescription>
+        <RouteModeSwitch
+          id="current-safe-reserve-apy-route-mode"
+          mode={routeMode}
+          onModeChange={setRouteMode}
+        />
       </CardHeader>
       <CardContent className="min-w-0 overflow-x-auto">
         <CurrentReserveApyTable routes={routes} rows={rows} />
@@ -1412,14 +1436,20 @@ export function RebalanceMonitorClient() {
     : state.data.routes;
   const filteredDecisions = selectedMintAddress
     ? state.data.decisions.filter(
-        (decision) => decision.liquidityMint === selectedMintAddress
+        (decision) =>
+          (decision.routeMode === "same_mint"
+            ? decision.liquidityMint
+            : decision.sourceLiquidityMint) === selectedMintAddress
       )
     : state.data.decisions;
   const filteredExecutedRebalances = selectedMintAddress
     ? {
         ...state.data.executedRebalances,
         executions: state.data.executedRebalances.executions.filter(
-          (execution) => execution.liquidityMint === selectedMintAddress
+          (execution) =>
+            (execution.routeMode === "same_mint"
+              ? execution.liquidityMint
+              : execution.sourceLiquidityMint) === selectedMintAddress
         ),
       }
     : state.data.executedRebalances;
@@ -1440,9 +1470,10 @@ export function RebalanceMonitorClient() {
         <CardHeader>
           <CardTitle className="font-bold">Stablecoin filter</CardTitle>
           <CardDescription>
-            Filters verified reserves, confirmed executions, and vault
-            frequency. The aggregate activity and paginated audit sections
-            remain all-mint.
+            Filters verified reserves, confirmed executions, and vault frequency
+            by same-mint or Crossmint source. Crossmint APY views still include
+            every supported target mint for comparison. The aggregate activity
+            and paginated audit sections remain all-mint.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -1462,12 +1493,34 @@ export function RebalanceMonitorClient() {
         </CardContent>
       </Card>
       <CurrentReserveApyCard
-        routes={filteredRoutes}
-        rows={filteredApyData.statuses}
+        dataByRouteMode={{
+          cross_mint: {
+            routes: state.data.routes,
+            rows: state.data.apyData.statuses,
+          },
+          same_mint: {
+            routes: filteredRoutes,
+            rows: filteredApyData.statuses,
+          },
+        }}
       />
       <SafeReserveApyChart
-        data={filteredApyData}
-        decisionMarkers={toDecisionMarkers(filteredDecisions)}
+        dataByRouteMode={{
+          cross_mint: state.data.apyData,
+          same_mint: filteredApyData,
+        }}
+        decisionMarkersByRouteMode={{
+          cross_mint: toDecisionMarkers(
+            filteredDecisions.filter(
+              (decision) => decision.routeMode === "cross_mint"
+            )
+          ),
+          same_mint: toDecisionMarkers(
+            filteredDecisions.filter(
+              (decision) => decision.routeMode === "same_mint"
+            )
+          ),
+        }}
       />
       <RebalanceActivityChart data={state.data.activity} />
       <ExecutedEarnRebalancesChart

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1386,14 +1386,14 @@ function CurrentReserveApyFallback() {
 
 function ApyChartFallback() {
   return (
-    <Card className="mx-auto w-full max-w-4xl">
+    <Card className="w-full">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2">
           <Skeleton className="h-5 w-40" />
           <Skeleton className="h-4 w-96 max-w-full" />
         </div>
       </CardHeader>
-      <CardContent className="px-2 pt-6 sm:p-6">
+      <CardContent className="px-2 sm:px-6">
         <Skeleton className="h-[300px] w-full" />
         <div className="mt-4 flex flex-wrap gap-3">
           {Array.from({ length: 4 }).map((_, index) => (

--- a/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
@@ -17,7 +17,7 @@ export function RouteModeSwitch({
   return (
     <div
       aria-label="Rebalance route"
-      className="inline-flex shrink-0 items-center rounded-lg bg-muted p-1"
+      className="inline-flex w-fit shrink-0 self-start rounded-lg bg-muted p-1"
       role="group"
     >
       <Button

--- a/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 import type { RebalanceRouteMode } from "./rebalance-data";
 
@@ -13,32 +14,46 @@ export function RouteModeSwitch({
   mode: RebalanceRouteMode;
   onModeChange: (mode: RebalanceRouteMode) => void;
 }) {
-  const isCrossMint = mode === "cross_mint";
-
   return (
-    <div className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
-      <span
-        className={
-          isCrossMint ? "text-muted-foreground" : "font-medium text-foreground"
-        }
+    <div
+      aria-label="Rebalance route"
+      className="inline-flex shrink-0 items-center rounded-lg bg-muted p-1"
+      role="group"
+    >
+      <Button
+        aria-label="Show same-mint monitoring"
+        aria-pressed={mode === "same_mint"}
+        className={cn(
+          "h-7 rounded-md px-2.5 text-xs shadow-none",
+          mode === "same_mint"
+            ? "bg-background text-foreground shadow-xs hover:bg-background"
+            : "text-muted-foreground"
+        )}
+        id={`${id}-same-mint`}
+        onClick={() => onModeChange("same_mint")}
+        size="sm"
+        type="button"
+        variant="ghost"
       >
         Same-mint
-      </span>
-      <Switch
+      </Button>
+      <Button
         aria-label="Show Crossmint monitoring"
-        checked={isCrossMint}
+        aria-pressed={mode === "cross_mint"}
+        className={cn(
+          "h-7 rounded-md px-2.5 text-xs shadow-none",
+          mode === "cross_mint"
+            ? "bg-background text-foreground shadow-xs hover:bg-background"
+            : "text-muted-foreground"
+        )}
         id={id}
-        onCheckedChange={(checked) =>
-          onModeChange(checked ? "cross_mint" : "same_mint")
-        }
-      />
-      <span
-        className={
-          isCrossMint ? "font-medium text-foreground" : "text-muted-foreground"
-        }
+        onClick={() => onModeChange("cross_mint")}
+        size="sm"
+        type="button"
+        variant="ghost"
       >
         Crossmint
-      </span>
+      </Button>
     </div>
   );
 }

--- a/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+
+import type { RebalanceRouteMode } from "./rebalance-data";
+
+export function RouteModeSwitch({
+  id,
+  mode,
+  onModeChange,
+}: {
+  id: string;
+  mode: RebalanceRouteMode;
+  onModeChange: (mode: RebalanceRouteMode) => void;
+}) {
+  const isCrossMint = mode === "cross_mint";
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span
+        className={
+          isCrossMint ? "text-muted-foreground" : "font-medium text-foreground"
+        }
+      >
+        Same-mint
+      </span>
+      <Switch
+        aria-label="Show Crossmint monitoring"
+        checked={isCrossMint}
+        id={id}
+        onCheckedChange={(checked) =>
+          onModeChange(checked ? "cross_mint" : "same_mint")
+        }
+      />
+      <span
+        className={
+          isCrossMint ? "font-medium text-foreground" : "text-muted-foreground"
+        }
+      >
+        Crossmint
+      </span>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/route-mode-switch.tsx
@@ -16,7 +16,7 @@ export function RouteModeSwitch({
   const isCrossMint = mode === "cross_mint";
 
   return (
-    <div className="flex items-center gap-2 text-xs">
+    <div className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
       <span
         className={
           isCrossMint ? "text-muted-foreground" : "font-medium text-foreground"

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -321,7 +321,7 @@ export function SafeReserveApyChart({
     .slice(0, 25);
 
   return (
-    <Card className="w-full py-4 sm:py-0">
+    <Card className="w-full">
       <CardHeader className="gap-4 border-b">
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
           <div>
@@ -382,7 +382,7 @@ export function SafeReserveApyChart({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="px-2 pt-6 sm:p-6">
+      <CardContent className="px-2 sm:px-6">
         {hasChartData ? (
           <ChartContainer
             config={chartConfig}

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -321,57 +321,64 @@ export function SafeReserveApyChart({
     .slice(0, 25);
 
   return (
-    <Card className="mx-auto w-full max-w-4xl py-4 sm:py-0">
-      <CardHeader className="flex flex-col items-start justify-between gap-3 border-b sm:flex-row sm:items-center">
-        <div>
-          <CardTitle className="font-bold">Safe reserve APY</CardTitle>
-          <CardDescription>
-            {routeMode === "cross_mint"
-              ? "Best currently eligible Safe reserve for each Crossmint target mint"
-              : "Selected stablecoin Safe basket"}
-            , last 7d,{" "}
-            {showRawData
-              ? `${data.sampleIntervalMinutes}m raw buckets`
-              : "30m median view"}{" "}
-            from Kamino Timescale
-          </CardDescription>
-        </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <RouteModeSwitch
-            id="safe-reserve-apy-route-mode"
-            mode={routeMode}
-            onModeChange={setRouteMode}
-          />
-          <Button
-            onClick={() => setShowRawData((value) => !value)}
-            size="sm"
-            type="button"
-            variant={showRawData ? "secondary" : "outline"}
-          >
-            {showRawData ? "Clean view" : "Raw 5m"}
-          </Button>
-          {decisionMarkers.length > 0 ? (
-            <Button
-              onClick={() => setShowDecisionMarkers((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showDecisionMarkers ? "secondary" : "outline"}
-            >
-              {showDecisionMarkers ? "Hide markers" : "Show markers"}
-            </Button>
-          ) : null}
-          {fullYMax > normalYMax ? (
-            <Button
-              onClick={() => setShowOutliers((value) => !value)}
-              size="sm"
-              type="button"
-              variant={showOutliers ? "secondary" : "outline"}
-            >
-              {showOutliers ? "Hide outliers" : "Show outliers"}
-            </Button>
-          ) : null}
-          <div className="text-right text-xs text-muted-foreground tabular-nums">
-            Updated {formatTooltipDate(data.generatedAt)}
+    <Card className="w-full py-4 sm:py-0">
+      <CardHeader className="gap-4 border-b">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+          <div>
+            <CardTitle className="font-bold">Safe reserve APY</CardTitle>
+            <CardDescription>
+              {routeMode === "cross_mint"
+                ? "Best currently eligible Safe reserve for each Crossmint target mint"
+                : "Selected stablecoin Safe basket"}
+              , last 7d,{" "}
+              {showRawData
+                ? `${data.sampleIntervalMinutes}m raw buckets`
+                : "30m median view"}{" "}
+              from Kamino Timescale
+            </CardDescription>
+          </div>
+          <div className="flex min-w-0 flex-col items-start gap-2 lg:items-end">
+            <RouteModeSwitch
+              id="safe-reserve-apy-route-mode"
+              mode={routeMode}
+              onModeChange={setRouteMode}
+            />
+            <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+              <Button
+                aria-pressed={showRawData}
+                onClick={() => setShowRawData((value) => !value)}
+                size="sm"
+                type="button"
+                variant={showRawData ? "secondary" : "outline"}
+              >
+                Raw samples
+              </Button>
+              {decisionMarkers.length > 0 ? (
+                <Button
+                  aria-pressed={showDecisionMarkers}
+                  onClick={() => setShowDecisionMarkers((value) => !value)}
+                  size="sm"
+                  type="button"
+                  variant={showDecisionMarkers ? "secondary" : "outline"}
+                >
+                  Markers
+                </Button>
+              ) : null}
+              {fullYMax > normalYMax ? (
+                <Button
+                  aria-pressed={showOutliers}
+                  onClick={() => setShowOutliers((value) => !value)}
+                  size="sm"
+                  type="button"
+                  variant={showOutliers ? "secondary" : "outline"}
+                >
+                  Outliers
+                </Button>
+              ) : null}
+            </div>
+            <div className="text-xs text-muted-foreground tabular-nums">
+              Updated {formatTooltipDate(data.generatedAt)}
+            </div>
           </div>
         </div>
       </CardHeader>

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -28,6 +28,8 @@ import type {
   SafeReserveApyMonitorData,
   SafeReserveRebalanceDecisionMarker,
 } from "@/lib/kamino/timescale-reserve-monitor.shared";
+import type { RebalanceRouteMode } from "./rebalance/rebalance-data";
+import { RouteModeSwitch } from "./rebalance/route-mode-switch";
 
 const COLLAPSED_REASON_LENGTH = 96;
 
@@ -247,12 +249,18 @@ function ApyTooltip({ active, label, labels, payload }: ApyTooltipProps) {
 }
 
 export function SafeReserveApyChart({
-  data,
-  decisionMarkers,
+  dataByRouteMode,
+  decisionMarkersByRouteMode,
 }: {
-  data: SafeReserveApyMonitorData;
-  decisionMarkers: SafeReserveRebalanceDecisionMarker[];
+  dataByRouteMode: Record<RebalanceRouteMode, SafeReserveApyMonitorData>;
+  decisionMarkersByRouteMode: Record<
+    RebalanceRouteMode,
+    SafeReserveRebalanceDecisionMarker[]
+  >;
 }) {
+  const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
+  const data = dataByRouteMode[routeMode];
+  const decisionMarkers = decisionMarkersByRouteMode[routeMode];
   const [focusedSeriesKey, setFocusedSeriesKey] = useState<string | null>(null);
   const [showDecisionMarkers, setShowDecisionMarkers] = useState(false);
   const [showOutliers, setShowOutliers] = useState(false);
@@ -318,7 +326,10 @@ export function SafeReserveApyChart({
         <div>
           <CardTitle className="font-bold">Safe reserve APY</CardTitle>
           <CardDescription>
-            Supported stablecoin Safe basket, last 7d,{" "}
+            {routeMode === "cross_mint"
+              ? "All supported stablecoin targets for Crossmint comparison"
+              : "Selected stablecoin Safe basket"}
+            , last 7d,{" "}
             {showRawData
               ? `${data.sampleIntervalMinutes}m raw buckets`
               : "30m median view"}{" "}
@@ -326,6 +337,11 @@ export function SafeReserveApyChart({
           </CardDescription>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
+          <RouteModeSwitch
+            id="safe-reserve-apy-route-mode"
+            mode={routeMode}
+            onModeChange={setRouteMode}
+          />
           <Button
             onClick={() => setShowRawData((value) => !value)}
             size="sm"

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -205,9 +205,24 @@ function getApyValues(args: {
 }
 
 function ApyTooltip({ active, label, labels, payload }: ApyTooltipProps) {
-  const visiblePayload = (payload ?? []).filter(
-    (item) => typeof item.value === "number"
-  );
+  const visiblePayload = (payload ?? [])
+    .filter(
+      (item): item is TooltipPayloadItem & { value: number } =>
+        typeof item.value === "number"
+    )
+    .sort((left, right) => {
+      const valueOrder = right.value - left.value;
+      if (valueOrder !== 0) {
+        return valueOrder;
+      }
+
+      const leftKey = String(left.dataKey ?? left.name ?? "");
+      const rightKey = String(right.dataKey ?? right.name ?? "");
+      return (labels[leftKey] ?? leftKey).localeCompare(
+        labels[rightKey] ?? rightKey,
+        "en-US"
+      );
+    });
 
   if (!active || visiblePayload.length === 0) {
     return null;

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -327,7 +327,7 @@ export function SafeReserveApyChart({
           <CardTitle className="font-bold">Safe reserve APY</CardTitle>
           <CardDescription>
             {routeMode === "cross_mint"
-              ? "All supported stablecoin targets for Crossmint comparison"
+              ? "Best currently eligible Safe reserve for each Crossmint target mint"
               : "Selected stablecoin Safe basket"}
             , last 7d,{" "}
             {showRawData

--- a/apps/admin/src/app/api/earn/rebalance/audit/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/audit/route.ts
@@ -7,6 +7,7 @@ import {
   getRebalanceAuditSummary,
   type RebalanceAuditErrorFilter,
   type RebalanceAuditRange,
+  type RebalanceRouteMode,
   type RebalanceAuditView,
 } from "../../../../(admin)/earn/rebalance/rebalance-data";
 
@@ -19,6 +20,7 @@ const views = new Set<RebalanceAuditView>([
   "errors",
 ]);
 const ranges = new Set<RebalanceAuditRange>(["24h", "7d", "30d", "all"]);
+const routeModes = new Set<RebalanceRouteMode>(["same_mint", "cross_mint"]);
 const errorFilters = new Set<RebalanceAuditErrorFilter>([
   "all",
   "rebalance",
@@ -42,6 +44,11 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const view = parseEnum(url.searchParams.get("view"), views, "errors");
   const range = parseEnum(url.searchParams.get("range"), ranges, "24h");
+  const routeMode = parseEnum(
+    url.searchParams.get("routeMode"),
+    routeModes,
+    "same_mint"
+  );
   const errorFilter = parseEnum(
     url.searchParams.get("errorFilter"),
     errorFilters,
@@ -55,6 +62,7 @@ export async function GET(request: Request) {
   if (
     !view ||
     !range ||
+    !routeMode ||
     !errorFilter ||
     (rawCursor && !cursor) ||
     (rawActiveCursor && !activeCursor)
@@ -66,16 +74,18 @@ export async function GET(request: Request) {
   }
 
   const [summary, page, activePage] = await Promise.all([
-    getRebalanceAuditSummary(range),
+    getRebalanceAuditSummary(range, routeMode),
     getRebalanceAuditPage({
       cursor,
       errorFilter,
       range,
+      routeMode,
       view,
     }),
     getRebalanceAuditActivePage({
       cursor: activeCursor,
       range,
+      routeMode,
     }),
   ]);
 

--- a/apps/admin/src/app/api/earn/rebalance/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/route.ts
@@ -35,7 +35,11 @@ async function loadRebalanceMonitorData() {
   ]);
 
   return {
-    activity,
+    activity: activity.map((point) => ({
+      ...point,
+      maxSwapFeeLamports: point.maxSwapFeeLamports.toString(),
+      swapFeeLamports: point.swapFeeLamports.toString(),
+    })),
     apyData,
     autodeposit: autodeposit.map((range) => ({
       bucketHours: range.bucketHours,
@@ -76,6 +80,7 @@ async function loadExecutedRebalances() {
         amountRaw: execution.amountRaw.toString(),
         confirmedSlot: execution.confirmedSlot.toString(),
         currentDepositRaw: execution.currentDepositRaw.toString(),
+        swapFeeLamports: execution.swapFeeLamports.toString(),
       })),
     };
   } catch (error) {

--- a/apps/admin/src/components/ui/chart.tsx
+++ b/apps/admin/src/components/ui/chart.tsx
@@ -66,20 +66,22 @@ const ChartContainer = React.forwardRef<HTMLDivElement, ChartContainerProps>(
             "[&_.recharts-layer]:outline-none",
             "[&_.recharts-sector[stroke='#fff']]:stroke-transparent",
             "[&_.recharts-dot[stroke='#fff']]:stroke-transparent",
-            className,
+            className
           )}
           {...props}
         >
           <ChartStyle id={chartId} config={config} />
           <RechartsPrimitive.ResponsiveContainer>
-            {children as React.ComponentProps<
-              typeof RechartsPrimitive.ResponsiveContainer
-            >["children"]}
+            {
+              children as React.ComponentProps<
+                typeof RechartsPrimitive.ResponsiveContainer
+              >["children"]
+            }
           </RechartsPrimitive.ResponsiveContainer>
         </div>
       </ChartContext.Provider>
     );
-  },
+  }
 );
 ChartContainer.displayName = "ChartContainer";
 
@@ -97,12 +99,28 @@ type ChartTooltipContentProps = React.ComponentProps<"div"> &
     hideLabel?: boolean;
     nameKey?: string;
     labelFormatter?: (value: unknown) => React.ReactNode;
+    valueFormatter?: (
+      value: number | string | undefined,
+      dataKey: string
+    ) => React.ReactNode;
   };
 
-const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltipContentProps>(
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  ChartTooltipContentProps
+>(
   (
-    { active, payload, className, hideLabel = false, label, labelFormatter, nameKey: _nameKey },
-    ref,
+    {
+      active,
+      payload,
+      className,
+      hideLabel = false,
+      label,
+      labelFormatter,
+      nameKey: _nameKey,
+      valueFormatter,
+    },
+    ref
   ) => {
     const { config } = useChart();
 
@@ -113,28 +131,35 @@ const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltipContent
     const renderedLabel = hideLabel
       ? null
       : labelFormatter
-        ? labelFormatter(label)
-        : label;
+      ? labelFormatter(label)
+      : label;
 
     return (
       <div
         ref={ref}
         className={cn(
           "grid min-w-[8rem] gap-1.5 rounded-lg border border-border/70 bg-background px-2.5 py-1.5 text-xs shadow-xl",
-          className,
+          className
         )}
       >
-        {renderedLabel ? <div className="font-medium text-foreground">{renderedLabel}</div> : null}
+        {renderedLabel ? (
+          <div className="font-medium text-foreground">{renderedLabel}</div>
+        ) : null}
         <div className="grid gap-1">
           {payload.map((item, index) => {
             const payloadItem = item as unknown as TooltipPayloadItem;
             const seriesKey = payloadItem.dataKey ?? "";
             const seriesConfig = config[seriesKey];
-            const seriesLabel = seriesConfig?.label ?? payloadItem.name ?? seriesKey;
-            const seriesColor = payloadItem.color ?? `var(--color-${seriesKey})`;
+            const seriesLabel =
+              seriesConfig?.label ?? payloadItem.name ?? seriesKey;
+            const seriesColor =
+              payloadItem.color ?? `var(--color-${seriesKey})`;
 
             return (
-              <div key={`${seriesKey}-${index}`} className="flex items-center justify-between gap-2">
+              <div
+                key={`${seriesKey}-${index}`}
+                className="flex items-center justify-between gap-2"
+              >
                 <div className="flex items-center gap-2">
                   <span
                     className="h-2.5 w-2.5 rounded-[2px]"
@@ -144,7 +169,9 @@ const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltipContent
                   <span className="text-muted-foreground">{seriesLabel}</span>
                 </div>
                 <span className="font-mono font-medium tabular-nums text-foreground">
-                  {typeof payloadItem.value === "number"
+                  {valueFormatter
+                    ? valueFormatter(payloadItem.value, seriesKey)
+                    : typeof payloadItem.value === "number"
                     ? payloadItem.value.toLocaleString()
                     : payloadItem.value}
                 </span>
@@ -154,7 +181,7 @@ const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltipContent
         </div>
       </div>
     );
-  },
+  }
 );
 ChartTooltipContent.displayName = "ChartTooltipContent";
 


### PR DESCRIPTION
## Goal

Give operators a quick way to compare normal rebalances with Crossmint rebalances and see whether Crossmint swaps are working without unusually high fees.

Linear: [ASK-2144](https://linear.app/askloyal/issue/ASK-2144/admin-charts-fixes-add-crossmint)

## Scope

- Add an independent Same-mint/Crossmint switch to each route-comparable Earn table and chart.
- Add a readable Crossmint Safe reserve APY view with one best eligible reserve per target mint.
- Extend the existing activity, execution, vault-frequency, and 30-day outcome views with Crossmint data.
- Show finalized swap fees as totals, average, largest fee, a time series, and per-execution values.
- Add the same route switch to Movement audit while keeping deposit records shared between modes.
- Fix the screenshot issues that hid Crossmint executions behind the global USDC filter, rounded small SOL fees to zero, and showed Crossmint mints as unknown.
- Replace the ambiguous switch rows with compact, intrinsically sized two-option selectors, keep every vault-frequency control on one toolbar row, and hide chart scale controls when the table view is active.
- When a route has no vaults, keep only the route selector and a concise empty state instead of showing range, scale, and table controls that cannot affect anything.
- Sort Safe reserve APYs highest-first in the hover tooltip so operators can scan the best target immediately.
- Normalize card spacing across APY, activity, vault-frequency, outcomes, and failure views, including the APY loading state, so headers and chart bodies use one consistent 24px rhythm.

## How it works

This keeps the dashboard operators already know. Each relevant card now has its own switch: Same-mint shows the current behavior, while Crossmint shows the same kind of information for `cross_mint_jupiter` routes. Crossmint data no longer depends on the page's single-mint filter, and the APY chart picks the best currently eligible reserve for each target mint so the comparison stays readable.

Swap costs come only from finalized swap transactions. Withdrawal and deposit transaction fees are not mixed into that number, so a fee spike on the chart points to the swap step itself.

## Verification

- `cd apps/admin && bun lint`
- `bunx tsc --noEmit -p apps/admin/tsconfig.json`
- `bun test apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-axis.test.ts apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-eligibility.test.ts` — 18 passed
- `bun run guard:admin-shared-schema`
- `cd apps/admin && bun run verify:earn-multi-stablecoin` — 13/13 passed
- Ran the changed queries read-only against production Yield Neon, including recent Crossmint decisions, confirmed executions, vault opt-ins, and finalized swap fees.
- Used the browser at a 1280px desktop viewport against a mainnet-backed local admin session to check every selector, table, card boundary, header/content gap, and the final control composition. Route selectors stay compact instead of stretching across their parent, and the vault-frequency route, range, scale, and table controls stay on one line. It showed 8 Crossmint executions, 0 active Crossmint-enabled vaults, 0.000047 SOL in finalized swap fees, and correct `USDT → USDG` / `CASH → USDG` mint attribution. No browser warnings or errors were reported.
- Rechecked the Crossmint vault-frequency empty state and Safe reserve APY hover tooltip in the browser: inactive controls are hidden, the empty message appears once, and tooltip APYs are ordered from highest to lowest.
- Frontend builds were not run locally, per repository instructions; the Vercel preview remains the build/deploy gate.

## Post-merge

Services to redeploy:

- `admin` Vercel app, with Root Directory `apps/admin`

No yield-router, orchestrator, fleet-worker, or database migration redeploy is needed because this PR only changes the admin read path and UI.

After deployment, open `/earn/rebalance` and smoke-check each Crossmint switch, the Safe reserve APY comparison, and finalized swap-fee values.
