### PR TITLE
perf(admin): speed up admin data loading

### DIFF
--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -1323,11 +1323,6 @@ export async function getAutodepositTimeSeries(): Promise<
           AND base.base_bucket < range.ended_at + range.bucket_size
         GROUP BY 1, 2
       ),
-      -- The scheduled-slot id is derived once per claim so the join key is a
-      -- plain column and the planner can hash-join the slots rather than run a
-      -- nested-loop index probe per claim per range. Claims whose token does
-      -- not match the autodeposit pattern keep a NULL id, so they still fall
-      -- through the LEFT JOIN to 'no_linked_error' as before.
       pre_pull_claims AS (
         SELECT
           claim.updated_at AS event_at,
@@ -1344,37 +1339,47 @@ export async function getAutodepositTimeSeries(): Promise<
           AND claim.status::text IN ('released', 'failed')
           AND claim.execution_id IS NULL
       ),
-      -- Slot ids are 1:1 with claims, so probing the slot primary key per claim
-      -- means ~187k random index lookups (~750k buffer hits). Classifying every
-      -- slot once behind MATERIALIZED forces a single sequential pass plus a
-      -- hash join on a narrow (id, cause) tuple instead.
+      -- Claim transitions also touch their scheduled slot, so slots linked to
+      -- the 30-day claim window are in the same slot-update window. Normalize
+      -- the bounded error text once, encode it narrowly, and avoid classifying
+      -- or materializing the older scheduled-slot history.
       slot_causes AS MATERIALIZED (
         SELECT
-          slot.id,
+          normalized.id,
           CASE
-            WHEN slot.last_error ILIKE '%AccountNotFound%'
-              THEN 'account_not_found'
-            WHEN slot.last_error ILIKE '%InsufficientFundsForRent%'
-              THEN 'insufficient_rent'
-            WHEN slot.last_error ILIKE '%owner does not match%'
-              OR slot.last_error ILIKE '%missing token delegate%'
-              THEN 'missing_token_delegate'
-            WHEN slot.last_error ILIKE '%unable to confirm transaction%'
-              OR slot.last_error ILIKE '%timed out%'
-              OR slot.last_error ILIKE '%BlockhashNotFound%'
-              THEN 'confirmation_or_timeout'
-            WHEN slot.last_error IS NULL OR slot.last_error = ''
-              THEN 'no_linked_error'
-            ELSE 'other_pre_pull'
-          END AS cause
-        FROM loyal_yield.balance_sweep_scheduled_slots AS slot
+            WHEN strpos(normalized.error_text, 'accountnotfound') > 0 THEN 1
+            WHEN strpos(normalized.error_text, 'insufficientfundsforrent') > 0
+              THEN 2
+            WHEN strpos(normalized.error_text, 'owner does not match') > 0
+              OR strpos(normalized.error_text, 'missing token delegate') > 0
+              THEN 3
+            WHEN strpos(
+              normalized.error_text,
+              'unable to confirm transaction'
+            ) > 0
+              OR strpos(normalized.error_text, 'timed out') > 0
+              OR strpos(normalized.error_text, 'blockhashnotfound') > 0
+              THEN 4
+            WHEN normalized.error_text IS NULL
+              OR normalized.error_text = ''
+              THEN 5
+            ELSE 6
+          END::smallint AS cause
+        FROM (
+          SELECT slot.id, lower(slot.last_error) AS error_text
+          FROM loyal_yield.balance_sweep_scheduled_slots AS slot
+          WHERE slot.updated_at >= (
+            SELECT started_at AT TIME ZONE 'UTC'
+            FROM window_bounds
+          )
+            AND slot.updated_at <= now()
+          OFFSET 0
+        ) AS normalized
       ),
       pre_pull_failure_events AS (
-        -- A claim with no matching slot has no linked error, which is the same
-        -- bucket a matched slot with an empty last_error falls into.
         SELECT
           claim.event_at,
-          COALESCE(slot.cause, 'no_linked_error') AS cause
+          COALESCE(slot.cause, 5::smallint) AS cause
         FROM pre_pull_claims AS claim
         LEFT JOIN slot_causes AS slot
           ON slot.id = claim.scheduled_slot_id
@@ -1386,24 +1391,18 @@ export async function getAutodepositTimeSeries(): Promise<
             failure.event_at AT TIME ZONE 'UTC',
             timestamp '1970-01-01 00:00:00'
           ) AS base_bucket,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'account_not_found'
-          )::bigint AS account_not_found,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'insufficient_rent'
-          )::bigint AS insufficient_rent,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'missing_token_delegate'
-          )::bigint AS missing_token_delegate,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'confirmation_or_timeout'
-          )::bigint AS confirmation_or_timeout,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'no_linked_error'
-          )::bigint AS no_linked_error,
-          COUNT(*) FILTER (
-            WHERE failure.cause = 'other_pre_pull'
-          )::bigint AS other_pre_pull
+          COUNT(*) FILTER (WHERE failure.cause = 1)::bigint
+            AS account_not_found,
+          COUNT(*) FILTER (WHERE failure.cause = 2)::bigint
+            AS insufficient_rent,
+          COUNT(*) FILTER (WHERE failure.cause = 3)::bigint
+            AS missing_token_delegate,
+          COUNT(*) FILTER (WHERE failure.cause = 4)::bigint
+            AS confirmation_or_timeout,
+          COUNT(*) FILTER (WHERE failure.cause = 5)::bigint
+            AS no_linked_error,
+          COUNT(*) FILTER (WHERE failure.cause = 6)::bigint
+            AS other_pre_pull
         FROM pre_pull_failure_events AS failure
         GROUP BY 1
       ),


### PR DESCRIPTION
## Goal

Speed up database-backed admin pages by finding and removing the real query bottleneck, without adding caches, tables, indexes, snapshots, or showing less data. Tracks ASK-1999.

## Scope

- Inventoried the database work behind every admin navigation page.
- Optimized `getAutodepositTimeSeries`, the only measured database query above 500 ms at current production size.
- Added a repeatable local PostgreSQL benchmark with small, production-size, and 2x fixtures, plus a read-only live mode.
- Documented the page inventory, measured root cause, and benchmark usage.
- Kept every page/API contract, chart range, ordering, category, and displayed value unchanged. There are no migrations or production data changes.

## How the fix works

In plain language: the slow chart only displays the last 30 days, but its query was still reading and categorizing every old scheduled-slot error in the database. That produced a large temporary result before the query could join it to the 30-day claims it actually needed.

The query now limits that work to the same 30-day window, converts each error to lowercase once, and carries a small category number through the aggregation. It still returns the same chart rows and labels; it simply does less unnecessary database work.

## Verification

- Local verifier: all 81 ordered rows were identical at small, production-size, and 2x scale.
- Production-size fixture: 674 ms -> 389 ms median (1.73x faster).
- 2x fixture: 1.33 s -> 733 ms median (1.81x faster); optimized growth was 1.88x versus 1.97x for the baseline.
- Read-only production run: all 81 rows identical, 1.83 s -> 1.14 s median (1.60x faster); temporary writes fell from 46,765 to 24,148 blocks.
- `bun run admin:lint`
- `bunx tsc -p apps/admin/tsconfig.json --noEmit`
- `bun run guard:admin-shared-schema`
- touched-file Prettier check and `git diff --check`
- No frontend build was run, per repository instructions.

## Post-merge

After Vercel deploys the change, cold-load Overview and Earn > Rebalance, rerun the read-only live verifier, and confirm the chart data still matches while watching admin request errors and latency. This PR does not claim that deployment has happened.
