### PR TITLE
chore(mobile): add the location purpose string ITMS-90683 demands

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -63,6 +63,13 @@ const config: ExpoConfig = {
     },
     infoPlist: {
       UIBackgroundModes: ["remote-notification"],
+      // The app never requests location and this prompt never shows. The
+      // OneSignal XCFramework ships an optional location module whose bare
+      // CLLocationManager reference makes App Store Connect demand a purpose
+      // string for every delivery (ITMS-90683). Honest copy on purpose — do
+      // not reword this to imply the app uses location.
+      NSLocationWhenInUseUsageDescription:
+        "Loyal does not use your location. This notice exists because a notifications library includes optional location code.",
     },
     entitlements: {
       "aps-environment": IS_DEV ? "development" : "production",


### PR DESCRIPTION
Apple flags every delivery with ITMS-90683 because the OneSignal XCFramework references CLLocationManager from its optional location module; the app itself never uses location and the prompt never shows. Adds an honest purpose string so the warning stops. Advisory only — build 2 remains valid for TestFlight.

ASK-2137