### PR TITLE
refactor(earn-max): collapse app projection to two typed reads

### DIFF
--- a/apps/web/src/app/api/smart-accounts/earn-max/performance/route.ts
+++ b/apps/web/src/app/api/smart-accounts/earn-max/performance/route.ts
@@ -1,3 +1,0 @@
-import { getPerformance } from "@/features/earn-max/server/service";
-
-export const GET = getPerformance;

--- a/apps/web/src/app/api/smart-accounts/earn-max/state/route.ts
+++ b/apps/web/src/app/api/smart-accounts/earn-max/state/route.ts
@@ -1,3 +1,0 @@
-import { getState } from "@/features/earn-max/server/service";
-
-export const GET = getState;

--- a/apps/web/src/app/api/smart-accounts/earn-max/summary/route.ts
+++ b/apps/web/src/app/api/smart-accounts/earn-max/summary/route.ts
@@ -1,0 +1,3 @@
+import { getSummary } from "@/features/earn-max/server/service";
+
+export const GET = getSummary;

--- a/apps/web/src/features/earn-max/index.ts
+++ b/apps/web/src/features/earn-max/index.ts
@@ -1,8 +1,11 @@
 export { useEarnMax } from "./use-earn-max";
 export type {
   EarnMaxActions,
+  EarnMaxActivityResponse,
   EarnMaxActivityItem,
   EarnMaxPerformancePoint,
+  EarnMaxSummary,
+  EarnMaxSummaryResponse,
   EarnMaxViewModel,
   EarnMaxWithdrawalView,
 } from "./types";

--- a/apps/web/src/features/earn-max/server/repository.server.ts
+++ b/apps/web/src/features/earn-max/server/repository.server.ts
@@ -4,6 +4,13 @@ import { sql } from "drizzle-orm";
 
 import { getYieldOptimizationClient } from "@/lib/yield-optimization/yield-neon-client.server";
 
+import type {
+  EarnMaxActivityResponse,
+  EarnMaxPolicyBinding,
+  EarnMaxSummary,
+  EarnMaxWithdrawalView,
+} from "../types";
+
 const EARN_MAX_VAULT_INDEX = 0;
 
 type QueryResult = { rows?: unknown[] } | unknown[];
@@ -16,34 +23,77 @@ function rows(result: QueryResult): Record<string, unknown>[] {
   );
 }
 
-export async function readEarnMaxState(settings: string) {
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function rawString(value: unknown): string {
+  return typeof value === "bigint" || typeof value === "number"
+    ? String(value)
+    : typeof value === "string" && /^-?\d+$/.test(value)
+    ? value
+    : "0";
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function dollars(value: unknown): number {
+  return Number(BigInt(rawString(value))) / 1_000_000;
+}
+
+function policyBindings(value: unknown): EarnMaxPolicyBinding[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const binding = record(entry);
+    if (!binding || typeof binding.account !== "string") return [];
+    return [
+      {
+        account: binding.account,
+        matches: binding.matches === true,
+        seed: rawString(binding.seed),
+      },
+    ];
+  });
+}
+
+function withdrawalView(
+  route: Record<string, unknown> | null
+): EarnMaxWithdrawalView | null {
+  const withdrawal = record(route?.withdrawal);
+  const status = withdrawal?.status;
+  if (
+    !withdrawal ||
+    !["requested", "unwinding", "claimable", "claimed"].includes(String(status))
+  ) {
+    return null;
+  }
+  return {
+    amountRaw: rawString(withdrawal.amountRaw),
+    canCancel: status === "requested" && route?.currentOperationId === null,
+    canClaim: status === "claimable",
+    readyBy: String(withdrawal.readyBy ?? ""),
+    requestId: String(withdrawal.requestId ?? ""),
+    status: status as EarnMaxWithdrawalView["status"],
+  };
+}
+
+export async function readEarnMaxSummary(
+  settings: string
+): Promise<EarnMaxSummary | null> {
   const result = await getYieldOptimizationClient().db.execute(sql`
     SELECT
-      route.route_key,
       route.state,
-      route.state_version,
-      route.updated_at,
-      policy.manifest_version,
-      policy.manifest_sha256,
       policy.status AS policy_status,
       policy.policy_accounts,
-      policy.observed_signature AS policy_observed_signature,
-      policy.observed_slot AS policy_observed_slot,
       snapshot.equity_usd_micros,
       snapshot.claim_raw,
-      snapshot.collateral_raw,
-      snapshot.debt_raw,
-      snapshot.collateral_value_usd_micros,
-      snapshot.debt_value_usd_micros,
-      snapshot.leverage_bps,
-      snapshot.ltv_bps,
-      snapshot.health_factor_ppm,
-      snapshot.supply_apy_bps,
-      snapshot.borrow_apy_bps,
       snapshot.forecast_apy_bps,
-      snapshot.valuation_source,
-      snapshot.valuation_slot,
-      snapshot.valuation_observed_at,
       snapshot.coverage_start_at,
       cash.confirmed_deposit_raw,
       cash.confirmed_claim_raw,
@@ -103,24 +153,44 @@ export async function readEarnMaxState(settings: string) {
       AND policy.vault_index = ${EARN_MAX_VAULT_INDEX}
     LIMIT 1
   `);
-  return rows(result as QueryResult)[0] ?? null;
+  const row = rows(result as QueryResult)[0];
+  if (!row) return null;
+  const route = record(row.state);
+  return {
+    balanceUsd: dollars(row.equity_usd_micros),
+    claimAmountRaw: rawString(row.claim_raw),
+    coverage:
+      row.performance_coverage === "complete"
+        ? "complete"
+        : "history_incomplete",
+    currentOperationId:
+      typeof route?.currentOperationId === "string"
+        ? route.currentOperationId
+        : null,
+    earnedUsd:
+      row.earned_usd_micros === null ? null : dollars(row.earned_usd_micros),
+    forecastApyBps: nullableNumber(row.forecast_apy_bps),
+    goal: typeof route?.goal === "string" ? route.goal : "not_installed",
+    policyAccounts: policyBindings(row.policy_accounts),
+    policyStatus:
+      typeof row.policy_status === "string" ? row.policy_status : null,
+    realizedApyBps: nullableNumber(row.realized_apy_bps),
+    withdrawal: withdrawalView(route),
+  };
 }
 
-export async function readEarnMaxActivity(settings: string) {
+export async function readEarnMaxActivity(
+  settings: string
+): Promise<EarnMaxActivityResponse> {
   const client = getYieldOptimizationClient();
   const [operationsResult, snapshotsResult] = await Promise.all([
     client.db.execute(sql`
       SELECT
         operation.operation_id,
         operation.action,
-        operation.strategy_key,
         operation.status,
         operation.transaction_signature,
-        operation.source_instruction_index,
-        operation.confirmed_slot,
-        operation.expected_effects,
-        operation.created_at,
-        operation.updated_at
+        operation.created_at
       FROM loyal_yield.multiply_operations operation
       INNER JOIN loyal_yield.multiply_route_states route
         ON route.route_key = operation.route_key
@@ -131,20 +201,9 @@ export async function readEarnMaxActivity(settings: string) {
     `),
     client.db.execute(sql`
       SELECT
-        snapshot.id,
-        snapshot.generation,
-        snapshot.observed_slot,
         snapshot.observed_at,
-        snapshot.strategy_key,
         snapshot.equity_usd_micros,
-        snapshot.leverage_bps,
-        snapshot.ltv_bps,
-        snapshot.health_factor_ppm,
-        snapshot.forecast_apy_bps,
-        snapshot.valuation_source,
-        snapshot.valuation_slot,
-        snapshot.valuation_observed_at,
-        snapshot.coverage_start_at
+        snapshot.valuation_observed_at
       FROM loyal_yield.multiply_position_snapshots snapshot
       INNER JOIN loyal_yield.multiply_route_states route
         ON route.route_key = snapshot.route_key
@@ -154,24 +213,30 @@ export async function readEarnMaxActivity(settings: string) {
       LIMIT 500
     `),
   ]);
+  const operations = rows(operationsResult as QueryResult).map((operation) => ({
+    action: String(operation.action ?? "activity"),
+    id: String(operation.operation_id ?? ""),
+    signature:
+      typeof operation.transaction_signature === "string"
+        ? operation.transaction_signature
+        : null,
+    status: String(operation.status ?? "unknown"),
+    timestamp: String(operation.created_at ?? ""),
+  }));
+  const performance = rows(snapshotsResult as QueryResult)
+    .flatMap((snapshot) => {
+      const equity = nullableNumber(snapshot.equity_usd_micros);
+      const timestamp = String(
+        snapshot.valuation_observed_at ?? snapshot.observed_at ?? ""
+      );
+      return equity === null || timestamp.length === 0
+        ? []
+        : [{ equityUsd: equity / 1_000_000, timestamp }];
+    })
+    .reverse();
   return {
-    operations: rows(operationsResult as QueryResult),
-    snapshots: rows(snapshotsResult as QueryResult),
-  };
-}
-
-export async function readEarnMaxPerformance(settings: string) {
-  const state = await readEarnMaxState(settings);
-  if (!state) return null;
-  return {
-    coverage_start_at: state.coverage_start_at,
-    earned_usd_micros: state.earned_usd_micros,
-    equity_usd_micros: state.equity_usd_micros,
-    forecast_apy_bps: state.forecast_apy_bps,
-    performance_coverage: state.performance_coverage,
-    realized_apy_bps: state.realized_apy_bps,
-    valuation_observed_at: state.valuation_observed_at,
-    valuation_slot: state.valuation_slot,
+    operations,
+    performance,
   };
 }
 

--- a/apps/web/src/features/earn-max/server/service.ts
+++ b/apps/web/src/features/earn-max/server/service.ts
@@ -7,21 +7,19 @@ import { assertAuthenticatedWalletControlsSettings } from "@/features/smart-acco
 import { getServerEnv } from "@/lib/core/config/server";
 import { getDeploymentPolicySignerPublicKey } from "@/lib/yield-optimization/deployment-policy-signer.server";
 
-import {
-  readEarnMaxActivity,
-  readEarnMaxPerformance,
-  readEarnMaxState,
-} from "./repository.server";
+import { readEarnMaxActivity, readEarnMaxSummary } from "./repository.server";
+
+import type { EarnMaxSummaryResponse } from "../types";
 
 const headers = {
-  "x-loyal-earn-max-contract": "earn-max-v2",
+  "x-loyal-earn-max-contract": "earn-max-v3",
   "x-loyal-deployment-revision":
     process.env.VERCEL_GIT_COMMIT_SHA ??
     process.env.RENDER_GIT_COMMIT ??
     "unknown",
 };
 
-function json(value: unknown, status = 200) {
+function json<T>(value: T, status = 200) {
   return NextResponse.json(value, { headers, status });
 }
 
@@ -36,9 +34,9 @@ async function settingsFor(request: Request): Promise<string | null> {
   return principal.settingsPda;
 }
 
-async function authenticatedRead(
+async function authenticatedRead<T>(
   request: Request,
-  read: (settings: string) => Promise<unknown>
+  read: (settings: string) => Promise<T>
 ) {
   const settings = await settingsFor(request);
   if (!settings) {
@@ -52,23 +50,17 @@ async function authenticatedRead(
   return json(await read(settings));
 }
 
-export function getState(request: Request) {
-  return authenticatedRead(request, async (settings) => {
-    const state = await readEarnMaxState(settings);
-    return {
+export function getSummary(request: Request) {
+  return authenticatedRead<EarnMaxSummaryResponse>(
+    request,
+    async (settings) => ({
       config: {
         delegatedSigner: getDeploymentPolicySignerPublicKey().toBase58(),
         programId: getServerEnv().loyalSmartAccounts.programId,
       },
-      state,
-    };
-  });
-}
-
-export function getPerformance(request: Request) {
-  return authenticatedRead(request, async (settings) => ({
-    performance: await readEarnMaxPerformance(settings),
-  }));
+      summary: await readEarnMaxSummary(settings),
+    })
+  );
 }
 
 export function getActivity(request: Request) {

--- a/apps/web/src/features/earn-max/types.ts
+++ b/apps/web/src/features/earn-max/types.ts
@@ -8,6 +8,12 @@ export type EarnMaxActivityItem = {
   timestamp: string;
 };
 
+export type EarnMaxPolicyBinding = {
+  account: string;
+  matches: boolean;
+  seed: string;
+};
+
 export type EarnMaxPerformancePoint = {
   equityUsd: number;
   timestamp: string;
@@ -20,6 +26,33 @@ export type EarnMaxWithdrawalView = {
   readyBy: string;
   requestId: string;
   status: "requested" | "unwinding" | "claimable" | "claimed";
+};
+
+export type EarnMaxSummary = {
+  balanceUsd: number;
+  claimAmountRaw: string;
+  coverage: EarnMaxCoverage;
+  currentOperationId: string | null;
+  earnedUsd: number | null;
+  forecastApyBps: number | null;
+  goal: string;
+  policyAccounts: EarnMaxPolicyBinding[];
+  policyStatus: string | null;
+  realizedApyBps: number | null;
+  withdrawal: EarnMaxWithdrawalView | null;
+};
+
+export type EarnMaxSummaryResponse = {
+  config: {
+    delegatedSigner: string;
+    programId: string;
+  };
+  summary: EarnMaxSummary | null;
+};
+
+export type EarnMaxActivityResponse = {
+  operations: EarnMaxActivityItem[];
+  performance: EarnMaxPerformancePoint[];
 };
 
 export type EarnMaxViewModel = {

--- a/apps/web/src/features/earn-max/use-earn-max.ts
+++ b/apps/web/src/features/earn-max/use-earn-max.ts
@@ -21,57 +21,19 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type {
   EarnMaxActions,
-  EarnMaxActivityItem,
-  EarnMaxPerformancePoint,
+  EarnMaxActivityResponse,
+  EarnMaxSummaryResponse,
   EarnMaxViewModel,
-  EarnMaxWithdrawalView,
 } from "./types";
 
-type JsonRecord = Record<string, unknown>;
-
-function record(value: unknown): JsonRecord | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as JsonRecord)
-    : null;
-}
-
-function records(value: unknown): JsonRecord[] {
-  return Array.isArray(value)
-    ? value.map(record).filter((item): item is JsonRecord => item !== null)
-    : [];
-}
-
-function raw(value: unknown): bigint | null {
-  if (typeof value === "bigint") return value;
-  if (typeof value === "number" && Number.isSafeInteger(value))
-    return BigInt(value);
-  if (typeof value === "string" && /^-?\d+$/.test(value)) return BigInt(value);
-  return null;
-}
-
-function number(value: unknown): number | null {
-  const parsed = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function dollars(value: unknown): number {
-  const micros = raw(value);
-  return micros === null ? 0 : Number(micros) / 1_000_000;
-}
-
-async function readJson(path: string): Promise<unknown> {
+async function readJson<T>(path: string): Promise<T> {
   const response = await fetch(path, {
     cache: "no-store",
     credentials: "include",
   });
-  const body = await response.json();
+  const body = (await response.json()) as T;
   if (!response.ok) {
-    const error = record(record(body)?.error);
-    throw new Error(
-      typeof error?.message === "string"
-        ? error.message
-        : `Earn MAX request failed (${response.status}).`
-    );
+    throw new Error(`Earn MAX request failed (${response.status}).`);
   }
   return body;
 }
@@ -92,94 +54,29 @@ function walletBridge(wallet: ReturnType<typeof useWallet>): WalletAdapterLike {
   };
 }
 
-function withdrawalView(
-  route: JsonRecord | null
-): EarnMaxWithdrawalView | null {
-  const withdrawal = record(route?.withdrawal);
-  const status = withdrawal?.status;
-  if (
-    !withdrawal ||
-    !["requested", "unwinding", "claimable", "claimed"].includes(String(status))
-  ) {
-    return null;
-  }
-  return {
-    amountRaw: String(withdrawal.amountRaw ?? "0"),
-    canCancel: status === "requested" && route?.currentOperationId === null,
-    canClaim: status === "claimable",
-    readyBy: String(withdrawal.readyBy ?? ""),
-    requestId: String(withdrawal.requestId ?? ""),
-    status: status as EarnMaxWithdrawalView["status"],
-  };
-}
-
 function viewModel(input: {
-  activity: unknown;
+  activity: EarnMaxActivityResponse | null;
   busy: boolean;
   error: string | null;
   loading: boolean;
-  performance: unknown;
-  state: unknown;
+  summary: EarnMaxSummaryResponse | null;
 }): EarnMaxViewModel {
-  const stateResponse = record(input.state);
-  const row = record(stateResponse?.state);
-  const route = record(row?.state);
-  const frontend = record(route?.frontend);
-  const performance = record(record(input.performance)?.performance);
-  const activity = record(input.activity);
-  const operations: EarnMaxActivityItem[] = records(activity?.operations).map(
-    (operation) => ({
-      action: String(operation.action ?? "activity"),
-      id: String(operation.operation_id ?? ""),
-      signature:
-        typeof operation.transaction_signature === "string"
-          ? operation.transaction_signature
-          : null,
-      status: String(operation.status ?? "unknown"),
-      timestamp: String(operation.created_at ?? ""),
-    })
-  );
-  const points: EarnMaxPerformancePoint[] = records(activity?.snapshots)
-    .flatMap((snapshot) => {
-      const equity = raw(snapshot.equity_usd_micros);
-      const timestamp = String(
-        snapshot.valuation_observed_at ?? snapshot.observed_at ?? ""
-      );
-      return equity === null || timestamp.length === 0
-        ? []
-        : [{ equityUsd: Number(equity) / 1_000_000, timestamp }];
-    })
-    .reverse();
-  const strategy = String(
-    frontend?.strategyKey ?? route?.targetStrategyKey ?? ""
-  );
+  const summary = input.summary?.summary;
   return {
-    activity: operations,
-    balanceUsd: dollars(
-      performance?.equity_usd_micros ?? row?.equity_usd_micros
-    ),
-    coverage:
-      performance?.performance_coverage === "complete"
-        ? "complete"
-        : "history_incomplete",
-    earnedUsd:
-      raw(performance?.earned_usd_micros) === null
-        ? null
-        : dollars(performance?.earned_usd_micros),
+    activity: input.activity?.operations ?? [],
+    balanceUsd: summary?.balanceUsd ?? 0,
+    coverage: summary?.coverage ?? "history_incomplete",
+    earnedUsd: summary?.earnedUsd ?? null,
     error: input.error,
-    forecastApyBps: number(performance?.forecast_apy_bps),
-    isBusy: input.busy || route?.currentOperationId !== null,
+    forecastApyBps: summary?.forecastApyBps ?? null,
+    isBusy: input.busy || Boolean(summary?.currentOperationId),
     isLoading: input.loading,
-    performance: points,
-    policyStatus:
-      typeof row?.policy_status === "string" ? row.policy_status : null,
-    realizedApyBps: number(performance?.realized_apy_bps),
-    status: String(frontend?.status ?? "not_installed"),
-    strategyLabel:
-      strategy === "syrup_usdc_pyusd"
-        ? "syrupUSDC / PYUSD"
-        : "syrupUSDC / USDC",
-    withdrawal: withdrawalView(route),
+    performance: input.activity?.performance ?? [],
+    policyStatus: summary?.policyStatus ?? null,
+    realizedApyBps: summary?.realizedApyBps ?? null,
+    status: summary?.goal ?? "not_installed",
+    strategyLabel: "syrupUSDC / USDC",
+    withdrawal: summary?.withdrawal ?? null,
   };
 }
 
@@ -189,9 +86,10 @@ export function useEarnMax(input: {
 }): { actions: EarnMaxActions; view: EarnMaxViewModel } {
   const { connection } = useConnection();
   const wallet = useWallet();
-  const [state, setState] = useState<unknown>(null);
-  const [performance, setPerformance] = useState<unknown>(null);
-  const [activity, setActivity] = useState<unknown>(null);
+  const [summary, setSummary] = useState<EarnMaxSummaryResponse | null>(null);
+  const [activity, setActivity] = useState<EarnMaxActivityResponse | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -202,13 +100,15 @@ export function useEarnMax(input: {
       return;
     }
     try {
-      const [nextState, nextPerformance, nextActivity] = await Promise.all([
-        readJson("/api/smart-accounts/earn-max/state"),
-        readJson("/api/smart-accounts/earn-max/performance"),
-        readJson("/api/smart-accounts/earn-max/activity"),
+      const [nextSummary, nextActivity] = await Promise.all([
+        readJson<EarnMaxSummaryResponse>(
+          "/api/smart-accounts/earn-max/summary"
+        ),
+        readJson<EarnMaxActivityResponse>(
+          "/api/smart-accounts/earn-max/activity"
+        ),
       ]);
-      setState(nextState);
-      setPerformance(nextPerformance);
+      setSummary(nextSummary);
       setActivity(nextActivity);
       setError(null);
     } catch (nextError) {
@@ -270,36 +170,33 @@ export function useEarnMax(input: {
   );
 
   const context = useCallback(() => {
-    const response = record(state);
-    const config = record(response?.config);
-    if (
-      !wallet.publicKey ||
-      !input.settingsPda ||
-      typeof config?.programId !== "string"
-    ) {
+    const config = summary?.config;
+    if (!wallet.publicKey || !input.settingsPda || !config) {
       throw new Error("Earn MAX smart-account context is not ready.");
     }
     return {
       config,
       feePayer: wallet.publicKey,
       programId: new PublicKey(config.programId),
-      row: record(response?.state),
+      summary: summary.summary,
       settings: new PublicKey(input.settingsPda),
     };
-  }, [input.settingsPda, state, wallet.publicKey]);
+  }, [input.settingsPda, summary, wallet.publicKey]);
 
   const actions = useMemo<EarnMaxActions>(
     () => ({
       refresh,
       install: () =>
         run(async () => {
-          const { config, feePayer, programId, row, settings } = context();
-          if (typeof config.delegatedSigner !== "string")
-            throw new Error("Earn MAX signer configuration is missing.");
-          const bindings = records(row?.policy_accounts);
-          const seeds = bindings
-            .map((binding) => raw(binding.seed))
-            .filter((seed): seed is bigint => seed !== null);
+          const {
+            config,
+            feePayer,
+            programId,
+            settings,
+            summary: currentSummary,
+          } = context();
+          const bindings = currentSummary?.policyAccounts ?? [];
+          const seeds = bindings.map((binding) => BigInt(binding.seed));
           return buildEarnMaxInstallInstructions({
             connection,
             delegatedSigner: new PublicKey(config.delegatedSigner),
@@ -310,8 +207,8 @@ export function useEarnMax(input: {
                 : undefined,
             matchingPolicyAccounts: new Set(
               bindings
-                .filter((binding) => binding.matches === true)
-                .map((binding) => String(binding.account))
+                .filter((binding) => binding.matches)
+                .map((binding) => binding.account)
             ),
             programId,
             settings,
@@ -350,8 +247,7 @@ export function useEarnMax(input: {
             busy: isBusy,
             error,
             loading: isLoading,
-            performance,
-            state,
+            summary,
           }).withdrawal;
           if (!current?.canCancel)
             throw new Error("Earn MAX withdrawal can no longer be cancelled.");
@@ -373,12 +269,10 @@ export function useEarnMax(input: {
             busy: isBusy,
             error,
             loading: isLoading,
-            performance,
-            state,
+            summary,
           }).withdrawal;
-          const row = record(record(state)?.state);
-          const available = raw(row?.claim_raw) ?? BigInt(0);
-          const requested = raw(current?.amountRaw) ?? BigInt(0);
+          const available = BigInt(summary?.summary?.claimAmountRaw ?? "0");
+          const requested = BigInt(current?.amountRaw ?? "0");
           const amountRaw = requested < available ? requested : available;
           if (!current?.canClaim || amountRaw <= BigInt(0))
             throw new Error("Earn MAX withdrawal is not claimable.");
@@ -397,15 +291,21 @@ export function useEarnMax(input: {
             connection,
             feePayer,
             programId,
+            requestId: current.requestId,
             settings,
           });
           return [...setup, claim.operation];
         }),
       close: () =>
         run(async () => {
-          const { feePayer, programId, row, settings } = context();
-          const policies = records(row?.policy_accounts).map(
-            (binding) => new PublicKey(String(binding.account))
+          const {
+            feePayer,
+            programId,
+            settings,
+            summary: currentSummary,
+          } = context();
+          const policies = (currentSummary?.policyAccounts ?? []).map(
+            (binding) => new PublicKey(binding.account)
           );
           const operation = await buildEarnMaxCloseInstructions({
             connection,
@@ -424,10 +324,9 @@ export function useEarnMax(input: {
       error,
       isBusy,
       isLoading,
-      performance,
       refresh,
       run,
-      state,
+      summary,
     ]
   );
 
@@ -438,8 +337,7 @@ export function useEarnMax(input: {
       busy: isBusy,
       error,
       loading: isLoading,
-      performance,
-      state,
+      summary,
     }),
   };
 }

--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -647,6 +647,26 @@ export async function buildEarnMaxDepositInstructions(input: {
           owner: input.feePayer,
           source: associatedToken(input.feePayer, topology.claimMint),
         }),
+        earnMaxCashFlowMemo({
+          accounts: [
+            { pubkey: input.feePayer, isSigner: true, isWritable: false },
+            { pubkey: input.settings, isSigner: false, isWritable: false },
+            {
+              pubkey: topology.claimCustody,
+              isSigner: false,
+              isWritable: false,
+            },
+            {
+              pubkey: associatedToken(input.feePayer, topology.claimMint),
+              isSigner: false,
+              isWritable: false,
+            },
+            { pubkey: input.programId, isSigner: false, isWritable: false },
+          ],
+          value: `loyal:earn-max:v1:deposit:${
+            input.amountRaw
+          }:${input.settings.toBase58()}`,
+        }),
       ],
       operation: "earnMaxDeposit",
       payer: input.feePayer,
@@ -676,6 +696,19 @@ function earnMaxIntent(
     // carry the vault through the writable-signer account class.
     keys: [{ pubkey: vault, isSigner: true, isWritable: true }],
     data: Buffer.from(value, "utf8"),
+  });
+}
+
+function earnMaxCashFlowMemo(input: {
+  accounts: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[];
+  value: string;
+}): TransactionInstruction {
+  if (Buffer.byteLength(input.value) > 220)
+    throw new Error("Earn MAX cash-flow evidence is too large.");
+  return new TransactionInstruction({
+    programId: MEMO,
+    keys: input.accounts,
+    data: Buffer.from(input.value, "utf8"),
   });
 }
 
@@ -734,6 +767,7 @@ export async function buildEarnMaxClaimInstructions(input: {
   connection: Connection;
   feePayer: PublicKey;
   programId: PublicKey;
+  requestId: string;
   settings: PublicKey;
 }): Promise<{ destination: PublicKey; operation: EarnMaxClientOperation }> {
   const topology = deriveEarnMaxTopology(input.settings);
@@ -751,6 +785,21 @@ export async function buildEarnMaxClaimInstructions(input: {
           mint: topology.claimMint,
           owner: topology.vault,
           source: topology.claimCustody,
+        }),
+        earnMaxCashFlowMemo({
+          accounts: [
+            { pubkey: topology.vault, isSigner: true, isWritable: true },
+            { pubkey: input.settings, isSigner: false, isWritable: false },
+            {
+              pubkey: topology.claimCustody,
+              isSigner: false,
+              isWritable: false,
+            },
+            { pubkey: destination, isSigner: false, isWritable: false },
+          ],
+          value: `loyal:earn-max:v1:claim:${requestId(input.requestId)}:${
+            input.amountRaw
+          }:${destination.toBase58()}:${input.settings.toBase58()}`,
         }),
       ],
     }),


### PR DESCRIPTION
Makes summary and activity the only Earn MAX read contracts, derives presentation at the boundary, and removes the persisted frontend projection. The product remains hidden behind the existing production visibility gate.