### PR TITLE
fix(earn-max): compile withdrawal marker signer

### DIFF
--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -660,7 +660,10 @@ function earnMaxIntent(
     throw new Error("Earn MAX intent is too large.");
   return new TransactionInstruction({
     programId: MEMO,
-    keys: [{ pubkey: vault, isSigner: true, isWritable: false }],
+    // The synchronous Smart Account compiler requires its signing vault to be
+    // writable. Memo does not mutate it, but the outer execution must still
+    // carry the vault through the writable-signer account class.
+    keys: [{ pubkey: vault, isSigner: true, isWritable: true }],
     data: Buffer.from(value, "utf8"),
   });
 }


### PR DESCRIPTION
Make the Earn MAX memo vault a writable signer so synchronous Smart Account request and cancel transactions compile. The product remains hidden by the existing production visibility gate.