### PR TITLE
fix(ui): hide Earn MAX until launch

### DIFF
--- a/apps/web/src/components/wallet-workspace/facelift/shell.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/shell.tsx
@@ -157,7 +157,7 @@ export function WorkspaceFaceliftShell() {
   const earnData = useEarnPositionData();
   const earnMax = useEarnMax({
     settingsPda: EARN_MAX_VISIBLE ? earnData.settingsPda : undefined,
-    walletAddress: EARN_MAX_VISIBLE ? earnData.walletAddress : undefined,
+    walletAddress: EARN_MAX_VISIBLE ? earnData.walletAddress : null,
   });
   // Bumped on every sidebar selection so CryptoPage abandons its in-progress
   // Send/Swap/Shield screens — including re-selecting the page it's already on.
@@ -408,7 +408,7 @@ export function WorkspaceFaceliftShell() {
             />
           ) : EARN_MAX_VISIBLE && activePage === "earnmax" ? (
             <EarnMaxPage actions={earnMax.actions} view={earnMax.view} />
-          ) : activePage !== "earn" ? (
+          ) : activePage !== "earn" && activePage !== "earnmax" ? (
             <CryptoPage
               navigationNonce={navigationNonce}
               onBack={() => handleSelectPage("wallet")}

--- a/apps/web/src/components/wallet-workspace/facelift/shell.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/shell.tsx
@@ -60,12 +60,12 @@ export type WorkspacePage =
 type MiddleView = "earn" | "deposit" | "withdraw" | "autodeposit" | "autoswap";
 
 const PAGE_STORAGE_KEY = "loyal:workspace-page";
+const EARN_MAX_VISIBLE = false;
 const WORKSPACE_PAGES: WorkspacePage[] = [
   "crypto",
   "stables",
   "activity",
   "earn",
-  "earnmax",
   "wallet",
 ];
 
@@ -74,7 +74,6 @@ const SHORTCUT_PAGES: Partial<Record<string, WorkspacePage>> = {
   a: "activity",
   c: "crypto",
   e: "earn",
-  m: "earnmax",
   s: "stables",
 };
 
@@ -157,8 +156,8 @@ export function WorkspaceFaceliftShell() {
   const [hasUnseenActivity, setHasUnseenActivity] = useState(false);
   const earnData = useEarnPositionData();
   const earnMax = useEarnMax({
-    settingsPda: earnData.settingsPda,
-    walletAddress: earnData.walletAddress,
+    settingsPda: EARN_MAX_VISIBLE ? earnData.settingsPda : undefined,
+    walletAddress: EARN_MAX_VISIBLE ? earnData.walletAddress : undefined,
   });
   // Bumped on every sidebar selection so CryptoPage abandons its in-progress
   // Send/Swap/Shield screens — including re-selecting the page it's already on.
@@ -195,6 +194,9 @@ export function WorkspaceFaceliftShell() {
     publicEnv.solanaEnv,
   ]);
   const handleSelectPage = (page: WorkspacePage) => {
+    if (!EARN_MAX_VISIBLE && page === "earnmax") {
+      return;
+    }
     // Disconnected wallets live on Earn — every other page needs a session,
     // so tapping one opens the connect-wallet modal instead of navigating.
     if (!isSignedIn && page !== "earn") {
@@ -375,6 +377,7 @@ export function WorkspaceFaceliftShell() {
           isEarnMaxBalanceLoading={earnMax.view.isLoading}
           onSelectPage={handleSelectPage}
           onUnseenActivityChange={setHasUnseenActivity}
+          showEarnMax={EARN_MAX_VISIBLE}
         />
         <div
           className={`flex h-full min-w-0 flex-1 flex-col ${
@@ -394,6 +397,7 @@ export function WorkspaceFaceliftShell() {
                 setMiddleView("autodeposit");
               }}
               showActivityBadge={hasUnseenActivity}
+              showEarnMax={EARN_MAX_VISIBLE}
             />
           ) : activePage === "activity" ? (
             <ActivityPage
@@ -402,7 +406,7 @@ export function WorkspaceFaceliftShell() {
               settingsPda={earnData.settingsPda}
               walletAddress={earnData.walletAddress}
             />
-          ) : activePage === "earnmax" ? (
+          ) : EARN_MAX_VISIBLE && activePage === "earnmax" ? (
             <EarnMaxPage actions={earnMax.actions} view={earnMax.view} />
           ) : activePage !== "earn" ? (
             <CryptoPage

--- a/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
@@ -142,6 +142,7 @@ export function FaceliftSidebar({
   isEarnMaxBalanceLoading,
   onSelectPage,
   onUnseenActivityChange,
+  showEarnMax,
 }: {
   activePage: WorkspacePage;
   earnBalanceUsd: number;
@@ -153,6 +154,7 @@ export function FaceliftSidebar({
   isEarnMaxBalanceLoading: boolean;
   onSelectPage: (page: WorkspacePage) => void;
   onUnseenActivityChange?: (hasUnseen: boolean) => void;
+  showEarnMax: boolean;
 }) {
   const data = useWalletDesktopData({});
   const publicEnv = usePublicEnv();
@@ -250,9 +252,9 @@ export function FaceliftSidebar({
     earnMaxForecastApyBps === null
       ? "—"
       : `${(earnMaxForecastApyBps / 100).toFixed(2)}% APY`;
-  // Wallet total plus both independently projected Earn products.
+  // Hidden products must not affect the public wallet total.
   const totalBalance = splitUsdBalance(
-    data.totalUsd + earnBalanceUsd + earnMaxBalanceUsd
+    data.totalUsd + earnBalanceUsd + (showEarnMax ? earnMaxBalanceUsd : 0)
   );
 
   const addressLabel = data.walletAddress
@@ -272,7 +274,9 @@ export function FaceliftSidebar({
   const isEarnBalanceRevealed = !isEarnBalanceLoading;
   const isEarnMaxBalanceRevealed = !isEarnMaxBalanceLoading;
   const isTotalRevealed =
-    isWalletDataRevealed && isEarnBalanceRevealed && isEarnMaxBalanceRevealed;
+    isWalletDataRevealed &&
+    isEarnBalanceRevealed &&
+    (!showEarnMax || isEarnMaxBalanceRevealed);
   const hasReportedBalancesReadyRef = useRef(false);
   useEffect(() => {
     if (
@@ -472,51 +476,52 @@ export function FaceliftSidebar({
           </span>
         </button>
 
-        {/* Earn MAX values come from the confirmed projection read model. */}
-        <button
-          className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${
-            activePage === "earnmax" ? "bg-accent" : "hover:bg-accent"
-          }`}
-          onClick={() => onSelectPage("earnmax")}
-          type="button"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="mr-3 size-11 shrink-0"
-            src={`${ASSET_BASE}/earn-max-icon.svg`}
-          />
-          <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
-            <span className="flex items-center gap-1">
-              <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
-                Earn MAX
-              </span>
-              <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="h-3 w-2"
-                  src="/wallet-workspace/earn-flash.svg"
-                />
-                <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
-                  {earnMaxApyLabel}
+        {showEarnMax ? (
+          <button
+            className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${
+              activePage === "earnmax" ? "bg-accent" : "hover:bg-accent"
+            }`}
+            onClick={() => onSelectPage("earnmax")}
+            type="button"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              alt=""
+              aria-hidden="true"
+              className="mr-3 size-11 shrink-0"
+              src={`${ASSET_BASE}/earn-max-icon.svg`}
+            />
+            <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
+              <span className="flex items-center gap-1">
+                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+                  Earn MAX
                 </span>
+                <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    alt=""
+                    aria-hidden="true"
+                    className="h-3 w-2"
+                    src="/wallet-workspace/earn-flash.svg"
+                  />
+                  <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
+                    {earnMaxApyLabel}
+                  </span>
+                </span>
+                <ShortcutKey
+                  isFlashed={flashedShortcut === "earnmax"}
+                  letter="M"
+                />
               </span>
-              <ShortcutKey
-                isFlashed={flashedShortcut === "earnmax"}
-                letter="M"
+              <SplitAmount
+                fraction={earnMaxBalance.balanceFraction}
+                isHidden={isBalanceHidden}
+                isRevealed={isEarnMaxBalanceRevealed}
+                whole={earnMaxBalance.balanceWhole}
               />
             </span>
-            <SplitAmount
-              fraction={earnMaxBalance.balanceFraction}
-              isHidden={isBalanceHidden}
-              isRevealed={isEarnMaxBalanceRevealed}
-              whole={earnMaxBalance.balanceWhole}
-            />
-          </span>
-        </button>
+          </button>
+        ) : null}
 
         <button
           className={`t-hover group flex w-full items-center rounded-2xl px-4 text-left ${

--- a/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
@@ -55,6 +55,7 @@ export function WalletHomePage({
   onSelectPage,
   onSetUpAutodeposit,
   showActivityBadge,
+  showEarnMax,
 }: {
   earnBalanceUsd: number;
   earnMaxBalanceUsd: number;
@@ -64,6 +65,7 @@ export function WalletHomePage({
   onSelectPage: (page: WorkspacePage) => void;
   onSetUpAutodeposit: () => void;
   showActivityBadge: boolean;
+  showEarnMax: boolean;
 }) {
   const data = useWalletDesktopData({});
   const publicEnv = usePublicEnv();
@@ -110,7 +112,7 @@ export function WalletHomePage({
       ? "—"
       : `${(earnMaxForecastApyBps / 100).toFixed(2)}%`;
   const totalBalance = splitUsdBalance(
-    data.totalUsd + earnBalanceUsd + earnMaxBalanceUsd
+    data.totalUsd + earnBalanceUsd + (showEarnMax ? earnMaxBalanceUsd : 0)
   );
 
   const addressLabel = data.walletAddress
@@ -124,7 +126,9 @@ export function WalletHomePage({
   const isEarnBalanceRevealed = !isEarnBalanceLoading;
   const isEarnMaxBalanceRevealed = !isEarnMaxBalanceLoading;
   const isTotalRevealed =
-    isWalletDataRevealed && isEarnBalanceRevealed && isEarnMaxBalanceRevealed;
+    isWalletDataRevealed &&
+    isEarnBalanceRevealed &&
+    (!showEarnMax || isEarnMaxBalanceRevealed);
 
   // Copied feedback, same icon swap the sidebar chip uses.
   const [isCopied, setIsCopied] = useState(false);
@@ -404,45 +408,46 @@ export function WalletHomePage({
                     />
                   </span>
                 </button>
-                {/* Earn MAX values come from the confirmed projection read model. */}
-                <button
-                  className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-accent p-4 text-left hover:bg-accent-selected"
-                  onClick={() => onSelectPage("earnmax")}
-                  type="button"
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-10 shrink-0 rounded-[10px]"
-                    src={`${ASSET_BASE}/earn-max-icon.svg`}
-                  />
-                  <span className="flex w-full flex-col gap-1">
-                    <span className="flex items-center gap-1">
-                      <span className="whitespace-nowrap font-semibold text-[15px] text-foreground leading-5">
-                        Earn MAX
-                      </span>
-                      <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          alt=""
-                          aria-hidden="true"
-                          className="h-3 w-2"
-                          src="/wallet-workspace/earn-flash.svg"
-                        />
-                        <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
-                          {earnMaxApyLabel}
+                {showEarnMax ? (
+                  <button
+                    className="t-hover flex flex-col items-start justify-between overflow-clip rounded-3xl bg-accent p-4 text-left hover:bg-accent-selected"
+                    onClick={() => onSelectPage("earnmax")}
+                    type="button"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      className="size-10 shrink-0 rounded-[10px]"
+                      src={`${ASSET_BASE}/earn-max-icon.svg`}
+                    />
+                    <span className="flex w-full flex-col gap-1">
+                      <span className="flex items-center gap-1">
+                        <span className="whitespace-nowrap font-semibold text-[15px] text-foreground leading-5">
+                          Earn MAX
+                        </span>
+                        <span className="inline-flex items-center gap-0.5 rounded-md bg-positive/[0.14] px-1 py-px">
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            alt=""
+                            aria-hidden="true"
+                            className="h-3 w-2"
+                            src="/wallet-workspace/earn-flash.svg"
+                          />
+                          <span className="whitespace-nowrap pt-px font-medium text-positive text-[11px] leading-[13px] tracking-[0.06px]">
+                            {earnMaxApyLabel}
+                          </span>
                         </span>
                       </span>
+                      <SplitAmount
+                        fraction={earnMaxBalance.balanceFraction}
+                        isHidden={isBalanceHidden}
+                        isRevealed={isEarnMaxBalanceRevealed}
+                        whole={earnMaxBalance.balanceWhole}
+                      />
                     </span>
-                    <SplitAmount
-                      fraction={earnMaxBalance.balanceFraction}
-                      isHidden={isBalanceHidden}
-                      isRevealed={isEarnMaxBalanceRevealed}
-                      whole={earnMaxBalance.balanceWhole}
-                    />
-                  </span>
-                </button>
+                  </button>
+                ) : null}
               </div>
             </div>
           </section>


### PR DESCRIPTION
Hide Earn MAX from production wallet navigation, balance totals, and mobile tiles while keeping the implementation and authenticated backend available for private verification.