### PR TITLE
fix(wallet): let Earn withdraw MAX close sub-cent dust positions

### DIFF
--- a/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -507,8 +507,12 @@ export function WithdrawPane({
                     if (usd > 0) {
                       // Floor to cents so the label never rounds above the
                       // real balance (full exits withdraw the exact raw).
+                      // Sub-cent dust floors to $0.00 and blocks the exit;
+                      // use the exact 6-decimal amount so the position can
+                      // still close (ASK-2207).
+                      const floored = Math.floor(usd * 100) / 100;
                       handleAmountChange(
-                        (Math.floor(usd * 100) / 100).toFixed(2)
+                        floored > 0 ? floored.toFixed(2) : usd.toFixed(6)
                       );
                     }
                   }}


### PR DESCRIPTION
Earn withdraw MAX floored sub-cent dust to $0.00, making dust-only positions unclosable. MAX now falls back to the exact 6-decimal amount so the full-exit path (exact amountRaw) can run. Fixes ASK-2207.