### PR TITLE
fix(mobile): classify reauthorized account mismatch

### DIFF
--- a/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -278,7 +278,7 @@ describe("MWA session error classification", () => {
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps a reauthorized account mismatch alertable", async () => {
+    it("classifies a reauthorized account mismatch and preserves recovery", async () => {
       const otherPublicKey = PublicKey.unique();
       mockTransact.mockImplementation(
         async (callback: (wallet: unknown) => unknown) =>
@@ -298,8 +298,12 @@ describe("MWA session error classification", () => {
 
       const error = await failureOf(signer().signMessage(new Uint8Array([1])));
 
-      expect(error).toBeInstanceOf(Error);
-      expect(error).not.toBeInstanceOf(WalletSessionError);
+      expect(error).toBeInstanceOf(WalletSessionError);
+      expect(error).toMatchObject({
+        failure: "account_mismatch",
+        message:
+          "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
+      });
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
   });

--- a/mobile/src/lib/wallet/mwa-signer.ts
+++ b/mobile/src/lib/wallet/mwa-signer.ts
@@ -33,9 +33,6 @@ const APP_IDENTITY = {
 const MWA_CHAIN =
   env.solanaEnv === "mainnet" ? "solana:mainnet" : "solana:devnet";
 
-const RECONNECT_MESSAGE =
-  "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.";
-
 const SIGNING_CANCELLED_MESSAGE =
   "Signing was cancelled in your wallet app. Try again and approve each prompt without switching apps or locking the screen.";
 
@@ -370,7 +367,7 @@ export class MwaSigner implements Signer {
         // to `request_failed` — naming an HTTP failure for a call that never
         // reached the network, and leaving the stale token in place so every
         // retry failed identically (ASK-1872 follow-up).
-        throw await this.forgetAuthorization(error);
+        throw await this.forgetAuthorization("authorization_expired", error);
       }
       // Only session-layer rejections become wallet-session failures. Protocol
       // errors, `reauthorize`'s reconnect instructions and our signature checks
@@ -389,16 +386,12 @@ export class MwaSigner implements Signer {
    * connected wallet whose every signature is refused, and the user has no way
    * to reach the reconnect flow from inside the failing screen.
    */
-  private async forgetAuthorization(cause?: unknown): Promise<Error> {
+  private async forgetAuthorization(
+    failure: "account_mismatch" | "authorization_expired",
+    cause?: unknown,
+  ): Promise<WalletSessionError> {
     await clearMwaAccount();
-    if (cause !== undefined) {
-      return new WalletSessionError(
-        "authorization_expired",
-        errorCodeOf(cause),
-        cause,
-      );
-    }
-    return new Error(RECONNECT_MESSAGE);
+    return new WalletSessionError(failure, errorCodeOf(cause), cause);
   }
 
   private async reauthorize(wallet: Web3MobileWallet): Promise<void> {
@@ -413,12 +406,12 @@ export class MwaSigner implements Signer {
       // ERROR_AUTHORIZATION_FAILED: the wallet revoked our authorization
       // (the user disconnected this app). Transient session errors rethrow.
       if (!hasErrorCode(error, -1)) throw error;
-      throw await this.forgetAuthorization(error);
+      throw await this.forgetAuthorization("authorization_expired", error);
     }
     const base64Address = toBase64Address(this.publicKey);
     if (!result.accounts.some((a) => a.address === base64Address)) {
       // The wallet reauthorized a different account than the one connected.
-      throw await this.forgetAuthorization();
+      throw await this.forgetAuthorization("account_mismatch");
     }
     if (result.auth_token !== this.authToken) {
       this.authToken = result.auth_token;

--- a/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/mobile/src/lib/wallet/wallet-session-error.ts
@@ -22,6 +22,8 @@
 export type WalletSessionFailure =
   /** The wallet revoked the stored authorization; reconnect is required. */
   | "authorization_expired"
+  /** The wallet reauthorized a different account; reconnect is required. */
+  | "account_mismatch"
   /** No MWA-capable wallet app is installed. */
   | "unavailable"
   /** The wallet app never connected back — the session never opened. */
@@ -35,6 +37,8 @@ export type WalletSessionFailure =
 // from the reason: telling someone to update a wallet app that simply was not
 // running sends them down the wrong path.
 const WALLET_SESSION_MESSAGES: Record<WalletSessionFailure, string> = {
+  account_mismatch:
+    "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   authorization_expired:
     "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   connection_failed:

--- a/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -170,6 +170,9 @@ describe("wallet session classification", () => {
     expect(
       mapLifecycleErrorCode(new WalletSessionError("authorization_expired")),
     ).toBe("wallet_authorization_expired");
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("account_mismatch")),
+    ).toBe("wallet_account_mismatch");
   });
 
   // The native module's own codes must not leak through the generic probe.
@@ -220,6 +223,23 @@ describe("wallet session classification", () => {
     });
     expect(JSON.stringify(sent[0])).not.toContain("authorization request failed");
     expect(sent[0]).not.toHaveProperty("httpStatus");
+  });
+
+  it("emits only the bounded account-mismatch lifecycle event", () => {
+    const sent = captureEnvelopes();
+    startLifecycleFlow({
+      flowName: "earn.withdrawal",
+      flowVariant: "partial",
+      reportUnexpectedErrors: true,
+    }).failFrom("prepare", new WalletSessionError("account_mismatch"));
+
+    expect(sent).toEqual([
+      expect.objectContaining({
+        outcome: "failed",
+        errorCode: "wallet_account_mismatch",
+      }),
+    ]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mobile/src/services/observability.ts
+++ b/mobile/src/services/observability.ts
@@ -357,6 +357,7 @@ type LifecycleErrorCode =
   | "send_failed"
   | "insufficient_native_sol"
   | "wallet_rejected"
+  | "wallet_account_mismatch"
   | "wallet_authorization_expired"
   | "wallet_unavailable"
   | "wallet_connection_failed"
@@ -459,6 +460,7 @@ const WALLET_SESSION_ERROR_CODES: Record<
   WalletSessionFailure,
   LifecycleErrorCode
 > = {
+  account_mismatch: "wallet_account_mismatch",
   authorization_expired: "wallet_authorization_expired",
   connection_failed: "wallet_connection_failed",
   signing_failed: "wallet_signing_failed",


### PR DESCRIPTION
## Goal

Name the already-handled Mobile Wallet Adapter account mismatch correctly. The user keeps the same reconnect message and the app still clears the stale authorization, but telemetry should say `wallet_account_mismatch` instead of reporting an unexpected app error.

## Alert fixed

```text
earn.withdrawal.prepare.failed
error_code: unexpected_error

[flow_id=ae7e1cb2-b4b6-47b4-a790-c5e9515a5216 flow_name=earn.withdrawal flow_stage=prepare] Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.
```

## What changed

When reauthorization returns a different account, the signer now throws a bounded `account_mismatch` wallet-session error after clearing the stored MWA account. Lifecycle telemetry maps that to `wallet_account_mismatch` and does not send the duplicate unexpected-error record.

The recovery text is unchanged:

```text
Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.
```

## Scope

Only the MWA signer, its wallet-session error contract, mobile lifecycle mapping, and focused contract tests changed. There are no API, database, alert-query, or UI changes.

## Verification

- Focused mobile wallet/lifecycle suites: 35 tests passed.
- Full Expo lint: 0 errors; 9 existing warnings.
- Mobile TypeScript check passed.
- The mismatch clears authorization once, keeps the exact message, emits one lifecycle record with `wallet_account_mismatch`, and emits no duplicate exception record.
- `git diff --check` passed.
- Verifier: `OVERALL: PASS`.
- No Expo dev server or frontend build was run.

## Post-merge

Merge and deploy main ingest-contract PR [#688](https://github.com/loyal-labs/loyal-app/pull/688) first. Then merge this PR to `ask-1355-mobile-earn-tab`, publish the OTA update, and confirm the next occurrence is INFO and absent from the Errors alert.

Linear: ASK-2182
