### PR TITLE
fix(admin): align Earn monitoring with migration 59

### DIFF
--- a/apps/admin/src/app/(admin)/earn/earn-data.ts
+++ b/apps/admin/src/app/(admin)/earn/earn-data.ts
@@ -248,6 +248,7 @@ export type EarnData = {
   autodepositStatusCounts: {
     active: number;
     closed: number;
+    inconsistent: number;
     paused: number;
     pending: number;
   };
@@ -489,7 +490,7 @@ async function loadEarnData(): Promise<EarnData> {
         (SELECT COUNT(DISTINCT policy_account)::text FROM loyal_yield.route_policies WHERE active = true) AS unique_earn_policies,
         (SELECT COUNT(DISTINCT policy.policy_account)::text FROM loyal_yield.balance_sweep_policies AS policy
           INNER JOIN loyal_yield.balance_sweep_targets AS target ON target.balance_sweep_policy_id = policy.id
-          WHERE policy.active = true AND target.active = true AND target.lifecycle_status = 'active') AS active_autodeposit_policies
+          WHERE policy.active = true AND target.desired_active = true AND target.chain_status = 'active') AS active_autodeposit_policies
       FROM normalized_active_positions
     ),
     top_positions AS (
@@ -581,15 +582,17 @@ async function loadEarnData(): Promise<EarnData> {
         target.last_seen_at,
         CASE
           WHEN policy.active = true
-            AND target.active = true
-            AND target.lifecycle_status = 'active'
+            AND target.desired_active = true
+            AND target.chain_status = 'active'
             THEN 'active'
           WHEN policy.active = true
-            AND target.active = false
-            AND target.lifecycle_status = 'active'
+            AND target.desired_active = false
+            AND target.chain_status = 'active'
             THEN 'paused'
-          WHEN target.lifecycle_status IN ('pending_delegation', 'closing')
+          WHEN target.chain_status = 'pending'
             THEN 'pending'
+          WHEN target.chain_status = 'inconsistent'
+            THEN 'inconsistent'
           ELSE 'closed'
         END AS status
       FROM loyal_yield.balance_sweep_targets AS target
@@ -631,8 +634,8 @@ async function loadEarnData(): Promise<EarnData> {
       LEFT JOIN loyal_yield.balance_sweep_policies AS policy
         ON policy.id = target.balance_sweep_policy_id
       WHERE policy.active = true
-        AND target.active = true
-        AND target.lifecycle_status = 'active'
+        AND target.desired_active = true
+        AND target.chain_status = 'active'
     ),
     executions AS (
       SELECT
@@ -718,6 +721,7 @@ async function loadEarnData(): Promise<EarnData> {
   const autodepositStatusCounts = {
     active: 0,
     closed: 0,
+    inconsistent: 0,
     paused: 0,
     pending: 0,
   };

--- a/apps/admin/src/app/(admin)/earn/earn-progressive-content.tsx
+++ b/apps/admin/src/app/(admin)/earn/earn-progressive-content.tsx
@@ -926,8 +926,8 @@ export function EarnDetailsContent({
                         Autodeposit status
                       </CardTitle>
                       <CardDescription>
-                        Active requires policy active, target active, and active
-                        lifecycle
+                        Active requires policy active, desired scheduling, and
+                        finalized active chain state
                       </CardDescription>
                     </CardHeader>
                     <CardContent>


### PR DESCRIPTION
## Goal

Restore the Admin `/earn` monitoring page after migration 59 changed the balance sweep target lifecycle columns.

Fixes the user-visible error:

> Monitoring data could not be loaded. Refresh to try again.

The monitoring query still referenced the removed `balance_sweep_targets.active` and `lifecycle_status` columns, causing PostgreSQL to fail with `column target.active does not exist`.

## Scope

- Update only the Admin Earn monitoring query and its explanatory UI copy.
- Use `desired_active` for scheduling intent and `chain_status` for finalized chain state.
- Preserve `inconsistent` as its own monitoring status instead of reporting it as closed.
- No web or mobile activity changes are included.

## Verification

- `cd apps/admin && bun run lint -- --file 'src/app/(admin)/earn/earn-data.ts' --file 'src/app/(admin)/earn/earn-progressive-content.tsx'`
- `cd apps/admin && bunx tsc --noEmit`
- Corrected SQL was checked read-only against the production Yield Neon schema.
- No frontend build was run, per repository policy.

## Post-merge

- Deploy the Admin app through Vercel.
- Open `/earn` and confirm monitoring loads without the error banner.

Linear: [ASK-2219](https://linear.app/askloyal/issue/ASK-2219/fix-admin-earn-monitoring-after-migration-59)
