### PR TITLE
fix(observability): classify wallet account mismatch as info

### DIFF
--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -166,6 +166,9 @@ export const LIFECYCLE_ERROR_CODES = [
   // A stored Mobile Wallet Adapter authorization was revoked. The app clears
   // it and sends the user through reconnect; no backend request was made.
   "wallet_authorization_expired",
+  // MWA reauthorized a different account than the one stored by Loyal. The
+  // app clears the stale account and tells the user to reconnect it.
+  "wallet_account_mismatch",
   // The wallet could not produce a signature. Distinct from
   // `invalid_wallet_signature`, which means a signature was produced and the
   // backend rejected it during verification.

--- a/apps/web/src/features/observability/otlp.test.ts
+++ b/apps/web/src/features/observability/otlp.test.ts
@@ -39,6 +39,7 @@ function severityText(event: NormalizedLifecycleEvent): string | undefined {
 
 describe("lifecycle alert severity", () => {
   test.each([
+    "wallet_account_mismatch",
     "wallet_authorization_expired",
     "wallet_connection_failed",
     "wallet_connection_timeout",
@@ -101,6 +102,22 @@ describe("lifecycle alert severity", () => {
   });
 
   test.each([
+    {
+      errorCode: "wallet_account_mismatch" as const,
+      recoveryRequired: true,
+    },
+    {
+      errorCode: "wallet_account_mismatch" as const,
+      persistenceState: "failed" as const,
+    },
+    {
+      chainState: "failed" as const,
+      errorCode: "wallet_account_mismatch" as const,
+    },
+    {
+      errorCode: "wallet_account_mismatch" as const,
+      httpStatus: 503,
+    },
     { errorCode: "wallet_authorization_expired" as const, httpStatus: 503 },
     {
       errorCode: "wallet_connection_failed" as const,

--- a/apps/web/src/features/observability/otlp.ts
+++ b/apps/web/src/features/observability/otlp.ts
@@ -32,6 +32,7 @@ function toUnixNano(timestamp: string): string {
 }
 
 const EXPECTED_LOCAL_WALLET_FAILURES = new Set([
+  "wallet_account_mismatch",
   "wallet_authorization_expired",
   "wallet_connection_failed",
   "wallet_connection_timeout",


### PR DESCRIPTION
## Goal

Stop paging on-call when the mobile app reconnects to a different wallet account. The app already clears the stale wallet connection and tells the user exactly how to recover, so this is useful product telemetry rather than a service outage.

## Alert fixed

```text
earn.withdrawal.prepare.failed
error_code: unexpected_error

[flow_id=ae7e1cb2-b4b6-47b4-a790-c5e9515a5216 flow_name=earn.withdrawal flow_stage=prepare] Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.
```

## What changed

The ingest contract now accepts `wallet_account_mismatch`. A normal failure with this code is recorded at INFO, so it stays searchable in ClickStack but does not enter the broad Errors alert.

We still emit ERROR when the same event says recovery is required, chain or persistence work failed, or a server returned 5xx. Unknown and unexpected failures also remain alertable.

## Scope

Only the lifecycle contract, severity policy, and focused policy tests changed. The Errors saved search and unrelated alert rules are unchanged.

## Verification

- Focused observability policy: 24 tests passed.
- `wallet_account_mismatch` is INFO in the normal case.
- Recovery-required, chain/persistence failure, and HTTP 5xx cases remain ERROR.
- Scoped repository formatting and `git diff --check` passed.
- Verifier: `OVERALL: PASS`.
- No frontend build was run.

## Post-merge

Deploy this contract first. Then merge and release mobile PR [#689](https://github.com/loyal-labs/loyal-app/pull/689) so the new OTA code is accepted as soon as devices send it.

Linear: ASK-2182
