### PR TITLE
feat(mobile): merge the iCloud wallet options into one default-on switch

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -28,15 +28,10 @@ import { getShowTips, setShowTips } from "@/lib/settings";
 import { mmkv } from "@/lib/storage";
 import { isBiometricAvailable } from "@/lib/wallet/biometrics";
 import {
-  getLastCloudBackupAt,
-  isCloudBackupSupported,
-  writeCloudBackup,
+  isICloudBackupEnabled,
+  setICloudBackupEnabled,
 } from "@/lib/wallet/icloud-backup";
-import {
-  isICloudSyncEnabled,
-  isICloudSyncSupported,
-  setICloudSyncEnabled,
-} from "@/lib/wallet/keypair-storage";
+import { isICloudSyncSupported } from "@/lib/wallet/keypair-storage";
 import { WALLET_PIN_LENGTH } from "@/lib/wallet/pin";
 import { isWalletUnlocked, useWallet } from "@/lib/wallet/wallet-provider";
 import { Pressable, ScrollView, Text, View } from "@/tw";
@@ -174,9 +169,7 @@ export default function ProfileScreen() {
   );
   const [showTips, setShowTipsState] = useState(getShowTips);
   const [biometricsAvailable, setBiometricsAvailable] = useState(false);
-  const [icloudSyncOn, setICloudSyncOn] = useState(isICloudSyncEnabled);
-  const [lastBackupAt, setLastBackupAt] = useState(getLastCloudBackupAt);
-  const [backingUp, setBackingUp] = useState(false);
+  const [icloudBackupOn, setICloudBackupOn] = useState(isICloudBackupEnabled);
   const [showBioPinInput, setShowBioPinInput] = useState(false);
   const [bioPin, setBioPin] = useState("");
   const [bioPinError, setBioPinError] = useState<string | null>(null);
@@ -254,44 +247,16 @@ export default function ProfileScreen() {
     [wallet],
   );
 
-  const handleICloudBackup = useCallback(() => {
-    if (backingUp) return;
-    Alert.alert(
-      "Back Up Wallet to iCloud",
-      "Stores your encrypted wallet in your iCloud. Restoring it on a new phone requires your wallet PIN.",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Back Up",
-          onPress: () => {
-            setBackingUp(true);
-            writeCloudBackup()
-              .then((envelope) => {
-                setLastBackupAt(envelope.createdAt);
-                Alert.alert("Backed Up", "Your wallet is backed up to iCloud.");
-              })
-              .catch((error: unknown) => {
-                Alert.alert(
-                  "Backup Failed",
-                  error instanceof Error ? error.message : "Please try again.",
-                );
-              })
-              .finally(() => setBackingUp(false));
-          },
-        },
-      ],
-    );
-  }, [backingUp]);
-
-  const handleICloudSyncToggle = useCallback((value: boolean) => {
+  const handleICloudBackupToggle = useCallback((value: boolean) => {
     if (process.env.EXPO_OS !== "web") {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     }
-    // Optimistic — the keychain write is fast and failures are logged.
-    setICloudSyncOn(value);
-    setICloudSyncEnabled(value).catch((error) => {
-      console.warn("[settings] iCloud Keychain toggle failed", error);
-      setICloudSyncOn(!value);
+    // Optimistic — drives both backends (keychain mirror + Drive file);
+    // failures are logged and the switch reverts.
+    setICloudBackupOn(value);
+    setICloudBackupEnabled(value).catch((error) => {
+      console.warn("[settings] iCloud backup toggle failed", error);
+      setICloudBackupOn(!value);
     });
   }, []);
 
@@ -491,28 +456,11 @@ export default function ProfileScreen() {
             {!isVaultBacked && isICloudSyncSupported() && (
               <ProfileCell
                 icon={<Cloud size={28} strokeWidth={1.5} color="rgba(0,0,0,0.6)" />}
-                title="Sync Wallet to iCloud Keychain"
+                title="iCloud Backup"
                 toggle={{
-                  value: icloudSyncOn,
-                  onValueChange: handleICloudSyncToggle,
+                  value: icloudBackupOn,
+                  onValueChange: handleICloudBackupToggle,
                 }}
-              />
-            )}
-
-            {!isVaultBacked && isCloudBackupSupported() && (
-              <ProfileCell
-                icon={
-                  <Cloud size={28} strokeWidth={1.5} color="rgba(0,0,0,0.6)" />
-                }
-                title={backingUp ? "Backing Up..." : "Back Up Wallet to iCloud"}
-                subtitle={
-                  lastBackupAt
-                    ? `Last backup ${new Date(lastBackupAt).toLocaleDateString()}`
-                    : undefined
-                }
-                showChevron
-                disabled={backingUp}
-                onPress={handleICloudBackup}
               />
             )}
 

--- a/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
@@ -57,6 +57,15 @@ beforeEach(async () => {
   await setICloudSyncEnabled(false);
 });
 
+test("iCloud backup is ON by default: a fresh install mirrors a new wallet with no toggle touched", async () => {
+  mmkv.delete("settings.icloudKeychainSync"); // brand-new install: flag unset
+  await storeKeypair(keypair, PIN);
+  expect(syncedStore.get("wallet_public_key")).toBe(
+    keypair.publicKey.toBase58(),
+  );
+  expect(syncedStore.get("wallet_encrypted_keypair")).toBeTruthy();
+});
+
 test("storeKeypair does not touch the synced keychain when sync is off", async () => {
   await storeKeypair(keypair, PIN);
   expect(localStore.size).toBeGreaterThan(0);

--- a/apps/mobile/src/lib/wallet/icloud-backup.ts
+++ b/apps/mobile/src/lib/wallet/icloud-backup.ts
@@ -7,12 +7,14 @@
 // react-native-cloud-storage is a TurboModule; it is loaded lazily so OTA
 // bundles running on binaries without it (and Jest) degrade to
 // "unsupported" instead of throwing at import time.
-import { mmkv } from "@/lib/storage";
-
-import { adoptEncryptedKeypair, getStoredBackupPayload } from "./keypair-storage";
+import {
+  adoptEncryptedKeypair,
+  getStoredBackupPayload,
+  isICloudSyncEnabled,
+  setICloudSyncEnabled,
+} from "./keypair-storage";
 
 const BACKUP_PATH = "/loyal-wallet-backup.json";
-const LAST_BACKUP_AT_KEY = "wallet.icloudBackup.lastAt";
 const READ_RETRIES = 3;
 const READ_RETRY_DELAY_MS = 800;
 
@@ -143,8 +145,46 @@ export async function writeCloudBackup(): Promise<WalletBackupEnvelope> {
     JSON.stringify(envelope),
     CloudStorageScope.AppData,
   );
-  mmkv.setString(LAST_BACKUP_AT_KEY, envelope.createdAt);
   return envelope;
+}
+
+/**
+ * The single user-facing "iCloud Backup" switch. Drives BOTH backends:
+ * the iCloud Keychain mirror (continuous, restores automatically on a new
+ * device) and the Drive file (explicit "Restore from iCloud" fallback for
+ * users who keep iCloud Keychain disabled). Off deletes both copies.
+ */
+export async function setICloudBackupEnabled(enabled: boolean): Promise<void> {
+  await setICloudSyncEnabled(enabled);
+  if (enabled) {
+    // Best-effort: the keychain mirror is the primary backend; a Drive
+    // failure (no iCloud Drive, offline) must not fail the toggle.
+    try {
+      await writeCloudBackup();
+    } catch (error) {
+      console.warn("[wallet] iCloud Drive backup failed", error);
+    }
+  } else {
+    await deleteCloudBackup();
+  }
+}
+
+export function isICloudBackupEnabled(): boolean {
+  return isICloudSyncEnabled();
+}
+
+/**
+ * Keep the Drive file in step with wallet changes (create/import/PIN change)
+ * while the switch is on. Fire-and-forget from the wallet provider.
+ */
+export async function refreshCloudBackupIfEnabled(): Promise<void> {
+  if (!isICloudSyncEnabled()) return;
+  if (!isCloudBackupSupported()) return;
+  try {
+    await writeCloudBackup();
+  } catch (error) {
+    console.warn("[wallet] iCloud Drive backup refresh failed", error);
+  }
 }
 
 /** Adopt a found backup locally; the user unlocks with the original PIN. */
@@ -162,12 +202,8 @@ export async function deleteCloudBackup(): Promise<void> {
     if (await CloudStorage.exists(BACKUP_PATH, CloudStorageScope.AppData)) {
       await CloudStorage.unlink(BACKUP_PATH, CloudStorageScope.AppData);
     }
-    mmkv.delete(LAST_BACKUP_AT_KEY);
   } catch (error) {
     console.warn("[wallet] iCloud backup deletion failed", error);
   }
 }
 
-export function getLastCloudBackupAt(): string | null {
-  return mmkv.getString(LAST_BACKUP_AT_KEY) ?? null;
-}

--- a/apps/mobile/src/lib/wallet/keypair-storage.ts
+++ b/apps/mobile/src/lib/wallet/keypair-storage.ts
@@ -106,11 +106,13 @@ export async function storeKeypair(
 }
 
 /**
- * Whether the wallet items are mirrored to the iCloud Keychain. Off by
- * default; toggled from Settings on iOS builds that ship the native module.
+ * Whether the wallet is backed up to iCloud (keychain mirror + Drive file —
+ * one user-facing switch drives both). ON by default per Vlad's 2026-08-20
+ * decision, so new wallets are recoverable out of the box; the Settings
+ * toggle opts out. Only consulted on iOS — both backends no-op elsewhere.
  */
 export function isICloudSyncEnabled(): boolean {
-  return mmkv.getBoolean(ICLOUD_SYNC_ENABLED_KEY) ?? false;
+  return mmkv.getBoolean(ICLOUD_SYNC_ENABLED_KEY) ?? true;
 }
 
 /** True when the running binary can talk to the synced keychain (iOS only). */

--- a/apps/mobile/src/lib/wallet/wallet-provider.tsx
+++ b/apps/mobile/src/lib/wallet/wallet-provider.tsx
@@ -30,7 +30,10 @@ import {
   enableBiometrics,
   isBiometricEnabled,
 } from "./biometrics";
-import { deleteCloudBackup } from "./icloud-backup";
+import {
+  deleteCloudBackup,
+  refreshCloudBackupIfEnabled,
+} from "./icloud-backup";
 import {
   clearStoredKeypair,
   generateKeypairInMemory,
@@ -246,6 +249,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           : WALLET_SETUP_EVENTS.walletCreated,
         { source },
       );
+      // Default-on iCloud backup: keep the Drive file in step with the new
+      // wallet. Best-effort; the keychain mirror already ran in storeKeypair.
+      void refreshCloudBackupIfEnabled();
     },
     [],
   );
@@ -352,6 +358,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       if (biometricEnabled) {
         await enableBiometrics(newPin);
       }
+      // The Drive backup holds the old-PIN blob after a PIN change — refresh
+      // it so restore always works with the current PIN.
+      void refreshCloudBackupIfEnabled();
     },
     [signer, biometricEnabled],
   );


### PR DESCRIPTION
Single "iCloud Backup" switch replaces the sync toggle + backup button; drives both backends (keychain mirror + Drive file with write-through on wallet changes), deletes both when off, **on by default** for new wallets. Restore unchanged: keychain automatic, Drive file as onboarding fallback. Device-verified transport (second iPad, same Apple ID) preceded this refactor.

tsc 0 errors, lint 0 errors, 153/153 tests (new contract test: default-on mirrors a fresh wallet). JS-only — OTA-able.

ASK-2162, ASK-2163