### PR TITLE
fix(autoswap): consume confirmed policy readiness

### DIFF
--- a/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/delete/readiness/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/delete/readiness/route.ts
@@ -32,7 +32,7 @@ function getConnection(cluster: SolanaEnv): Connection {
   }
   const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
-    commitment: "finalized",
+    commitment: "confirmed",
     disableRetryOnRateLimit: true,
     fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
     wsEndpoint: websocketEndpoint,
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
     );
     const accounts = await getConnection(solanaEnv).getMultipleAccountsInfo(
       policies,
-      "finalized"
+      "confirmed"
     );
     const remainingPolicies = policies.filter(
       (_policy, index) => accounts[index] !== null

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/toggle/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/cross-mint/toggle/route.ts
@@ -31,7 +31,7 @@ function getConnection(cluster: SolanaEnv): Connection {
   }
   const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
-    commitment: "finalized",
+    commitment: "confirmed",
     disableRetryOnRateLimit: true,
     fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
     wsEndpoint: websocketEndpoint,

--- a/apps/web/src/components/wallet-workspace/facelift/autoswap-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/autoswap-pane.tsx
@@ -221,7 +221,7 @@ export function AutoswapPane({
 
           {isFinalizing ? (
             <p className="mt-4 rounded-2xl bg-primary/10 px-4 py-3 text-[13px] leading-5 text-primary">
-              The policies are finalized on-chain. Loyal is verifying both
+              The policies are confirmed on-chain. Loyal is verifying both
               permissions before routing can begin.
             </p>
           ) : null}

--- a/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.test.ts
@@ -19,7 +19,7 @@ const projectionRow = {
   policyAccount: "classic-policy",
   policySeed: BigInt(7),
   settings: "settings",
-  sourceCommitment: "finalized",
+  sourceCommitment: "confirmed",
   sourceShard: "classic",
   startEligible: true,
   vaultIndex: 1,

--- a/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-cross-mint-repository.server.ts
@@ -124,8 +124,8 @@ export async function findEarnCrossMintSnapshot(
   if (!(classic && token2022)) {
     return { autoswap: null, autoswapIndex };
   }
-  const pairIsFinalized = autoswapIndex.policies.every(
-    (policy) => policy.sourceCommitment === "finalized"
+  const pairIsReady = autoswapIndex.policies.every((policy) =>
+    ["confirmed", "finalized"].includes(policy.sourceCommitment)
   );
   const boundPolicies: EarnCrossMintState["boundPolicies"] = [
     {
@@ -139,7 +139,7 @@ export async function findEarnCrossMintSnapshot(
       sourceShard: "token_2022",
     },
   ];
-  const policies = pairIsFinalized
+  const policies = pairIsReady
     ? [classic, token2022].map((policy, index) => ({
         ...boundPolicies[index],
         lastSeenSignature: policy.lastSeenSignature,
@@ -156,7 +156,7 @@ export async function findEarnCrossMintSnapshot(
       maxSlippageBps: classic.maxSlippageBps,
       policies,
       status: optIn.enabled
-        ? pairIsFinalized
+        ? pairIsReady
           ? "on"
           : "finalizing"
         : "paused",


### PR DESCRIPTION
## Goal

Show Autoswap as installed when its two policy transactions are confirmed, instead of leaving the user on **Set up** until Solana reaches finalized.

## Implementation and scope

The web client now treats confirmed and finalized projected policy pairs as ready, and its direct account reads use confirmed commitment for Autoswap setup, pause, and delete readiness. The copy now describes confirmed completion consistently.

This PR changes only `apps/web`. No `apps/mobile` change is required because mobile does not contain this Autoswap setup/status flow. Telegram miniapp and extension upgrades are intentionally excluded and will be handled later.

This client change depends on [loyal-yield-routing#92](https://github.com/loyal-labs/loyal-yield-routing/pull/92), which repairs existing confirmed records and emits the normal Autoswap SSE state.

## Verification

The cross-repository verifier passed with `PASS_AUTOSWAP_CONFIRMED_RECONCILIATION`. It covers confirmed setup/removal, installed/removed SSE events, database reconciliation, fleet admission, focused web tests and lint, and repository scope. The repository pre-push checks also passed for the app, admin, and frontend packages.

## Post-merge

1. Merge and deploy the routing PR first so confirmed state is projected and reconciled server-side.
2. Deploy the Loyal web app from `apps/web`.
3. Verify the affected wallet shows Autoswap installed without waiting for finalized commitment.

No mobile, Telegram miniapp, or extension deployment is needed for this PR.
