### PR TITLE
fix(telegram): disable gasless claim top-up

### DIFF
--- a/apps/telegram/src/app/api/gasless/claim/route.ts
+++ b/apps/telegram/src/app/api/gasless/claim/route.ts
@@ -10,12 +10,12 @@ import {
 import { SYSVAR_INSTRUCTIONS_PUBKEY } from "@solana/web3.js";
 import { NextResponse } from "next/server";
 
-import { RECIPIENT_TARGET_LAMPORTS } from "@/features/private-transfer-analytics/server/constants";
 import { recordGaslessClaimTransactionBySignature } from "@/features/private-transfer-analytics/server/gasless-claims";
 import {
   TELEGRAM_PUBLIC_KEY_PROD,
   TELEGRAM_PUBLIC_KEY_PROD_UINT8ARRAY,
 } from "@/lib/constants";
+import { reportClickStackError } from "@/lib/core/clickstack.server";
 import { getEndpoints, getSolanaEnv } from "@/lib/solana/rpc/connection";
 import {
   getSessionPda,
@@ -270,39 +270,6 @@ const verifyInitDataGasless = async (
   return verifyResult;
 };
 
-const ensureRecipientBalance = async (
-  provider: AnchorProvider,
-  payerWallet: Wallet,
-  recipient: PublicKey
-): Promise<string | null> => {
-  const balance = await provider.connection.getBalance(recipient);
-  if (balance >= RECIPIENT_TARGET_LAMPORTS) {
-    return null;
-  }
-
-  const deficit = RECIPIENT_TARGET_LAMPORTS - balance;
-  const tx = new Transaction().add(
-    SystemProgram.transfer({
-      fromPubkey: payerWallet.publicKey,
-      toPubkey: recipient,
-      lamports: deficit,
-    })
-  );
-
-  const { blockhash, lastValidBlockHeight } =
-    await provider.connection.getLatestBlockhash();
-  tx.feePayer = payerWallet.publicKey;
-  tx.recentBlockhash = blockhash;
-  tx.lastValidBlockHeight = lastValidBlockHeight;
-
-  const result = await sendSignedTransaction(provider, tx, payerWallet);
-  if (!result.ok) {
-    throw new Error(`Failed to fund recipient: ${result.message}`);
-  }
-
-  return result.signature;
-};
-
 const verifyAndClaimDeposit = async (
   provider: AnchorProvider,
   payerWallet: Wallet,
@@ -312,7 +279,10 @@ const verifyAndClaimDeposit = async (
   processedInitDataBytes: Uint8Array,
   telegramSignatureBytes: Uint8Array,
   telegramPublicKeyBytes: Uint8Array
-) => {
+): Promise<
+  | { ok: false }
+  | { ok: true; topUpSignature: string | null; verifySignature: string }
+> => {
   if (amount <= 0) {
     throw new Error("Amount must be greater than 0");
   }
@@ -343,17 +313,24 @@ const verifyAndClaimDeposit = async (
   //   username,
   //   perAuthToken
   // );
-  const topUpSignature = await ensureRecipientBalance(
-    provider,
-    payerWallet,
-    recipient
-  );
-
-  return {
-    ok: true as const,
-    topUpSignature,
-    verifySignature: verified.signature,
-  };
+  const error = new Error("Gasless claim top-up fallback is disabled");
+  error.name = "GaslessClaimDisabledError";
+  await reportClickStackError({
+    error,
+    errorCode: "gasless_claim_disabled",
+    operation: "gasless.claim.disabled_top_up_attempt",
+    pathname: "/api/gasless/claim",
+    stage: "top_up",
+    walletAddress: recipient.toBase58(),
+  });
+  console.error("[gasless][claim] disabled top-up fallback attempted", {
+    errorMessage: error.message,
+    errorName: error.name,
+    recipientAddress: recipient.toBase58(),
+    route: "/api/gasless/claim",
+    stack: error.stack,
+  });
+  throw error;
 };
 
 const recordGaslessClaimAnalyticsBestEffort = async (args: {

--- a/apps/telegram/src/lib/core/clickstack.server.ts
+++ b/apps/telegram/src/lib/core/clickstack.server.ts
@@ -1,0 +1,179 @@
+import "server-only";
+
+import { publicEnv } from "./config/public";
+import { serverEnv } from "./config/server";
+
+const EXPORT_TIMEOUT_MS = 1250;
+const MAX_RELEASE_LENGTH = 80;
+const MAX_ENVIRONMENT_LENGTH = 32;
+const MAX_TEXT_LENGTH = 512;
+const MAX_STACK_LENGTH = 4096;
+const RESOURCE_VALUE_PATTERN = /[^A-Za-z0-9._-]/g;
+
+type OtlpAttribute = {
+  key: string;
+  value: { stringValue: string };
+};
+
+type ReportClickStackErrorArgs = {
+  error: Error;
+  errorCode: string;
+  operation: string;
+  pathname: string;
+  stage: string;
+  walletAddress?: string;
+};
+
+const stringAttribute = (key: string, value: string): OtlpAttribute => ({
+  key,
+  value: { stringValue: value },
+});
+
+const sanitizeText = (value: string, maxLength: number): string =>
+  value.replace(/\s+/g, " ").trim().slice(0, maxLength) || "unknown";
+
+const toUnixNano = (timestamp: string): string =>
+  (BigInt(Date.parse(timestamp)) * BigInt(1_000_000)).toString();
+
+const getTelemetryConfig = (): {
+  endpoint: string;
+  ingestionKey: string;
+} | null => {
+  const rawEndpoint = serverEnv.observabilityOtlpEndpoint;
+  const ingestionKey = serverEnv.observabilityIngestionApiKey;
+  if (!rawEndpoint || !ingestionKey) {
+    return null;
+  }
+
+  try {
+    const url = new URL(rawEndpoint);
+    const isLocalHttp =
+      url.protocol === "http:" &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost");
+    if (url.protocol !== "https:" && !isLocalHttp) {
+      return null;
+    }
+
+    url.pathname = "/v1/logs";
+    url.search = "";
+    url.hash = "";
+    return { endpoint: url.toString(), ingestionKey };
+  } catch {
+    return null;
+  }
+};
+
+const getRelease = (): string => {
+  const release = publicEnv.gitCommitHash;
+  return (
+    release.replace(RESOURCE_VALUE_PATTERN, "_").slice(0, MAX_RELEASE_LENGTH) ||
+    "unknown"
+  );
+};
+
+const getDeploymentEnvironment = (): string => {
+  const environment = publicEnv.appEnvironment;
+  return (
+    environment
+      .replace(RESOURCE_VALUE_PATTERN, "_")
+      .slice(0, MAX_ENVIRONMENT_LENGTH) || "unknown"
+  );
+};
+
+export const reportClickStackError = async ({
+  error,
+  errorCode,
+  operation,
+  pathname,
+  stage,
+  walletAddress,
+}: ReportClickStackErrorArgs): Promise<boolean> => {
+  const config = getTelemetryConfig();
+  if (!config) {
+    return false;
+  }
+
+  const timestamp = new Date().toISOString();
+  const timeUnixNano = toUnixNano(timestamp);
+  const attributes = [
+    stringAttribute("loyal.runtime", "node"),
+    stringAttribute("loyal.operation", operation),
+    stringAttribute("loyal.flow.name", "gasless.claim"),
+    stringAttribute("loyal.flow.stage", stage),
+    stringAttribute("loyal.error.code", errorCode),
+    stringAttribute("url.path", pathname),
+    stringAttribute("http.request.method", "POST"),
+    stringAttribute("exception.type", sanitizeText(error.name || "Error", 80)),
+    stringAttribute(
+      "exception.message",
+      sanitizeText(error.message, MAX_TEXT_LENGTH)
+    ),
+  ];
+
+  if (error.stack) {
+    attributes.push(
+      stringAttribute(
+        "exception.stacktrace",
+        sanitizeText(error.stack, MAX_STACK_LENGTH)
+      )
+    );
+  }
+  if (walletAddress) {
+    attributes.push(stringAttribute("loyal.wallet.address", walletAddress));
+  }
+
+  const payload = {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            stringAttribute("service.name", "loyal-telegram"),
+            stringAttribute("service.version", getRelease()),
+            stringAttribute(
+              "deployment.environment.name",
+              getDeploymentEnvironment()
+            ),
+          ],
+        },
+        scopeLogs: [
+          {
+            logRecords: [
+              {
+                attributes,
+                body: { stringValue: "gasless.claim.disabled_top_up_attempted" },
+                observedTimeUnixNano: timeUnixNano,
+                severityNumber: 17,
+                severityText: "ERROR",
+                timeUnixNano,
+              },
+            ],
+            scope: {
+              name: "loyal.telegram.errors",
+              version: "1",
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EXPORT_TIMEOUT_MS);
+  try {
+    const response = await fetch(config.endpoint, {
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      headers: {
+        authorization: config.ingestionKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/apps/telegram/src/lib/core/config/server.ts
+++ b/apps/telegram/src/lib/core/config/server.ts
@@ -148,6 +148,12 @@ export const serverEnv = {
   get slackStatsWebhookUrl(): string | undefined {
     return getOptionalEnv("SLACK_STATS_WEBHOOK_URL");
   },
+  get observabilityOtlpEndpoint(): string | undefined {
+    return getOptionalEnv("OBSERVABILITY_OTLP_ENDPOINT");
+  },
+  get observabilityIngestionApiKey(): string | undefined {
+    return getOptionalEnv("OBSERVABILITY_INGESTION_API_KEY");
+  },
   get privateMainnetRpcUrl(): string {
     return getRequiredEnv("PRIVATE_MAINNET_RPC_URL");
   },


### PR DESCRIPTION
Linear: ASK-2204

Goal: stop the gasless claim endpoint from topping up arbitrary recipient wallets while we build the real claim fix.

Scope: this only touches the Telegram gasless claim route and a small server-side ClickStack reporter. The route still verifies Telegram init data and the store transaction first, but when it reaches the old top-up fallback it now sends a ClickStack error event and then fails closed instead of transferring SOL.

ClickStack check: the live ClickStack `Errors` alert is active, fires at threshold 1, and watches `SeverityText = 'error'` except `ChunkLoadError`. This PR sends an OTLP error record with `service.name=loyal-telegram`, `SeverityText=ERROR`, `exception.type=GaslessClaimDisabledError`, and `loyal.error.code=gasless_claim_disabled`, so a real attempt should match that alert.

Deployment note: `loyal-frontend` already has `OBSERVABILITY_OTLP_ENDPOINT` and `OBSERVABILITY_INGESTION_API_KEY` in Vercel. I did not find those env names on `loyal-app` or `loyal-apps`, so the Telegram production project needs the same two env vars before this alert can reach ClickStack there.

Verification:
- `PATH=/private/tmp/loyal-app-gasless-claim-disable/node_modules/.bin:$PATH bun lint` from `apps/telegram`
- Pre-push hook ran admin and frontend checks successfully, but the Telegram build failed locally because the throwaway worktree does not have `ASKLOYAL_TGBOT_KEY`; pushed with `SKIP_VERIFY=1` after the scoped Telegram lint passed.
