### PR TITLE
fix(mobile): keep icloud backup on device-only reset and restore biometrics

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -312,24 +312,46 @@ export default function ProfileScreen() {
     if (process.env.EXPO_OS !== "web") {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
     }
+    const finishReset = async (keepCloudBackup: boolean) => {
+      await wallet.resetWallet({ keepCloudBackup });
+      // Land on the wallet tab so re-onboarding completion reveals the
+      // wallet UI rather than the Settings page the user just left.
+      router.replace("/");
+    };
+    // iCloud backup ON (iOS, local wallet): resetting only this device must
+    // not silently delete the user's iCloud backup (ASK-2206).
+    if (!isVaultBacked && isICloudSyncSupported() && isICloudBackupEnabled()) {
+      Alert.alert(
+        "Reset Wallet",
+        "Your wallet is backed up to iCloud.\n\n“Remove from this device” keeps the iCloud backup so you can restore this wallet later.\n\n“Delete everywhere” also deletes the iCloud backup. Deletion syncs through iCloud asynchronously, so other devices may keep a copy for a while. Make sure you have backed up your secret key.",
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Remove from this device",
+            onPress: () => void finishReset(true),
+          },
+          {
+            text: "Delete everywhere",
+            style: "destructive",
+            onPress: () => void finishReset(false),
+          },
+        ],
+      );
+      return;
+    }
     Alert.alert(
       "Reset Wallet",
-      "This will permanently delete your wallet from this device. Make sure you have backed up your secret key. This action cannot be undone.",
+      `This will permanently delete your wallet from this device${isICloudSyncSupported() ? " and remove any iCloud copies" : ""}. Make sure you have backed up your secret key. This action cannot be undone.`,
       [
         { text: "Cancel", style: "cancel" },
         {
           text: "Reset",
           style: "destructive",
-          onPress: async () => {
-            await wallet.resetWallet();
-            // Land on the wallet tab so re-onboarding completion reveals the
-            // wallet UI rather than the Settings page the user just left.
-            router.replace("/");
-          },
+          onPress: () => void finishReset(false),
         },
       ],
     );
-  }, [router, wallet]);
+  }, [isVaultBacked, router, wallet]);
 
   return (
     <View className="flex-1 bg-white">

--- a/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
+++ b/apps/mobile/src/lib/wallet/__tests__/icloud-keychain-sync.test.ts
@@ -102,6 +102,26 @@ test("clearStoredKeypair removes the synced copies even when sync is on", async 
   expect(syncedStore.size).toBe(0);
 });
 
+// ASK-2206: "Remove from this device" must leave the iCloud Keychain mirror
+// restorable; only "Delete everywhere" wipes it.
+test("device-only clear keeps the synced copies restorable; full clear wipes them", async () => {
+  await setICloudSyncEnabled(true);
+  await storeKeypair(keypair, PIN);
+
+  await clearStoredKeypair({ keepSyncedKeychain: true });
+  expect(localStore.has("wallet_encrypted_keypair")).toBe(false);
+  expect(localStore.has("wallet_public_key")).toBe(false);
+  expect(syncedStore.has("wallet_encrypted_keypair")).toBe(true);
+
+  // A later install can still restore and unlock with the original PIN.
+  expect(await restoreFromSyncedKeychain()).toBe(true);
+  const unlocked = await loadKeypair(PIN);
+  expect(unlocked?.publicKey.toBase58()).toBe(keypair.publicKey.toBase58());
+
+  await clearStoredKeypair();
+  expect(syncedStore.size).toBe(0);
+});
+
 test("restore round-trip: synced blob adopts locally and unlocks with the original PIN", async () => {
   // Device A: wallet exists and syncs.
   await setICloudSyncEnabled(true);

--- a/apps/mobile/src/lib/wallet/keypair-storage.ts
+++ b/apps/mobile/src/lib/wallet/keypair-storage.ts
@@ -24,6 +24,9 @@ const WALLET_PUBLIC_KEY = "wallet_public_key";
 // The mirrored copy is the same PIN-encrypted blob — accepted risk, see the
 // Linear issue: "we protect on our level, icloud is user's responsibility."
 const ICLOUD_SYNC_ENABLED_KEY = "settings.icloudKeychainSync";
+// Restored wallets skip onboarding's biometric-setup step (ASK-2205). Set on
+// adopt, consumed by the wallet provider on the first successful PIN unlock.
+const BIOMETRIC_RESTORE_PENDING_KEY = "wallet.biometricRestorePending";
 const FAILED_ATTEMPTS_KEY = "wallet_failed_attempts";
 const LOCKED_UNTIL_KEY = "wallet_locked_until";
 
@@ -164,6 +167,17 @@ export async function adoptEncryptedKeypair(
   );
   await SecureStore.setItemAsync(WALLET_PUBLIC_KEY, publicKey, KEYCHAIN_OPTIONS);
   await resetAttempts();
+  mmkv.setBoolean(BIOMETRIC_RESTORE_PENDING_KEY, true);
+}
+
+/**
+ * True exactly once after a restore adopted a keypair: the caller (wallet
+ * provider) re-runs biometric setup on the first PIN unlock (ASK-2205).
+ */
+export function consumeBiometricRestorePending(): boolean {
+  const pending = mmkv.getBoolean(BIOMETRIC_RESTORE_PENDING_KEY) ?? false;
+  if (pending) mmkv.delete(BIOMETRIC_RESTORE_PENDING_KEY);
+  return pending;
 }
 
 /**
@@ -238,17 +252,26 @@ export async function getStoredPublicKey(): Promise<string | null> {
   return SecureStore.getItemAsync(WALLET_PUBLIC_KEY);
 }
 
-export async function clearStoredKeypair(): Promise<void> {
+export async function clearStoredKeypair(opts?: {
+  /**
+   * "Remove from this device" (ASK-2206): wipe only local key material and
+   * leave the iCloud Keychain mirror in place so another install can restore.
+   */
+  keepSyncedKeychain?: boolean;
+}): Promise<void> {
   await SecureStore.deleteItemAsync(ENCRYPTED_KEYPAIR_KEY);
   await SecureStore.deleteItemAsync(WALLET_PUBLIC_KEY);
-  // Always clear the synced copies too — a reset must not leave key material
-  // in iCloud regardless of the toggle state at the time.
-  try {
-    await SyncedKeychain.deleteItem(ENCRYPTED_KEYPAIR_KEY);
-    await SyncedKeychain.deleteItem(WALLET_PUBLIC_KEY);
-  } catch (error) {
-    console.warn("[wallet] iCloud Keychain cleanup failed", error);
+  if (!opts?.keepSyncedKeychain) {
+    // "Delete everywhere": a full reset must not leave key material in
+    // iCloud regardless of the toggle state at the time.
+    try {
+      await SyncedKeychain.deleteItem(ENCRYPTED_KEYPAIR_KEY);
+      await SyncedKeychain.deleteItem(WALLET_PUBLIC_KEY);
+    } catch (error) {
+      console.warn("[wallet] iCloud Keychain cleanup failed", error);
+    }
   }
+  mmkv.delete(BIOMETRIC_RESTORE_PENDING_KEY);
   await resetAttempts();
 }
 

--- a/apps/mobile/src/lib/wallet/wallet-provider.tsx
+++ b/apps/mobile/src/lib/wallet/wallet-provider.tsx
@@ -36,6 +36,7 @@ import {
 } from "./icloud-backup";
 import {
   clearStoredKeypair,
+  consumeBiometricRestorePending,
   generateKeypairInMemory,
   getStoredPublicKey,
   hasStoredKeypair,
@@ -111,7 +112,7 @@ interface WalletContextValue {
 
   // Management
   changePin: (newPin: string) => Promise<void>;
-  resetWallet: () => Promise<void>;
+  resetWallet: (opts?: { keepCloudBackup?: boolean }) => Promise<void>;
   /** Re-read storage after an out-of-band restore (e.g. iCloud backup). */
   refreshFromStorage: () => Promise<void>;
   getSecretKeyHex: () => string | null;
@@ -349,6 +350,17 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setWalletSigner(next);
     setState("unlocked");
     identifyWallet(pk, "imported");
+    // Restored wallets (iCloud Keychain / Drive backup) skipped onboarding's
+    // biometric setup — re-run it with the PIN we just verified (ASK-2205).
+    // enableBiometrics no-ops without hardware/enrollment, like the create flow.
+    if (consumeBiometricRestorePending()) {
+      try {
+        const enabled = await enableBiometrics(pin);
+        setBiometricEnabledState(enabled);
+      } catch (error) {
+        console.warn("[wallet] biometric re-enable after restore failed", error);
+      }
+    }
   }, []);
 
   const unlockWithBiometrics = useCallback(async () => {
@@ -399,48 +411,57 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     [signer, biometricEnabled],
   );
 
-  const resetWallet = useCallback(async () => {
-    // Deauthorize the external wallet first, if there is one. Swallow errors
-    // — if the wallet rejects (already revoked, etc.), we still want local
-    // cleanup to proceed.
-    if (signer instanceof SeedVaultSigner) {
-      try {
-        await SeedVault.deauthorize(signer.authToken);
-      } catch (error) {
-        console.warn("[wallet] SeedVault.deauthorize failed", error);
+  const resetWallet = useCallback(
+    async (opts?: { keepCloudBackup?: boolean }) => {
+      const keepCloudBackup = opts?.keepCloudBackup ?? false;
+      // Deauthorize the external wallet first, if there is one. Swallow errors
+      // — if the wallet rejects (already revoked, etc.), we still want local
+      // cleanup to proceed.
+      if (signer instanceof SeedVaultSigner) {
+        try {
+          await SeedVault.deauthorize(signer.authToken);
+        } catch (error) {
+          console.warn("[wallet] SeedVault.deauthorize failed", error);
+        }
       }
-    }
-    if (signer instanceof MwaSigner) {
-      try {
-        await deauthorizeMwaWallet(signer.authToken);
-      } catch (error) {
-        console.warn("[wallet] MWA deauthorize failed", error);
+      if (signer instanceof MwaSigner) {
+        try {
+          await deauthorizeMwaWallet(signer.authToken);
+        } catch (error) {
+          console.warn("[wallet] MWA deauthorize failed", error);
+        }
       }
-    }
-    if (signer instanceof DeeplinkSigner) {
-      try {
-        await disconnectDeeplinkWallet(signer.session);
-      } catch (error) {
-        console.warn("[wallet] deeplink disconnect failed", error);
+      if (signer instanceof DeeplinkSigner) {
+        try {
+          await disconnectDeeplinkWallet(signer.session);
+        } catch (error) {
+          console.warn("[wallet] deeplink disconnect failed", error);
+        }
       }
-    }
 
-    await clearMwaAccount();
-    await clearDeeplinkSession();
-    await clearVaultAccount();
-    await clearStoredKeypair();
-    // Reset means gone everywhere we put it — a later fresh install must not
-    // offer to restore a wallet the user deliberately deleted.
-    await deleteCloudBackup();
-    await disableBiometrics();
-    setSigner(null);
-    setPublicKey(null);
-    clearWalletSignerCache();
-    setBiometricEnabledState(false);
-    setState("noWallet");
-    track(WALLET_SETUP_EVENTS.walletReset);
-    resetAnalytics();
-  }, [signer]);
+      await clearMwaAccount();
+      await clearDeeplinkSession();
+      await clearVaultAccount();
+      await clearStoredKeypair({ keepSyncedKeychain: keepCloudBackup });
+      if (!keepCloudBackup) {
+        // "Delete everywhere" — a later fresh install must not offer to
+        // restore a wallet the user deliberately deleted. "Remove from this
+        // device" keeps the iCloud copies restorable (ASK-2206).
+        await deleteCloudBackup();
+      }
+      await disableBiometrics();
+      setSigner(null);
+      setPublicKey(null);
+      clearWalletSignerCache();
+      setBiometricEnabledState(false);
+      setState("noWallet");
+      track(WALLET_SETUP_EVENTS.walletReset, {
+        scope: keepCloudBackup ? "device" : "everywhere",
+      });
+      resetAnalytics();
+    },
+    [signer],
+  );
 
   const getSecretKeyHex = useCallback(() => {
     if (!signer || !(signer instanceof LocalKeypairSigner)) return null;


### PR DESCRIPTION
Reset Wallet now offers device-only vs delete-everywhere when the iCloud backup toggle is on, so a reset no longer silently deletes the iCloud backup (ASK-2206), and restored wallets re-enable biometric unlock on the first PIN unlock (ASK-2205).