### PR TITLE
fix(mobile): summon the keyboard from a Pressable and center the caret

### DIFF
--- a/apps/mobile/src/components/earn/AutodepositSetupSheet.tsx
+++ b/apps/mobile/src/components/earn/AutodepositSetupSheet.tsx
@@ -155,7 +155,7 @@ export function AutodepositSetupSheet({
   const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
     null,
   );
-  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
   const [isFocused, setIsFocused] = useState(false);
@@ -375,7 +375,7 @@ export function AutodepositSetupSheet({
 
         <View style={styles.body}>
           <Text style={styles.inputLabel}>Deposit anything above</Text>
-          <View style={styles.amountRow}>
+          <Pressable style={styles.amountRow} onPress={openKeyboard}>
             <View style={styles.amountVisual} pointerEvents="none">
               <Text style={[styles.amountText, { fontSize: amountFontSize }]}>
                 $
@@ -392,7 +392,6 @@ export function AutodepositSetupSheet({
             </View>
             <BottomSheetTextInput
               ref={inputRef as unknown as React.Ref<never>}
-              onPressIn={rescueKeyboardFocus}
               value={displayValue}
               onChangeText={handleAmountChange}
               onFocus={() => setIsFocused(true)}
@@ -401,10 +400,11 @@ export function AutodepositSetupSheet({
               inputMode="decimal"
               maxLength={15}
               caretHidden
+              pointerEvents="none"
               style={styles.overlayInput}
               accessibilityLabel="Autodeposit threshold"
             />
-          </View>
+          </Pressable>
           <View style={styles.caption}>
             <Info size={20} color={COLOR_RED} strokeWidth={2} />
             <Text style={styles.captionText}>
@@ -577,7 +577,9 @@ const styles = StyleSheet.create({
     width: 2,
     height: 40,
     marginHorizontal: 2,
-    marginBottom: 4,
+    // Centered like the glyphs: both platforms center text in the 58pt line
+    // box, so a bottom-pinned caret rendered below the digits on iOS.
+    alignSelf: "center",
     borderRadius: 1,
     backgroundColor: COLOR_BLACK,
   },

--- a/apps/mobile/src/components/earn/DepositSheet.tsx
+++ b/apps/mobile/src/components/earn/DepositSheet.tsx
@@ -189,7 +189,7 @@ export function DepositSheet({
   const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
     null,
   );
-  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
   const [selectedSymbol, setSelectedSymbol] = useState("USDC");
@@ -443,7 +443,7 @@ export function DepositSheet({
               re-focusing. The value is entered in dollars (USDC ≈ $1). */}
           <View style={styles.body}>
             <View style={styles.amountInputWrap}>
-              <View style={styles.amountRow}>
+              <Pressable style={styles.amountRow} onPress={openKeyboard}>
                 <View style={styles.amountVisual} pointerEvents="none">
                   <Text style={[styles.amountText, { fontSize: amountFontSize }]}>
                     $
@@ -458,12 +458,13 @@ export function DepositSheet({
                     ]}
                   />
                 </View>
-                {/* Transparent overlay input — sits on top of the row, captures
-                    taps directly so re-focus after keyboard dismiss is just a
-                    tap (no JS .focus() roundtrip needed). */}
+                {/* Transparent overlay input. pointerEvents none: taps go to
+                    the wrapping Pressable, whose openKeyboard blur+focus
+                    escapes the iPad stuck-responder state (dismiss key hides
+                    the keyboard without blurring). Typing still reaches the
+                    focused input. */}
                 <BottomSheetTextInput
                   ref={inputRef as unknown as React.Ref<never>}
-                  onPressIn={rescueKeyboardFocus}
                   value={displayValue}
                   onChangeText={handleAmountChange}
                   onFocus={handleFocus}
@@ -472,10 +473,11 @@ export function DepositSheet({
                   inputMode="decimal"
                   maxLength={15}
                   caretHidden
+                  pointerEvents="none"
                   style={styles.overlayInput}
                   accessibilityLabel="Deposit amount"
                 />
-              </View>
+              </Pressable>
             </View>
           </View>
 
@@ -707,7 +709,9 @@ const styles = StyleSheet.create({
     width: 2,
     height: 40,
     marginHorizontal: 2,
-    marginBottom: 4,
+    // Centered like the glyphs: both platforms center text in the 58pt line
+    // box, so a bottom-pinned caret rendered below the digits on iOS.
+    alignSelf: "center",
     borderRadius: 1,
     backgroundColor: COLOR_BLACK,
   },

--- a/apps/mobile/src/components/earn/WithdrawSheet.tsx
+++ b/apps/mobile/src/components/earn/WithdrawSheet.tsx
@@ -204,7 +204,7 @@ export function WithdrawSheet({
   const inputRef = useRef<{ focus: () => void; blur?: () => void } | null>(
     null,
   );
-  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(inputRef);
   const submitInFlightRef = useRef(false);
   const insets = useSafeAreaInsets();
   const [amount, setAmount] = useState("");
@@ -436,7 +436,7 @@ export function WithdrawSheet({
 
           <View style={styles.body}>
             <View style={styles.amountInputWrap}>
-              <View style={styles.amountRow}>
+              <Pressable style={styles.amountRow} onPress={openKeyboard}>
                 <View style={styles.amountVisual} pointerEvents="none">
                   <Text
                     style={[styles.amountText, { fontSize: amountFontSize }]}
@@ -457,7 +457,6 @@ export function WithdrawSheet({
                 </View>
                 <BottomSheetTextInput
                   ref={inputRef as unknown as React.Ref<never>}
-                  onPressIn={rescueKeyboardFocus}
                   value={displayValue}
                   onChangeText={handleAmountChange}
                   onFocus={() => setIsFocused(true)}
@@ -466,10 +465,11 @@ export function WithdrawSheet({
                   inputMode="decimal"
                   maxLength={15}
                   caretHidden
+                  pointerEvents="none"
                   style={styles.overlayInput}
                   accessibilityLabel="Withdraw amount"
                 />
-              </View>
+              </Pressable>
             </View>
           </View>
 
@@ -700,7 +700,9 @@ const styles = StyleSheet.create({
     width: 2,
     height: 40,
     marginHorizontal: 2,
-    marginBottom: 4,
+    // Centered like the glyphs: both platforms center text in the 58pt line
+    // box, so a bottom-pinned caret rendered below the digits on iOS.
+    alignSelf: "center",
     borderRadius: 1,
     backgroundColor: COLOR_BLACK,
   },

--- a/apps/mobile/src/components/wallet/SendSheet.tsx
+++ b/apps/mobile/src/components/wallet/SendSheet.tsx
@@ -1316,7 +1316,7 @@ function AmountStep({
     blur?: () => void;
   } | null>;
 }) {
-  const { onPressIn: rescueKeyboardFocus } = useKeyboardRescueFocus(inputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(inputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -1423,8 +1423,9 @@ function AmountStep({
           taps/keyboard; the visible "$"+digits + custom caret render on top
           (pointerEvents="none"). */}
       <View style={{ paddingTop: 36, paddingHorizontal: 16 }}>
-        <View
+        <Pressable
           style={{ position: "relative", height: 58, justifyContent: "flex-end" }}
+          onPress={openKeyboard}
         >
           <View
             style={{
@@ -1443,7 +1444,9 @@ function AmountStep({
                 width: 2,
                 height: 40,
                 marginHorizontal: 2,
-                marginBottom: 4,
+                // Centered like the glyphs — both platforms center text in
+                // the 58pt line box; bottom-pinned sat below the digits.
+                alignSelf: "center",
                 borderRadius: 1,
                 backgroundColor: "#000",
                 opacity: isFocused && caretOn ? 1 : 0,
@@ -1452,7 +1455,6 @@ function AmountStep({
           </View>
           <BottomSheetTextInput
             ref={inputRef as unknown as React.Ref<never>}
-            onPressIn={rescueKeyboardFocus}
             value={displayAmount}
             onChangeText={(t) => onAmountChange(stripAmountInput(t))}
             onFocus={() => setIsFocused(true)}
@@ -1461,6 +1463,7 @@ function AmountStep({
             inputMode="decimal"
             maxLength={15}
             caretHidden
+            pointerEvents="none"
             style={{
               position: "absolute",
               top: 0,
@@ -1492,7 +1495,7 @@ function AmountStep({
               <SwapCurrencyIcon width={28} height={28} />
             </Pressable>
           ) : null}
-        </View>
+        </Pressable>
         <Text
           className="text-[15px] font-normal"
           style={{

--- a/apps/mobile/src/components/wallet/ShieldSheet.tsx
+++ b/apps/mobile/src/components/wallet/ShieldSheet.tsx
@@ -682,8 +682,7 @@ function FormStep({
   onClose: () => void;
   amountInputRef: React.RefObject<TextInput | null>;
 }) {
-  const { onPressIn: rescueKeyboardFocus } =
-    useKeyboardRescueFocus(amountInputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(amountInputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -772,7 +771,7 @@ function FormStep({
         <View className="flex-row items-center" style={{ height: 58 }}>
           <Pressable
             style={{ flex: 1, position: "relative", justifyContent: "center" }}
-            onPress={() => amountInputRef.current?.focus()}
+            onPress={openKeyboard}
           >
             <View
               className="flex-row items-center"
@@ -800,7 +799,6 @@ function FormStep({
             </View>
             <BottomSheetTextInput
               ref={amountInputRef as unknown as React.Ref<never>}
-              onPressIn={rescueKeyboardFocus}
               value={amountStr}
               onChangeText={onAmountChange}
               onFocus={() => setIsFocused(true)}
@@ -809,6 +807,7 @@ function FormStep({
               inputMode="decimal"
               maxLength={15}
               caretHidden
+              pointerEvents="none"
               style={{
                 position: "absolute",
                 top: 0,

--- a/apps/mobile/src/components/wallet/SwapSheet.tsx
+++ b/apps/mobile/src/components/wallet/SwapSheet.tsx
@@ -1309,8 +1309,7 @@ function FormStep({
   onReview: () => void;
   swapInputRef: React.RefObject<TextInput | null>;
 }) {
-  const { onPressIn: rescueKeyboardFocus } =
-    useKeyboardRescueFocus(swapInputRef);
+  const { openKeyboard } = useKeyboardRescueFocus(swapInputRef);
   const insets = useSafeAreaInsets();
   const keyboard = useAnimatedKeyboard();
   const footerStyle = useAnimatedStyle(() => ({
@@ -1420,7 +1419,7 @@ function FormStep({
                 position: "relative",
                 justifyContent: "center",
               }}
-              onPress={() => swapInputRef.current?.focus()}
+              onPress={openKeyboard}
             >
               <View
                 className="flex-row items-center"
@@ -1447,7 +1446,6 @@ function FormStep({
               </View>
               <BottomSheetTextInput
                 ref={swapInputRef as unknown as React.Ref<never>}
-                onPressIn={rescueKeyboardFocus}
                 value={amountStr}
                 onChangeText={(t) => onAmountChange(stripAmountInput(t))}
                 onFocus={() => setIsFocused(true)}
@@ -1456,6 +1454,7 @@ function FormStep({
                 inputMode="decimal"
                 maxLength={15}
                 caretHidden
+                pointerEvents="none"
                 style={{
                   position: "absolute",
                   top: 0,

--- a/apps/mobile/src/hooks/useKeyboardRescueFocus.ts
+++ b/apps/mobile/src/hooks/useKeyboardRescueFocus.ts
@@ -4,22 +4,25 @@ import { Keyboard } from "react-native";
 type FocusableInput = { focus: () => void; blur?: () => void };
 
 /**
- * iOS rescue for the transparent amount inputs inside bottom sheets.
+ * Deterministic keyboard summon for the transparent amount inputs inside
+ * bottom sheets.
  *
- * The money sheets dismiss the keyboard imperatively (MAX buttons, token
- * pickers call Keyboard.dismiss()). After that, tapping the overlay
- * BottomSheetTextInput on iOS sometimes never re-summons the keyboard —
- * @gorhom/bottom-sheet v5's keyboard state gets stuck and the native focus
- * path produces nothing (no fix in 5.2.9–5.2.14). Android is unaffected.
+ * On iPad the keyboard's dismiss key hides the keyboard WITHOUT blurring the
+ * input: the input stays first responder, so both native taps and focus()
+ * become no-ops and the user is stuck with no keyboard. The same stuck state
+ * can follow Keyboard.dismiss() with @gorhom/bottom-sheet v5 on iOS. The only
+ * reliable escape is blur-then-focus.
  *
- * Attach the returned handler to the input's onPressIn. It waits long enough
- * for the native path to work; if no keyboard appeared, it blurs and
- * refocuses the input, which reliably brings the keyboard back. When the
- * native path works (first focus, Android, healthy iOS), it is a no-op.
+ * The tap must reach JS deterministically, so the amount row is a Pressable
+ * whose onPress calls the returned openKeyboard, and the overlay input gets
+ * pointerEvents="none" (typing still works — keyboard events go to the
+ * focused input regardless of pointer events). An earlier attempt used
+ * onPressIn on the gesture-handler input; those touches never fired in the
+ * stuck state.
  */
 export function useKeyboardRescueFocus(
   inputRef: React.RefObject<FocusableInput | null>,
-): { onPressIn: () => void } {
+): { openKeyboard: () => void } {
   const keyboardVisible = useRef(false);
 
   useEffect(() => {
@@ -35,15 +38,17 @@ export function useKeyboardRescueFocus(
     };
   }, []);
 
-  const onPressIn = useCallback(() => {
-    setTimeout(() => {
-      if (keyboardVisible.current) return;
-      const input = inputRef.current;
-      if (!input) return;
-      input.blur?.();
-      setTimeout(() => input.focus(), 60);
-    }, 160);
+  const openKeyboard = useCallback(() => {
+    // Keyboard already up: the input is focused and typing works — a tap on
+    // the row must not bounce the keyboard.
+    if (keyboardVisible.current) return;
+    const input = inputRef.current;
+    if (!input) return;
+    // Unconditional: if the input silently stayed first responder, focus()
+    // alone is a no-op; blurring first always breaks the stuck state.
+    input.blur?.();
+    setTimeout(() => input.focus(), 60);
   }, [inputRef]);
 
-  return { onPressIn };
+  return { openKeyboard };
 }


### PR DESCRIPTION
Round 2 from iPad testing: the dismiss key hides the keyboard without blurring, so the input stays first responder and taps/focus() no-op — the onPressIn rescue never fired. Amount rows are now Pressables driving an unconditional blur->focus (`openKeyboard`), overlay inputs take `pointerEvents="none"`. Carets align center to match the glyphs' position in the 58pt line box instead of hugging the row bottom.

Verified: tsc 0 errors, lint 0 errors, 152/152 tests. JS-only — OTA-able.

ASK-2190