### PR TITLE
fix(web): cache and rate-limit public token market endpoint

### DIFF
--- a/apps/web/src/app/api/tokens/[mint]/market/route.ts
+++ b/apps/web/src/app/api/tokens/[mint]/market/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
 
-import { fetchTokenMarketByMint } from "@/lib/market/token-detail.server";
+import {
+  fetchTokenMarketByMint,
+  isLikelySolanaMint,
+  TOKEN_DETAIL_RESPONSE_CACHE_CONTROL,
+} from "@/lib/market/token-detail.server";
+
+const CACHE_HEADERS = {
+  "Cache-Control": TOKEN_DETAIL_RESPONSE_CACHE_CONTROL,
+};
 
 export async function GET(
   _request: Request,
@@ -9,16 +17,17 @@ export async function GET(
   const { mint } = await params;
   const normalizedMint = mint?.trim();
 
-  if (!normalizedMint) {
+  if (!normalizedMint || !isLikelySolanaMint(normalizedMint)) {
+    // Deterministic per-URL, so let the CDN absorb repeated invalid-mint spam.
     return NextResponse.json(
-      { error: "Token mint is required" },
-      { status: 400 }
+      { error: "Invalid token mint" },
+      { headers: CACHE_HEADERS, status: 400 }
     );
   }
 
   try {
     const market = await fetchTokenMarketByMint(normalizedMint);
-    return NextResponse.json(market);
+    return NextResponse.json(market, { headers: CACHE_HEADERS });
   } catch (error) {
     console.error(
       "[api/tokens/[mint]/market] Failed to fetch token market",

--- a/apps/web/src/app/api/tokens/[mint]/route.ts
+++ b/apps/web/src/app/api/tokens/[mint]/route.ts
@@ -3,9 +3,15 @@ import { NextResponse } from "next/server";
 import {
   fetchTokenChartByMint,
   fetchTokenDetailByMint,
+  isLikelySolanaMint,
   TOKEN_CHART_DAYS,
+  TOKEN_DETAIL_RESPONSE_CACHE_CONTROL,
   type TokenChartDays,
 } from "@/lib/market/token-detail.server";
+
+const CACHE_HEADERS = {
+  "Cache-Control": TOKEN_DETAIL_RESPONSE_CACHE_CONTROL,
+};
 
 export async function GET(
   request: Request,
@@ -14,10 +20,10 @@ export async function GET(
   const { mint } = await params;
   const normalizedMint = mint?.trim();
 
-  if (!normalizedMint) {
+  if (!normalizedMint || !isLikelySolanaMint(normalizedMint)) {
     return NextResponse.json(
-      { error: "Token mint is required" },
-      { status: 400 }
+      { error: "Invalid token mint" },
+      { headers: CACHE_HEADERS, status: 400 }
     );
   }
 
@@ -30,18 +36,18 @@ export async function GET(
       if (!TOKEN_CHART_DAYS.includes(chartDays as TokenChartDays)) {
         return NextResponse.json(
           { error: "Invalid chartDays" },
-          { status: 400 }
+          { headers: CACHE_HEADERS, status: 400 }
         );
       }
       const chart = await fetchTokenChartByMint(
         normalizedMint,
         chartDays as TokenChartDays
       );
-      return NextResponse.json({ chart });
+      return NextResponse.json({ chart }, { headers: CACHE_HEADERS });
     }
 
     const detail = await fetchTokenDetailByMint(normalizedMint);
-    return NextResponse.json(detail);
+    return NextResponse.json(detail, { headers: CACHE_HEADERS });
   } catch (error) {
     console.error("[api/tokens/[mint]] Failed to fetch token detail", error);
     return NextResponse.json(

--- a/apps/web/src/lib/market/token-detail.server.ts
+++ b/apps/web/src/lib/market/token-detail.server.ts
@@ -3,7 +3,21 @@ import "server-only";
 const COINGECKO_BASE_URL = "https://pro-api.coingecko.com/api/v3";
 const SOLANA_NETWORK = "solana";
 const SOLANA_POOL_PREFIX = "solana_";
-const TOKEN_DETAIL_CACHE_TTL_MS = 5 * 60 * 1000;
+const TOKEN_DETAIL_CACHE_TTL_SECONDS = 5 * 60;
+const TOKEN_DETAIL_CACHE_TTL_MS = TOKEN_DETAIL_CACHE_TTL_SECONDS * 1000;
+
+// CDN cache header for the public token detail/market routes so repeated
+// unauthenticated reads are served by the CDN instead of invoking a function
+// (see ASK-2203: same-URL spam throttled the whole Vercel project).
+export const TOKEN_DETAIL_RESPONSE_CACHE_CONTROL = `public, max-age=60, s-maxage=${TOKEN_DETAIL_CACHE_TTL_SECONDS}, stale-while-revalidate=3600`;
+
+const BASE58_MINT_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+// ponytail: charset/length check only, not full base58 32-byte decode;
+// CoinGecko handles the rare well-formed-but-nonexistent mint.
+export function isLikelySolanaMint(mint: string): boolean {
+  return BASE58_MINT_PATTERN.test(mint);
+}
 
 export type TokenDetailChartPoint = {
   timestamp: number;


### PR DESCRIPTION
Adds CDN cache headers (`s-maxage=300, stale-while-revalidate=3600`) and base58 mint validation to `/api/tokens/[mint]` and `/api/tokens/[mint]/market` so same-URL spam is absorbed by the CDN instead of invoking functions (ASK-2203). Invalid mints (including the lowercase spam variant) now get a cacheable 400 before any CoinGecko call.