### PR TITLE
fix(earn-max): claim confirmed custody amount

### DIFF
--- a/apps/web/src/features/earn-max/server/service.ts
+++ b/apps/web/src/features/earn-max/server/service.ts
@@ -253,7 +253,12 @@ export async function prepareTransaction(request: Request) {
 
     if (parsed.action === "claim") {
       const withdrawal = record(route.withdrawal);
-      const amountRaw = rawAmount(withdrawal?.amountRaw);
+      const requestedAmountRaw = rawAmount(withdrawal?.amountRaw);
+      const availableAmountRaw = rawAmount(state.claim_raw);
+      let amountRaw: bigint | null = null;
+      if (requestedAmountRaw !== null && availableAmountRaw !== null) {
+        amountRaw = requestedAmountRaw < availableAmountRaw ? requestedAmountRaw : availableAmountRaw;
+      }
       if (withdrawal?.status !== "claimable" || !amountRaw || amountRaw <= BigInt(0)) {
         return jsonError(409, "earn_max_not_claimable", "The withdrawal is not claimable yet.");
       }


### PR DESCRIPTION
Bounds the user claim to the smaller of the request and confirmed claim custody, preserving the request cap while reconciling real swap output. The current canary proves 550234 requested versus 549967 confirmed claimable raw.