### PR TITLE
perf(admin): remove monitoring query bottlenecks

### DIFF
--- a/apps/admin/src/app/(admin)/earn/autonomous-vault/autonomous-vault-data.ts
+++ b/apps/admin/src/app/(admin)/earn/autonomous-vault/autonomous-vault-data.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import DLMM from "@meteora-ag/dlmm";
+import DLMM, {
+  createProgram,
+  getPriceOfBinByBinId,
+  wrapPosition,
+} from "@meteora-ag/dlmm";
 import {
   calculateKaminoRedeemableLiquidityAmountRaw,
   parseKaminoObligationAccount,
@@ -12,7 +16,12 @@ import {
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import { type AccountInfo, Connection, PublicKey } from "@solana/web3.js";
+import {
+  AccountInfo,
+  Connection,
+  PublicKey,
+  SYSVAR_CLOCK_PUBKEY,
+} from "@solana/web3.js";
 
 import { serverEnv } from "@/lib/core/config/server";
 
@@ -158,17 +167,45 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
       true
     );
 
-    const [kaminoAccounts, dlmm] = await Promise.all([
-      connection.getMultipleAccountsInfoAndContext(
-        [
-          MANIFEST.kaminoObligation,
-          MANIFEST.kaminoReserve,
-          vaultUsdc,
-          vaultLoyal,
-        ],
-        { commitment: "finalized" }
-      ),
-      DLMM.create(connection, MANIFEST.meteoraPool),
+    const kaminoAccountsPromise = connection.getMultipleAccountsInfoAndContext(
+      [
+        MANIFEST.kaminoObligation,
+        MANIFEST.kaminoReserve,
+        vaultUsdc,
+        vaultLoyal,
+        MANIFEST.meteoraPosition,
+      ],
+      { commitment: "finalized" }
+    );
+    const dlmmPromise = DLMM.create(connection, MANIFEST.meteoraPool);
+    const kaminoAccounts = await kaminoAccountsPromise;
+    const positionAccount = kaminoAccounts.value[4] ?? null;
+    if (!positionAccount) {
+      throw new Error(
+        "Meteora position is missing from finalized mainnet state."
+      );
+    }
+
+    // Decode the already-fetched position to derive its bin-array coverage.
+    // This starts the only position-specific batch while DLMM.create is still
+    // fetching the pool's reserve and mint accounts.
+    const positionProgram = createProgram(connection);
+    const decodedPosition = wrapPosition(
+      positionProgram,
+      MANIFEST.meteoraPosition,
+      positionAccount
+    );
+    const positionAccountKeys = [
+      SYSVAR_CLOCK_PUBKEY,
+      ...decodedPosition.getBinArrayKeysCoverage(positionProgram.programId),
+    ];
+    const positionAccountsPromise = connection.getMultipleAccountsInfo(
+      positionAccountKeys,
+      { commitment: "finalized" }
+    );
+    const [dlmm, positionAccounts] = await Promise.all([
+      dlmmPromise,
+      positionAccountsPromise,
     ]);
     const obligationAccount = requireAccount(
       kaminoAccounts.value[0] ?? null,
@@ -224,14 +261,50 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
     ) {
       throw new Error("Meteora pool mints differ from the manifest.");
     }
-    const [position, activeBin] = await Promise.all([
-      dlmm.getPosition(MANIFEST.meteoraPosition),
-      dlmm.getActiveBin(),
-    ]);
+    requireAccount(positionAccount, "Meteora position", dlmm.program.programId);
+    const originalGetAccountInfo = connection.getAccountInfo;
+    const originalGetAccountInfoBound = originalGetAccountInfo.bind(connection);
+    const originalGetMultipleAccountsInfo = connection.getMultipleAccountsInfo;
+    const originalGetMultipleAccountsInfoBound =
+      originalGetMultipleAccountsInfo.bind(connection);
+    connection.getAccountInfo = (async (...args) => {
+      const [publicKey] = args;
+      if (publicKey.equals(MANIFEST.meteoraPosition)) {
+        return positionAccount;
+      }
+      return originalGetAccountInfoBound(...args);
+    }) as typeof connection.getAccountInfo;
+    connection.getMultipleAccountsInfo = (async (...args) => {
+      const [publicKeys] = args;
+      const isPositionAccountsRead =
+        publicKeys.length === positionAccountKeys.length &&
+        publicKeys.every((publicKey, index) =>
+          publicKey.equals(positionAccountKeys[index]!)
+        );
+      if (isPositionAccountsRead) {
+        return positionAccounts;
+      }
+      return originalGetMultipleAccountsInfoBound(...args);
+    }) as typeof connection.getMultipleAccountsInfo;
+
+    let position;
+    try {
+      position = await dlmm.getPosition(MANIFEST.meteoraPosition);
+    } finally {
+      connection.getAccountInfo = originalGetAccountInfo;
+      connection.getMultipleAccountsInfo = originalGetMultipleAccountsInfo;
+    }
     if (!position.positionData.owner.equals(MANIFEST.vault)) {
       throw new Error("Meteora position is not owned by the autonomous vault.");
     }
-    const priceUsdcPerLoyal = parseReferencePrice(activeBin.pricePerToken);
+    // DLMM.create already fetched the finalized pool account. Reuse its active
+    // bin instead of fetching the same pool and bin-array accounts again.
+    const activeBinId = dlmm.lbPair.activeId;
+    const priceUsdcPerLoyal = parseReferencePrice(
+      dlmm.fromPricePerLamport(
+        getPriceOfBinByBinId(activeBinId, dlmm.lbPair.binStep).toNumber()
+      )
+    );
     const feesLoyalRaw = bigintFromSdk(position.positionData.feeX);
     const feesUsdcRaw = bigintFromSdk(position.positionData.feeY);
     const meteoraLoyalRaw =
@@ -241,13 +314,10 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
     const fundedRange = getFundedRange(position.positionData.positionBinData);
     const inFundedRange =
       fundedRange !== null &&
-      activeBin.binId >= fundedRange.min &&
-      activeBin.binId <= fundedRange.max;
+      activeBinId >= fundedRange.min &&
+      activeBinId <= fundedRange.max;
     const poolEnabled = Number(dlmm.lbPair.status) === 0;
-    const observedSlot = Math.max(
-      kaminoAccounts.context.slot,
-      await connection.getSlot("finalized")
-    );
+    const snapshotSlot = kaminoAccounts.context.slot;
     const deployedUsdcRaw = kaminoValueUsdcRaw + meteoraUsdcRaw;
 
     return {
@@ -262,14 +332,14 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
         valueUsdcRaw: kaminoValueUsdcRaw,
       },
       meteora: {
-        activeBin: activeBin.binId,
+        activeBin: activeBinId,
         loyalRaw: meteoraLoyalRaw,
         position: MANIFEST.meteoraPosition.toBase58(),
         priceUsdcPerLoyal,
         usdcRaw: meteoraUsdcRaw,
       },
       observedAt,
-      observedSlot,
+      observedSlot: snapshotSlot,
       status: poolEnabled && inFundedRange ? "healthy" : "attention",
       totalLoyalRaw: meteoraLoyalRaw + idleLoyalRaw,
       totalUsdcRaw: deployedUsdcRaw + idleUsdcRaw,

--- a/apps/admin/src/app/(admin)/earn/autonomous-vault/autonomous-vault-data.ts
+++ b/apps/admin/src/app/(admin)/earn/autonomous-vault/autonomous-vault-data.ts
@@ -2,7 +2,10 @@ import "server-only";
 
 import DLMM, {
   createProgram,
+  decodeAccount,
+  deriveBinArrayBitmapExtension,
   getPriceOfBinByBinId,
+  type LbPair,
   wrapPosition,
 } from "@meteora-ag/dlmm";
 import {
@@ -167,46 +170,128 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
       true
     );
 
-    const kaminoAccountsPromise = connection.getMultipleAccountsInfoAndContext(
-      [
-        MANIFEST.kaminoObligation,
-        MANIFEST.kaminoReserve,
-        vaultUsdc,
-        vaultLoyal,
-        MANIFEST.meteoraPosition,
-      ],
+    const positionProgram = createProgram(connection);
+    const [binArrayBitmapExtension] = deriveBinArrayBitmapExtension(
+      MANIFEST.meteoraPool,
+      positionProgram.programId
+    );
+    const initialAccountKeys = [
+      MANIFEST.kaminoObligation,
+      MANIFEST.kaminoReserve,
+      vaultUsdc,
+      vaultLoyal,
+      MANIFEST.meteoraPosition,
+      MANIFEST.meteoraPool,
+      binArrayBitmapExtension,
+      SYSVAR_CLOCK_PUBKEY,
+    ];
+    // The pool and position are independent of Kamino state, so fetch every
+    // account needed to derive the dependent keys in one finalized round.
+    const kaminoAccounts = await connection.getMultipleAccountsInfoAndContext(
+      initialAccountKeys,
       { commitment: "finalized" }
     );
-    const dlmmPromise = DLMM.create(connection, MANIFEST.meteoraPool);
-    const kaminoAccounts = await kaminoAccountsPromise;
     const positionAccount = kaminoAccounts.value[4] ?? null;
+    const poolAccount = kaminoAccounts.value[5] ?? null;
     if (!positionAccount) {
       throw new Error(
         "Meteora position is missing from finalized mainnet state."
       );
     }
+    if (!poolAccount) {
+      throw new Error("Meteora pool is missing from finalized mainnet state.");
+    }
 
-    // Decode the already-fetched position to derive its bin-array coverage.
-    // This starts the only position-specific batch while DLMM.create is still
-    // fetching the pool's reserve and mint accounts.
-    const positionProgram = createProgram(connection);
     const decodedPosition = wrapPosition(
       positionProgram,
       MANIFEST.meteoraPosition,
       positionAccount
     );
+    const lbPair = decodeAccount<LbPair>(
+      positionProgram,
+      "lbPair",
+      poolAccount.data
+    );
     const positionAccountKeys = [
       SYSVAR_CLOCK_PUBKEY,
       ...decodedPosition.getBinArrayKeysCoverage(positionProgram.programId),
     ];
-    const positionAccountsPromise = connection.getMultipleAccountsInfo(
-      positionAccountKeys,
+    const dlmmAccountKeys = [
+      lbPair.reserveX,
+      lbPair.reserveY,
+      lbPair.tokenXMint,
+      lbPair.tokenYMint,
+      lbPair.rewardInfos[0].vault,
+      lbPair.rewardInfos[1].vault,
+      lbPair.rewardInfos[0].mint,
+      lbPair.rewardInfos[1].mint,
+    ];
+    const initialAccountKeySet = new Set(
+      initialAccountKeys.map((publicKey) => publicKey.toBase58())
+    );
+    const dependentAccountKeys = [
+      ...new Map(
+        [...dlmmAccountKeys, ...positionAccountKeys]
+          .filter(
+            (publicKey) => !initialAccountKeySet.has(publicKey.toBase58())
+          )
+          .map((publicKey) => [publicKey.toBase58(), publicKey])
+      ).values(),
+    ];
+    const dependentAccounts = await connection.getMultipleAccountsInfo(
+      dependentAccountKeys,
       { commitment: "finalized" }
     );
-    const [dlmm, positionAccounts] = await Promise.all([
-      dlmmPromise,
-      positionAccountsPromise,
-    ]);
+    const accountCache = new Map<string, AccountInfo<Buffer> | null>();
+    for (const [index, publicKey] of initialAccountKeys.entries()) {
+      accountCache.set(
+        publicKey.toBase58(),
+        kaminoAccounts.value[index] ?? null
+      );
+    }
+    for (const [index, publicKey] of dependentAccountKeys.entries()) {
+      accountCache.set(publicKey.toBase58(), dependentAccounts[index] ?? null);
+    }
+    const cachedAccountsFor = (publicKeys: PublicKey[]) => {
+      if (
+        !publicKeys.every((publicKey) => accountCache.has(publicKey.toBase58()))
+      ) {
+        return null;
+      }
+      return publicKeys.map(
+        (publicKey) => accountCache.get(publicKey.toBase58()) ?? null
+      );
+    };
+    const originalGetAccountInfo = connection.getAccountInfo;
+    const originalGetAccountInfoBound = originalGetAccountInfo.bind(connection);
+    const originalGetMultipleAccountsInfo = connection.getMultipleAccountsInfo;
+    const originalGetMultipleAccountsInfoBound =
+      originalGetMultipleAccountsInfo.bind(connection);
+    connection.getAccountInfo = (async (...args) => {
+      const [publicKey] = args;
+      if (accountCache.has(publicKey.toBase58())) {
+        return accountCache.get(publicKey.toBase58()) ?? null;
+      }
+      return originalGetAccountInfoBound(...args);
+    }) as typeof connection.getAccountInfo;
+    connection.getMultipleAccountsInfo = (async (...args) => {
+      const [publicKeys] = args;
+      const cachedAccounts = cachedAccountsFor(publicKeys);
+      if (cachedAccounts) {
+        return cachedAccounts;
+      }
+      return originalGetMultipleAccountsInfoBound(...args);
+    }) as typeof connection.getMultipleAccountsInfo;
+
+    let dlmm;
+    let position;
+    try {
+      dlmm = await DLMM.create(connection, MANIFEST.meteoraPool);
+      position = await dlmm.getPosition(MANIFEST.meteoraPosition);
+    } finally {
+      connection.getAccountInfo = originalGetAccountInfo;
+      connection.getMultipleAccountsInfo = originalGetMultipleAccountsInfo;
+    }
     const obligationAccount = requireAccount(
       kaminoAccounts.value[0] ?? null,
       "Kamino obligation",
@@ -262,38 +347,6 @@ async function loadAutonomousVaultData(): Promise<AutonomousVaultData> {
       throw new Error("Meteora pool mints differ from the manifest.");
     }
     requireAccount(positionAccount, "Meteora position", dlmm.program.programId);
-    const originalGetAccountInfo = connection.getAccountInfo;
-    const originalGetAccountInfoBound = originalGetAccountInfo.bind(connection);
-    const originalGetMultipleAccountsInfo = connection.getMultipleAccountsInfo;
-    const originalGetMultipleAccountsInfoBound =
-      originalGetMultipleAccountsInfo.bind(connection);
-    connection.getAccountInfo = (async (...args) => {
-      const [publicKey] = args;
-      if (publicKey.equals(MANIFEST.meteoraPosition)) {
-        return positionAccount;
-      }
-      return originalGetAccountInfoBound(...args);
-    }) as typeof connection.getAccountInfo;
-    connection.getMultipleAccountsInfo = (async (...args) => {
-      const [publicKeys] = args;
-      const isPositionAccountsRead =
-        publicKeys.length === positionAccountKeys.length &&
-        publicKeys.every((publicKey, index) =>
-          publicKey.equals(positionAccountKeys[index]!)
-        );
-      if (isPositionAccountsRead) {
-        return positionAccounts;
-      }
-      return originalGetMultipleAccountsInfoBound(...args);
-    }) as typeof connection.getMultipleAccountsInfo;
-
-    let position;
-    try {
-      position = await dlmm.getPosition(MANIFEST.meteoraPosition);
-    } finally {
-      connection.getAccountInfo = originalGetAccountInfo;
-      connection.getMultipleAccountsInfo = originalGetMultipleAccountsInfo;
-    }
     if (!position.positionData.owner.equals(MANIFEST.vault)) {
       throw new Error("Meteora position is not owned by the autonomous vault.");
     }

--- a/apps/admin/src/app/(admin)/earn/earn-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-data.ts
@@ -45,9 +45,16 @@ const ACTIVE_EARN_HOLDINGS_CTE = `
         reserve.planning_metadata->>'redeemable_source_liquidity_amount_raw'
       ) AS redeemable_amount_raw_text
     FROM active_positions AS active
-    INNER JOIN loyal_yield.vault_reserve_positions_current AS reserve
-      ON reserve.vault_id = active.vault_id
-      AND reserve.liquidity_mint = active.deposit_mint
+    CROSS JOIN LATERAL (
+      SELECT
+        reserve.amount_raw,
+        reserve.planning_metadata,
+        reserve.liquidity_mint,
+        reserve.vault_id
+      FROM loyal_yield.vault_reserve_positions_current AS reserve
+      WHERE reserve.vault_id = active.vault_id
+        AND reserve.liquidity_mint = active.deposit_mint
+    ) AS reserve
   ),
   normalized_reserve_by_position AS (
     SELECT
@@ -344,6 +351,20 @@ type MintHoldingSummaryRow = {
   latest_rebalance_at: Date | string | null;
 };
 
+type CombinedHoldingsRow = {
+  headline: HeadlineRow | null;
+  mint_summaries: MintHoldingSummaryRow[];
+  top_positions: PositionRow[];
+};
+
+type SmallMetricsRow = {
+  executions: ExecutionRow | null;
+  flow: FlowRow[];
+  freshness: FreshnessRow | null;
+  scheduled: ScheduledRow | null;
+  status: AutodepositStatusRow[];
+};
+
 function toBigInt(value: string | number | bigint | null | undefined): bigint {
   if (typeof value === "bigint") {
     return value;
@@ -410,272 +431,284 @@ async function loadEarnData(): Promise<EarnData> {
   const queryRows = <T>(query: string) =>
     sql.query(query) as unknown as Promise<T[]>;
 
-  const [
-    headlineRows,
-    flowRows,
-    statusRows,
-    scheduledRows,
-    executionRows,
-    freshnessRows,
-    mintHoldingSummaryRows,
-    positionRows,
-  ] = await Promise.all([
-    queryRows<HeadlineRow>(
-      `
-        ${ACTIVE_EARN_HOLDINGS_CTE}
-        SELECT
-          COALESCE(SUM(normalized_aum_raw), 0)::text AS active_aum_raw,
-          COALESCE(SUM(normalized_reserve_raw), 0)::text AS active_reserve_raw,
-          COALESCE(SUM(idle_raw), 0)::text AS active_idle_raw,
-          COALESCE(SUM(current_amount_raw), 0)::text AS active_stored_current_pointer_raw,
-          COALESCE(SUM(current_pointer_delta_raw), 0)::text AS active_current_pointer_delta_raw,
-          COALESCE(SUM(principal_amount_raw), 0)::text AS active_principal_raw,
-          COALESCE(SUM(collateral_stored_amount_raw), 0)::text AS active_collateral_stored_amount_raw,
-          COALESCE(SUM(excluded_reserve_raw), 0)::text AS active_excluded_reserve_raw,
-          COALESCE(SUM(redeemable_reserve_rows), 0)::text AS active_redeemable_reserve_rows,
-          COALESCE(SUM(collateral_reserve_rows), 0)::text AS active_collateral_reserve_rows,
-          COALESCE(SUM(missing_redeemable_metadata_rows), 0)::text AS active_missing_redeemable_metadata_rows,
-          COALESCE(SUM(unknown_reserve_semantics_rows), 0)::text AS active_unknown_reserve_semantics_rows,
-          COALESCE(SUM(missing_managed_vault_rows), 0)::text AS active_missing_managed_vault_rows,
-          (
-            SELECT COUNT(DISTINCT COALESCE(NULLIF(wallet_address, ''), settings))::text
-            FROM loyal_yield.user_yield_positions
-            WHERE status = 'active'
-          ) AS unique_earn_users,
-          (
-            SELECT COUNT(DISTINCT policy_account)::text
-            FROM loyal_yield.route_policies
-            WHERE active = true
-          ) AS unique_earn_policies,
-          (
-            SELECT COUNT(DISTINCT policy.policy_account)::text
-            FROM loyal_yield.balance_sweep_policies AS policy
-            INNER JOIN loyal_yield.balance_sweep_targets AS target
-              ON target.balance_sweep_policy_id = policy.id
-            WHERE policy.active = true
-              AND target.active = true
-              AND target.lifecycle_status = 'active'
-          ) AS active_autodeposit_policies
-        FROM normalized_active_positions
-      `
+  const combinedHoldingsQuery = `
+    ${ACTIVE_EARN_HOLDINGS_CTE},
+    holdings_by_mint AS (
+      SELECT deposit_mint, COUNT(*)::text AS active_position_count,
+        COALESCE(SUM(normalized_aum_raw), 0)::text AS active_aum_raw,
+        COALESCE(SUM(excluded_reserve_raw), 0)::text AS active_excluded_reserve_raw,
+        COALESCE(SUM(normalized_reserve_raw), 0)::text AS active_reserve_raw,
+        COALESCE(SUM(idle_raw), 0)::text AS active_idle_raw,
+        COALESCE(SUM(principal_amount_raw), 0)::text AS active_principal_raw,
+        COALESCE(SUM(current_amount_raw), 0)::text AS active_stored_current_pointer_raw,
+        COALESCE(SUM(current_pointer_delta_raw), 0)::text AS current_pointer_delta_raw
+      FROM normalized_active_positions GROUP BY deposit_mint
     ),
-    queryRows<FlowRow>(
-      `
-        WITH bounds AS (
-          SELECT
-            ((date_trunc('day', now() AT TIME ZONE 'UTC')::date + 1) - 30)::date AS start_day,
-            (date_trunc('day', now() AT TIME ZONE 'UTC')::date + 1)::date AS end_day
-        ),
-        stable_mints(liquidity_mint) AS (
-          VALUES ${STABLE_MINT_VALUES_SQL}
-        ),
-        days AS (
-          SELECT generate_series(
-            (SELECT start_day FROM bounds),
-            (SELECT end_day FROM bounds) - 1,
-            interval '1 day'
-          )::date AS day
-        ),
-        confirmed_flow_events AS (
-          SELECT
-            (deposit.confirmed_at AT TIME ZONE 'UTC')::date AS day,
-            'deposit'::text AS direction,
-            'earn_deposit'::text AS source,
-            deposit.id AS source_id,
-            deposit.deposit_mint AS liquidity_mint,
-            deposit.principal_amount_raw AS amount_raw
-          FROM loyal_yield.user_yield_position_deposits AS deposit
-          WHERE deposit.confirmed_at >= (SELECT start_day FROM bounds)
-            AND deposit.confirmed_at < (SELECT end_day FROM bounds)
-          UNION ALL
-          SELECT
-            (withdrawal.confirmed_at AT TIME ZONE 'UTC')::date AS day,
-            'withdrawal'::text AS direction,
-            'earn_withdrawal'::text AS source,
-            withdrawal.id AS source_id,
-            withdrawal.liquidity_mint,
-            withdrawal.withdrawn_amount_raw AS amount_raw
-          FROM loyal_yield.user_yield_position_withdrawals AS withdrawal
-          WHERE withdrawal.confirmed_at >= (SELECT start_day FROM bounds)
-            AND withdrawal.confirmed_at < (SELECT end_day FROM bounds)
-        ),
-        flow_by_day AS (
-          SELECT
-            day,
-            liquidity_mint,
-            SUM(amount_raw) FILTER (WHERE direction = 'deposit') AS deposited_raw,
-            SUM(amount_raw) FILTER (WHERE direction = 'withdrawal') AS withdrawn_raw
-          FROM confirmed_flow_events
-          GROUP BY day, liquidity_mint
-        )
-        SELECT
-          to_char(days.day, 'YYYY-MM-DD') AS day,
-          stable_mints.liquidity_mint,
-          COALESCE(flow_by_day.deposited_raw, 0)::text AS deposited_raw,
-          COALESCE(flow_by_day.withdrawn_raw, 0)::text AS withdrawn_raw
-        FROM days
-        CROSS JOIN stable_mints
-        LEFT JOIN flow_by_day
-          ON flow_by_day.day = days.day
-          AND flow_by_day.liquidity_mint = stable_mints.liquidity_mint
-        ORDER BY days.day ASC, stable_mints.liquidity_mint ASC
-      `
+    latest_rebalance_by_mint AS (
+      SELECT liquidity_mint AS deposit_mint, MAX(updated_at) AS latest_rebalance_at
+      FROM loyal_yield.rebalance_decisions
+      WHERE status = 'confirmed' AND execution_plan->>'kind' = 'same_mint'
+        AND liquidity_mint IS NOT NULL
+      GROUP BY liquidity_mint
     ),
-    queryRows<AutodepositStatusRow>(
-      `
-        WITH classified AS (
-          SELECT
-            CASE
-              WHEN policy.active = true
-                AND target.active = true
-                AND target.lifecycle_status = 'active'
-                THEN 'active'
-              WHEN policy.active = true
-                AND target.active = false
-                AND target.lifecycle_status = 'active'
-                THEN 'paused'
-              WHEN target.lifecycle_status IN ('pending_delegation', 'closing')
-                THEN 'pending'
-              ELSE 'closed'
-            END AS status
+    mint_summary AS (
+      SELECT COALESCE(holdings.deposit_mint, rebalance.deposit_mint) AS deposit_mint,
+        COALESCE(holdings.active_position_count, '0') AS active_position_count,
+        COALESCE(holdings.active_aum_raw, '0') AS active_aum_raw,
+        COALESCE(holdings.active_excluded_reserve_raw, '0') AS active_excluded_reserve_raw,
+        COALESCE(holdings.active_reserve_raw, '0') AS active_reserve_raw,
+        COALESCE(holdings.active_idle_raw, '0') AS active_idle_raw,
+        COALESCE(holdings.active_principal_raw, '0') AS active_principal_raw,
+        COALESCE(holdings.active_stored_current_pointer_raw, '0') AS active_stored_current_pointer_raw,
+        COALESCE(holdings.current_pointer_delta_raw, '0') AS current_pointer_delta_raw,
+        rebalance.latest_rebalance_at
+      FROM holdings_by_mint AS holdings
+      FULL OUTER JOIN latest_rebalance_by_mint AS rebalance
+        ON rebalance.deposit_mint = holdings.deposit_mint
+    ),
+    headline AS (
+      SELECT COALESCE(SUM(normalized_aum_raw), 0)::text AS active_aum_raw,
+        COALESCE(SUM(normalized_reserve_raw), 0)::text AS active_reserve_raw,
+        COALESCE(SUM(idle_raw), 0)::text AS active_idle_raw,
+        COALESCE(SUM(current_amount_raw), 0)::text AS active_stored_current_pointer_raw,
+        COALESCE(SUM(current_pointer_delta_raw), 0)::text AS active_current_pointer_delta_raw,
+        COALESCE(SUM(principal_amount_raw), 0)::text AS active_principal_raw,
+        COALESCE(SUM(collateral_stored_amount_raw), 0)::text AS active_collateral_stored_amount_raw,
+        COALESCE(SUM(excluded_reserve_raw), 0)::text AS active_excluded_reserve_raw,
+        COALESCE(SUM(redeemable_reserve_rows), 0)::text AS active_redeemable_reserve_rows,
+        COALESCE(SUM(collateral_reserve_rows), 0)::text AS active_collateral_reserve_rows,
+        COALESCE(SUM(missing_redeemable_metadata_rows), 0)::text AS active_missing_redeemable_metadata_rows,
+        COALESCE(SUM(unknown_reserve_semantics_rows), 0)::text AS active_unknown_reserve_semantics_rows,
+        COALESCE(SUM(missing_managed_vault_rows), 0)::text AS active_missing_managed_vault_rows,
+        (SELECT COUNT(DISTINCT COALESCE(NULLIF(wallet_address, ''), settings))::text FROM loyal_yield.user_yield_positions WHERE status = 'active') AS unique_earn_users,
+        (SELECT COUNT(DISTINCT policy_account)::text FROM loyal_yield.route_policies WHERE active = true) AS unique_earn_policies,
+        (SELECT COUNT(DISTINCT policy.policy_account)::text FROM loyal_yield.balance_sweep_policies AS policy
+          INNER JOIN loyal_yield.balance_sweep_targets AS target ON target.balance_sweep_policy_id = policy.id
+          WHERE policy.active = true AND target.active = true AND target.lifecycle_status = 'active') AS active_autodeposit_policies
+      FROM normalized_active_positions
+    ),
+    top_positions AS (
+      SELECT wallet_address, settings, deposit_mint, current_reserve,
+        normalized_aum_raw::text, normalized_reserve_raw::text, idle_raw::text,
+        current_amount_raw::text AS stored_current_pointer_raw,
+        current_pointer_delta_raw::text, principal_amount_raw::text,
+        collateral_stored_amount_raw::text, excluded_reserve_raw::text,
+        redeemable_reserve_rows::text, collateral_reserve_rows::text,
+        missing_redeemable_metadata_rows::text, unknown_reserve_semantics_rows::text,
+        missing_managed_vault_rows::text, current_observed_at
+      FROM normalized_active_positions
+      ORDER BY normalized_aum_raw DESC, current_observed_at DESC LIMIT 25
+    )
+    SELECT (SELECT row_to_json(headline) FROM headline) AS headline,
+      COALESCE((SELECT json_agg(mint_summary ORDER BY deposit_mint) FROM mint_summary), '[]'::json) AS mint_summaries,
+      COALESCE((SELECT json_agg(top_positions ORDER BY normalized_aum_raw DESC, current_observed_at DESC) FROM top_positions), '[]'::json) AS top_positions
+  `;
+
+  const smallMetricsQuery = `
+    WITH bounds AS (
+      SELECT
+        ((date_trunc('day', now() AT TIME ZONE 'UTC')::date + 1) - 30)::date AS start_day,
+        (date_trunc('day', now() AT TIME ZONE 'UTC')::date + 1)::date AS end_day
+    ),
+    stable_mints(liquidity_mint) AS (
+      VALUES ${STABLE_MINT_VALUES_SQL}
+    ),
+    days AS (
+      SELECT generate_series(
+        (SELECT start_day FROM bounds),
+        (SELECT end_day FROM bounds) - 1,
+        interval '1 day'
+      )::date AS day
+    ),
+    confirmed_flow_events AS (
+      SELECT
+        (deposit.confirmed_at AT TIME ZONE 'UTC')::date AS day,
+        'deposit'::text AS direction,
+        'earn_deposit'::text AS source,
+        deposit.id AS source_id,
+        deposit.deposit_mint AS liquidity_mint,
+        deposit.principal_amount_raw AS amount_raw
+      FROM loyal_yield.user_yield_position_deposits AS deposit
+      WHERE deposit.confirmed_at >= (SELECT start_day FROM bounds)
+        AND deposit.confirmed_at < (SELECT end_day FROM bounds)
+      UNION ALL
+      SELECT
+        (withdrawal.confirmed_at AT TIME ZONE 'UTC')::date AS day,
+        'withdrawal'::text AS direction,
+        'earn_withdrawal'::text AS source,
+        withdrawal.id AS source_id,
+        withdrawal.liquidity_mint,
+        withdrawal.withdrawn_amount_raw AS amount_raw
+      FROM loyal_yield.user_yield_position_withdrawals AS withdrawal
+      WHERE withdrawal.confirmed_at >= (SELECT start_day FROM bounds)
+        AND withdrawal.confirmed_at < (SELECT end_day FROM bounds)
+    ),
+    flow_by_day AS (
+      SELECT
+        day,
+        liquidity_mint,
+        SUM(amount_raw) FILTER (WHERE direction = 'deposit') AS deposited_raw,
+        SUM(amount_raw) FILTER (WHERE direction = 'withdrawal') AS withdrawn_raw
+      FROM confirmed_flow_events
+      GROUP BY day, liquidity_mint
+    ),
+    flow_rows AS (
+      SELECT
+        to_char(days.day, 'YYYY-MM-DD') AS day,
+        stable_mints.liquidity_mint,
+        COALESCE(flow_by_day.deposited_raw, 0)::text AS deposited_raw,
+        COALESCE(flow_by_day.withdrawn_raw, 0)::text AS withdrawn_raw
+      FROM days
+      CROSS JOIN stable_mints
+      LEFT JOIN flow_by_day
+        ON flow_by_day.day = days.day
+        AND flow_by_day.liquidity_mint = stable_mints.liquidity_mint
+    ),
+    flow_json AS (
+      SELECT COALESCE(
+        json_agg(flow_rows ORDER BY flow_rows.day, flow_rows.liquidity_mint),
+        '[]'::json
+      ) AS value
+      FROM flow_rows
+    ),
+    classified_statuses AS (
+      SELECT
+        CASE
+          WHEN policy.active = true
+            AND target.active = true
+            AND target.lifecycle_status = 'active'
+            THEN 'active'
+          WHEN policy.active = true
+            AND target.active = false
+            AND target.lifecycle_status = 'active'
+            THEN 'paused'
+          WHEN target.lifecycle_status IN ('pending_delegation', 'closing')
+            THEN 'pending'
+          ELSE 'closed'
+        END AS status
+      FROM loyal_yield.balance_sweep_targets AS target
+      LEFT JOIN loyal_yield.balance_sweep_policies AS policy
+        ON policy.id = target.balance_sweep_policy_id
+    ),
+    status_json AS (
+      SELECT COALESCE(
+        json_agg(status_rows ORDER BY status_rows.status),
+        '[]'::json
+      ) AS value
+      FROM (
+        SELECT status, COUNT(*)::text AS total
+        FROM classified_statuses
+        GROUP BY status
+      ) AS status_rows
+    ),
+    scheduled AS (
+      SELECT
+        (COUNT(*) FILTER (
+          WHERE lot.status = 'open' AND lot.remaining_amount_raw > 0
+        ))::text AS open_lot_count,
+        COALESCE(SUM(lot.remaining_amount_raw) FILTER (
+          WHERE lot.status = 'open' AND lot.remaining_amount_raw > 0
+        ), 0)::text AS open_amount_raw,
+        (COUNT(*) FILTER (
+          WHERE lot.status = 'open'
+            AND lot.remaining_amount_raw > 0
+            AND lot.eligible_after <= now()
+        ))::text AS eligible_lot_count,
+        COALESCE(SUM(lot.remaining_amount_raw) FILTER (
+          WHERE lot.status = 'open'
+            AND lot.remaining_amount_raw > 0
+            AND lot.eligible_after <= now()
+        ), 0)::text AS eligible_amount_raw
+      FROM loyal_yield.balance_sweep_surplus_lots AS lot
+      INNER JOIN loyal_yield.balance_sweep_targets AS target
+        ON target.id = lot.target_id
+      LEFT JOIN loyal_yield.balance_sweep_policies AS policy
+        ON policy.id = target.balance_sweep_policy_id
+      WHERE policy.active = true
+        AND target.active = true
+        AND target.lifecycle_status = 'active'
+    ),
+    executions AS (
+      SELECT
+        COUNT(*)::text AS count,
+        COALESCE(SUM(amount_raw), 0)::text AS amount_raw,
+        (COUNT(*) FILTER (
+          WHERE received_at >= now() - interval '30 days'
+        ))::text AS count_30d,
+        COALESCE(SUM(amount_raw) FILTER (
+          WHERE received_at >= now() - interval '30 days'
+        ), 0)::text AS amount_30d_raw
+      FROM loyal_yield.balance_sweep_executions
+    ),
+    wallet_balance_event_freshness AS (
+      SELECT
+        (
+          SELECT observed_at
+          FROM loyal_yield.balance_sweep_wallet_balance_events
+          ORDER BY observed_at DESC
+          LIMIT 1
+        ) AS latest_wallet_balance_event_observed_at,
+        (
+          SELECT projected_at
+          FROM loyal_yield.balance_sweep_wallet_balance_events
+          ORDER BY projected_at DESC
+          LIMIT 1
+        ) AS latest_wallet_balance_projected_at
+    ),
+    freshness AS (
+      SELECT
+        (SELECT MAX(current_observed_at)
+         FROM loyal_yield.user_yield_positions
+         WHERE status = 'active') AS latest_position_observed_at,
+        (
+          SELECT MAX(target.last_seen_at)
           FROM loyal_yield.balance_sweep_targets AS target
           LEFT JOIN loyal_yield.balance_sweep_policies AS policy
             ON policy.id = target.balance_sweep_policy_id
-        )
-        SELECT status, COUNT(*)::text AS total
-        FROM classified
-        GROUP BY status
-      `
-    ),
-    queryRows<ScheduledRow>(
-      `
-        SELECT
-          (COUNT(*) FILTER (WHERE lot.status = 'open' AND lot.remaining_amount_raw > 0))::text AS open_lot_count,
-          COALESCE(SUM(lot.remaining_amount_raw) FILTER (WHERE lot.status = 'open' AND lot.remaining_amount_raw > 0), 0)::text AS open_amount_raw,
-          (COUNT(*) FILTER (
-            WHERE lot.status = 'open'
-              AND lot.remaining_amount_raw > 0
-              AND lot.eligible_after <= now()
-          ))::text AS eligible_lot_count,
-          COALESCE(SUM(lot.remaining_amount_raw) FILTER (
-            WHERE lot.status = 'open'
-              AND lot.remaining_amount_raw > 0
-              AND lot.eligible_after <= now()
-          ), 0)::text AS eligible_amount_raw
-        FROM loyal_yield.balance_sweep_surplus_lots AS lot
-        INNER JOIN loyal_yield.balance_sweep_targets AS target
-          ON target.id = lot.target_id
-        LEFT JOIN loyal_yield.balance_sweep_policies AS policy
-          ON policy.id = target.balance_sweep_policy_id
-        WHERE policy.active = true
-          AND target.active = true
-          AND target.lifecycle_status = 'active'
-      `
-    ),
-    queryRows<ExecutionRow>(
-      `
-        SELECT
-          COUNT(*)::text AS count,
-          COALESCE(SUM(amount_raw), 0)::text AS amount_raw,
-          (COUNT(*) FILTER (WHERE received_at >= now() - interval '30 days'))::text AS count_30d,
-          COALESCE(SUM(amount_raw) FILTER (WHERE received_at >= now() - interval '30 days'), 0)::text AS amount_30d_raw
-        FROM loyal_yield.balance_sweep_executions
-      `
-    ),
-    queryRows<FreshnessRow>(
-      `
-        SELECT
-          (SELECT MAX(current_observed_at) FROM loyal_yield.user_yield_positions WHERE status = 'active') AS latest_position_observed_at,
-          (
-            SELECT MAX(target.last_seen_at)
-            FROM loyal_yield.balance_sweep_targets AS target
-            LEFT JOIN loyal_yield.balance_sweep_policies AS policy
-              ON policy.id = target.balance_sweep_policy_id
-            WHERE policy.active = true
-              AND target.active = true
-              AND target.lifecycle_status = 'active'
-          ) AS latest_target_seen_at,
-          (SELECT MAX(received_at) FROM loyal_yield.balance_sweep_executions) AS latest_sweep_execution_received_at,
-          (SELECT MAX(observed_at) FROM loyal_yield.balance_sweep_wallet_balances_current) AS latest_wallet_balance_observed_at,
-          (SELECT MAX(observed_at) FROM loyal_yield.balance_sweep_wallet_balance_events) AS latest_wallet_balance_event_observed_at,
-          (SELECT MAX(projected_at) FROM loyal_yield.balance_sweep_wallet_balance_events) AS latest_wallet_balance_projected_at
-      `
-    ),
-    queryRows<MintHoldingSummaryRow>(
-      `
-        ${ACTIVE_EARN_HOLDINGS_CTE},
-        holdings_by_mint AS (
-          SELECT
-            deposit_mint,
-            COUNT(*)::text AS active_position_count,
-            COALESCE(SUM(normalized_aum_raw), 0)::text AS active_aum_raw,
-            COALESCE(SUM(excluded_reserve_raw), 0)::text AS active_excluded_reserve_raw,
-            COALESCE(SUM(normalized_reserve_raw), 0)::text AS active_reserve_raw,
-            COALESCE(SUM(idle_raw), 0)::text AS active_idle_raw,
-            COALESCE(SUM(principal_amount_raw), 0)::text AS active_principal_raw,
-            COALESCE(SUM(current_amount_raw), 0)::text AS active_stored_current_pointer_raw,
-            COALESCE(SUM(current_pointer_delta_raw), 0)::text AS current_pointer_delta_raw
-          FROM normalized_active_positions
-          GROUP BY deposit_mint
-        ),
-        latest_rebalance_by_mint AS (
-          SELECT
-            liquidity_mint AS deposit_mint,
-            MAX(updated_at) AS latest_rebalance_at
-          FROM loyal_yield.rebalance_decisions
-          WHERE status = 'confirmed'
-            AND execution_plan->>'kind' = 'same_mint'
-            AND liquidity_mint IS NOT NULL
-          GROUP BY liquidity_mint
-        )
-        SELECT
-          COALESCE(holdings.deposit_mint, rebalance.deposit_mint) AS deposit_mint,
-          COALESCE(holdings.active_position_count, '0') AS active_position_count,
-          COALESCE(holdings.active_aum_raw, '0') AS active_aum_raw,
-          COALESCE(holdings.active_excluded_reserve_raw, '0') AS active_excluded_reserve_raw,
-          COALESCE(holdings.active_reserve_raw, '0') AS active_reserve_raw,
-          COALESCE(holdings.active_idle_raw, '0') AS active_idle_raw,
-          COALESCE(holdings.active_principal_raw, '0') AS active_principal_raw,
-          COALESCE(holdings.active_stored_current_pointer_raw, '0') AS active_stored_current_pointer_raw,
-          COALESCE(holdings.current_pointer_delta_raw, '0') AS current_pointer_delta_raw,
-          rebalance.latest_rebalance_at
-        FROM holdings_by_mint AS holdings
-        FULL OUTER JOIN latest_rebalance_by_mint AS rebalance
-          ON rebalance.deposit_mint = holdings.deposit_mint
-      `
-    ),
-    queryRows<PositionRow>(
-      `
-        ${ACTIVE_EARN_HOLDINGS_CTE}
-        SELECT
-          wallet_address,
-          settings,
-          deposit_mint,
-          current_reserve,
-          normalized_aum_raw::text,
-          normalized_reserve_raw::text,
-          idle_raw::text,
-          current_amount_raw::text AS stored_current_pointer_raw,
-          current_pointer_delta_raw::text,
-          principal_amount_raw::text,
-          collateral_stored_amount_raw::text,
-          excluded_reserve_raw::text,
-          redeemable_reserve_rows::text,
-          collateral_reserve_rows::text,
-          missing_redeemable_metadata_rows::text,
-          unknown_reserve_semantics_rows::text,
-          missing_managed_vault_rows::text,
-          current_observed_at
-        FROM normalized_active_positions
-        ORDER BY normalized_aum_raw DESC, current_observed_at DESC
-        LIMIT 25
-      `
-    ),
+          WHERE policy.active = true
+            AND target.active = true
+            AND target.lifecycle_status = 'active'
+        ) AS latest_target_seen_at,
+        (SELECT MAX(received_at)
+         FROM loyal_yield.balance_sweep_executions)
+          AS latest_sweep_execution_received_at,
+        (SELECT MAX(observed_at)
+         FROM loyal_yield.balance_sweep_wallet_balances_current)
+          AS latest_wallet_balance_observed_at,
+        wallet_balance_event_freshness.latest_wallet_balance_event_observed_at,
+        wallet_balance_event_freshness.latest_wallet_balance_projected_at
+      FROM wallet_balance_event_freshness
+    )
+    SELECT
+      (SELECT value FROM flow_json) AS flow,
+      (SELECT value FROM status_json) AS status,
+      (SELECT row_to_json(scheduled) FROM scheduled) AS scheduled,
+      (SELECT row_to_json(executions) FROM executions) AS executions,
+      (SELECT row_to_json(freshness) FROM freshness) AS freshness
+  `;
+
+  const [holdingsRows, smallMetricsRows] = await Promise.all([
+    queryRows<CombinedHoldingsRow>(combinedHoldingsQuery),
+    queryRows<SmallMetricsRow>(smallMetricsQuery),
   ]);
 
-  const headline = headlineRows[0];
-  const scheduled = scheduledRows[0];
-  const executions = executionRows[0];
+  const combinedHoldings = holdingsRows[0] ?? {
+    headline: null,
+    mint_summaries: [],
+    top_positions: [],
+  };
+  const headline = combinedHoldings.headline;
+  const mintHoldingSummaryRows = combinedHoldings.mint_summaries;
+  const positionRows = combinedHoldings.top_positions;
+  const smallMetrics = smallMetricsRows[0] ?? {
+    executions: null,
+    flow: [],
+    freshness: null,
+    scheduled: null,
+    status: [],
+  };
+  const scheduled = smallMetrics.scheduled;
+  const executions = smallMetrics.executions;
   const autodepositStatusCounts = {
     active: 0,
     closed: 0,
@@ -683,7 +716,7 @@ async function loadEarnData(): Promise<EarnData> {
     pending: 0,
   };
 
-  for (const row of statusRows) {
+  for (const row of smallMetrics.status) {
     if (row.status in autodepositStatusCounts) {
       autodepositStatusCounts[
         row.status as keyof typeof autodepositStatusCounts
@@ -691,7 +724,7 @@ async function loadEarnData(): Promise<EarnData> {
     }
   }
 
-  const flow30d = flowRows.map((row) => {
+  const flow30d = smallMetrics.flow.map((row) => {
     const depositedRaw = toBigInt(row.deposited_raw);
     const withdrawnRaw = toBigInt(row.withdrawn_raw);
 
@@ -774,7 +807,7 @@ async function loadEarnData(): Promise<EarnData> {
     autodepositExecutionCount: toNumber(executions?.count),
     autodepositStatusCounts,
     flow30d,
-    freshness: createFreshnessMetrics(freshnessRows[0]),
+    freshness: createFreshnessMetrics(smallMetrics.freshness ?? undefined),
     scheduledEligibleAmountRaw: toBigInt(scheduled?.eligible_amount_raw),
     scheduledEligibleLotCount: toNumber(scheduled?.eligible_lot_count),
     scheduledOpenAmountRaw: toBigInt(scheduled?.open_amount_raw),

--- a/apps/admin/src/app/(admin)/earn/earn-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-data.ts
@@ -10,6 +10,7 @@ import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.serv
 const STABLE_MINT_VALUES_SQL = EARN_STABLECOIN_DESCRIPTORS.map(
   ({ mint }) => `('${mint}')`
 ).join(", ");
+
 const ACTIVE_EARN_HOLDINGS_CTE = `
   WITH active_positions AS (
     SELECT
@@ -278,6 +279,7 @@ type HeadlineRow = {
   active_stored_current_pointer_raw: string | number | bigint | null;
   active_unknown_reserve_semantics_rows: string | number | bigint | null;
   active_autodeposit_policies: string | number | bigint | null;
+  latest_position_observed_at: Date | string | null;
   unique_earn_policies: string | number | bigint | null;
   unique_earn_users: string | number | bigint | null;
 };
@@ -306,6 +308,7 @@ type ExecutionRow = {
   amount_raw: string | number | bigint | null;
   count_30d: string | number | bigint | null;
   count: string | number | bigint | null;
+  latest_received_at: Date | string | null;
 };
 
 type FreshnessRow = {
@@ -480,7 +483,8 @@ async function loadEarnData(): Promise<EarnData> {
         COALESCE(SUM(missing_redeemable_metadata_rows), 0)::text AS active_missing_redeemable_metadata_rows,
         COALESCE(SUM(unknown_reserve_semantics_rows), 0)::text AS active_unknown_reserve_semantics_rows,
         COALESCE(SUM(missing_managed_vault_rows), 0)::text AS active_missing_managed_vault_rows,
-        (SELECT COUNT(DISTINCT COALESCE(NULLIF(wallet_address, ''), settings))::text FROM loyal_yield.user_yield_positions WHERE status = 'active') AS unique_earn_users,
+        MAX(current_observed_at) AS latest_position_observed_at,
+        COUNT(DISTINCT COALESCE(NULLIF(wallet_address, ''), settings))::text AS unique_earn_users,
         (SELECT COUNT(DISTINCT policy_account)::text FROM loyal_yield.route_policies WHERE active = true) AS unique_earn_policies,
         (SELECT COUNT(DISTINCT policy.policy_account)::text FROM loyal_yield.balance_sweep_policies AS policy
           INNER JOIN loyal_yield.balance_sweep_targets AS target ON target.balance_sweep_policy_id = policy.id
@@ -571,8 +575,9 @@ async function loadEarnData(): Promise<EarnData> {
       ) AS value
       FROM flow_rows
     ),
-    classified_statuses AS (
+    target_observations AS MATERIALIZED (
       SELECT
+        target.last_seen_at,
         CASE
           WHEN policy.active = true
             AND target.active = true
@@ -597,7 +602,7 @@ async function loadEarnData(): Promise<EarnData> {
       ) AS value
       FROM (
         SELECT status, COUNT(*)::text AS total
-        FROM classified_statuses
+        FROM target_observations
         GROUP BY status
       ) AS status_rows
     ),
@@ -637,7 +642,8 @@ async function loadEarnData(): Promise<EarnData> {
         ))::text AS count_30d,
         COALESCE(SUM(amount_raw) FILTER (
           WHERE received_at >= now() - interval '30 days'
-        ), 0)::text AS amount_30d_raw
+        ), 0)::text AS amount_30d_raw,
+        MAX(received_at) AS latest_received_at
       FROM loyal_yield.balance_sweep_executions
     ),
     wallet_balance_event_freshness AS (
@@ -657,20 +663,11 @@ async function loadEarnData(): Promise<EarnData> {
     ),
     freshness AS (
       SELECT
-        (SELECT MAX(current_observed_at)
-         FROM loyal_yield.user_yield_positions
-         WHERE status = 'active') AS latest_position_observed_at,
-        (
-          SELECT MAX(target.last_seen_at)
-          FROM loyal_yield.balance_sweep_targets AS target
-          LEFT JOIN loyal_yield.balance_sweep_policies AS policy
-            ON policy.id = target.balance_sweep_policy_id
-          WHERE policy.active = true
-            AND target.active = true
-            AND target.lifecycle_status = 'active'
-        ) AS latest_target_seen_at,
-        (SELECT MAX(received_at)
-         FROM loyal_yield.balance_sweep_executions)
+        NULL::timestamptz AS latest_position_observed_at,
+        (SELECT MAX(last_seen_at)
+         FROM target_observations
+         WHERE status = 'active') AS latest_target_seen_at,
+        (SELECT latest_received_at FROM executions)
           AS latest_sweep_execution_received_at,
         (SELECT MAX(observed_at)
          FROM loyal_yield.balance_sweep_wallet_balances_current)
@@ -709,6 +706,14 @@ async function loadEarnData(): Promise<EarnData> {
   };
   const scheduled = smallMetrics.scheduled;
   const executions = smallMetrics.executions;
+  const freshness = smallMetrics.freshness
+    ? {
+        ...smallMetrics.freshness,
+        latest_position_observed_at:
+          headline?.latest_position_observed_at ??
+          smallMetrics.freshness.latest_position_observed_at,
+      }
+    : null;
   const autodepositStatusCounts = {
     active: 0,
     closed: 0,
@@ -807,7 +812,7 @@ async function loadEarnData(): Promise<EarnData> {
     autodepositExecutionCount: toNumber(executions?.count),
     autodepositStatusCounts,
     flow30d,
-    freshness: createFreshnessMetrics(smallMetrics.freshness ?? undefined),
+    freshness: createFreshnessMetrics(freshness ?? undefined),
     scheduledEligibleAmountRaw: toBigInt(scheduled?.eligible_amount_raw),
     scheduledEligibleLotCount: toNumber(scheduled?.eligible_lot_count),
     scheduledOpenAmountRaw: toBigInt(scheduled?.open_amount_raw),

--- a/apps/admin/src/app/(admin)/earn/earn-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-data.ts
@@ -55,6 +55,7 @@ const ACTIVE_EARN_HOLDINGS_CTE = `
       FROM loyal_yield.vault_reserve_positions_current AS reserve
       WHERE reserve.vault_id = active.vault_id
         AND reserve.liquidity_mint = active.deposit_mint
+      OFFSET 0
     ) AS reserve
   ),
   normalized_reserve_by_position AS (

--- a/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -7,9 +7,9 @@ import {
 import {
   Connection,
   PublicKey,
-  type ParsedTransactionWithMeta,
+  type VersionedTransactionResponse,
 } from "@solana/web3.js";
-import { and, count, desc, eq, gte, inArray, max } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lt, max, sql } from "drizzle-orm";
 
 import { getDatabase } from "@/lib/core/database";
 import { serverEnv } from "@/lib/core/config/server";
@@ -97,6 +97,7 @@ export type OperationalWalletSpendEvent = {
   lamports: string;
   occurredAt: string;
   signature: string | null;
+  transactionCount: number;
 };
 
 export type EarnFundingData = {
@@ -134,12 +135,16 @@ type SpendEventObservationRow = {
   lamports: string | number | null;
   occurred_at: string | Date | null;
   signature: string | null;
+  transaction_count: string | number | null;
 };
 
 type SpendSourceResult = {
   events: OperationalWalletSpendEvent[];
   failed: boolean;
+  spend: Map<string, WalletSpend>;
 };
+
+type SpendWindow = { endedAt: Date; startedAt: Date };
 
 type WalletSpend = {
   spend24hLamports: string | null;
@@ -449,6 +454,7 @@ function toSpendEvent(args: {
   lamports: string | number | null | undefined;
   occurredAt: string | Date | null | undefined;
   signature: string | null | undefined;
+  transactionCount?: number;
 }): OperationalWalletSpendEvent | null {
   const normalizedAddress = normalizeAddress(args.address);
   const occurredAt = toIsoString(args.occurredAt);
@@ -472,6 +478,7 @@ function toSpendEvent(args: {
     lamports: lamports.toString(),
     occurredAt,
     signature: normalizeAddress(args.signature),
+    transactionCount: args.transactionCount ?? 1,
   };
 }
 
@@ -483,28 +490,100 @@ function gaslessSpendGroup(transactionType: string) {
 // sponsored transaction finalizes.
 async function loadSponsorshipSpendRows(
   addresses: string[],
-  startedAt: Date
+  window: SpendWindow
 ): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
-    const rows = await db
-      .select({
-        address: appSmartAccountSponsorshipTransactions.payerAddress,
-        lamports: appSmartAccountSponsorshipTransactions.spentLamports,
-        occurredAt: appSmartAccountSponsorshipTransactions.occurredAt,
-        signature: appSmartAccountSponsorshipTransactions.signature,
-      })
-      .from(appSmartAccountSponsorshipTransactions)
-      .where(
-        and(
-          eq(appSmartAccountSponsorshipTransactions.solanaEnv, MAINNET_APP_ENV),
-          inArray(
-            appSmartAccountSponsorshipTransactions.payerAddress,
-            addresses
-          ),
-          gte(appSmartAccountSponsorshipTransactions.occurredAt, startedAt)
+    const recentCutoff = new Date(
+      window.endedAt.getTime() - 24 * 60 * 60 * 1_000
+    );
+    const [recentRows, historicalRows, summaryRows] = await Promise.all([
+      db
+        .select({
+          address: appSmartAccountSponsorshipTransactions.payerAddress,
+          lamports: appSmartAccountSponsorshipTransactions.spentLamports,
+          occurredAt: appSmartAccountSponsorshipTransactions.occurredAt,
+          signature: appSmartAccountSponsorshipTransactions.signature,
+        })
+        .from(appSmartAccountSponsorshipTransactions)
+        .where(
+          and(
+            eq(
+              appSmartAccountSponsorshipTransactions.solanaEnv,
+              MAINNET_APP_ENV
+            ),
+            inArray(
+              appSmartAccountSponsorshipTransactions.payerAddress,
+              addresses
+            ),
+            gte(appSmartAccountSponsorshipTransactions.occurredAt, recentCutoff)
+          )
+        ),
+      db
+        .select({
+          address: appSmartAccountSponsorshipTransactions.payerAddress,
+          lamports: sql<string>`SUM(${appSmartAccountSponsorshipTransactions.spentLamports})::text`,
+          occurredAt: sql<Date>`date_trunc('day', ${appSmartAccountSponsorshipTransactions.occurredAt})`,
+          signature: sql<string | null>`NULL`,
+          transactionCount: sql<string>`COUNT(*)::text`,
+        })
+        .from(appSmartAccountSponsorshipTransactions)
+        .where(
+          and(
+            eq(
+              appSmartAccountSponsorshipTransactions.solanaEnv,
+              MAINNET_APP_ENV
+            ),
+            inArray(
+              appSmartAccountSponsorshipTransactions.payerAddress,
+              addresses
+            ),
+            gte(
+              appSmartAccountSponsorshipTransactions.occurredAt,
+              window.startedAt
+            ),
+            lt(appSmartAccountSponsorshipTransactions.occurredAt, recentCutoff)
+          )
         )
-      );
+        .groupBy(
+          appSmartAccountSponsorshipTransactions.payerAddress,
+          sql`date_trunc('day', ${appSmartAccountSponsorshipTransactions.occurredAt})`
+        ),
+      db
+        .select({
+          address: appSmartAccountSponsorshipTransactions.payerAddress,
+          spend24hLamports: sql<string>`COALESCE(SUM(${appSmartAccountSponsorshipTransactions.spentLamports}) FILTER (WHERE ${appSmartAccountSponsorshipTransactions.occurredAt} >= ${recentCutoff}), 0)::text`,
+          spend7dLamports: sql<string>`COALESCE(SUM(${
+            appSmartAccountSponsorshipTransactions.spentLamports
+          }) FILTER (WHERE ${
+            appSmartAccountSponsorshipTransactions.occurredAt
+          } >= ${new Date(
+            window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
+          )}), 0)::text`,
+        })
+        .from(appSmartAccountSponsorshipTransactions)
+        .where(
+          and(
+            eq(
+              appSmartAccountSponsorshipTransactions.solanaEnv,
+              MAINNET_APP_ENV
+            ),
+            inArray(
+              appSmartAccountSponsorshipTransactions.payerAddress,
+              addresses
+            ),
+            gte(
+              appSmartAccountSponsorshipTransactions.occurredAt,
+              window.startedAt
+            )
+          )
+        )
+        .groupBy(appSmartAccountSponsorshipTransactions.payerAddress),
+    ]);
+    const rows = [
+      ...recentRows.map((row) => ({ ...row, transactionCount: "1" })),
+      ...historicalRows,
+    ];
 
     return {
       events: rows
@@ -516,15 +595,25 @@ async function loadSponsorshipSpendRows(
             lamports: row.lamports,
             occurredAt: row.occurredAt,
             signature: row.signature,
+            transactionCount: toNumber(row.transactionCount) || 1,
           })
         )
         .filter((event): event is OperationalWalletSpendEvent =>
           Boolean(event)
         ),
       failed: false,
+      spend: new Map(
+        summaryRows.map((row) => [
+          row.address,
+          {
+            spend24hLamports: row.spend24hLamports,
+            spend7dLamports: row.spend7dLamports,
+          },
+        ])
+      ),
     };
   } catch {
-    return { events: [], failed: true };
+    return { events: [], failed: true, spend: new Map() };
   }
 }
 
@@ -532,26 +621,77 @@ async function loadSponsorshipSpendRows(
 // private-transfer-analytics cron.
 async function loadGaslessClaimSpendRows(
   addresses: string[],
-  startedAt: Date
+  window: SpendWindow
 ): Promise<SpendSourceResult> {
   try {
     const db = getDatabase();
-    const rows = await db
-      .select({
-        address: gaslessClaimTransactions.payerAddress,
-        lamports: gaslessClaimTransactions.spentLamports,
-        occurredAt: gaslessClaimTransactions.occurredAt,
-        signature: gaslessClaimTransactions.signature,
-        transactionType: gaslessClaimTransactions.transactionType,
-      })
-      .from(gaslessClaimTransactions)
-      .where(
-        and(
-          eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
-          inArray(gaslessClaimTransactions.payerAddress, addresses),
-          gte(gaslessClaimTransactions.occurredAt, startedAt)
+    const recentCutoff = new Date(
+      window.endedAt.getTime() - 24 * 60 * 60 * 1_000
+    );
+    const [recentRows, historicalRows, summaryRows] = await Promise.all([
+      db
+        .select({
+          address: gaslessClaimTransactions.payerAddress,
+          lamports: gaslessClaimTransactions.spentLamports,
+          occurredAt: gaslessClaimTransactions.occurredAt,
+          signature: gaslessClaimTransactions.signature,
+          transactionType: gaslessClaimTransactions.transactionType,
+        })
+        .from(gaslessClaimTransactions)
+        .where(
+          and(
+            eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
+            inArray(gaslessClaimTransactions.payerAddress, addresses),
+            gte(gaslessClaimTransactions.occurredAt, recentCutoff)
+          )
+        ),
+      db
+        .select({
+          address: gaslessClaimTransactions.payerAddress,
+          lamports: sql<string>`SUM(${gaslessClaimTransactions.spentLamports})::text`,
+          occurredAt: sql<Date>`date_trunc('day', ${gaslessClaimTransactions.occurredAt})`,
+          signature: sql<string | null>`NULL`,
+          transactionType: gaslessClaimTransactions.transactionType,
+          transactionCount: sql<string>`COUNT(*)::text`,
+        })
+        .from(gaslessClaimTransactions)
+        .where(
+          and(
+            eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
+            inArray(gaslessClaimTransactions.payerAddress, addresses),
+            gte(gaslessClaimTransactions.occurredAt, window.startedAt),
+            lt(gaslessClaimTransactions.occurredAt, recentCutoff)
+          )
         )
-      );
+        .groupBy(
+          gaslessClaimTransactions.payerAddress,
+          gaslessClaimTransactions.transactionType,
+          sql`date_trunc('day', ${gaslessClaimTransactions.occurredAt})`
+        ),
+      db
+        .select({
+          address: gaslessClaimTransactions.payerAddress,
+          spend24hLamports: sql<string>`COALESCE(SUM(${gaslessClaimTransactions.spentLamports}) FILTER (WHERE ${gaslessClaimTransactions.occurredAt} >= ${recentCutoff}), 0)::text`,
+          spend7dLamports: sql<string>`COALESCE(SUM(${
+            gaslessClaimTransactions.spentLamports
+          }) FILTER (WHERE ${gaslessClaimTransactions.occurredAt} >= ${new Date(
+            window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
+          )}), 0)::text`,
+        })
+        .from(gaslessClaimTransactions)
+        .where(
+          and(
+            eq(gaslessClaimTransactions.solanaEnv, MAINNET_APP_ENV),
+            inArray(gaslessClaimTransactions.payerAddress, addresses),
+            gte(gaslessClaimTransactions.occurredAt, window.startedAt)
+          )
+        )
+        .groupBy(gaslessClaimTransactions.payerAddress),
+    ]);
+    const rows = [
+      ...recentRows.map((row) => ({ ...row, transactionCount: "1" })),
+      ...historicalRows,
+    ];
 
     return {
       events: rows
@@ -563,15 +703,25 @@ async function loadGaslessClaimSpendRows(
             lamports: row.lamports,
             occurredAt: row.occurredAt,
             signature: row.signature,
+            transactionCount: toNumber(row.transactionCount) || 1,
           })
         )
         .filter((event): event is OperationalWalletSpendEvent =>
           Boolean(event)
         ),
       failed: false,
+      spend: new Map(
+        summaryRows.map((row) => [
+          row.address,
+          {
+            spend24hLamports: row.spend24hLamports,
+            spend7dLamports: row.spend7dLamports,
+          },
+        ])
+      ),
     };
   } catch {
-    return { events: [], failed: true };
+    return { events: [], failed: true, spend: new Map() };
   }
 }
 
@@ -579,48 +729,139 @@ async function loadGaslessClaimSpendRows(
 // rent, both paid by the Earn policy wallet.
 async function loadYieldSpendRows(
   addresses: string[],
-  startedAt: Date
+  window: SpendWindow
 ): Promise<SpendSourceResult> {
   try {
     const sql = getYieldNeonSql();
-    const [routeRows, lookupTableRows] = await Promise.all([
-      sql.query(
-        `
-        SELECT
-          fee_payer AS address,
-          'compiled_fee' AS amount_basis,
-          'yield_route_fee' AS group_key,
-          compiled_fee_lamports::text AS lamports,
-          confirmed_at AS occurred_at,
-          transaction_signature AS signature
+    const recentCutoff = new Date(
+      window.endedAt.getTime() - 24 * 60 * 60 * 1_000
+    );
+    const sevenDayCutoff = new Date(
+      window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
+    );
+    const [routeRows, lookupTableRows, routeSummaryRows, lookupSummaryRows] =
+      await Promise.all([
+        sql.query(
+          `
+        WITH source_rows AS (
+          SELECT fee_payer AS address, compiled_fee_lamports AS lamports,
+            confirmed_at AS occurred_at, transaction_signature AS signature
+          FROM loyal_yield.signed_route_submissions
+          WHERE cluster = $1 AND confirmed_at IS NOT NULL
+            AND fee_payer = ANY($2::text[]) AND confirmed_at >= $3::timestamptz
+        )
+        SELECT address, 'compiled_fee' AS amount_basis,
+          'yield_route_fee' AS group_key, lamports::text, occurred_at, signature,
+          1::text AS transaction_count
+        FROM source_rows WHERE occurred_at >= $4::timestamptz
+        UNION ALL
+        SELECT address, 'compiled_fee', 'yield_route_fee', SUM(lamports)::text,
+          date_trunc('day', occurred_at), NULL, COUNT(*)::text
+        FROM source_rows WHERE occurred_at < $4::timestamptz
+        GROUP BY address, date_trunc('day', occurred_at)
+      `,
+          [
+            MAINNET_YIELD_CLUSTER,
+            addresses,
+            window.startedAt.toISOString(),
+            recentCutoff.toISOString(),
+          ]
+        ) as unknown as Promise<SpendEventObservationRow[]>,
+        sql.query(
+          `
+        WITH source_rows AS (
+          SELECT family.payer AS address,
+            'lookup_table_' || operation.operation_kind AS group_key,
+            GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0) AS lamports,
+            operation.confirmed_at AS occurred_at,
+            operation.transaction_signature AS signature
+          FROM loyal_yield.lookup_table_operations AS operation
+          JOIN loyal_yield.lookup_table_families AS family ON family.id = operation.family_id
+          WHERE family.cluster = $1 AND operation.confirmed_at IS NOT NULL
+            AND family.payer = ANY($2::text[]) AND operation.confirmed_at >= $3::timestamptz
+        )
+        SELECT address, 'confirmed_payer_outflow' AS amount_basis, group_key,
+          lamports::text, occurred_at, signature, 1::text AS transaction_count
+        FROM source_rows WHERE occurred_at >= $4::timestamptz
+        UNION ALL
+        SELECT address, 'confirmed_payer_outflow', group_key, SUM(lamports)::text,
+          date_trunc('day', occurred_at), NULL, COUNT(*)::text
+        FROM source_rows WHERE occurred_at < $4::timestamptz
+        GROUP BY address, group_key, date_trunc('day', occurred_at)
+      `,
+          [
+            MAINNET_YIELD_CLUSTER,
+            addresses,
+            window.startedAt.toISOString(),
+            recentCutoff.toISOString(),
+          ]
+        ) as unknown as Promise<SpendEventObservationRow[]>,
+        sql.query(
+          `
+        SELECT fee_payer AS address,
+          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= $4::timestamptz), 0)::text AS spend24h_lamports,
+          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= $5::timestamptz), 0)::text AS spend7d_lamports
         FROM loyal_yield.signed_route_submissions
-        WHERE cluster = $1
-          AND confirmed_at IS NOT NULL
-          AND fee_payer = ANY($2::text[])
-          AND confirmed_at >= $3::timestamptz
+        WHERE cluster = $1 AND confirmed_at IS NOT NULL
+          AND fee_payer = ANY($2::text[]) AND confirmed_at >= $3::timestamptz
+        GROUP BY fee_payer
       `,
-        [MAINNET_YIELD_CLUSTER, addresses, startedAt.toISOString()]
-      ) as unknown as Promise<SpendEventObservationRow[]>,
-      sql.query(
-        `
-        SELECT
-          family.payer AS address,
-          'confirmed_payer_outflow' AS amount_basis,
-          'lookup_table_' || operation.operation_kind AS group_key,
-          GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)::text AS lamports,
-          operation.confirmed_at AS occurred_at,
-          operation.transaction_signature AS signature
+          [
+            MAINNET_YIELD_CLUSTER,
+            addresses,
+            window.startedAt.toISOString(),
+            recentCutoff.toISOString(),
+            sevenDayCutoff.toISOString(),
+          ]
+        ) as unknown as Promise<
+          Array<{
+            address: string;
+            spend24h_lamports: string;
+            spend7d_lamports: string;
+          }>
+        >,
+        sql.query(
+          `
+        SELECT family.payer AS address,
+          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= $4::timestamptz), 0)::text AS spend24h_lamports,
+          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= $5::timestamptz), 0)::text AS spend7d_lamports
         FROM loyal_yield.lookup_table_operations AS operation
-        JOIN loyal_yield.lookup_table_families AS family
-          ON family.id = operation.family_id
-        WHERE family.cluster = $1
-          AND operation.confirmed_at IS NOT NULL
-          AND family.payer = ANY($2::text[])
-          AND operation.confirmed_at >= $3::timestamptz
+        JOIN loyal_yield.lookup_table_families AS family ON family.id = operation.family_id
+        WHERE family.cluster = $1 AND operation.confirmed_at IS NOT NULL
+          AND family.payer = ANY($2::text[]) AND operation.confirmed_at >= $3::timestamptz
+        GROUP BY family.payer
       `,
-        [MAINNET_YIELD_CLUSTER, addresses, startedAt.toISOString()]
-      ) as unknown as Promise<SpendEventObservationRow[]>,
-    ]);
+          [
+            MAINNET_YIELD_CLUSTER,
+            addresses,
+            window.startedAt.toISOString(),
+            recentCutoff.toISOString(),
+            sevenDayCutoff.toISOString(),
+          ]
+        ) as unknown as Promise<
+          Array<{
+            address: string;
+            spend24h_lamports: string;
+            spend7d_lamports: string;
+          }>
+        >,
+      ]);
+
+    const spend = new Map<string, WalletSpend>();
+    for (const row of [...routeSummaryRows, ...lookupSummaryRows]) {
+      const existing = spend.get(row.address) ?? {
+        spend24hLamports: "0",
+        spend7dLamports: "0",
+      };
+      spend.set(row.address, {
+        spend24hLamports: (
+          BigInt(existing.spend24hLamports ?? 0) + BigInt(row.spend24h_lamports)
+        ).toString(),
+        spend7dLamports: (
+          BigInt(existing.spend7dLamports ?? 0) + BigInt(row.spend7d_lamports)
+        ).toString(),
+      });
+    }
 
     return {
       events: [...routeRows, ...lookupTableRows]
@@ -632,15 +873,17 @@ async function loadYieldSpendRows(
             lamports: row.lamports,
             occurredAt: row.occurred_at,
             signature: row.signature,
+            transactionCount: toNumber(row.transaction_count) || 1,
           })
         )
         .filter((event): event is OperationalWalletSpendEvent =>
           Boolean(event)
         ),
       failed: false,
+      spend,
     };
   } catch {
-    return { events: [], failed: true };
+    return { events: [], failed: true, spend: new Map() };
   }
 }
 
@@ -664,9 +907,9 @@ async function loadWalletSpend(
   }
 
   const [sponsorship, gasless, yieldSpend] = await Promise.all([
-    loadSponsorshipSpendRows(addresses, window.startedAt),
-    loadGaslessClaimSpendRows(addresses, window.startedAt),
-    loadYieldSpendRows(addresses, window.startedAt),
+    loadSponsorshipSpendRows(addresses, window),
+    loadGaslessClaimSpendRows(addresses, window),
+    loadYieldSpendRows(addresses, window),
   ]);
 
   const sources: Array<{ error: string; result: SpendSourceResult }> = [
@@ -694,12 +937,9 @@ async function loadWalletSpend(
     return { events: [], sourceErrors, spend: new Map() };
   }
 
-  const events = sources
+  const rawEvents = sources
     .flatMap((source) => source.result.events)
     .sort((left, right) => left.occurredAt.localeCompare(right.occurredAt));
-  const cutoff24h = window.endedAt.getTime() - 24 * 60 * 60 * 1000;
-  const cutoff7d = window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1000;
-
   // Every source answered, so each requested address now has a known spend.
   // Seed them all at zero: an address with no rows anywhere spent nothing,
   // which is an observation rather than missing data.
@@ -709,27 +949,23 @@ async function loadWalletSpend(
       { lamports24h: BigInt(0), lamports7d: BigInt(0) },
     ])
   );
-  for (const event of events) {
-    const occurredAt = Date.parse(event.occurredAt);
-    const lamports = BigInt(event.lamports);
-    const existing = totals.get(event.address) ?? {
-      lamports24h: BigInt(0),
-      lamports7d: BigInt(0),
-    };
-    totals.set(event.address, {
-      lamports24h:
-        occurredAt >= cutoff24h
-          ? existing.lamports24h + lamports
-          : existing.lamports24h,
-      lamports7d:
-        occurredAt >= cutoff7d
-          ? existing.lamports7d + lamports
-          : existing.lamports7d,
-    });
+  for (const source of sources) {
+    for (const [address, sourceSpend] of source.result.spend) {
+      const existing = totals.get(address) ?? {
+        lamports24h: BigInt(0),
+        lamports7d: BigInt(0),
+      };
+      totals.set(address, {
+        lamports24h:
+          existing.lamports24h + BigInt(sourceSpend.spend24hLamports ?? 0),
+        lamports7d:
+          existing.lamports7d + BigInt(sourceSpend.spend7dLamports ?? 0),
+      });
+    }
   }
 
   return {
-    events,
+    events: rawEvents,
     sourceErrors,
     spend: new Map(
       Array.from(totals.entries()).map(([address, total]) => [
@@ -744,7 +980,7 @@ async function loadWalletSpend(
 }
 
 function calculateFinalizedPayerOutflow(
-  transaction: ParsedTransactionWithMeta,
+  transaction: VersionedTransactionResponse,
   payerAddress: string
 ): bigint | null {
   if (!transaction.meta) {
@@ -752,7 +988,7 @@ function calculateFinalizedPayerOutflow(
   }
 
   const feePayer =
-    transaction.transaction.message.accountKeys[0]?.pubkey.toBase58();
+    transaction.transaction.message.staticAccountKeys[0]?.toBase58();
   if (feePayer !== payerAddress) {
     return BigInt(0);
   }
@@ -861,7 +1097,7 @@ async function loadSettingsAuthoritySpend(
                 start + SETTINGS_AUTHORITY_TRANSACTION_BATCH_CONCURRENCY
               )
               .map((batch) =>
-                connection.getParsedTransactions(batch, {
+                connection.getTransactions(batch, {
                   commitment: "finalized",
                   maxSupportedTransactionVersion: 0,
                 })
@@ -1305,6 +1541,18 @@ function createWallets(args: {
 async function loadFundingData(): Promise<EarnFundingData> {
   const spendWindow = getOperationalWalletSpendWindow(new Date());
   const configuredSettingsAuthority = serverEnv.earnSettingsAuthorityPublicKey;
+  // The settings-authority identity query is deliberately restricted to this
+  // configured address, so its finalized spend can begin with the identity
+  // reads instead of waiting for their database round trip.
+  const settingsAuthoritySpendPromise = loadSettingsAuthoritySpend(
+    uniqueAddresses([configuredSettingsAuthority]),
+    {
+      endedAt: spendWindow.endedAt,
+      startedAt: new Date(
+        spendWindow.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
+      ),
+    }
+  );
   const [appObservations, yieldObservations] = await Promise.all([
     loadAppIdentityObservations(),
     loadYieldIdentityObservations(
@@ -1329,15 +1577,6 @@ async function loadFundingData(): Promise<EarnFundingData> {
       ...definition.observation.observedAddresses.map((row) => row.address),
     ])
   );
-  const settingsAuthorityAddresses = uniqueAddresses(
-    definitions
-      .filter((definition) => definition.key === "settings_authority")
-      .flatMap((definition) => [
-        ...definition.observation.configuredAddresses,
-        ...definition.observation.observedAddresses.map((row) => row.address),
-      ])
-  );
-
   // Only addresses with a database-backed spend role are sent to the App/Yield
   // loaders. The settings authority is measured independently from finalized
   // RPC transactions so an RPC failure cannot erase known spend for the other
@@ -1354,12 +1593,7 @@ async function loadFundingData(): Promise<EarnFundingData> {
     await Promise.all([
       loadBalances(addresses),
       loadWalletSpend(databaseSpendTrackedAddresses, spendWindow),
-      loadSettingsAuthoritySpend(settingsAuthorityAddresses, {
-        endedAt: spendWindow.endedAt,
-        startedAt: new Date(
-          spendWindow.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
-        ),
-      }),
+      settingsAuthoritySpendPromise,
     ]);
   if (balanceResult.error) {
     sourceErrors.push(balanceResult.error);

--- a/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-funding-data.ts
@@ -144,6 +144,21 @@ type SpendSourceResult = {
   spend: Map<string, WalletSpend>;
 };
 
+type YieldSpendPayloadRow = {
+  lookup_rows: SpendEventObservationRow[];
+  lookup_summary_rows: Array<{
+    address: string;
+    spend24h_lamports: string;
+    spend7d_lamports: string;
+  }>;
+  route_rows: SpendEventObservationRow[];
+  route_summary_rows: Array<{
+    address: string;
+    spend24h_lamports: string;
+    spend7d_lamports: string;
+  }>;
+};
+
 type SpendWindow = { endedAt: Date; startedAt: Date };
 
 type WalletSpend = {
@@ -739,37 +754,41 @@ async function loadYieldSpendRows(
     const sevenDayCutoff = new Date(
       window.endedAt.getTime() - 7 * 24 * 60 * 60 * 1_000
     );
-    const [routeRows, lookupTableRows, routeSummaryRows, lookupSummaryRows] =
-      await Promise.all([
-        sql.query(
-          `
-        WITH source_rows AS (
+    const payloadRows = (await sql.query(
+      `
+        WITH route_source_rows AS MATERIALIZED (
           SELECT fee_payer AS address, compiled_fee_lamports AS lamports,
             confirmed_at AS occurred_at, transaction_signature AS signature
           FROM loyal_yield.signed_route_submissions
           WHERE cluster = $1 AND confirmed_at IS NOT NULL
             AND fee_payer = ANY($2::text[]) AND confirmed_at >= $3::timestamptz
-        )
-        SELECT address, 'compiled_fee' AS amount_basis,
-          'yield_route_fee' AS group_key, lamports::text, occurred_at, signature,
-          1::text AS transaction_count
-        FROM source_rows WHERE occurred_at >= $4::timestamptz
-        UNION ALL
-        SELECT address, 'compiled_fee', 'yield_route_fee', SUM(lamports)::text,
-          date_trunc('day', occurred_at), NULL, COUNT(*)::text
-        FROM source_rows WHERE occurred_at < $4::timestamptz
-        GROUP BY address, date_trunc('day', occurred_at)
-      `,
-          [
-            MAINNET_YIELD_CLUSTER,
-            addresses,
-            window.startedAt.toISOString(),
-            recentCutoff.toISOString(),
-          ]
-        ) as unknown as Promise<SpendEventObservationRow[]>,
-        sql.query(
-          `
-        WITH source_rows AS (
+        ),
+        route_event_rows AS (
+          SELECT address, 'compiled_fee' AS amount_basis,
+            'yield_route_fee' AS group_key, lamports::text, occurred_at,
+            signature, 1::text AS transaction_count
+          FROM route_source_rows
+          WHERE occurred_at >= $4::timestamptz
+          UNION ALL
+          SELECT address, 'compiled_fee', 'yield_route_fee',
+            SUM(lamports)::text, date_trunc('day', occurred_at), NULL,
+            COUNT(*)::text
+          FROM route_source_rows
+          WHERE occurred_at < $4::timestamptz
+          GROUP BY address, date_trunc('day', occurred_at)
+        ),
+        route_summary_rows AS (
+          SELECT address,
+            COALESCE(SUM(lamports) FILTER (
+              WHERE occurred_at >= $4::timestamptz
+            ), 0)::text AS spend24h_lamports,
+            COALESCE(SUM(lamports) FILTER (
+              WHERE occurred_at >= $5::timestamptz
+            ), 0)::text AS spend7d_lamports
+          FROM route_source_rows
+          GROUP BY address
+        ),
+        lookup_source_rows AS MATERIALIZED (
           SELECT family.payer AS address,
             'lookup_table_' || operation.operation_kind AS group_key,
             GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0) AS lamports,
@@ -779,73 +798,68 @@ async function loadYieldSpendRows(
           JOIN loyal_yield.lookup_table_families AS family ON family.id = operation.family_id
           WHERE family.cluster = $1 AND operation.confirmed_at IS NOT NULL
             AND family.payer = ANY($2::text[]) AND operation.confirmed_at >= $3::timestamptz
+        ),
+        lookup_event_rows AS (
+          SELECT address, 'confirmed_payer_outflow' AS amount_basis,
+            group_key, lamports::text, occurred_at, signature,
+            1::text AS transaction_count
+          FROM lookup_source_rows
+          WHERE occurred_at >= $4::timestamptz
+          UNION ALL
+          SELECT address, 'confirmed_payer_outflow', group_key,
+            SUM(lamports)::text, date_trunc('day', occurred_at), NULL,
+            COUNT(*)::text
+          FROM lookup_source_rows
+          WHERE occurred_at < $4::timestamptz
+          GROUP BY address, group_key, date_trunc('day', occurred_at)
+        ),
+        lookup_summary_rows AS (
+          SELECT address,
+            COALESCE(SUM(lamports) FILTER (
+              WHERE occurred_at >= $4::timestamptz
+            ), 0)::text AS spend24h_lamports,
+            COALESCE(SUM(lamports) FILTER (
+              WHERE occurred_at >= $5::timestamptz
+            ), 0)::text AS spend7d_lamports
+          FROM lookup_source_rows
+          GROUP BY address
         )
-        SELECT address, 'confirmed_payer_outflow' AS amount_basis, group_key,
-          lamports::text, occurred_at, signature, 1::text AS transaction_count
-        FROM source_rows WHERE occurred_at >= $4::timestamptz
-        UNION ALL
-        SELECT address, 'confirmed_payer_outflow', group_key, SUM(lamports)::text,
-          date_trunc('day', occurred_at), NULL, COUNT(*)::text
-        FROM source_rows WHERE occurred_at < $4::timestamptz
-        GROUP BY address, group_key, date_trunc('day', occurred_at)
+        SELECT
+          COALESCE((
+            SELECT json_agg(route_event_rows ORDER BY occurred_at, signature)
+            FROM route_event_rows
+          ), '[]'::json) AS route_rows,
+          COALESCE((
+            SELECT json_agg(lookup_event_rows ORDER BY occurred_at, signature)
+            FROM lookup_event_rows
+          ), '[]'::json) AS lookup_rows,
+          COALESCE((
+            SELECT json_agg(route_summary_rows ORDER BY address)
+            FROM route_summary_rows
+          ), '[]'::json) AS route_summary_rows,
+          COALESCE((
+            SELECT json_agg(lookup_summary_rows ORDER BY address)
+            FROM lookup_summary_rows
+          ), '[]'::json) AS lookup_summary_rows
       `,
-          [
-            MAINNET_YIELD_CLUSTER,
-            addresses,
-            window.startedAt.toISOString(),
-            recentCutoff.toISOString(),
-          ]
-        ) as unknown as Promise<SpendEventObservationRow[]>,
-        sql.query(
-          `
-        SELECT fee_payer AS address,
-          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= $4::timestamptz), 0)::text AS spend24h_lamports,
-          COALESCE(SUM(compiled_fee_lamports) FILTER (WHERE confirmed_at >= $5::timestamptz), 0)::text AS spend7d_lamports
-        FROM loyal_yield.signed_route_submissions
-        WHERE cluster = $1 AND confirmed_at IS NOT NULL
-          AND fee_payer = ANY($2::text[]) AND confirmed_at >= $3::timestamptz
-        GROUP BY fee_payer
-      `,
-          [
-            MAINNET_YIELD_CLUSTER,
-            addresses,
-            window.startedAt.toISOString(),
-            recentCutoff.toISOString(),
-            sevenDayCutoff.toISOString(),
-          ]
-        ) as unknown as Promise<
-          Array<{
-            address: string;
-            spend24h_lamports: string;
-            spend7d_lamports: string;
-          }>
-        >,
-        sql.query(
-          `
-        SELECT family.payer AS address,
-          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= $4::timestamptz), 0)::text AS spend24h_lamports,
-          COALESCE(SUM(GREATEST(COALESCE(operation.actual_fee_lamports, 0) + COALESCE(operation.actual_rent_lamports, 0) - COALESCE(operation.reclaimed_rent_lamports, 0), 0)) FILTER (WHERE operation.confirmed_at >= $5::timestamptz), 0)::text AS spend7d_lamports
-        FROM loyal_yield.lookup_table_operations AS operation
-        JOIN loyal_yield.lookup_table_families AS family ON family.id = operation.family_id
-        WHERE family.cluster = $1 AND operation.confirmed_at IS NOT NULL
-          AND family.payer = ANY($2::text[]) AND operation.confirmed_at >= $3::timestamptz
-        GROUP BY family.payer
-      `,
-          [
-            MAINNET_YIELD_CLUSTER,
-            addresses,
-            window.startedAt.toISOString(),
-            recentCutoff.toISOString(),
-            sevenDayCutoff.toISOString(),
-          ]
-        ) as unknown as Promise<
-          Array<{
-            address: string;
-            spend24h_lamports: string;
-            spend7d_lamports: string;
-          }>
-        >,
-      ]);
+      [
+        MAINNET_YIELD_CLUSTER,
+        addresses,
+        window.startedAt.toISOString(),
+        recentCutoff.toISOString(),
+        sevenDayCutoff.toISOString(),
+      ]
+    )) as unknown as YieldSpendPayloadRow[];
+    const payload = payloadRows[0] ?? {
+      lookup_rows: [],
+      lookup_summary_rows: [],
+      route_rows: [],
+      route_summary_rows: [],
+    };
+    const routeRows = payload.route_rows;
+    const lookupTableRows = payload.lookup_rows;
+    const routeSummaryRows = payload.route_summary_rows;
+    const lookupSummaryRows = payload.lookup_summary_rows;
 
     const spend = new Map<string, WalletSpend>();
     for (const row of [...routeSummaryRows, ...lookupSummaryRows]) {

--- a/apps/admin/src/app/(admin)/earn/operational-wallet-spending-charts.tsx
+++ b/apps/admin/src/app/(admin)/earn/operational-wallet-spending-charts.tsx
@@ -174,6 +174,14 @@ function SpendEventTooltip({
             </dd>
           </>
         ) : null}
+        {point.transactionCount > 1 ? (
+          <>
+            <dt className="text-muted-foreground">Transactions</dt>
+            <dd className="text-right font-medium tabular-nums">
+              {point.transactionCount.toLocaleString("en-US")}
+            </dd>
+          </>
+        ) : null}
       </dl>
     </div>
   );
@@ -392,6 +400,10 @@ export function OperationalWalletSpendingCharts({
             const walletScatter = scatterByWallet.get(wallet.address);
             const walletGroups = walletScatter?.groups ?? [];
             const walletPoints = walletScatter?.points ?? [];
+            const walletTransactionCount = walletPoints.reduce(
+              (total, point) => total + point.transactionCount,
+              0
+            );
             const isSettingsAuthority = wallet.roles.some(
               (role) => role.key === "settings_authority"
             );
@@ -408,7 +420,8 @@ export function OperationalWalletSpendingCharts({
                     </p>
                   </div>
                   <p className="text-xs text-muted-foreground tabular-nums">
-                    {walletPoints.length.toLocaleString("en-US")} transactions
+                    {walletTransactionCount.toLocaleString("en-US")}{" "}
+                    transactions
                   </p>
                 </div>
                 {walletPoints.length === 0 || walletGroups.length === 0 ? (

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -334,9 +334,11 @@ function VaultFrequencyTooltip({
 
 export function EarnVaultRebalanceFrequencyChart({
   data,
+  liquidityMint,
   reserveStatuses,
 }: {
   data: SerializedEarnVaultRebalanceFrequency;
+  liquidityMint: string | null;
   reserveStatuses: SafeReserveApyStatusRow[];
 }) {
   const [range, setRange] = useState<RangeKey>("all");
@@ -469,8 +471,12 @@ export function EarnVaultRebalanceFrequencyChart({
 
     setDetailStatus("loading");
     try {
+      const searchParams = new URLSearchParams({ kind: "frequency" });
+      if (liquidityMint !== null) {
+        searchParams.set("liquidityMint", liquidityMint);
+      }
       const response = await fetch(
-        "/api/earn/rebalance/details?kind=frequency",
+        `/api/earn/rebalance/details?${searchParams.toString()}`,
         { cache: "no-store", credentials: "same-origin" }
       );
       if (!response.ok) {

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -78,10 +78,29 @@ export type SerializedEarnVaultRebalanceFrequencyRow = {
 };
 
 export type SerializedEarnVaultRebalanceFrequency = {
+  chartPoints: SerializedEarnVaultRebalanceFrequencyRow[];
+  details: SerializedEarnVaultRebalanceFrequencyRow[];
   generatedAt: string;
   status: "available" | "unavailable";
+  summaries: SerializedEarnVaultRebalanceFrequencySummary[];
   vaultCount: number;
-  vaults: SerializedEarnVaultRebalanceFrequencyRow[];
+};
+
+export type SerializedEarnVaultRebalanceFrequencySummary = {
+  eligibleCount: number;
+  liquidityMint: string | null;
+  opportunity12hCount: number;
+  opportunity2hCount: number;
+  opportunity7dCount: number;
+  opportunityAllCount: number;
+  positionCount: number;
+  rebalance12hCount: number;
+  rebalance2hCount: number;
+  rebalance7dCount: number;
+  rebalanceAllCount: number;
+  rebalancedVaultCount: number;
+  routeMode: RebalanceRouteMode;
+  vaultCount: number;
 };
 
 type RangeKey = "12h" | "2h" | "7d" | "all";
@@ -282,7 +301,7 @@ export function EarnVaultRebalanceFrequencyChart({
     RANGE_OPTIONS.find((option) => option.key === range) ?? RANGE_OPTIONS[0];
   const rankedVaults = useMemo(
     () =>
-      [...data.vaults]
+      [...data.chartPoints]
         .filter((vault) => vault.routeMode === routeMode)
         .sort((left, right) => {
           const amountOrder = compareRawAmounts(
@@ -297,7 +316,7 @@ export function EarnVaultRebalanceFrequencyChart({
           ...vault,
           depositRank: index + 1,
         })),
-    [data.vaults, routeMode]
+    [data.chartPoints, routeMode]
   );
   const points = useMemo(
     () =>
@@ -369,22 +388,66 @@ export function EarnVaultRebalanceFrequencyChart({
     (maximum, point) => Math.max(maximum, point.rebalanceCount),
     0
   );
-  const rebalancedVaultCount = points.filter(
-    (point) => point.rebalanceCount > 0
-  ).length;
-  const totalRebalances = points.reduce(
-    (total, point) => total + point.rebalanceCount,
+  const tableRows = useMemo(
+    () =>
+      data.details
+        .filter((vault) => vault.routeMode === routeMode)
+        .sort((left, right) => {
+          const amountOrder = compareRawAmounts(
+            right.currentDepositRaw,
+            left.currentDepositRaw
+          );
+          return (
+            amountOrder || right.vaultPubkey.localeCompare(left.vaultPubkey)
+          );
+        })
+        .map(
+          (vault): ChartPoint => ({
+            ...vault,
+            depositAmount: toDepositAmount(vault.currentDepositRaw),
+            opportunityCount: vault[rangeOption.opportunityKey],
+            rebalanceCount: vault[rangeOption.countKey],
+          })
+        ),
+    [data.details, rangeOption.countKey, rangeOption.opportunityKey, routeMode]
+  );
+  const summaries = data.summaries.filter(
+    (summary) => summary.routeMode === routeMode
+  );
+  const exactVaultCount = summaries.reduce(
+    (total, summary) => total + summary.vaultCount,
     0
   );
-  const tableRows = [...points].reverse().slice(0, 100);
+  const exactEligibleCount = summaries.reduce(
+    (total, summary) => total + summary.eligibleCount,
+    0
+  );
+  const exactRebalancedVaultCount = summaries.reduce(
+    (total, summary) => total + summary.rebalancedVaultCount,
+    0
+  );
+  const exactRebalanceCount = summaries.reduce(
+    (total, summary) =>
+      total +
+      (range === "all"
+        ? summary.rebalanceAllCount
+        : range === "7d"
+        ? summary.rebalance7dCount
+        : range === "12h"
+        ? summary.rebalance12hCount
+        : summary.rebalance2hCount),
+    0
+  );
   const primaryLiquidityMint =
     points.find((point) => point.liquidityMint !== null)?.liquidityMint ?? null;
   const eligibilityFloorRaw = computeRebalanceEligibilityFloorRaw(
     reserveStatuses,
     STABLECOIN_DECIMALS
   );
-  const { eligibleCount, eligibleRebalancedCount } =
-    summarizeRebalanceEligibility(points, eligibilityFloorRaw);
+  const {
+    eligibleCount: sampledEligibleCount,
+    eligibleRebalancedCount: sampledEligibleRebalancedCount,
+  } = summarizeRebalanceEligibility(points, eligibilityFloorRaw);
   const positiveDeposits = points
     .map((point) => point.depositAmount)
     .filter((amount) => amount > 0 && Number.isFinite(amount));
@@ -483,20 +546,21 @@ export function EarnVaultRebalanceFrequencyChart({
           <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
             {points.length === 0 ? null : eligibilityFloorRaw === null ? (
               <span>
-                {rebalancedVaultCount.toLocaleString("en-US")} of{" "}
-                {points.length.toLocaleString("en-US")} funded vaults rebalanced
+                {exactRebalancedVaultCount.toLocaleString("en-US")} of{" "}
+                {exactEligibleCount.toLocaleString("en-US")} exact funded vaults
+                rebalanced
               </span>
             ) : (
               <span className="text-foreground">
-                {eligibleRebalancedCount.toLocaleString("en-US")} of{" "}
-                {eligibleCount.toLocaleString("en-US")} economically eligible
-                vaults rebalanced
+                {sampledEligibleRebalancedCount.toLocaleString("en-US")} of{" "}
+                {sampledEligibleCount.toLocaleString("en-US")} sampled
+                economically eligible points rebalanced
               </span>
             )}
             {points.length > 0 ? (
               <span>
-                {points.length.toLocaleString("en-US")} funded vaults ·{" "}
-                {rebalancedVaultCount.toLocaleString("en-US")} with rebalances
+                {points.length.toLocaleString("en-US")} representative points ·{" "}
+                {exactVaultCount.toLocaleString("en-US")} exact funded vaults
               </span>
             ) : null}
             {points.length === 0 || eligibilityFloorRaw === null ? null : (
@@ -511,8 +575,8 @@ export function EarnVaultRebalanceFrequencyChart({
             )}
             {points.length > 0 ? (
               <span>
-                {totalRebalances.toLocaleString("en-US")} confirmed executions ·{" "}
-                {rangeOption.label}
+                {exactRebalanceCount.toLocaleString("en-US")} exact confirmed
+                executions · {rangeOption.label}
               </span>
             ) : null}
             <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
@@ -699,7 +763,7 @@ export function EarnVaultRebalanceFrequencyChart({
                       ? "No confirmed rebalances occurred in this window; every vault is shown at zero."
                       : "Hover a dot for the exact vault, current deposit, reserve APY, and counts for every window."}
                     {showTable
-                      ? " The table shows the 100 largest current deposits."
+                      ? " The table shows the exact top 100 current deposits; chart points are representative samples."
                       : " Idle-only vaults use the neutral legend color."}
                     {!showTable && useLogScale && zeroDepositCount > 0
                       ? ` ${zeroDepositCount.toLocaleString("en-US")} vault${

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   CartesianGrid,
   Scatter,
@@ -41,10 +41,7 @@ import type { SafeReserveApyStatusRow } from "@/lib/kamino/timescale-reserve-mon
 
 import { buildLogTicks, formatDepositTick } from "./earn-vault-rebalance-axis";
 import { DepositScaleSwitch, type DepositScale } from "./deposit-scale-switch";
-import {
-  computeRebalanceEligibilityFloorRaw,
-  summarizeRebalanceEligibility,
-} from "./earn-vault-rebalance-eligibility";
+import { computeRebalanceEligibilityFloorRaw } from "./earn-vault-rebalance-eligibility";
 import type { RebalanceRouteMode } from "./rebalance-data";
 import { RouteModeSwitch } from "./route-mode-switch";
 
@@ -67,10 +64,6 @@ export type SerializedEarnVaultRebalanceFrequencyRow = {
   last2hCount: number;
   last7dCount: number;
   liquidityMint: string | null;
-  opportunity12hCount: number;
-  opportunity2hCount: number;
-  opportunity7dCount: number;
-  opportunityAllCount: number;
   positionCount: number;
   routeMode: RebalanceRouteMode;
   vaultId: string;
@@ -88,11 +81,10 @@ export type SerializedEarnVaultRebalanceFrequency = {
 
 export type SerializedEarnVaultRebalanceFrequencySummary = {
   eligibleCount: number;
+  eligibleCount12h: number;
+  eligibleCount2h: number;
+  eligibleCount7d: number;
   liquidityMint: string | null;
-  opportunity12hCount: number;
-  opportunity2hCount: number;
-  opportunity7dCount: number;
-  opportunityAllCount: number;
   positionCount: number;
   rebalance12hCount: number;
   rebalance2hCount: number;
@@ -105,17 +97,20 @@ export type SerializedEarnVaultRebalanceFrequencySummary = {
 
 type RangeKey = "12h" | "2h" | "7d" | "all";
 type CountKey = "allCount" | "last7dCount" | "last12hCount" | "last2hCount";
-type OpportunityKey =
-  | "opportunityAllCount"
-  | "opportunity7dCount"
-  | "opportunity12hCount"
-  | "opportunity2hCount";
 
 type ChartPoint = SerializedEarnVaultRebalanceFrequencyRow & {
   depositAmount: number;
   depositRank: number;
-  opportunityCount: number;
   rebalanceCount: number;
+};
+
+type VaultOpportunityCounts = {
+  allCount: number;
+  last12hCount: number;
+  last2hCount: number;
+  last7dCount: number;
+  routeMode: RebalanceRouteMode;
+  vaultId: string;
 };
 
 type ReserveSeries = {
@@ -131,35 +126,30 @@ const RANGE_OPTIONS: ReadonlyArray<{
   countKey: CountKey;
   key: RangeKey;
   label: string;
-  opportunityKey: OpportunityKey;
   tabLabel: string;
 }> = [
   {
     countKey: "allCount",
     key: "all",
     label: "All history",
-    opportunityKey: "opportunityAllCount",
     tabLabel: "All",
   },
   {
     countKey: "last7dCount",
     key: "7d",
     label: "Last 7 days",
-    opportunityKey: "opportunity7dCount",
     tabLabel: "7 days",
   },
   {
     countKey: "last12hCount",
     key: "12h",
     label: "Last 12 hours",
-    opportunityKey: "opportunity12hCount",
     tabLabel: "12 hours",
   },
   {
     countKey: "last2hCount",
     key: "2h",
     label: "Last 2 hours",
-    opportunityKey: "opportunity2hCount",
     tabLabel: "2 hours",
   },
 ];
@@ -226,18 +216,71 @@ function toDepositAmount(raw: string): number {
 function VaultFrequencyTooltip({
   active,
   payload,
+  range,
   rangeLabel,
   reserveSeriesByKey,
 }: {
   active?: boolean;
   payload?: Array<{ payload?: ChartPoint }>;
+  range: RangeKey;
   rangeLabel: string;
   reserveSeriesByKey: ReadonlyMap<string, ReserveSeries>;
 }) {
   const point = payload?.[0]?.payload;
+  const vaultId = point?.vaultId;
+  const routeMode = point?.routeMode;
+  const [opportunityCounts, setOpportunityCounts] = useState<
+    | { data: VaultOpportunityCounts; status: "ready" }
+    | { status: "error" | "idle" | "loading" }
+  >({ status: "idle" });
+
+  useEffect(() => {
+    if (!vaultId || !routeMode) {
+      setOpportunityCounts({ status: "idle" });
+      return;
+    }
+
+    const controller = new AbortController();
+    const params = new URLSearchParams({ routeMode, vaultId });
+    setOpportunityCounts({ status: "loading" });
+
+    void fetch(`/api/earn/rebalance/vault-opportunities?${params}`, {
+      credentials: "same-origin",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Vault opportunity request failed: ${response.status}`
+          );
+        }
+
+        return (await response.json()) as VaultOpportunityCounts;
+      })
+      .then((data) => setOpportunityCounts({ data, status: "ready" }))
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setOpportunityCounts({ status: "error" });
+        }
+      });
+
+    return () => controller.abort();
+  }, [routeMode, vaultId]);
+
   if (!active || !point) {
     return null;
   }
+
+  const opportunityCount =
+    opportunityCounts.status === "ready"
+      ? range === "all"
+        ? opportunityCounts.data.allCount
+        : range === "7d"
+        ? opportunityCounts.data.last7dCount
+        : range === "12h"
+        ? opportunityCounts.data.last12hCount
+        : opportunityCounts.data.last2hCount
+      : null;
 
   const series = reserveSeriesByKey.get(point.currentReserve ?? NO_RESERVE_KEY);
 
@@ -269,7 +312,11 @@ function VaultFrequencyTooltip({
         </dd>
         <dt className="text-muted-foreground">Opportunities raised</dt>
         <dd className="text-right tabular-nums">
-          {point.opportunityCount.toLocaleString("en-US")}
+          {opportunityCount === null
+            ? opportunityCounts.status === "error"
+              ? "Unavailable"
+              : "Loading exact count…"
+            : opportunityCount.toLocaleString("en-US")}
         </dd>
         <dt className="text-muted-foreground">Positive positions</dt>
         <dd className="text-right tabular-nums">{point.positionCount}</dd>
@@ -296,6 +343,10 @@ export function EarnVaultRebalanceFrequencyChart({
   const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
   const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
+  const [detailRows, setDetailRows] = useState(data.details);
+  const [detailStatus, setDetailStatus] = useState<
+    "idle" | "loading" | "error"
+  >("idle");
 
   const rangeOption =
     RANGE_OPTIONS.find((option) => option.key === range) ?? RANGE_OPTIONS[0];
@@ -311,11 +362,7 @@ export function EarnVaultRebalanceFrequencyChart({
           return (
             amountOrder || left.vaultPubkey.localeCompare(right.vaultPubkey)
           );
-        })
-        .map((vault, index) => ({
-          ...vault,
-          depositRank: index + 1,
-        })),
+        }),
     [data.chartPoints, routeMode]
   );
   const points = useMemo(
@@ -324,11 +371,10 @@ export function EarnVaultRebalanceFrequencyChart({
         (vault): ChartPoint => ({
           ...vault,
           depositAmount: toDepositAmount(vault.currentDepositRaw),
-          opportunityCount: vault[rangeOption.opportunityKey],
           rebalanceCount: vault[rangeOption.countKey],
         })
       ),
-    [rangeOption.countKey, rangeOption.opportunityKey, rankedVaults]
+    [rangeOption.countKey, rankedVaults]
   );
   const apyByReserve = useMemo(
     () => new Map(reserveStatuses.map((status) => [status.reserve, status])),
@@ -390,7 +436,7 @@ export function EarnVaultRebalanceFrequencyChart({
   );
   const tableRows = useMemo(
     () =>
-      data.details
+      detailRows
         .filter((vault) => vault.routeMode === routeMode)
         .sort((left, right) => {
           const amountOrder = compareRawAmounts(
@@ -405,12 +451,41 @@ export function EarnVaultRebalanceFrequencyChart({
           (vault): ChartPoint => ({
             ...vault,
             depositAmount: toDepositAmount(vault.currentDepositRaw),
-            opportunityCount: vault[rangeOption.opportunityKey],
             rebalanceCount: vault[rangeOption.countKey],
           })
         ),
-    [data.details, rangeOption.countKey, rangeOption.opportunityKey, routeMode]
+    [detailRows, rangeOption.countKey, routeMode]
   );
+
+  async function toggleTable() {
+    if (showTable) {
+      setShowTable(false);
+      return;
+    }
+    if (detailRows.length > 0 || data.status !== "available") {
+      setShowTable(true);
+      return;
+    }
+
+    setDetailStatus("loading");
+    try {
+      const response = await fetch(
+        "/api/earn/rebalance/details?kind=frequency",
+        { cache: "no-store", credentials: "same-origin" }
+      );
+      if (!response.ok) {
+        throw new Error(`Vault details request failed: ${response.status}`);
+      }
+      const result = (await response.json()) as {
+        details: SerializedEarnVaultRebalanceFrequencyRow[];
+      };
+      setDetailRows(result.details);
+      setDetailStatus("idle");
+      setShowTable(true);
+    } catch {
+      setDetailStatus("error");
+    }
+  }
   const summaries = data.summaries.filter(
     (summary) => summary.routeMode === routeMode
   );
@@ -419,7 +494,15 @@ export function EarnVaultRebalanceFrequencyChart({
     0
   );
   const exactEligibleCount = summaries.reduce(
-    (total, summary) => total + summary.eligibleCount,
+    (total, summary) =>
+      total +
+      (range === "all"
+        ? summary.eligibleCount
+        : range === "7d"
+        ? summary.eligibleCount7d
+        : range === "12h"
+        ? summary.eligibleCount12h
+        : summary.eligibleCount2h),
     0
   );
   const exactRebalancedVaultCount = summaries.reduce(
@@ -444,10 +527,6 @@ export function EarnVaultRebalanceFrequencyChart({
     reserveStatuses,
     STABLECOIN_DECIMALS
   );
-  const {
-    eligibleCount: sampledEligibleCount,
-    eligibleRebalancedCount: sampledEligibleRebalancedCount,
-  } = summarizeRebalanceEligibility(points, eligibilityFloorRaw);
   const positiveDeposits = points
     .map((point) => point.depositAmount)
     .filter((amount) => amount > 0 && Number.isFinite(amount));
@@ -533,12 +612,17 @@ export function EarnVaultRebalanceFrequencyChart({
                 />
                 <Button
                   aria-pressed={showTable}
-                  onClick={() => setShowTable((value) => !value)}
+                  disabled={detailStatus === "loading"}
+                  onClick={() => void toggleTable()}
                   size="sm"
                   type="button"
                   variant={showTable ? "secondary" : "outline"}
                 >
-                  Table
+                  {detailStatus === "loading"
+                    ? "Loading table…"
+                    : detailStatus === "error"
+                    ? "Retry table"
+                    : "Table"}
                 </Button>
               </>
             ) : null}
@@ -547,20 +631,21 @@ export function EarnVaultRebalanceFrequencyChart({
             {points.length === 0 ? null : eligibilityFloorRaw === null ? (
               <span>
                 {exactRebalancedVaultCount.toLocaleString("en-US")} of{" "}
-                {exactEligibleCount.toLocaleString("en-US")} exact funded vaults
+                {exactEligibleCount.toLocaleString("en-US")} funded vaults
                 rebalanced
               </span>
             ) : (
               <span className="text-foreground">
-                {sampledEligibleRebalancedCount.toLocaleString("en-US")} of{" "}
-                {sampledEligibleCount.toLocaleString("en-US")} sampled
-                economically eligible points rebalanced
+                {exactRebalancedVaultCount.toLocaleString("en-US")} of{" "}
+                {exactEligibleCount.toLocaleString("en-US")} economically
+                eligible vaults rebalanced
               </span>
             )}
             {points.length > 0 ? (
               <span>
-                {points.length.toLocaleString("en-US")} representative points ·{" "}
-                {exactVaultCount.toLocaleString("en-US")} exact funded vaults
+                {exactVaultCount.toLocaleString("en-US")} funded vaults ·{" "}
+                {exactRebalancedVaultCount.toLocaleString("en-US")} with
+                rebalances
               </span>
             ) : null}
             {points.length === 0 || eligibilityFloorRaw === null ? null : (
@@ -575,7 +660,7 @@ export function EarnVaultRebalanceFrequencyChart({
             )}
             {points.length > 0 ? (
               <span>
-                {exactRebalanceCount.toLocaleString("en-US")} exact confirmed
+                {exactRebalanceCount.toLocaleString("en-US")} confirmed
                 executions · {rangeOption.label}
               </span>
             ) : null}
@@ -736,6 +821,7 @@ export function EarnVaultRebalanceFrequencyChart({
                       <ChartTooltip
                         content={
                           <VaultFrequencyTooltip
+                            range={range}
                             rangeLabel={rangeOption.label}
                             reserveSeriesByKey={reserveSeriesByKey}
                           />

--- a/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/earn-vault-rebalance-frequency-chart.tsx
@@ -849,7 +849,7 @@ export function EarnVaultRebalanceFrequencyChart({
                       ? "No confirmed rebalances occurred in this window; every vault is shown at zero."
                       : "Hover a dot for the exact vault, current deposit, reserve APY, and counts for every window."}
                     {showTable
-                      ? " The table shows the exact top 100 current deposits; chart points are representative samples."
+                      ? " The table shows the exact top 100 current deposits."
                       : " Idle-only vaults use the neutral legend color."}
                     {!showTable && useLogScale && zeroDepositCount > 0
                       ? ` ${zeroDepositCount.toLocaleString("en-US")} vault${

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -69,9 +69,20 @@ export type SerializedExecutedEarnRebalanceRow = {
 };
 
 export type SerializedExecutedEarnRebalanceHistory = {
-  executions: SerializedExecutedEarnRebalanceRow[];
+  chartPoints: SerializedExecutedEarnRebalanceRow[];
+  details: SerializedExecutedEarnRebalanceRow[];
   generatedAt: string;
   status: "available" | "unavailable";
+  summaries: SerializedExecutedEarnRebalanceSummary[];
+};
+
+export type SerializedExecutedEarnRebalanceSummary = {
+  executionCount: number;
+  executionCount30d: number;
+  executionCount7d: number;
+  liquidityMint: string | null;
+  routeMode: RebalanceRouteMode;
+  swapFeeLamports: string;
   userCount: number;
 };
 
@@ -231,7 +242,7 @@ export function ExecutedEarnRebalancesChart({
 
   const points = useMemo(
     () =>
-      data.executions
+      data.chartPoints
         .filter((execution) => execution.routeMode === routeMode)
         .map((execution) => ({
           ...execution,
@@ -241,7 +252,22 @@ export function ExecutedEarnRebalancesChart({
           executedAtMs: Date.parse(execution.executedAt),
         }))
         .filter((execution) => Number.isFinite(execution.executedAtMs)),
-    [data.executions, routeMode]
+    [data.chartPoints, routeMode]
+  );
+
+  const details = useMemo(
+    () =>
+      data.details
+        .filter((execution) => execution.routeMode === routeMode)
+        .map((execution) => ({
+          ...execution,
+          depositAmount:
+            Number(BigInt(execution.currentDepositRaw)) /
+            10 ** STABLECOIN_DECIMALS,
+          executedAtMs: Date.parse(execution.executedAt),
+        }))
+        .filter((execution) => Number.isFinite(execution.executedAtMs)),
+    [data.details, routeMode]
   );
 
   const filteredPoints = useMemo(() => {
@@ -254,6 +280,17 @@ export function ExecutedEarnRebalancesChart({
       (point) => point.executedAtMs >= latest - days * DAY_MS
     );
   }, [points, range]);
+
+  const filteredDetails = useMemo(() => {
+    if (range === "all" || details.length === 0) {
+      return details;
+    }
+    const latest = details[0].executedAtMs;
+    const days = range === "7d" ? 7 : 30;
+    return details.filter(
+      (point) => point.executedAtMs >= latest - days * DAY_MS
+    );
+  }, [details, range]);
 
   const sourceReserves = useMemo(
     () => [...new Set(points.map((point) => point.sourceReserve))].sort(),
@@ -272,8 +309,23 @@ export function ExecutedEarnRebalancesChart({
     ])
   ) satisfies ChartConfig;
 
-  const distinctUserCount = new Set(points.map((point) => point.authority))
-    .size;
+  const routeSummaries = data.summaries.filter(
+    (item) => item.routeMode === routeMode
+  );
+  const exactExecutionCount = routeSummaries.reduce(
+    (total, item) =>
+      total +
+      (range === "all"
+        ? item.executionCount
+        : range === "30d"
+        ? item.executionCount30d
+        : item.executionCount7d),
+    0
+  );
+  const distinctUserCount = routeSummaries.reduce(
+    (total, item) => total + item.userCount,
+    0
+  );
   const positiveDeposits = filteredPoints
     .map((point) => point.depositAmount)
     .filter((amount) => amount > 0 && Number.isFinite(amount));
@@ -295,11 +347,10 @@ export function ExecutedEarnRebalancesChart({
     ...point,
     logDepositAmount: point.depositAmount > 0 ? point.depositAmount : logFloor,
   }));
-  const tableRows = [...filteredPoints].reverse().slice(0, 50);
-  const swapFeeLamports = points.reduce(
-    (total, point) => total + BigInt(point.swapFeeLamports),
-    BigInt(0)
-  );
+  const tableRows = filteredDetails.slice(0, 50);
+  const swapFeeLamports = routeSummaries
+    .reduce((total, item) => total + BigInt(item.swapFeeLamports), BigInt(0))
+    .toString();
 
   if (data.status === "unavailable") {
     return (
@@ -386,19 +437,19 @@ export function ExecutedEarnRebalancesChart({
         </div>
         <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
           <span>
-            {points.length.toLocaleString("en-US")} confirmed executions
+            {exactExecutionCount.toLocaleString("en-US")} confirmed executions
           </span>
           <span>
             {distinctUserCount.toLocaleString("en-US")} distinct users
           </span>
           <span>
-            {filteredPoints.length.toLocaleString("en-US")} shown ·{" "}
+            {exactExecutionCount.toLocaleString("en-US")} shown ·{" "}
             {rangeLabel(range)}
           </span>
           <span>Updated {formatUtcTimestamp(data.generatedAt)}</span>
           {routeMode === "cross_mint" ? (
             <span className="font-medium text-foreground">
-              {formatSwapFee(swapFeeLamports.toString())} finalized swap fees
+              {formatSwapFee(swapFeeLamports)} finalized swap fees
             </span>
           ) : null}
         </div>
@@ -592,7 +643,8 @@ export function ExecutedEarnRebalancesChart({
           </p>
         ) : (
           <p className="mt-3 text-xs text-muted-foreground">
-            Showing the 50 most recent executions in the selected range.
+            Showing the exact 50 most recent executions in the selected range;
+            chart points are representative samples.
           </p>
         )}
       </CardContent>

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -233,9 +233,11 @@ function ExecutedRebalanceTooltip({
 
 export function ExecutedEarnRebalancesChart({
   data,
+  liquidityMint,
   reserveLabels,
 }: {
   data: SerializedExecutedEarnRebalanceHistory;
+  liquidityMint: string | null;
   reserveLabels: ReadonlyMap<string, string>;
 }) {
   const [range, setRange] = useState<RangeKey>("all");
@@ -289,8 +291,12 @@ export function ExecutedEarnRebalancesChart({
 
     setDetailStatus("loading");
     try {
+      const searchParams = new URLSearchParams({ kind: "executed" });
+      if (liquidityMint !== null) {
+        searchParams.set("liquidityMint", liquidityMint);
+      }
       const response = await fetch(
-        "/api/earn/rebalance/details?kind=executed",
+        `/api/earn/rebalance/details?${searchParams.toString()}`,
         {
           cache: "no-store",
           credentials: "same-origin",
@@ -372,10 +378,9 @@ export function ExecutedEarnRebalancesChart({
         : item.fullyWithdrawnCount7d),
     0
   );
-  const distinctUserCount = routeSummaries.reduce(
-    (total, item) => total + item.userCount,
-    0
-  );
+  const distinctUserCount = new Set(
+    filteredPoints.map((point) => point.authority)
+  ).size;
   const positiveDeposits = filteredPoints
     .map((point) => point.depositAmount)
     .filter((amount) => amount > 0 && Number.isFinite(amount));

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -701,8 +701,7 @@ export function ExecutedEarnRebalancesChart({
           </p>
         ) : (
           <p className="mt-3 text-xs text-muted-foreground">
-            Showing the exact 50 most recent executions in the selected range;
-            chart points are representative samples.
+            Showing the exact 50 most recent executions in the selected range.
           </p>
         )}
       </CardContent>

--- a/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/executed-earn-rebalances-chart.tsx
@@ -80,6 +80,9 @@ export type SerializedExecutedEarnRebalanceSummary = {
   executionCount: number;
   executionCount30d: number;
   executionCount7d: number;
+  fullyWithdrawnCount: number;
+  fullyWithdrawnCount30d: number;
+  fullyWithdrawnCount7d: number;
   liquidityMint: string | null;
   routeMode: RebalanceRouteMode;
   swapFeeLamports: string;
@@ -239,6 +242,10 @@ export function ExecutedEarnRebalancesChart({
   const [routeMode, setRouteMode] = useState<RebalanceRouteMode>("same_mint");
   const [scale, setScale] = useState<DepositScale>("log");
   const [showTable, setShowTable] = useState(false);
+  const [detailRows, setDetailRows] = useState(data.details);
+  const [detailStatus, setDetailStatus] = useState<
+    "idle" | "loading" | "error"
+  >("idle");
 
   const points = useMemo(
     () =>
@@ -257,7 +264,7 @@ export function ExecutedEarnRebalancesChart({
 
   const details = useMemo(
     () =>
-      data.details
+      detailRows
         .filter((execution) => execution.routeMode === routeMode)
         .map((execution) => ({
           ...execution,
@@ -267,8 +274,41 @@ export function ExecutedEarnRebalancesChart({
           executedAtMs: Date.parse(execution.executedAt),
         }))
         .filter((execution) => Number.isFinite(execution.executedAtMs)),
-    [data.details, routeMode]
+    [detailRows, routeMode]
   );
+
+  async function toggleTable() {
+    if (showTable) {
+      setShowTable(false);
+      return;
+    }
+    if (detailRows.length > 0 || data.status !== "available") {
+      setShowTable(true);
+      return;
+    }
+
+    setDetailStatus("loading");
+    try {
+      const response = await fetch(
+        "/api/earn/rebalance/details?kind=executed",
+        {
+          cache: "no-store",
+          credentials: "same-origin",
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`Execution details request failed: ${response.status}`);
+      }
+      const result = (await response.json()) as {
+        details: SerializedExecutedEarnRebalanceRow[];
+      };
+      setDetailRows(result.details);
+      setDetailStatus("idle");
+      setShowTable(true);
+    } catch {
+      setDetailStatus("error");
+    }
+  }
 
   const filteredPoints = useMemo(() => {
     if (range === "all" || points.length === 0) {
@@ -322,6 +362,16 @@ export function ExecutedEarnRebalancesChart({
         : item.executionCount7d),
     0
   );
+  const exactFullyWithdrawnCount = routeSummaries.reduce(
+    (total, item) =>
+      total +
+      (range === "all"
+        ? item.fullyWithdrawnCount
+        : range === "30d"
+        ? item.fullyWithdrawnCount30d
+        : item.fullyWithdrawnCount7d),
+    0
+  );
   const distinctUserCount = routeSummaries.reduce(
     (total, item) => total + item.userCount,
     0
@@ -340,7 +390,6 @@ export function ExecutedEarnRebalancesChart({
     logFloor,
     useLogScale ? Math.max(...positiveDeposits) : 1
   );
-  const zeroDepositCount = filteredPoints.length - positiveDeposits.length;
   const maxDepositAmount =
     positiveDeposits.length > 0 ? Math.max(...positiveDeposits) : 1;
   const scatterPoints = filteredPoints.map((point) => ({
@@ -418,12 +467,17 @@ export function ExecutedEarnRebalancesChart({
               </div>
               <Button
                 aria-pressed={showTable}
-                onClick={() => setShowTable((value) => !value)}
+                disabled={detailStatus === "loading"}
+                onClick={() => void toggleTable()}
                 size="sm"
                 type="button"
                 variant={showTable ? "secondary" : "outline"}
               >
-                Table
+                {detailStatus === "loading"
+                  ? "Loading table…"
+                  : detailStatus === "error"
+                  ? "Retry table"
+                  : "Table"}
               </Button>
             </div>
             {showTable ? null : (
@@ -635,9 +689,13 @@ export function ExecutedEarnRebalancesChart({
               : "Y-axis labels sample current deposit amounts"}
             ; hover a dot for the exact wallet, current deposit, route, amount,
             decision, and slot.
-            {useLogScale && zeroDepositCount > 0
-              ? ` ${zeroDepositCount.toLocaleString("en-US")} fully withdrawn ${
-                  zeroDepositCount === 1 ? "execution sits" : "executions sit"
+            {useLogScale && exactFullyWithdrawnCount > 0
+              ? ` ${exactFullyWithdrawnCount.toLocaleString(
+                  "en-US"
+                )} fully withdrawn ${
+                  exactFullyWithdrawnCount === 1
+                    ? "execution sits"
+                    : "executions sit"
                 } on the axis floor.`
               : ""}
           </p>

--- a/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/last-30-days-rebalance-chart.tsx
@@ -105,13 +105,13 @@ export function Last30DaysRebalanceChart({
           <div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-t-0 sm:border-l sm:px-8 sm:py-6">
             <span className="text-xs text-muted-foreground">Successful</span>
             <span className="text-lg leading-none font-bold tabular-nums sm:text-3xl">
-              {totals.confirmed.toLocaleString()}
+              {totals.confirmed.toLocaleString("en-US")}
             </span>
           </div>
           <div className="flex flex-1 flex-col justify-center gap-1 border-t border-l px-6 py-4 text-left sm:border-t-0 sm:px-8 sm:py-6">
             <span className="text-xs text-muted-foreground">Failed</span>
             <span className="text-lg leading-none font-bold tabular-nums sm:text-3xl">
-              {totals.failed.toLocaleString()}
+              {totals.failed.toLocaleString("en-US")}
             </span>
           </div>
         </div>

--- a/apps/admin/src/app/(admin)/earn/rebalance/page.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/page.tsx
@@ -1,11 +1,14 @@
 import { PageContainer } from "@/components/layout/page-container";
 import { SectionHeader } from "@/components/layout/section-header";
+import { loadRebalancePageData } from "../../../api/earn/rebalance/route";
 
 import { RebalanceMonitorClient } from "./rebalance-monitor-client";
 
 export const dynamic = "force-dynamic";
 
-export default function EarnRebalancePage() {
+export default async function EarnRebalancePage() {
+  const initialData = await loadRebalancePageData();
+
   return (
     <PageContainer>
       <SectionHeader
@@ -14,7 +17,7 @@ export default function EarnRebalancePage() {
         title="Rebalance"
       />
 
-      <RebalanceMonitorClient />
+      <RebalanceMonitorClient initialData={initialData} />
     </PageContainer>
   );
 }

--- a/apps/admin/src/app/(admin)/earn/rebalance/page.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/page.tsx
@@ -7,7 +7,14 @@ import { RebalanceMonitorClient } from "./rebalance-monitor-client";
 export const dynamic = "force-dynamic";
 
 export default async function EarnRebalancePage() {
-  const initialData = await loadRebalancePageData();
+  const initialData = await loadRebalancePageData().catch((error) => {
+    console.error("Initial rebalance page data load failed", {
+      errorMessage:
+        error instanceof Error ? error.message : "Unknown data load error",
+      errorName: error instanceof Error ? error.name : "Error",
+    });
+    return undefined;
+  });
 
   return (
     <PageContainer>

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-activity-chart.tsx
@@ -350,7 +350,7 @@ export function RebalanceActivityChart({
           <div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-t-0 sm:border-l sm:px-8 sm:py-6">
             <span className="text-xs text-muted-foreground">Confirmed</span>
             <span className="text-lg leading-none font-bold tabular-nums sm:text-3xl">
-              {totals.confirmed.toLocaleString()}
+              {totals.confirmed.toLocaleString("en-US")}
             </span>
           </div>
           <div className="flex flex-1 flex-col justify-center gap-1 border-t border-l px-6 py-4 text-left sm:border-t-0 sm:px-8 sm:py-6">
@@ -358,7 +358,7 @@ export function RebalanceActivityChart({
               Failure records
             </span>
             <span className="text-lg leading-none font-bold tabular-nums sm:text-3xl">
-              {totals.failures.toLocaleString()}
+              {totals.failures.toLocaleString("en-US")}
             </span>
           </div>
         </div>

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -138,6 +138,9 @@ export type ExecutedEarnRebalanceSummary = {
   executionCount: number;
   executionCount30d: number;
   executionCount7d: number;
+  fullyWithdrawnCount: number;
+  fullyWithdrawnCount30d: number;
+  fullyWithdrawnCount7d: number;
   liquidityMint: string | null;
   routeMode: RebalanceRouteMode;
   swapFeeLamports: bigint;
@@ -153,10 +156,6 @@ export type EarnVaultRebalanceFrequencyRow = {
   last2hCount: number;
   last7dCount: number;
   liquidityMint: string | null;
-  opportunity12hCount: number;
-  opportunity2hCount: number;
-  opportunity7dCount: number;
-  opportunityAllCount: number;
   positionCount: number;
   routeMode: RebalanceRouteMode;
   vaultId: string;
@@ -173,11 +172,10 @@ export type EarnVaultRebalanceFrequency = {
 
 export type EarnVaultRebalanceFrequencySummary = {
   eligibleCount: number;
+  eligibleCount12h: number;
+  eligibleCount2h: number;
+  eligibleCount7d: number;
   liquidityMint: string | null;
-  opportunity12hCount: number;
-  opportunity2hCount: number;
-  opportunity7dCount: number;
-  opportunityAllCount: number;
   positionCount: number;
   rebalance12hCount: number;
   rebalance2hCount: number;
@@ -186,6 +184,15 @@ export type EarnVaultRebalanceFrequencySummary = {
   rebalancedVaultCount: number;
   routeMode: RebalanceRouteMode;
   vaultCount: number;
+};
+
+export type EarnVaultOpportunityCounts = {
+  allCount: number;
+  last12hCount: number;
+  last2hCount: number;
+  last7dCount: number;
+  routeMode: RebalanceRouteMode;
+  vaultId: string;
 };
 
 export type RebalanceAuditRow = {
@@ -322,27 +329,13 @@ type Last30DaysRebalanceSqlRow = {
   terminal_attempts: SqlScalar;
 };
 
-type ExecutedEarnRebalanceSqlRow = {
-  amount_raw: SqlScalar;
-  authority: string;
-  confirmed_slot: SqlScalar;
-  current_deposit_raw: SqlScalar;
-  executed_at: Date | string;
-  id: string;
-  liquidity_mint: string | null;
-  route_mode: string;
-  source_reserve: string;
-  source_liquidity_mint: string | null;
-  swap_fee_lamports: SqlScalar;
-  target_reserve: string;
-  target_liquidity_mint: string | null;
-  user_rank: SqlScalar;
-};
-
 type ExecutedEarnRebalanceSummarySqlRow = {
   execution_count: SqlScalar;
   execution_count_30d: SqlScalar;
   execution_count_7d: SqlScalar;
+  fully_withdrawn_count: SqlScalar;
+  fully_withdrawn_count_30d: SqlScalar;
+  fully_withdrawn_count_7d: SqlScalar;
   liquidity_mint: string | null;
   route_mode: string;
   swap_fee_lamports: SqlScalar;
@@ -350,38 +343,34 @@ type ExecutedEarnRebalanceSummarySqlRow = {
 };
 
 type ExecutedEarnRebalancePayloadSqlRow = {
-  chart_points: ExecutedEarnRebalanceSqlRow[];
-  details: ExecutedEarnRebalanceSqlRow[];
+  chart_points: ExecutedEarnRebalanceSqlTuple[];
+  details: ExecutedEarnRebalanceSqlTuple[];
   summaries: ExecutedEarnRebalanceSummarySqlRow[];
 };
 
-type EarnVaultRebalanceFrequencySqlRow = {
-  all_count: SqlScalar;
-  opportunity_all_count: SqlScalar;
-  opportunity_last_12h_count: SqlScalar;
-  opportunity_last_2h_count: SqlScalar;
-  opportunity_last_7d_count: SqlScalar;
-  current_deposit_raw: SqlScalar;
-  current_reserve: string | null;
-  deposit_rank: SqlScalar;
-  last_12h_count: SqlScalar;
-  last_2h_count: SqlScalar;
-  last_7d_count: SqlScalar;
-  liquidity_mint: string | null;
-  position_count: SqlScalar;
-  route_mode: string;
-  vault_count: SqlScalar;
-  vault_id: string;
-  vault_pubkey: string;
-};
+type ExecutedEarnRebalanceSqlTuple = [
+  amountRaw: SqlScalar,
+  authority: string,
+  confirmedSlot: SqlScalar,
+  currentDepositRaw: SqlScalar,
+  executedAt: Date | string,
+  id: string,
+  liquidityMint: string | null,
+  routeMode: string,
+  sourceReserve: string,
+  sourceLiquidityMint: string | null,
+  swapFeeLamports: SqlScalar,
+  targetReserve: string,
+  targetLiquidityMint: string | null,
+  userRank: SqlScalar
+];
 
 type EarnVaultRebalanceFrequencySummarySqlRow = {
   eligible_count: SqlScalar;
+  eligible_count_12h: SqlScalar;
+  eligible_count_2h: SqlScalar;
+  eligible_count_7d: SqlScalar;
   liquidity_mint: string | null;
-  opportunity_last_12h_count: SqlScalar;
-  opportunity_last_2h_count: SqlScalar;
-  opportunity_last_7d_count: SqlScalar;
-  opportunity_all_count: SqlScalar;
   position_count: SqlScalar;
   rebalance_last_12h_count: SqlScalar;
   rebalance_last_2h_count: SqlScalar;
@@ -393,9 +382,33 @@ type EarnVaultRebalanceFrequencySummarySqlRow = {
 };
 
 type EarnVaultRebalanceFrequencyPayloadSqlRow = {
-  chart_points: EarnVaultRebalanceFrequencySqlRow[];
-  details: EarnVaultRebalanceFrequencySqlRow[];
+  chart_points: EarnVaultRebalanceFrequencySqlTuple[];
+  details: EarnVaultRebalanceFrequencySqlTuple[];
   summaries: EarnVaultRebalanceFrequencySummarySqlRow[];
+};
+
+type EarnVaultRebalanceFrequencySqlTuple = [
+  allCount: SqlScalar,
+  currentDepositRaw: SqlScalar,
+  currentReserve: string | null,
+  depositRank: SqlScalar,
+  last12hCount: SqlScalar,
+  last2hCount: SqlScalar,
+  last7dCount: SqlScalar,
+  liquidityMint: string | null,
+  positionCount: SqlScalar,
+  routeMode: string,
+  vaultId: string,
+  vaultPubkey: string
+];
+
+type EarnVaultOpportunityCountsSqlRow = {
+  all_count: SqlScalar;
+  last_12h_count: SqlScalar;
+  last_2h_count: SqlScalar;
+  last_7d_count: SqlScalar;
+  route_mode: string;
+  vault_id: SqlScalar;
 };
 
 type RebalanceAuditSqlRow = {
@@ -1709,7 +1722,9 @@ export async function getLast30DaysRebalanceSeries(): Promise<
   }));
 }
 
-export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnRebalanceHistory> {
+export async function getExecutedEarnRebalanceHistory({
+  includeDetails = true,
+}: { includeDetails?: boolean } = {}): Promise<ExecutedEarnRebalanceHistory> {
   const rows = await queryRows<ExecutedEarnRebalancePayloadSqlRow>(
     `
       WITH executed AS MATERIALIZED (
@@ -1795,18 +1810,26 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
             END
           )::bigint AS amount_raw
         FROM relevant_vault_ids AS relevant
-        INNER JOIN loyal_yield.vault_reserve_positions_current AS position
-          ON position.vault_id = relevant.vault_id
-        WHERE position.has_value = true
-          AND position.amount_raw > 0
+        CROSS JOIN LATERAL (
+          SELECT position.*
+          FROM loyal_yield.vault_reserve_positions_current AS position
+          WHERE position.vault_id = relevant.vault_id
+            AND position.has_value = true
+            AND position.amount_raw > 0
+          OFFSET 0
+        ) AS position
         GROUP BY position.vault_id
       ),
       current_idle_by_vault AS MATERIALIZED (
         SELECT idle.vault_id, SUM(idle.amount_raw)::bigint AS amount_raw
         FROM relevant_vault_ids AS relevant
-        INNER JOIN loyal_yield.vault_idle_token_balances_current AS idle
-          ON idle.vault_id = relevant.vault_id
-        WHERE idle.amount_raw > 0
+        CROSS JOIN LATERAL (
+          SELECT idle.*
+          FROM loyal_yield.vault_idle_token_balances_current AS idle
+          WHERE idle.vault_id = relevant.vault_id
+            AND idle.amount_raw > 0
+          OFFSET 0
+        ) AS idle
         GROUP BY idle.vault_id
       ),
       current_user_deposits AS MATERIALIZED (
@@ -1861,7 +1884,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
             PARTITION BY executed.route_mode, executed.liquidity_mint
             ORDER BY executed.executed_at DESC, executed.id DESC
           )::integer AS detail_rank,
-          NTILE(200) OVER (
+          NTILE(50) OVER (
             PARTITION BY executed.route_mode, executed.liquidity_mint
             ORDER BY executed.executed_at ASC, executed.id ASC
           )::integer AS chart_bucket
@@ -1908,7 +1931,7 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
           current_deposit_raw::text AS current_deposit_raw,
           user_rank
         FROM execution_rows
-        WHERE detail_rank <= 50
+        WHERE detail_rank <= ${includeDetails ? 50 : 0}
       ),
       summary_rows AS (
         SELECT
@@ -1921,6 +1944,17 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
           COUNT(*) FILTER (
             WHERE executed_at >= now() - interval '7 days'
           )::integer AS execution_count_7d,
+          COUNT(*) FILTER (
+            WHERE current_deposit_raw::bigint = 0
+          )::integer AS fully_withdrawn_count,
+          COUNT(*) FILTER (
+            WHERE current_deposit_raw::bigint = 0
+              AND executed_at >= now() - interval '30 days'
+          )::integer AS fully_withdrawn_count_30d,
+          COUNT(*) FILTER (
+            WHERE current_deposit_raw::bigint = 0
+              AND executed_at >= now() - interval '7 days'
+          )::integer AS fully_withdrawn_count_7d,
           COUNT(DISTINCT authority)::integer AS user_count,
           COALESCE(SUM(swap_fee_lamports::bigint), 0)::text AS swap_fee_lamports
         FROM execution_rows
@@ -1937,6 +1971,9 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
                 execution_count,
                 execution_count_30d,
                 execution_count_7d,
+                fully_withdrawn_count,
+                fully_withdrawn_count_30d,
+                fully_withdrawn_count_7d,
                 user_count,
                 swap_fee_lamports
               FROM summary_rows
@@ -1946,14 +1983,50 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         ) AS summaries,
         COALESCE(
           (
-            SELECT json_agg(chart_row ORDER BY executed_at ASC, id ASC)
+            SELECT json_agg(
+              json_build_array(
+                chart_row.amount_raw,
+                chart_row.authority,
+                chart_row.confirmed_slot,
+                chart_row.current_deposit_raw,
+                chart_row.executed_at,
+                chart_row.id,
+                chart_row.liquidity_mint,
+                chart_row.route_mode,
+                chart_row.source_reserve,
+                chart_row.source_liquidity_mint,
+                chart_row.swap_fee_lamports,
+                chart_row.target_reserve,
+                chart_row.target_liquidity_mint,
+                chart_row.user_rank
+              )
+              ORDER BY chart_row.executed_at ASC, chart_row.id ASC
+            )
             FROM chart_rows AS chart_row
           ),
           '[]'::json
         ) AS chart_points,
         COALESCE(
           (
-            SELECT json_agg(detail_row ORDER BY executed_at DESC, id DESC)
+            SELECT json_agg(
+              json_build_array(
+                detail_row.amount_raw,
+                detail_row.authority,
+                detail_row.confirmed_slot,
+                detail_row.current_deposit_raw,
+                detail_row.executed_at,
+                detail_row.id,
+                detail_row.liquidity_mint,
+                detail_row.route_mode,
+                detail_row.source_reserve,
+                detail_row.source_liquidity_mint,
+                detail_row.swap_fee_lamports,
+                detail_row.target_reserve,
+                detail_row.target_liquidity_mint,
+                detail_row.user_rank
+              )
+              ORDER BY detail_row.executed_at DESC, detail_row.id DESC
+            )
             FROM detail_rows AS detail_row
           ),
           '[]'::json
@@ -1962,21 +2035,21 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
   );
 
   const payload = rows[0];
-  const mapRow = (row: ExecutedEarnRebalanceSqlRow) => ({
-    amountRaw: toBigInt(row.amount_raw),
-    authority: row.authority,
-    confirmedSlot: toBigInt(row.confirmed_slot),
-    currentDepositRaw: toBigInt(row.current_deposit_raw),
-    executedAt: toIsoString(row.executed_at) ?? "",
-    id: row.id,
-    liquidityMint: row.liquidity_mint,
-    routeMode: mapRouteMode(row.route_mode),
-    sourceReserve: row.source_reserve,
-    sourceLiquidityMint: row.source_liquidity_mint,
-    swapFeeLamports: toBigInt(row.swap_fee_lamports),
-    targetReserve: row.target_reserve,
-    targetLiquidityMint: row.target_liquidity_mint,
-    userRank: toNumber(row.user_rank),
+  const mapRow = (row: ExecutedEarnRebalanceSqlTuple) => ({
+    amountRaw: toBigInt(row[0]),
+    authority: row[1],
+    confirmedSlot: toBigInt(row[2]),
+    currentDepositRaw: toBigInt(row[3]),
+    executedAt: toIsoString(row[4]) ?? "",
+    id: row[5],
+    liquidityMint: row[6],
+    routeMode: mapRouteMode(row[7]),
+    sourceReserve: row[8],
+    sourceLiquidityMint: row[9],
+    swapFeeLamports: toBigInt(row[10]),
+    targetReserve: row[11],
+    targetLiquidityMint: row[12],
+    userRank: toNumber(row[13]),
   });
 
   return {
@@ -1988,6 +2061,9 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         executionCount: toNumber(row.execution_count),
         executionCount30d: toNumber(row.execution_count_30d),
         executionCount7d: toNumber(row.execution_count_7d),
+        fullyWithdrawnCount: toNumber(row.fully_withdrawn_count),
+        fullyWithdrawnCount30d: toNumber(row.fully_withdrawn_count_30d),
+        fullyWithdrawnCount7d: toNumber(row.fully_withdrawn_count_7d),
         liquidityMint: row.liquidity_mint,
         routeMode: mapRouteMode(row.route_mode),
         swapFeeLamports: toBigInt(row.swap_fee_lamports),
@@ -1996,7 +2072,19 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
   };
 }
 
-export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalanceFrequency> {
+export async function getEarnVaultRebalanceFrequency({
+  eligibilityFloorRaw = null,
+  includeDetails = true,
+}: {
+  eligibilityFloorRaw?: bigint | null;
+  includeDetails?: boolean;
+} = {}): Promise<EarnVaultRebalanceFrequency> {
+  const eligibleWhen = (countColumn: string, includeOpportunity = false) =>
+    eligibilityFloorRaw === null
+      ? "TRUE"
+      : `(current_deposit_raw >= ${eligibilityFloorRaw.toString()}::bigint OR ${countColumn} > 0${
+          includeOpportunity ? " OR has_opportunity" : ""
+        })`;
   const rows = await queryRows<EarnVaultRebalanceFrequencyPayloadSqlRow>(
     `
       WITH active_vaults AS MATERIALIZED (
@@ -2061,10 +2149,14 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             ELSE 0::bigint
           END AS normalized_amount_raw
         FROM active_vaults AS vault
-        INNER JOIN loyal_yield.vault_reserve_positions_current AS position
-          ON position.vault_id = vault.id
-          AND position.has_value = true
-          AND position.amount_raw > 0
+        CROSS JOIN LATERAL (
+          SELECT position.*
+          FROM loyal_yield.vault_reserve_positions_current AS position
+          WHERE position.vault_id = vault.id
+            AND position.has_value = true
+            AND position.amount_raw > 0
+          OFFSET 0
+        ) AS position
       ),
       positive_positions AS MATERIALIZED (
         SELECT *
@@ -2098,9 +2190,13 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       positive_idle AS MATERIALIZED (
         SELECT idle.*
         FROM active_vaults AS vault
-        INNER JOIN loyal_yield.vault_idle_token_balances_current AS idle
-          ON idle.vault_id = vault.id
-          AND idle.amount_raw > 0
+        CROSS JOIN LATERAL (
+          SELECT idle.*
+          FROM loyal_yield.vault_idle_token_balances_current AS idle
+          WHERE idle.vault_id = vault.id
+            AND idle.amount_raw > 0
+          OFFSET 0
+        ) AS idle
       ),
       idle_totals AS MATERIALIZED (
         SELECT vault_id, SUM(amount_raw)::bigint AS amount_raw
@@ -2149,58 +2245,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           AND decision.target_reserve IS NOT NULL
         GROUP BY decision.vault_id, decision.execution_plan->>'kind'
       ),
-      -- Evidence that a vault was genuinely actionable, used to keep it in the
-      -- eligible denominator even when it now sits under the modelled floor.
-      -- The reserve filter must mirror rebalance_counts above: idle-vault
-      -- deposits carry a NULL source_reserve and can never produce a confirmed
-      -- reserve-to-reserve decision, so counting them would admit vaults the
-      -- numerator is structurally unable to match.
-      opportunity_counts AS MATERIALIZED (
-        SELECT
-          opportunity.vault_id,
-          'same_mint'::text AS route_mode,
-          COUNT(*)::integer AS all_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
-          )::integer AS last_7d_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '12 hours'
-          )::integer AS last_12h_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
-          )::integer AS last_2h_count
-        FROM loyal_yield.rebalance_opportunities AS opportunity
-        INNER JOIN active_vaults AS active_vault
-          ON active_vault.id = opportunity.vault_id
-        WHERE opportunity.source_reserve IS NOT NULL
-          AND opportunity.target_reserve IS NOT NULL
-          AND opportunity.execution_plan->>'kind' = 'same_mint'
-        GROUP BY opportunity.vault_id
-        UNION ALL
-        SELECT
-          opportunity.vault_id,
-          'cross_mint_jupiter'::text AS route_mode,
-          COUNT(*)::integer AS all_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
-          )::integer AS last_7d_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '12 hours'
-          )::integer AS last_12h_count,
-          COUNT(*) FILTER (
-            WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
-          )::integer AS last_2h_count
-        FROM loyal_yield.rebalance_opportunities AS opportunity
-        INNER JOIN active_vaults AS active_vault
-          ON active_vault.id = opportunity.vault_id
-        WHERE opportunity.source_reserve IS NOT NULL
-          AND opportunity.target_reserve IS NOT NULL
-          AND opportunity.execution_plan->>'kind' = 'cross_mint_jupiter'
-        GROUP BY opportunity.vault_id
-      ),
-      current_vaults AS MATERIALIZED (
+      current_vaults_base AS MATERIALIZED (
         SELECT
           vault.id,
+          vault.cluster,
           vault.vault_pubkey,
           vault.route_mode,
           primary_position.reserve AS current_reserve,
@@ -2213,11 +2261,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           COALESCE(rebalance.all_count, 0) AS all_count,
           COALESCE(rebalance.last_7d_count, 0) AS last_7d_count,
           COALESCE(rebalance.last_12h_count, 0) AS last_12h_count,
-          COALESCE(rebalance.last_2h_count, 0) AS last_2h_count,
-          COALESCE(opportunity.all_count, 0) AS opportunity_all_count,
-          COALESCE(opportunity.last_7d_count, 0) AS opportunity_last_7d_count,
-          COALESCE(opportunity.last_12h_count, 0) AS opportunity_last_12h_count,
-          COALESCE(opportunity.last_2h_count, 0) AS opportunity_last_2h_count
+          COALESCE(rebalance.last_2h_count, 0) AS last_2h_count
         FROM monitored_vault_modes AS vault
         LEFT JOIN position_totals AS position_total
           ON position_total.vault_id = vault.id
@@ -2230,11 +2274,44 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         LEFT JOIN rebalance_counts AS rebalance
           ON rebalance.vault_id = vault.id
           AND rebalance.route_mode = vault.route_mode
-        LEFT JOIN opportunity_counts AS opportunity
-          ON opportunity.vault_id = vault.id
-          AND opportunity.route_mode = vault.route_mode
         WHERE COALESCE(position_total.amount_raw, 0::bigint)
           + COALESCE(idle_total.amount_raw, 0::bigint) > 0
+      ),
+      current_vaults AS MATERIALIZED (
+        SELECT
+          base.*,
+          CASE
+            WHEN ${
+              eligibilityFloorRaw === null
+                ? "FALSE"
+                : `base.current_deposit_raw < ${eligibilityFloorRaw.toString()}::bigint AND base.all_count = 0`
+            }
+              THEN CASE
+                WHEN base.route_mode = 'same_mint' THEN EXISTS (
+                  SELECT 1
+                  FROM loyal_yield.rebalance_opportunities AS opportunity
+                  WHERE opportunity.cluster = base.cluster
+                    AND opportunity.vault_id = base.id
+                    AND opportunity.source_reserve IS NOT NULL
+                    AND opportunity.target_reserve IS NOT NULL
+                    AND opportunity.execution_plan->>'kind' = 'same_mint'
+                  LIMIT 1
+                )
+                WHEN base.route_mode = 'cross_mint_jupiter' THEN EXISTS (
+                  SELECT 1
+                  FROM loyal_yield.rebalance_opportunities AS opportunity
+                  WHERE opportunity.cluster = base.cluster
+                    AND opportunity.vault_id = base.id
+                    AND opportunity.source_reserve IS NOT NULL
+                    AND opportunity.target_reserve IS NOT NULL
+                    AND opportunity.execution_plan->>'kind' = 'cross_mint_jupiter'
+                  LIMIT 1
+                )
+                ELSE FALSE
+              END
+            ELSE FALSE
+          END AS has_opportunity
+        FROM current_vaults_base AS base
       ),
       ranked_vaults AS MATERIALIZED (
         SELECT
@@ -2254,18 +2331,29 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             PARTITION BY ranked_vault.route_mode
           )::integer AS vault_count,
           ROW_NUMBER() OVER (
-            PARTITION BY ranked_vault.route_mode, ranked_vault.liquidity_mint
+            PARTITION BY
+              ranked_vault.route_mode,
+              ranked_vault.liquidity_mint,
+              ranked_vault.current_reserve
             ORDER BY ranked_vault.current_deposit_raw DESC, ranked_vault.vault_pubkey DESC
           )::integer AS detail_rank,
-          NTILE(150) OVER (
-            PARTITION BY ranked_vault.route_mode, ranked_vault.liquidity_mint
+          NTILE(50) OVER (
+            PARTITION BY
+              ranked_vault.route_mode,
+              ranked_vault.liquidity_mint,
+              ranked_vault.current_reserve
             ORDER BY ranked_vault.current_deposit_raw ASC, ranked_vault.vault_pubkey ASC
           )::integer AS chart_bucket
         FROM ranked_vaults AS ranked_vault
       ),
       chart_rows AS (
-        SELECT DISTINCT ON (route_mode, liquidity_mint, chart_bucket)
-          id,
+        SELECT DISTINCT ON (
+          route_mode,
+          liquidity_mint,
+          current_reserve,
+          chart_bucket
+        )
+          id::text AS vault_id,
           vault_pubkey,
           current_reserve,
           liquidity_mint,
@@ -2276,19 +2364,15 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           last_7d_count,
           last_12h_count,
           last_2h_count,
-          opportunity_all_count,
-          opportunity_last_7d_count,
-          opportunity_last_12h_count,
-          opportunity_last_2h_count,
           deposit_rank
           ,vault_count
         FROM frequency_rows
-        ORDER BY route_mode, liquidity_mint, chart_bucket,
+        ORDER BY route_mode, liquidity_mint, current_reserve, chart_bucket,
           current_deposit_raw DESC, vault_pubkey DESC
       ),
       detail_rows AS (
         SELECT
-          id,
+          id::text AS vault_id,
           vault_pubkey,
           current_reserve,
           liquidity_mint,
@@ -2299,31 +2383,34 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
           last_7d_count,
           last_12h_count,
           last_2h_count,
-          opportunity_all_count,
-          opportunity_last_7d_count,
-          opportunity_last_12h_count,
-          opportunity_last_2h_count,
           deposit_rank
           ,vault_count
         FROM frequency_rows
-        WHERE detail_rank <= 100
+        WHERE detail_rank <= ${includeDetails ? 100 : 0}
       ),
       summary_rows AS (
         SELECT
           route_mode,
           liquidity_mint,
           COUNT(*)::integer AS vault_count,
-          COUNT(*)::integer AS eligible_count,
+          COUNT(*) FILTER (
+            WHERE ${eligibleWhen("all_count", true)}
+          )::integer AS eligible_count,
+          COUNT(*) FILTER (
+            WHERE ${eligibleWhen("last_7d_count")}
+          )::integer AS eligible_count_7d,
+          COUNT(*) FILTER (
+            WHERE ${eligibleWhen("last_12h_count")}
+          )::integer AS eligible_count_12h,
+          COUNT(*) FILTER (
+            WHERE ${eligibleWhen("last_2h_count")}
+          )::integer AS eligible_count_2h,
           COUNT(*) FILTER (WHERE all_count > 0)::integer AS rebalanced_vault_count,
           COALESCE(SUM(position_count), 0)::integer AS position_count,
           COALESCE(SUM(all_count), 0)::integer AS rebalance_all_count,
           COALESCE(SUM(last_7d_count), 0)::integer AS rebalance_last_7d_count,
           COALESCE(SUM(last_12h_count), 0)::integer AS rebalance_last_12h_count,
-          COALESCE(SUM(last_2h_count), 0)::integer AS rebalance_last_2h_count,
-          COALESCE(SUM(opportunity_all_count), 0)::integer AS opportunity_all_count,
-          COALESCE(SUM(opportunity_last_7d_count), 0)::integer AS opportunity_last_7d_count,
-          COALESCE(SUM(opportunity_last_12h_count), 0)::integer AS opportunity_last_12h_count,
-          COALESCE(SUM(opportunity_last_2h_count), 0)::integer AS opportunity_last_2h_count
+          COALESCE(SUM(last_2h_count), 0)::integer AS rebalance_last_2h_count
         FROM current_vaults
         GROUP BY route_mode, liquidity_mint
       )
@@ -2337,14 +2424,46 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         ) AS summaries,
         COALESCE(
           (
-            SELECT json_agg(chart_row ORDER BY route_mode, deposit_rank)
+            SELECT json_agg(
+              json_build_array(
+                chart_row.all_count,
+                chart_row.current_deposit_raw,
+                chart_row.current_reserve,
+                chart_row.deposit_rank,
+                chart_row.last_12h_count,
+                chart_row.last_2h_count,
+                chart_row.last_7d_count,
+                chart_row.liquidity_mint,
+                chart_row.position_count,
+                chart_row.route_mode,
+                chart_row.vault_id,
+                chart_row.vault_pubkey
+              )
+              ORDER BY chart_row.route_mode, chart_row.deposit_rank
+            )
             FROM chart_rows AS chart_row
           ),
           '[]'::json
         ) AS chart_points,
         COALESCE(
           (
-            SELECT json_agg(detail_row ORDER BY route_mode, detail_row.deposit_rank)
+            SELECT json_agg(
+              json_build_array(
+                detail_row.all_count,
+                detail_row.current_deposit_raw,
+                detail_row.current_reserve,
+                detail_row.deposit_rank,
+                detail_row.last_12h_count,
+                detail_row.last_2h_count,
+                detail_row.last_7d_count,
+                detail_row.liquidity_mint,
+                detail_row.position_count,
+                detail_row.route_mode,
+                detail_row.vault_id,
+                detail_row.vault_pubkey
+              )
+              ORDER BY detail_row.route_mode, detail_row.deposit_rank
+            )
             FROM detail_rows AS detail_row
           ),
           '[]'::json
@@ -2353,23 +2472,19 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
   );
 
   const payload = rows[0];
-  const mapRow = (row: EarnVaultRebalanceFrequencySqlRow) => ({
-    allCount: toNumber(row.all_count),
-    currentDepositRaw: toBigInt(row.current_deposit_raw),
-    currentReserve: row.current_reserve,
-    depositRank: toNumber(row.deposit_rank),
-    last12hCount: toNumber(row.last_12h_count),
-    last2hCount: toNumber(row.last_2h_count),
-    last7dCount: toNumber(row.last_7d_count),
-    liquidityMint: row.liquidity_mint,
-    opportunity12hCount: toNumber(row.opportunity_last_12h_count),
-    opportunity2hCount: toNumber(row.opportunity_last_2h_count),
-    opportunity7dCount: toNumber(row.opportunity_last_7d_count),
-    opportunityAllCount: toNumber(row.opportunity_all_count),
-    positionCount: toNumber(row.position_count),
-    routeMode: mapRouteMode(row.route_mode),
-    vaultId: row.vault_id,
-    vaultPubkey: row.vault_pubkey,
+  const mapRow = (row: EarnVaultRebalanceFrequencySqlTuple) => ({
+    allCount: toNumber(row[0]),
+    currentDepositRaw: toBigInt(row[1]),
+    currentReserve: row[2],
+    depositRank: toNumber(row[3]),
+    last12hCount: toNumber(row[4]),
+    last2hCount: toNumber(row[5]),
+    last7dCount: toNumber(row[6]),
+    liquidityMint: row[7],
+    positionCount: toNumber(row[8]),
+    routeMode: mapRouteMode(row[9]),
+    vaultId: row[10],
+    vaultPubkey: row[11],
   });
 
   return {
@@ -2379,11 +2494,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
     summaries:
       payload?.summaries?.map((row) => ({
         eligibleCount: toNumber(row.eligible_count),
+        eligibleCount12h: toNumber(row.eligible_count_12h),
+        eligibleCount2h: toNumber(row.eligible_count_2h),
+        eligibleCount7d: toNumber(row.eligible_count_7d),
         liquidityMint: row.liquidity_mint,
-        opportunity12hCount: toNumber(row.opportunity_last_12h_count),
-        opportunity2hCount: toNumber(row.opportunity_last_2h_count),
-        opportunity7dCount: toNumber(row.opportunity_last_7d_count),
-        opportunityAllCount: toNumber(row.opportunity_all_count),
         positionCount: toNumber(row.position_count),
         rebalance12hCount: toNumber(row.rebalance_last_12h_count),
         rebalance2hCount: toNumber(row.rebalance_last_2h_count),
@@ -2398,6 +2512,66 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
         (total, row) => total + toNumber(row.vault_count),
         0
       ) ?? 0,
+  };
+}
+
+export async function getEarnVaultOpportunityCounts(
+  vaultId: string,
+  routeMode: RebalanceRouteMode
+): Promise<EarnVaultOpportunityCounts | null> {
+  if (!/^\d+$/.test(vaultId)) {
+    return null;
+  }
+
+  const databaseRouteMode =
+    routeMode === "cross_mint" ? "cross_mint_jupiter" : "same_mint";
+  const rows = await queryRows<EarnVaultOpportunityCountsSqlRow>(
+    `
+      WITH target_vault AS MATERIALIZED (
+        SELECT vault.id, policy.cluster
+        FROM loyal_yield.managed_vaults AS vault
+        INNER JOIN loyal_yield.route_policies AS policy
+          ON policy.id = vault.active_policy_id
+        WHERE vault.id = ${vaultId}::bigint
+          AND vault.active = true
+          AND vault.vault_index = 1
+      )
+      SELECT
+        target.id::text AS vault_id,
+        '${databaseRouteMode}'::text AS route_mode,
+        COUNT(opportunity.id)::integer AS all_count,
+        COUNT(opportunity.id) FILTER (
+          WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
+        )::integer AS last_7d_count,
+        COUNT(opportunity.id) FILTER (
+          WHERE opportunity.created_at >= NOW() - INTERVAL '12 hours'
+        )::integer AS last_12h_count,
+        COUNT(opportunity.id) FILTER (
+          WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
+        )::integer AS last_2h_count
+      FROM target_vault AS target
+      LEFT JOIN loyal_yield.rebalance_opportunities AS opportunity
+        ON opportunity.cluster = target.cluster
+        AND opportunity.vault_id = target.id
+        AND opportunity.source_reserve IS NOT NULL
+        AND opportunity.target_reserve IS NOT NULL
+        AND opportunity.execution_plan->>'kind' = '${databaseRouteMode}'
+      GROUP BY target.id
+    `
+  );
+  const row = rows[0];
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    allCount: toNumber(row.all_count),
+    last12hCount: toNumber(row.last_12h_count),
+    last2hCount: toNumber(row.last_2h_count),
+    last7dCount: toNumber(row.last_7d_count),
+    routeMode: mapRouteMode(row.route_mode),
+    vaultId: String(row.vault_id),
   };
 }
 

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -1883,11 +1883,7 @@ export async function getExecutedEarnRebalanceHistory({
           ROW_NUMBER() OVER (
             PARTITION BY executed.route_mode, executed.liquidity_mint
             ORDER BY executed.executed_at DESC, executed.id DESC
-          )::integer AS detail_rank,
-          NTILE(50) OVER (
-            PARTITION BY executed.route_mode, executed.liquidity_mint
-            ORDER BY executed.executed_at ASC, executed.id ASC
-          )::integer AS chart_bucket
+          )::integer AS detail_rank
         FROM executed
         INNER JOIN ranked_users
           ON ranked_users.authority = executed.authority
@@ -1896,7 +1892,7 @@ export async function getExecutedEarnRebalanceHistory({
           ON swap_fee.decision_id = executed.id
       ),
       chart_rows AS (
-        SELECT DISTINCT ON (route_mode, liquidity_mint, chart_bucket)
+        SELECT
           id,
           executed_at,
           amount_raw,
@@ -1912,7 +1908,6 @@ export async function getExecutedEarnRebalanceHistory({
           current_deposit_raw::text AS current_deposit_raw,
           user_rank
         FROM execution_rows
-        ORDER BY route_mode, liquidity_mint, chart_bucket, executed_at DESC, id DESC
       ),
       detail_rows AS (
         SELECT
@@ -2336,23 +2331,11 @@ export async function getEarnVaultRebalanceFrequency({
               ranked_vault.liquidity_mint,
               ranked_vault.current_reserve
             ORDER BY ranked_vault.current_deposit_raw DESC, ranked_vault.vault_pubkey DESC
-          )::integer AS detail_rank,
-          NTILE(50) OVER (
-            PARTITION BY
-              ranked_vault.route_mode,
-              ranked_vault.liquidity_mint,
-              ranked_vault.current_reserve
-            ORDER BY ranked_vault.current_deposit_raw ASC, ranked_vault.vault_pubkey ASC
-          )::integer AS chart_bucket
+          )::integer AS detail_rank
         FROM ranked_vaults AS ranked_vault
       ),
       chart_rows AS (
-        SELECT DISTINCT ON (
-          route_mode,
-          liquidity_mint,
-          current_reserve,
-          chart_bucket
-        )
+        SELECT
           id::text AS vault_id,
           vault_pubkey,
           current_reserve,
@@ -2367,8 +2350,6 @@ export async function getEarnVaultRebalanceFrequency({
           deposit_rank
           ,vault_count
         FROM frequency_rows
-        ORDER BY route_mode, liquidity_mint, current_reserve, chart_bucket,
-          current_deposit_raw DESC, vault_pubkey DESC
       ),
       detail_rows AS (
         SELECT

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-data.ts
@@ -128,8 +128,19 @@ export type ExecutedEarnRebalanceRow = {
 };
 
 export type ExecutedEarnRebalanceHistory = {
-  executions: ExecutedEarnRebalanceRow[];
+  chartPoints: ExecutedEarnRebalanceRow[];
+  details: ExecutedEarnRebalanceRow[];
   generatedAt: string;
+  summaries: ExecutedEarnRebalanceSummary[];
+};
+
+export type ExecutedEarnRebalanceSummary = {
+  executionCount: number;
+  executionCount30d: number;
+  executionCount7d: number;
+  liquidityMint: string | null;
+  routeMode: RebalanceRouteMode;
+  swapFeeLamports: bigint;
   userCount: number;
 };
 
@@ -153,9 +164,28 @@ export type EarnVaultRebalanceFrequencyRow = {
 };
 
 export type EarnVaultRebalanceFrequency = {
+  chartPoints: EarnVaultRebalanceFrequencyRow[];
+  details: EarnVaultRebalanceFrequencyRow[];
   generatedAt: string;
+  summaries: EarnVaultRebalanceFrequencySummary[];
   vaultCount: number;
-  vaults: EarnVaultRebalanceFrequencyRow[];
+};
+
+export type EarnVaultRebalanceFrequencySummary = {
+  eligibleCount: number;
+  liquidityMint: string | null;
+  opportunity12hCount: number;
+  opportunity2hCount: number;
+  opportunity7dCount: number;
+  opportunityAllCount: number;
+  positionCount: number;
+  rebalance12hCount: number;
+  rebalance2hCount: number;
+  rebalance7dCount: number;
+  rebalanceAllCount: number;
+  rebalancedVaultCount: number;
+  routeMode: RebalanceRouteMode;
+  vaultCount: number;
 };
 
 export type RebalanceAuditRow = {
@@ -306,8 +336,23 @@ type ExecutedEarnRebalanceSqlRow = {
   swap_fee_lamports: SqlScalar;
   target_reserve: string;
   target_liquidity_mint: string | null;
-  user_count: SqlScalar;
   user_rank: SqlScalar;
+};
+
+type ExecutedEarnRebalanceSummarySqlRow = {
+  execution_count: SqlScalar;
+  execution_count_30d: SqlScalar;
+  execution_count_7d: SqlScalar;
+  liquidity_mint: string | null;
+  route_mode: string;
+  swap_fee_lamports: SqlScalar;
+  user_count: SqlScalar;
+};
+
+type ExecutedEarnRebalancePayloadSqlRow = {
+  chart_points: ExecutedEarnRebalanceSqlRow[];
+  details: ExecutedEarnRebalanceSqlRow[];
+  summaries: ExecutedEarnRebalanceSummarySqlRow[];
 };
 
 type EarnVaultRebalanceFrequencySqlRow = {
@@ -328,6 +373,29 @@ type EarnVaultRebalanceFrequencySqlRow = {
   vault_count: SqlScalar;
   vault_id: string;
   vault_pubkey: string;
+};
+
+type EarnVaultRebalanceFrequencySummarySqlRow = {
+  eligible_count: SqlScalar;
+  liquidity_mint: string | null;
+  opportunity_last_12h_count: SqlScalar;
+  opportunity_last_2h_count: SqlScalar;
+  opportunity_last_7d_count: SqlScalar;
+  opportunity_all_count: SqlScalar;
+  position_count: SqlScalar;
+  rebalance_last_12h_count: SqlScalar;
+  rebalance_last_2h_count: SqlScalar;
+  rebalance_last_7d_count: SqlScalar;
+  rebalance_all_count: SqlScalar;
+  rebalanced_vault_count: SqlScalar;
+  route_mode: string;
+  vault_count: SqlScalar;
+};
+
+type EarnVaultRebalanceFrequencyPayloadSqlRow = {
+  chart_points: EarnVaultRebalanceFrequencySqlRow[];
+  details: EarnVaultRebalanceFrequencySqlRow[];
+  summaries: EarnVaultRebalanceFrequencySummarySqlRow[];
 };
 
 type RebalanceAuditSqlRow = {
@@ -1046,15 +1114,10 @@ export async function getRebalanceActivity(): Promise<
           AND decision.updated_at >= (SELECT window_started_at FROM bounds)
         GROUP BY 1, 2
       ),
-      opportunity_activity AS (
+      recent_failed_opportunities AS MATERIALIZED (
         SELECT
           opportunity.execution_plan->>'kind' AS route_mode,
-          date_bin(
-            interval '2 hours',
-            opportunity.state_entered_at,
-            timestamptz '1970-01-01 00:00:00+00'
-          ) AS bucket_started_at,
-          COUNT(*)::bigint AS failed_opportunities
+          opportunity.state_entered_at
         FROM loyal_yield.rebalance_opportunities AS opportunity
         WHERE opportunity.execution_plan->>'kind' IN (
             'same_mint',
@@ -1064,25 +1127,72 @@ export async function getRebalanceActivity(): Promise<
           AND opportunity.state_entered_at >= (
             SELECT window_started_at FROM bounds
           )
+      ),
+      opportunity_activity AS (
+        SELECT
+          opportunity.route_mode,
+          date_bin(
+            interval '2 hours',
+            opportunity.state_entered_at,
+            timestamptz '1970-01-01 00:00:00+00'
+          ) AS bucket_started_at,
+          COUNT(*)::bigint AS failed_opportunities
+        FROM recent_failed_opportunities AS opportunity
         GROUP BY 1, 2
+      ),
+      recent_claim_opportunities AS MATERIALIZED (
+        SELECT
+          opportunity.execution_plan->>'kind' AS route_mode,
+          opportunity.created_at,
+          opportunity.attempt_count
+        FROM loyal_yield.rebalance_opportunities AS opportunity
+        WHERE opportunity.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
+          AND opportunity.created_at >= (SELECT window_started_at FROM bounds)
+      ),
+      recent_submissions AS MATERIALIZED (
+        SELECT
+          decision.execution_plan->>'kind' AS route_mode,
+          submission.submission_state,
+          submission.submission_state_entered_at,
+          submission.movement_leg,
+          submission.finalized_at,
+          submission.compiled_fee_lamports
+        FROM loyal_yield.signed_route_submissions AS submission
+        INNER JOIN loyal_yield.rebalance_decisions AS decision
+          ON decision.id = submission.decision_id
+        WHERE decision.execution_plan->>'kind' IN (
+            'same_mint',
+            'cross_mint_jupiter'
+          )
+          AND (
+            submission.submission_state_entered_at >= (
+              SELECT window_started_at FROM bounds
+            )
+            OR submission.finalized_at >= (SELECT window_started_at FROM bounds)
+          )
+          AND (
+            submission.submission_state = 'expired'
+            OR (
+              submission.movement_leg = 'swap'
+              AND submission.finalized_at IS NOT NULL
+              AND decision.execution_plan->>'kind' = 'cross_mint_jupiter'
+            )
+          )
       ),
       submission_activity AS (
         SELECT
-          decision.execution_plan->>'kind' AS route_mode,
+          submission.route_mode,
           date_bin(
             interval '2 hours',
             submission.submission_state_entered_at,
             timestamptz '1970-01-01 00:00:00+00'
           ) AS bucket_started_at,
           COUNT(*)::bigint AS expired_submissions
-        FROM loyal_yield.signed_route_submissions AS submission
-        INNER JOIN loyal_yield.rebalance_decisions AS decision
-          ON decision.id = submission.decision_id
+        FROM recent_submissions AS submission
         WHERE submission.submission_state = 'expired'
-          AND decision.execution_plan->>'kind' IN (
-            'same_mint',
-            'cross_mint_jupiter'
-          )
           AND submission.submission_state_entered_at >= (
             SELECT window_started_at FROM bounds
           )
@@ -1090,19 +1200,15 @@ export async function getRebalanceActivity(): Promise<
       ),
       opportunity_claims AS (
         SELECT
-          opportunity.execution_plan->>'kind' AS route_mode,
+          opportunity.route_mode,
           date_bin(
             interval '2 hours',
             opportunity.created_at,
             timestamptz '1970-01-01 00:00:00+00'
           ) AS bucket_started_at,
           COALESCE(SUM(opportunity.attempt_count), 0)::bigint AS fleet_claims
-        FROM loyal_yield.rebalance_opportunities AS opportunity
-        WHERE opportunity.execution_plan->>'kind' IN (
-            'same_mint',
-            'cross_mint_jupiter'
-          )
-          AND opportunity.created_at >= (SELECT window_started_at FROM bounds)
+        FROM recent_claim_opportunities AS opportunity
+        WHERE opportunity.created_at >= (SELECT window_started_at FROM bounds)
         GROUP BY 1, 2
       ),
       swap_fee_activity AS (
@@ -1118,10 +1224,8 @@ export async function getRebalanceActivity(): Promise<
             AS swap_fee_lamports,
           COALESCE(MAX(submission.compiled_fee_lamports), 0)::bigint
             AS max_swap_fee_lamports
-        FROM loyal_yield.signed_route_submissions AS submission
-        INNER JOIN loyal_yield.rebalance_decisions AS decision
-          ON decision.id = submission.decision_id
-        WHERE decision.execution_plan->>'kind' = 'cross_mint_jupiter'
+        FROM recent_submissions AS submission
+        WHERE submission.route_mode = 'cross_mint_jupiter'
           AND submission.movement_leg = 'swap'
           AND submission.finalized_at IS NOT NULL
           AND submission.finalized_at >= (
@@ -1339,72 +1443,62 @@ export async function getAutodepositTimeSeries(): Promise<
           AND claim.status::text IN ('released', 'failed')
           AND claim.execution_id IS NULL
       ),
-      -- Claim transitions also touch their scheduled slot, so slots linked to
-      -- the 30-day claim window are in the same slot-update window. Normalize
-      -- the bounded error text once, encode it narrowly, and avoid classifying
-      -- or materializing the older scheduled-slot history.
-      slot_causes AS MATERIALIZED (
+      scheduled_slots AS MATERIALIZED (
         SELECT
-          normalized.id,
+          slot.id,
           CASE
-            WHEN strpos(normalized.error_text, 'accountnotfound') > 0 THEN 1
-            WHEN strpos(normalized.error_text, 'insufficientfundsforrent') > 0
+            WHEN strpos(lower(slot.last_error), 'accountnotfound') > 0 THEN 1
+            WHEN strpos(lower(slot.last_error), 'insufficientfundsforrent') > 0
               THEN 2
-            WHEN strpos(normalized.error_text, 'owner does not match') > 0
-              OR strpos(normalized.error_text, 'missing token delegate') > 0
+            WHEN strpos(lower(slot.last_error), 'owner does not match') > 0
+              OR strpos(lower(slot.last_error), 'missing token delegate') > 0
               THEN 3
-            WHEN strpos(
-              normalized.error_text,
-              'unable to confirm transaction'
-            ) > 0
-              OR strpos(normalized.error_text, 'timed out') > 0
-              OR strpos(normalized.error_text, 'blockhashnotfound') > 0
+            WHEN strpos(lower(slot.last_error), 'unable to confirm transaction') > 0
+              OR strpos(lower(slot.last_error), 'timed out') > 0
+              OR strpos(lower(slot.last_error), 'blockhashnotfound') > 0
               THEN 4
-            WHEN normalized.error_text IS NULL
-              OR normalized.error_text = ''
-              THEN 5
+            WHEN slot.last_error IS NULL OR slot.last_error = '' THEN 5
             ELSE 6
           END::smallint AS cause
-        FROM (
-          SELECT slot.id, lower(slot.last_error) AS error_text
-          FROM loyal_yield.balance_sweep_scheduled_slots AS slot
-          WHERE slot.updated_at >= (
-            SELECT started_at AT TIME ZONE 'UTC'
-            FROM window_bounds
-          )
-            AND slot.updated_at <= now()
-          OFFSET 0
-        ) AS normalized
+        FROM loyal_yield.balance_sweep_scheduled_slots AS slot
       ),
-      pre_pull_failure_events AS (
-        SELECT
-          claim.event_at,
-          COALESCE(slot.cause, 5::smallint) AS cause
-        FROM pre_pull_claims AS claim
-        LEFT JOIN slot_causes AS slot
-          ON slot.id = claim.scheduled_slot_id
-      ),
-      pre_pull_base AS (
+      pre_pull_claim_buckets AS MATERIALIZED (
         SELECT
           date_bin(
             interval '2 hours',
-            failure.event_at AT TIME ZONE 'UTC',
+            claim.event_at AT TIME ZONE 'UTC',
             timestamp '1970-01-01 00:00:00'
           ) AS base_bucket,
-          COUNT(*) FILTER (WHERE failure.cause = 1)::bigint
-            AS account_not_found,
-          COUNT(*) FILTER (WHERE failure.cause = 2)::bigint
-            AS insufficient_rent,
-          COUNT(*) FILTER (WHERE failure.cause = 3)::bigint
-            AS missing_token_delegate,
-          COUNT(*) FILTER (WHERE failure.cause = 4)::bigint
-            AS confirmation_or_timeout,
-          COUNT(*) FILTER (WHERE failure.cause = 5)::bigint
-            AS no_linked_error,
-          COUNT(*) FILTER (WHERE failure.cause = 6)::bigint
-            AS other_pre_pull
-        FROM pre_pull_failure_events AS failure
-        GROUP BY 1
+          claim.scheduled_slot_id,
+          COUNT(*)::bigint AS event_count
+        FROM pre_pull_claims AS claim
+        GROUP BY 1, 2
+      ),
+      pre_pull_base AS (
+        SELECT
+          claim.base_bucket,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 1
+          ), 0)::bigint AS account_not_found,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 2
+          ), 0)::bigint AS insufficient_rent,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 3
+          ), 0)::bigint AS missing_token_delegate,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 4
+          ), 0)::bigint AS confirmation_or_timeout,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 5 OR slot.id IS NULL
+          ), 0)::bigint AS no_linked_error,
+          COALESCE(SUM(claim.event_count) FILTER (
+            WHERE slot.cause = 6
+          ), 0)::bigint AS other_pre_pull
+        FROM pre_pull_claim_buckets AS claim
+        LEFT JOIN scheduled_slots AS slot
+          ON slot.id = claim.scheduled_slot_id
+        GROUP BY claim.base_bucket
       ),
       pre_pull_failure_activity AS (
         SELECT
@@ -1616,7 +1710,7 @@ export async function getLast30DaysRebalanceSeries(): Promise<
 }
 
 export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnRebalanceHistory> {
-  const rows = await queryRows<ExecutedEarnRebalanceSqlRow>(
+  const rows = await queryRows<ExecutedEarnRebalancePayloadSqlRow>(
     `
       WITH executed AS MATERIALIZED (
         SELECT
@@ -1652,6 +1746,8 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
           COALESCE(SUM(submission.compiled_fee_lamports), 0)::bigint
             AS swap_fee_lamports
         FROM loyal_yield.signed_route_submissions AS submission
+        INNER JOIN executed
+          ON executed.id = submission.decision_id
         WHERE submission.movement_leg = 'swap'
           AND submission.finalized_at IS NOT NULL
         GROUP BY submission.decision_id
@@ -1744,59 +1840,164 @@ export async function getExecutedEarnRebalanceHistory(): Promise<ExecutedEarnReb
         LEFT JOIN current_user_deposits AS deposit_total
           ON deposit_total.authority = executed_user.authority
           AND deposit_total.route_mode = executed_user.route_mode
+      ),
+      execution_rows AS MATERIALIZED (
+        SELECT
+          executed.id::text,
+          executed.executed_at,
+          executed.amount_raw::text,
+          executed.source_reserve,
+          executed.target_reserve,
+          executed.liquidity_mint,
+          executed.source_liquidity_mint,
+          executed.target_liquidity_mint,
+          executed.route_mode,
+          COALESCE(swap_fee.swap_fee_lamports, 0)::text AS swap_fee_lamports,
+          executed.confirmed_slot::text,
+          executed.authority,
+          ranked_users.current_deposit_raw::text,
+          ranked_users.user_rank::text,
+          ROW_NUMBER() OVER (
+            PARTITION BY executed.route_mode, executed.liquidity_mint
+            ORDER BY executed.executed_at DESC, executed.id DESC
+          )::integer AS detail_rank,
+          NTILE(200) OVER (
+            PARTITION BY executed.route_mode, executed.liquidity_mint
+            ORDER BY executed.executed_at ASC, executed.id ASC
+          )::integer AS chart_bucket
+        FROM executed
+        INNER JOIN ranked_users
+          ON ranked_users.authority = executed.authority
+          AND ranked_users.route_mode = executed.route_mode
+        LEFT JOIN swap_fees AS swap_fee
+          ON swap_fee.decision_id = executed.id
+      ),
+      chart_rows AS (
+        SELECT DISTINCT ON (route_mode, liquidity_mint, chart_bucket)
+          id,
+          executed_at,
+          amount_raw,
+          source_reserve,
+          target_reserve,
+          liquidity_mint,
+          source_liquidity_mint,
+          target_liquidity_mint,
+          route_mode,
+          swap_fee_lamports,
+          confirmed_slot,
+          authority,
+          current_deposit_raw::text AS current_deposit_raw,
+          user_rank
+        FROM execution_rows
+        ORDER BY route_mode, liquidity_mint, chart_bucket, executed_at DESC, id DESC
+      ),
+      detail_rows AS (
+        SELECT
+          id,
+          executed_at,
+          amount_raw,
+          source_reserve,
+          target_reserve,
+          liquidity_mint,
+          source_liquidity_mint,
+          target_liquidity_mint,
+          route_mode,
+          swap_fee_lamports,
+          confirmed_slot,
+          authority,
+          current_deposit_raw::text AS current_deposit_raw,
+          user_rank
+        FROM execution_rows
+        WHERE detail_rank <= 50
+      ),
+      summary_rows AS (
+        SELECT
+          route_mode,
+          liquidity_mint,
+          COUNT(*)::integer AS execution_count,
+          COUNT(*) FILTER (
+            WHERE executed_at >= now() - interval '30 days'
+          )::integer AS execution_count_30d,
+          COUNT(*) FILTER (
+            WHERE executed_at >= now() - interval '7 days'
+          )::integer AS execution_count_7d,
+          COUNT(DISTINCT authority)::integer AS user_count,
+          COALESCE(SUM(swap_fee_lamports::bigint), 0)::text AS swap_fee_lamports
+        FROM execution_rows
+        GROUP BY route_mode, liquidity_mint
       )
       SELECT
-        executed.id::text,
-        executed.executed_at,
-        executed.amount_raw::text,
-        executed.source_reserve,
-        executed.target_reserve,
-        executed.liquidity_mint,
-        executed.source_liquidity_mint,
-        executed.target_liquidity_mint,
-        executed.route_mode,
-        COALESCE(swap_fee.swap_fee_lamports, 0)::text AS swap_fee_lamports,
-        executed.confirmed_slot::text,
-        executed.authority,
-        ranked_users.current_deposit_raw::text,
-        ranked_users.user_rank::text,
-        MAX(ranked_users.user_rank) OVER (
-          PARTITION BY executed.route_mode
-        )::text AS user_count
-      FROM executed
-      INNER JOIN ranked_users
-        ON ranked_users.authority = executed.authority
-        AND ranked_users.route_mode = executed.route_mode
-      LEFT JOIN swap_fees AS swap_fee
-        ON swap_fee.decision_id = executed.id
-      ORDER BY executed.executed_at ASC, executed.id ASC
+        COALESCE(
+          (
+            SELECT json_agg(summary_row ORDER BY route_mode, liquidity_mint)
+            FROM (
+              SELECT
+                route_mode,
+                liquidity_mint,
+                execution_count,
+                execution_count_30d,
+                execution_count_7d,
+                user_count,
+                swap_fee_lamports
+              FROM summary_rows
+            ) AS summary_row
+          ),
+          '[]'::json
+        ) AS summaries,
+        COALESCE(
+          (
+            SELECT json_agg(chart_row ORDER BY executed_at ASC, id ASC)
+            FROM chart_rows AS chart_row
+          ),
+          '[]'::json
+        ) AS chart_points,
+        COALESCE(
+          (
+            SELECT json_agg(detail_row ORDER BY executed_at DESC, id DESC)
+            FROM detail_rows AS detail_row
+          ),
+          '[]'::json
+        ) AS details
     `
   );
 
+  const payload = rows[0];
+  const mapRow = (row: ExecutedEarnRebalanceSqlRow) => ({
+    amountRaw: toBigInt(row.amount_raw),
+    authority: row.authority,
+    confirmedSlot: toBigInt(row.confirmed_slot),
+    currentDepositRaw: toBigInt(row.current_deposit_raw),
+    executedAt: toIsoString(row.executed_at) ?? "",
+    id: row.id,
+    liquidityMint: row.liquidity_mint,
+    routeMode: mapRouteMode(row.route_mode),
+    sourceReserve: row.source_reserve,
+    sourceLiquidityMint: row.source_liquidity_mint,
+    swapFeeLamports: toBigInt(row.swap_fee_lamports),
+    targetReserve: row.target_reserve,
+    targetLiquidityMint: row.target_liquidity_mint,
+    userRank: toNumber(row.user_rank),
+  });
+
   return {
-    executions: rows.map((row) => ({
-      amountRaw: toBigInt(row.amount_raw),
-      authority: row.authority,
-      confirmedSlot: toBigInt(row.confirmed_slot),
-      currentDepositRaw: toBigInt(row.current_deposit_raw),
-      executedAt: toIsoString(row.executed_at) ?? "",
-      id: row.id,
-      liquidityMint: row.liquidity_mint,
-      routeMode: mapRouteMode(row.route_mode),
-      sourceReserve: row.source_reserve,
-      sourceLiquidityMint: row.source_liquidity_mint,
-      swapFeeLamports: toBigInt(row.swap_fee_lamports),
-      targetReserve: row.target_reserve,
-      targetLiquidityMint: row.target_liquidity_mint,
-      userRank: toNumber(row.user_rank),
-    })),
+    chartPoints: payload?.chart_points?.map(mapRow) ?? [],
+    details: payload?.details?.map(mapRow) ?? [],
     generatedAt: new Date().toISOString(),
-    userCount: rows.length > 0 ? toNumber(rows[0].user_count) : 0,
+    summaries:
+      payload?.summaries?.map((row) => ({
+        executionCount: toNumber(row.execution_count),
+        executionCount30d: toNumber(row.execution_count_30d),
+        executionCount7d: toNumber(row.execution_count_7d),
+        liquidityMint: row.liquidity_mint,
+        routeMode: mapRouteMode(row.route_mode),
+        swapFeeLamports: toBigInt(row.swap_fee_lamports),
+        userCount: toNumber(row.user_count),
+      })) ?? [],
   };
 }
 
 export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalanceFrequency> {
-  const rows = await queryRows<EarnVaultRebalanceFrequencySqlRow>(
+  const rows = await queryRows<EarnVaultRebalanceFrequencyPayloadSqlRow>(
     `
       WITH active_vaults AS MATERIALIZED (
         SELECT
@@ -1860,14 +2061,10 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             ELSE 0::bigint
           END AS normalized_amount_raw
         FROM active_vaults AS vault
-        INNER JOIN LATERAL (
-          SELECT position.*
-          FROM loyal_yield.vault_reserve_positions_current AS position
-          WHERE position.vault_id = vault.id
-            AND position.has_value = true
-            AND position.amount_raw > 0
-          OFFSET 0
-        ) AS position ON true
+        INNER JOIN loyal_yield.vault_reserve_positions_current AS position
+          ON position.vault_id = vault.id
+          AND position.has_value = true
+          AND position.amount_raw > 0
       ),
       positive_positions AS MATERIALIZED (
         SELECT *
@@ -1901,13 +2098,9 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       positive_idle AS MATERIALIZED (
         SELECT idle.*
         FROM active_vaults AS vault
-        INNER JOIN LATERAL (
-          SELECT idle.*
-          FROM loyal_yield.vault_idle_token_balances_current AS idle
-          WHERE idle.vault_id = vault.id
-            AND idle.amount_raw > 0
-          OFFSET 0
-        ) AS idle ON true
+        INNER JOIN loyal_yield.vault_idle_token_balances_current AS idle
+          ON idle.vault_id = vault.id
+          AND idle.amount_raw > 0
       ),
       idle_totals AS MATERIALIZED (
         SELECT vault_id, SUM(amount_raw)::bigint AS amount_raw
@@ -1945,6 +2138,8 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             WHERE decision.updated_at >= NOW() - INTERVAL '2 hours'
           )::integer AS last_2h_count
         FROM loyal_yield.rebalance_decisions AS decision
+        INNER JOIN active_vaults AS active_vault
+          ON active_vault.id = decision.vault_id
         WHERE decision.status = 'confirmed'
           AND decision.execution_plan->>'kind' IN (
             'same_mint',
@@ -1963,7 +2158,7 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
       opportunity_counts AS MATERIALIZED (
         SELECT
           opportunity.vault_id,
-          opportunity.execution_plan->>'kind' AS route_mode,
+          'same_mint'::text AS route_mode,
           COUNT(*)::integer AS all_count,
           COUNT(*) FILTER (
             WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
@@ -1975,13 +2170,33 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
             WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
           )::integer AS last_2h_count
         FROM loyal_yield.rebalance_opportunities AS opportunity
+        INNER JOIN active_vaults AS active_vault
+          ON active_vault.id = opportunity.vault_id
         WHERE opportunity.source_reserve IS NOT NULL
           AND opportunity.target_reserve IS NOT NULL
-          AND opportunity.execution_plan->>'kind' IN (
-            'same_mint',
-            'cross_mint_jupiter'
-          )
-        GROUP BY opportunity.vault_id, opportunity.execution_plan->>'kind'
+          AND opportunity.execution_plan->>'kind' = 'same_mint'
+        GROUP BY opportunity.vault_id
+        UNION ALL
+        SELECT
+          opportunity.vault_id,
+          'cross_mint_jupiter'::text AS route_mode,
+          COUNT(*)::integer AS all_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '7 days'
+          )::integer AS last_7d_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '12 hours'
+          )::integer AS last_12h_count,
+          COUNT(*) FILTER (
+            WHERE opportunity.created_at >= NOW() - INTERVAL '2 hours'
+          )::integer AS last_2h_count
+        FROM loyal_yield.rebalance_opportunities AS opportunity
+        INNER JOIN active_vaults AS active_vault
+          ON active_vault.id = opportunity.vault_id
+        WHERE opportunity.source_reserve IS NOT NULL
+          AND opportunity.target_reserve IS NOT NULL
+          AND opportunity.execution_plan->>'kind' = 'cross_mint_jupiter'
+        GROUP BY opportunity.vault_id
       ),
       current_vaults AS MATERIALIZED (
         SELECT
@@ -2031,56 +2246,158 @@ export async function getEarnVaultRebalanceFrequency(): Promise<EarnVaultRebalan
               current_vault.vault_pubkey ASC
           )::integer AS deposit_rank
         FROM current_vaults AS current_vault
+      ),
+      frequency_rows AS MATERIALIZED (
+        SELECT
+          ranked_vault.*,
+          MAX(ranked_vault.deposit_rank) OVER (
+            PARTITION BY ranked_vault.route_mode
+          )::integer AS vault_count,
+          ROW_NUMBER() OVER (
+            PARTITION BY ranked_vault.route_mode, ranked_vault.liquidity_mint
+            ORDER BY ranked_vault.current_deposit_raw DESC, ranked_vault.vault_pubkey DESC
+          )::integer AS detail_rank,
+          NTILE(150) OVER (
+            PARTITION BY ranked_vault.route_mode, ranked_vault.liquidity_mint
+            ORDER BY ranked_vault.current_deposit_raw ASC, ranked_vault.vault_pubkey ASC
+          )::integer AS chart_bucket
+        FROM ranked_vaults AS ranked_vault
+      ),
+      chart_rows AS (
+        SELECT DISTINCT ON (route_mode, liquidity_mint, chart_bucket)
+          id,
+          vault_pubkey,
+          current_reserve,
+          liquidity_mint,
+          route_mode,
+          current_deposit_raw::text AS current_deposit_raw,
+          position_count,
+          all_count,
+          last_7d_count,
+          last_12h_count,
+          last_2h_count,
+          opportunity_all_count,
+          opportunity_last_7d_count,
+          opportunity_last_12h_count,
+          opportunity_last_2h_count,
+          deposit_rank
+          ,vault_count
+        FROM frequency_rows
+        ORDER BY route_mode, liquidity_mint, chart_bucket,
+          current_deposit_raw DESC, vault_pubkey DESC
+      ),
+      detail_rows AS (
+        SELECT
+          id,
+          vault_pubkey,
+          current_reserve,
+          liquidity_mint,
+          route_mode,
+          current_deposit_raw::text AS current_deposit_raw,
+          position_count,
+          all_count,
+          last_7d_count,
+          last_12h_count,
+          last_2h_count,
+          opportunity_all_count,
+          opportunity_last_7d_count,
+          opportunity_last_12h_count,
+          opportunity_last_2h_count,
+          deposit_rank
+          ,vault_count
+        FROM frequency_rows
+        WHERE detail_rank <= 100
+      ),
+      summary_rows AS (
+        SELECT
+          route_mode,
+          liquidity_mint,
+          COUNT(*)::integer AS vault_count,
+          COUNT(*)::integer AS eligible_count,
+          COUNT(*) FILTER (WHERE all_count > 0)::integer AS rebalanced_vault_count,
+          COALESCE(SUM(position_count), 0)::integer AS position_count,
+          COALESCE(SUM(all_count), 0)::integer AS rebalance_all_count,
+          COALESCE(SUM(last_7d_count), 0)::integer AS rebalance_last_7d_count,
+          COALESCE(SUM(last_12h_count), 0)::integer AS rebalance_last_12h_count,
+          COALESCE(SUM(last_2h_count), 0)::integer AS rebalance_last_2h_count,
+          COALESCE(SUM(opportunity_all_count), 0)::integer AS opportunity_all_count,
+          COALESCE(SUM(opportunity_last_7d_count), 0)::integer AS opportunity_last_7d_count,
+          COALESCE(SUM(opportunity_last_12h_count), 0)::integer AS opportunity_last_12h_count,
+          COALESCE(SUM(opportunity_last_2h_count), 0)::integer AS opportunity_last_2h_count
+        FROM current_vaults
+        GROUP BY route_mode, liquidity_mint
       )
       SELECT
-        ranked_vault.id::text AS vault_id,
-        ranked_vault.vault_pubkey,
-        ranked_vault.current_reserve,
-        ranked_vault.liquidity_mint,
-        ranked_vault.route_mode,
-        ranked_vault.current_deposit_raw::text,
-        ranked_vault.position_count::text,
-        ranked_vault.all_count::text,
-        ranked_vault.last_7d_count::text,
-        ranked_vault.last_12h_count::text,
-        ranked_vault.last_2h_count::text,
-        ranked_vault.opportunity_all_count::text,
-        ranked_vault.opportunity_last_7d_count::text,
-        ranked_vault.opportunity_last_12h_count::text,
-        ranked_vault.opportunity_last_2h_count::text,
-        ranked_vault.deposit_rank::text,
-        MAX(ranked_vault.deposit_rank) OVER (
-          PARTITION BY ranked_vault.route_mode
-        )::text AS vault_count
-      FROM ranked_vaults AS ranked_vault
-      ORDER BY ranked_vault.route_mode ASC, ranked_vault.deposit_rank ASC
+        COALESCE(
+          (
+            SELECT json_agg(summary_row ORDER BY route_mode, liquidity_mint)
+            FROM summary_rows AS summary_row
+          ),
+          '[]'::json
+        ) AS summaries,
+        COALESCE(
+          (
+            SELECT json_agg(chart_row ORDER BY route_mode, deposit_rank)
+            FROM chart_rows AS chart_row
+          ),
+          '[]'::json
+        ) AS chart_points,
+        COALESCE(
+          (
+            SELECT json_agg(detail_row ORDER BY route_mode, detail_row.deposit_rank)
+            FROM detail_rows AS detail_row
+          ),
+          '[]'::json
+        ) AS details
     `
   );
 
+  const payload = rows[0];
+  const mapRow = (row: EarnVaultRebalanceFrequencySqlRow) => ({
+    allCount: toNumber(row.all_count),
+    currentDepositRaw: toBigInt(row.current_deposit_raw),
+    currentReserve: row.current_reserve,
+    depositRank: toNumber(row.deposit_rank),
+    last12hCount: toNumber(row.last_12h_count),
+    last2hCount: toNumber(row.last_2h_count),
+    last7dCount: toNumber(row.last_7d_count),
+    liquidityMint: row.liquidity_mint,
+    opportunity12hCount: toNumber(row.opportunity_last_12h_count),
+    opportunity2hCount: toNumber(row.opportunity_last_2h_count),
+    opportunity7dCount: toNumber(row.opportunity_last_7d_count),
+    opportunityAllCount: toNumber(row.opportunity_all_count),
+    positionCount: toNumber(row.position_count),
+    routeMode: mapRouteMode(row.route_mode),
+    vaultId: row.vault_id,
+    vaultPubkey: row.vault_pubkey,
+  });
+
   return {
+    chartPoints: payload?.chart_points?.map(mapRow) ?? [],
+    details: payload?.details?.map(mapRow) ?? [],
     generatedAt: new Date().toISOString(),
-    vaultCount: rows.reduce(
-      (maximum, row) => Math.max(maximum, toNumber(row.vault_count)),
-      0
-    ),
-    vaults: rows.map((row) => ({
-      allCount: toNumber(row.all_count),
-      currentDepositRaw: toBigInt(row.current_deposit_raw),
-      currentReserve: row.current_reserve,
-      depositRank: toNumber(row.deposit_rank),
-      last12hCount: toNumber(row.last_12h_count),
-      last2hCount: toNumber(row.last_2h_count),
-      last7dCount: toNumber(row.last_7d_count),
-      liquidityMint: row.liquidity_mint,
-      opportunity12hCount: toNumber(row.opportunity_last_12h_count),
-      opportunity2hCount: toNumber(row.opportunity_last_2h_count),
-      opportunity7dCount: toNumber(row.opportunity_last_7d_count),
-      opportunityAllCount: toNumber(row.opportunity_all_count),
-      positionCount: toNumber(row.position_count),
-      routeMode: mapRouteMode(row.route_mode),
-      vaultId: row.vault_id,
-      vaultPubkey: row.vault_pubkey,
-    })),
+    summaries:
+      payload?.summaries?.map((row) => ({
+        eligibleCount: toNumber(row.eligible_count),
+        liquidityMint: row.liquidity_mint,
+        opportunity12hCount: toNumber(row.opportunity_last_12h_count),
+        opportunity2hCount: toNumber(row.opportunity_last_2h_count),
+        opportunity7dCount: toNumber(row.opportunity_last_7d_count),
+        opportunityAllCount: toNumber(row.opportunity_all_count),
+        positionCount: toNumber(row.position_count),
+        rebalance12hCount: toNumber(row.rebalance_last_12h_count),
+        rebalance2hCount: toNumber(row.rebalance_last_2h_count),
+        rebalance7dCount: toNumber(row.rebalance_last_7d_count),
+        rebalanceAllCount: toNumber(row.rebalance_all_count),
+        rebalancedVaultCount: toNumber(row.rebalanced_vault_count),
+        routeMode: mapRouteMode(row.route_mode),
+        vaultCount: toNumber(row.vault_count),
+      })) ?? [],
+    vaultCount:
+      payload?.summaries?.reduce(
+        (total, row) => total + toNumber(row.vault_count),
+        0
+      ) ?? 0,
   };
 }
 

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1533,24 +1533,53 @@ export function RebalanceMonitorClient() {
   const filteredExecutedRebalances = selectedMintAddress
     ? {
         ...state.data.executedRebalances,
-        executions: state.data.executedRebalances.executions.filter(
+        chartPoints: state.data.executedRebalances.chartPoints.filter(
           (execution) =>
             execution.routeMode === "cross_mint" ||
             execution.liquidityMint === selectedMintAddress
         ),
+        details: state.data.executedRebalances.details.filter(
+          (execution) =>
+            execution.routeMode === "cross_mint" ||
+            execution.liquidityMint === selectedMintAddress
+        ),
+        summaries: state.data.executedRebalances.summaries.filter(
+          (summary) =>
+            summary.routeMode === "cross_mint" ||
+            summary.liquidityMint === selectedMintAddress
+        ),
       }
     : state.data.executedRebalances;
   const filteredFrequencyVaults = selectedMintAddress
-    ? state.data.vaultRebalanceFrequency.vaults.filter(
+    ? state.data.vaultRebalanceFrequency.chartPoints.filter(
         (vault) =>
           vault.routeMode === "cross_mint" ||
           vault.liquidityMint === selectedMintAddress
       )
-    : state.data.vaultRebalanceFrequency.vaults;
+    : state.data.vaultRebalanceFrequency.chartPoints;
+  const filteredFrequencyDetails = selectedMintAddress
+    ? state.data.vaultRebalanceFrequency.details.filter(
+        (vault) =>
+          vault.routeMode === "cross_mint" ||
+          vault.liquidityMint === selectedMintAddress
+      )
+    : state.data.vaultRebalanceFrequency.details;
+  const filteredFrequencySummaries = selectedMintAddress
+    ? state.data.vaultRebalanceFrequency.summaries.filter(
+        (summary) =>
+          summary.routeMode === "cross_mint" ||
+          summary.liquidityMint === selectedMintAddress
+      )
+    : state.data.vaultRebalanceFrequency.summaries;
   const filteredVaultRebalanceFrequency = {
     ...state.data.vaultRebalanceFrequency,
-    vaultCount: filteredFrequencyVaults.length,
-    vaults: filteredFrequencyVaults,
+    chartPoints: filteredFrequencyVaults,
+    details: filteredFrequencyDetails,
+    summaries: filteredFrequencySummaries,
+    vaultCount: filteredFrequencySummaries.reduce(
+      (total, summary) => total + summary.vaultCount,
+      0
+    ),
   };
   const crossMintApyData = getCrossMintApyData(state.data.apyData);
 

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowDownIcon, ArrowUpIcon, RefreshCwIcon } from "lucide-react";
 
 import {
@@ -114,10 +114,171 @@ type RebalanceApiData = {
   autodeposit: SerializedAutodepositFailureRange[];
   decisions: SerializedRebalanceDecisionRow[];
   executedRebalances: SerializedExecutedEarnRebalanceHistory;
+  initialAudit: AuditApiData;
   last30DaysRebalances: Last30DaysRebalancePoint[];
   routes: SerializedActiveReserveRouteRow[];
   vaultRebalanceFrequency: SerializedEarnVaultRebalanceFrequency;
 };
+
+type SerializedSafeReserveApyMonitorData = Omit<
+  SafeReserveApyMonitorData,
+  "chartPoints"
+> & {
+  observedAtMs: number[];
+  values: Array<Array<number | null>>;
+};
+
+type SerializedExecutedRebalanceTuple = readonly [
+  amountRaw: string,
+  authorityIndex: number,
+  confirmedSlot: string,
+  currentDepositRaw: string,
+  executedAt: string,
+  id: string,
+  liquidityMintIndex: number | null,
+  routeMode: RebalanceRouteMode,
+  sourceReserveIndex: number,
+  sourceLiquidityMintIndex: number | null,
+  swapFeeLamports: string,
+  targetReserveIndex: number,
+  targetLiquidityMintIndex: number | null,
+  userRank: number
+];
+
+type SerializedVaultFrequencyTuple = readonly [
+  allCount: number,
+  currentDepositRaw: string,
+  currentReserve: string | null,
+  depositRank: number,
+  last12hCount: number,
+  last2hCount: number,
+  last7dCount: number,
+  liquidityMint: string | null,
+  positionCount: number,
+  routeMode: RebalanceRouteMode,
+  vaultId: string,
+  vaultPubkey: string
+];
+
+type RebalanceApiWireData = Omit<
+  RebalanceApiData,
+  "apyData" | "executedRebalances" | "vaultRebalanceFrequency"
+> & {
+  apyData: SerializedSafeReserveApyMonitorData;
+  executedRebalances: Omit<
+    SerializedExecutedEarnRebalanceHistory,
+    "chartPoints" | "details"
+  > & {
+    chartPoints: ReadonlyArray<SerializedExecutedRebalanceTuple>;
+    details: ReadonlyArray<SerializedExecutedRebalanceTuple>;
+    strings: string[];
+  };
+  vaultRebalanceFrequency: Omit<
+    SerializedEarnVaultRebalanceFrequency,
+    "chartPoints" | "details"
+  > & {
+    chartPoints: ReadonlyArray<SerializedVaultFrequencyTuple>;
+    details: ReadonlyArray<SerializedVaultFrequencyTuple>;
+  };
+};
+
+function deserializeExecutedRebalance(
+  [
+    amountRaw,
+    authorityIndex,
+    confirmedSlot,
+    currentDepositRaw,
+    executedAt,
+    id,
+    liquidityMintIndex,
+    routeMode,
+    sourceReserveIndex,
+    sourceLiquidityMintIndex,
+    swapFeeLamports,
+    targetReserveIndex,
+    targetLiquidityMintIndex,
+    userRank,
+  ]: SerializedExecutedRebalanceTuple,
+  strings: readonly string[]
+): SerializedExecutedEarnRebalanceHistory["chartPoints"][number] {
+  return {
+    amountRaw,
+    authority: strings[authorityIndex] ?? "",
+    confirmedSlot,
+    currentDepositRaw,
+    executedAt,
+    id,
+    liquidityMint:
+      liquidityMintIndex === null ? null : strings[liquidityMintIndex] ?? null,
+    routeMode,
+    sourceLiquidityMint:
+      sourceLiquidityMintIndex === null
+        ? null
+        : strings[sourceLiquidityMintIndex] ?? null,
+    sourceReserve: strings[sourceReserveIndex] ?? "",
+    swapFeeLamports,
+    targetLiquidityMint:
+      targetLiquidityMintIndex === null
+        ? null
+        : strings[targetLiquidityMintIndex] ?? null,
+    targetReserve: strings[targetReserveIndex] ?? "",
+    userRank,
+  };
+}
+
+function deserializeVaultFrequency([
+  allCount,
+  currentDepositRaw,
+  currentReserve,
+  depositRank,
+  last12hCount,
+  last2hCount,
+  last7dCount,
+  liquidityMint,
+  positionCount,
+  routeMode,
+  vaultId,
+  vaultPubkey,
+]: SerializedVaultFrequencyTuple): SerializedEarnVaultRebalanceFrequency["chartPoints"][number] {
+  return {
+    allCount,
+    currentDepositRaw,
+    currentReserve,
+    depositRank,
+    last12hCount,
+    last2hCount,
+    last7dCount,
+    liquidityMint,
+    positionCount,
+    routeMode,
+    vaultId,
+    vaultPubkey,
+  };
+}
+
+function deserializeApyData(
+  data: SerializedSafeReserveApyMonitorData
+): SafeReserveApyMonitorData {
+  return {
+    chartPoints: data.observedAtMs.map((observedAtMs, pointIndex) => {
+      const point: SafeReserveApyMonitorData["chartPoints"][number] = {
+        observedAt: new Date(observedAtMs).toISOString(),
+        observedAtMs,
+      };
+
+      for (const [seriesIndex, series] of data.series.entries()) {
+        point[series.key] = data.values[seriesIndex]?.[pointIndex] ?? null;
+      }
+
+      return point;
+    }),
+    generatedAt: data.generatedAt,
+    sampleIntervalMinutes: data.sampleIntervalMinutes,
+    series: data.series,
+    statuses: data.statuses,
+    window: data.window,
+  };
+}
 
 type LoadState =
   | { status: "loading" }
@@ -1000,8 +1161,10 @@ function AuditSummaryStrip({
 }
 
 function RebalanceAuditCard({
+  initialData,
   reserveLabels,
 }: {
+  initialData: AuditApiData;
   reserveLabels: ReadonlyMap<string, string>;
 }) {
   const [view, setView] = useState<RebalanceAuditView>(DEFAULT_AUDIT_VIEW);
@@ -1013,7 +1176,11 @@ function RebalanceAuditCard({
   const [activeCursor, setActiveCursor] = useState<string | null>(null);
   const [hydrated, setHydrated] = useState(false);
   const [refreshToken, setRefreshToken] = useState(0);
-  const [state, setState] = useState<AuditLoadState>({ status: "loading" });
+  const [state, setState] = useState<AuditLoadState>({
+    data: initialData,
+    status: "ready",
+  });
+  const skipInitialDefaultLoad = useRef(true);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1043,6 +1210,21 @@ function RebalanceAuditCard({
     if (!hydrated) {
       return;
     }
+
+    if (
+      skipInitialDefaultLoad.current &&
+      view === DEFAULT_AUDIT_VIEW &&
+      range === DEFAULT_AUDIT_RANGE &&
+      routeMode === "same_mint" &&
+      errorFilter === DEFAULT_ERROR_FILTER &&
+      cursor === null &&
+      activeCursor === null &&
+      refreshToken === 0
+    ) {
+      skipInitialDefaultLoad.current = false;
+      return;
+    }
+    skipInitialDefaultLoad.current = false;
 
     const controller = new AbortController();
     let mounted = true;
@@ -1443,11 +1625,50 @@ function RebalanceMonitorFallback() {
   );
 }
 
-export function RebalanceMonitorClient() {
-  const [state, setState] = useState<LoadState>({ status: "loading" });
+function deserializeRebalanceApiData(
+  wireData: RebalanceApiWireData
+): RebalanceApiData {
+  return {
+    ...wireData,
+    apyData: deserializeApyData(wireData.apyData),
+    executedRebalances: {
+      ...wireData.executedRebalances,
+      chartPoints: wireData.executedRebalances.chartPoints.map((row) =>
+        deserializeExecutedRebalance(row, wireData.executedRebalances.strings)
+      ),
+      details: wireData.executedRebalances.details.map((row) =>
+        deserializeExecutedRebalance(row, wireData.executedRebalances.strings)
+      ),
+    },
+    vaultRebalanceFrequency: {
+      ...wireData.vaultRebalanceFrequency,
+      chartPoints: wireData.vaultRebalanceFrequency.chartPoints.map(
+        deserializeVaultFrequency
+      ),
+      details: wireData.vaultRebalanceFrequency.details.map(
+        deserializeVaultFrequency
+      ),
+    },
+  };
+}
+
+export function RebalanceMonitorClient({
+  initialData,
+}: {
+  initialData?: RebalanceApiWireData;
+}) {
+  const [state, setState] = useState<LoadState>(() =>
+    initialData
+      ? { data: deserializeRebalanceApiData(initialData), status: "ready" }
+      : { status: "loading" }
+  );
   const [selectedMint, setSelectedMint] = useState("USDC");
 
   useEffect(() => {
+    if (initialData) {
+      return;
+    }
+
     const controller = new AbortController();
 
     async function loadMonitor() {
@@ -1463,8 +1684,11 @@ export function RebalanceMonitorClient() {
           );
         }
 
-        const data = (await response.json()) as RebalanceApiData;
-        setState({ data, status: "ready" });
+        const wireData = (await response.json()) as RebalanceApiWireData;
+        setState({
+          data: deserializeRebalanceApiData(wireData),
+          status: "ready",
+        });
       } catch (error) {
         if (controller.signal.aborted) {
           return;
@@ -1483,7 +1707,7 @@ export function RebalanceMonitorClient() {
     void loadMonitor();
 
     return () => controller.abort();
-  }, []);
+  }, [initialData]);
 
   if (state.status === "loading") {
     return <RebalanceMonitorFallback />;
@@ -1597,7 +1821,9 @@ export function RebalanceMonitorClient() {
         <CardContent>
           <Select value={selectedMint} onValueChange={setSelectedMint}>
             <SelectTrigger className="w-full sm:w-56">
-              <SelectValue placeholder="Select stablecoin" />
+              <SelectValue>
+                {selectedMint === "all" ? "All stablecoins" : selectedMint}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">All stablecoins</SelectItem>
@@ -1659,7 +1885,10 @@ export function RebalanceMonitorClient() {
       />
       <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />
       <AutodepositFailuresChart data={state.data.autodeposit} />
-      <RebalanceAuditCard reserveLabels={reserveLabels} />
+      <RebalanceAuditCard
+        initialData={state.data.initialAudit}
+        reserveLabels={reserveLabels}
+      />
     </div>
   );
 }

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1138,8 +1138,8 @@ function AuditSummaryStrip({
       </div>
       <div className="mt-2 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
         <span>
-          Showing {activePage.rows.length.toLocaleString("en-US")} newest in-progress
-          rows
+          Showing {activePage.rows.length.toLocaleString("en-US")} newest
+          in-progress rows
         </span>
         {activePage.nextCursor ? (
           <Button
@@ -1445,13 +1445,17 @@ function RebalanceAuditCard({
                 <TabsTrigger value="completed_rebalances" className="h-10">
                   Completed rebalances
                   <Badge variant="outline">
-                    {state.data.summary.completedRebalances.toLocaleString("en-US")}
+                    {state.data.summary.completedRebalances.toLocaleString(
+                      "en-US"
+                    )}
                   </Badge>
                 </TabsTrigger>
                 <TabsTrigger value="completed_deposits" className="h-10">
                   Completed deposits
                   <Badge variant="outline">
-                    {state.data.summary.completedDeposits.toLocaleString("en-US")}
+                    {state.data.summary.completedDeposits.toLocaleString(
+                      "en-US"
+                    )}
                   </Badge>
                 </TabsTrigger>
                 <TabsTrigger value="errors" className="h-10">
@@ -1509,8 +1513,8 @@ function RebalanceAuditCard({
             </div>
             <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3 text-xs text-muted-foreground">
               <span>
-                Showing {state.data.page.rows.length.toLocaleString("en-US")} newest
-                rows
+                Showing {state.data.page.rows.length.toLocaleString("en-US")}{" "}
+                newest rows
               </span>
               <Button
                 disabled={!state.data.page.nextCursor}
@@ -1877,10 +1881,14 @@ export function RebalanceMonitorClient({
       <RebalanceActivityChart data={state.data.activity} />
       <ExecutedEarnRebalancesChart
         data={filteredExecutedRebalances}
+        key={`executed-${selectedMint}`}
+        liquidityMint={selectedMintAddress}
         reserveLabels={reserveLabels}
       />
       <EarnVaultRebalanceFrequencyChart
         data={filteredVaultRebalanceFrequency}
+        key={`frequency-${selectedMint}`}
+        liquidityMint={selectedMintAddress}
         reserveStatuses={filteredApyData.statuses}
       />
       <Last30DaysRebalanceChart data={state.data.last30DaysRebalances} />

--- a/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
+++ b/apps/admin/src/app/(admin)/earn/rebalance/rebalance-monitor-client.tsx
@@ -1138,7 +1138,7 @@ function AuditSummaryStrip({
       </div>
       <div className="mt-2 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
         <span>
-          Showing {activePage.rows.length.toLocaleString()} newest in-progress
+          Showing {activePage.rows.length.toLocaleString("en-US")} newest in-progress
           rows
         </span>
         {activePage.nextCursor ? (
@@ -1445,13 +1445,13 @@ function RebalanceAuditCard({
                 <TabsTrigger value="completed_rebalances" className="h-10">
                   Completed rebalances
                   <Badge variant="outline">
-                    {state.data.summary.completedRebalances.toLocaleString()}
+                    {state.data.summary.completedRebalances.toLocaleString("en-US")}
                   </Badge>
                 </TabsTrigger>
                 <TabsTrigger value="completed_deposits" className="h-10">
                   Completed deposits
                   <Badge variant="outline">
-                    {state.data.summary.completedDeposits.toLocaleString()}
+                    {state.data.summary.completedDeposits.toLocaleString("en-US")}
                   </Badge>
                 </TabsTrigger>
                 <TabsTrigger value="errors" className="h-10">
@@ -1461,7 +1461,7 @@ function RebalanceAuditCard({
                       state.data.summary.errors > 0 ? "destructive" : "outline"
                     }
                   >
-                    {state.data.summary.errors.toLocaleString()}
+                    {state.data.summary.errors.toLocaleString("en-US")}
                   </Badge>
                 </TabsTrigger>
               </TabsList>
@@ -1495,7 +1495,7 @@ function RebalanceAuditCard({
                     type="button"
                     variant={errorFilter === value ? "secondary" : "ghost"}
                   >
-                    {label} ({count.toLocaleString()})
+                    {label} ({count.toLocaleString("en-US")})
                   </Button>
                 ))}
               </div>
@@ -1509,7 +1509,7 @@ function RebalanceAuditCard({
             </div>
             <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3 text-xs text-muted-foreground">
               <span>
-                Showing {state.data.page.rows.length.toLocaleString()} newest
+                Showing {state.data.page.rows.length.toLocaleString("en-US")} newest
                 rows
               </span>
               <Button

--- a/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
+++ b/apps/admin/src/app/(admin)/earn/safe-reserve-apy-chart.tsx
@@ -280,6 +280,32 @@ export function SafeReserveApyChart({
   const [showDecisionMarkers, setShowDecisionMarkers] = useState(false);
   const [showOutliers, setShowOutliers] = useState(false);
   const [showRawData, setShowRawData] = useState(false);
+  const [rawData, setRawData] = useState<SafeReserveApyMonitorData | null>(
+    null
+  );
+  const [rawLoadStatus, setRawLoadStatus] = useState<
+    "idle" | "loading" | "error"
+  >("idle");
+  const rawDataForSelection = useMemo(() => {
+    if (!rawData) {
+      return null;
+    }
+    const selectedReserves = new Set(
+      data.series.map((series) => series.reserve)
+    );
+
+    return {
+      ...rawData,
+      series: rawData.series.filter((series) =>
+        selectedReserves.has(series.reserve)
+      ),
+      statuses: rawData.statuses.filter((status) =>
+        selectedReserves.has(status.reserve)
+      ),
+    };
+  }, [data.series, rawData]);
+  const chartData =
+    showRawData && rawDataForSelection ? rawDataForSelection : data;
   const chartConfig = data.series.reduce<ChartConfig>(
     (config, series, index) => {
       const style = SERIES_STYLES[index % SERIES_STYLES.length];
@@ -309,12 +335,14 @@ export function SafeReserveApyChart({
     );
   const chartPoints = useMemo(
     () =>
-      showRawData ? data.chartPoints : bucketChartPoints(data, 30 * 60 * 1000),
-    [data, showRawData]
+      showRawData
+        ? chartData.chartPoints
+        : bucketChartPoints(chartData, 30 * 60 * 1000),
+    [chartData, showRawData]
   );
   const apyValues = useMemo(
-    () => getApyValues({ chartPoints, data }),
-    [chartPoints, data]
+    () => getApyValues({ chartPoints, data: chartData }),
+    [chartData, chartPoints]
   );
   const fullYMax = Math.max(8, Math.ceil(Math.max(...apyValues, 0) + 1));
   const normalYMax = Math.max(
@@ -335,6 +363,33 @@ export function SafeReserveApyChart({
     })
     .slice(0, 25);
 
+  async function toggleRawData() {
+    if (showRawData) {
+      setShowRawData(false);
+      return;
+    }
+    if (rawData) {
+      setShowRawData(true);
+      return;
+    }
+
+    setRawLoadStatus("loading");
+    try {
+      const response = await fetch("/api/earn/rebalance/apy-samples", {
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        throw new Error(`APY samples request failed: ${response.status}`);
+      }
+      setRawData((await response.json()) as SafeReserveApyMonitorData);
+      setRawLoadStatus("idle");
+      setShowRawData(true);
+    } catch {
+      setRawLoadStatus("error");
+    }
+  }
+
   return (
     <Card className="w-full">
       <CardHeader className="gap-4 border-b">
@@ -347,7 +402,7 @@ export function SafeReserveApyChart({
                 : "Selected stablecoin Safe basket"}
               , last 7d,{" "}
               {showRawData
-                ? `${data.sampleIntervalMinutes}m raw buckets`
+                ? `${chartData.sampleIntervalMinutes}m raw buckets`
                 : "30m median view"}{" "}
               from Kamino Timescale
             </CardDescription>
@@ -361,12 +416,17 @@ export function SafeReserveApyChart({
             <div className="flex flex-wrap items-center gap-2 lg:justify-end">
               <Button
                 aria-pressed={showRawData}
-                onClick={() => setShowRawData((value) => !value)}
+                disabled={rawLoadStatus === "loading"}
+                onClick={() => void toggleRawData()}
                 size="sm"
                 type="button"
                 variant={showRawData ? "secondary" : "outline"}
               >
-                Raw samples
+                {rawLoadStatus === "loading"
+                  ? "Loading samples…"
+                  : rawLoadStatus === "error"
+                  ? "Retry raw samples"
+                  : "Raw samples"}
               </Button>
               {decisionMarkers.length > 0 ? (
                 <Button

--- a/apps/admin/src/app/(admin)/metrics/earn-rebalance-latency-data.ts
+++ b/apps/admin/src/app/(admin)/metrics/earn-rebalance-latency-data.ts
@@ -36,6 +36,18 @@ export type EarnLatencyPoint = {
   targetReserve: string;
 };
 
+export type EarnLatencyChartPoint = {
+  bucketStartedAt: string;
+  decisionToSignedMs: number | null;
+  monitorToSubmittedMs: number | null;
+  observedToOpportunityMs: number | null;
+  opportunityToReadyMs: number | null;
+  readyToDecisionMs: number | null;
+  sampleCount: number;
+  signedToSubmittedMs: number | null;
+  submittedToConfirmedMs: number | null;
+};
+
 export type EarnLatencyStageSummary = {
   key: EarnLatencyStageKey;
   label: string;
@@ -49,7 +61,8 @@ export type EarnRebalanceLatencyData = {
   measuredCount: number;
   monitorToSubmittedP50Ms: number;
   monitorToSubmittedP95Ms: number;
-  points: EarnLatencyPoint[];
+  latestPoints: EarnLatencyPoint[];
+  points: EarnLatencyChartPoint[];
   rangeEndedAt: string | null;
   rangeStartedAt: string | null;
   stages: EarnLatencyStageSummary[];
@@ -59,7 +72,7 @@ export type EarnRebalanceLatencyData = {
   totalConfirmed: number;
 };
 
-type EarnLatencySqlRow = {
+type EarnLatencySqlDetail = {
   confirmed_at: Date | string;
   decision_at: Date | string;
   decision_to_signed_ms: SqlScalar;
@@ -78,6 +91,39 @@ type EarnLatencySqlRow = {
   submitted_to_confirmed_ms: SqlScalar;
   target_observed_at: Date | string;
   target_reserve: string;
+};
+
+type EarnLatencySqlChartPoint = {
+  bucket_started_at: Date | string;
+  decision_to_signed_ms: SqlScalar;
+  monitor_to_submitted_ms: SqlScalar;
+  observed_to_opportunity_ms: SqlScalar;
+  opportunity_to_ready_ms: SqlScalar;
+  ready_to_decision_ms: SqlScalar;
+  sample_count: SqlScalar;
+  signed_to_submitted_ms: SqlScalar;
+  submitted_to_confirmed_ms: SqlScalar;
+};
+
+type EarnLatencySqlStage = {
+  key: EarnLatencyStageKey;
+  label: string;
+  measured_count: SqlScalar;
+  p50_ms: SqlScalar;
+  p95_ms: SqlScalar;
+};
+
+type EarnLatencySqlRow = {
+  chart_points: EarnLatencySqlChartPoint[] | null;
+  latest_points: EarnLatencySqlDetail[] | null;
+  measured_count: SqlScalar;
+  monitor_to_submitted_p50_ms: SqlScalar;
+  monitor_to_submitted_p95_ms: SqlScalar;
+  range_ended_at: Date | string | null;
+  range_started_at: Date | string | null;
+  stages: EarnLatencySqlStage[] | null;
+  submitted_to_confirmed_p50_ms: SqlScalar;
+  submitted_to_confirmed_p95_ms: SqlScalar;
   total_confirmed: SqlScalar;
 };
 
@@ -124,40 +170,6 @@ function toNullableNumber(value: SqlScalar): number | null {
   }
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
-}
-
-function percentile(values: readonly number[], level: number): number {
-  if (values.length === 0) {
-    return 0;
-  }
-
-  const sorted = [...values].sort((left, right) => left - right);
-  const position = (sorted.length - 1) * level;
-  const lowerIndex = Math.floor(position);
-  const upperIndex = Math.ceil(position);
-  const lower = sorted[lowerIndex];
-  const upper = sorted[upperIndex];
-
-  return lower + (upper - lower) * (position - lowerIndex);
-}
-
-function summarize(
-  points: EarnLatencyPoint[],
-  key: EarnLatencyStageKey,
-  label: string
-): EarnLatencyStageSummary {
-  const values = points.flatMap((point) => {
-    const value = point[key];
-    return typeof value === "number" ? [value] : [];
-  });
-
-  return {
-    key,
-    label,
-    measuredCount: values.length,
-    p50Ms: percentile(values, 0.5),
-    p95Ms: percentile(values, 0.95),
-  };
 }
 
 async function loadEarnRebalanceLatencyData(): Promise<EarnRebalanceLatencyData> {
@@ -215,99 +227,333 @@ async function loadEarnRebalanceLatencyData(): Promise<EarnRebalanceLatencyData>
         AND decision_at <= signed_at
         AND signed_at <= submitted_at
         AND submitted_at <= confirmed_at
-    )
-    SELECT
-      valid.id::text,
-      valid.source_reserve,
-      valid.target_reserve,
-      valid.liquidity_mint,
-      valid.target_observed_at,
-      valid.opportunity_at,
-      valid.ready_at,
-      valid.decision_at,
-      valid.signed_at,
-      valid.submitted_at,
-      valid.confirmed_at,
-      ROUND(EXTRACT(epoch FROM (
-        valid.opportunity_at - valid.target_observed_at
-      ))::numeric * 1000)::bigint::text AS observed_to_opportunity_ms,
+    ),
+    measured AS MATERIALIZED (
+      SELECT
+        valid.*,
+        ROUND(EXTRACT(epoch FROM (
+          valid.opportunity_at - valid.target_observed_at
+        ))::numeric * 1000)::bigint AS observed_to_opportunity_ms,
       CASE
         WHEN valid.ready_at >= valid.opportunity_at
           AND valid.ready_at <= valid.decision_at
           THEN ROUND(EXTRACT(epoch FROM (
             valid.ready_at - valid.opportunity_at
-          ))::numeric * 1000)::bigint::text
+          ))::numeric * 1000)::bigint
       END AS opportunity_to_ready_ms,
       CASE
         WHEN valid.ready_at >= valid.opportunity_at
           AND valid.ready_at <= valid.decision_at
           THEN ROUND(EXTRACT(epoch FROM (
             valid.decision_at - valid.ready_at
-          ))::numeric * 1000)::bigint::text
+          ))::numeric * 1000)::bigint
       END AS ready_to_decision_ms,
       ROUND(EXTRACT(epoch FROM (
         valid.signed_at - valid.decision_at
-      ))::numeric * 1000)::bigint::text AS decision_to_signed_ms,
+        ))::numeric * 1000)::bigint AS decision_to_signed_ms,
       ROUND(EXTRACT(epoch FROM (
         valid.submitted_at - valid.signed_at
-      ))::numeric * 1000)::bigint::text AS signed_to_submitted_ms,
+        ))::numeric * 1000)::bigint AS signed_to_submitted_ms,
       ROUND(EXTRACT(epoch FROM (
         valid.confirmed_at - valid.submitted_at
-      ))::numeric * 1000)::bigint::text AS submitted_to_confirmed_ms,
+        ))::numeric * 1000)::bigint AS submitted_to_confirmed_ms,
       ROUND(EXTRACT(epoch FROM (
         valid.submitted_at - valid.target_observed_at
-      ))::numeric * 1000)::bigint::text AS monitor_to_submitted_ms,
-      (
-        SELECT COUNT(*)::integer
+        ))::numeric * 1000)::bigint AS monitor_to_submitted_ms_number
+      FROM valid
+    ),
+    summary AS (
+      SELECT
+        COUNT(*)::integer AS measured_count,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY monitor_to_submitted_ms_number
+        ) AS monitor_to_submitted_p50_ms,
+        percentile_cont(0.95) WITHIN GROUP (
+          ORDER BY monitor_to_submitted_ms_number
+        ) AS monitor_to_submitted_p95_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY submitted_to_confirmed_ms
+        ) AS submitted_to_confirmed_p50_ms,
+        percentile_cont(0.95) WITHIN GROUP (
+          ORDER BY submitted_to_confirmed_ms
+        ) AS submitted_to_confirmed_p95_ms,
+        MIN(submitted_at) AS range_started_at,
+        MAX(submitted_at) AS range_ended_at
+      FROM measured
+    ),
+    stage_summaries AS (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'key', stage.key,
+          'label', stage.label,
+          'measured_count', stage.measured_count,
+          'p50_ms', stage.p50_ms,
+          'p95_ms', stage.p95_ms
+        )
+        ORDER BY stage.position
+      ) AS stages
+      FROM (
+        SELECT
+          1 AS position,
+          'observedToOpportunityMs'::text AS key,
+          'Observed → opportunity'::text AS label,
+          COUNT(measured.observed_to_opportunity_ms)::integer AS measured_count,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.observed_to_opportunity_ms
+          ) AS p50_ms,
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.observed_to_opportunity_ms
+          ) AS p95_ms
+        FROM measured
+
+        UNION ALL
+
+        SELECT
+          2,
+          'opportunityToReadyMs',
+          'Opportunity → ready',
+          COUNT(measured.opportunity_to_ready_ms)::integer,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.opportunity_to_ready_ms
+          ),
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.opportunity_to_ready_ms
+          )
+        FROM measured
+
+        UNION ALL
+
+        SELECT
+          3,
+          'readyToDecisionMs',
+          'Ready → decision',
+          COUNT(measured.ready_to_decision_ms)::integer,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.ready_to_decision_ms
+          ),
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.ready_to_decision_ms
+          )
+        FROM measured
+
+        UNION ALL
+
+        SELECT
+          4,
+          'decisionToSignedMs',
+          'Decision → signed',
+          COUNT(measured.decision_to_signed_ms)::integer,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.decision_to_signed_ms
+          ),
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.decision_to_signed_ms
+          )
+        FROM measured
+
+        UNION ALL
+
+        SELECT
+          5,
+          'signedToSubmittedMs',
+          'Signed → submitted',
+          COUNT(measured.signed_to_submitted_ms)::integer,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.signed_to_submitted_ms
+          ),
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.signed_to_submitted_ms
+          )
+        FROM measured
+
+        UNION ALL
+
+        SELECT
+          6,
+          'submittedToConfirmedMs',
+          'Submitted → confirmed',
+          COUNT(measured.submitted_to_confirmed_ms)::integer,
+          percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY measured.submitted_to_confirmed_ms
+          ),
+          percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY measured.submitted_to_confirmed_ms
+          )
+        FROM measured
+      ) AS stage
+    ),
+    chart_points AS (
+      SELECT
+        date_bin(
+          interval '1 day',
+          measured.submitted_at,
+          timestamptz '1970-01-01 00:00:00+00'
+        ) AS bucket_started_at,
+        COUNT(*)::integer AS sample_count,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.monitor_to_submitted_ms_number
+        ) AS monitor_to_submitted_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.observed_to_opportunity_ms
+        ) AS observed_to_opportunity_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.opportunity_to_ready_ms
+        ) AS opportunity_to_ready_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.ready_to_decision_ms
+        ) AS ready_to_decision_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.decision_to_signed_ms
+        ) AS decision_to_signed_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.signed_to_submitted_ms
+        ) AS signed_to_submitted_ms,
+        percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY measured.submitted_to_confirmed_ms
+        ) AS submitted_to_confirmed_ms
+      FROM measured
+      GROUP BY 1
+    ),
+    latest_points AS (
+      SELECT measured.*
+      FROM measured
+      ORDER BY measured.submitted_at DESC, measured.id DESC
+      LIMIT 50
+    ),
+    total_confirmed AS (
+      SELECT COUNT(*)::integer AS total_confirmed
         FROM loyal_yield.rebalance_decisions AS total
         WHERE total.status = 'confirmed'
           AND total.source_reserve IS NOT NULL
           AND total.target_reserve IS NOT NULL
-      )::text AS total_confirmed
-    FROM valid
-    ORDER BY valid.submitted_at ASC, valid.id ASC
+    )
+    SELECT
+      summary.measured_count,
+      summary.monitor_to_submitted_p50_ms,
+      summary.monitor_to_submitted_p95_ms,
+      summary.range_started_at,
+      summary.range_ended_at,
+      summary.submitted_to_confirmed_p50_ms,
+      summary.submitted_to_confirmed_p95_ms,
+      total_confirmed.total_confirmed,
+      stage_summaries.stages,
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'bucket_started_at', chart.bucket_started_at,
+              'decision_to_signed_ms', chart.decision_to_signed_ms,
+              'monitor_to_submitted_ms', chart.monitor_to_submitted_ms,
+              'observed_to_opportunity_ms', chart.observed_to_opportunity_ms,
+              'opportunity_to_ready_ms', chart.opportunity_to_ready_ms,
+              'ready_to_decision_ms', chart.ready_to_decision_ms,
+              'sample_count', chart.sample_count,
+              'signed_to_submitted_ms', chart.signed_to_submitted_ms,
+              'submitted_to_confirmed_ms', chart.submitted_to_confirmed_ms
+            )
+            ORDER BY chart.bucket_started_at
+          )
+          FROM chart_points AS chart
+        ),
+        '[]'::jsonb
+      ) AS chart_points,
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'confirmed_at', latest.confirmed_at,
+              'decision_at', latest.decision_at,
+              'decision_to_signed_ms', latest.decision_to_signed_ms,
+              'id', latest.id::text,
+              'liquidity_mint', latest.liquidity_mint,
+              'monitor_to_submitted_ms', latest.monitor_to_submitted_ms_number,
+              'observed_to_opportunity_ms', latest.observed_to_opportunity_ms,
+              'opportunity_at', latest.opportunity_at,
+              'opportunity_to_ready_ms', latest.opportunity_to_ready_ms,
+              'ready_at', latest.ready_at,
+              'ready_to_decision_ms', latest.ready_to_decision_ms,
+              'signed_at', latest.signed_at,
+              'signed_to_submitted_ms', latest.signed_to_submitted_ms,
+              'source_reserve', latest.source_reserve,
+              'submitted_at', latest.submitted_at,
+              'submitted_to_confirmed_ms', latest.submitted_to_confirmed_ms,
+              'target_observed_at', latest.target_observed_at,
+              'target_reserve', latest.target_reserve
+            )
+            ORDER BY latest.submitted_at DESC, latest.id DESC
+          )
+          FROM latest_points AS latest
+        ),
+        '[]'::jsonb
+      ) AS latest_points
+    FROM summary
+    CROSS JOIN stage_summaries
+    CROSS JOIN total_confirmed
   `)) as unknown as EarnLatencySqlRow[];
 
-  const points = rows.map(
-    (row): EarnLatencyPoint => ({
-      confirmedAt: toIsoString(row.confirmed_at) ?? "",
-      decisionAt: toIsoString(row.decision_at) ?? "",
-      decisionId: row.id,
-      decisionToSignedMs: toNumber(row.decision_to_signed_ms),
-      monitorToSubmittedMs: toNumber(row.monitor_to_submitted_ms),
-      observedToOpportunityMs: toNumber(row.observed_to_opportunity_ms),
-      opportunityAt: toIsoString(row.opportunity_at) ?? "",
-      opportunityToReadyMs: toNullableNumber(row.opportunity_to_ready_ms),
-      readyAt: toIsoString(row.ready_at),
-      readyToDecisionMs: toNullableNumber(row.ready_to_decision_ms),
-      signedAt: toIsoString(row.signed_at) ?? "",
-      signedToSubmittedMs: toNumber(row.signed_to_submitted_ms),
-      liquidityMint: row.liquidity_mint,
-      sourceReserve: row.source_reserve,
-      submittedAt: toIsoString(row.submitted_at) ?? "",
-      submittedToConfirmedMs: toNumber(row.submitted_to_confirmed_ms),
-      targetObservedAt: toIsoString(row.target_observed_at) ?? "",
-      targetReserve: row.target_reserve,
+  const row = rows[0];
+  const latestPoints = (row?.latest_points ?? []).map(
+    (point): EarnLatencyPoint => ({
+      confirmedAt: toIsoString(point.confirmed_at) ?? "",
+      decisionAt: toIsoString(point.decision_at) ?? "",
+      decisionId: point.id,
+      decisionToSignedMs: toNumber(point.decision_to_signed_ms),
+      monitorToSubmittedMs: toNumber(point.monitor_to_submitted_ms),
+      observedToOpportunityMs: toNumber(point.observed_to_opportunity_ms),
+      opportunityAt: toIsoString(point.opportunity_at) ?? "",
+      opportunityToReadyMs: toNullableNumber(point.opportunity_to_ready_ms),
+      readyAt: toIsoString(point.ready_at),
+      readyToDecisionMs: toNullableNumber(point.ready_to_decision_ms),
+      signedAt: toIsoString(point.signed_at) ?? "",
+      signedToSubmittedMs: toNumber(point.signed_to_submitted_ms),
+      liquidityMint: point.liquidity_mint,
+      sourceReserve: point.source_reserve,
+      submittedAt: toIsoString(point.submitted_at) ?? "",
+      submittedToConfirmedMs: toNumber(point.submitted_to_confirmed_ms),
+      targetObservedAt: toIsoString(point.target_observed_at) ?? "",
+      targetReserve: point.target_reserve,
     })
   );
-  const monitorToSubmitted = points.map((point) => point.monitorToSubmittedMs);
-  const submittedToConfirmed = points.map(
-    (point) => point.submittedToConfirmedMs
+  const points = (row?.chart_points ?? []).map(
+    (point): EarnLatencyChartPoint => ({
+      bucketStartedAt: toIsoString(point.bucket_started_at) ?? "",
+      decisionToSignedMs: toNullableNumber(point.decision_to_signed_ms),
+      monitorToSubmittedMs: toNullableNumber(point.monitor_to_submitted_ms),
+      observedToOpportunityMs: toNullableNumber(
+        point.observed_to_opportunity_ms
+      ),
+      opportunityToReadyMs: toNullableNumber(point.opportunity_to_ready_ms),
+      readyToDecisionMs: toNullableNumber(point.ready_to_decision_ms),
+      sampleCount: toNumber(point.sample_count),
+      signedToSubmittedMs: toNullableNumber(point.signed_to_submitted_ms),
+      submittedToConfirmedMs: toNullableNumber(point.submitted_to_confirmed_ms),
+    })
   );
 
   return {
     fetchedAt: new Date().toISOString(),
-    measuredCount: points.length,
-    monitorToSubmittedP50Ms: percentile(monitorToSubmitted, 0.5),
-    monitorToSubmittedP95Ms: percentile(monitorToSubmitted, 0.95),
+    measuredCount: toNumber(row?.measured_count ?? null),
+    monitorToSubmittedP50Ms: toNumber(row?.monitor_to_submitted_p50_ms ?? null),
+    monitorToSubmittedP95Ms: toNumber(row?.monitor_to_submitted_p95_ms ?? null),
+    latestPoints,
     points,
-    rangeEndedAt: points.at(-1)?.submittedAt ?? null,
-    rangeStartedAt: points[0]?.submittedAt ?? null,
-    stages: STAGES.map(({ key, label }) => summarize(points, key, label)),
+    rangeEndedAt: toIsoString(row?.range_ended_at ?? null),
+    rangeStartedAt: toIsoString(row?.range_started_at ?? null),
+    stages: (row?.stages ?? []).map((stage) => ({
+      key: stage.key,
+      label: stage.label,
+      measuredCount: toNumber(stage.measured_count),
+      p50Ms: toNumber(stage.p50_ms),
+      p95Ms: toNumber(stage.p95_ms),
+    })),
     status: "available",
-    submittedToConfirmedP50Ms: percentile(submittedToConfirmed, 0.5),
-    submittedToConfirmedP95Ms: percentile(submittedToConfirmed, 0.95),
-    totalConfirmed: rows.length > 0 ? toNumber(rows[0].total_confirmed) : 0,
+    submittedToConfirmedP50Ms: toNumber(
+      row?.submitted_to_confirmed_p50_ms ?? null
+    ),
+    submittedToConfirmedP95Ms: toNumber(
+      row?.submitted_to_confirmed_p95_ms ?? null
+    ),
+    totalConfirmed: toNumber(row?.total_confirmed ?? null),
   };
 }
 
@@ -332,6 +578,7 @@ export async function getEarnRebalanceLatencyData(): Promise<EarnRebalanceLatenc
       measuredCount: 0,
       monitorToSubmittedP50Ms: 0,
       monitorToSubmittedP95Ms: 0,
+      latestPoints: [],
       points: [],
       rangeEndedAt: null,
       rangeStartedAt: null,

--- a/apps/admin/src/app/(admin)/metrics/earn-rebalance-latency.tsx
+++ b/apps/admin/src/app/(admin)/metrics/earn-rebalance-latency.tsx
@@ -37,6 +37,7 @@ import {
 import { getEarnStablecoinSymbol } from "@/lib/earn/stablecoin-monitor.shared";
 
 import type {
+  EarnLatencyChartPoint,
   EarnLatencyPoint,
   EarnLatencyStageKey,
   EarnLatencyStageSummary,
@@ -48,10 +49,10 @@ const DAY_MS = 24 * 60 * 60 * 1_000;
 type LatencySeriesKey = EarnLatencyStageKey | "monitorToSubmittedMs";
 type RangeKey = "7d" | "30d" | "all";
 
-type ScatterPoint = EarnLatencyPoint & {
+type ScatterPoint = EarnLatencyChartPoint & {
   durationMs: number;
   seriesLabel: string;
-  submittedAtMs: number;
+  bucketStartedAtMs: number;
 };
 
 const SERIES: ReadonlyArray<{
@@ -174,17 +175,8 @@ function LatencyTooltip({
         {formatDuration(point.durationMs)}
       </div>
       <div className="text-muted-foreground">
-        Submitted {formatUtcTimestamp(point.submittedAtMs)}
-      </div>
-      <div className="text-muted-foreground">
-        {formatShortAddress(point.sourceReserve)} →{" "}
-        {formatShortAddress(point.targetReserve)}
-      </div>
-      <div className="text-muted-foreground">
-        Mint {getEarnStablecoinSymbol(point.liquidityMint) ?? "unknown"}
-      </div>
-      <div className="font-mono text-muted-foreground">
-        Decision {point.decisionId}
+        Bucket {formatUtcTimestamp(point.bucketStartedAtMs)} ·{" "}
+        {point.sampleCount.toLocaleString("en-US")} bucket samples
       </div>
     </div>
   );
@@ -253,7 +245,7 @@ function LatencyTable({
   points: EarnLatencyPoint[];
   selectedSeries: LatencySeriesKey[];
 }) {
-  const rows = [...points].reverse().slice(0, 50);
+  const rows = points.slice(0, 50);
 
   return (
     <div className="max-h-[420px] overflow-auto rounded-md border">
@@ -317,12 +309,18 @@ export function EarnRebalanceLatency({
     if (range === "all" || data.points.length === 0) {
       return data.points;
     }
-    const latest = Date.parse(data.points[data.points.length - 1].submittedAt);
+    const latest = Date.parse(
+      data.points[data.points.length - 1].bucketStartedAt
+    );
     const days = range === "7d" ? 7 : 30;
     return data.points.filter(
-      (point) => Date.parse(point.submittedAt) >= latest - days * DAY_MS
+      (point) => Date.parse(point.bucketStartedAt) >= latest - days * DAY_MS
     );
   }, [data.points, range]);
+  const filteredExecutionCount = filteredPoints.reduce(
+    (total, point) => total + point.sampleCount,
+    0
+  );
 
   const scatterBySeries = useMemo(
     () =>
@@ -339,7 +337,7 @@ export function EarnRebalanceLatency({
                 ...point,
                 durationMs: duration,
                 seriesLabel: series.label,
-                submittedAtMs: Date.parse(point.submittedAt),
+                bucketStartedAtMs: Date.parse(point.bucketStartedAt),
               },
             ];
           }),
@@ -495,14 +493,14 @@ export function EarnRebalanceLatency({
             })}
           </div>
           <p className="text-xs text-muted-foreground">
-            {filteredPoints.length.toLocaleString("en-US")} executions in the
+            {filteredExecutionCount.toLocaleString("en-US")} executions in the
             selected range · updated {formatUtcTimestamp(data.fetchedAt)}
           </p>
         </CardHeader>
         <CardContent className="min-w-0">
           {showTable ? (
             <LatencyTable
-              points={filteredPoints}
+              points={data.latestPoints}
               selectedSeries={selectedSeries}
             />
           ) : (
@@ -517,9 +515,9 @@ export function EarnRebalanceLatency({
                 <CartesianGrid />
                 <XAxis
                   axisLine={false}
-                  dataKey="submittedAtMs"
+                  dataKey="bucketStartedAtMs"
                   domain={["dataMin", "dataMax"]}
-                  name="First submission time"
+                  name="Bucket start time"
                   tickFormatter={formatUtcTick}
                   tickLine={false}
                   tickMargin={8}

--- a/apps/admin/src/app/(admin)/push-notifications/page.tsx
+++ b/apps/admin/src/app/(admin)/push-notifications/page.tsx
@@ -3,7 +3,7 @@ import {
   pushNotificationTickets,
   pushTokens,
 } from "@loyal-labs/db-core/schema";
-import { and, count, desc, eq, inArray, isNotNull } from "drizzle-orm";
+import { desc, eq, inArray, sql } from "drizzle-orm";
 
 import { PageContainer } from "@/components/layout/page-container";
 import { SectionHeader } from "@/components/layout/section-header";
@@ -52,38 +52,14 @@ function toSingleValue(value: string | string[] | undefined) {
   return value;
 }
 
-function getActionMessage(result: string | undefined, message: string | undefined) {
+function getActionMessage(
+  result: string | undefined,
+  message: string | undefined
+) {
   if (!message) return null;
   if (result === "success") return { kind: "success" as const, message };
   if (result === "error") return { kind: "error" as const, message };
   return null;
-}
-
-function getTicketError(row: {
-  ticketError: string | null;
-  ticketMessage: string | null;
-}) {
-  if (row.ticketError && row.ticketMessage) {
-    return `${row.ticketError}: ${row.ticketMessage}`;
-  }
-  return row.ticketError ?? row.ticketMessage;
-}
-
-async function getPushTokenCount(platform?: "ios" | "android") {
-  const db = getDatabase();
-  const [row] = await db
-    .select({ count: count() })
-    .from(pushTokens)
-    .where(
-      platform
-        ? and(
-            isNotNull(pushTokens.walletPublicKey),
-            eq(pushTokens.platform, platform)
-          )
-        : isNotNull(pushTokens.walletPublicKey)
-    );
-
-  return row?.count ?? 0;
 }
 
 export default async function PushNotificationsPage({
@@ -94,10 +70,22 @@ export default async function PushNotificationsPage({
   const message = toSingleValue(resolvedSearchParams.message);
   const actionMessage = getActionMessage(result, message);
   const db = getDatabase();
-  const [all, ios, android, recentSendRows] = await Promise.all([
-    getPushTokenCount(),
-    getPushTokenCount("ios"),
-    getPushTokenCount("android"),
+  const [[tokenCounts], recentSendRows] = await Promise.all([
+    db
+      .select({
+        all: sql<number>`count(*) FILTER (
+          WHERE ${pushTokens.walletPublicKey} IS NOT NULL
+        )`,
+        android: sql<number>`count(*) FILTER (
+          WHERE ${pushTokens.walletPublicKey} IS NOT NULL
+            AND ${pushTokens.platform} = 'android'
+        )`,
+        ios: sql<number>`count(*) FILTER (
+          WHERE ${pushTokens.walletPublicKey} IS NOT NULL
+            AND ${pushTokens.platform} = 'ios'
+        )`,
+      })
+      .from(pushTokens),
     db
       .select({
         id: pushNotificationSends.id,
@@ -122,15 +110,27 @@ export default async function PushNotificationsPage({
       .orderBy(desc(pushNotificationSends.createdAt))
       .limit(20) as Promise<RecentSendBaseRow[]>,
   ]);
-  const ticketRows =
+  const ticketMetaRows =
     recentSendRows.length > 0
       ? await db
           .select({
             sendId: pushNotificationTickets.sendId,
-            ticketId: pushNotificationTickets.ticketId,
-            ticketStatus: pushNotificationTickets.ticketStatus,
-            ticketMessage: pushNotificationTickets.ticketMessage,
-            ticketError: pushNotificationTickets.ticketError,
+            receiptIdCount: sql<number>`count(*) FILTER (
+              WHERE ${pushNotificationTickets.ticketId} IS NOT NULL
+            )`,
+            lastTicketError: sql<string | null>`(
+              ARRAY_AGG(
+                NULLIF(
+                  CONCAT_WS(
+                    ': ',
+                    ${pushNotificationTickets.ticketError},
+                    ${pushNotificationTickets.ticketMessage}
+                  ),
+                  ''
+                )
+                ORDER BY ${pushNotificationTickets.updatedAt} DESC
+              ) FILTER (WHERE ${pushNotificationTickets.ticketStatus} = 'error')
+            )[1]`,
           })
           .from(pushNotificationTickets)
           .where(
@@ -139,28 +139,16 @@ export default async function PushNotificationsPage({
               recentSendRows.map((send) => send.id)
             )
           )
+          .groupBy(pushNotificationTickets.sendId)
       : [];
-  const ticketMetaBySendId = new Map<
-    string,
-    { receiptIdCount: number; lastTicketError: string | null }
-  >();
-
-  for (const row of ticketRows) {
-    const meta = ticketMetaBySendId.get(row.sendId) ?? {
-      receiptIdCount: 0,
-      lastTicketError: null,
-    };
-    if (row.ticketId) {
-      meta.receiptIdCount += 1;
-    }
-    if (row.ticketStatus === "error") {
-      meta.lastTicketError = getTicketError(row);
-    }
-    ticketMetaBySendId.set(row.sendId, meta);
-  }
+  const ticketMetaBySendId = new Map(
+    ticketMetaRows.map((row) => [row.sendId, row])
+  );
   const recentSends = recentSendRows.map((send) => ({
     ...send,
-    receiptIdCount: ticketMetaBySendId.get(send.id)?.receiptIdCount ?? 0,
+    receiptIdCount: Number(
+      ticketMetaBySendId.get(send.id)?.receiptIdCount ?? 0
+    ),
     lastTicketError: ticketMetaBySendId.get(send.id)?.lastTicketError ?? null,
   }));
 
@@ -172,7 +160,11 @@ export default async function PushNotificationsPage({
         subtitle="Manual mobile broadcasts and Expo delivery cleanup."
       />
       <ManualPushPanel
-        counts={{ all, ios, android }}
+        counts={{
+          all: Number(tokenCounts?.all ?? 0),
+          android: Number(tokenCounts?.android ?? 0),
+          ios: Number(tokenCounts?.ios ?? 0),
+        }}
         actionMessage={actionMessage}
         recentSends={recentSends.map((send) => ({
           ...send,

--- a/apps/admin/src/app/api/earn/rebalance/apy-samples/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/apy-samples/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { getSafeReserveApyMonitorData } from "@/lib/kamino/timescale-reserve-client.server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json(await getSafeReserveApyMonitorData(), {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/apps/admin/src/app/api/earn/rebalance/details/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/details/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+
+import {
+  getEarnVaultRebalanceFrequency,
+  getExecutedEarnRebalanceHistory,
+} from "../../../../(admin)/earn/rebalance/rebalance-data";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  const kind = new URL(request.url).searchParams.get("kind");
+
+  if (kind === "executed") {
+    const history = await getExecutedEarnRebalanceHistory();
+    return NextResponse.json(
+      {
+        details: history.details.map((execution) => ({
+          ...execution,
+          amountRaw: execution.amountRaw.toString(),
+          confirmedSlot: execution.confirmedSlot.toString(),
+          currentDepositRaw: execution.currentDepositRaw.toString(),
+          swapFeeLamports: execution.swapFeeLamports.toString(),
+        })),
+      },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  }
+
+  if (kind === "frequency") {
+    const frequency = await getEarnVaultRebalanceFrequency();
+    return NextResponse.json(
+      {
+        details: frequency.details.map((vault) => ({
+          ...vault,
+          currentDepositRaw: vault.currentDepositRaw.toString(),
+        })),
+      },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  }
+
+  return NextResponse.json(
+    { error: "Invalid rebalance detail kind." },
+    { status: 400 }
+  );
+}

--- a/apps/admin/src/app/api/earn/rebalance/details/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/details/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { getEarnStablecoinByMint } from "@/lib/earn/stablecoin-monitor.shared";
+
 import {
   getEarnVaultRebalanceFrequency,
   getExecutedEarnRebalanceHistory,
@@ -9,13 +11,33 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(request: Request) {
-  const kind = new URL(request.url).searchParams.get("kind");
+  const searchParams = new URL(request.url).searchParams;
+  const kind = searchParams.get("kind");
+  const liquidityMint = searchParams.get("liquidityMint");
+
+  if (
+    liquidityMint !== null &&
+    getEarnStablecoinByMint(liquidityMint) === null
+  ) {
+    return NextResponse.json(
+      { error: "Invalid stablecoin mint." },
+      { status: 400 }
+    );
+  }
+
+  const matchesStablecoin = (row: {
+    liquidityMint: string | null;
+    routeMode: "cross_mint" | "same_mint";
+  }) =>
+    liquidityMint === null ||
+    row.routeMode === "cross_mint" ||
+    row.liquidityMint === liquidityMint;
 
   if (kind === "executed") {
     const history = await getExecutedEarnRebalanceHistory();
     return NextResponse.json(
       {
-        details: history.details.map((execution) => ({
+        details: history.details.filter(matchesStablecoin).map((execution) => ({
           ...execution,
           amountRaw: execution.amountRaw.toString(),
           confirmedSlot: execution.confirmedSlot.toString(),
@@ -31,7 +53,7 @@ export async function GET(request: Request) {
     const frequency = await getEarnVaultRebalanceFrequency();
     return NextResponse.json(
       {
-        details: frequency.details.map((vault) => ({
+        details: frequency.details.filter(matchesStablecoin).map((vault) => ({
           ...vault,
           currentDepositRaw: vault.currentDepositRaw.toString(),
         })),

--- a/apps/admin/src/app/api/earn/rebalance/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/route.ts
@@ -1,8 +1,16 @@
-import { unstable_cache } from "next/cache";
 import { NextResponse } from "next/server";
 
-import { getSafeReserveApyMonitorData } from "@/lib/kamino/timescale-reserve-client.server";
-import { DATA_CACHE_TTL_SECONDS } from "@/lib/data-cache";
+import {
+  getCurrentSafeReserveApyStatuses,
+  getKaminoTimescaleDb,
+  getSafeReserveApyMonitorData,
+  getSafeReserveApyMonitorDataFromStatuses,
+} from "@/lib/kamino/timescale-reserve-client.server";
+import type { SafeReserveApyMonitorData } from "@/lib/kamino/timescale-reserve-monitor.shared";
+import {
+  EARN_STABLECOIN_DESCRIPTORS,
+  STABLECOIN_DECIMALS,
+} from "@/lib/earn/stablecoin-monitor.shared";
 
 import {
   getActiveReserveRoutes,
@@ -10,14 +18,71 @@ import {
   getEarnVaultRebalanceFrequency,
   getExecutedEarnRebalanceHistory,
   getLast30DaysRebalanceSeries,
+  getRebalanceAuditActivePage,
+  getRebalanceAuditPage,
+  getRebalanceAuditSummary,
   getRebalanceActivity,
   getRecentRebalanceDecisions,
 } from "../../../(admin)/earn/rebalance/rebalance-data";
+import { computeRebalanceEligibilityFloorRaw } from "../../../(admin)/earn/rebalance/earn-vault-rebalance-eligibility";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-async function loadRebalanceMonitorData() {
+function serializeApyData(data: SafeReserveApyMonitorData) {
+  const bucketMs = 30 * 60 * 1_000;
+  const windowStartedAtMs = Date.parse(data.window.startedAt);
+  const buckets = new Map<number, Array<number[]>>();
+
+  for (const point of data.chartPoints) {
+    const bucketTime =
+      windowStartedAtMs +
+      Math.floor((point.observedAtMs - windowStartedAtMs) / bucketMs) *
+        bucketMs;
+    const bucket =
+      buckets.get(bucketTime) ?? data.series.map(() => new Array<number>());
+
+    for (const [seriesIndex, series] of data.series.entries()) {
+      const value = point[series.key];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        bucket[seriesIndex]?.push(value);
+      }
+    }
+    buckets.set(bucketTime, bucket);
+  }
+
+  const orderedBuckets = [...buckets.entries()].sort(
+    ([left], [right]) => left - right
+  );
+  const median = (values: number[]) => {
+    if (values.length === 0) {
+      return null;
+    }
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.round((sorted.length - 1) * 0.5)] ?? null;
+  };
+
+  return {
+    generatedAt: data.generatedAt,
+    sampleIntervalMinutes: 30,
+    series: data.series,
+    statuses: data.statuses,
+    values: data.series.map((_series, seriesIndex) =>
+      orderedBuckets.map(([, bucket]) => {
+        const value = median(bucket[seriesIndex] ?? []);
+        return value === null
+          ? null
+          : Math.round(value * 1_000_000) / 1_000_000;
+      })
+    ),
+    observedAtMs: orderedBuckets.map(([observedAtMs]) => observedAtMs),
+    window: data.window,
+  };
+}
+
+async function loadRebalanceMonitorData(
+  apyDataPromise: Promise<SafeReserveApyMonitorData> = getSafeReserveApyMonitorData()
+) {
   const [
     apyData,
     routes,
@@ -26,7 +91,7 @@ async function loadRebalanceMonitorData() {
     last30DaysRebalances,
     autodeposit,
   ] = await Promise.all([
-    getSafeReserveApyMonitorData(),
+    apyDataPromise,
     getActiveReserveRoutes(),
     getRecentRebalanceDecisions(),
     getRebalanceActivity(),
@@ -40,7 +105,7 @@ async function loadRebalanceMonitorData() {
       maxSwapFeeLamports: point.maxSwapFeeLamports.toString(),
       swapFeeLamports: point.swapFeeLamports.toString(),
     })),
-    apyData,
+    apyData: serializeApyData(apyData),
     autodeposit: autodeposit.map((range) => ({
       bucketHours: range.bucketHours,
       key: range.key,
@@ -70,25 +135,48 @@ async function loadRebalanceMonitorData() {
 
 async function loadExecutedRebalances() {
   try {
-    const history = await getExecutedEarnRebalanceHistory();
+    const history = await getExecutedEarnRebalanceHistory({
+      includeDetails: false,
+    });
+    const strings: string[] = [];
+    const stringIndexes = new Map<string, number>();
+    const stringIndex = (value: string | null) => {
+      if (value === null) {
+        return null;
+      }
+      const existing = stringIndexes.get(value);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const index = strings.length;
+      strings.push(value);
+      stringIndexes.set(value, index);
+      return index;
+    };
+    const serialize = (execution: (typeof history.chartPoints)[number]) =>
+      [
+        execution.amountRaw.toString(),
+        stringIndex(execution.authority)!,
+        execution.confirmedSlot.toString(),
+        execution.currentDepositRaw.toString(),
+        execution.executedAt,
+        execution.id,
+        stringIndex(execution.liquidityMint),
+        execution.routeMode,
+        stringIndex(execution.sourceReserve)!,
+        stringIndex(execution.sourceLiquidityMint),
+        execution.swapFeeLamports.toString(),
+        stringIndex(execution.targetReserve)!,
+        stringIndex(execution.targetLiquidityMint),
+        execution.userRank,
+      ] as const;
 
     return {
       ...history,
       status: "available" as const,
-      chartPoints: history.chartPoints.map((execution) => ({
-        ...execution,
-        amountRaw: execution.amountRaw.toString(),
-        confirmedSlot: execution.confirmedSlot.toString(),
-        currentDepositRaw: execution.currentDepositRaw.toString(),
-        swapFeeLamports: execution.swapFeeLamports.toString(),
-      })),
-      details: history.details.map((execution) => ({
-        ...execution,
-        amountRaw: execution.amountRaw.toString(),
-        confirmedSlot: execution.confirmedSlot.toString(),
-        currentDepositRaw: execution.currentDepositRaw.toString(),
-        swapFeeLamports: execution.swapFeeLamports.toString(),
-      })),
+      chartPoints: history.chartPoints.map(serialize),
+      details: history.details.map(serialize),
+      strings,
       summaries: history.summaries.map((summary) => ({
         ...summary,
         swapFeeLamports: summary.swapFeeLamports.toString(),
@@ -106,26 +194,24 @@ async function loadExecutedRebalances() {
       details: [],
       generatedAt: new Date().toISOString(),
       status: "unavailable" as const,
+      strings: [],
       summaries: [],
     };
   }
 }
 
-async function loadVaultRebalanceFrequency() {
+async function loadVaultRebalanceFrequency(eligibilityFloorRaw: bigint | null) {
   try {
-    const frequency = await getEarnVaultRebalanceFrequency();
+    const frequency = await getEarnVaultRebalanceFrequency({
+      eligibilityFloorRaw,
+      includeDetails: false,
+    });
 
     return {
       ...frequency,
       status: "available" as const,
-      chartPoints: frequency.chartPoints.map((vault) => ({
-        ...vault,
-        currentDepositRaw: vault.currentDepositRaw.toString(),
-      })),
-      details: frequency.details.map((vault) => ({
-        ...vault,
-        currentDepositRaw: vault.currentDepositRaw.toString(),
-      })),
+      chartPoints: frequency.chartPoints.map(serializeVaultFrequency),
+      details: frequency.details.map(serializeVaultFrequency),
     };
   } catch (error) {
     console.error("Earn vault rebalance frequency query failed", {
@@ -145,26 +231,104 @@ async function loadVaultRebalanceFrequency() {
   }
 }
 
-const getCachedRebalanceMonitorData = unstable_cache(
-  loadRebalanceMonitorData,
-  ["earn-rebalance-monitor"],
-  { revalidate: DATA_CACHE_TTL_SECONDS }
-);
+function serializeVaultFrequency(
+  vault: Awaited<
+    ReturnType<typeof getEarnVaultRebalanceFrequency>
+  >["chartPoints"][number]
+) {
+  return [
+    vault.allCount,
+    vault.currentDepositRaw.toString(),
+    vault.currentReserve,
+    vault.depositRank,
+    vault.last12hCount,
+    vault.last2hCount,
+    vault.last7dCount,
+    vault.liquidityMint,
+    vault.positionCount,
+    vault.routeMode,
+    vault.vaultId,
+    vault.vaultPubkey,
+  ] as const;
+}
+
+async function loadInitialAudit() {
+  const [summary, page, activePage] = await Promise.all([
+    getRebalanceAuditSummary("24h", "same_mint"),
+    getRebalanceAuditPage({
+      errorFilter: "all",
+      range: "24h",
+      routeMode: "same_mint",
+      view: "completed_rebalances",
+    }),
+    getRebalanceAuditActivePage({
+      range: "24h",
+      routeMode: "same_mint",
+    }),
+  ]);
+  const serializePage = (auditPage: typeof page) => ({
+    ...auditPage,
+    rows: auditPage.rows.map((row) => ({
+      ...row,
+      amountRaw: row.amountRaw?.toString() ?? null,
+      confirmedSlot: row.confirmedSlot?.toString() ?? null,
+      submittedSlot: row.submittedSlot?.toString() ?? null,
+    })),
+  });
+
+  return {
+    activePage: serializePage(activePage),
+    generatedAt: new Date().toISOString(),
+    page: serializePage(page),
+    summary,
+  };
+}
+
+export async function loadRebalancePageData() {
+  const currentStatusesPromise = getCurrentSafeReserveApyStatuses(
+    getKaminoTimescaleDb()
+  );
+  const apyDataPromise = currentStatusesPromise.then((statuses) =>
+    getSafeReserveApyMonitorDataFromStatuses(statuses)
+  );
+  const monitorDataPromise = loadRebalanceMonitorData(apyDataPromise);
+  const executedRebalancesPromise = loadExecutedRebalances();
+  const initialAuditPromise = loadInitialAudit();
+  const frequencyPromise = currentStatusesPromise.then((statuses) => {
+    const defaultMint = EARN_STABLECOIN_DESCRIPTORS.find(
+      (descriptor) => descriptor.symbol === "USDC"
+    )?.mint;
+    const eligibilityFloorRaw = computeRebalanceEligibilityFloorRaw(
+      statuses.filter((status) => status.liquidityMint === defaultMint),
+      STABLECOIN_DECIMALS
+    );
+
+    return loadVaultRebalanceFrequency(eligibilityFloorRaw);
+  });
+  const [
+    monitorData,
+    executedRebalances,
+    vaultRebalanceFrequency,
+    initialAudit,
+  ] = await Promise.all([
+    monitorDataPromise,
+    executedRebalancesPromise,
+    frequencyPromise,
+    initialAuditPromise,
+  ]);
+
+  return {
+    ...monitorData,
+    executedRebalances,
+    initialAudit,
+    vaultRebalanceFrequency,
+  };
+}
 
 export async function GET() {
-  const [monitorData, executedRebalances, vaultRebalanceFrequency] =
-    await Promise.all([
-      getCachedRebalanceMonitorData(),
-      loadExecutedRebalances(),
-      loadVaultRebalanceFrequency(),
-    ]);
-
-  return NextResponse.json(
-    { ...monitorData, executedRebalances, vaultRebalanceFrequency },
-    {
-      headers: {
-        "Cache-Control": "private, no-store",
-      },
-    }
-  );
+  return NextResponse.json(await loadRebalancePageData(), {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
 }

--- a/apps/admin/src/app/api/earn/rebalance/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/route.ts
@@ -75,12 +75,23 @@ async function loadExecutedRebalances() {
     return {
       ...history,
       status: "available" as const,
-      executions: history.executions.map((execution) => ({
+      chartPoints: history.chartPoints.map((execution) => ({
         ...execution,
         amountRaw: execution.amountRaw.toString(),
         confirmedSlot: execution.confirmedSlot.toString(),
         currentDepositRaw: execution.currentDepositRaw.toString(),
         swapFeeLamports: execution.swapFeeLamports.toString(),
+      })),
+      details: history.details.map((execution) => ({
+        ...execution,
+        amountRaw: execution.amountRaw.toString(),
+        confirmedSlot: execution.confirmedSlot.toString(),
+        currentDepositRaw: execution.currentDepositRaw.toString(),
+        swapFeeLamports: execution.swapFeeLamports.toString(),
+      })),
+      summaries: history.summaries.map((summary) => ({
+        ...summary,
+        swapFeeLamports: summary.swapFeeLamports.toString(),
       })),
     };
   } catch (error) {
@@ -91,10 +102,11 @@ async function loadExecutedRebalances() {
     });
 
     return {
-      executions: [],
+      chartPoints: [],
+      details: [],
       generatedAt: new Date().toISOString(),
       status: "unavailable" as const,
-      userCount: 0,
+      summaries: [],
     };
   }
 }
@@ -106,7 +118,11 @@ async function loadVaultRebalanceFrequency() {
     return {
       ...frequency,
       status: "available" as const,
-      vaults: frequency.vaults.map((vault) => ({
+      chartPoints: frequency.chartPoints.map((vault) => ({
+        ...vault,
+        currentDepositRaw: vault.currentDepositRaw.toString(),
+      })),
+      details: frequency.details.map((vault) => ({
         ...vault,
         currentDepositRaw: vault.currentDepositRaw.toString(),
       })),
@@ -121,8 +137,10 @@ async function loadVaultRebalanceFrequency() {
     return {
       generatedAt: new Date().toISOString(),
       status: "unavailable" as const,
+      chartPoints: [],
+      details: [],
+      summaries: [],
       vaultCount: 0,
-      vaults: [],
     };
   }
 }

--- a/apps/admin/src/app/api/earn/rebalance/vault-opportunities/route.ts
+++ b/apps/admin/src/app/api/earn/rebalance/vault-opportunities/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+import {
+  getEarnVaultOpportunityCounts,
+  type RebalanceRouteMode,
+} from "../../../../(admin)/earn/rebalance/rebalance-data";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const routeModes = new Set<RebalanceRouteMode>(["same_mint", "cross_mint"]);
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const vaultId = url.searchParams.get("vaultId") ?? "";
+  const routeMode = url.searchParams.get("routeMode") ?? "";
+
+  if (
+    !/^\d+$/.test(vaultId) ||
+    !routeModes.has(routeMode as RebalanceRouteMode)
+  ) {
+    return NextResponse.json(
+      { error: "Invalid vault opportunity query." },
+      { status: 400 }
+    );
+  }
+
+  const counts = await getEarnVaultOpportunityCounts(
+    vaultId,
+    routeMode as RebalanceRouteMode
+  );
+
+  if (!counts) {
+    return NextResponse.json(
+      { error: "Active Earn vault not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(counts, {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/apps/admin/src/lib/kamino/timescale-reserve-client.server.ts
+++ b/apps/admin/src/lib/kamino/timescale-reserve-client.server.ts
@@ -21,7 +21,7 @@ import {
 } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
 const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-const SAMPLE_INTERVAL_SECONDS = 30 * 60;
+const SAMPLE_INTERVAL_SECONDS = 5 * 60;
 const MIN_TOTAL_SUPPLY_USD = 100_000;
 const MAX_SUPPLY_APY = 0.5;
 export const VERIFIED_RESERVE_MAX_AGE_MS = 240 * 1000;
@@ -237,7 +237,7 @@ async function loadCurrentCandidates(
   }));
 }
 
-async function loadCurrentReserveStatuses(
+export async function getCurrentSafeReserveApyStatuses(
   db: KaminoTimescaleDb
 ): Promise<SafeReserveApyStatusRow[]> {
   return createStatusRows(await loadCurrentCandidates(db));
@@ -246,36 +246,25 @@ async function loadCurrentReserveStatuses(
 async function loadApyHistoryRows(args: {
   db: KaminoTimescaleDb;
   endedAt: Date;
+  reserves: readonly string[];
   startedAt: Date;
 }): Promise<HistoryRow[]> {
+  if (args.reserves.length === 0) {
+    return [];
+  }
+
+  const reserveIds = [...new Set(args.reserves)];
   const startIso = args.startedAt.toISOString();
   const endIso = args.endedAt.toISOString();
   const startTimestamp = sql.raw(
     `${toSqlStringLiteral(startIso)}::timestamptz`
   );
   const endTimestamp = sql.raw(`${toSqlStringLiteral(endIso)}::timestamptz`);
-  const stablecoinMints = sql.raw(
-    toSqlTextArrayLiteral(
-      EARN_STABLECOIN_DESCRIPTORS.map((descriptor) => descriptor.mint)
-    )
-  );
-  const safeMarkets = sql.raw(
-    toSqlTextArrayLiteral(
-      RISK_BASKET_MARKETS[RiskBasket.Safe].map((market) => market.toBase58())
-    )
-  );
-  const excludedReserves = sql.raw(
-    toSqlTextArrayLiteral([...EXCLUDED_GRAPH_RESERVES])
-  );
+  const reserveArray = sql.raw(toSqlTextArrayLiteral(reserveIds));
 
   const result = await args.db.execute(sql<HistoryRow>`
     WITH reserve_ids AS (
-      SELECT DISTINCT supported.reserve
-      FROM kamino.supported_reserves AS supported
-      WHERE supported.active = true
-        AND supported.liquidity_mint = ANY(${stablecoinMints})
-        AND supported.market = ANY(${safeMarkets})
-        AND supported.reserve <> ALL(${excludedReserves})
+      SELECT unnest(${reserveArray}) AS reserve
     ),
     previous_samples AS (
       SELECT
@@ -307,7 +296,7 @@ async function loadApyHistoryRows(args: {
         updates.reserve,
         updates.supply_apy
       FROM kamino.reserve_updates AS updates
-      WHERE updates.reserve IN (SELECT reserve FROM reserve_ids)
+      WHERE updates.reserve = ANY(${reserveArray})
         AND updates.observed_at >= ${startTimestamp}
         AND updates.observed_at <= ${endTimestamp}
         AND updates.reserve_last_update_stale = false
@@ -463,19 +452,22 @@ function withApySummaries(args: {
 }
 
 async function loadSafeReserveApyMonitorData(
-  now = new Date()
+  now = new Date(),
+  currentStatuses?: readonly SafeReserveApyStatusRow[]
 ): Promise<SafeReserveApyMonitorData> {
   const db = getKaminoTimescaleDb();
   const endedAt = now;
   const startedAt = new Date(endedAt.getTime() - WINDOW_MS);
-  const [currentStatuses, historyRows] = await Promise.all([
-    loadCurrentReserveStatuses(db),
-    loadApyHistoryRows({ db, endedAt, startedAt }),
-  ]);
-  const baseStatuses = currentStatuses.filter(
-    (status) => !EXCLUDED_GRAPH_RESERVES.has(status.reserve)
-  );
+  const baseStatuses = (
+    currentStatuses ?? (await getCurrentSafeReserveApyStatuses(db))
+  ).filter((status) => !EXCLUDED_GRAPH_RESERVES.has(status.reserve));
   const series = createSeries(baseStatuses);
+  const historyRows = await loadApyHistoryRows({
+    db,
+    endedAt,
+    reserves: series.map((item) => item.reserve),
+    startedAt,
+  });
   const chartPoints = createChartPoints({
     endedAt,
     historyRows,
@@ -502,6 +494,13 @@ async function loadSafeReserveApyMonitorData(
   };
 
   return data;
+}
+
+export async function getSafeReserveApyMonitorDataFromStatuses(
+  currentStatuses: readonly SafeReserveApyStatusRow[],
+  now = new Date()
+): Promise<SafeReserveApyMonitorData> {
+  return loadSafeReserveApyMonitorData(now, currentStatuses);
 }
 
 export async function getSafeReserveApyMonitorData(
@@ -544,7 +543,9 @@ export async function getSafeReserveApyMonitorData(
 export async function getCurrentVerifiedReserveEligibilityByMint(): Promise<
   SafeReserveMintEligibilitySummary[]
 > {
-  const statuses = await loadCurrentReserveStatuses(getKaminoTimescaleDb());
+  const statuses = await getCurrentSafeReserveApyStatuses(
+    getKaminoTimescaleDb()
+  );
 
   return summarizeSafeReserveEligibilityByMint({
     stablecoins: EARN_STABLECOIN_DESCRIPTORS,

--- a/apps/admin/src/lib/kamino/timescale-reserve-client.server.ts
+++ b/apps/admin/src/lib/kamino/timescale-reserve-client.server.ts
@@ -21,7 +21,7 @@ import {
 } from "@/lib/kamino/timescale-reserve-monitor.shared";
 
 const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-const SAMPLE_INTERVAL_SECONDS = 5 * 60;
+const SAMPLE_INTERVAL_SECONDS = 30 * 60;
 const MIN_TOTAL_SUPPLY_USD = 100_000;
 const MAX_SUPPLY_APY = 0.5;
 export const VERIFIED_RESERVE_MAX_AGE_MS = 240 * 1000;
@@ -246,25 +246,36 @@ async function loadCurrentReserveStatuses(
 async function loadApyHistoryRows(args: {
   db: KaminoTimescaleDb;
   endedAt: Date;
-  reserves: readonly string[];
   startedAt: Date;
 }): Promise<HistoryRow[]> {
-  if (args.reserves.length === 0) {
-    return [];
-  }
-
-  const reserveIds = [...new Set(args.reserves)];
   const startIso = args.startedAt.toISOString();
   const endIso = args.endedAt.toISOString();
   const startTimestamp = sql.raw(
     `${toSqlStringLiteral(startIso)}::timestamptz`
   );
   const endTimestamp = sql.raw(`${toSqlStringLiteral(endIso)}::timestamptz`);
-  const reserveArray = sql.raw(toSqlTextArrayLiteral(reserveIds));
+  const stablecoinMints = sql.raw(
+    toSqlTextArrayLiteral(
+      EARN_STABLECOIN_DESCRIPTORS.map((descriptor) => descriptor.mint)
+    )
+  );
+  const safeMarkets = sql.raw(
+    toSqlTextArrayLiteral(
+      RISK_BASKET_MARKETS[RiskBasket.Safe].map((market) => market.toBase58())
+    )
+  );
+  const excludedReserves = sql.raw(
+    toSqlTextArrayLiteral([...EXCLUDED_GRAPH_RESERVES])
+  );
 
   const result = await args.db.execute(sql<HistoryRow>`
     WITH reserve_ids AS (
-      SELECT unnest(${reserveArray}) AS reserve
+      SELECT DISTINCT supported.reserve
+      FROM kamino.supported_reserves AS supported
+      WHERE supported.active = true
+        AND supported.liquidity_mint = ANY(${stablecoinMints})
+        AND supported.market = ANY(${safeMarkets})
+        AND supported.reserve <> ALL(${excludedReserves})
     ),
     previous_samples AS (
       SELECT
@@ -296,7 +307,7 @@ async function loadApyHistoryRows(args: {
         updates.reserve,
         updates.supply_apy
       FROM kamino.reserve_updates AS updates
-      WHERE updates.reserve = ANY(${reserveArray})
+      WHERE updates.reserve IN (SELECT reserve FROM reserve_ids)
         AND updates.observed_at >= ${startTimestamp}
         AND updates.observed_at <= ${endTimestamp}
         AND updates.reserve_last_update_stale = false
@@ -457,16 +468,14 @@ async function loadSafeReserveApyMonitorData(
   const db = getKaminoTimescaleDb();
   const endedAt = now;
   const startedAt = new Date(endedAt.getTime() - WINDOW_MS);
-  const baseStatuses = (await loadCurrentReserveStatuses(db)).filter(
+  const [currentStatuses, historyRows] = await Promise.all([
+    loadCurrentReserveStatuses(db),
+    loadApyHistoryRows({ db, endedAt, startedAt }),
+  ]);
+  const baseStatuses = currentStatuses.filter(
     (status) => !EXCLUDED_GRAPH_RESERVES.has(status.reserve)
   );
   const series = createSeries(baseStatuses);
-  const historyRows = await loadApyHistoryRows({
-    db,
-    endedAt,
-    reserves: series.map((item) => item.reserve),
-    startedAt,
-  });
   const chartPoints = createChartPoints({
     endedAt,
     historyRows,


### PR DESCRIPTION
## Goal

Make the admin pages load their real data faster. The charts must keep the same meaning and show every execution and funded vault, not a smaller sample.

## What changed

The admin was spending time on large database scans, repeated lookups, oversized object responses, and sequential RPC calls. This PR rewrites those reads so PostgreSQL does less repeated work, sends compact rows, loads table details only when someone opens them, and batches the autonomous-vault RPC work. It adds no cache and no new table.

An earlier version made the Rebalance response smaller by plotting a sample while still showing the full totals. That made the charts fast but wrong. This update removes that sampling: every execution and funded vault is sent to the chart again. The compact response format and separately loaded tables remain. It also fixes locale-dependent number formatting that caused React to throw away server-rendered content and rebuild it in the browser.

Expanded tables now request the selected stablecoin and reset when that filter changes, so they cannot retain rows from another mint. “Distinct users” is calculated from the actual filtered executions, so a wallet active in two stablecoins is counted once. If the first server-side monitoring load fails, the page still renders and hands control to the existing client loading/error state instead of showing a full-page Next.js error.

The routing-owned indexes used by these queries are in [loyal-yield-routing#73](https://github.com/loyal-labs/loyal-yield-routing/pull/73).

## Verification

- A read-only production-data check returned 6,515 chart execution rows for 6,515 summarized executions and 2,064 chart vault rows for 2,064 summarized vaults, with no route or mint mismatch.
- The authenticated exact-head Vercel check rendered all 6,507 selected same-mint execution dots and all 2,061 selected same-mint vault dots.
- The deployed check found 704 exact distinct same-mint users, zero wrong-mint rows in either expanded table, and zero stale tables after changing the stablecoin filter.
- The deployed page completed without browser errors, hydration failures, or a Next.js error overlay.
- Admin lint and `git diff --check` pass. Per repository instructions, no local frontend build was run.
- The authenticated deployed page needed about 5.6 seconds to render the complete charts. The chart is correct again, but the one-second performance goal is not met yet.

## Scope

Admin Earn, Rebalance, Autonomous Vault, rebalance-latency metrics, and push-notification data loading. No cache, copied schema, or new table is included.

## After merge

Deploy the admin, rerun the authenticated browser verifier against the deployed version, and compare a fresh HAR with production. Do not call the performance work complete until the pages show the full data near the one-second target.

Linear: ASK-1999
