### PR TITLE
perf(earn): cache earn banner artwork across carousel rotations

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -1,7 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { describe, expect, test } from "bun:test";
-import { unstable_getResponseFromNextConfig } from "next/experimental/testing/server";
 
 import nextConfig from "./next.config";
+
+// Next's config test helper reads globalThis.AsyncLocalStorage, which Node sets
+// through its server runtime but Bun does not — without this the whole file
+// throws "AsyncLocalStorage accessed in runtime where it is not available"
+// before any test runs. Assign it before the helper module is evaluated, hence
+// the dynamic import below.
+(
+  globalThis as typeof globalThis & { AsyncLocalStorage?: unknown }
+).AsyncLocalStorage ??= AsyncLocalStorage;
+
+const { unstable_getResponseFromNextConfig } = await import(
+  "next/experimental/testing/server"
+);
 
 describe("frame security headers", () => {
   test("allows only the Cherry entry to be framed by the Cherry web host", async () => {
@@ -30,6 +44,33 @@ describe("frame security headers", () => {
 
       expect(response.headers.get("x-frame-options")).toBe("SAMEORIGIN");
       expect(response.headers.get("content-security-policy")).toBeNull();
+    }
+  });
+});
+
+describe("earn banner asset caching", () => {
+  test("serves versioned banner art as immutable", async () => {
+    const response = await unstable_getResponseFromNextConfig({
+      url: "https://askloyal.com/wallet-workspace/facelift/earn-banner-art-dog.svg?v=abc123",
+      nextConfig,
+    });
+
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+  });
+
+  test("leaves unversioned requests on the default revalidate policy", async () => {
+    for (const url of [
+      "https://askloyal.com/wallet-workspace/facelift/earn-banner-art-dog.svg",
+      "https://askloyal.com/wallet-workspace/facelift/earn-icon.svg?v=abc123",
+    ]) {
+      const response = await unstable_getResponseFromNextConfig({
+        url,
+        nextConfig,
+      });
+
+      expect(response.headers.get("cache-control")).toBeNull();
     }
   });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -101,6 +101,22 @@ const nextConfig: NextConfig = {
         headers: [{ key: "Content-Type", value: "application/json" }],
       },
       {
+        // The Earn banner carousel remounts its artwork every few seconds, and
+        // Next serves /public with `max-age=0, must-revalidate`, so each
+        // rotation cost a revalidation round-trip per asset (ASK-2214).
+        // earn-banner.tsx requests these with a ?v=<commit> buster, so a deploy
+        // always produces a fresh URL — hence immutable is safe here, and the
+        // `has` guard keeps it off unversioned (hand-typed) requests.
+        source: "/wallet-workspace/facelift/:asset(earn-banner-.*)",
+        has: [{ type: "query", key: "v" }],
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
         source: "/app/cherry",
         headers: [
           ...COMMON_SECURITY_HEADERS,

--- a/apps/web/src/components/wallet-workspace/facelift/earn-banner.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-banner.tsx
@@ -7,6 +7,15 @@ import { BannerTitleChars } from "@/components/wallet-workspace/facelift/wallet-
 import { LOYAL_TOKEN_MINT } from "@/lib/market/loyal-token-ticker.shared";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
+// Banner art remounts on every carousel rotation, so it is served immutable
+// (see the cache rule in next.config.ts). The commit hash is what invalidates
+// it: a deploy changes the URL, so a rotation never re-hits the network but a
+// release never serves stale artwork.
+const ASSET_VERSION = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? "dev";
+
+function bannerAsset(file: string): string {
+  return `${ASSET_BASE}/${file}?v=${ASSET_VERSION}`;
+}
 
 // Same autoplay clock as the mobile home carousel; the story pill fill reads
 // it too, so the bar always lands exactly when the banner rolls.
@@ -42,7 +51,7 @@ function TiltedIconPair({ rightArt }: { rightArt: string }) {
           alt=""
           aria-hidden="true"
           className="size-full"
-          src={`${ASSET_BASE}/earn-banner-art-dog.svg`}
+          src={bannerAsset("earn-banner-art-dog.svg")}
         />
       </div>
       <div className="absolute left-[179.23px] top-[241.23px] size-[169.82px]">
@@ -107,14 +116,14 @@ function Texture({ src }: { src: string }) {
 const BANNERS: EarnBannerConfig[] = [
   {
     accent: "#f9363c",
-    art: <TiltedIconPair rightArt={`${ASSET_BASE}/earn-banner-art-x.svg`} />,
+    art: <TiltedIconPair rightArt={bannerAsset("earn-banner-art-x.svg")} />,
     buttonColor: "black",
     buttonLabel: "Follow",
     fade: FADE_RED,
     href: "https://x.com/loyal_hq",
-    icon: `${ASSET_BASE}/earn-banner-icon-x.svg`,
+    icon: bannerAsset("earn-banner-icon-x.svg"),
     key: "x",
-    texture: <Texture src={`${ASSET_BASE}/earn-banner-tex-red.png`} />,
+    texture: <Texture src={bannerAsset("earn-banner-tex-red.png")} />,
     title: "Follow Loyal on X",
     titleClassName: "w-[244px] text-white",
   },
@@ -129,7 +138,7 @@ const BANNERS: EarnBannerConfig[] = [
           alt=""
           aria-hidden="true"
           className="size-full"
-          src={`${ASSET_BASE}/earn-banner-art-mascot.svg`}
+          src={bannerAsset("earn-banner-art-mascot.svg")}
         />
       </div>
     ),
@@ -137,22 +146,22 @@ const BANNERS: EarnBannerConfig[] = [
     buttonLabel: "Go to Jupiter",
     fade: FADE_MAROON,
     href: `https://jup.ag/tokens/${LOYAL_TOKEN_MINT}`,
-    icon: `${ASSET_BASE}/earn-banner-icon-jupiter.svg`,
+    icon: bannerAsset("earn-banner-icon-jupiter.svg"),
     key: "jupiter",
-    texture: <Texture src={`${ASSET_BASE}/earn-banner-tex-dark.png`} />,
+    texture: <Texture src={bannerAsset("earn-banner-tex-dark.png")} />,
     title: "Buy $LOYAL on Jupiter",
     titleClassName: "w-[270px] text-white",
   },
   {
     accent: "#f9363c",
     art: (
-      <TiltedIconPair rightArt={`${ASSET_BASE}/earn-banner-art-telegram.svg`} />
+      <TiltedIconPair rightArt={bannerAsset("earn-banner-art-telegram.svg")} />
     ),
     buttonColor: "black",
     buttonLabel: "Join",
     fade: FADE_RED,
     href: "https://t.me/loyal_tgchat",
-    icon: `${ASSET_BASE}/earn-banner-icon-telegram.svg`,
+    icon: bannerAsset("earn-banner-icon-telegram.svg"),
     key: "telegram",
     // The zigzag is a single oversized vector (Figma 4965:65661), placed with
     // its design offsets rather than covered like the raster textures.
@@ -164,7 +173,7 @@ const BANNERS: EarnBannerConfig[] = [
             alt=""
             aria-hidden="true"
             className="block size-full max-w-none"
-            src={`${ASSET_BASE}/earn-banner-tex-zigzag.svg`}
+            src={bannerAsset("earn-banner-tex-zigzag.svg")}
           />
         </div>
       </div>
@@ -181,7 +190,7 @@ const BANNERS: EarnBannerConfig[] = [
           alt=""
           aria-hidden="true"
           className="size-full"
-          src={`${ASSET_BASE}/earn-banner-art-coins.svg`}
+          src={bannerAsset("earn-banner-art-coins.svg")}
         />
       </div>
     ),
@@ -189,9 +198,9 @@ const BANNERS: EarnBannerConfig[] = [
     buttonLabel: "Set up Autodeposit",
     fade: FADE_MAROON,
     href: null,
-    icon: `${ASSET_BASE}/earn-banner-icon-autodeposit.svg`,
+    icon: bannerAsset("earn-banner-icon-autodeposit.svg"),
     key: "autodeposit",
-    texture: <Texture src={`${ASSET_BASE}/earn-banner-tex-dark.png`} />,
+    texture: <Texture src={bannerAsset("earn-banner-tex-dark.png")} />,
     title: "Earn more without manual deposits",
     titleClassName: "w-[352px] text-[#f9363c]",
   },


### PR DESCRIPTION
Next serves `/public` with `max-age=0, must-revalidate`, so every carousel rotation re-hit the network to revalidate each banner asset (ASK-2214).

The banner now requests its artwork with a `?v=<commit>` buster, and `next.config.ts` serves those versioned URLs `immutable` for a year. A deploy changes the commit hash, so the URL changes too — no stale artwork. The `has: query v` guard keeps the immutable policy off unversioned requests, and the rule is scoped to `earn-banner-*` so no other static asset changes behaviour.

Kept the direct `<img>` tags rather than moving to `next/image`: these are fixed-size decorative assets and the SVG art would require `dangerouslyAllowSVG`.

Verified in a headless Chrome over 3 visits — unversioned assets cost a 304 round-trip each visit, versioned ones are served from cache with no network request after the first load. Also revived `next.config.test.ts`, which threw on import under Bun (missing `globalThis.AsyncLocalStorage`) and so ran zero tests; it now covers the new cache rule.

Fixes ASK-2214