### PR TITLE
fix(earn-max): mark claim vault signer writable

### DIFF
--- a/apps/web/src/features/earn-max/server/prepared.server.ts
+++ b/apps/web/src/features/earn-max/server/prepared.server.ts
@@ -78,7 +78,7 @@ function transferChecked(input: {
       { pubkey: input.source, isSigner: false, isWritable: true },
       { pubkey: input.mint, isSigner: false, isWritable: false },
       { pubkey: input.destination, isSigner: false, isWritable: true },
-      { pubkey: input.owner, isSigner: true, isWritable: false },
+      { pubkey: input.owner, isSigner: true, isWritable: true },
     ],
     data: Buffer.concat([Buffer.from([12]), amount, Buffer.from([6])]),
   });


### PR DESCRIPTION
Marks the vault authority writable for the inner SPL claim transfer so Squads synchronous-message compilation has its required writable signer key. Earn MAX-only TypeScript validation and a direct synchronous compile probe pass.