### PR TITLE
build(mobile): pull production EAS environment into dapp-store builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -60,6 +60,7 @@
     "dapp-store": {
       "autoIncrement": true,
       "channel": "dapp-store",
+      "environment": "production",
       "env": {
         "DAPP_STORE_BUILD": "true",
         "EXPO_PUBLIC_API_BASE_URL": "https://solana-telegram-transactions.vercel.app",


### PR DESCRIPTION
Without `environment: production` the dapp-store build profile misses EAS server-hosted env vars — notably `EXPO_PUBLIC_MIXPANEL_TOKEN`, which has no fallback, so Seeker binaries would ship with analytics disabled. Matches the production profile.