### PR TITLE
fix(mobile): repair sheet layout, keyboard refocus and clipped text on iOS

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1316,14 +1316,20 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     gap: 2,
     paddingHorizontal: 12,
-    paddingVertical: 3,
+    // The 48pt line box below already carries the vertical breathing room;
+    // pill height stays ~the same as the old 40+3+3.
+    paddingVertical: 0,
     borderRadius: 48,
     backgroundColor: COLOR_BADGE_GREEN,
   },
   heroBadgeText: {
     fontFamily: "Geist_900Black",
     fontSize: 40,
-    lineHeight: 40,
+    // iOS renders Geist Black's caps above a line box pinned to the font
+    // size, so the text overflowed the pill's top while the pill hugged the
+    // box ("green bg misplaced towards the lower"). 48pt centers the glyphs
+    // on both platforms; do not pin this back to the font size.
+    lineHeight: 48,
     letterSpacing: -0.4,
     color: "#FFF",
   },

--- a/apps/mobile/src/components/earn/AutodepositHelpSheet.tsx
+++ b/apps/mobile/src/components/earn/AutodepositHelpSheet.tsx
@@ -4,9 +4,8 @@ import {
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
 import { X } from "lucide-react-native";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
-  Dimensions,
   Pressable,
   StyleSheet,
   Text,
@@ -22,13 +21,12 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
 import HelpCoin from "../../../assets/images/earn/help-coin.svg";
 import HelpDog from "../../../assets/images/earn/help-dog.svg";
 
 // Autodeposit "?" help sheet (Figma 137-6178). Red dog mascot peeking up with
 // three gold coins floating above its head; each coin hovers independently.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 
 // Hero artboard is 400×500 in Figma; everything below is expressed in that base
 // space and scaled by `s = heroWidth / 400` so the layout stays pixel-faithful.
@@ -147,7 +145,7 @@ export function AutodepositHelpSheet({
   const sheetRef = useRef<BottomSheetModal>(null);
   const insets = useSafeAreaInsets();
   const { width: windowWidth } = useWindowDimensions();
-  const snapPoints = useMemo(() => ["94%"], []);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
 
   const heroWidth = windowWidth;
   const heroHeight = heroWidth * HERO_ASPECT;
@@ -193,7 +191,7 @@ export function AutodepositHelpSheet({
       handleComponent={null}
       backgroundStyle={styles.sheetBackground}
     >
-      <BottomSheetView style={styles.container}>
+      <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
         <View style={[styles.hero, { width: heroWidth, height: heroHeight }]}>
           <HelpDog width={heroWidth} height={heroHeight} />
           {COINS.map((spec) => (
@@ -248,7 +246,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 38,
   },
   container: {
-    height: SHEET_HEIGHT,
     backgroundColor: "#FFF",
     borderTopLeftRadius: 38,
     borderTopRightRadius: 38,

--- a/apps/mobile/src/components/earn/AutodepositSetupSheet.tsx
+++ b/apps/mobile/src/components/earn/AutodepositSetupSheet.tsx
@@ -21,6 +21,8 @@ import Animated, {
   useAnimatedStyle,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import AutodepositIcon from "../../../assets/images/earn/autodeposit.svg";
 
@@ -28,9 +30,7 @@ import AutodepositIcon from "../../../assets/images/earn/autodeposit.svg";
 // anything above it auto-routes to Earn. The "edit" mode (settings icon on the
 // control) is identical except the CTA reads "Confirm". Mirrors DepositSheet's
 // input + keyboard-riding footer mechanics.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
 const SCREEN_WIDTH = Dimensions.get("screen").width;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 
 const AMOUNT_MAX_FONT_SIZE = 48;
 const AMOUNT_MIN_FONT_SIZE = 22;
@@ -152,7 +152,10 @@ export function AutodepositSetupSheet({
   setupSolShortfall?: number | null;
 }) {
   const sheetRef = useRef<BottomSheetModal>(null);
-  const inputRef = useRef<{ focus: () => void } | null>(null);
+  const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
+    null,
+  );
+  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
   const [isFocused, setIsFocused] = useState(false);
@@ -160,7 +163,7 @@ export function AutodepositSetupSheet({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const snapPoints = useMemo(() => ["94%"], []);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   // The two flow cells show the CURRENT balances of the two accounts (wallet
   // USDC → Earn), so they reflect reality and don't move as you type a
   // threshold. The threshold only governs the future sweep, not these numbers.
@@ -335,7 +338,7 @@ export function AutodepositSetupSheet({
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
     >
-      <BottomSheetView style={styles.container}>
+      <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
         <View style={styles.toolbar}>
           <Pressable
             onPress={handleClose}
@@ -389,6 +392,7 @@ export function AutodepositSetupSheet({
             </View>
             <BottomSheetTextInput
               ref={inputRef as unknown as React.Ref<never>}
+              onPressIn={rescueKeyboardFocus}
               value={displayValue}
               onChangeText={handleAmountChange}
               onFocus={() => setIsFocused(true)}
@@ -504,7 +508,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 38,
   },
   container: {
-    height: SHEET_HEIGHT,
     backgroundColor: "#FFF",
     borderTopLeftRadius: 38,
     borderTopRightRadius: 38,
@@ -551,7 +554,8 @@ const styles = StyleSheet.create({
   },
   amountRow: {
     position: "relative",
-    height: 48,
+    // Matches the amount text's 58pt line box (see amountText).
+    height: 58,
     justifyContent: "flex-end",
     marginTop: 4,
   },
@@ -562,7 +566,10 @@ const styles = StyleSheet.create({
   amountText: {
     fontFamily: "Geist_600SemiBold",
     fontSize: 48,
-    lineHeight: 48,
+    // iOS clips Geist's ascenders when lineHeight == fontSize (Android
+    // forgave it via includeFontPadding). Bottom alignment keeps the
+    // baseline and caret in place; the headroom goes to the top.
+    lineHeight: 58,
     color: COLOR_BLACK,
     includeFontPadding: false,
   },

--- a/apps/mobile/src/components/earn/DepositSheet.tsx
+++ b/apps/mobile/src/components/earn/DepositSheet.tsx
@@ -29,6 +29,8 @@ import Animated, {
   useAnimatedStyle,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import { env } from "@/config/env";
 import { getEarnProductAssets } from "@/lib/solana/earn/earn-product-mints";
@@ -97,9 +99,7 @@ const COLOR_ERROR_TEXT = "#F9363C";
 // NOT shrink when the keyboard opens (unlike `useWindowDimensions`, which
 // follows the window and can be racy inside the modal portal). This lets us
 // pin BottomSheetView to a definite height matching the modal's snap point.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
 const SCREEN_WIDTH = Dimensions.get("screen").width;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 
 // Amount auto-shrink: when "$12,345.67" gets too wide for the row, the font
 // scales down so it stays on one line, while `lineHeight` stays pinned at the
@@ -186,7 +186,10 @@ export function DepositSheet({
   const sourceSheetRef = useRef<BottomSheetModal>(null);
   // The underlying input is gesture-handler's TextInput (forwarded through
   // @gorhom/bottom-sheet); only `.focus()` is called here.
-  const inputRef = useRef<{ focus: () => void } | null>(null);
+  const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
+    null,
+  );
+  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
   const [selectedSymbol, setSelectedSymbol] = useState("USDC");
@@ -207,7 +210,7 @@ export function DepositSheet({
     return () => clearTimeout(timer);
   }, [submitting, isFirstDeposit]);
 
-  const snapPoints = useMemo(() => ["94%"], []);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   // One row per Earn product asset, funded coins first (the sheet opens
   // downward, so funded rows sit nearest the trigger); product order within
   // each group. Empty rows stay visible but disabled so the coin set reads
@@ -414,7 +417,7 @@ export function DepositSheet({
         keyboardBlurBehavior="restore"
         android_keyboardInputMode="adjustResize"
       >
-        <BottomSheetView style={styles.container}>
+        <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
           {/* Toolbar — three flex children so the absolute title doesn't eat
               taps on the close button (the bug in the previous version). */}
           <View style={styles.toolbar}>
@@ -460,6 +463,7 @@ export function DepositSheet({
                     tap (no JS .focus() roundtrip needed). */}
                 <BottomSheetTextInput
                   ref={inputRef as unknown as React.Ref<never>}
+                  onPressIn={rescueKeyboardFocus}
                   value={displayValue}
                   onChangeText={handleAmountChange}
                   onFocus={handleFocus}
@@ -638,7 +642,6 @@ const styles = StyleSheet.create({
     // Definite height matching the modal's snap point. Without an explicit
     // height, BottomSheetView sizes to content and absolute `bottom: 0`
     // children land at the content's bottom, not the sheet's bottom.
-    height: SHEET_HEIGHT,
     backgroundColor: "#FFF",
     borderTopLeftRadius: 38,
     borderTopRightRadius: 38,
@@ -679,7 +682,8 @@ const styles = StyleSheet.create({
   },
   amountRow: {
     position: "relative",
-    height: 48,
+    // Matches the amount text's 58pt line box (see amountText).
+    height: 58,
     justifyContent: "flex-end",
   },
   amountVisual: {
@@ -692,7 +696,10 @@ const styles = StyleSheet.create({
   amountText: {
     fontFamily: "Geist_600SemiBold",
     fontSize: 48,
-    lineHeight: 48,
+    // iOS clips Geist's ascenders when lineHeight == fontSize (Android
+    // forgave it via includeFontPadding). Bottom alignment keeps the
+    // baseline and caret in place; the headroom goes to the top.
+    lineHeight: 58,
     color: COLOR_BLACK,
     includeFontPadding: false,
   },

--- a/apps/mobile/src/components/earn/PositionsSheet.tsx
+++ b/apps/mobile/src/components/earn/PositionsSheet.tsx
@@ -7,7 +7,6 @@ import * as Haptics from "expo-haptics";
 import { ArrowUp, Plus } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
-  Dimensions,
   Image,
   Pressable,
   StyleSheet,
@@ -15,6 +14,7 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
 
 import type { EarnWithdrawSourceInfo } from "@/lib/solana/earn/earn-api";
 import { resolveEarnPositionDisplay } from "@/lib/solana/earn/earn-position-display";
@@ -33,8 +33,6 @@ const COLOR_LABEL_DIM = "rgba(60, 60, 67, 0.6)";
 const COLOR_VALUE_DIM = "rgba(60, 60, 67, 0.4)";
 const COLOR_WITHDRAW_BG = "#F5F5F5";
 
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.92);
 
 // Round to integer cents BEFORE splitting — trunc-then-round-cents renders
 // 3.999999 (Kamino floor-valued $4) as "$3.100" (see the Earn balance twin).
@@ -78,7 +76,7 @@ export function PositionsSheet({
 }: PositionsSheetProps) {
   const sheetRef = useRef<BottomSheetModal>(null);
   const insets = useSafeAreaInsets();
-  const snapPoints = useMemo(() => ["92%"], []);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout(0.92);
 
   useEffect(() => {
     if (open) {
@@ -128,7 +126,7 @@ export function PositionsSheet({
       backgroundStyle={styles.sheetBackground}
     >
       <BottomSheetScrollView
-        style={{ height: SHEET_HEIGHT }}
+        style={{ height: sheetHeight }}
         contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
         showsVerticalScrollIndicator={false}
       >

--- a/apps/mobile/src/components/earn/WithdrawSheet.tsx
+++ b/apps/mobile/src/components/earn/WithdrawSheet.tsx
@@ -22,6 +22,8 @@ import Animated, {
   useAnimatedStyle,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import type { EarnWithdrawSourceInfo } from "@/lib/solana/earn/earn-api";
 import { resolveEarnPositionDisplay } from "@/lib/solana/earn/earn-position-display";
@@ -102,9 +104,7 @@ const COLOR_BLACK = "#000";
 const COLOR_ERROR_BG = "rgba(249, 54, 60, 0.14)";
 const COLOR_ERROR_TEXT = "#F9363C";
 
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
 const SCREEN_WIDTH = Dimensions.get("screen").width;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 
 const AMOUNT_MAX_FONT_SIZE = 48;
 const AMOUNT_MIN_FONT_SIZE = 22;
@@ -201,7 +201,10 @@ export function WithdrawSheet({
 }: WithdrawSheetProps) {
   const sheetRef = useRef<BottomSheetModal>(null);
   const sourceSheetRef = useRef<BottomSheetModal>(null);
-  const inputRef = useRef<{ focus: () => void } | null>(null);
+  const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
+    null,
+  );
+  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
   const submitInFlightRef = useRef(false);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
@@ -214,7 +217,7 @@ export function WithdrawSheet({
   // balance (5.939), so we display a floored value but submit the exact amount.
   const [maxSelected, setMaxSelected] = useState(false);
 
-  const snapPoints = useMemo(() => ["94%"], []);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   const sourceList = useMemo(() => sources ?? [], [sources]);
   const hasPicker = sourceList.length > 0;
   const isDropdown = sourceList.length > 1;
@@ -413,7 +416,7 @@ export function WithdrawSheet({
         keyboardBlurBehavior="restore"
         android_keyboardInputMode="adjustResize"
       >
-        <BottomSheetView style={styles.container}>
+        <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
           <View style={styles.toolbar}>
             <Pressable
               onPress={handleClose}
@@ -454,6 +457,7 @@ export function WithdrawSheet({
                 </View>
                 <BottomSheetTextInput
                   ref={inputRef as unknown as React.Ref<never>}
+                  onPressIn={rescueKeyboardFocus}
                   value={displayValue}
                   onChangeText={handleAmountChange}
                   onFocus={() => setIsFocused(true)}
@@ -634,7 +638,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 38,
   },
   container: {
-    height: SHEET_HEIGHT,
     backgroundColor: "#FFF",
     borderTopLeftRadius: 38,
     borderTopRightRadius: 38,
@@ -675,7 +678,8 @@ const styles = StyleSheet.create({
   },
   amountRow: {
     position: "relative",
-    height: 48,
+    // Matches the amount text's 58pt line box (see amountText).
+    height: 58,
     justifyContent: "flex-end",
   },
   amountVisual: {
@@ -685,7 +689,10 @@ const styles = StyleSheet.create({
   amountText: {
     fontFamily: "Geist_600SemiBold",
     fontSize: 48,
-    lineHeight: 48,
+    // iOS clips Geist's ascenders when lineHeight == fontSize (Android
+    // forgave it via includeFontPadding). Bottom alignment keeps the
+    // baseline and caret in place; the headroom goes to the top.
+    lineHeight: 58,
     color: COLOR_BLACK,
     includeFontPadding: false,
   },

--- a/apps/mobile/src/components/wallet/ReceiveSheet.tsx
+++ b/apps/mobile/src/components/wallet/ReceiveSheet.tsx
@@ -7,16 +7,15 @@ import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { Copy, Share as ShareIcon, X } from "lucide-react-native";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Dimensions, Share, StyleSheet } from "react-native";
+import { Share, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
 import QRCode from "react-native-qrcode-svg";
 
 import { Pressable, Text, View } from "@/tw";
 
 const COPIED_RESET_MS = 2000;
 
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
 
 const COLOR_CARD_BG = "#F2F2F7";
 const COLOR_ICON = "#3C3C43";
@@ -50,6 +49,7 @@ export function ReceiveSheet({
   onClose,
   walletAddress,
 }: ReceiveSheetProps) {
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const insets = useSafeAreaInsets();
   const [copied, setCopied] = useState(false);
@@ -98,7 +98,7 @@ export function ReceiveSheet({
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
-      snapPoints={["94%"]}
+      snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose
       backdropComponent={renderBackdrop}
@@ -106,7 +106,7 @@ export function ReceiveSheet({
       handleComponent={null}
       backgroundStyle={styles.sheetBackground}
     >
-      <BottomSheetView style={styles.container}>
+      <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
         {/* Header: close (left) + centered title */}
         <View className="flex-row items-center justify-between px-4 py-4">
           <Pressable
@@ -268,7 +268,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 38,
   },
   container: {
-    height: SHEET_HEIGHT,
     backgroundColor: "#FFF",
     borderTopLeftRadius: 38,
     borderTopRightRadius: 38,

--- a/apps/mobile/src/components/wallet/SendSheet.tsx
+++ b/apps/mobile/src/components/wallet/SendSheet.tsx
@@ -46,6 +46,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import { useShield } from "@/hooks/wallet/useShield";
 import { useWalletTransactions } from "@/hooks/wallet/useWalletTransactions";
@@ -143,13 +145,12 @@ function formatFeeUsd(feeUsd: number | null): string {
   return `≈ ${formatUsdAmount(feeUsd)}`;
 }
 
-// Sheet is pinned to a definite height (matches the 94% snap, like
-// DepositSheet) so the absolute keyboard-riding footer's `bottom: 0` lands at
-// the sheet bottom rather than the content bottom.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
+// Sheet is pinned to a definite height so the absolute keyboard-riding
+// footer's `bottom: 0` lands at the sheet bottom rather than the content
+// bottom. Height + snap point both come from useFixedSheetLayout so they can
+// never diverge (screen-height math overshot the sheet on iPad/notched
+// iPhones and clipped the CTA).
 const SCREEN_WIDTH = Dimensions.get("screen").width;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
-const SEND_SNAP_POINTS = ["94%"];
 
 // Amount auto-shrink (ported from DepositSheet): keep the big amount on one
 // line by scaling the font down; lineHeight stays pinned so the baseline holds.
@@ -413,6 +414,7 @@ export function SendSheet({
 }: SendSheetProps) {
   const { signer, publicKey } = useWallet();
   const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   const recipientInputRef = useRef<{ focus: () => void } | null>(null);
   const amountInputRef = useRef<{ focus: () => void } | null>(null);
   const sheetSettledRef = useRef(false);
@@ -842,7 +844,7 @@ export function SendSheet({
     <>
     <BottomSheetModal
       ref={bottomSheetRef}
-      snapPoints={SEND_SNAP_POINTS}
+      snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose={step !== "result" || !isSending}
       backdropComponent={renderBackdrop}
@@ -856,7 +858,7 @@ export function SendSheet({
     >
       <BottomSheetView
         style={{
-          height: SHEET_HEIGHT,
+          height: sheetHeight,
           backgroundColor: "#fff",
           borderTopLeftRadius: 38,
           borderTopRightRadius: 38,
@@ -1056,7 +1058,10 @@ function RecipientStep({
   onPickRecipient: (address: string) => void;
   onProceed: () => void;
   recentRecipients: RecentRecipient[];
-  inputRef: React.MutableRefObject<{ focus: () => void } | null>;
+  inputRef: React.MutableRefObject<{
+    focus: () => void;
+    blur?: () => void;
+  } | null>;
 }) {
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
@@ -1306,8 +1311,12 @@ function AmountStep({
   isValidAmount: boolean;
   isFormValid: boolean;
   onNext: () => void;
-  inputRef: React.MutableRefObject<{ focus: () => void } | null>;
+  inputRef: React.MutableRefObject<{
+    focus: () => void;
+    blur?: () => void;
+  } | null>;
 }) {
+  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -1361,7 +1370,8 @@ function AmountStep({
   const amountTextStyle = {
     fontFamily: "Geist_600SemiBold",
     fontSize: amountFontSize,
-    lineHeight: 48,
+    // 58pt line box: iOS clips Geist's ascenders at lineHeight == fontSize.
+    lineHeight: 58,
     color: "#000",
     includeFontPadding: false,
   } as const;
@@ -1414,7 +1424,7 @@ function AmountStep({
           (pointerEvents="none"). */}
       <View style={{ paddingTop: 36, paddingHorizontal: 16 }}>
         <View
-          style={{ position: "relative", height: 48, justifyContent: "flex-end" }}
+          style={{ position: "relative", height: 58, justifyContent: "flex-end" }}
         >
           <View
             style={{
@@ -1442,6 +1452,7 @@ function AmountStep({
           </View>
           <BottomSheetTextInput
             ref={inputRef as unknown as React.Ref<never>}
+            onPressIn={rescueKeyboardFocus}
             value={displayAmount}
             onChangeText={(t) => onAmountChange(stripAmountInput(t))}
             onFocus={() => setIsFocused(true)}

--- a/apps/mobile/src/components/wallet/ShieldSheet.tsx
+++ b/apps/mobile/src/components/wallet/ShieldSheet.tsx
@@ -9,7 +9,7 @@ import { Image } from "expo-image";
 import * as Haptics from "expo-haptics";
 import { ArrowLeft, ChevronDown, Search, X } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Dimensions, Keyboard, Linking, TextInput } from "react-native";
+import { Keyboard, Linking, TextInput } from "react-native";
 import Animated, {
   cancelAnimation,
   Easing,
@@ -21,6 +21,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import { useShield, type ShieldFeeEstimate } from "@/hooks/wallet/useShield";
 import type { TokenDetailsByMint } from "@/hooks/wallet/useTokenDetails";
@@ -50,9 +52,8 @@ const shieldBadge = require("../../../assets/images/shield-badge.png");
 
 // Fixed-height sheet (mirrors SendSheet/SwapSheet). A fixed height lets each
 // step's flex-1 region size + center correctly and keeps the footer pinned.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
-const SHIELD_SNAP_POINTS = ["94%"];
+// Height + snap point both come from useFixedSheetLayout so they can never
+// diverge (screen-height math overshot the sheet on iPad/notched iPhones).
 const LAMPORTS_PER_SOL_NUM = 1_000_000_000;
 
 type ShieldStep = "form" | "confirm" | "result";
@@ -158,6 +159,7 @@ export function ShieldSheet({
   initialDirection,
 }: ShieldSheetProps) {
   const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   const sheetSettledRef = useRef(false);
   const amountInputRef = useRef<TextInput | null>(null);
   const [step, setStep] = useState<ShieldStep>("form");
@@ -499,7 +501,7 @@ export function ShieldSheet({
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
-      snapPoints={SHIELD_SNAP_POINTS}
+      snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose={step !== "result" || !isProcessing}
       backdropComponent={renderBackdrop}
@@ -513,7 +515,7 @@ export function ShieldSheet({
     >
       <BottomSheetView
         style={{
-          height: SHEET_HEIGHT,
+          height: sheetHeight,
           backgroundColor: "#fff",
           borderTopLeftRadius: 38,
           borderTopRightRadius: 38,
@@ -680,6 +682,8 @@ function FormStep({
   onClose: () => void;
   amountInputRef: React.RefObject<TextInput | null>;
 }) {
+  const { onPressIn: rescueKeyboardFocus } =
+    useKeyboardRescueFocus(amountInputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -765,7 +769,7 @@ function FormStep({
 
       {/* Amount */}
       <View style={{ paddingHorizontal: 16, paddingTop: 36 }}>
-        <View className="flex-row items-center" style={{ height: 48 }}>
+        <View className="flex-row items-center" style={{ height: 58 }}>
           <Pressable
             style={{ flex: 1, position: "relative", justifyContent: "center" }}
             onPress={() => amountInputRef.current?.focus()}
@@ -777,7 +781,8 @@ function FormStep({
             >
               <Text
                 className="font-semibold text-black"
-                style={{ fontSize: 48, lineHeight: 48, flexShrink: 1 }}
+                // 58pt line box: iOS clips ascenders at lineHeight == fontSize.
+                style={{ fontSize: 48, lineHeight: 58, flexShrink: 1 }}
                 numberOfLines={1}
               >
                 {bigText}
@@ -795,6 +800,7 @@ function FormStep({
             </View>
             <BottomSheetTextInput
               ref={amountInputRef as unknown as React.Ref<never>}
+              onPressIn={rescueKeyboardFocus}
               value={amountStr}
               onChangeText={onAmountChange}
               onFocus={() => setIsFocused(true)}

--- a/apps/mobile/src/components/wallet/SwapSheet.tsx
+++ b/apps/mobile/src/components/wallet/SwapSheet.tsx
@@ -18,7 +18,6 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
-  Dimensions,
   Keyboard,
   Linking,
   TextInput,
@@ -34,6 +33,9 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import { useKeyboardRescueFocus } from "@/hooks/useKeyboardRescueFocus";
 
 import type { PopularToken } from "@/hooks/wallet/usePopularTokens";
 import { usePopularTokens } from "@/hooks/wallet/usePopularTokens";
@@ -75,9 +77,9 @@ const shieldBadge = require("../../../assets/images/shield-badge.png");
 
 // Fixed-height sheet (mirrors SendSheet). A fixed height is what lets each
 // step's `flex-1` regions size + center correctly and keeps the footer pinned.
-const SCREEN_HEIGHT = Dimensions.get("screen").height;
-const SHEET_HEIGHT = Math.floor(SCREEN_HEIGHT * 0.94);
-const SWAP_SNAP_POINTS = ["94%"];
+// Height and snap point come from useFixedSheetLayout — the same pixel value
+// for both, so the box can never overshoot the visible sheet (it did on
+// iPad/notched iPhones when this was screen-height math vs a "94%" snap).
 const DEFAULT_SOL_MAX_FEE_RESERVE_LAMPORTS = 50_000;
 
 type SwapStep = "form" | "confirm" | "result";
@@ -289,6 +291,7 @@ export function SwapSheet({
 }: SwapSheetProps) {
   const { signer } = useWallet();
   const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const { sheetHeight, snapPoints } = useFixedSheetLayout();
   const sheetSettledRef = useRef(false);
   const swapInputRef = useRef<TextInput | null>(null);
   const [step, setStep] = useState<SwapStep>("form");
@@ -801,7 +804,7 @@ export function SwapSheet({
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
-      snapPoints={SWAP_SNAP_POINTS}
+      snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose={step !== "result" || !isSwapping}
       backdropComponent={renderBackdrop}
@@ -815,7 +818,7 @@ export function SwapSheet({
     >
       <BottomSheetView
         style={{
-          height: SHEET_HEIGHT,
+          height: sheetHeight,
           backgroundColor: "#fff",
           borderTopLeftRadius: 38,
           borderTopRightRadius: 38,
@@ -1306,6 +1309,8 @@ function FormStep({
   onReview: () => void;
   swapInputRef: React.RefObject<TextInput | null>;
 }) {
+  const { onPressIn: rescueKeyboardFocus } =
+    useKeyboardRescueFocus(swapInputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -1442,6 +1447,7 @@ function FormStep({
               </View>
               <BottomSheetTextInput
                 ref={swapInputRef as unknown as React.Ref<never>}
+                onPressIn={rescueKeyboardFocus}
                 value={amountStr}
                 onChangeText={(t) => onAmountChange(stripAmountInput(t))}
                 onFocus={() => setIsFocused(true)}

--- a/apps/mobile/src/hooks/useFixedSheetLayout.ts
+++ b/apps/mobile/src/hooks/useFixedSheetLayout.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+/**
+ * Height + snap points for the app's fixed-height bottom sheets.
+ *
+ * The sheets used to pair a percentage snap point ("94%") with a content box
+ * sized from Dimensions.get("screen"). Those resolve against different
+ * things: the percentage against the container @gorhom/bottom-sheet actually
+ * measures (the window, minus the top safe area on iOS), the box against the
+ * physical screen. On iPhones with a notch the box overshot the sheet by the
+ * top inset; on an iPad running the app in iPhone-compatibility or windowed
+ * mode the window is far smaller than the screen and the sheet's bottom CTA
+ * landed completely off-screen with no way to scroll to it.
+ *
+ * Returning the SAME pixel value as both the numeric snap point and the
+ * content-box height makes divergence impossible, on every device shape.
+ * The top-inset clamp keeps the sheet from reaching under the notch.
+ */
+export function useFixedSheetLayout(fraction = 0.94): {
+  sheetHeight: number;
+  snapPoints: [number];
+} {
+  const { height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  return useMemo(() => {
+    const sheetHeight = Math.min(
+      Math.floor(height * fraction),
+      Math.floor(height - insets.top - 12),
+    );
+    return { sheetHeight, snapPoints: [sheetHeight] };
+  }, [height, insets.top, fraction]);
+}

--- a/apps/mobile/src/hooks/useKeyboardRescueFocus.ts
+++ b/apps/mobile/src/hooks/useKeyboardRescueFocus.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Keyboard } from "react-native";
+
+type FocusableInput = { focus: () => void; blur?: () => void };
+
+/**
+ * iOS rescue for the transparent amount inputs inside bottom sheets.
+ *
+ * The money sheets dismiss the keyboard imperatively (MAX buttons, token
+ * pickers call Keyboard.dismiss()). After that, tapping the overlay
+ * BottomSheetTextInput on iOS sometimes never re-summons the keyboard —
+ * @gorhom/bottom-sheet v5's keyboard state gets stuck and the native focus
+ * path produces nothing (no fix in 5.2.9–5.2.14). Android is unaffected.
+ *
+ * Attach the returned handler to the input's onPressIn. It waits long enough
+ * for the native path to work; if no keyboard appeared, it blurs and
+ * refocuses the input, which reliably brings the keyboard back. When the
+ * native path works (first focus, Android, healthy iOS), it is a no-op.
+ */
+export function useKeyboardRescueFocus(
+  inputRef: React.RefObject<FocusableInput | null>,
+): { onPressIn: () => void } {
+  const keyboardVisible = useRef(false);
+
+  useEffect(() => {
+    const show = Keyboard.addListener("keyboardDidShow", () => {
+      keyboardVisible.current = true;
+    });
+    const hide = Keyboard.addListener("keyboardDidHide", () => {
+      keyboardVisible.current = false;
+    });
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
+  const onPressIn = useCallback(() => {
+    setTimeout(() => {
+      if (keyboardVisible.current) return;
+      const input = inputRef.current;
+      if (!input) return;
+      input.blur?.();
+      setTimeout(() => input.focus(), 60);
+    }, 160);
+  }, [inputRef]);
+
+  return { onPressIn };
+}


### PR DESCRIPTION
Fixes the three sheet regressions from TestFlight build 2 on iPad: CTA cut off in the fixed-height sheets (screen-vs-container math — one shared `useFixedSheetLayout` hook now feeds the identical pixel value to snap point and content box in all 9 sheets), keyboard unable to reopen after `Keyboard.dismiss()` (shared `useKeyboardRescueFocus` on all 6 overlay amount inputs), and top-clipped amount/APY text (`lineHeight` == `fontSize` clips Geist ascenders on iOS; line boxes grown with bottom alignment preserved).

Verified: lint 0 errors, tsc 0 errors, 152/152 tests. Needs on-device confirmation on the iPad + an iPhone.

ASK-2190