### PR TITLE
feat(mobile): connect Phantom/Solflare on iOS via wallet deeplinks

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -69,6 +69,10 @@ const config: ExpoConfig = {
     },
     infoPlist: {
       UIBackgroundModes: ["remote-notification"],
+      // Lets Linking.canOpenURL probe for installed deeplink wallets
+      // (src/lib/wallet/deeplink-signer.ts). iOS answers false for any
+      // scheme not declared here.
+      LSApplicationQueriesSchemes: ["phantom", "solflare"],
       // The app never requests location and this prompt never shows. The
       // OneSignal XCFramework ships an optional location module whose bare
       // CLLocationManager reference makes App Store Connect demand a purpose

--- a/apps/mobile/app/ul/[...path].tsx
+++ b/apps/mobile/app/ul/[...path].tsx
@@ -1,0 +1,10 @@
+import { Redirect } from "expo-router";
+
+// Wallet deeplink return URLs (https://askloyal.com/ul/wallet/<action> and the
+// loyal[-dev]://ul/wallet/<action> dev fallback) are consumed by the pending-
+// request listener in src/lib/wallet/deeplink-signer.ts, not by navigation.
+// Expo Router still routes every incoming URL, so without this catch-all the
+// wallet's redirect would land the user on the not-found screen.
+export default function UniversalLinkReturn() {
+  return <Redirect href="/" />;
+}

--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -93,6 +93,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4",
         "text-encoding": "^0.7.0",
+        "tweetnacl": "^1.0.3",
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.6",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -99,7 +99,8 @@
     "react-native-worklets": "0.5.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4",
-    "text-encoding": "^0.7.0"
+    "text-encoding": "^0.7.0",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.6",

--- a/apps/mobile/src/components/wallet/OnboardingGate.tsx
+++ b/apps/mobile/src/components/wallet/OnboardingGate.tsx
@@ -1,6 +1,6 @@
 import { Keypair } from "@solana/web3.js";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, StyleSheet } from "react-native";
+import { ActionSheetIOS, ActivityIndicator, Platform, StyleSheet } from "react-native";
 import * as SeedVault from "expo-seed-vault";
 import Animated, {
   Easing,
@@ -27,8 +27,18 @@ import {
   restoreCloudBackup,
   type WalletBackupEnvelope,
 } from "@/lib/wallet/icloud-backup";
+import {
+  DeeplinkResponseError,
+  type DeeplinkWalletProvider,
+} from "@/lib/wallet/deeplink-protocol";
+import {
+  connectDeeplinkWallet,
+  DEEPLINK_WALLET_LABELS,
+  getInstalledDeeplinkWallets,
+} from "@/lib/wallet/deeplink-signer";
 import { connectMwaWallet, isMwaSupported } from "@/lib/wallet/mwa-signer";
 import { WalletRejectedError } from "@/lib/wallet/rejection";
+import { isWalletSessionError } from "@/lib/wallet/wallet-session-error";
 import { isSeedVaultUserDecline } from "@/lib/wallet/seed-vault-signer";
 import { useWallet } from "@/lib/wallet/wallet-provider";
 import {
@@ -62,10 +72,41 @@ const SCREEN_EXITING_ANIMATION = FadeOut.duration(160).easing(
   Easing.out(Easing.quad),
 );
 
+// iOS-only by construction: the deeplink connect mode is only reachable on
+// iOS, where ActionSheetIOS is the native chooser.
+function chooseDeeplinkProvider(
+  providers: DeeplinkWalletProvider[],
+): Promise<DeeplinkWalletProvider | null> {
+  if (providers.length === 1) return Promise.resolve(providers[0]);
+  return new Promise((resolve) => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        title: "Connect Wallet",
+        options: [
+          ...providers.map((provider) => DEEPLINK_WALLET_LABELS[provider]),
+          "Cancel",
+        ],
+        cancelButtonIndex: providers.length,
+      },
+      (index) => resolve(index >= providers.length ? null : providers[index]),
+    );
+  });
+}
+
+// `reason` prop for wallet_connect_failed (contract shared with ASK-2199).
+function connectFailureReason(error: unknown): string {
+  if (isWalletSessionError(error)) return error.failure;
+  if (error instanceof DeeplinkResponseError) {
+    return `wallet_error_${error.errorCode}`;
+  }
+  return "unexpected_error";
+}
+
 export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
   const {
     finalizeSigner,
     finalizeMwaSigner,
+    finalizeDeeplinkSigner,
     finalizeVaultSigner,
     refreshFromStorage,
   } = useWallet();
@@ -76,6 +117,9 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
   const [pendingPin, setPendingPin] = useState<string | null>(null);
   const [finalizing, setFinalizing] = useState(false);
   const [seedVaultAvailable, setSeedVaultAvailable] = useState(false);
+  const [deeplinkWallets, setDeeplinkWallets] = useState<
+    DeeplinkWalletProvider[]
+  >([]);
   const [connectWalletPending, setConnectWalletPending] = useState(false);
   const [connectWalletError, setConnectWalletError] = useState<string | null>(
     null,
@@ -109,16 +153,24 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
   );
 
   // MWA when the binary has the native module; direct Seed Vault as the
-  // legacy fallback on pre-MWA Seeker builds receiving this bundle via OTA.
+  // legacy fallback on pre-MWA Seeker builds receiving this bundle via OTA;
+  // Phantom/Solflare deeplinks on iOS when either wallet is installed.
   const connectMode: WalletConnectMode = isMwaSupported()
     ? "mwa"
     : seedVaultAvailable
       ? "seed-vault"
-      : "none";
+      : deeplinkWallets.length > 0
+        ? "deeplink"
+        : "none";
 
   useEffect(() => {
     if (isMwaSupported()) return;
     SeedVault.isAvailable().then(setSeedVaultAvailable);
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== "ios") return;
+    getInstalledDeeplinkWallets().then(setDeeplinkWallets);
   }, []);
 
   // iCloud Drive wallet backup, if the user made one on a previous install
@@ -257,6 +309,46 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
     authFlowRef.current?.complete("completion");
   }, [finalizeMwaSigner]);
 
+  // iOS external-wallet connect over Phantom-style deeplinks. Null from the
+  // connect call means the user declined in the wallet or switched back
+  // without answering — a choice, not an error.
+  const connectDeeplink = useCallback(async () => {
+    const provider = await chooseDeeplinkProvider(deeplinkWallets);
+    if (!provider) {
+      authFlowRef.current?.cancel("wallet_connect");
+      return;
+    }
+    track(WALLET_CONNECT_EVENTS.pressed, { provider, surface: "onboarding" });
+    try {
+      const session = await connectDeeplinkWallet(provider);
+      if (!session) {
+        track(WALLET_CONNECT_EVENTS.failed, {
+          provider,
+          surface: "onboarding",
+          reason: "cancelled",
+        });
+        authFlowRef.current?.cancel("wallet_connect");
+        return;
+      }
+      track(WALLET_CONNECT_EVENTS.returned, {
+        provider,
+        surface: "onboarding",
+      });
+      authFlowRef.current?.setWalletAddress(session.publicKey);
+      authFlowRef.current?.observe("wallet_connect");
+      setFinalizing(true);
+      await finalizeDeeplinkSigner(session);
+      authFlowRef.current?.complete("completion");
+    } catch (e) {
+      track(WALLET_CONNECT_EVENTS.failed, {
+        provider,
+        surface: "onboarding",
+        reason: connectFailureReason(e),
+      });
+      throw e;
+    }
+  }, [deeplinkWallets, finalizeDeeplinkSigner]);
+
   const handleConnectWallet = useCallback(async () => {
     if (connectWalletPending) return;
     setConnectWalletError(null);
@@ -271,6 +363,8 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
     try {
       if (connectMode === "seed-vault") {
         await connectSeedVault();
+      } else if (connectMode === "deeplink") {
+        await connectDeeplink();
       } else {
         await connectMwa();
       }
@@ -293,6 +387,7 @@ export function OnboardingGate({ mode = "setup", onReplayDone }: Props) {
     connectWalletPending,
     connectMode,
     connectSeedVault,
+    connectDeeplink,
     connectMwa,
     beginAuthFlow,
   ]);

--- a/apps/mobile/src/components/wallet/onboarding-slides.ts
+++ b/apps/mobile/src/components/wallet/onboarding-slides.ts
@@ -13,10 +13,10 @@ export type WalletSetupAction = {
 /**
  * Which external-wallet connect path this binary supports: "mwa" on builds
  * with the MWA native module, "seed-vault" as the legacy fallback on older
- * Seeker builds receiving this bundle via OTA, "none" elsewhere (iOS,
- * non-Seeker Android without MWA).
+ * Seeker builds receiving this bundle via OTA, "deeplink" on iOS with
+ * Phantom/Solflare installed, "none" elsewhere.
  */
-export type WalletConnectMode = "mwa" | "seed-vault" | "none";
+export type WalletConnectMode = "mwa" | "seed-vault" | "deeplink" | "none";
 
 export type OnboardingMode = "setup" | "replay";
 
@@ -65,7 +65,10 @@ export function buildWalletSetupActions(
       : {
           id: "connect-wallet",
           label: "Connect Wallet",
-          helperText: "Phantom, Solflare, or Seed Vault",
+          helperText:
+            connectMode === "deeplink"
+              ? "Phantom or Solflare"
+              : "Phantom, Solflare, or Seed Vault",
         },
     ...createAndImport,
   ];

--- a/apps/mobile/src/lib/analytics/analytics.ts
+++ b/apps/mobile/src/lib/analytics/analytics.ts
@@ -95,7 +95,7 @@ export function track(event: string, properties?: AnalyticsProperties): void {
 
 export function identifyWallet(
   publicKey: string,
-  source: "created" | "imported" | "vault" | "mwa",
+  source: "created" | "imported" | "vault" | "mwa" | "deeplink",
 ): void {
   const distinctId = `mob:${publicKey}`;
   identifyDatadogUser({

--- a/apps/mobile/src/lib/solana/earn/send-prepared.ts
+++ b/apps/mobile/src/lib/solana/earn/send-prepared.ts
@@ -283,7 +283,12 @@ export async function signAndSendPreparedOperations(args: {
   // guards are stale and it fails on-chain with Lighthouse AssertionFailed
   // (custom error 0x1900). Sign each stage in its own wallet session, after
   // the previous stage confirmed, so the wallet simulates against real state.
-  if (signer.kind === "mwa" && operations.length > 1) {
+  // Deeplink signers (Solflare on iOS) have the same transaction-protection
+  // behavior, and each of their sign calls is a full app switch anyway.
+  if (
+    (signer.kind === "mwa" || signer.kind === "deeplink") &&
+    operations.length > 1
+  ) {
     const sent: SentTransaction[] = [];
     for (const operation of operations) {
       try {

--- a/apps/mobile/src/lib/wallet/__tests__/deeplink-protocol.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/deeplink-protocol.test.ts
@@ -1,0 +1,148 @@
+// Guards the Phantom/Solflare deeplink encryption/session contract
+// (docs.phantom.com deeplinks; Solflare mirrors it). The connect handshake
+// must derive the same x25519 shared secret the wallet derives, our request
+// payloads must decrypt on the wallet side, wallet responses must decrypt on
+// ours, and error redirects must classify without touching crypto. All of it
+// still compiles while broken, so it is asserted against a simulated wallet.
+
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+
+import {
+  buildRequestUrl,
+  decryptResponseData,
+  DeeplinkResponseError,
+  generateDappKeypair,
+  parseConnectResponse,
+} from "../deeplink-protocol";
+
+type WalletSide = {
+  encryptionPublicKey: string;
+  sharedSecret: Uint8Array;
+  encrypt: (payload: Record<string, unknown>) => { nonce: string; data: string };
+  decrypt: (nonceB58: string, payloadB58: string) => Record<string, unknown>;
+};
+
+// The wallet's half of the Diffie-Hellman exchange, per the spec.
+function makeWallet(dappPublicKey: string): WalletSide {
+  const pair = nacl.box.keyPair();
+  const sharedSecret = nacl.box.before(
+    bs58.decode(dappPublicKey),
+    pair.secretKey,
+  );
+  return {
+    encryptionPublicKey: bs58.encode(pair.publicKey),
+    sharedSecret,
+    encrypt: (payload) => {
+      const nonce = nacl.randomBytes(24);
+      const data = nacl.box.after(
+        new Uint8Array(Buffer.from(JSON.stringify(payload), "utf8")),
+        nonce,
+        sharedSecret,
+      );
+      return { nonce: bs58.encode(nonce), data: bs58.encode(data) };
+    },
+    decrypt: (nonceB58, payloadB58) => {
+      const opened = nacl.box.open.after(
+        bs58.decode(payloadB58),
+        bs58.decode(nonceB58),
+        sharedSecret,
+      );
+      if (!opened) throw new Error("wallet could not decrypt payload");
+      return JSON.parse(Buffer.from(opened).toString("utf8"));
+    },
+  };
+}
+
+describe("deeplink connect handshake", () => {
+  it("derives the wallet's shared secret and decrypts the session grant", async () => {
+    const dapp = await generateDappKeypair();
+    const wallet = makeWallet(dapp.publicKey);
+    const { nonce, data } = wallet.encrypt({
+      public_key: "BSFtCudCd4pR4LSFqWPjbtXPKSNVbGkc35gRNdnqjMCU",
+      session: "session-token",
+    });
+
+    const result = await parseConnectResponse({
+      provider: "solflare",
+      params: {
+        solflare_encryption_public_key: wallet.encryptionPublicKey,
+        nonce,
+        data,
+      },
+      dappSecretKey: dapp.secretKey,
+    });
+
+    expect(result.walletPublicKey).toBe(
+      "BSFtCudCd4pR4LSFqWPjbtXPKSNVbGkc35gRNdnqjMCU",
+    );
+    expect(result.session).toBe("session-token");
+    expect(bs58.decode(result.sharedSecret)).toEqual(wallet.sharedSecret);
+  });
+
+  it("throws the wallet's error redirect as a classified decline", async () => {
+    const dapp = await generateDappKeypair();
+    const attempt = parseConnectResponse({
+      provider: "phantom",
+      params: { errorCode: "4001", errorMessage: "User rejected the request." },
+      dappSecretKey: dapp.secretKey,
+    });
+    await expect(attempt).rejects.toThrow(DeeplinkResponseError);
+    await expect(attempt).rejects.toMatchObject({ isUserDecline: true });
+  });
+});
+
+describe("deeplink request/response encryption", () => {
+  it("round-trips: wallet decrypts our payload, we decrypt its response", async () => {
+    const dapp = await generateDappKeypair();
+    const wallet = makeWallet(dapp.publicKey);
+    const sharedSecret = bs58.encode(wallet.sharedSecret);
+
+    const url = await buildRequestUrl({
+      provider: "phantom",
+      method: "signMessage",
+      dappPublicKey: dapp.publicKey,
+      sharedSecret,
+      redirectLink: "https://askloyal.com/ul/wallet/signMessage",
+      payload: { message: bs58.encode(Buffer.from("hi")), session: "s1" },
+    });
+
+    const params = new URL(url).searchParams;
+    expect(url.startsWith("https://phantom.app/ul/v1/signMessage?")).toBe(true);
+    expect(params.get("redirect_link")).toBe(
+      "https://askloyal.com/ul/wallet/signMessage",
+    );
+    // The wallet must be able to open our encrypted payload…
+    const requestPayload = wallet.decrypt(
+      params.get("nonce")!,
+      params.get("payload")!,
+    );
+    expect(requestPayload).toEqual({
+      message: bs58.encode(Buffer.from("hi")),
+      session: "s1",
+    });
+
+    // …and we must be able to open its encrypted response.
+    const response = wallet.encrypt({ signature: "sig" });
+    await expect(
+      decryptResponseData(
+        { nonce: response.nonce, data: response.data },
+        sharedSecret,
+      ),
+    ).resolves.toEqual({ signature: "sig" });
+  });
+
+  it("rejects a tampered response instead of returning garbage", async () => {
+    const dapp = await generateDappKeypair();
+    const wallet = makeWallet(dapp.publicKey);
+    const response = wallet.encrypt({ signature: "sig" });
+    const tampered = bs58.decode(response.data);
+    tampered[0] ^= 0xff;
+    await expect(
+      decryptResponseData(
+        { nonce: response.nonce, data: bs58.encode(tampered) },
+        bs58.encode(wallet.sharedSecret),
+      ),
+    ).rejects.toThrow(/could not be decrypted/);
+  });
+});

--- a/apps/mobile/src/lib/wallet/deeplink-protocol.ts
+++ b/apps/mobile/src/lib/wallet/deeplink-protocol.ts
@@ -1,0 +1,249 @@
+import bs58 from "bs58";
+import { Buffer } from "buffer";
+
+// Phantom's deeplink provider protocol (docs.phantom.com → Phantom Deeplinks),
+// which Solflare implements verbatim (docs.solflare.com → Deep Links): every
+// method is a universal link under <wallet>/ul/v1/<method>, request payloads
+// and responses are nacl.box-encrypted with an x25519 shared secret, and all
+// binary values travel base58-encoded. This module is the pure protocol half —
+// no React Native imports — so the encryption/session contract stays testable
+// under Jest; the app-switch orchestration lives in deeplink-signer.ts.
+
+export type DeeplinkWalletProvider = "phantom" | "solflare";
+
+export const DEEPLINK_BASE_URLS: Record<DeeplinkWalletProvider, string> = {
+  phantom: "https://phantom.app/ul/v1",
+  solflare: "https://solflare.com/ul/v1",
+};
+
+// The connect response carries the wallet's x25519 public key under a
+// provider-branded param name; everything else is shared.
+const RESPONSE_KEY_PARAM: Record<DeeplinkWalletProvider, string> = {
+  phantom: "phantom_encryption_public_key",
+  solflare: "solflare_encryption_public_key",
+};
+
+export type DeeplinkMethod =
+  | "connect"
+  | "disconnect"
+  | "signMessage"
+  | "signTransaction"
+  | "signAllTransactions";
+
+/** Everything needed to encrypt/decrypt and authorize follow-up requests. */
+export type DeeplinkConnectResult = {
+  /** Base58 Solana public key the user approved. */
+  walletPublicKey: string;
+  /** Opaque session token the wallet requires on every subsequent method. */
+  session: string;
+  /** Base58 nacl.box shared secret derived from the wallet's x25519 key. */
+  sharedSecret: string;
+};
+
+/** The wallet answered with an error instead of a payload. */
+export class DeeplinkResponseError extends Error {
+  constructor(
+    readonly errorCode: string,
+    errorMessage: string,
+  ) {
+    super(errorMessage || `Wallet returned error ${errorCode}`);
+    this.name = "DeeplinkResponseError";
+  }
+
+  /** 4001: the user tapped reject in the wallet — a choice, not a failure. */
+  get isUserDecline(): boolean {
+    return this.errorCode === "4001";
+  }
+
+  /**
+   * 4100: the wallet no longer honors our session token (user disconnected
+   * the app inside the wallet). The stored session must be discarded.
+   */
+  get isUnauthorized(): boolean {
+    return this.errorCode === "4100";
+  }
+}
+
+type TweetNaclBox = {
+  keyPair(): { publicKey: Uint8Array; secretKey: Uint8Array };
+  before(theirPublicKey: Uint8Array, mySecretKey: Uint8Array): Uint8Array;
+  after(
+    message: Uint8Array,
+    nonce: Uint8Array,
+    sharedKey: Uint8Array,
+  ): Uint8Array;
+  open: {
+    after(
+      box: Uint8Array,
+      nonce: Uint8Array,
+      sharedKey: Uint8Array,
+    ): Uint8Array | null;
+  };
+};
+
+type TweetNacl = {
+  box: TweetNaclBox;
+  randomBytes(length: number): Uint8Array;
+};
+
+// Lazy-loaded so tweetnacl's Buffer access never runs at module top-level
+// (same pattern as signer.ts).
+async function getNacl(): Promise<TweetNacl> {
+  const mod = (await import("tweetnacl")) as unknown as {
+    box?: TweetNaclBox;
+    randomBytes?: (length: number) => Uint8Array;
+    default?: TweetNacl;
+  };
+  if (typeof mod.box?.before === "function" && mod.randomBytes) {
+    return { box: mod.box, randomBytes: mod.randomBytes };
+  }
+  if (typeof mod.default?.box?.before === "function") return mod.default;
+  throw new Error("tweetnacl box is unavailable");
+}
+
+/** New x25519 keypair for a connect handshake, both halves base58-encoded. */
+export async function generateDappKeypair(): Promise<{
+  publicKey: string;
+  secretKey: string;
+}> {
+  const nacl = await getNacl();
+  const pair = nacl.box.keyPair();
+  return {
+    publicKey: bs58.encode(pair.publicKey),
+    secretKey: bs58.encode(pair.secretKey),
+  };
+}
+
+// React Native's built-in URLSearchParams throws "not implemented" from
+// toString(), so query strings are assembled by hand.
+function toQueryString(params: Record<string, string>): string {
+  return Object.entries(params)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join("&");
+}
+
+export function buildConnectUrl(args: {
+  provider: DeeplinkWalletProvider;
+  dappPublicKey: string;
+  redirectLink: string;
+  appUrl: string;
+  cluster: "mainnet-beta" | "devnet" | "testnet";
+}): string {
+  const query = toQueryString({
+    app_url: args.appUrl,
+    dapp_encryption_public_key: args.dappPublicKey,
+    redirect_link: args.redirectLink,
+    cluster: args.cluster,
+  });
+  return `${DEEPLINK_BASE_URLS[args.provider]}/connect?${query}`;
+}
+
+/**
+ * Encrypt `payload` and build the universal link for any post-connect method.
+ * A fresh random nonce per request, as the spec requires.
+ */
+export async function buildRequestUrl(args: {
+  provider: DeeplinkWalletProvider;
+  method: Exclude<DeeplinkMethod, "connect">;
+  dappPublicKey: string;
+  sharedSecret: string;
+  redirectLink: string;
+  payload: Record<string, unknown>;
+}): Promise<string> {
+  const nacl = await getNacl();
+  const nonce = nacl.randomBytes(24);
+  const encrypted = nacl.box.after(
+    new Uint8Array(Buffer.from(JSON.stringify(args.payload), "utf8")),
+    nonce,
+    bs58.decode(args.sharedSecret),
+  );
+  const query = toQueryString({
+    dapp_encryption_public_key: args.dappPublicKey,
+    nonce: bs58.encode(nonce),
+    redirect_link: args.redirectLink,
+    payload: bs58.encode(encrypted),
+  });
+  return `${DEEPLINK_BASE_URLS[args.provider]}/${args.method}?${query}`;
+}
+
+function param(
+  params: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = params[key];
+  if (typeof value === "string" && value.length > 0) return value;
+  // expo-linking's queryParams can hold arrays for repeated keys.
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return undefined;
+}
+
+/** Throw the wallet's error response, if the redirect carries one. */
+export function throwIfErrorResponse(params: Record<string, unknown>): void {
+  const errorCode = param(params, "errorCode");
+  if (errorCode === undefined) return;
+  throw new DeeplinkResponseError(errorCode, param(params, "errorMessage") ?? "");
+}
+
+/** Decrypt the `data` param of an approve response and parse it as JSON. */
+export async function decryptResponseData(
+  params: Record<string, unknown>,
+  sharedSecret: string,
+): Promise<Record<string, unknown>> {
+  throwIfErrorResponse(params);
+  const data = param(params, "data");
+  const nonce = param(params, "nonce");
+  if (!data || !nonce) {
+    throw new Error("The wallet response is missing the encrypted payload.");
+  }
+  const nacl = await getNacl();
+  const opened = nacl.box.open.after(
+    bs58.decode(data),
+    bs58.decode(nonce),
+    bs58.decode(sharedSecret),
+  );
+  if (!opened) {
+    throw new Error(
+      "The wallet response could not be decrypted with the session key.",
+    );
+  }
+  const parsed: unknown = JSON.parse(Buffer.from(opened).toString("utf8"));
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("The wallet response payload is not an object.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Handle a connect redirect: derive the shared secret from the wallet's
+ * x25519 public key + our secret key, then decrypt the session grant.
+ */
+export async function parseConnectResponse(args: {
+  provider: DeeplinkWalletProvider;
+  params: Record<string, unknown>;
+  dappSecretKey: string;
+}): Promise<DeeplinkConnectResult> {
+  throwIfErrorResponse(args.params);
+  const walletEncryptionKey = param(
+    args.params,
+    RESPONSE_KEY_PARAM[args.provider],
+  );
+  if (!walletEncryptionKey) {
+    throw new Error("The wallet response is missing its encryption key.");
+  }
+  const nacl = await getNacl();
+  const sharedSecret = bs58.encode(
+    nacl.box.before(
+      bs58.decode(walletEncryptionKey),
+      bs58.decode(args.dappSecretKey),
+    ),
+  );
+  const data = await decryptResponseData(args.params, sharedSecret);
+  if (typeof data.public_key !== "string" || typeof data.session !== "string") {
+    throw new Error("The wallet connect response is missing the account.");
+  }
+  return {
+    walletPublicKey: data.public_key,
+    session: data.session,
+    sharedSecret,
+  };
+}

--- a/apps/mobile/src/lib/wallet/deeplink-session-storage.ts
+++ b/apps/mobile/src/lib/wallet/deeplink-session-storage.ts
@@ -1,0 +1,68 @@
+import * as SecureStore from "expo-secure-store";
+
+import type { DeeplinkWalletProvider } from "./deeplink-protocol";
+
+const DEEPLINK_SESSION_KEY = "loyal.deeplinkWalletSession";
+
+/**
+ * Persistent record of a Phantom/Solflare deeplink authorization. The keys
+ * stay inside the wallet app; we remember the opaque session token, the
+ * resolved base58 Solana address, and the encryption material every follow-up
+ * request needs: the x25519 shared secret derived during connect and the dapp
+ * public key the wallet indexes it by. The dapp secret key is NOT kept — once
+ * the shared secret exists it has no further use, so it dies with connect.
+ */
+export type StoredDeeplinkSession = {
+  provider: DeeplinkWalletProvider;
+  /** Base58-encoded Solana public key. */
+  publicKey: string;
+  /** Opaque wallet session token, sent with every request. */
+  session: string;
+  /** Base58 nacl.box shared secret for request/response encryption. */
+  sharedSecret: string;
+  /** Base58 dapp x25519 public key the wallet maps to the shared secret. */
+  dappPublicKey: string;
+};
+
+function parseStoredDeeplinkSession(
+  value: unknown,
+): StoredDeeplinkSession | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (
+    (v.provider !== "phantom" && v.provider !== "solflare") ||
+    typeof v.publicKey !== "string" ||
+    typeof v.session !== "string" ||
+    typeof v.sharedSecret !== "string" ||
+    typeof v.dappPublicKey !== "string"
+  ) {
+    return null;
+  }
+  return {
+    provider: v.provider,
+    publicKey: v.publicKey,
+    session: v.session,
+    sharedSecret: v.sharedSecret,
+    dappPublicKey: v.dappPublicKey,
+  };
+}
+
+export async function storeDeeplinkSession(
+  session: StoredDeeplinkSession,
+): Promise<void> {
+  await SecureStore.setItemAsync(DEEPLINK_SESSION_KEY, JSON.stringify(session));
+}
+
+export async function loadDeeplinkSession(): Promise<StoredDeeplinkSession | null> {
+  const raw = await SecureStore.getItemAsync(DEEPLINK_SESSION_KEY);
+  if (!raw) return null;
+  try {
+    return parseStoredDeeplinkSession(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export async function clearDeeplinkSession(): Promise<void> {
+  await SecureStore.deleteItemAsync(DEEPLINK_SESSION_KEY);
+}

--- a/apps/mobile/src/lib/wallet/deeplink-signer.ts
+++ b/apps/mobile/src/lib/wallet/deeplink-signer.ts
@@ -1,0 +1,366 @@
+import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
+import bs58 from "bs58";
+import * as Linking from "expo-linking";
+import { AppState } from "react-native";
+
+import { env } from "@/config/env";
+
+import {
+  buildConnectUrl,
+  buildRequestUrl,
+  decryptResponseData,
+  DeeplinkResponseError,
+  type DeeplinkMethod,
+  type DeeplinkWalletProvider,
+  generateDappKeypair,
+  parseConnectResponse,
+  throwIfErrorResponse,
+} from "./deeplink-protocol";
+import {
+  clearDeeplinkSession,
+  type StoredDeeplinkSession,
+} from "./deeplink-session-storage";
+import { WalletRejectedError } from "./rejection";
+import { assertOwnVersionedSignature, type Signer } from "./signer";
+import { WalletSessionError } from "./wallet-session-error";
+
+// External-wallet signing on iOS, where MWA cannot exist: every operation is
+// a full app switch — we open a phantom.app/solflare.com universal link, the
+// wallet shows its approval UI, and redirects back to our /ul/wallet/<action>
+// return link with the (encrypted) response in query params. Protocol
+// encoding/encryption lives in deeplink-protocol.ts; this module owns the
+// app-switch round trip and the Signer implementation.
+
+export const DEEPLINK_WALLET_LABELS: Record<DeeplinkWalletProvider, string> = {
+  phantom: "Phantom",
+  solflare: "Solflare",
+};
+
+const WALLET_PROBE_SCHEMES: Record<DeeplinkWalletProvider, string> = {
+  phantom: "phantom://",
+  solflare: "solflare://",
+};
+
+// Shown in the wallet's connect approval dialog and stored in its session
+// token for validation.
+const APP_URL = "https://askloyal.com";
+
+const SIGNING_DECLINED_MESSAGE =
+  "The request was declined in your wallet app. Try again and approve each prompt.";
+
+const CANCELLED_MESSAGE =
+  "The wallet request was cancelled. Try again and approve the prompt in your wallet app.";
+
+// How long after the app returns to the foreground we still wait for the
+// wallet's redirect to deliver a URL event before treating the switch-back as
+// a cancellation. The redirect's URL event lands right around activation, so
+// real approvals never wait this long.
+const RETURN_WITHOUT_RESPONSE_GRACE_MS = 4_000;
+
+/**
+ * Deeplink wallets installed on this device, probed via their custom schemes.
+ * iOS answers canOpenURL only for schemes declared in
+ * LSApplicationQueriesSchemes (app.config.ts).
+ */
+export async function getInstalledDeeplinkWallets(): Promise<
+  DeeplinkWalletProvider[]
+> {
+  const providers = Object.keys(
+    WALLET_PROBE_SCHEMES,
+  ) as DeeplinkWalletProvider[];
+  const installed = await Promise.all(
+    providers.map(async (provider) => {
+      const canOpen = await Linking.canOpenURL(
+        WALLET_PROBE_SCHEMES[provider],
+      ).catch(() => false);
+      return canOpen ? provider : null;
+    }),
+  );
+  return installed.filter((p): p is DeeplinkWalletProvider => p !== null);
+}
+
+// Return path the wallet redirects to. Production uses our universal link
+// (AASA + Associated Domains ship with ASK-2199 and must be in the binary);
+// dev builds use the dev-client custom scheme (loyal-dev://ul/wallet/<action>)
+// so the flow is testable before associated domains are configured.
+function buildRedirectLink(action: DeeplinkMethod): string {
+  return __DEV__
+    ? Linking.createURL(`ul/wallet/${action}`)
+    : `https://askloyal.com/ul/wallet/${action}`;
+}
+
+function deeplinkCluster(): "mainnet-beta" | "devnet" {
+  // No localnet in the deeplink protocol; devnet is the closest for local
+  // development (same rule as MWA_CHAIN).
+  return env.solanaEnv === "mainnet" ? "mainnet-beta" : "devnet";
+}
+
+type PendingDeeplinkRequest = {
+  cancel: () => void;
+};
+
+// One in-flight request per action. The process dies with the pending map, so
+// a request that outlives the app (iOS killed us while the wallet was open)
+// simply has no waiter when the cold-start URL arrives — the user retries.
+const pendingRequests = new Map<string, PendingDeeplinkRequest>();
+
+/**
+ * Open a wallet universal link and wait for the redirect back to
+ * /ul/wallet/<action>. Resolves with the redirect's query params. Rejects
+ * with WalletRejectedError when the user returns to the app without a
+ * response (switch-back is the only cancel signal this protocol has).
+ */
+function performDeeplinkRequest(
+  action: DeeplinkMethod,
+  url: string,
+): Promise<Record<string, unknown>> {
+  // A stale pending request (the user came back without responding, then
+  // retried) must not swallow the new request's response.
+  pendingRequests.get(action)?.cancel();
+
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    let settled = false;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (outcome: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      urlSub.remove();
+      appStateSub.remove();
+      if (pendingRequests.get(action) === entry) {
+        pendingRequests.delete(action);
+      }
+      outcome();
+    };
+
+    const entry: PendingDeeplinkRequest = {
+      cancel: () =>
+        finish(() => reject(new WalletRejectedError(CANCELLED_MESSAGE))),
+    };
+    pendingRequests.set(action, entry);
+
+    const urlSub = Linking.addEventListener("url", ({ url: incoming }) => {
+      // Accept both the universal link (https://askloyal.com/ul/wallet/…)
+      // and the custom-scheme dev fallback (loyal[-dev]://ul/wallet/…).
+      const match = /ul\/wallet\/([A-Za-z]+)/.exec(incoming);
+      if (!match || match[1] !== action) return;
+      const { queryParams } = Linking.parse(incoming);
+      finish(() => resolve((queryParams ?? {}) as Record<string, unknown>));
+    });
+
+    // The user can switch back without answering the wallet's prompt; no URL
+    // means no answer, so once the app is active and the grace window passes
+    // without a redirect, treat it as a cancellation instead of spinning
+    // forever.
+    const appStateSub = AppState.addEventListener("change", (state) => {
+      if (state !== "active") return;
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      graceTimer = setTimeout(
+        () => entry.cancel(),
+        RETURN_WITHOUT_RESPONSE_GRACE_MS,
+      );
+    });
+
+    Linking.openURL(url).catch((error) => finish(() => reject(error)));
+  });
+}
+
+function isUserCancellation(error: unknown): boolean {
+  return (
+    error instanceof WalletRejectedError ||
+    (error instanceof DeeplinkResponseError && error.isUserDecline)
+  );
+}
+
+/**
+ * Run the connect handshake with the chosen wallet app. Returns the session
+ * to persist, or null when the user declined in the wallet or switched back
+ * without answering. A fresh x25519 keypair per attempt, per the spec; the
+ * secret key is dropped once the shared secret exists.
+ */
+export async function connectDeeplinkWallet(
+  provider: DeeplinkWalletProvider,
+): Promise<StoredDeeplinkSession | null> {
+  const keypair = await generateDappKeypair();
+  const url = buildConnectUrl({
+    provider,
+    dappPublicKey: keypair.publicKey,
+    redirectLink: buildRedirectLink("connect"),
+    appUrl: APP_URL,
+    cluster: deeplinkCluster(),
+  });
+  try {
+    const params = await performDeeplinkRequest("connect", url);
+    const result = await parseConnectResponse({
+      provider,
+      params,
+      dappSecretKey: keypair.secretKey,
+    });
+    return {
+      provider,
+      publicKey: result.walletPublicKey,
+      session: result.session,
+      sharedSecret: result.sharedSecret,
+      dappPublicKey: keypair.publicKey,
+    };
+  } catch (error) {
+    if (isUserCancellation(error)) return null;
+    // Wallet-reported connect errors keep their own identity: the wallet WAS
+    // reachable, so none of the wallet-session failure messages fit, and the
+    // wallet's errorMessage is already user-readable copy.
+    throw error;
+  }
+}
+
+/** Best-effort disconnect used by wallet reset. Opens the wallet app. */
+export async function disconnectDeeplinkWallet(
+  session: StoredDeeplinkSession,
+): Promise<void> {
+  const url = await buildRequestUrl({
+    provider: session.provider,
+    method: "disconnect",
+    dappPublicKey: session.dappPublicKey,
+    sharedSecret: session.sharedSecret,
+    redirectLink: buildRedirectLink("disconnect"),
+    payload: { session: session.session },
+  });
+  const params = await performDeeplinkRequest("disconnect", url);
+  throwIfErrorResponse(params);
+}
+
+function serializeForSigning(tx: Transaction | VersionedTransaction): string {
+  const bytes =
+    tx instanceof VersionedTransaction
+      ? tx.serialize()
+      : tx.serialize({ requireAllSignatures: false, verifySignatures: false });
+  return bs58.encode(bytes);
+}
+
+/**
+ * Signer backed by an external wallet app over Phantom-style deeplinks
+ * (Phantom, Solflare). Keys never reach this app; each sign call opens the
+ * wallet app, which shows its own approval UI and redirects back with the
+ * encrypted result. If the wallet revoked our session the stored record is
+ * cleared so the next launch lands in reconnect onboarding, and a reconnect
+ * instruction is thrown instead of the raw error (same recovery as MwaSigner).
+ */
+export class DeeplinkSigner implements Signer {
+  readonly kind = "deeplink" as const;
+  readonly publicKey: PublicKey;
+
+  constructor(readonly session: StoredDeeplinkSession) {
+    this.publicKey = new PublicKey(session.publicKey);
+  }
+
+  get provider(): DeeplinkWalletProvider {
+    return this.session.provider;
+  }
+
+  async signMessage(bytes: Uint8Array): Promise<Uint8Array> {
+    const data = await this.request("signMessage", {
+      message: bs58.encode(bytes),
+      display: "utf8",
+    });
+    if (typeof data.signature !== "string") {
+      throw new Error("Wallet returned no message signature.");
+    }
+    return bs58.decode(data.signature);
+  }
+
+  async signTransaction<T extends Transaction | VersionedTransaction>(
+    tx: T,
+  ): Promise<T> {
+    const data = await this.request("signTransaction", {
+      transaction: serializeForSigning(tx),
+    });
+    if (typeof data.transaction !== "string") {
+      throw new Error("Wallet returned no signed transaction.");
+    }
+    await this.adoptSignedTransaction(tx, data.transaction, 0);
+    return tx;
+  }
+
+  async signAllTransactions<T extends Transaction | VersionedTransaction>(
+    txs: T[],
+  ): Promise<T[]> {
+    if (txs.length === 0) return txs;
+    const data = await this.request("signAllTransactions", {
+      transactions: txs.map(serializeForSigning),
+    });
+    const signed = data.transactions;
+    if (!Array.isArray(signed) || signed.length !== txs.length) {
+      throw new Error(
+        "Wallet returned a mismatched number of signed transactions.",
+      );
+    }
+    for (let index = 0; index < txs.length; index++) {
+      const encoded: unknown = signed[index];
+      if (typeof encoded !== "string") {
+        throw new Error(
+          `Wallet returned no signed transaction at position ${index + 1}.`,
+        );
+      }
+      await this.adoptSignedTransaction(txs[index], encoded, index);
+    }
+    return txs;
+  }
+
+  // Same rule as MwaSigner: the wallet-returned bytes are the signed truth —
+  // the wallet may return a modified transaction (Lighthouse guards, priority
+  // fees), so adopt its message AND signatures onto the caller's object, then
+  // verify our signature locally.
+  private async adoptSignedTransaction(
+    tx: Transaction | VersionedTransaction,
+    encoded: string,
+    index: number,
+  ): Promise<void> {
+    const bytes = bs58.decode(encoded);
+    if (tx instanceof VersionedTransaction) {
+      const src = VersionedTransaction.deserialize(bytes);
+      tx.message = src.message;
+      tx.signatures = src.signatures;
+      await assertOwnVersionedSignature(tx, this.publicKey, index);
+    } else {
+      tx.signatures = Transaction.from(bytes).signatures;
+    }
+  }
+
+  private async request(
+    method: "signMessage" | "signTransaction" | "signAllTransactions",
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const url = await buildRequestUrl({
+      provider: this.session.provider,
+      method,
+      dappPublicKey: this.session.dappPublicKey,
+      sharedSecret: this.session.sharedSecret,
+      redirectLink: buildRedirectLink(method),
+      payload: { ...payload, session: this.session.session },
+    });
+    try {
+      const params = await performDeeplinkRequest(method, url);
+      return await decryptResponseData(params, this.session.sharedSecret);
+    } catch (error) {
+      if (error instanceof DeeplinkResponseError) {
+        if (error.isUserDecline) {
+          throw new WalletRejectedError(SIGNING_DECLINED_MESSAGE);
+        }
+        if (error.isUnauthorized) {
+          // The user disconnected this app inside the wallet — the same dead
+          // authorization as MWA's ERROR_AUTHORIZATION_FAILED. Clearing the
+          // stored session is the half that matters: without it the app keeps
+          // presenting a connected wallet whose every signature is refused.
+          await clearDeeplinkSession();
+          throw new WalletSessionError(
+            "authorization_expired",
+            error.errorCode,
+            error,
+          );
+        }
+        throw new WalletSessionError("signing_failed", error.errorCode, error);
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/mobile/src/lib/wallet/mwa-signer.ts
+++ b/apps/mobile/src/lib/wallet/mwa-signer.ts
@@ -7,7 +7,7 @@ import { Platform, TurboModuleRegistry } from "react-native";
 import { env } from "@/config/env";
 
 import { WalletRejectedError } from "./rejection";
-import type { Signer } from "./signer";
+import { assertOwnVersionedSignature, type Signer } from "./signer";
 import {
   clearMwaAccount,
   storeMwaAccount,
@@ -164,27 +164,6 @@ function toWalletSessionFailure(
   return null;
 }
 
-type TweetNaclVerify = (
-  message: Uint8Array,
-  signature: Uint8Array,
-  publicKey: Uint8Array,
-) => boolean;
-
-// Lazy-loaded so tweetnacl's Buffer access never runs at module top-level
-// (same pattern as signer.ts).
-async function getTweetNaclVerify(): Promise<TweetNaclVerify> {
-  const mod = (await import("tweetnacl")) as unknown as {
-    sign?: { detached?: { verify?: TweetNaclVerify } };
-    default?: { sign?: { detached?: { verify?: TweetNaclVerify } } };
-  };
-  const verify =
-    mod.sign?.detached?.verify ?? mod.default?.sign?.detached?.verify;
-  if (typeof verify !== "function") {
-    throw new Error("tweetnacl sign.detached.verify is unavailable");
-  }
-  return verify;
-}
-
 function toBase64Address(publicKey: PublicKey): string {
   return Buffer.from(publicKey.toBytes()).toString("base64");
 }
@@ -299,41 +278,12 @@ export class MwaSigner implements Signer {
         const src = source as VersionedTransaction;
         tx.message = src.message;
         tx.signatures = src.signatures;
-        await this.assertOwnSignature(tx, index);
+        await assertOwnVersionedSignature(tx, this.publicKey, index);
       } else {
         (tx as Transaction).signatures = (source as Transaction).signatures;
       }
     }
     return txs;
-  }
-
-  private async assertOwnSignature(
-    tx: VersionedTransaction,
-    index: number,
-  ): Promise<void> {
-    const address = this.publicKey.toBase58();
-    const signerIndex = tx.message.staticAccountKeys.findIndex((key) =>
-      key.equals(this.publicKey),
-    );
-    if (
-      signerIndex < 0 ||
-      signerIndex >= tx.message.header.numRequiredSignatures
-    ) {
-      throw new Error(
-        `Wallet returned transaction ${index + 1} without ${address} as a signer.`,
-      );
-    }
-    const verify = await getTweetNaclVerify();
-    const valid = verify(
-      tx.message.serialize(),
-      tx.signatures[signerIndex],
-      this.publicKey.toBytes(),
-    );
-    if (!valid) {
-      throw new Error(
-        `The wallet returned an invalid signature for ${address} on transaction ${index + 1}. It may have signed with a different account — reset your wallet in Settings and reconnect.`,
-      );
-    }
   }
 
   private async withWallet<T>(

--- a/apps/mobile/src/lib/wallet/signer.ts
+++ b/apps/mobile/src/lib/wallet/signer.ts
@@ -12,7 +12,7 @@ import {
  */
 export interface Signer {
   readonly publicKey: PublicKey;
-  readonly kind: "local" | "seed-vault" | "mwa";
+  readonly kind: "local" | "seed-vault" | "mwa" | "deeplink";
   signMessage(bytes: Uint8Array): Promise<Uint8Array>;
   signTransaction<T extends Transaction | VersionedTransaction>(
     tx: T,
@@ -85,5 +85,62 @@ export class LocalKeypairSigner implements Signer {
     return Array.from(this.keypair.secretKey)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
+  }
+}
+
+type TweetNaclVerify = (
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+) => boolean;
+
+// Lazy-loaded for the same reason as getTweetNaclSign above.
+async function getTweetNaclVerify(): Promise<TweetNaclVerify> {
+  const mod = (await import("tweetnacl")) as unknown as {
+    sign?: { detached?: { verify?: TweetNaclVerify } };
+    default?: { sign?: { detached?: { verify?: TweetNaclVerify } } };
+  };
+  const verify =
+    mod.sign?.detached?.verify ?? mod.default?.sign?.detached?.verify;
+  if (typeof verify !== "function") {
+    throw new Error("tweetnacl sign.detached.verify is unavailable");
+  }
+  return verify;
+}
+
+/**
+ * Assert an external wallet actually signed `tx` with `publicKey`. Wallet apps
+ * (MWA or deeplink) may return a modified transaction, so after adopting the
+ * returned message + signatures this check fails with a precise error instead
+ * of an opaque RPC preflight failure. `index` is 0-based and only used for the
+ * error copy.
+ */
+export async function assertOwnVersionedSignature(
+  tx: VersionedTransaction,
+  publicKey: PublicKey,
+  index: number,
+): Promise<void> {
+  const address = publicKey.toBase58();
+  const signerIndex = tx.message.staticAccountKeys.findIndex((key) =>
+    key.equals(publicKey),
+  );
+  if (
+    signerIndex < 0 ||
+    signerIndex >= tx.message.header.numRequiredSignatures
+  ) {
+    throw new Error(
+      `Wallet returned transaction ${index + 1} without ${address} as a signer.`,
+    );
+  }
+  const verify = await getTweetNaclVerify();
+  const valid = verify(
+    tx.message.serialize(),
+    tx.signatures[signerIndex],
+    publicKey.toBytes(),
+  );
+  if (!valid) {
+    throw new Error(
+      `The wallet returned an invalid signature for ${address} on transaction ${index + 1}. It may have signed with a different account — reset your wallet in Settings and reconnect.`,
+    );
   }
 }

--- a/apps/mobile/src/lib/wallet/wallet-provider.tsx
+++ b/apps/mobile/src/lib/wallet/wallet-provider.tsx
@@ -46,6 +46,13 @@ import {
   changePin as changeKeypairPin,
 } from "./keypair-storage";
 import {
+  clearDeeplinkSession,
+  loadDeeplinkSession,
+  storeDeeplinkSession,
+  type StoredDeeplinkSession,
+} from "./deeplink-session-storage";
+import { DeeplinkSigner, disconnectDeeplinkWallet } from "./deeplink-signer";
+import {
   clearMwaAccount,
   loadMwaAccount,
   storeMwaAccount,
@@ -90,6 +97,7 @@ interface WalletContextValue {
     opts?: { alreadyStored?: boolean },
   ) => Promise<void>;
   finalizeMwaSigner: (account: StoredMwaAccount) => Promise<void>;
+  finalizeDeeplinkSigner: (session: StoredDeeplinkSession) => Promise<void>;
   finalizeVaultSigner: (account: VaultAccount) => Promise<void>;
 
   // Lock / unlock
@@ -136,6 +144,16 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         const next = new MwaSigner(mwa.authToken, mwa.publicKey, mwa.label);
         setSigner(next);
         setPublicKey(mwa.publicKey);
+        setWalletSigner(next);
+        setState("vault-unlocked");
+        return;
+      }
+
+      const deeplink = await loadDeeplinkSession();
+      if (deeplink) {
+        const next = new DeeplinkSigner(deeplink);
+        setSigner(next);
+        setPublicKey(deeplink.publicKey);
         setWalletSigner(next);
         setState("vault-unlocked");
         return;
@@ -273,6 +291,22 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     track(WALLET_SETUP_EVENTS.walletCreated, { source: "mwa" });
   }, []);
 
+  // Deeplink (Phantom/Solflare on iOS) accounts finalize without
+  // PIN/biometric setup, like MWA: the wallet app owns all approval UI.
+  const finalizeDeeplinkSigner = useCallback(
+    async (session: StoredDeeplinkSession) => {
+      await storeDeeplinkSession(session);
+      const next = new DeeplinkSigner(session);
+      setSigner(next);
+      setPublicKey(session.publicKey);
+      setWalletSigner(next);
+      setState("vault-unlocked");
+      identifyWallet(session.publicKey, "deeplink");
+      track(WALLET_SETUP_EVENTS.walletCreated, { source: session.provider });
+    },
+    [],
+  );
+
   // Legacy direct Seed Vault connect — the onboarding fallback for binaries
   // that predate the MWA native module (pre-42 builds receiving current JS
   // via OTA). Like MWA, finalizes without PIN/biometric setup.
@@ -383,8 +417,16 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         console.warn("[wallet] MWA deauthorize failed", error);
       }
     }
+    if (signer instanceof DeeplinkSigner) {
+      try {
+        await disconnectDeeplinkWallet(signer.session);
+      } catch (error) {
+        console.warn("[wallet] deeplink disconnect failed", error);
+      }
+    }
 
     await clearMwaAccount();
+    await clearDeeplinkSession();
     await clearVaultAccount();
     await clearStoredKeypair();
     // Reset means gone everywhere we put it — a later fresh install must not
@@ -423,6 +465,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       importWallet,
       finalizeSigner,
       finalizeMwaSigner,
+      finalizeDeeplinkSigner,
       finalizeVaultSigner,
       unlock,
       unlockWithBiometrics,
@@ -445,6 +488,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       importWallet,
       finalizeSigner,
       finalizeMwaSigner,
+      finalizeDeeplinkSigner,
       finalizeVaultSigner,
       unlock,
       unlockWithBiometrics,


### PR DESCRIPTION
Implements ASK-2202: external-wallet connect on iOS over Phantom's deeplink protocol (Solflare mirrors it) — x25519/nacl-box encrypted connect/sign/disconnect round-trips, persisted session surviving restart, a Phantom/Solflare chooser in onboarding, and wallet_connect_* events. Depends on ASK-2199's PR (AASA + Associated Domains for the https://askloyal.com/ul/wallet/* return links and the canonical wallet-connect-events file); rebase on it before landing.