### PR TITLE
fix(observability): page only actionable lifecycle failures

### DIFF
--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -163,6 +163,9 @@ export const LIFECYCLE_ERROR_CODES = [
   // `wallet_connection_timeout`, which means one of our settle watchdogs
   // elapsed while the adapter never resolved either way.
   "wallet_connection_failed",
+  // A stored Mobile Wallet Adapter authorization was revoked. The app clears
+  // it and sends the user through reconnect; no backend request was made.
+  "wallet_authorization_expired",
   // The wallet could not produce a signature. Distinct from
   // `invalid_wallet_signature`, which means a signature was produced and the
   // backend rejected it during verification.

--- a/apps/web/src/features/observability/lifecycle-error-detail.test.ts
+++ b/apps/web/src/features/observability/lifecycle-error-detail.test.ts
@@ -35,6 +35,14 @@ function envelope(overrides: Record<string, unknown> = {}) {
 }
 
 describe("lifecycle errorDetail", () => {
+  test("accepts the bounded expired wallet authorization code", () => {
+    const parsed = parseBrowserLifecycleEnvelope(
+      envelope({ errorCode: "wallet_authorization_expired" })
+    );
+
+    expect(parsed.errorCode).toBe("wallet_authorization_expired");
+  });
+
   test("is accepted alongside a category error code", () => {
     const parsed = parseBrowserLifecycleEnvelope(
       envelope({

--- a/apps/web/src/features/observability/otlp.test.ts
+++ b/apps/web/src/features/observability/otlp.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import type { NormalizedLifecycleEvent } from "./lifecycle-contract";
+import { buildOtlpLifecyclePayload, isAlertableLifecycleEvent } from "./otlp";
+
+function lifecycleEvent(
+  overrides: Partial<NormalizedLifecycleEvent> = {}
+): NormalizedLifecycleEvent {
+  return {
+    deploymentEnvironment: "prod",
+    durationMs: 100,
+    elapsedMs: 100,
+    flowId: "40697037-d01c-43b7-8379-acd8ff9073be",
+    flowName: "earn.withdrawal",
+    flowVariant: "full",
+    outcome: "failed",
+    pathname: "/",
+    release: "0.1.2_test",
+    runtime: "mobile",
+    serviceName: "loyal-mobile",
+    source: "mobile_app",
+    stage: "prepare",
+    timestamp: "2026-08-19T20:20:11.133Z",
+    ...overrides,
+  };
+}
+
+function severityText(event: NormalizedLifecycleEvent): string | undefined {
+  const payload = buildOtlpLifecyclePayload(event) as {
+    resourceLogs?: Array<{
+      scopeLogs?: Array<{
+        logRecords?: Array<{ severityText?: string }>;
+      }>;
+    }>;
+  };
+  return payload.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords?.[0]
+    ?.severityText;
+}
+
+describe("lifecycle alert severity", () => {
+  test.each([
+    "wallet_authorization_expired",
+    "wallet_connection_failed",
+    "wallet_connection_timeout",
+    "wallet_signing_failed",
+    "wallet_unavailable",
+  ] as const)("keeps expected local %s failures at INFO", (errorCode) => {
+    const event = lifecycleEvent({ errorCode });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+
+  test.each([
+    { errorDetail: "network_unreachable" as const },
+    { errorDetail: "request_timeout" as const },
+    { httpStatus: 409 },
+  ])("keeps expected request failure %# at INFO", (diagnostics) => {
+    const event = lifecycleEvent({
+      errorCode: "request_failed",
+      ...diagnostics,
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+
+  test.each([
+    { errorCode: "unexpected_error" as const },
+    { errorCode: "request_failed" as const, httpStatus: 502 },
+    {
+      errorCode: "request_failed" as const,
+      errorDetail: "kamino_upstream_unavailable" as const,
+    },
+    {
+      errorCode: "request_failed" as const,
+      errorDetail: "rpc_request_failed" as const,
+    },
+    // Unknown cause from an older mobile build: fail closed until classified.
+    { errorCode: "request_failed" as const },
+    { errorCode: "wallet_mismatch" as const },
+  ])("keeps actionable failure %# at ERROR", (diagnostics) => {
+    const event = lifecycleEvent(diagnostics);
+
+    expect(isAlertableLifecycleEvent(event)).toBe(true);
+    expect(severityText(event)).toBe("ERROR");
+  });
+
+  test("a cancellation after landed work still pages for recovery", () => {
+    const event = lifecycleEvent({
+      chainState: "confirmed",
+      errorCode: "backend_confirmation_failed",
+      outcome: "cancelled",
+      persistenceState: "failed",
+      recoveryRequired: true,
+      stage: "backend_confirm",
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(true);
+    expect(severityText(event)).toBe("ERROR");
+  });
+
+  test.each([
+    { errorCode: "wallet_authorization_expired" as const, httpStatus: 503 },
+    {
+      errorCode: "wallet_connection_failed" as const,
+      persistenceState: "failed" as const,
+    },
+    {
+      chainState: "failed" as const,
+      errorCode: "wallet_signing_failed" as const,
+    },
+  ])(
+    "actionable state overrides a normally local failure %#",
+    (diagnostics) => {
+      const event = lifecycleEvent(diagnostics);
+
+      expect(isAlertableLifecycleEvent(event)).toBe(true);
+      expect(severityText(event)).toBe("ERROR");
+    }
+  );
+
+  test("ordinary cancellation stays INFO", () => {
+    const event = lifecycleEvent({
+      errorCode: "wallet_rejected",
+      outcome: "cancelled",
+    });
+
+    expect(isAlertableLifecycleEvent(event)).toBe(false);
+    expect(severityText(event)).toBe("INFO");
+  });
+});

--- a/apps/web/src/features/observability/otlp.ts
+++ b/apps/web/src/features/observability/otlp.ts
@@ -31,6 +31,56 @@ function toUnixNano(timestamp: string): string {
   return (BigInt(Date.parse(timestamp)) * BigInt(1_000_000)).toString();
 }
 
+const EXPECTED_LOCAL_WALLET_FAILURES = new Set([
+  "wallet_authorization_expired",
+  "wallet_connection_failed",
+  "wallet_connection_timeout",
+  "wallet_signing_failed",
+  "wallet_unavailable",
+]);
+
+/**
+ * The generic Errors alert is a service-health page, not a feed of every
+ * user-visible failure. Keep expected device/session and caller-state failures
+ * observable at INFO while failing closed for unknown causes, our own bugs,
+ * upstream/RPC incidents and anything that may need money-movement recovery.
+ */
+export function isAlertableLifecycleEvent(
+  event: NormalizedLifecycleEvent
+): boolean {
+  if (event.recoveryRequired === true) return true;
+  if (event.outcome !== "failed") return false;
+  if (
+    event.persistenceState === "failed" ||
+    event.chainState === "failed" ||
+    (event.httpStatus !== undefined && event.httpStatus >= 500) ||
+    event.errorDetail === "kamino_upstream_unavailable" ||
+    event.errorDetail === "rpc_request_failed"
+  ) {
+    return true;
+  }
+  if (event.errorCode && EXPECTED_LOCAL_WALLET_FAILURES.has(event.errorCode)) {
+    return false;
+  }
+  if (event.errorCode !== "request_failed") return true;
+  if (
+    event.errorDetail === "network_unreachable" ||
+    event.errorDetail === "request_timeout"
+  ) {
+    return false;
+  }
+  if (
+    event.httpStatus !== undefined &&
+    event.httpStatus >= 400 &&
+    event.httpStatus < 500
+  ) {
+    return false;
+  }
+  // Old clients do not carry a cause token. Keep unknown statusless failures
+  // alertable until their cause is known rather than silently hiding a bug.
+  return true;
+}
+
 export function buildOtlpErrorPayload(event: NormalizedErrorEvent): unknown {
   const attributes = [
     stringAttribute("loyal.runtime", event.runtime),
@@ -214,7 +264,7 @@ export function buildOtlpLifecyclePayload(
   }
 
   const timeUnixNano = toUnixNano(event.timestamp);
-  const isError = event.outcome === "failed" || event.recoveryRequired === true;
+  const isError = isAlertableLifecycleEvent(event);
   return {
     resourceLogs: [
       {

--- a/observability/README.md
+++ b/observability/README.md
@@ -186,6 +186,15 @@ more matched rows. It delivers to a generic webhook pointing at
 `loyal-clickstack-telegram-relay` over the private network, which posts to
 Telegram.
 
+Lifecycle export decides which failures receive ERROR severity. Expected local
+wallet-session failures, device network/timeouts, and ordinary HTTP 4xx
+rejections stay visible at INFO and do not page through this broad alert.
+Unknown legacy failures, Loyal bugs, HTTP 5xx responses, exhausted Kamino/RPC
+failures, and every recovery-required event remain ERROR. A dedicated
+wallet-health alert should be added only after measuring normal traffic, and
+should require recurrence across multiple wallets or a single build rather
+than paging on one device losing its wallet session.
+
 The relay, not ClickStack, decides what the chats see. Each accepted alert is
 sent to both Telegram and Loyal Slack `#logs`. The first delivery for a
 signature is posted immediately; repeats of it are held until the next daily


### PR DESCRIPTION
## Goal

Keep the broad ClickStack Errors alert focused on failures somebody can act on. Expected phone-side wallet/session failures, device network timeouts, and ordinary 4xx responses remain searchable at INFO; app bugs, unknown old-client failures, 5xx, Kamino/RPC failures, and anything requiring recovery remain ERROR.

## Alert in scope

```text
Timestamp: 2026-08-19T20:20:11.133000000Z
ServiceName: loyal-mobile
Body: earn.withdrawal.prepare.failed
service.version: 0.1.2_019ff0b1
flow_id: 40697037-d01c-43b7-8379-acd8ff9073be
flow_name: earn.withdrawal
flow_stage: prepare
error_code: request_failed
duration_ms: 7206
http_status: absent
error_detail: absent
```

The 48-hour review covered `2026-08-18T05:53:01.000Z` through `2026-08-20T05:53:01.000Z`: 503 `loyal-mobile` events, 55 ERROR rows, and 30 failed flows. Nineteen were Earn-withdraw prepare failures: 15 `unexpected_error`, 2 `wallet_signing_failed`, and 2 `request_failed`.

The supplied flow contains only `prepare.started` at `2026-08-19T20:20:03.927Z` and `prepare.failed` at `2026-08-19T20:20:11.133Z`. It is conclusively client-side/pre-backend/pre-chain: there is no HTTP/detail token, backend event, signature/chain marker, persistence marker, or recovery event. Yield Neon has no confirmed deposit or withdrawal for the scoped wallet in the window and still has one active position. No balance, signature, transaction payload, or unrelated wallet data is included. ClickStack ingestion was healthy, so Render is not presented as the cause; without a signature there is no chain lookup to fabricate.

That old release did not include a cause token, so the logs cannot prove which native error produced this exact row. This PR intentionally keeps unknown, statusless old-client failures at ERROR. The companion mobile PR fixes a reproduced Mobile Wallet Adapter plain-object authorization gap so future occurrences arrive with a bounded cause and can be kept at INFO safely.

## How this works

The lifecycle exporter now decides severity from the facts already on the event instead of treating every failed outcome as an alert. Local wallet/session failures, device network/timeouts, and normal 4xx rejections are INFO. HTTP 5xx, Kamino/RPC failures, persistence/chain failures, unknown causes, and `recoveryRequired` are ERROR. Recovery state wins over every lower-severity category.

The ingest contract also accepts `wallet_authorization_expired`, without changing the raw exception payload or accepting native wallet text/codes.

## Scope

- `apps/web/src/features/observability`: lifecycle contract, severity policy, and focused contract tests
- `observability/README.md`: the operator-facing alert boundary
- No mobile implementation, database write, alert rule mutation, or production data change

## Verification

- `cd apps/web && bun test src/features/observability/lifecycle-error-detail.test.ts src/features/observability/otlp.test.ts` — 34 passed
- `cd apps/web && bun run lint` — passed; existing warnings only
- Focused Prettier check and `git diff --check` — passed
- No frontend build was run, per repository instructions
- GitHub checks are green for this PR

## Post-merge

1. Deploy this main-based ingest/severity change first.
2. Merge and release the companion mobile PR from `ask-1355-mobile-earn-tab`.
3. Watch the bounded cause counts and broad ERROR alert for 24–48 hours. Add a separate wallet-health alert only if the new cause repeats across multiple wallets or clusters in one build.

Linear: ASK-2182
Companion mobile PR: https://github.com/loyal-labs/loyal-app/pull/674
