### PR TITLE
fix(earn-max): install current Squads policy seeds

### DIFF
--- a/apps/web/src/features/earn-max/server/prepared.server.ts
+++ b/apps/web/src/features/earn-max/server/prepared.server.ts
@@ -117,13 +117,26 @@ export async function prepareEarnMaxInstall(input: {
   connection: Connection;
   delegatedSigner: PublicKey;
   feePayer: PublicKey;
+  firstPolicySeed?: bigint;
   programId: PublicKey;
   settings: PublicKey;
   matchingPolicyAccounts: ReadonlySet<string>;
 }): Promise<Prepared[]> {
+  const client = createLoyalSmartAccountsClient({
+    connection: input.connection,
+    programId: input.programId,
+  });
+  const firstPolicySeed =
+    input.firstPolicySeed ??
+    BigInt(
+      (
+        await client.smartAccounts.queries.fetchSettings(input.settings)
+      ).policySeed?.toString() ?? "0"
+    ) + BigInt(1);
   const manifest = createEarnMaxPolicyManifest({
     authority: input.feePayer,
     delegatedSigner: input.delegatedSigner,
+    firstPolicySeed,
     settings: input.settings,
   });
   const accounts = await input.connection.getMultipleAccountsInfo(
@@ -312,16 +325,12 @@ export async function prepareEarnMaxClaim(input: {
 export async function prepareEarnMaxClose(input: {
   connection: Connection;
   feePayer: PublicKey;
+  policies: readonly PublicKey[];
   programId: PublicKey;
   settings: PublicKey;
 }): Promise<Prepared | null> {
-  const policies = createEarnMaxPolicyManifest({
-    authority: input.feePayer,
-    delegatedSigner: input.feePayer,
-    settings: input.settings,
-  }).map((entry) => entry.policy);
-  const accounts = await input.connection.getMultipleAccountsInfo(policies, "confirmed");
-  const existing = policies.filter((_, index) => accounts[index]);
+  const accounts = await input.connection.getMultipleAccountsInfo([...input.policies], "confirmed");
+  const existing = input.policies.filter((_, index) => accounts[index]);
   if (existing.length === 0) return null;
   return createSmartAccountVaultsClient({
     connection: input.connection,

--- a/apps/web/src/features/earn-max/server/service.ts
+++ b/apps/web/src/features/earn-max/server/service.ts
@@ -152,6 +152,24 @@ function rawAmount(value: unknown): bigint | null {
   return null;
 }
 
+function projectedPolicies(value: unknown): Array<{
+  account: string;
+  matches: boolean;
+  seed: bigint;
+}> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const policy = record(entry);
+    const seed = rawAmount(policy?.seed);
+    return policy &&
+      typeof policy.account === "string" &&
+      typeof policy.matches === "boolean" &&
+      seed !== null
+      ? [{ account: policy.account, matches: policy.matches, seed }]
+      : [];
+  });
+}
+
 export async function prepareTransaction(request: Request) {
   const authenticated = await principal(request);
   if (!authenticated) {
@@ -174,19 +192,23 @@ export async function prepareTransaction(request: Request) {
     const connection = getConnection();
     if (parsed.action === "install_policies") {
       const projected = await readEarnMaxState(authenticated.settingsPda);
-      const matchingPolicyAccounts = new Set<string>();
-      if (Array.isArray(projected?.policy_accounts)) {
-        for (const value of projected.policy_accounts) {
-          const evidence = record(value);
-          if (evidence?.matches === true && typeof evidence.account === "string") {
-            matchingPolicyAccounts.add(evidence.account);
-          }
-        }
-      }
+      const projectedBindings = projectedPolicies(projected?.policy_accounts);
+      const matchingPolicyAccounts = new Set(
+        projectedBindings
+          .filter((binding) => binding.matches)
+          .map((binding) => binding.account)
+      );
+      const firstPolicySeed = projectedBindings.length === 6
+        ? projectedBindings.reduce(
+            (minimum, binding) => binding.seed < minimum ? binding.seed : minimum,
+            projectedBindings[0]!.seed
+          )
+        : undefined;
       const operations = await prepareEarnMaxInstall({
         connection,
         delegatedSigner: getDeploymentPolicySignerPublicKey(),
         feePayer,
+        firstPolicySeed,
         matchingPolicyAccounts,
         programId,
         settings,
@@ -269,7 +291,17 @@ export async function prepareTransaction(request: Request) {
     if (withdrawal && withdrawal.status !== "claimed") {
       return jsonError(409, "earn_max_withdrawal_open", "The Earn MAX withdrawal is not complete.");
     }
-    const operation = await prepareEarnMaxClose({ connection, feePayer, programId, settings });
+    const policyBindings = projectedPolicies(state.policy_accounts);
+    if (policyBindings.length !== 6) {
+      return jsonError(409, "earn_max_policy_projection_incomplete", "The exact Earn MAX policy set is unavailable.");
+    }
+    const operation = await prepareEarnMaxClose({
+      connection,
+      feePayer,
+      policies: policyBindings.map((binding) => new PublicKey(binding.account)),
+      programId,
+      settings,
+    });
     return NextResponse.json({
       action: parsed.action,
       preparedOperations: operation ? [serializePreparedOperation(operation)] : [],

--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -112,6 +112,7 @@ function pubkey(accountIndex: number, ...pubkeys: PublicKey[]) {
 export function createEarnMaxPolicyManifest(input: {
   authority: PublicKey;
   delegatedSigner: PublicKey;
+  firstPolicySeed: bigint;
   settings: PublicKey;
 }): readonly EarnMaxPolicyPreparation[] {
   const config = clusterConfigFor(LoyalCluster.MainnetBeta);
@@ -143,7 +144,9 @@ export function createEarnMaxPolicyManifest(input: {
       family.includes("swap")
         ? [finalConstraint]
         : [refreshReserve, refreshObligation, finalConstraint],
-      seed
+      seed,
+      [],
+      "legacy"
     );
     const policy = instruction.keys[5]!.pubkey;
     return {
@@ -169,7 +172,7 @@ export function createEarnMaxPolicyManifest(input: {
   };
 
   return [
-    policy("deposit", BigInt(32), {
+    policy("deposit", input.firstPolicySeed, {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault), pubkey(1, topology.obligation),
@@ -178,7 +181,7 @@ export function createEarnMaxPolicyManifest(input: {
       ],
       dataConstraints: [sliceEquals(DEPOSIT)],
     }),
-    policy("repay", BigInt(33), {
+    policy("repay", input.firstPolicySeed + BigInt(1), {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault), pubkey(1, topology.obligation), pubkey(3, DEBT_RESERVE),
@@ -187,7 +190,7 @@ export function createEarnMaxPolicyManifest(input: {
       ],
       dataConstraints: [sliceEquals(REPAY)],
     }),
-    policy("borrow", BigInt(34), {
+    policy("borrow", input.firstPolicySeed + BigInt(2), {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault), pubkey(1, topology.obligation), pubkey(4, DEBT_RESERVE),
@@ -196,7 +199,7 @@ export function createEarnMaxPolicyManifest(input: {
       ],
       dataConstraints: [sliceEquals(BORROW)],
     }),
-    policy("forward_swap", BigInt(35), {
+    policy("forward_swap", input.firstPolicySeed + BigInt(3), {
       programId: config.jupiterV6ProgramId,
       accountConstraints: [
         pubkey(0, TOKEN), pubkey(2, topology.vault), pubkey(3, topology.claimCustody),
@@ -206,7 +209,7 @@ export function createEarnMaxPolicyManifest(input: {
       ],
       dataConstraints: [sliceEquals(SHARED_ACCOUNTS_ROUTE)],
     }),
-    policy("withdraw", BigInt(36), {
+    policy("withdraw", input.firstPolicySeed + BigInt(4), {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault), pubkey(1, topology.obligation),
@@ -215,7 +218,7 @@ export function createEarnMaxPolicyManifest(input: {
       ],
       dataConstraints: [sliceEquals(WITHDRAW)],
     }),
-    policy("reverse_swap", BigInt(44), {
+    policy("reverse_swap", input.firstPolicySeed + BigInt(5), {
       programId: config.jupiterV6ProgramId,
       accountConstraints: [
         pubkey(0, TOKEN), pubkey(2, topology.vault), pubkey(3, topology.collateralCustody),

--- a/packages/loyal-actions/src/internal/squads.ts
+++ b/packages/loyal-actions/src/internal/squads.ts
@@ -12,6 +12,8 @@ const SQUADS_SEED_PREFIX = new TextEncoder().encode("smart_account");
 const SQUADS_SEED_POLICY = new TextEncoder().encode("policy");
 const SQUADS_FULL_PERMISSIONS_MASK = 7;
 const SQUADS_SYNC_SIGNER_COUNT = 1;
+const POLICY_CREATION_PAYLOAD_LEGACY_PROGRAM_INTERACTION = 3;
+const POLICY_CREATION_PAYLOAD_PROGRAM_INTERACTION = 4;
 const EXECUTE_SETTINGS_TRANSACTION_SYNC_DISCRIMINATOR = [
   138, 209, 64, 163, 79, 67, 233, 76,
 ] as const;
@@ -80,7 +82,8 @@ export function createProgramInteractionPolicyInstruction(
   context: SquadsContext,
   constraints: readonly InstructionConstraint[],
   policySeed: PolicySeed,
-  spendingLimits: readonly DailySpendingLimit[] = []
+  spendingLimits: readonly DailySpendingLimit[] = [],
+  creationEncoding: "compact" | "legacy" = "compact"
 ): TransactionInstruction {
   const normalizedSeed = normalizeU64(policySeed, "policySeed");
   const actionAccount = deriveActionAccount(
@@ -88,15 +91,24 @@ export function createProgramInteractionPolicyInstruction(
     context.settings,
     normalizedSeed
   );
-  const data = serializeSettingsActions(
-    context.delegatedSigner,
-    normalizedSeed,
-    compileProgramInteractionPayload(
-      context.accountIndex,
-      constraints,
-      spendingLimits
-    )
-  );
+  const data =
+    creationEncoding === "legacy"
+      ? serializeLegacySettingsActions(
+          context.delegatedSigner,
+          normalizedSeed,
+          context.accountIndex,
+          constraints,
+          spendingLimits
+        )
+      : serializeSettingsActions(
+          context.delegatedSigner,
+          normalizedSeed,
+          compileProgramInteractionPayload(
+            context.accountIndex,
+            constraints,
+            spendingLimits
+          )
+        );
 
   return new TransactionInstruction({
     programId: config.squadsSmartAccountProgramId,
@@ -140,7 +152,7 @@ export function updateProgramInteractionPolicyInstruction(
     });
     encoder.pushU16(1);
     encoder.pushU32(0);
-    encoder.pushU8(4);
+    encoder.pushU8(POLICY_CREATION_PAYLOAD_PROGRAM_INTERACTION);
     encodeProgramInteractionPayload(encoder, payload);
     encoder.pushOption<never>(undefined, () => undefined);
   });
@@ -280,7 +292,7 @@ function encodePolicyCreateAction(
 ): void {
   encoder.pushU8(7);
   encoder.pushU64(seed);
-  encoder.pushU8(4);
+  encoder.pushU8(POLICY_CREATION_PAYLOAD_PROGRAM_INTERACTION);
   encodeProgramInteractionPayload(encoder, payload);
   encoder.pushVec([delegatedSigner], (signer) => {
     encoder.pushPubkey(signer);
@@ -292,6 +304,89 @@ function encodePolicyCreateAction(
     encoder.pushU64(timestamp)
   );
   encoder.pushOption<never>(undefined, () => undefined);
+}
+
+function serializeLegacySettingsActions(
+  delegatedSigner: PublicKey,
+  seed: bigint,
+  accountIndex: number,
+  constraints: readonly InstructionConstraint[],
+  spendingLimits: readonly DailySpendingLimit[]
+): Uint8Array {
+  const encoder = new BytesEncoder();
+  encoder.pushBytes(EXECUTE_SETTINGS_TRANSACTION_SYNC_DISCRIMINATOR);
+  encoder.pushU8(SQUADS_SYNC_SIGNER_COUNT);
+  encoder.pushVec([undefined], () => {
+    encoder.pushU8(7);
+    encoder.pushU64(seed);
+    encoder.pushU8(POLICY_CREATION_PAYLOAD_LEGACY_PROGRAM_INTERACTION);
+    encodeLegacyProgramInteractionPayload(
+      encoder,
+      accountIndex,
+      constraints,
+      spendingLimits
+    );
+    encoder.pushVec([delegatedSigner], (signer) => {
+      encoder.pushPubkey(signer);
+      encoder.pushU8(SQUADS_FULL_PERMISSIONS_MASK);
+    });
+    encoder.pushU16(1);
+    encoder.pushU32(0);
+    encoder.pushOption<bigint>(undefined, (timestamp) =>
+      encoder.pushU64(timestamp)
+    );
+    encoder.pushOption<never>(undefined, () => undefined);
+  });
+  encoder.pushOption<string>(undefined, (memo) => {
+    const bytes = new TextEncoder().encode(memo);
+    encoder.pushU32(bytes.length);
+    encoder.pushBytes(bytes);
+  });
+  return encoder.finish();
+}
+
+function encodeLegacyProgramInteractionPayload(
+  encoder: BytesEncoder,
+  accountIndex: number,
+  constraints: readonly InstructionConstraint[],
+  spendingLimits: readonly DailySpendingLimit[]
+): void {
+  encoder.pushU8(accountIndex);
+  encoder.pushVec(constraints, (constraint) => {
+    encoder.pushPubkey(constraint.programId);
+    encoder.pushVec(constraint.accountConstraints, (accountConstraint) => {
+      encoder.pushU8(accountConstraint.accountIndex);
+      if (accountConstraint.kind.type === "pubkey") {
+        encoder.pushU8(0);
+        encoder.pushVec(accountConstraint.kind.pubkeys, (pubkey) =>
+          encoder.pushPubkey(pubkey)
+        );
+      } else {
+        encoder.pushU8(1);
+        encoder.pushVec(
+          accountConstraint.kind.dataConstraints,
+          (dataConstraint) => encodeDataConstraint(encoder, dataConstraint)
+        );
+      }
+      encoder.pushOption(accountConstraint.owner, (owner) =>
+        encoder.pushPubkey(owner)
+      );
+    });
+    encoder.pushVec(constraint.dataConstraints, (dataConstraint) =>
+      encodeDataConstraint(encoder, dataConstraint)
+    );
+  });
+  encoder.pushOption<never>(undefined, () => undefined);
+  encoder.pushOption<never>(undefined, () => undefined);
+  encoder.pushVec(spendingLimits, (spendingLimit) => {
+    encoder.pushPubkey(spendingLimit.mint);
+    encoder.pushI64(BigInt(0));
+    encoder.pushOption<bigint>(undefined, (expiration) =>
+      encoder.pushI64(expiration)
+    );
+    encoder.pushU8(1);
+    encoder.pushU64(spendingLimit.maxPerPeriod);
+  });
 }
 
 function encodeProgramInteractionPayload(

--- a/packages/loyal-actions/test/sdk.test.ts
+++ b/packages/loyal-actions/test/sdk.test.ts
@@ -42,6 +42,7 @@ import {
   createSubscriptionSweepPolicyPlan,
   createJupiterCrossMintPolicyPlan,
   createJupiterCrossMintPolicySet,
+  createEarnMaxPolicyManifest,
   createVaultSubscriptionSweepPolicyPlan,
   createVaultYieldRoutingPolicyPlan,
   createLoyalActionsSdk,
@@ -78,6 +79,27 @@ const smartAccount = {
   authority,
   delegatedSigner,
 };
+
+describe("Earn MAX policy manifest", () => {
+  test("uses the mainnet-compatible legacy create payload for all six policies", () => {
+    const manifest = createEarnMaxPolicyManifest({
+      authority,
+      delegatedSigner,
+      firstPolicySeed: BigInt(234),
+      settings,
+    });
+
+    expect(manifest).toHaveLength(6);
+    expect(manifest.map((entry) => decodePolicyCreate(entry.instruction.data).seed)).toEqual([
+      BigInt(234),
+      BigInt(235),
+      BigInt(236),
+      BigInt(237),
+      BigInt(238),
+      BigInt(239),
+    ]);
+  });
+});
 
 describe("Loyal cluster helpers", () => {
   test("normalizes canonical and legacy cluster names", () => {
@@ -420,9 +442,60 @@ function decodePolicyCreate(data: Uint8Array): {
   expect(cursor.readU32()).toBe(1);
   expect(cursor.readU8()).toBe(7);
   const seed = cursor.readU64();
-  expect(cursor.readU8()).toBe(4);
-  const payload = decodeProgramInteractionPayload(cursor);
+  const payloadTag = cursor.readU8();
+  const payload =
+    payloadTag === 3
+      ? decodeLegacyProgramInteractionPayload(cursor)
+      : decodeProgramInteractionPayload(cursor);
   return { seed, payload };
+}
+
+function decodeLegacyProgramInteractionPayload(cursor: Cursor) {
+  const accountIndex = cursor.readU8();
+  const pubkeyTable: PublicKey[] = [];
+  const tableIndex = (pubkey: PublicKey) => {
+    const existing = pubkeyTable.findIndex((candidate) =>
+      candidate.equals(pubkey)
+    );
+    if (existing !== -1) return existing;
+    pubkeyTable.push(pubkey);
+    return pubkeyTable.length - 1;
+  };
+  const instructionConstraints = cursor.readVec(() => ({
+    programIdIndex: tableIndex(cursor.readPubkey()),
+    accountConstraints: cursor.readVec(() => {
+      const accountIndex = cursor.readU8();
+      const kindTag = cursor.readU8();
+      const kind =
+        kindTag === 0
+          ? {
+              type: "pubkey" as const,
+              pubkeyIndexes: cursor.readVec(() => tableIndex(cursor.readPubkey())),
+            }
+          : {
+              type: "accountData" as const,
+              dataConstraints: cursor.readVec(() => decodeDataConstraint(cursor)),
+            };
+      const owner = cursor.readOption(() => cursor.readPubkey());
+      return {
+        accountIndex,
+        kind,
+        ownerIndex: owner ? tableIndex(owner) : undefined,
+      };
+    }),
+    dataConstraints: cursor.readVec(() => decodeDataConstraint(cursor)),
+  }));
+  expect(cursor.readOption(() => cursor.readU8())).toBeUndefined();
+  expect(cursor.readOption(() => cursor.readU8())).toBeUndefined();
+  const spendingLimits = cursor.readVec(() => {
+    const mint = cursor.readPubkey();
+    expect(cursor.readU64()).toBe(BigInt(0));
+    expect(cursor.readOption(() => cursor.readU64())).toBeUndefined();
+    const period = cursor.readU8();
+    const maxPerPeriod = cursor.readU64();
+    return { mint, maxPerPeriod, period };
+  });
+  return { accountIndex, pubkeyTable, instructionConstraints, spendingLimits };
 }
 
 function decodeProgramInteractionPayload(cursor: Cursor) {
@@ -558,6 +631,11 @@ class Cursor {
 
   readSmallVec<T>(decode: () => T): T[] {
     const length = this.readU8();
+    return Array.from({ length }, decode);
+  }
+
+  readVec<T>(decode: () => T): T[] {
+    const length = this.readU32();
     return Array.from({ length }, decode);
   }
 


### PR DESCRIPTION
Use each user's current monotonic Squads policy seed for the six Earn MAX bindings and legacy-compatible create payloads. Mainnet simulations pass for every policy family, while existing compact policy builders retain their packet fit.