### PR TITLE
fix(earn-max): recreate obligation before partial redeploy

### DIFF
--- a/apps/web/src/features/earn-max/use-earn-max.ts
+++ b/apps/web/src/features/earn-max/use-earn-max.ts
@@ -5,6 +5,7 @@ import {
   buildEarnMaxCloseInstructions,
   buildEarnMaxDepositInstructions,
   buildEarnMaxInstallInstructions,
+  buildEarnMaxSetupInstructions,
   buildEarnMaxWithdrawalCancelInstructions,
   buildEarnMaxWithdrawalRequestInstructions,
   deriveEarnMaxWalletClaimAta,
@@ -382,17 +383,23 @@ export function useEarnMax(input: {
           if (!current?.canClaim || amountRaw <= BigInt(0))
             throw new Error("Earn MAX withdrawal is not claimable.");
           const { feePayer, programId, settings } = context();
-          return [
-            (
-              await buildEarnMaxClaimInstructions({
-                amountRaw,
-                connection,
-                feePayer,
-                programId,
-                settings,
-              })
-            ).operation,
-          ];
+          const setup =
+            amountRaw < available
+              ? await buildEarnMaxSetupInstructions({
+                  connection,
+                  feePayer,
+                  programId,
+                  settings,
+                })
+              : [];
+          const claim = await buildEarnMaxClaimInstructions({
+            amountRaw,
+            connection,
+            feePayer,
+            programId,
+            settings,
+          });
+          return [...setup, claim.operation];
         }),
       close: () =>
         run(async () => {

--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -495,8 +495,7 @@ function initUserMetadata(vault: PublicKey, userMetadata: PublicKey) {
   });
 }
 
-export async function buildEarnMaxDepositInstructions(input: {
-  amountRaw: bigint;
+export async function buildEarnMaxSetupInstructions(input: {
   connection: Connection;
   feePayer: PublicKey;
   programId: PublicKey;
@@ -626,6 +625,18 @@ export async function buildEarnMaxDepositInstructions(input: {
       })
     );
   }
+  return operations;
+}
+
+export async function buildEarnMaxDepositInstructions(input: {
+  amountRaw: bigint;
+  connection: Connection;
+  feePayer: PublicKey;
+  programId: PublicKey;
+  settings: PublicKey;
+}): Promise<EarnMaxClientOperation[]> {
+  const topology = deriveEarnMaxTopology(input.settings);
+  const operations = await buildEarnMaxSetupInstructions(input);
   operations.push(
     prepared({
       instructions: [

--- a/packages/loyal-actions/src/index.ts
+++ b/packages/loyal-actions/src/index.ts
@@ -96,6 +96,7 @@ export {
   buildEarnMaxCloseInstructions,
   buildEarnMaxDepositInstructions,
   buildEarnMaxInstallInstructions,
+  buildEarnMaxSetupInstructions,
   buildEarnMaxWithdrawalCancelInstructions,
   buildEarnMaxWithdrawalRequestInstructions,
   createEarnMaxPolicyManifest,


### PR DESCRIPTION
Reuses the existing root-signed Earn MAX setup before a partial claim so the remaining balance can redeploy after Kamino closes the fully unwound obligation. Full claims remain unchanged.