### PR TITLE
fix(earn-max): create three raw policy accounts

### DIFF
--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -4,6 +4,8 @@ import {
   type PreparedLoyalSmartAccountsOperation,
 } from "@loyal-labs/loyal-smart-accounts";
 import {
+  AddressLookupTableAccount,
+  AddressLookupTableProgram,
   PublicKey,
   SYSVAR_RENT_PUBKEY,
   SystemProgram,
@@ -14,7 +16,6 @@ import {
 import { clusterConfigFor } from "./cluster.ts";
 import {
   createProgramInteractionPolicyInstruction,
-  updateProgramInteractionPolicyInstruction,
 } from "./internal/squads.ts";
 import { LoyalCluster } from "./types.ts";
 
@@ -170,7 +171,6 @@ export type EarnMaxPolicyPreparation = {
   seed: bigint;
   policy: PublicKey;
   instruction: TransactionInstruction;
-  updateInstruction: TransactionInstruction;
 };
 
 function associatedToken(
@@ -246,8 +246,41 @@ function sliceEquals(value: readonly number[]) {
   };
 }
 
+function u16Equals(value: number) {
+  return {
+    dataOffset: BigInt(0),
+    dataValue: { type: "u16Le" as const, value },
+    operator: "equals" as const,
+  };
+}
+
 function pubkey(accountIndex: number, ...pubkeys: PublicKey[]) {
   return { accountIndex, kind: { type: "pubkey" as const, pubkeys } };
+}
+
+function accountDataPubkey(
+  accountIndex: number,
+  owner: PublicKey,
+  dataOffset: bigint,
+  value: PublicKey
+) {
+  return {
+    accountIndex,
+    kind: {
+      type: "accountData" as const,
+      dataConstraints: [
+        {
+          dataOffset,
+          dataValue: {
+            type: "u8Slice" as const,
+            value: [...value.toBytes()],
+          },
+          operator: "equals" as const,
+        },
+      ],
+    },
+    owner,
+  };
 }
 
 function uniquePubkeys(pubkeys: readonly PublicKey[]): PublicKey[] {
@@ -265,12 +298,7 @@ export function createEarnMaxPolicyManifest(input: {
   const policy = (
     family: EarnMaxPolicyPreparation["family"],
     seed: bigint,
-    constraints: Parameters<
-      typeof createProgramInteractionPolicyInstruction
-    >[2],
-    bootstrapConstraints: Parameters<
-      typeof createProgramInteractionPolicyInstruction
-    >[2]
+    constraints: Parameters<typeof createProgramInteractionPolicyInstruction>[2]
   ): EarnMaxPolicyPreparation => {
     const instruction = createProgramInteractionPolicyInstruction(
       config,
@@ -281,7 +309,7 @@ export function createEarnMaxPolicyManifest(input: {
         accountIndex: EARN_MAX_VAULT_INDEX,
         vault: topology.vault,
       },
-      bootstrapConstraints,
+      constraints,
       seed,
       [],
       "legacy"
@@ -292,51 +320,45 @@ export function createEarnMaxPolicyManifest(input: {
       seed,
       policy,
       instruction,
-      updateInstruction: updateProgramInteractionPolicyInstruction(
-        config,
-        {
-          settings: input.settings,
-          authority: input.authority,
-          delegatedSigner: input.delegatedSigner,
-          accountIndex: EARN_MAX_VAULT_INDEX,
-          vault: topology.vault,
-        },
-        constraints,
-        policy
-      ),
     };
   };
 
-  const swapLane = (source: PublicKey, destination: PublicKey) => ({
+  const swapBiclique = (
+    sources: readonly PublicKey[],
+    destinations: readonly PublicKey[]
+  ) => ({
     programId: config.jupiterV6ProgramId,
     accountConstraints: [
       pubkey(2, topology.vault),
-      pubkey(3, source),
-      pubkey(6, destination),
+      pubkey(3, ...sources),
+      pubkey(6, ...destinations),
     ],
-    dataConstraints: [sliceEquals(SHARED_ACCOUNTS_ROUTE)],
+    dataConstraints: [
+      u16Equals(
+        SHARED_ACCOUNTS_ROUTE[0] | (SHARED_ACCOUNTS_ROUTE[1] << 8)
+      ),
+    ],
   });
 
-  const obligations = topology.strategies.map(({ obligation }) => obligation);
+  const markets = uniquePubkeys(topology.strategies.map(({ market }) => market));
   const collateralReserves = uniquePubkeys(topology.strategies.map(({ collateralReserve }) => collateralReserve));
   const collateralCustodies = uniquePubkeys(topology.strategies.map(({ collateralCustody }) => collateralCustody));
-  const debtReserves = topology.strategies.map(({ debtReserve }) => debtReserve);
   const debtCustodies = uniquePubkeys(topology.strategies.map(({ debtCustody }) => debtCustody));
-  const debtTokenPrograms = uniquePubkeys(topology.strategies.map(({ debtTokenProgram }) => debtTokenProgram));
+  const obligationOwnedByVault = accountDataPubkey(
+    1,
+    KLEND,
+    BigInt(64),
+    topology.vault
+  );
 
   const collateralConstraints = [
     {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault),
-        pubkey(1, ...obligations),
+        obligationOwnedByVault,
         pubkey(4, ...collateralReserves),
         pubkey(9, ...collateralCustodies),
-        pubkey(11, TOKEN),
-        pubkey(12, TOKEN),
-        pubkey(14, KLEND),
-        pubkey(15, KLEND),
-        pubkey(16, FARMS),
       ],
       dataConstraints: [sliceEquals(DEPOSIT)],
     },
@@ -344,14 +366,9 @@ export function createEarnMaxPolicyManifest(input: {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault),
-        pubkey(1, ...obligations),
+        obligationOwnedByVault,
         pubkey(4, ...collateralReserves),
         pubkey(9, ...collateralCustodies),
-        pubkey(11, TOKEN),
-        pubkey(12, TOKEN),
-        pubkey(14, KLEND),
-        pubkey(15, KLEND),
-        pubkey(16, FARMS),
       ],
       dataConstraints: [sliceEquals(WITHDRAW)],
     },
@@ -361,11 +378,9 @@ export function createEarnMaxPolicyManifest(input: {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault),
-        pubkey(1, ...obligations),
-        pubkey(4, ...debtReserves),
+        obligationOwnedByVault,
+        pubkey(2, ...markets),
         pubkey(8, ...debtCustodies),
-        pubkey(10, ...debtTokenPrograms),
-        pubkey(14, FARMS),
       ],
       dataConstraints: [sliceEquals(BORROW)],
     },
@@ -373,30 +388,32 @@ export function createEarnMaxPolicyManifest(input: {
       programId: KLEND,
       accountConstraints: [
         pubkey(0, topology.vault),
-        pubkey(1, ...obligations),
-        pubkey(3, ...debtReserves),
+        obligationOwnedByVault,
+        pubkey(2, ...markets),
         pubkey(6, ...debtCustodies),
-        pubkey(7, ...debtTokenPrograms),
-        pubkey(12, FARMS),
       ],
       dataConstraints: [sliceEquals(REPAY)],
     },
   ] as const;
-  const swapConstraints = topology.strategies.flatMap((strategy) => [
-    swapLane(strategy.debtCustody, strategy.collateralCustody),
-    swapLane(strategy.collateralCustody, strategy.debtCustody),
-  ]);
+  const strategy = (key: EarnMaxStrategyKey) =>
+    topology.strategies.find((candidate) => candidate.key === key)!;
+  const usdc = strategy("onyc_usdc").debtCustody;
+  const usds = strategy("onyc_usds").debtCustody;
+  const pyusd = strategy("prime_pyusd").debtCustody;
+  const onyc = strategy("onyc_usdc").collateralCustody;
+  const prime = strategy("prime_usdc").collateralCustody;
+  const syrup = strategy("syrup_usdc_usdc").collateralCustody;
+  const swapConstraints = [
+    swapBiclique([usdc, usds], [onyc, prime]),
+    swapBiclique([usdc, pyusd], [prime, syrup]),
+    swapBiclique([onyc, prime], [usdc, usds]),
+    swapBiclique([prime, syrup], [usdc, pyusd]),
+  ];
 
   return [
-    policy("collateral", input.firstPolicySeed, collateralConstraints, [
-      collateralConstraints[1],
-    ]),
-    policy("debt", input.firstPolicySeed + BigInt(1), debtConstraints, [
-      debtConstraints[1],
-    ]),
-    policy("swap", input.firstPolicySeed + BigInt(2), swapConstraints, [
-      swapConstraints[1]!,
-    ]),
+    policy("collateral", input.firstPolicySeed, collateralConstraints),
+    policy("debt", input.firstPolicySeed + BigInt(1), debtConstraints),
+    policy("swap", input.firstPolicySeed + BigInt(2), swapConstraints),
   ];
 }
 
@@ -455,9 +472,10 @@ function prepared(
   input: Omit<
     EarnMaxClientOperation,
     "lookupTableAccounts" | "requiresConfirmation"
-  >
+  >,
+  lookupTableAccounts: readonly AddressLookupTableAccount[] = []
 ): EarnMaxClientOperation {
-  return { ...input, lookupTableAccounts: [], requiresConfirmation: true };
+  return { ...input, lookupTableAccounts, requiresConfirmation: true };
 }
 
 function createAssociatedTokenAccount(
@@ -560,33 +578,81 @@ export async function buildEarnMaxInstallInstructions(input: {
     "confirmed"
   );
   const matching = input.matchingPolicyAccounts ?? new Set<string>();
-  return manifest.flatMap((entry, index) =>
-    accounts[index] && matching.has(entry.policy.toBase58())
-      ? []
-      : accounts[index]
-      ? [
-          prepared({
-            instructions: [entry.updateInstruction],
-            operation: `earnMaxInstall:update:${entry.family}`,
-            payer: input.feePayer,
-            programId: input.programId,
-          }),
-        ]
-      : [
-          prepared({
-            instructions: [entry.instruction],
-            operation: `earnMaxInstall:create:${entry.family}`,
-            payer: input.feePayer,
-            programId: input.programId,
-          }),
-          prepared({
-            instructions: [entry.updateInstruction],
-            operation: `earnMaxInstall:update:${entry.family}`,
-            payer: input.feePayer,
-            programId: input.programId,
-          }),
-        ]
-  );
+  const missing = manifest.filter((entry, index) => {
+    const exists = Boolean(accounts[index]);
+    const matches = matching.has(entry.policy.toBase58());
+    if (exists && !matches) {
+      throw new Error(
+        `Earn MAX ${entry.family} policy exists with non-canonical bytes; close it before reinstalling.`
+      );
+    }
+    return !exists;
+  });
+  if (missing.length === 0) return [];
+
+  const operations: EarnMaxClientOperation[] = [];
+  const swap = missing.find((entry) => entry.family === "swap");
+  let swapLookupTable: AddressLookupTableAccount | undefined;
+  if (swap) {
+    const recentSlot = await input.connection.getSlot("confirmed");
+    const [createLookupTable, lookupTableAddress] =
+      AddressLookupTableProgram.createLookupTable({
+        authority: input.feePayer,
+        payer: input.feePayer,
+        recentSlot,
+      });
+    const addresses = uniquePubkeys([
+      swap.instruction.programId,
+      ...swap.instruction.keys
+        .filter(({ isSigner }) => !isSigner)
+        .map(({ pubkey }) => pubkey),
+    ]);
+    const extendLookupTable = AddressLookupTableProgram.extendLookupTable({
+      authority: input.feePayer,
+      lookupTable: lookupTableAddress,
+      payer: input.feePayer,
+      addresses,
+    });
+    swapLookupTable = new AddressLookupTableAccount({
+      key: lookupTableAddress,
+      state: {
+        authority: input.feePayer,
+        addresses,
+        deactivationSlot: BigInt("18446744073709551615"),
+        lastExtendedSlot: recentSlot,
+        lastExtendedSlotStartIndex: 0,
+      },
+    });
+    operations.push(
+      prepared({
+        instructions: [createLookupTable],
+        operation: "earnMaxInstall:createLookupTable",
+        payer: input.feePayer,
+        programId: AddressLookupTableProgram.programId,
+      }),
+      prepared({
+        instructions: [extendLookupTable],
+        operation: "earnMaxInstall:extendLookupTable",
+        payer: input.feePayer,
+        programId: AddressLookupTableProgram.programId,
+      })
+    );
+  }
+
+  for (const entry of missing) {
+    operations.push(
+      prepared(
+        {
+          instructions: [entry.instruction],
+          operation: `earnMaxInstall:create:${entry.family}`,
+          payer: input.feePayer,
+          programId: input.programId,
+        },
+        entry.family === "swap" && swapLookupTable ? [swapLookupTable] : []
+      )
+    );
+  }
+  return operations;
 }
 
 function initUserMetadata(vault: PublicKey, userMetadata: PublicKey) {

--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -594,7 +594,9 @@ export async function buildEarnMaxInstallInstructions(input: {
   const swap = missing.find((entry) => entry.family === "swap");
   let swapLookupTable: AddressLookupTableAccount | undefined;
   if (swap) {
-    const recentSlot = await input.connection.getSlot("confirmed");
+    const confirmedSlot = await input.connection.getSlot("confirmed");
+    if (confirmedSlot < 1) throw new Error("Solana confirmed slot is invalid.");
+    const recentSlot = confirmedSlot - 1;
     const [createLookupTable, lookupTableAddress] =
       AddressLookupTableProgram.createLookupTable({
         authority: input.feePayer,

--- a/packages/loyal-actions/src/earn-max.ts
+++ b/packages/loyal-actions/src/earn-max.ts
@@ -69,13 +69,9 @@ type EarnMaxStrategyTemplate = {
   marketAuthority: string;
   collateralReserve: string;
   collateralMint: string;
-  collateralLiquiditySupply: string;
-  collateralReceiptSupply: string;
   debtReserve: string;
   debtMint: string;
   debtTokenProgram: "token" | "token2022";
-  debtLiquiditySupply: string;
-  debtFeeVault: string;
   debtFarm?: string;
   targetLtvBps: number;
 };
@@ -85,60 +81,49 @@ const STRATEGY_TEMPLATES: readonly EarnMaxStrategyTemplate[] = [
     key: "onyc_usdc", label: "ONyc / USDC",
     market: "47tfyEG9SsdEnUm9cw5kY9BXngQGqu3LBoop9j5uTAv8", marketAuthority: "FsvTiXTUFDc4aLbrov4PrvDTjXCWCniL1dxTUkZ1T2ss",
     collateralReserve: "6ZxkBSJEqsXA3Kdm2PDAzHLUdPTPUK93Lf4bAezec1UQ", collateralMint: "5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5",
-    collateralLiquiditySupply: "9YuHgsPVGgWrkpsaRZmeZCV2uXweMEn6TEAcusQKRjgG", collateralReceiptSupply: "2c42iUaea3QVLvSPQHUBZBwqdvpiQo5vmePq9qx8eo",
     debtReserve: "AYL4LMc4ZCVyq3Z7XPJGWDM4H9PiWjqXAAuuHBEGVR2Z", debtMint: USDC_MINT.toBase58(), debtTokenProgram: "token",
-    debtLiquiditySupply: "8BkQTZsT8ssKMU643De4iiV5Wf3pENdUFTsdtHPueKjB", debtFeeVault: "5iLRav31Y7DJwM6bZ7s92jqvV3zd1wZMcp4mYeKXh8cj",
     debtFarm: "7vNfe1qX8iDxP5p3A4fosrjLqdn1YjmmGcZZkG2b4APF", targetLtvBps: 5_000,
   },
   {
     key: "onyc_usds", label: "ONyc / USDS",
     market: "47tfyEG9SsdEnUm9cw5kY9BXngQGqu3LBoop9j5uTAv8", marketAuthority: "FsvTiXTUFDc4aLbrov4PrvDTjXCWCniL1dxTUkZ1T2ss",
     collateralReserve: "6ZxkBSJEqsXA3Kdm2PDAzHLUdPTPUK93Lf4bAezec1UQ", collateralMint: "5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5",
-    collateralLiquiditySupply: "9YuHgsPVGgWrkpsaRZmeZCV2uXweMEn6TEAcusQKRjgG", collateralReceiptSupply: "2c42iUaea3QVLvSPQHUBZBwqdvpiQo5vmePq9qx8eo",
     debtReserve: "3yDc9ARvtPLhYxZLgucZGuBtZ9bHshBvXTwHxGe3nhmC", debtMint: USDS_MINT.toBase58(), debtTokenProgram: "token",
-    debtLiquiditySupply: "21Skwocv5cJoftyejSTtXVaHJWTg88xcWGQtnRvUyKLx", debtFeeVault: "CmMAn2UtLWHsQhwv31Trz4BZwVravs2jgxZYK2daTHaK",
     debtFarm: "5piFMvvPonJM8zJbCGoPD2jZt59hNURDLDTpXQzgbydc", targetLtvBps: 5_000,
   },
   {
     key: "prime_usdc", label: "PRIME / USDC",
     market: "CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA", marketAuthority: "9SLBVnPz8dRGvafST6zNBZYSSt3HtdU68XQLGR13t3uM",
     collateralReserve: "BUTND9T7Ux4KR8RAEgd4WoZwnP7xA279oA1y3iPVcvSh", collateralMint: "3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7",
-    collateralLiquiditySupply: "FkSkbRU5A6JXRXo5uaFwCS7jQ6jHYa1DxFtfpXfTz352", collateralReceiptSupply: "Eg4wKFWc8aGfAqrcmYu3paz2afY5VqJMo17K95Y4VqFN",
     debtReserve: "9GJ9GBRwCp4pHmWrQ43L5xpc9Vykg7jnfwcFGN8FoHYu", debtMint: USDC_MINT.toBase58(), debtTokenProgram: "token",
-    debtLiquiditySupply: "H6JUwz8c61eQnYUx8avGXydKztKPyGvgWAUjmZUPS3BC", debtFeeVault: "BzSw9sWTxUumr2wHhDiezkaLy3QZQS1KT4a9Fz8GvAQ6", targetLtvBps: 6_500,
+    targetLtvBps: 6_500,
   },
   {
     key: "prime_pyusd", label: "PRIME / PYUSD",
     market: "CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA", marketAuthority: "9SLBVnPz8dRGvafST6zNBZYSSt3HtdU68XQLGR13t3uM",
     collateralReserve: "BUTND9T7Ux4KR8RAEgd4WoZwnP7xA279oA1y3iPVcvSh", collateralMint: "3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7",
-    collateralLiquiditySupply: "FkSkbRU5A6JXRXo5uaFwCS7jQ6jHYa1DxFtfpXfTz352", collateralReceiptSupply: "Eg4wKFWc8aGfAqrcmYu3paz2afY5VqJMo17K95Y4VqFN",
     debtReserve: "3ZUAwhEtK8XWfK4fy98z4yoptm4GeyeAu21L11HPXaZ5", debtMint: PYUSD_MINT.toBase58(), debtTokenProgram: "token2022",
-    debtLiquiditySupply: "4LF3i8grZPRbk8d6gXvzRux4rYjGd5AmqrpLLYFpPKKt", debtFeeVault: "4b9U55muKtwx9RimJSuztvyZaKWkmaoferVexgvxrYJr", targetLtvBps: 6_500,
+    targetLtvBps: 6_500,
   },
   {
     key: "prime_usds", label: "PRIME / USDS",
     market: "CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA", marketAuthority: "9SLBVnPz8dRGvafST6zNBZYSSt3HtdU68XQLGR13t3uM",
     collateralReserve: "BUTND9T7Ux4KR8RAEgd4WoZwnP7xA279oA1y3iPVcvSh", collateralMint: "3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7",
-    collateralLiquiditySupply: "FkSkbRU5A6JXRXo5uaFwCS7jQ6jHYa1DxFtfpXfTz352", collateralReceiptSupply: "Eg4wKFWc8aGfAqrcmYu3paz2afY5VqJMo17K95Y4VqFN",
     debtReserve: "7SzMWArC8WAenndXFmRyfvcvrNPodqUFkmPrmmoRZvn4", debtMint: USDS_MINT.toBase58(), debtTokenProgram: "token",
-    debtLiquiditySupply: "5tP1kDJBYnjtrpUaRQhsrU1Y28ahiJVjz8p9mbqJFpz5", debtFeeVault: "DjmdtvsvctUXCZ32y6UGdCEvXPTds6Ci7LFnVhw5HaQY", targetLtvBps: 6_500,
+    targetLtvBps: 6_500,
   },
   {
     key: "syrup_usdc_usdc", label: "syrupUSDC / USDC",
     market: "6WEGfej9B9wjxRs6t4BYpb9iCXd8CpTpJ8fVSNzHCC5y", marketAuthority: "6QbtpY2jDNcncRFmVf343NThnCdaY8gCAsYATPnYQR9g",
     collateralReserve: "AwCyCPZYJSZ93xcVKNK7jR8e1BHzJXq1D4bReNuh9woY", collateralMint: "AvZZF1YaZDziPY2RCK4oJrRVrbN3mTD9NL24hPeaZeUj",
-    collateralLiquiditySupply: "8Se5SK1Tty2bH4EQVrKW8hwr9Lc9E2cEbkaN59DpcB6i", collateralReceiptSupply: "21GK6yHS3MKhTnF5pN5FuSmnpLiyPXTDrpxxbqMEoX58",
     debtReserve: "Atj6UREVWa7WxbF2EMKNyfmYUY1U1txughe2gjhcPDCo", debtMint: USDC_MINT.toBase58(), debtTokenProgram: "token",
-    debtLiquiditySupply: "BBcwMNSMyhhBnYE9pevEvkxKHGzTafMP9v3j7Kk7nAWM", debtFeeVault: "HH7GLnRcGHJrdkEueVVj7mccNUjnSeWobDmtu9cHLkJV",
     debtFarm: "87gUNr8LwYJCT25HjPEHnrfBBjwEMAjfqCfnKcJNqy9Y", targetLtvBps: 6_500,
   },
   {
     key: "syrup_usdc_pyusd", label: "syrupUSDC / PYUSD",
     market: "6WEGfej9B9wjxRs6t4BYpb9iCXd8CpTpJ8fVSNzHCC5y", marketAuthority: "6QbtpY2jDNcncRFmVf343NThnCdaY8gCAsYATPnYQR9g",
     collateralReserve: "AwCyCPZYJSZ93xcVKNK7jR8e1BHzJXq1D4bReNuh9woY", collateralMint: "AvZZF1YaZDziPY2RCK4oJrRVrbN3mTD9NL24hPeaZeUj",
-    collateralLiquiditySupply: "8Se5SK1Tty2bH4EQVrKW8hwr9Lc9E2cEbkaN59DpcB6i", collateralReceiptSupply: "21GK6yHS3MKhTnF5pN5FuSmnpLiyPXTDrpxxbqMEoX58",
     debtReserve: "92qeAka3ZzCGPfJriDXrE7tiNqfATVCAM6ZjjctR3TrS", debtMint: PYUSD_MINT.toBase58(), debtTokenProgram: "token2022",
-    debtLiquiditySupply: "GUENeLN1ufX4K5622DbyYoQFhaWxMKoCFycvLSEYsykN", debtFeeVault: "AwnzukUiajn7b3T9hXcwy19RLPZcHmLANUeqZnzXT6dU",
     debtFarm: "9AUA7XZ1rynUsZcmVCgj8UFdQuDozFSMpaNGBZAtiPWj", targetLtvBps: 6_500,
   },
 ] as const;
@@ -762,20 +747,11 @@ export async function buildEarnMaxDepositInstructions(input: {
           source: associatedToken(input.feePayer, topology.claimMint),
         }),
         earnMaxCashFlowMemo({
+          // SPL Memo requires every supplied account to sign. The memo text
+          // binds Settings and amount; LaserStream derives custody/source and
+          // proves them against the confirmed transfer in this transaction.
           accounts: [
             { pubkey: input.feePayer, isSigner: true, isWritable: false },
-            { pubkey: input.settings, isSigner: false, isWritable: false },
-            {
-              pubkey: topology.claimCustody,
-              isSigner: false,
-              isWritable: false,
-            },
-            {
-              pubkey: associatedToken(input.feePayer, topology.claimMint),
-              isSigner: false,
-              isWritable: false,
-            },
-            { pubkey: input.programId, isSigner: false, isWritable: false },
           ],
           value: `loyal:earn-max:v2:deposit:${
             input.amountRaw
@@ -901,15 +877,11 @@ export async function buildEarnMaxClaimInstructions(input: {
           source: topology.claimCustody,
         }),
         earnMaxCashFlowMemo({
+          // The Squads vault is the only Memo account because every Memo
+          // account must sign. Settings, destination and amount are in the
+          // payload and independently reconciled to confirmed token deltas.
           accounts: [
             { pubkey: topology.vault, isSigner: true, isWritable: true },
-            { pubkey: input.settings, isSigner: false, isWritable: false },
-            {
-              pubkey: topology.claimCustody,
-              isSigner: false,
-              isWritable: false,
-            },
-            { pubkey: destination, isSigner: false, isWritable: false },
           ],
           value: `loyal:earn-max:v2:claim:${requestId(input.requestId)}:${
             input.amountRaw

--- a/packages/loyal-actions/test/sdk.test.ts
+++ b/packages/loyal-actions/test/sdk.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
+  AddressLookupTableAccount,
   type Connection,
   PublicKey,
   TransactionMessage,
@@ -132,35 +133,41 @@ describe("Earn MAX policy manifest", () => {
     expect(
       manifest.map((entry) => decodePolicyCreate(entry.instruction.data).seed)
     ).toEqual([BigInt(234), BigInt(235), BigInt(236)]);
-    const wireBytes = manifest.map((entry) => ({
-      create: new VersionedTransaction(
+    const swap = manifest[2]!;
+    const lookupAddresses = [
+      swap.instruction.programId,
+      ...swap.instruction.keys
+        .filter(({ isSigner }) => !isSigner)
+        .map(({ pubkey }) => pubkey),
+    ].filter(
+      (candidate, index, values) =>
+        values.findIndex((value) => value.equals(candidate)) === index
+    );
+    const lookup = new AddressLookupTableAccount({
+      key: PublicKey.unique(),
+      state: {
+        authority,
+        addresses: lookupAddresses,
+        deactivationSlot: BigInt("18446744073709551615"),
+        lastExtendedSlot: 1,
+        lastExtendedSlotStartIndex: 0,
+      },
+    });
+    const wireBytes = manifest.map((entry) =>
+      new VersionedTransaction(
         new TransactionMessage({
           payerKey: authority,
           recentBlockhash: PublicKey.default.toBase58(),
           instructions: [entry.instruction],
-        }).compileToLegacyMessage()
-      ).serialize().length,
-      update: new VersionedTransaction(
-        new TransactionMessage({
-          payerKey: authority,
-          recentBlockhash: PublicKey.default.toBase58(),
-          instructions: [entry.updateInstruction],
-        }).compileToLegacyMessage()
-      ).serialize().length,
-    }));
-    expect(wireBytes).toEqual([
-      { create: 1085, update: 1074 },
-      { create: 1128, update: 1214 },
-      { create: 531, update: 1186 },
-    ]);
-    for (const pair of wireBytes) {
-      expect(pair.create).toBeLessThan(1232);
-      expect(pair.update).toBeLessThan(1232);
-    }
-    expect(manifest.map(({ updateInstruction }) => instructionFingerprint(updateInstruction))).toEqual([
-      "ef32ee403e4a472b19f927e14a224e318b8572073c7bd40260b6c4b1be45e224",
-      "ad1b0ca8316a1e03644b27c0e6050dc58703326f9f095db2697e58de5df72f5c",
-      "88320a43b00cafad090780a28ec23c773e5ef595621d4262ba08fc208ebbc2af",
+        }).compileToV0Message(entry.family === "swap" ? [lookup] : [])
+      ).serialize().length
+    );
+    expect(wireBytes).toEqual([1138, 1138, 1227]);
+    for (const bytes of wireBytes) expect(bytes).toBeLessThan(1232);
+    expect(manifest.map(({ instruction }) => instructionFingerprint(instruction))).toEqual([
+      "c9aae4e32ef1659c0f9ef7367f7e3f920809bb5842e4d838c67681b6de39ca43",
+      "791ba0305d76427d970f3550989707767da2aadac7d0979acecaff2a40a7db4e",
+      "6e50e231456bb7a67fb551b219ef56fc2bf83b5f1594a5b6d80c82eb1e0475ad",
     ]);
   });
 

--- a/packages/loyal-actions/test/sdk.test.ts
+++ b/packages/loyal-actions/test/sdk.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
+  type Connection,
   PublicKey,
   TransactionMessage,
   VersionedTransaction,
@@ -43,6 +44,7 @@ import {
   createJupiterCrossMintPolicyPlan,
   createJupiterCrossMintPolicySet,
   createEarnMaxPolicyManifest,
+  buildEarnMaxDepositInstructions,
   deriveEarnMaxTopology,
   createVaultSubscriptionSweepPolicyPlan,
   createVaultYieldRoutingPolicyPlan,
@@ -159,6 +161,31 @@ describe("Earn MAX policy manifest", () => {
       "ef32ee403e4a472b19f927e14a224e318b8572073c7bd40260b6c4b1be45e224",
       "ad1b0ca8316a1e03644b27c0e6050dc58703326f9f095db2697e58de5df72f5c",
       "88320a43b00cafad090780a28ec23c773e5ef595621d4262ba08fc208ebbc2af",
+    ]);
+  });
+
+  test("keeps deposit evidence executable by supplying only the real Memo signer", async () => {
+    const connection = {
+      getBalance: async () => 0,
+      getMultipleAccountsInfo: async (keys: readonly PublicKey[]) =>
+        keys.map(() => ({ data: Buffer.alloc(0) })),
+    } as unknown as Connection;
+    const operations = await buildEarnMaxDepositInstructions({
+      amountRaw: 400_000n,
+      connection,
+      feePayer: authority,
+      programId: new PublicKey("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG"),
+      settings,
+    });
+    const deposit = operations.at(-1)!;
+    const memo = deposit.instructions.at(-1)!;
+
+    expect(deposit.operation).toBe("earnMaxDeposit");
+    expect(memo.programId.toBase58()).toBe(
+      "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+    );
+    expect(memo.keys).toEqual([
+      { pubkey: authority, isSigner: true, isWritable: false },
     ]);
   });
 });


### PR DESCRIPTION
Replace bootstrap/update policy installation with three full legacy creates and an install-only ALT for the swap packet. Preserve the hidden Earn MAX UI and verify Rust/TypeScript policy fingerprints and packet limits.