### PR TITLE
fix(mobile): port wallet authorization recovery to main

### DIFF
--- a/apps/mobile/scripts/verify-mwa-authorization-e2e.ts
+++ b/apps/mobile/scripts/verify-mwa-authorization-e2e.ts
@@ -1,0 +1,588 @@
+import assert from "node:assert/strict";
+import {
+  accessSync,
+  constants,
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+
+const APP_PACKAGE = "com.loyal.app.dev";
+const APP_SCHEME = "loyal-dev";
+const DEFAULT_AVD = "SkyVerse_API_35";
+const DEFAULT_METRO_PORT = 8082;
+const DEFAULT_PROXY_PORT = 4320;
+const PUBLIC_KEY = "11111111111111111111111111111111";
+const ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const AUTH_TOKEN = "fixture-auth-token";
+const RECONNECT_MESSAGE =
+  "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.";
+const UI_XML = "/sdcard/loyal-mwa-authorization-ui.xml";
+type LifecycleEvent = {
+  flowName?: string;
+  stage?: string;
+  outcome?: string;
+  errorCode?: string;
+  httpStatus?: number;
+  [key: string]: unknown;
+};
+type UiNode = {
+  bounds: [number, number, number, number];
+  contentDescription: string;
+  text: string;
+};
+
+const avd = process.env.MOBILE_MWA_AUTHORIZATION_AVD ?? DEFAULT_AVD;
+const metroPort = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_METRO_PORT ?? DEFAULT_METRO_PORT
+);
+const proxyPort = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_PROXY_PORT ?? DEFAULT_PROXY_PORT
+);
+const timeoutMs = Number(
+  process.env.MOBILE_MWA_AUTHORIZATION_TIMEOUT_MS ?? "600000"
+);
+const tempRoot = mkdtempSync(join(tmpdir(), "loyal-mwa-authorization-"));
+const logPath = join(tempRoot, "processes.log");
+const log = createWriteStream(logPath, { flags: "a" });
+const children: ChildProcess[] = [];
+const snapshots: Array<{ path: string; source: string }> = [];
+const lifecycleEvents: LifecycleEvent[] = [];
+const unexpectedRequests: string[] = [];
+const moduleBuildPaths = [
+  resolve(import.meta.dir, "../modules/expo-seed-vault/android/build"),
+];
+const generatedModuleBuildPaths = moduleBuildPaths.filter(
+  (path) => !existsSync(path)
+);
+let serial: string | null = null;
+let ownsEmulator = false;
+let ownsAndroid = false;
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; quiet?: boolean } = {}
+): string {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? resolve(import.meta.dir, ".."),
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    stdio: options.quiet ? "pipe" : ["pipe", "inherit", "inherit"],
+  });
+  if (result.status !== 0)
+    throw new Error(
+      `${command} exited with status ${String(result.status)}${
+        options.quiet && result.stderr ? `: ${result.stderr.trim()}` : ""
+      }`
+    );
+  return options.quiet ? result.stdout.trim() : "";
+}
+
+function start(
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}
+): ChildProcess {
+  const child = spawn(command, args, {
+    cwd: options.cwd ?? resolve(import.meta.dir, ".."),
+    env: options.env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(log);
+  child.stderr?.pipe(log);
+  children.push(child);
+  return child;
+}
+
+async function waitFor<T>(
+  description: string,
+  read: () => T | false | Promise<T | false>,
+  limitMs = 120_000
+): Promise<T> {
+  const deadline = Date.now() + limitMs;
+  while (Date.now() < deadline) {
+    try {
+      const value = await read();
+      if (value) return value;
+    } catch {
+      /* retry */
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(`Timed out waiting for ${description}.`);
+}
+
+function executable(candidates: string[], label: string): string {
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      /* next */
+    }
+  }
+  throw new Error(`${label} executable was not found.`);
+}
+
+const sdk =
+  process.env.ANDROID_HOME ??
+  process.env.ANDROID_SDK_ROOT ??
+  "/opt/homebrew/share/android-commandlinetools";
+const adb = executable(
+  [
+    join(sdk, "platform-tools/adb"),
+    "/opt/homebrew/bin/adb",
+    "/opt/homebrew/share/android-commandlinetools/platform-tools/adb",
+  ],
+  "ADB"
+);
+const emulator = executable(
+  [
+    join(sdk, "emulator/emulator"),
+    "/opt/homebrew/share/android-commandlinetools/emulator/emulator",
+  ],
+  "Android emulator"
+);
+function adbRun(args: string[]): string {
+  assert.ok(serial);
+  return run(adb, ["-s", serial, ...args], { quiet: true });
+}
+function connected(): string | null {
+  for (const line of run(adb, ["devices"], { quiet: true })
+    .split("\n")
+    .slice(1)) {
+    const [name, state] = line.trim().split(/\s+/, 2);
+    if (name?.startsWith("emulator-") && state === "device") return name;
+  }
+  return null;
+}
+async function ensureEmulator(): Promise<void> {
+  serial = connected();
+  if (serial) return;
+  start(emulator, [
+    "-avd",
+    avd,
+    "-no-window",
+    "-no-audio",
+    "-no-boot-anim",
+    "-gpu",
+    "swiftshader_indirect",
+  ]);
+  ownsEmulator = true;
+  serial = await waitFor("the emulator", () => connected() ?? false, 180_000);
+  await waitFor(
+    "Android boot completion",
+    () => adbRun(["shell", "getprop", "sys.boot_completed"]) === "1",
+    180_000
+  );
+}
+
+function envForVerifier(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ANDROID_HOME: sdk,
+    ANDROID_SDK_ROOT: sdk,
+    APP_VARIANT: "development",
+    EXPO_PUBLIC_API_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+    EXPO_PUBLIC_EARN_API_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+    EXPO_PUBLIC_MWA_AUTHORIZATION_E2E: "1",
+    EXPO_PUBLIC_SOLANA_ENV: "devnet",
+    JAVA_HOME:
+      process.env.JAVA_HOME ??
+      "/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home",
+  };
+}
+
+function replaceSource(path: string, source: string): void {
+  snapshots.push({ path, source: readFileSync(path, "utf8") });
+  writeFileSync(path, source);
+}
+function patchSource(path: string, marker: string, replacement: string): void {
+  const source = readFileSync(path, "utf8");
+  assert.equal(
+    source.split(marker).length - 1,
+    1,
+    `Expected one marker in ${path}`
+  );
+  snapshots.push({ path, source });
+  writeFileSync(path, source.replace(marker, replacement));
+}
+function addSource(path: string, source: string): void {
+  assert.equal(existsSync(path), false, `Temporary route exists: ${path}`);
+  snapshots.push({ path, source: "" });
+  writeFileSync(path, source);
+}
+
+function installFixture(): void {
+  patchSource(
+    resolve(import.meta.dir, "../src/lib/wallet/mwa-signer.ts"),
+    `async function getMwa() {\n  return import("@solana-mobile/mobile-wallet-adapter-protocol-web3js");\n}`,
+    `async function getMwa() {
+  if (process.env.EXPO_PUBLIC_MWA_AUTHORIZATION_E2E === "1") {
+    const fixture = {
+      authorize: async () => ({ accounts: [{ address: "${ADDRESS}" }], auth_token: "${AUTH_TOKEN}" }),
+      signMessages: async () => { throw { code: -1, message: "authorization request failed" }; },
+      signTransactions: async () => { throw { code: -1, message: "authorization request failed" }; },
+    };
+    return { transact: async (callback: (wallet: typeof fixture) => unknown) => callback(fixture) } as never;
+  }
+  return import("@solana-mobile/mobile-wallet-adapter-protocol-web3js");
+}`
+  );
+  patchSource(
+    resolve(import.meta.dir, "../src/lib/solana/earn/withdraw.ts"),
+    `  await assertSolForFees(\n    getConnection(),\n    args.signer.publicKey,\n    WITHDRAW_MIN_FEE_LAMPORTS,\n  ).catch((error) => {\n    flow.failFrom("prepare", error);\n    throw error;\n  });`,
+    `  if (process.env.EXPO_PUBLIC_MWA_AUTHORIZATION_E2E !== "1") {
+    await assertSolForFees(getConnection(), args.signer.publicKey, WITHDRAW_MIN_FEE_LAMPORTS).catch((error) => {
+      flow.failFrom("prepare", error);
+      throw error;
+    });
+  }`
+  );
+  replaceSource(
+    resolve(import.meta.dir, "../app/_layout.tsx"),
+    `import "@/global.css";\nimport { Stack } from "expo-router";\nexport default function RootLayout() { return <Stack initialRouteName="mwa-authorization-e2e" screenOptions={{ headerShown: false }} />; }\n`
+  );
+  replaceSource(
+    resolve(import.meta.dir, "../app/(tabs)/_layout.tsx"),
+    `import { Redirect } from "expo-router";\nexport default function TabsLayout() { return <Redirect href="/mwa-authorization-e2e" />; }\n`
+  );
+  const cmakePath = resolve(
+    import.meta.dir,
+    "../node_modules/react-native-reanimated/android/CMakeLists.txt"
+  );
+  const cmakeMarker =
+    '"${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"';
+  if (existsSync(cmakePath)) {
+    const cmake = readFileSync(cmakePath, "utf8");
+    if (cmake.includes(cmakeMarker)) {
+      patchSource(
+        cmakePath,
+        cmakeMarker,
+        '"${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/prefab_package/${BUILD_TYPE}/prefab/modules/worklets/libs/android.${ANDROID_ABI}/libworklets.so"'
+      );
+    }
+  }
+  addSource(
+    resolve(import.meta.dir, "../app/mwa-authorization-e2e.tsx"),
+    `import { useEffect, useRef, useState } from "react";
+import { Text, View } from "react-native";
+import { executeEarnWithdraw } from "@/lib/solana/earn/withdraw";
+import { loadMwaAccount, storeMwaAccount } from "@/lib/wallet/mwa-account-storage";
+import { MwaSigner } from "@/lib/wallet/mwa-signer";
+const PUBLIC_KEY = "${PUBLIC_KEY}";
+const AUTH_TOKEN = "${AUTH_TOKEN}";
+const EXPECTED = ${JSON.stringify(RECONNECT_MESSAGE)};
+const account = { authToken: AUTH_TOKEN, publicKey: PUBLIC_KEY, label: "MWA E2E fixture" };
+export default function MwaAuthorizationE2e() {
+  const ran = useRef(false);
+  const [result, setResult] = useState("MWA E2E starting");
+  const [storage, setStorage] = useState("account pending");
+  const [code, setCode] = useState("error code pending");
+  const [copy, setCopy] = useState("reconnect copy pending");
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    void (async () => {
+      await storeMwaAccount(account);
+      let authError: unknown;
+      try { await executeEarnWithdraw({ signer: new MwaSigner(AUTH_TOKEN, PUBLIC_KEY), amountUsd: 1, mode: "full" }); }
+      catch (error) { authError = error; }
+      const auth = authError as { failure?: string; message?: string };
+      const authCleared = (await loadMwaAccount()) === null;
+      await storeMwaAccount(account);
+      let txError: unknown;
+      try { await new MwaSigner(AUTH_TOKEN, PUBLIC_KEY).signAllTransactions([]); }
+      catch (error) { txError = error; }
+      const tx = txError as { failure?: string };
+      const txCleared = (await loadMwaAccount()) === null;
+      const passed = auth.failure === "authorization_expired" && auth.message === EXPECTED && tx.failure === "authorization_expired" && authCleared && txCleared;
+      setStorage(passed ? "MWA account cleared" : "MWA account NOT cleared");
+      setCode(passed ? "wallet_authorization_expired" : "unexpected error code");
+      setCopy(auth.message === EXPECTED ? EXPECTED : "unexpected reconnect message");
+      setResult(passed ? "MWA E2E PASS" : "MWA E2E FAIL");
+    })().catch((error: unknown) => setResult(\`MWA E2E FAIL: \${error instanceof Error ? error.message : String(error)}\`));
+  }, []);
+  return <View style={{ flex: 1, paddingTop: 80, paddingHorizontal: 24 }}><Text accessible accessibilityLabel={result}>{result}</Text><Text accessible accessibilityLabel={storage}>{storage}</Text><Text accessible accessibilityLabel={code}>{code}</Text><Text accessible accessibilityLabel={copy}>{copy}</Text></View>;
+}
+`
+  );
+}
+
+function restoreSources(): void {
+  for (const snapshot of snapshots.reverse()) {
+    if (snapshot.source === "") rmSync(snapshot.path, { force: true });
+    else writeFileSync(snapshot.path, snapshot.source);
+  }
+  snapshots.length = 0;
+}
+function decodeXml(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+function dumpUi(): UiNode[] {
+  adbRun(["shell", "uiautomator", "dump", UI_XML]);
+  const xml = adbRun(["exec-out", "cat", UI_XML]);
+  const nodes: UiNode[] = [];
+  for (const match of xml.matchAll(/<node\s+([^>]+)\/?/g)) {
+    const attrs = new Map<string, string>();
+    for (const attr of match[1].matchAll(/([\w-]+)="([^"]*)"/g))
+      attrs.set(attr[1], decodeXml(attr[2]));
+    const bounds = attrs
+      .get("bounds")
+      ?.match(/^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$/);
+    if (bounds)
+      nodes.push({
+        bounds: [
+          Number(bounds[1]),
+          Number(bounds[2]),
+          Number(bounds[3]),
+          Number(bounds[4]),
+        ],
+        contentDescription: attrs.get("content-desc") ?? "",
+        text: attrs.get("text") ?? "",
+      });
+  }
+  return nodes;
+}
+function node(label: string): UiNode | null {
+  const nodes = dumpUi();
+  return (
+    nodes.find((item) => item.contentDescription === label) ??
+    nodes.find((item) => item.text === label) ??
+    null
+  );
+}
+async function waitForNode(
+  label: string,
+  limitMs = timeoutMs
+): Promise<UiNode> {
+  return waitFor(`UI node ${label}`, () => node(label) ?? false, limitMs);
+}
+async function openDevClient(): Promise<void> {
+  const intro = await waitFor(
+    "development client",
+    () =>
+      node("Continue") ?? node("Close") ?? node("MWA E2E starting") ?? false,
+    180_000
+  );
+  if (
+    intro.text === "MWA E2E starting" ||
+    intro.contentDescription === "MWA E2E starting"
+  )
+    return;
+  const [left, top, right, bottom] = intro.bounds;
+  adbRun([
+    "shell",
+    "input",
+    "tap",
+    String(Math.round((left + right) / 2)),
+    String(Math.round((top + bottom) / 2)),
+  ]);
+  if (intro.text === "Continue" || intro.contentDescription === "Continue") {
+    const close = await waitForNode("Close", 30_000).catch(() => null);
+    if (close) {
+      const [l, t, r, b] = close.bounds;
+      adbRun([
+        "shell",
+        "input",
+        "tap",
+        String(Math.round((l + r) / 2)),
+        String(Math.round((t + b) / 2)),
+      ]);
+    }
+  }
+}
+
+function proxy(): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: proxyPort,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/observability/mobile/events"
+      ) {
+        const event = (await request
+          .json()
+          .catch(() => null)) as LifecycleEvent | null;
+        if (event?.flowName === "earn.withdrawal") lifecycleEvents.push(event);
+        return Response.json({ accepted: true }, { status: 202 });
+      }
+      unexpectedRequests.push(`${request.method} ${url.pathname}`);
+      return Response.json({ accepted: false }, { status: 500 });
+    },
+  });
+}
+
+async function main(): Promise<void> {
+  assert.ok(Number.isFinite(timeoutMs) && timeoutMs > 0);
+  const localProxy = proxy();
+  const env = envForVerifier();
+  try {
+    installFixture();
+    await ensureEmulator();
+    const android = resolve(import.meta.dir, "../android");
+    if (!existsSync(android)) {
+      ownsAndroid = true;
+      run("npx", ["expo", "prebuild", "--platform", "android", "--clean"], {
+        env,
+      });
+    }
+    const abi = adbRun(["shell", "getprop", "ro.product.cpu.abi"]);
+    assert.match(abi, /^[a-z0-9_-]+$/i);
+    run(
+      "./gradlew",
+      [
+        "app:assembleDebug",
+        "--no-parallel",
+        `-PreactNativeArchitectures=${abi}`,
+      ],
+      { cwd: android, env }
+    );
+    adbRun([
+      "install",
+      "-r",
+      join(android, "app/build/outputs/apk/debug/app-debug.apk"),
+    ]);
+    adbRun(["shell", "pm", "clear", APP_PACKAGE]);
+    adbRun(["reverse", `tcp:${metroPort}`, `tcp:${metroPort}`]);
+    adbRun(["reverse", `tcp:${proxyPort}`, `tcp:${proxyPort}`]);
+    const metro = start(
+      "npx",
+      [
+        "expo",
+        "start",
+        "--dev-client",
+        "--localhost",
+        "--clear",
+        "--port",
+        String(metroPort),
+      ],
+      { env }
+    );
+    await waitFor(
+      "Metro",
+      async () =>
+        metro.exitCode === null &&
+        (await fetch(`http://127.0.0.1:${metroPort}/status`)
+          .then((response) => response.ok)
+          .catch(() => false)),
+      180_000
+    );
+    const devUrl = `${APP_SCHEME}://expo-development-client/?url=${encodeURIComponent(
+      `http://127.0.0.1:${metroPort}`
+    )}`;
+    adbRun([
+      "shell",
+      "am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      devUrl,
+      APP_PACKAGE,
+    ]);
+    await openDevClient();
+    adbRun([
+      "shell",
+      "am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      `${APP_SCHEME}:///mwa-authorization-e2e`,
+      APP_PACKAGE,
+    ]);
+    await waitForNode("MWA E2E PASS");
+    await waitForNode("MWA account cleared");
+    await waitForNode("wallet_authorization_expired");
+    await waitForNode(RECONNECT_MESSAGE);
+    const event = await waitFor(
+      "failed withdrawal lifecycle event",
+      () =>
+        lifecycleEvents.find(
+          (item) =>
+            item.flowName === "earn.withdrawal" &&
+            item.stage === "prepare" &&
+            item.outcome === "failed"
+        ) ?? false
+    );
+    assert.equal(event.errorCode, "wallet_authorization_expired");
+    assert.equal(event.httpStatus, undefined);
+    assert.doesNotMatch(JSON.stringify(event), /authorization request failed/);
+    assert.equal(
+      Object.values(event).some((value) => value === -1 || value === "-1"),
+      false
+    );
+    assert.deepEqual(unexpectedRequests, []);
+    console.info(
+      JSON.stringify(
+        {
+          accountCleared: true,
+          backendOrRpcRequests: 0,
+          errorCode: event.errorCode,
+          nativeContentLeaked: false,
+          ui: "MWA E2E PASS",
+        },
+        null,
+        2
+      )
+    );
+  } finally {
+    localProxy.stop(true);
+  }
+}
+
+function cleanup(): void {
+  for (const child of children.reverse())
+    if (child.exitCode === null) child.kill("SIGTERM");
+  if (serial) {
+    spawnSync(adb, ["-s", serial, "shell", "pm", "clear", APP_PACKAGE], {
+      stdio: "ignore",
+    });
+    spawnSync(adb, ["-s", serial, "reverse", "--remove", `tcp:${metroPort}`], {
+      stdio: "ignore",
+    });
+    spawnSync(adb, ["-s", serial, "reverse", "--remove", `tcp:${proxyPort}`], {
+      stdio: "ignore",
+    });
+    spawnSync(adb, ["-s", serial, "shell", "rm", "-f", UI_XML], {
+      stdio: "ignore",
+    });
+  }
+  if (ownsEmulator && serial)
+    spawnSync(adb, ["-s", serial, "emu", "kill"], { stdio: "ignore" });
+  restoreSources();
+  if (ownsAndroid)
+    rmSync(resolve(import.meta.dir, "../android"), {
+      recursive: true,
+      force: true,
+    });
+  for (const path of generatedModuleBuildPaths)
+    rmSync(path, { recursive: true, force: true });
+  log.end();
+}
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error(`Process logs: ${logPath}`);
+  process.exitCode = 1;
+} finally {
+  cleanup();
+  if (process.exitCode !== 1)
+    rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -278,7 +278,7 @@ describe("MWA session error classification", () => {
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps a reauthorized account mismatch alertable", async () => {
+    it("classifies a reauthorized account mismatch and preserves recovery", async () => {
       const otherPublicKey = PublicKey.unique();
       mockTransact.mockImplementation(
         async (callback: (wallet: unknown) => unknown) =>
@@ -298,8 +298,12 @@ describe("MWA session error classification", () => {
 
       const error = await failureOf(signer().signMessage(new Uint8Array([1])));
 
-      expect(error).toBeInstanceOf(Error);
-      expect(error).not.toBeInstanceOf(WalletSessionError);
+      expect(error).toBeInstanceOf(WalletSessionError);
+      expect(error).toMatchObject({
+        failure: "account_mismatch",
+        message:
+          "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
+      });
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
   });

--- a/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/mwa-session-error.test.ts
@@ -52,6 +52,10 @@ function codedError(code: string | number, message = "native failure"): Error {
   return Object.assign(new Error(message), { code });
 }
 
+function plainCodedError(code: string | number, message = "native failure") {
+  return { code, message };
+}
+
 const publicKey = PublicKey.unique().toBase58();
 const authToken = "auth-token";
 
@@ -227,37 +231,75 @@ describe("MWA session error classification", () => {
   // stale token survived. One user retried 41 times over six hours against the
   // same dead token, with 904 USDC stranded, and never saw a reconnect prompt.
   describe("authorization revoked mid-session (ERROR_AUTHORIZATION_FAILED)", () => {
-    it("tells the user to reconnect instead of reporting a request failure", async () => {
-      failAfterSession(codedError(-1, "-1/authorization request failed"));
+    it("recovers a plain native rejection and retains it only as the cause", async () => {
+      const nativeError = plainCodedError(-1, "authorization request failed");
+      failAfterSession(nativeError);
 
       const error = await failureOf(signer().signMessage(new Uint8Array([1])));
 
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toBe(
-        "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
-      );
-      // A surviving `code` is precisely what routed this to `request_failed`.
+      expect(error).toMatchObject({
+        failure: "authorization_expired",
+        walletCode: -1,
+        cause: nativeError,
+      });
+      expect((error as Error).message).toMatch(/reconnect your wallet/);
       expect(error).not.toHaveProperty("code");
-    });
-
-    // Without this the app keeps showing a connected wallet that cannot sign,
-    // so every retry repeats the same failure and the user is stuck.
-    it("clears the dead authorization so the next launch can reconnect", async () => {
-      failAfterSession(codedError(-1, "-1/authorization request failed"));
-
-      await failureOf(signer().signMessage(new Uint8Array([1])));
-
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
 
     // Signing transactions goes through the same session wrapper, so a fix
     // that only covered `signMessage` would still strand the send path.
-    it("recovers the same way when signing transactions", async () => {
-      failAfterSession(codedError(-1, "-1/authorization request failed"));
+    it("recovers a plain rejection when signing transactions", async () => {
+      failAfterSession(plainCodedError(-1, "authorization request failed"));
 
       const error = await failureOf(signer().signAllTransactions([]));
 
-      expect((error as Error).message).toMatch(/reconnect your wallet/);
+      expect(error).toMatchObject({ failure: "authorization_expired" });
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers a plain rejection during token reauthorization", async () => {
+      const nativeError = plainCodedError(-1, "authorization request failed");
+      mockTransact.mockImplementation(
+        async (callback: (wallet: unknown) => unknown) =>
+          callback({
+            authorize: async () => {
+              throw nativeError;
+            },
+          }),
+      );
+
+      const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(error).toMatchObject({
+        failure: "authorization_expired",
+        cause: nativeError,
+      });
+      expect(clearMwaAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a reauthorized account mismatch alertable", async () => {
+      const otherPublicKey = PublicKey.unique();
+      mockTransact.mockImplementation(
+        async (callback: (wallet: unknown) => unknown) =>
+          callback({
+            authorize: async () => ({
+              accounts: [
+                {
+                  address: Buffer.from(otherPublicKey.toBytes()).toString(
+                    "base64",
+                  ),
+                },
+              ],
+              auth_token: authToken,
+            }),
+          }),
+      );
+
+      const error = await failureOf(signer().signMessage(new Uint8Array([1])));
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(WalletSessionError);
       expect(clearMwaAccount).toHaveBeenCalledTimes(1);
     });
   });

--- a/apps/mobile/src/lib/wallet/mwa-signer.ts
+++ b/apps/mobile/src/lib/wallet/mwa-signer.ts
@@ -58,19 +58,20 @@ async function getMwa() {
   return import("@solana-mobile/mobile-wallet-adapter-protocol-web3js");
 }
 
-// SolanaMobileWalletAdapter(Protocol)Error instances carry a `code` — string
-// for session-level errors, negative number for wallet protocol errors.
-// Property check instead of instanceof avoids coupling to the class exports.
+// SolanaMobileWalletAdapter(Protocol)Error rejections carry a `code` — string
+// for session-level errors, negative number for wallet protocol errors. React
+// Native can deliver a native rejection as a plain object, so do not require
+// the value to inherit from Error (or from one particular JS realm).
 function hasErrorCode(error: unknown, code: string | number): boolean {
-  return (
-    error instanceof Error &&
-    (error as { code?: string | number }).code === code
-  );
+  return errorCodeOf(error) === code;
 }
 
 function errorCodeOf(error: unknown): string | number | undefined {
-  if (!(error instanceof Error)) return undefined;
-  return (error as { code?: string | number }).code;
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" || typeof code === "number"
+    ? code
+    : undefined;
 }
 
 // Backing out of the wallet chooser rejects with a *sentence* as the code:
@@ -369,7 +370,7 @@ export class MwaSigner implements Signer {
         // to `request_failed` — naming an HTTP failure for a call that never
         // reached the network, and leaving the stale token in place so every
         // retry failed identically (ASK-1872 follow-up).
-        throw await this.forgetAuthorization();
+        throw await this.forgetAuthorization(error);
       }
       // Only session-layer rejections become wallet-session failures. Protocol
       // errors, `reauthorize`'s reconnect instructions and our signature checks
@@ -388,8 +389,15 @@ export class MwaSigner implements Signer {
    * connected wallet whose every signature is refused, and the user has no way
    * to reach the reconnect flow from inside the failing screen.
    */
-  private async forgetAuthorization(): Promise<Error> {
+  private async forgetAuthorization(cause?: unknown): Promise<Error> {
     await clearMwaAccount();
+    if (cause !== undefined) {
+      return new WalletSessionError(
+        "authorization_expired",
+        errorCodeOf(cause),
+        cause,
+      );
+    }
     return new Error(RECONNECT_MESSAGE);
   }
 
@@ -405,7 +413,7 @@ export class MwaSigner implements Signer {
       // ERROR_AUTHORIZATION_FAILED: the wallet revoked our authorization
       // (the user disconnected this app). Transient session errors rethrow.
       if (!hasErrorCode(error, -1)) throw error;
-      throw await this.forgetAuthorization();
+      throw await this.forgetAuthorization(error);
     }
     const base64Address = toBase64Address(this.publicKey);
     if (!result.accounts.some((a) => a.address === base64Address)) {

--- a/apps/mobile/src/lib/wallet/mwa-signer.ts
+++ b/apps/mobile/src/lib/wallet/mwa-signer.ts
@@ -33,9 +33,6 @@ const APP_IDENTITY = {
 const MWA_CHAIN =
   env.solanaEnv === "mainnet" ? "solana:mainnet" : "solana:devnet";
 
-const RECONNECT_MESSAGE =
-  "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.";
-
 const SIGNING_CANCELLED_MESSAGE =
   "Signing was cancelled in your wallet app. Try again and approve each prompt without switching apps or locking the screen.";
 
@@ -370,7 +367,7 @@ export class MwaSigner implements Signer {
         // to `request_failed` — naming an HTTP failure for a call that never
         // reached the network, and leaving the stale token in place so every
         // retry failed identically (ASK-1872 follow-up).
-        throw await this.forgetAuthorization(error);
+        throw await this.forgetAuthorization("authorization_expired", error);
       }
       // Only session-layer rejections become wallet-session failures. Protocol
       // errors, `reauthorize`'s reconnect instructions and our signature checks
@@ -389,16 +386,12 @@ export class MwaSigner implements Signer {
    * connected wallet whose every signature is refused, and the user has no way
    * to reach the reconnect flow from inside the failing screen.
    */
-  private async forgetAuthorization(cause?: unknown): Promise<Error> {
+  private async forgetAuthorization(
+    failure: "account_mismatch" | "authorization_expired",
+    cause?: unknown,
+  ): Promise<WalletSessionError> {
     await clearMwaAccount();
-    if (cause !== undefined) {
-      return new WalletSessionError(
-        "authorization_expired",
-        errorCodeOf(cause),
-        cause,
-      );
-    }
-    return new Error(RECONNECT_MESSAGE);
+    return new WalletSessionError(failure, errorCodeOf(cause), cause);
   }
 
   private async reauthorize(wallet: Web3MobileWallet): Promise<void> {
@@ -413,12 +406,12 @@ export class MwaSigner implements Signer {
       // ERROR_AUTHORIZATION_FAILED: the wallet revoked our authorization
       // (the user disconnected this app). Transient session errors rethrow.
       if (!hasErrorCode(error, -1)) throw error;
-      throw await this.forgetAuthorization(error);
+      throw await this.forgetAuthorization("authorization_expired", error);
     }
     const base64Address = toBase64Address(this.publicKey);
     if (!result.accounts.some((a) => a.address === base64Address)) {
       // The wallet reauthorized a different account than the one connected.
-      throw await this.forgetAuthorization();
+      throw await this.forgetAuthorization("account_mismatch");
     }
     if (result.auth_token !== this.authToken) {
       this.authToken = result.auth_token;

--- a/apps/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/apps/mobile/src/lib/wallet/wallet-session-error.ts
@@ -22,6 +22,8 @@
 export type WalletSessionFailure =
   /** The wallet revoked the stored authorization; reconnect is required. */
   | "authorization_expired"
+  /** The wallet reauthorized a different account; reconnect is required. */
+  | "account_mismatch"
   /** No MWA-capable wallet app is installed. */
   | "unavailable"
   /** The wallet app never connected back — the session never opened. */
@@ -35,6 +37,8 @@ export type WalletSessionFailure =
 // from the reason: telling someone to update a wallet app that simply was not
 // running sends them down the wrong path.
 const WALLET_SESSION_MESSAGES: Record<WalletSessionFailure, string> = {
+  account_mismatch:
+    "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   authorization_expired:
     "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   connection_failed:

--- a/apps/mobile/src/lib/wallet/wallet-session-error.ts
+++ b/apps/mobile/src/lib/wallet/wallet-session-error.ts
@@ -20,6 +20,8 @@
 // the actual failure instead of a blanket `request_failed`.
 
 export type WalletSessionFailure =
+  /** The wallet revoked the stored authorization; reconnect is required. */
+  | "authorization_expired"
   /** No MWA-capable wallet app is installed. */
   | "unavailable"
   /** The wallet app never connected back — the session never opened. */
@@ -33,6 +35,8 @@ export type WalletSessionFailure =
 // from the reason: telling someone to update a wallet app that simply was not
 // running sends them down the wrong path.
 const WALLET_SESSION_MESSAGES: Record<WalletSessionFailure, string> = {
+  authorization_expired:
+    "Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.",
   connection_failed:
     "Couldn't reach your wallet app. Open it once so it's running, then try again.",
   signing_failed:

--- a/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -170,6 +170,9 @@ describe("wallet session classification", () => {
     expect(
       mapLifecycleErrorCode(new WalletSessionError("authorization_expired")),
     ).toBe("wallet_authorization_expired");
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("account_mismatch")),
+    ).toBe("wallet_account_mismatch");
   });
 
   // The native module's own codes must not leak through the generic probe.
@@ -220,6 +223,23 @@ describe("wallet session classification", () => {
     });
     expect(JSON.stringify(sent[0])).not.toContain("authorization request failed");
     expect(sent[0]).not.toHaveProperty("httpStatus");
+  });
+
+  it("emits only the bounded account-mismatch lifecycle event", () => {
+    const sent = captureEnvelopes();
+    startLifecycleFlow({
+      flowName: "earn.withdrawal",
+      flowVariant: "partial",
+      reportUnexpectedErrors: true,
+    }).failFrom("prepare", new WalletSessionError("account_mismatch"));
+
+    expect(sent).toEqual([
+      expect.objectContaining({
+        outcome: "failed",
+        errorCode: "wallet_account_mismatch",
+      }),
+    ]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -167,6 +167,9 @@ describe("wallet session classification", () => {
     expect(mapLifecycleErrorCode(new WalletSessionError("signing_failed"))).toBe(
       "wallet_signing_failed",
     );
+    expect(
+      mapLifecycleErrorCode(new WalletSessionError("authorization_expired")),
+    ).toBe("wallet_authorization_expired");
   });
 
   // The native module's own codes must not leak through the generic probe.
@@ -201,6 +204,22 @@ describe("wallet session classification", () => {
       errorCode: "wallet_connection_failed",
     });
     expect(sent[0].httpStatus).toBeUndefined();
+  });
+
+  it("exports only the bounded authorization-expired code", async () => {
+    const sent = captureEnvelopes();
+    const nativeError = { code: -1, message: "authorization request failed" };
+    newFlow().failFrom(
+      "prepare",
+      new WalletSessionError("authorization_expired", -1, nativeError),
+    );
+
+    expect(sent[0]).toMatchObject({
+      outcome: "failed",
+      errorCode: "wallet_authorization_expired",
+    });
+    expect(JSON.stringify(sent[0])).not.toContain("authorization request failed");
+    expect(sent[0]).not.toHaveProperty("httpStatus");
   });
 });
 

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -357,6 +357,7 @@ type LifecycleErrorCode =
   | "send_failed"
   | "insufficient_native_sol"
   | "wallet_rejected"
+  | "wallet_authorization_expired"
   | "wallet_unavailable"
   | "wallet_connection_failed"
   | "wallet_connection_timeout"
@@ -458,6 +459,7 @@ const WALLET_SESSION_ERROR_CODES: Record<
   WalletSessionFailure,
   LifecycleErrorCode
 > = {
+  authorization_expired: "wallet_authorization_expired",
   connection_failed: "wallet_connection_failed",
   signing_failed: "wallet_signing_failed",
   timeout: "wallet_connection_timeout",

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -357,6 +357,7 @@ type LifecycleErrorCode =
   | "send_failed"
   | "insufficient_native_sol"
   | "wallet_rejected"
+  | "wallet_account_mismatch"
   | "wallet_authorization_expired"
   | "wallet_unavailable"
   | "wallet_connection_failed"
@@ -459,6 +460,7 @@ const WALLET_SESSION_ERROR_CODES: Record<
   WalletSessionFailure,
   LifecycleErrorCode
 > = {
+  account_mismatch: "wallet_account_mismatch",
   authorization_expired: "wallet_authorization_expired",
   connection_failed: "wallet_connection_failed",
   signing_failed: "wallet_signing_failed",


### PR DESCRIPTION
## Goal

Port the two ASK-2182 Mobile Wallet Adapter recovery fixes from the retired ask-1355-mobile-earn-tab branch into the authoritative apps/mobile tree on main. This supersedes #689 and carries forward the old-branch fix from #674.

## Alerts fixed

> Timestamp: 2026-08-19T20:20:11.133000000Z
> ServiceName: loyal-mobile
> Body: earn.withdrawal.prepare.failed
> error_code: request_failed
> error_detail: absent

> earn.withdrawal.prepare.failed
> error_code: unexpected_error
> Wallet authorization is no longer valid. Reset your wallet in Settings and reconnect your wallet.

## Scope and implementation

The MWA signer now recognizes revoked authorization codes delivered as plain React Native objects, clears stale authorization once, and reports wallet_authorization_expired without leaking native error content. A reauthorization account mismatch keeps the existing recovery behavior but reports wallet_account_mismatch instead of an unexpected app error. The old mobile paths were ported into apps/mobile; there are no API, database, chain, alert-query, or UI changes.

## Verification

- Mobile Jest: 18 suites, 156 tests passed
- Expo lint: 0 errors, 9 existing warnings
- TypeScript: npx tsc --noEmit passed
- git diff --check passed
- No frontend build was run

## Post-merge

1. Publish the next mobile build or OTA update.
2. Monitor wallet_authorization_expired and wallet_account_mismatch for 24 to 48 hours and confirm both remain outside the broad Errors alert.
3. Keep ask-1355-mobile-earn-tab retired and target all future mobile PRs to main.

Linear: ASK-2182