### PR TITLE
feat(web): open earn autoswap enrollment via wildcard rollout

### DIFF
--- a/apps/web/src/lib/yield-optimization/earn-autoswap-rollout.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autoswap-rollout.server.test.ts
@@ -24,14 +24,22 @@ describe("Autoswap enrollment rollout", () => {
     expect(isEarnAutoswapEnrollmentEnabled(WALLET_B, env)).toBe(false);
   });
 
-  test("rejects wildcard rollout configuration", async () => {
+  test("wildcard opens enrollment to every wallet", async () => {
     const { isEarnAutoswapEnrollmentEnabled } = await import(
       "./earn-autoswap-rollout.server"
     );
+    const env = { EARN_AUTOSWAP_ENABLED_WALLETS: "*" };
 
+    expect(isEarnAutoswapEnrollmentEnabled(WALLET_A, env)).toBe(true);
+    expect(isEarnAutoswapEnrollmentEnabled(WALLET_B, env)).toBe(true);
+    expect(
+      isEarnAutoswapEnrollmentEnabled(WALLET_A, {
+        EARN_AUTOSWAP_ENABLED_WALLETS: " * ",
+      })
+    ).toBe(true);
     expect(() =>
       isEarnAutoswapEnrollmentEnabled(WALLET_A, {
-        EARN_AUTOSWAP_ENABLED_WALLETS: "*",
+        EARN_AUTOSWAP_ENABLED_WALLETS: `*,${WALLET_A}`,
       })
     ).toThrow("invalid wallet");
   });

--- a/apps/web/src/lib/yield-optimization/earn-autoswap-rollout.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autoswap-rollout.server.ts
@@ -19,6 +19,9 @@ export function isEarnAutoswapEnrollmentEnabled(
   if (!raw) {
     return false;
   }
+  if (raw === "*") {
+    return true;
+  }
   const entries = raw.split(",").map((entry) => entry.trim());
   if (entries.some((entry) => entry.length === 0)) {
     throw new Error(`${AUTOSWAP_WALLETS_ENV} contains an empty wallet entry.`);


### PR DESCRIPTION
Supports EARN_AUTOSWAP_ENABLED_WALLETS="*" to open Earn autoswap enrollment to all wallets; allowlist/fail-closed behavior unchanged. Linear: ASK-2197