### PR TITLE
feat(web): add landing link to logged-out earn header

### DIFF
--- a/apps/web/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 import { DogLottie } from "@/components/wallet-workspace/facelift/dog-lottie";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
@@ -68,6 +70,14 @@ export function EarnEmptyPane({
             text="Earn yield on your idle USDC"
           />
         </div>
+        {isHydrated && !isSignedIn ? (
+          <Link
+            className="t-hover flex h-11 shrink-0 items-center rounded-3xl px-4 font-medium text-[14px] text-muted-foreground hover:bg-accent hover:text-foreground"
+            href="/"
+          >
+            About Loyal
+          </Link>
+        ) : null}
         <button
           aria-label="Open chart"
           className="t-hover flex size-11 shrink-0 items-center justify-center rounded-3xl hover:bg-accent min-[1204px]:hidden"

--- a/apps/web/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-empty-pane.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import Link from "next/link";
-
 import { DogLottie } from "@/components/wallet-workspace/facelift/dog-lottie";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
 import { PopDigits } from "@/components/wallet-workspace/facelift/pop-digits";
@@ -71,12 +69,18 @@ export function EarnEmptyPane({
           />
         </div>
         {isHydrated && !isSignedIn ? (
-          <Link
-            className="t-hover flex h-11 shrink-0 items-center rounded-3xl px-4 font-medium text-[14px] text-muted-foreground hover:bg-accent hover:text-foreground"
-            href="/"
+          <a
+            className="t-hover flex h-11 shrink-0 items-center gap-2 rounded-3xl px-4 hover:bg-accent"
+            href="https://askloyal.com"
           >
-            About Loyal
-          </Link>
+            <ThemedIcon
+              className="size-6 text-tertiary"
+              src={`${ASSET_BASE}/icon-globe.svg`}
+            />
+            <span className="whitespace-nowrap font-medium text-[14px] text-muted-foreground">
+              askloyal.com
+            </span>
+          </a>
         ) : null}
         <button
           aria-label="Open chart"


### PR DESCRIPTION
Adds an About Loyal text link to the landing page in the Earn header for logged-out users (mobile has no sidebar, so there was no way back to the landing page).