### PR TITLE
fix(ui): stretch the wallet page to the screen instead of scrolling

### DIFF
--- a/apps/mobile/app/(tabs)/wallet.tsx
+++ b/apps/mobile/app/(tabs)/wallet.tsx
@@ -399,12 +399,19 @@ export default function WalletScreen() {
   return (
     <View className="flex-1 bg-white">
       <LogoHeader onScanPress={() => openSend(true)} />
+      {/* Fits the viewport and stretches (grid rows compress before anything
+          scrolls); the ScrollView stays for pull-to-refresh and as overflow
+          fallback on screens shorter than the grid's compression floor.
+          alwaysBounceVertical keeps the refresh gesture working when content
+          fits exactly and there is nothing to scroll. */}
       <ScrollView
         className="flex-1"
         contentContainerStyle={{
           flexGrow: 1,
           paddingBottom: insets.bottom + 78,
         }}
+        alwaysBounceVertical
+        showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
         }

--- a/apps/mobile/src/features/wallet-categories/ui/WalletCategoryGrid.tsx
+++ b/apps/mobile/src/features/wallet-categories/ui/WalletCategoryGrid.tsx
@@ -30,7 +30,13 @@ const CELL_BG_SOFT = "rgba(0, 0, 0, 0.03)";
 // minimum row height keeps the two rows visually balanced.
 const GRID_PADDING = 16;
 const GRID_GAP = 8;
-const ROW_MIN_HEIGHT = 188;
+// Compression floor, not a target: rows stretch to split the free space
+// evenly and only stop shrinking here. Mirrors the web wallet home, where
+// the grid rows are minmax(0,1fr) inside a min-h-[400px] grid (~133px/row) —
+// the page fits the viewport on every current iPhone and the ScrollView
+// only actually scrolls below this floor. Designer call 2026-08-21:
+// stretch, don't scroll.
+const ROW_MIN_HEIGHT = 132;
 
 // Red pill that deposits straight into Earn without leaving the wallet. Anchored
 // to the right of the Earn card's bottom row (Figma 257:82753).


### PR DESCRIPTION
Wallet category grid rows now compress (floor 132, mirroring the web grid's minmax(0,1fr) rows) so the page fits and stretches to the viewport like the web mobile view; the ScrollView remains only for pull-to-refresh and as a fallback below the floor.