### PR TITLE
fix(mobile): recover expired MWA authorization

### DIFF
--- a/apps/mobile/docs/mwa-authorization-e2e.md
+++ b/apps/mobile/docs/mwa-authorization-e2e.md
@@ -1,0 +1,28 @@
+# MWA authorization recovery verifier
+
+`verify:mwa-authorization:e2e` is an explicit, opt-in Android emulator check
+for the Mobile Wallet Adapter authorization-expired path. It temporarily adds a
+development-only route and a fixture to the checkout, builds and runs the real
+development APK, then restores both files before exiting. The fixture rejects
+the signing call with the plain object shape delivered by the React Native
+bridge (`{ code: -1, message: ... }`); it does not install a wallet, use a
+private key, send a transaction, or call production APIs.
+
+Prerequisites:
+
+- Bun/npm dependencies installed in `apps/mobile`.
+- Android SDK with `adb`, `emulator`, Java 21, and an API-35 AVD named
+  `SkyVerse_API_35` (override with `MOBILE_MWA_AUTHORIZATION_AVD`).
+- A machine capable of building the Expo development APK.
+
+Run only when an emulator/build check is intended:
+
+```sh
+cd apps/mobile
+bun run verify:mwa-authorization:e2e
+```
+
+The verifier owns an emulator it starts, Metro, local telemetry proxy, ADB
+reverse mappings, generated Android output, and temporary source changes. It
+clears the app and removes those resources during cleanup. A pre-existing
+emulator or generated `android/` directory is left in place.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,8 @@
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest",
-    "verify:withdraw-latency:e2e": "bun run scripts/verify-withdraw-latency-e2e.ts"
+    "verify:withdraw-latency:e2e": "bun run scripts/verify-withdraw-latency-e2e.ts",
+    "verify:mwa-authorization:e2e": "bun run scripts/verify-mwa-authorization-e2e.ts"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",

--- a/apps/mobile/scripts/verify-mwa-authorization-e2e.ts
+++ b/apps/mobile/scripts/verify-mwa-authorization-e2e.ts
@@ -1,0 +1,669 @@
+import assert from "node:assert/strict";
+import {
+  accessSync,
+  constants,
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import {
+  buildOtlpLifecyclePayload,
+  isAlertableLifecycleEvent,
+} from "../../web/src/features/observability/otlp";
+import type { NormalizedLifecycleEvent } from "../../web/src/features/observability/lifecycle-contract";
+
+const APP_PACKAGE = "com.loyal.app.dev";
+const APP_SCHEME = "loyal-dev";
+const DEFAULT_AVD = "SkyVerse_API_35";
+const DEFAULT_METRO_PORT = 8082;
+const DEFAULT_PROXY_PORT = 4320;
+const FIXTURE_PUBLIC_KEY = "11111111111111111111111111111111";
+const FIXTURE_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const NATIVE_MESSAGE = "authorization request failed";
+const EXPECTED_MESSAGE =
+  "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.";
+const UI_XML_PATH = "/sdcard/loyal-mwa-authorization-ui.xml";
+
+type UiNode = {
+  bounds: [number, number, number, number];
+  contentDescription: string;
+  text: string;
+};
+type LifecycleEvent = {
+  flowName?: string;
+  stage?: string;
+  outcome?: string;
+  errorCode?: string;
+  errorDetail?: string;
+  httpStatus?: number;
+  flowId?: string;
+  flowVariant?: string;
+  durationMs?: number;
+  elapsedMs?: number;
+  pathname?: string;
+  release?: string;
+  runtime?: string;
+  source?: string;
+  timestamp?: string;
+  walletAddress?: string;
+  [key: string]: unknown;
+};
+
+const avdName = process.env.MOBILE_MWA_AUTHORIZATION_AVD ?? DEFAULT_AVD;
+const metroPort = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_METRO_PORT ?? DEFAULT_METRO_PORT
+);
+const proxyPort = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_PROXY_PORT ?? DEFAULT_PROXY_PORT
+);
+const timeoutMs = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_TIMEOUT_MS ?? "600000"
+);
+const tempRoot = mkdtempSync(join(tmpdir(), "loyal-mwa-authorization-"));
+const processLogPath = join(tempRoot, "processes.log");
+const processLog = createWriteStream(processLogPath, { flags: "a" });
+const children: ChildProcess[] = [];
+const lifecycleEvents: LifecycleEvent[] = [];
+let emulatorSerial: string | null = null;
+let emulatorStarted = false;
+let generatedAndroid = false;
+const sourceSnapshots: Array<{ path: string; source: string }> = [];
+const moduleBuildPaths = [
+  resolve(import.meta.dir, "../modules/expo-seed-vault/android/build"),
+  resolve(import.meta.dir, "../modules/expo-synced-keychain/android/build"),
+];
+const generatedModuleBuildPaths = moduleBuildPaths.filter(
+  (path) => !existsSync(path)
+);
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; quiet?: boolean } = {}
+): string {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? resolve(import.meta.dir, ".."),
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    stdio: options.quiet ? "pipe" : ["pipe", "inherit", "inherit"],
+  });
+  if (result.status !== 0)
+    throw new Error(
+      `${command} exited with status ${String(result.status)}${
+        options.quiet && result.stderr ? `: ${result.stderr.trim()}` : ""
+      }`
+    );
+  return options.quiet ? result.stdout.trim() : "";
+}
+
+function start(
+  command: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv
+): ChildProcess {
+  const child = spawn(command, args, {
+    cwd: resolve(import.meta.dir, ".."),
+    env: env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(processLog);
+  child.stderr?.pipe(processLog);
+  children.push(child);
+  return child;
+}
+
+async function waitFor<T>(
+  description: string,
+  read: () => T | false | Promise<T | false>,
+  limitMs = 120_000
+): Promise<T> {
+  const deadline = Date.now() + limitMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const result = await read();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `Timed out waiting for ${description}${
+      lastError instanceof Error ? `: ${lastError.message}` : ""
+    }.`
+  );
+}
+
+function findExecutable(
+  candidates: Array<string | null>,
+  label: string
+): string {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  throw new Error(`${label} executable was not found.`);
+}
+
+const androidRoot =
+  process.env.ANDROID_HOME ??
+  process.env.ANDROID_SDK_ROOT ??
+  "/opt/homebrew/share/android-commandlinetools";
+const adb = findExecutable(
+  [
+    join(androidRoot, "platform-tools/adb"),
+    "/opt/homebrew/bin/adb",
+    "/opt/homebrew/share/android-commandlinetools/platform-tools/adb",
+  ],
+  "ADB"
+);
+const emulator = findExecutable(
+  [
+    join(androidRoot, "emulator/emulator"),
+    "/opt/homebrew/share/android-commandlinetools/emulator/emulator",
+  ],
+  "Android emulator"
+);
+
+function adbRun(args: string[], quiet = true): string {
+  assert.ok(emulatorSerial, "Emulator serial is unavailable.");
+  return run(adb, ["-s", emulatorSerial, ...args], { quiet });
+}
+
+function connectedEmulator(): string | null {
+  const output = run(adb, ["devices"], { quiet: true });
+  for (const line of output.split("\n").slice(1)) {
+    const [serial, state] = line.trim().split(/\s+/, 2);
+    if (serial?.startsWith("emulator-") && state === "device") return serial;
+  }
+  return null;
+}
+
+async function ensureEmulator(): Promise<string> {
+  const connected = connectedEmulator();
+  if (connected) {
+    emulatorSerial = connected;
+    return connected;
+  }
+  start(emulator, [
+    "-avd",
+    avdName,
+    "-no-window",
+    "-no-audio",
+    "-no-boot-anim",
+    "-gpu",
+    "swiftshader_indirect",
+  ]);
+  emulatorStarted = true;
+  emulatorSerial = await waitFor(
+    "the emulator to connect",
+    () => connectedEmulator() ?? false,
+    180_000
+  );
+  await waitFor(
+    "Android boot completion",
+    () => adbRun(["shell", "getprop", "sys.boot_completed"]) === "1",
+    180_000
+  );
+  return emulatorSerial;
+}
+
+function verifierEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ANDROID_HOME: androidRoot,
+    ANDROID_SDK_ROOT: androidRoot,
+    APP_VARIANT: "development",
+    EXPO_PUBLIC_API_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+    EXPO_PUBLIC_EARN_API_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+    EXPO_PUBLIC_MWA_E2E_FIXTURE: "authorization-failed",
+    EXPO_PUBLIC_SOLANA_ENV: "mainnet",
+    JAVA_HOME:
+      process.env.JAVA_HOME ??
+      "/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home",
+  };
+}
+
+function patchSource(path: string, marker: string, replacement: string): void {
+  const source = readFileSync(path, "utf8");
+  assert.equal(
+    source.split(marker).length - 1,
+    1,
+    `Source marker missing in ${path}`
+  );
+  sourceSnapshots.push({ path, source });
+  writeFileSync(path, source.replace(marker, replacement));
+}
+
+function replaceSource(path: string, replacement: string): void {
+  const source = readFileSync(path, "utf8");
+  sourceSnapshots.push({ path, source });
+  writeFileSync(path, replacement);
+}
+
+function installTemporaryFixture(): void {
+  patchSource(
+    resolve(import.meta.dir, "../src/lib/wallet/mwa-signer.ts"),
+    `async function getMwa() {\n  return import("@solana-mobile/mobile-wallet-adapter-protocol-web3js");\n}`,
+    `async function getMwa() {\n  if (process.env.EXPO_PUBLIC_MWA_E2E_FIXTURE === "authorization-failed") {\n    const fixture = {\n      authorize: async () => ({ accounts: [{ address: "${FIXTURE_ADDRESS}" }], auth_token: "fixture-auth-token" }),\n      signMessages: async () => { throw { code: -1, message: "${NATIVE_MESSAGE}" }; },\n      signTransactions: async () => { throw { code: -1, message: "${NATIVE_MESSAGE}" }; },\n    };\n    return { transact: async (callback: (wallet: typeof fixture) => unknown) => callback(fixture) } as any;\n  }\n  return import("@solana-mobile/mobile-wallet-adapter-protocol-web3js");\n}`
+  );
+  replaceSource(
+    resolve(import.meta.dir, "../app/_layout.tsx"),
+    'import "@/global.css";\nimport { Stack } from "expo-router";\nexport default function RootLayout() { return <Stack screenOptions={{ headerShown: false }} />; }\n'
+  );
+  patchSource(
+    resolve(
+      import.meta.dir,
+      "../node_modules/react-native-reanimated/android/CMakeLists.txt"
+    ),
+    '"${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"',
+    '"${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/prefab_package/${BUILD_TYPE}/prefab/modules/worklets/libs/android.${ANDROID_ABI}/libworklets.so"'
+  );
+  replaceSource(
+    resolve(import.meta.dir, "../app/(tabs)/index.tsx"),
+    'export { default } from "../mwa-authorization-e2e";\n'
+  );
+  replaceSource(
+    resolve(import.meta.dir, "../app/(tabs)/_layout.tsx"),
+    'import { Slot } from "expo-router";\nexport default function TabsLayout() { return <Slot />; }\n'
+  );
+
+  const routePath = resolve(
+    import.meta.dir,
+    "../app/mwa-authorization-e2e.tsx"
+  );
+  assert.equal(
+    existsSync(routePath),
+    false,
+    "Temporary E2E route already exists."
+  );
+  const routeSource = [
+    'import { useEffect, useRef, useState } from "react";',
+    'import { Text, View } from "react-native";',
+    'import { loadMwaAccount, storeMwaAccount } from "@/lib/wallet/mwa-account-storage";',
+    'import { MwaSigner } from "@/lib/wallet/mwa-signer";',
+    'import { startLifecycleFlow } from "@/services/observability";',
+    `const EXPECTED_MESSAGE = ${JSON.stringify(EXPECTED_MESSAGE)};`,
+    `const FIXTURE_PUBLIC_KEY = ${JSON.stringify(FIXTURE_PUBLIC_KEY)};`,
+    "export default function MwaAuthorizationE2eScreen() {",
+    "  const exercised = useRef(false);",
+    '  const [result, setResult] = useState("MWA E2E starting");',
+    '  const [accountState, setAccountState] = useState("MWA account pending");',
+    '  const [errorClass, setErrorClass] = useState("error class pending");',
+    '  const [userMessage, setUserMessage] = useState("reconnect message pending");',
+    "  useEffect(() => {",
+    "    if (exercised.current) return;",
+    "    exercised.current = true;",
+    "    void (async () => {",
+    '      await storeMwaAccount({ authToken: "fixture-auth-token", publicKey: FIXTURE_PUBLIC_KEY, label: "MWA E2E fixture" });',
+    '      const signer = new MwaSigner("fixture-auth-token", FIXTURE_PUBLIC_KEY, "MWA E2E fixture");',
+    '      const flow = startLifecycleFlow({ flowName: "earn.withdrawal", flowVariant: "full", walletAddress: FIXTURE_PUBLIC_KEY });',
+    '      flow.start("intent");',
+    '      flow.start("prepare");',
+    '      await signer.signMessage(new Uint8Array([1, 2, 3])).then(() => setResult("MWA E2E FAIL: fixture unexpectedly signed"), async (error: unknown) => {',
+    '      flow.failFrom("prepare", error);',
+    "      const cleared = (await loadMwaAccount()) === null;",
+    '      setAccountState(cleared ? "MWA account cleared" : "MWA account NOT cleared");',
+    "      const typed = error as { failure?: string; message?: string };",
+    '      const valid = typed.failure === "authorization_expired" && typed.message === EXPECTED_MESSAGE;',
+    '      setUserMessage(typed.message === EXPECTED_MESSAGE ? EXPECTED_MESSAGE : "unexpected reconnect message");',
+    '      setErrorClass(valid ? "wallet_authorization_expired" : "unexpected error class");',
+    '      setResult(valid && cleared ? "MWA E2E PASS" : "MWA E2E FAIL");',
+    "    });",
+    "    })();",
+    "  }, []);",
+    "  return (<View style={{ flex: 1, paddingTop: 80, paddingHorizontal: 24 }}>",
+    "    <Text accessible accessibilityLabel={result}>{result}</Text>",
+    "    <Text accessible accessibilityLabel={accountState}>{accountState}</Text>",
+    "    <Text accessible accessibilityLabel={errorClass}>{errorClass}</Text>",
+    "    <Text accessible accessibilityLabel={userMessage}>{userMessage}</Text>",
+    "  </View>);",
+    "}",
+    "",
+  ].join("\n");
+  writeFileSync(routePath, routeSource);
+  sourceSnapshots.push({ path: routePath, source: "" });
+}
+
+function restoreSources(): void {
+  for (const snapshot of sourceSnapshots.reverse()) {
+    if (snapshot.source === "") rmSync(snapshot.path, { force: true });
+    else writeFileSync(snapshot.path, snapshot.source);
+  }
+  sourceSnapshots.length = 0;
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function dumpUi(): UiNode[] {
+  adbRun(["shell", "uiautomator", "dump", UI_XML_PATH]);
+  const xml = adbRun(["exec-out", "cat", UI_XML_PATH]);
+  const nodes: UiNode[] = [];
+  for (const match of xml.matchAll(/<node\s+([^>]+)\/?/g)) {
+    const attrs = new Map<string, string>();
+    for (const attr of match[1].matchAll(/([\w-]+)="([^"]*)"/g))
+      attrs.set(attr[1], decodeXml(attr[2]));
+    const bounds = attrs
+      .get("bounds")
+      ?.match(/^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$/);
+    if (bounds)
+      nodes.push({
+        bounds: [
+          Number(bounds[1]),
+          Number(bounds[2]),
+          Number(bounds[3]),
+          Number(bounds[4]),
+        ],
+        contentDescription: attrs.get("content-desc") ?? "",
+        text: attrs.get("text") ?? "",
+      });
+  }
+  return nodes;
+}
+
+function findNode(nodes: UiNode[], label: string): UiNode | null {
+  return (
+    nodes.find((node) => node.contentDescription === label) ??
+    nodes.find((node) => node.text === label) ??
+    null
+  );
+}
+
+async function waitForNode(label: string, limitMs = 120_000): Promise<UiNode> {
+  return waitFor(
+    `UI node ${JSON.stringify(label)}`,
+    () => findNode(dumpUi(), label) ?? false,
+    limitMs
+  );
+}
+
+async function dismissDevClientIntro(): Promise<void> {
+  const intro = await waitFor(
+    "the development-client intro or app",
+    () => {
+      const nodes = dumpUi();
+      const continueButton = findNode(nodes, "Continue");
+      if (continueButton)
+        return { kind: "continue" as const, node: continueButton };
+      const closeButton = findNode(nodes, "Close");
+      if (closeButton) return { kind: "close" as const, node: closeButton };
+      if (
+        findNode(nodes, "MWA E2E starting") ||
+        findNode(nodes, "MWA E2E PASS")
+      ) {
+        return { kind: "ready" as const };
+      }
+      return false;
+    },
+    180_000
+  );
+  if (intro.kind === "ready") return;
+  const [left, top, right, bottom] = intro.node.bounds;
+  adbRun([
+    "shell",
+    "input",
+    "tap",
+    String(Math.round((left + right) / 2)),
+    String(Math.round((top + bottom) / 2)),
+  ]);
+  if (intro.kind === "continue") {
+    const close = await waitForNode("Close", 180_000).catch(() => null);
+    if (close) {
+      const [closeLeft, closeTop, closeRight, closeBottom] = close.bounds;
+      adbRun([
+        "shell",
+        "input",
+        "tap",
+        String(Math.round((closeLeft + closeRight) / 2)),
+        String(Math.round((closeTop + closeBottom) / 2)),
+      ]);
+    }
+  }
+}
+
+function startProxy(): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: proxyPort,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/observability/mobile/events"
+      ) {
+        const body = (await request
+          .json()
+          .catch(() => null)) as LifecycleEvent | null;
+        if (body?.flowName === "earn.withdrawal") lifecycleEvents.push(body);
+        return Response.json({ accepted: true }, { status: 202 });
+      }
+      return Response.json({ accepted: true }, { status: 202 });
+    },
+  });
+}
+
+function normalized(event: LifecycleEvent): NormalizedLifecycleEvent {
+  return {
+    deploymentEnvironment: "dev",
+    durationMs: event.durationMs ?? 1,
+    elapsedMs: event.elapsedMs ?? 1,
+    flowId: event.flowId ?? "40697037-d01c-43b7-8379-acd8ff9073be",
+    flowName: "earn.withdrawal",
+    flowVariant: "full",
+    outcome: "failed",
+    pathname: event.pathname ?? "/",
+    release: event.release ?? "0.1.2_e2e",
+    runtime: "mobile",
+    serviceName: "loyal-mobile",
+    source: "mobile_app",
+    stage: event.stage ?? "prepare",
+    timestamp: event.timestamp ?? new Date().toISOString(),
+    errorCode: event.errorCode,
+    errorDetail: event.errorDetail,
+    httpStatus: event.httpStatus,
+    walletAddress: event.walletAddress,
+  } as NormalizedLifecycleEvent;
+}
+
+function severityText(payload: unknown): string | undefined {
+  const value = payload as {
+    resourceLogs?: Array<{
+      scopeLogs?: Array<{ logRecords?: Array<{ severityText?: string }> }>;
+    }>;
+  };
+  return value.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords?.[0]?.severityText;
+}
+
+async function main(): Promise<void> {
+  assert.ok(Number.isFinite(timeoutMs) && timeoutMs > 0);
+  const proxy = startProxy();
+  const env = verifierEnv();
+  try {
+    installTemporaryFixture();
+    await ensureEmulator();
+    const androidPath = resolve(import.meta.dir, "../android");
+    if (!existsSync(androidPath)) {
+      generatedAndroid = true;
+      run("npx", ["expo", "prebuild", "--platform", "android", "--clean"], {
+        env,
+      });
+    }
+    const emulatorAbi = adbRun(["shell", "getprop", "ro.product.cpu.abi"]);
+    assert.match(emulatorAbi, /^[a-z0-9_-]+$/i, "Unexpected emulator ABI.");
+    // Reanimated 4.1.6 expects AGP's legacy Worklets republish directory,
+    // which is empty for macOS /private/tmp worktrees. The temporary CMake
+    // patch above points at the stable prefab artifact Gradle does produce.
+    // Build only the phone's ABI so this isolated check stays deterministic.
+    run(
+      "./gradlew",
+      [
+        "app:assembleDebug",
+        "--no-parallel",
+        `-PreactNativeArchitectures=${emulatorAbi}`,
+      ],
+      { cwd: androidPath, env }
+    );
+    adbRun([
+      "install",
+      "-r",
+      join(androidPath, "app/build/outputs/apk/debug/app-debug.apk"),
+    ]);
+    adbRun(["shell", "pm", "clear", APP_PACKAGE]);
+    adbRun(["reverse", `tcp:${metroPort}`, `tcp:${metroPort}`]);
+    adbRun(["reverse", `tcp:${proxyPort}`, `tcp:${proxyPort}`]);
+    const metro = start(
+      "npx",
+      [
+        "expo",
+        "start",
+        "--dev-client",
+        "--localhost",
+        "--clear",
+        "--port",
+        String(metroPort),
+      ],
+      env
+    );
+    await waitFor(
+      "Metro",
+      async () =>
+        metro.exitCode === null &&
+        (await fetch(`http://127.0.0.1:${metroPort}/status`)
+          .then((response) => response.ok)
+          .catch(() => false)),
+      180_000
+    );
+    const devClientUrl = `${APP_SCHEME}://expo-development-client/?url=${encodeURIComponent(
+      `http://127.0.0.1:${metroPort}`
+    )}`;
+    adbRun([
+      "shell",
+      "am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      devClientUrl,
+      APP_PACKAGE,
+    ]);
+    await dismissDevClientIntro();
+    adbRun([
+      "shell",
+      "am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      `${APP_SCHEME}:///mwa-authorization-e2e`,
+      APP_PACKAGE,
+    ]);
+    await waitForNode("MWA E2E PASS", timeoutMs);
+    await waitForNode("MWA account cleared", timeoutMs);
+    await waitForNode("wallet_authorization_expired", timeoutMs);
+    await waitForNode(EXPECTED_MESSAGE, timeoutMs);
+    const event = await waitFor(
+      "failed withdrawal lifecycle event",
+      () =>
+        lifecycleEvents.find(
+          (candidate) =>
+            candidate.flowName === "earn.withdrawal" &&
+            candidate.stage === "prepare" &&
+            candidate.outcome === "failed"
+        ) ?? false,
+      timeoutMs
+    );
+    assert.equal(event.errorCode, "wallet_authorization_expired");
+    assert.notEqual(event.errorCode, "request_failed");
+    assert.equal(event.httpStatus, undefined);
+    assert.doesNotMatch(JSON.stringify(event), /authorization request failed/);
+    assert.equal(
+      Object.values(event).some((value) => value === -1 || value === "-1"),
+      false
+    );
+    const eventForClassifier = normalized(event);
+    assert.equal(isAlertableLifecycleEvent(eventForClassifier), false);
+    assert.equal(
+      severityText(buildOtlpLifecyclePayload(eventForClassifier)),
+      "INFO"
+    );
+    console.info(
+      JSON.stringify(
+        {
+          accountCleared: true,
+          errorCode: event.errorCode,
+          flow: `${event.flowName}.${event.stage}.${event.outcome}`,
+          otlpSeverity: "INFO",
+          rawNativeContentLeaked: false,
+          ui: "MWA E2E PASS",
+        },
+        null,
+        2
+      )
+    );
+  } finally {
+    proxy.stop(true);
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error(`Process logs: ${processLogPath}`);
+  process.exitCode = 1;
+} finally {
+  for (const child of children.reverse())
+    if (child.exitCode === null) child.kill("SIGTERM");
+  if (emulatorSerial) {
+    spawnSync(
+      adb,
+      ["-s", emulatorSerial, "shell", "pm", "clear", APP_PACKAGE],
+      { stdio: "ignore" }
+    );
+    spawnSync(
+      adb,
+      ["-s", emulatorSerial, "reverse", "--remove", `tcp:${metroPort}`],
+      { stdio: "ignore" }
+    );
+    spawnSync(
+      adb,
+      ["-s", emulatorSerial, "reverse", "--remove", `tcp:${proxyPort}`],
+      { stdio: "ignore" }
+    );
+    spawnSync(adb, ["-s", emulatorSerial, "shell", "rm", "-f", UI_XML_PATH], {
+      stdio: "ignore",
+    });
+  }
+  if (emulatorStarted && emulatorSerial)
+    spawnSync(adb, ["-s", emulatorSerial, "emu", "kill"], { stdio: "ignore" });
+  restoreSources();
+  if (generatedAndroid)
+    rmSync(resolve(import.meta.dir, "../android"), {
+      recursive: true,
+      force: true,
+    });
+  for (const path of generatedModuleBuildPaths)
+    rmSync(path, { recursive: true, force: true });
+  processLog.end();
+  if (process.exitCode !== 1)
+    rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -52,6 +52,10 @@ function codedError(code: string | number, message = "native failure"): Error {
   return Object.assign(new Error(message), { code });
 }
 
+function plainCodedError(code: string | number, message = "native failure") {
+  return { code, message };
+}
+
 const publicKey = PublicKey.unique().toBase58();
 const authToken = "auth-token";
 
@@ -84,6 +88,18 @@ function failAfterSession(error: unknown) {
     // Same session wrapper as `signMessages`, so both privileged calls can be
     // exercised against an identical rejection.
     signTransactions: async () => {
+      throw error;
+    },
+  };
+  mockTransact.mockImplementation(async (callback: (w: unknown) => unknown) =>
+    callback(wallet),
+  );
+}
+
+/** Opens the session, then rejects while reauthorizing the stored token. */
+function failDuringReauthorization(error: unknown) {
+  const wallet = {
+    authorize: async () => {
       throw error;
     },
   };
@@ -233,11 +249,43 @@ describe("MWA session error classification", () => {
       const error = await failureOf(signer().signMessage(new Uint8Array([1])));
 
       expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        failure: "authorization_expired",
+        walletCode: -1,
+      });
       expect((error as Error).message).toBe(
         "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
       );
       // A surviving `code` is precisely what routed this to `request_failed`.
       expect(error).not.toHaveProperty("code");
+    });
+
+    it("recovers a plain-object native rejection after reauthorization", async () => {
+      const native = plainCodedError(-1, "authorization request failed");
+      failAfterSession(native);
+
+      const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(error).toMatchObject({
+        failure: "authorization_expired",
+        walletCode: -1,
+      });
+      expect((error as Error).cause).toBe(native);
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers a plain-object rejection during reauthorization", async () => {
+      const native = plainCodedError(-1, "authorization request failed");
+      failDuringReauthorization(native);
+
+      const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(error).toMatchObject({
+        failure: "authorization_expired",
+        walletCode: -1,
+      });
+      expect((error as Error).cause).toBe(native);
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
 
     // Without this the app keeps showing a connected wallet that cannot sign,

--- a/apps/mobile/src/lib/wallet/mwa-signer.ts
+++ b/apps/mobile/src/lib/wallet/mwa-signer.ts
@@ -62,15 +62,15 @@ async function getMwa() {
 // for session-level errors, negative number for wallet protocol errors.
 // Property check instead of instanceof avoids coupling to the class exports.
 function hasErrorCode(error: unknown, code: string | number): boolean {
-  return (
-    error instanceof Error &&
-    (error as { code?: string | number }).code === code
-  );
+  return errorCodeOf(error) === code;
 }
 
 function errorCodeOf(error: unknown): string | number | undefined {
-  if (!(error instanceof Error)) return undefined;
-  return (error as { code?: string | number }).code;
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" || typeof code === "number"
+    ? code
+    : undefined;
 }
 
 // Backing out of the wallet chooser rejects with a *sentence* as the code:
@@ -369,7 +369,7 @@ export class MwaSigner implements Signer {
         // to `request_failed` — naming an HTTP failure for a call that never
         // reached the network, and leaving the stale token in place so every
         // retry failed identically (ASK-1872 follow-up).
-        throw await this.forgetAuthorization();
+        throw await this.forgetAuthorization(error);
       }
       // Only session-layer rejections become wallet-session failures. Protocol
       // errors, `reauthorize`'s reconnect instructions and our signature checks
@@ -388,9 +388,18 @@ export class MwaSigner implements Signer {
    * connected wallet whose every signature is refused, and the user has no way
    * to reach the reconnect flow from inside the failing screen.
    */
-  private async forgetAuthorization(): Promise<Error> {
+  private async forgetAuthorization(cause?: unknown): Promise<Error> {
     await clearMwaAccount();
-    return new Error(RECONNECT_MESSAGE);
+    // A different reauthorized account is a deterministic protocol mismatch,
+    // not an expired native authorization. Keep its existing unexpected-error
+    // identity so the alert policy does not hide a Loyal/wallet integration
+    // defect behind the expected revoked-token recovery path.
+    if (cause === undefined) return new Error(RECONNECT_MESSAGE);
+    return new WalletSessionError(
+      "authorization_expired",
+      errorCodeOf(cause),
+      cause,
+    );
   }
 
   private async reauthorize(wallet: Web3MobileWallet): Promise<void> {
@@ -405,7 +414,7 @@ export class MwaSigner implements Signer {
       // ERROR_AUTHORIZATION_FAILED: the wallet revoked our authorization
       // (the user disconnected this app). Transient session errors rethrow.
       if (!hasErrorCode(error, -1)) throw error;
-      throw await this.forgetAuthorization();
+      throw await this.forgetAuthorization(error);
     }
     const base64Address = toBase64Address(this.publicKey);
     if (!result.accounts.some((a) => a.address === base64Address)) {

--- a/apps/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/apps/mobile/src/lib/wallet/wallet-session-error.ts
@@ -20,6 +20,8 @@
 // the actual failure instead of a blanket `request_failed`.
 
 export type WalletSessionFailure =
+  /** The wallet revoked the authorization token stored by Loyal. */
+  | "authorization_expired"
   /** No MWA-capable wallet app is installed. */
   | "unavailable"
   /** The wallet app never connected back — the session never opened. */
@@ -33,6 +35,8 @@ export type WalletSessionFailure =
 // from the reason: telling someone to update a wallet app that simply was not
 // running sends them down the wrong path.
 const WALLET_SESSION_MESSAGES: Record<WalletSessionFailure, string> = {
+  authorization_expired:
+    "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   connection_failed:
     "Couldn't reach your wallet app. Open it once so it's running, then try again.",
   signing_failed:

--- a/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -167,6 +167,9 @@ describe("wallet session classification", () => {
     expect(mapLifecycleErrorCode(new WalletSessionError("signing_failed"))).toBe(
       "wallet_signing_failed",
     );
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("authorization_expired")),
+    ).toBe("wallet_authorization_expired");
   });
 
   // The native module's own codes must not leak through the generic probe.
@@ -201,6 +204,23 @@ describe("wallet session classification", () => {
       errorCode: "wallet_connection_failed",
     });
     expect(sent[0].httpStatus).toBeUndefined();
+  });
+
+  it("emits a bounded expired-authorization code, not a request failure", () => {
+    const sent = captureEnvelopes();
+    const native = { code: -1, message: "authorization request failed" };
+    newFlow().failFrom(
+      "prepare",
+      new WalletSessionError("authorization_expired", -1, native),
+    );
+
+    expect(sent[0]).toMatchObject({
+      outcome: "failed",
+      errorCode: "wallet_authorization_expired",
+    });
+    expect(JSON.stringify(sent[0])).not.toContain(
+      "authorization request failed",
+    );
   });
 });
 

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -357,6 +357,7 @@ type LifecycleErrorCode =
   | "send_failed"
   | "insufficient_native_sol"
   | "wallet_rejected"
+  | "wallet_authorization_expired"
   | "wallet_unavailable"
   | "wallet_connection_failed"
   | "wallet_connection_timeout"
@@ -458,6 +459,7 @@ const WALLET_SESSION_ERROR_CODES: Record<
   WalletSessionFailure,
   LifecycleErrorCode
 > = {
+  authorization_expired: "wallet_authorization_expired",
   connection_failed: "wallet_connection_failed",
   signing_failed: "wallet_signing_failed",
   timeout: "wallet_connection_timeout",

--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -163,6 +163,9 @@ export const LIFECYCLE_ERROR_CODES = [
   // `wallet_connection_timeout`, which means one of our settle watchdogs
   // elapsed while the adapter never resolved either way.
   "wallet_connection_failed",
+  // A stored Mobile Wallet Adapter authorization was revoked. The app clears
+  // it and sends the user through reconnect; no backend request was made.
+  "wallet_authorization_expired",
   // The wallet could not produce a signature. Distinct from
   // `invalid_wallet_signature`, which means a signature was produced and the
   // backend rejected it during verification.

--- a/apps/web/src/features/observability/lifecycle-error-detail.test.ts
+++ b/apps/web/src/features/observability/lifecycle-error-detail.test.ts
@@ -35,6 +35,14 @@ function envelope(overrides: Record<string, unknown> = {}) {
 }
 
 describe("lifecycle errorDetail", () => {
+  test("accepts the bounded expired wallet authorization code", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorCode: "wallet_authorization_expired" })
+    );
+
+    expect(parsed.errorCode).toBe("wallet_authorization_expired");
+  });
+
   test("is accepted alongside a category error code", () => {
     const parsed = parseBrowserLifecycleEnvelope(
       envelope({

--- a/apps/web/src/features/observability/otlp.test.ts
+++ b/apps/web/src/features/observability/otlp.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import type { NormalizedLifecycleEvent } from "./lifecycle-contract";
+import { buildOtlpLifecyclePayload, isAlertableLifecycleEvent } from "./otlp";
+
+function lifecycleEvent(
+  overrides: Partial<NormalizedLifecycleEvent> = {}
+): NormalizedLifecycleEvent {
+  return {
+    deploymentEnvironment: "prod",
+    durationMs: 100,
+    elapsedMs: 100,
+    flowId: "40697037-d01c-43b7-8379-acd8ff9073be",
+    flowName: "earn.withdrawal",
+    flowVariant: "full",
+    outcome: "failed",
+    pathname: "/",
+    release: "0.1.2_test",
+    runtime: "mobile",
+    serviceName: "loyal-mobile",
+    source: "mobile_app",
+    stage: "prepare",
+    timestamp: "2026-08-19T20:20:11.133Z",
+    ...overrides,
+  };
+}
+
+function severityText(event: NormalizedLifecycleEvent): string | undefined {
+  const payload = buildOtlpLifecyclePayload(event) as {
+    resourceLogs?: Array<{
+      scopeLogs?: Array<{
+        logRecords?: Array<{ severityText?: string }>;
+      }>;
+    }>;
+  };
+  return payload.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords?.[0]
+    ?.severityText;
+}
+
+describe("lifecycle alert severity", () => {
+  test.each([
+    "wallet_authorization_expired",
+    "wallet_connection_failed",
+    "wallet_connection_timeout",
+    "wallet_signing_failed",
+    "wallet_unavailable",
+  ] as const)("keeps expected local %s failures at INFO", (errorCode) => {
+    const event = lifecycleEvent({ errorCode });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+
+  test.each([
+    { errorDetail: "network_unreachable" as const },
+    { errorDetail: "request_timeout" as const },
+    { httpStatus: 409 },
+  ])("keeps expected request failure %# at INFO", (diagnostics) => {
+    const event = lifecycleEvent({
+      errorCode: "request_failed",
+      ...diagnostics,
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+
+  test.each([
+    { errorCode: "unexpected_error" as const },
+    { errorCode: "request_failed" as const, httpStatus: 502 },
+    {
+      errorCode: "request_failed" as const,
+      errorDetail: "kamino_upstream_unavailable" as const,
+    },
+    {
+      errorCode: "request_failed" as const,
+      errorDetail: "rpc_request_failed" as const,
+    },
+    // Unknown cause from an older mobile build: fail closed until classified.
+    { errorCode: "request_failed" as const },
+    { errorCode: "wallet_mismatch" as const },
+  ])("keeps actionable failure %# at ERROR", (diagnostics) => {
+    const event = lifecycleEvent(diagnostics);
+
+    expect(isAlertableLifecycleEvent(event)).toBe(true);
+    expect(severityText(event)).toBe("ERROR");
+  });
+
+  test("a cancellation after landed work still pages for recovery", () => {
+    const event = lifecycleEvent({
+      chainState: "confirmed",
+      errorCode: "backend_confirmation_failed",
+      outcome: "cancelled",
+      persistenceState: "failed",
+      recoveryRequired: true,
+      stage: "backend_confirm",
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(true);
+    expect(severityText(event)).toBe("ERROR");
+  });
+
+  test("ordinary cancellation stays INFO", () => {
+    const event = lifecycleEvent({
+      errorCode: "wallet_rejected",
+      outcome: "cancelled",
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+});

--- a/apps/web/src/features/observability/otlp.ts
+++ b/apps/web/src/features/observability/otlp.ts
@@ -31,6 +31,53 @@ function toUnixNano(timestamp: string): string {
   return (BigInt(Date.parse(timestamp)) * BigInt(1_000_000)).toString();
 }
 
+const EXPECTED_LOCAL_WALLET_FAILURES = new Set([
+  "wallet_authorization_expired",
+  "wallet_connection_failed",
+  "wallet_connection_timeout",
+  "wallet_signing_failed",
+  "wallet_unavailable",
+]);
+
+/**
+ * The generic Errors alert is a service-health page, not a feed of every
+ * user-visible failure. Keep expected device/session and caller-state failures
+ * observable at INFO while failing closed for unknown causes, our own bugs,
+ * upstream/RPC incidents and anything that may need money-movement recovery.
+ */
+export function isAlertableLifecycleEvent(
+  event: NormalizedLifecycleEvent
+): boolean {
+  if (event.recoveryRequired === true) return true;
+  if (event.outcome !== "failed") return false;
+  if (event.errorCode && EXPECTED_LOCAL_WALLET_FAILURES.has(event.errorCode)) {
+    return false;
+  }
+  if (event.errorCode !== "request_failed") return true;
+  if (
+    event.errorDetail === "kamino_upstream_unavailable" ||
+    event.errorDetail === "rpc_request_failed"
+  ) {
+    return true;
+  }
+  if (
+    event.errorDetail === "network_unreachable" ||
+    event.errorDetail === "request_timeout"
+  ) {
+    return false;
+  }
+  if (
+    event.httpStatus !== undefined &&
+    event.httpStatus >= 400 &&
+    event.httpStatus < 500
+  ) {
+    return false;
+  }
+  // Old clients do not carry a cause token. Keep unknown statusless failures
+  // alertable until their cause is known rather than silently hiding a bug.
+  return true;
+}
+
 export function buildOtlpErrorPayload(event: NormalizedErrorEvent): unknown {
   const attributes = [
     stringAttribute("loyal.runtime", event.runtime),
@@ -214,7 +261,7 @@ export function buildOtlpLifecyclePayload(
   }
 
   const timeUnixNano = toUnixNano(event.timestamp);
-  const isError = event.outcome === "failed" || event.recoveryRequired === true;
+  const isError = isAlertableLifecycleEvent(event);
   return {
     resourceLogs: [
       {

--- a/observability/README.md
+++ b/observability/README.md
@@ -186,6 +186,15 @@ more matched rows. It delivers to a generic webhook pointing at
 `loyal-clickstack-telegram-relay` over the private network, which posts to
 Telegram.
 
+Lifecycle export decides which failures receive ERROR severity. Expected local
+wallet-session failures, device network/timeouts, and ordinary HTTP 4xx
+rejections stay visible at INFO and do not page through this broad alert.
+Unknown legacy failures, Loyal bugs, HTTP 5xx responses, exhausted Kamino/RPC
+failures, and every recovery-required event remain ERROR. A dedicated
+wallet-health alert should be added only after measuring normal traffic, and
+should require recurrence across multiple wallets or a single build rather
+than paging on one device losing its wallet session.
+
 The relay, not ClickStack, decides what the chats see. Each accepted alert is
 sent to both Telegram and Loyal Slack `#logs`. The first delivery for a
 signature is posted immediately; repeats of it are held until the next daily


### PR DESCRIPTION
## Goal

Stop an expired Android wallet authorization from looking like a backend outage. When the wallet says its saved authorization is no longer valid, the app should forget that authorization, tell the user to reconnect, and keep the event visible without paging on-call.

Linear: [ASK-2182](https://linear.app/askloyal/issue/ASK-2182/fixmobile-recover-plain-object-mwa-authorization-failures-without)

## Alert fixed

The exact production alert investigated was:

```text
Timestamp: 2026-08-19T20:20:11.133Z
ServiceName: loyal-mobile
SeverityText: error
Body: earn.withdrawal.prepare.failed
loyal.error.code: request_failed
loyal.flow.id: 40697037-d01c-43b7-8379-acd8ff9073be
loyal.flow.stage: prepare
loyal.flow.outcome: failed
loyal.duration_ms: 7206
http.status_code: absent
```

In the bounded ClickStack window `2026-08-17T20:31:29Z` to `2026-08-19T20:31:29Z`, there were 49 `loyal-mobile` error events and 20 withdrawal prepare failures. This flow had only `prepare.started` and `prepare.failed`: no API ingress, HTTP response, submission, chain, confirmation, or persistence stage. A read-only Yield Neon check found no withdrawal row in the alert window while other wallets were recording withdrawals during the same 48 hours, so this was not a concurrent backend or database outage. There was no signature to look up on-chain because the flow stopped before submission.

## What was happening

Android sometimes gives JavaScript a plain object like `{ code: -1, message: "authorization request failed" }` instead of an `Error`. We only read the native code from real `Error` instances. That meant the existing expired-authorization recovery never ran: the saved wallet link stayed in place, and telemetry called a phone-local signing failure `request_failed` even though no request reached Loyal.

The fix accepts both native shapes, clears the stale authorization once, preserves the original object only as the local error cause, and emits the bounded `wallet_authorization_expired` code. The user sees the existing reconnect instruction instead of being left with a wallet that can never sign.

The OTLP exporter now keeps expected phone/session failures, local network timeouts, and caller HTTP 4xx responses at INFO. Unknown legacy failures, Loyal bugs, HTTP 5xx, exhausted Kamino/RPC failures, deterministic protocol mismatches, and anything requiring recovery remain ERROR. In plain terms: one phone losing its wallet connection should not wake the team; a service fault, unknown failure, repeated cross-wallet pattern, or money-movement recovery still should.

## Verification

- Android API-35 emulator E2E: real development APK and real app JS path; injected a plain-object native `-1`, then verified `MWA E2E PASS`, saved authorization cleared, reconnect copy shown, `wallet_authorization_expired`, OTLP `INFO`, and no native code/message leak.
- `cd apps/mobile && bun run test --runInBand src/lib/wallet/__tests__/mwa-session-error.test.ts src/services/__tests__/lifecycle-rejection.test.ts` — 35 tests passed.
- `cd apps/mobile && npx tsc --noEmit` — passed.
- `cd apps/mobile && npx expo lint` — passed with 0 errors (9 existing warnings in untouched files).
- `cd apps/web && bun test src/features/observability/lifecycle-error-detail.test.ts src/features/observability/otlp.test.ts` — 31 tests passed.
- `cd apps/web && bun run lint` — passed with existing warnings only.
- Focused formatting and `git diff --check` — passed.
- No local frontend build was run, per repository instructions.

## Scope

- Mobile MWA error normalization and reconnect recovery.
- Mobile/web lifecycle error-code contract and OTLP severity policy.
- Focused contract tests and an opt-in, self-cleaning Android emulator verifier.
- Alert-policy documentation.
- No API behavior, database schema/data, chain transaction logic, or production configuration changes.

## Post-merge

1. Deploy the web lifecycle ingest/exporter first so it accepts `wallet_authorization_expired` and applies the INFO severity policy.
2. Publish the mobile update after that deployment is live.
3. Watch ClickStack for 24–48 hours. Keep the broad ERROR alert for unknown/actionable failures; only add a wallet-health alert after normal traffic establishes a useful threshold, and require recurrence across wallets or a build rather than one device event.
