### PR TITLE
fix(earn): preserve API compatibility during projection

### DIFF
--- a/apps/mobile/scripts/verify-earn-local-api.ts
+++ b/apps/mobile/scripts/verify-earn-local-api.ts
@@ -1,0 +1,401 @@
+import { appendFileSync, readFileSync } from "node:fs";
+
+import {
+  getKaminoUsdcEarnTargetForCluster,
+  LoyalCluster,
+} from "@loyal-labs/actions";
+import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+
+type LocalState = {
+  collateralMint: string;
+  market: string;
+  marketAuthority: string;
+  obligation: string;
+  policyAccount: string;
+  policySeed: string;
+  reserve: string;
+  reserveLiquiditySupply: string;
+  settingsPda: string;
+  setupPolicyAccount: string;
+  setupPolicySeed: string;
+  usdcMint: string;
+  vaultCollateralAta: string;
+  vaultPubkey: string;
+  walletAddress: string;
+};
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce<string[][]>((pairs, value, index, all) => {
+    if (index % 2 === 0) pairs.push([value.replace(/^--/, ""), all[index + 1]!]);
+    return pairs;
+  }, []),
+) as Record<string, string>;
+
+for (const key of ["state", "rpc-url", "transactions", "port", "amount-raw"]) {
+  if (!args[key]) throw new Error(`Missing --${key}.`);
+}
+
+const state = JSON.parse(readFileSync(args.state!, "utf8")) as LocalState;
+const connection = new Connection(args["rpc-url"]!, "confirmed");
+const policySigner = Keypair.fromSeed(new Uint8Array(32).fill(9)).publicKey;
+const programId = "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG";
+const KAMINO_FARMS_PROGRAM = new PublicKey(
+  "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+);
+const KAMINO_DEPOSIT_DISCRIMINATOR = Buffer.from([
+  216, 224, 191, 27, 204, 151, 102, 175,
+]);
+const KAMINO_WITHDRAW_DISCRIMINATOR = Buffer.from([
+  235, 52, 119, 152, 149, 197, 20, 7,
+]);
+let amountRaw = args["amount-raw"]!;
+
+function decimalAmountToRaw(amount: string): bigint {
+  const [whole, fraction = ""] = amount.split(".");
+  return (
+    BigInt(whole || "0") * BigInt(1_000_000) +
+    BigInt(fraction.padEnd(6, "0").slice(0, 6) || "0")
+  );
+}
+
+function encodedAmount(discriminator: Buffer, raw: bigint): string {
+  const data = Buffer.alloc(16);
+  discriminator.copy(data);
+  data.writeBigUInt64LE(raw, 8);
+  return data.toString("base64");
+}
+
+function kaminoInstructions(deposit: boolean, raw: bigint) {
+  const lendProgramId = getKaminoUsdcEarnTargetForCluster(
+    LoyalCluster.MainnetBeta,
+  ).lendProgramId.toBase58();
+  const vaultUsdcAta = getAssociatedTokenAddressSync(
+    new PublicKey(state.usdcMint),
+    new PublicKey(state.vaultPubkey),
+    true,
+    TOKEN_PROGRAM_ID,
+  ).toBase58();
+  const ro = (address: string) => ({ address, role: "READONLY" });
+  const rw = (address: string) => ({ address, role: "WRITABLE" });
+  const signer = (address: string) => ({
+    address,
+    role: "WRITABLE_SIGNER",
+  });
+  const common = [
+    signer(state.vaultPubkey),
+    rw(state.obligation),
+    ro(state.market),
+    ro(state.marketAuthority),
+    rw(state.reserve),
+    ro(state.usdcMint),
+  ];
+  const accounts = deposit
+    ? [
+        ...common,
+        rw(state.reserveLiquiditySupply),
+        rw(state.collateralMint),
+        rw(state.vaultCollateralAta),
+        rw(vaultUsdcAta),
+      ]
+    : [
+        ...common,
+        rw(state.vaultCollateralAta),
+        rw(state.collateralMint),
+        rw(state.reserveLiquiditySupply),
+        rw(vaultUsdcAta),
+      ];
+  accounts.push(
+    ro(lendProgramId),
+    ro(TOKEN_PROGRAM_ID.toBase58()),
+    ro(TOKEN_PROGRAM_ID.toBase58()),
+    ro("Sysvar1nstructions1111111111111111111111111"),
+    ro(lendProgramId),
+    ro(lendProgramId),
+    ro(KAMINO_FARMS_PROGRAM.toBase58()),
+  );
+  return {
+    instructions: [
+      {
+        accounts,
+        data: encodedAmount(
+          deposit
+            ? KAMINO_DEPOSIT_DISCRIMINATOR
+            : KAMINO_WITHDRAW_DISCRIMINATOR,
+          raw,
+        ),
+        programAddress: lendProgramId,
+      },
+    ],
+  };
+}
+
+async function assertFinalized(signature: string): Promise<number> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const statuses = await connection.getSignatureStatuses([signature], {
+      searchTransactionHistory: true,
+    });
+    const status = statuses.value[0];
+    if (status?.err) {
+      throw new Error(
+        `Signature ${signature} failed: ${JSON.stringify(status.err)}.`,
+      );
+    }
+    if (status?.confirmationStatus === "finalized") {
+      const transaction = await connection.getTransaction(signature, {
+        commitment: "finalized",
+        maxSupportedTransactionVersion: 0,
+      });
+      if (!transaction) {
+        throw new Error(`Finalized transaction ${signature} is absent.`);
+      }
+      return transaction.slot;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Signature ${signature} did not finalize in time.`);
+}
+
+function json(value: unknown, status = 200): Response {
+  return Response.json(value, { status });
+}
+
+function positionResponse() {
+  return {
+    position: {
+      currentAmountRaw: amountRaw,
+      currentSupplyApyBps: "300",
+      principalAmountRaw: amountRaw,
+      status: amountRaw === "0" ? "withdrawn" : "active",
+    },
+    settingsPda: state.settingsPda,
+    smartAccountAddress: state.vaultPubkey,
+  };
+}
+
+function holding() {
+  return {
+    amountRaw,
+    kind: "kamino",
+    label: "Kamino USDC",
+    liquidityMint: state.usdcMint,
+    market: state.market,
+    marketName: "Kamino",
+    reserve: state.reserve,
+  };
+}
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: Number(args.port),
+  async fetch(request) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    try {
+      if (
+        request.method === "POST" &&
+        (path.endsWith("/klend/deposit-instructions") ||
+          path.endsWith("/klend/withdraw-instructions"))
+      ) {
+        const body = (await request.json()) as {
+          amount?: string;
+          wallet?: string;
+        };
+        if (!body.amount || body.wallet !== state.vaultPubkey) {
+          return json({ error: { code: "invalid_kamino_fixture_request" } }, 400);
+        }
+        return json(
+          kaminoInstructions(
+            path.endsWith("/deposit-instructions"),
+            decimalAmountToRaw(body.amount),
+          ),
+        );
+      }
+      if (request.method === "GET" && path.endsWith("/earn/state")) {
+        return json(positionResponse());
+      }
+      if (request.method === "GET" && path.endsWith("/earn/holdings")) {
+        const slot = await connection.getSlot("confirmed");
+        return json({
+          currentTotalAmountRaw: amountRaw,
+          holdings: amountRaw === "0" ? [] : [holding()],
+          observedAt: new Date().toISOString(),
+          observedSlot: String(slot),
+          settingsPda: state.settingsPda,
+          smartAccountAddress: state.vaultPubkey,
+        });
+      }
+      if (request.method === "GET" && path.endsWith("/withdraw/sources")) {
+        return json({
+          sources:
+            amountRaw === "0"
+              ? []
+              : [
+                  {
+                    ...holding(),
+                    id: state.reserve,
+                    sourceId: `reserve:${state.reserve}`,
+                    tokenAccount: null,
+                    type: "reserve",
+                  },
+                ],
+          settingsPda: state.settingsPda,
+          smartAccountAddress: state.vaultPubkey,
+        });
+      }
+      if (request.method === "GET" && path.endsWith("/autodeposit/state")) {
+        return json({
+          autodeposit: null,
+          prepareContext: { cluster: "mainnet-beta", policySigner: policySigner.toBase58(), programId },
+          settingsPda: state.settingsPda,
+          smartAccountAddress: state.vaultPubkey,
+        });
+      }
+      if (
+        request.method === "GET" &&
+        path.endsWith("/earn-forecast/summary")
+      ) {
+        const now = new Date().toISOString();
+        return json({
+          forecast: {
+            apyBps: 300,
+            rangeHighBps: 300,
+            rangeLowBps: 300,
+            window: { startedAt: now, endedAt: now },
+          },
+          history: { samples: [] },
+        });
+      }
+      if (request.method === "POST" && path.endsWith("/withdraw/prepare-context")) {
+        return json({
+          cluster: "mainnet-beta",
+          programId,
+          settingsPda: state.settingsPda,
+          smartAccountAddress: state.vaultPubkey,
+          withdrawInput: {
+            amountRaw,
+            mode: "full",
+            closePoliciesOnFullWithdrawal: false,
+            policySigner: policySigner.toBase58(),
+            source: {
+              type: "reserve",
+              id: state.reserve,
+              amountRaw,
+              liquidityMint: state.usdcMint,
+              market: state.market,
+              reserve: state.reserve,
+            },
+            target: {
+              reserve: state.reserve,
+              market: state.market,
+              liquidityMint: state.usdcMint,
+              supplyApyBps: "300",
+            },
+            fullWithdrawalTargets: [
+              {
+                amountRaw,
+                liquidityMint: state.usdcMint,
+                market: state.market,
+                reserve: state.reserve,
+                reserveCollateralMint: state.collateralMint,
+                reserveLiquiditySupply: state.reserveLiquiditySupply,
+                supplyApyBps: "300",
+                vaultCollateralAta: state.vaultCollateralAta,
+              },
+            ],
+            yieldRoutingPolicy: {
+              account: state.policyAccount,
+              seed: state.policySeed,
+              setupPolicy: {
+                account: state.setupPolicyAccount,
+                seed: state.setupPolicySeed,
+              },
+            },
+            autodepositClose: null,
+          },
+        });
+      }
+      if (request.method === "POST" && path.endsWith("/withdraw/confirm")) {
+        const body = (await request.json()) as { withdrawalSignature?: string };
+        if (!body.withdrawalSignature) return json({ error: { code: "invalid_request" } }, 400);
+        const slot = await assertFinalized(body.withdrawalSignature);
+        appendFileSync(
+          args.transactions!,
+          `${JSON.stringify({ signature: body.withdrawalSignature, slot, stage: "full_withdrawal" })}\n`,
+        );
+        amountRaw = "0";
+        return json({ ok: true, status: "full_exit_verified", position: positionResponse().position });
+      }
+      if (request.method === "POST" && path.endsWith("/cleanup/prepare-context")) {
+        if (amountRaw !== "0") return json({ error: { code: "full_exit_incomplete" } }, 409);
+        const vaultUsdcAta = getAssociatedTokenAddressSync(
+          new PublicKey(state.usdcMint),
+          new PublicKey(state.vaultPubkey),
+          true,
+          TOKEN_PROGRAM_ID,
+        );
+        return json({
+          cluster: "mainnet-beta",
+          programId,
+          settingsPda: state.settingsPda,
+          cleanupInput: {
+            policySigner: policySigner.toBase58(),
+            vaultTokenAccounts: [
+              {
+                address: state.vaultCollateralAta,
+                amountRaw: "0",
+                decimals: 6,
+                mint: state.collateralMint,
+                tokenProgramId: TOKEN_PROGRAM_ID.toBase58(),
+              },
+              {
+                address: vaultUsdcAta.toBase58(),
+                amountRaw: "0",
+                decimals: 6,
+                mint: state.usdcMint,
+                tokenProgramId: TOKEN_PROGRAM_ID.toBase58(),
+              },
+            ],
+            yieldRoutingPolicy: {
+              account: state.policyAccount,
+              seed: state.policySeed,
+              setupPolicy: {
+                account: state.setupPolicyAccount,
+                seed: state.setupPolicySeed,
+              },
+            },
+          },
+        });
+      }
+      if (request.method === "POST" && path.endsWith("/cleanup/confirm")) {
+        const body = (await request.json()) as { cleanupSignature?: string };
+        if (!body.cleanupSignature) return json({ error: { code: "invalid_request" } }, 400);
+        await assertFinalized(body.cleanupSignature);
+        const accounts = await connection.getMultipleAccountsInfo(
+          [state.policyAccount, state.setupPolicyAccount].map((value) => new PublicKey(value)),
+          "finalized",
+        );
+        if (accounts.some(Boolean)) {
+          return json({ error: { code: "cleanup_not_finalized", message: "Policy remains open." } }, 409);
+        }
+        return json({ ok: true, status: "full_exit_closed" });
+      }
+      if (request.method === "GET" && path.includes("/earn/earnings")) {
+        return json({ bars: [], summary: null });
+      }
+      return json({ error: { code: "isolated_fixture_route_missing", path } }, 404);
+    } catch (error) {
+      return json(
+        { error: { code: "isolated_fixture_failed", message: error instanceof Error ? error.message : String(error) } },
+        500,
+      );
+    }
+  },
+});
+
+console.info(`READY http://${server.hostname}:${server.port}`);
+await new Promise<void>((resolve) => {
+  process.once("SIGINT", resolve);
+  process.once("SIGTERM", resolve);
+});
+server.stop(true);

--- a/apps/mobile/scripts/verify-earn-local-api.ts
+++ b/apps/mobile/scripts/verify-earn-local-api.ts
@@ -1,11 +1,24 @@
-import { appendFileSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { userInfo } from "node:os";
 
 import {
   getKaminoUsdcEarnTargetForCluster,
   LoyalCluster,
 } from "@loyal-labs/actions";
-import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import postgres from "postgres";
 
 type LocalState = {
   collateralMint: string;
@@ -27,9 +40,10 @@ type LocalState = {
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce<string[][]>((pairs, value, index, all) => {
-    if (index % 2 === 0) pairs.push([value.replace(/^--/, ""), all[index + 1]!]);
+    if (index % 2 === 0)
+      pairs.push([value.replace(/^--/, ""), all[index + 1]!]);
     return pairs;
-  }, []),
+  }, [])
 ) as Record<string, string>;
 
 for (const key of ["state", "rpc-url", "transactions", "port", "amount-raw"]) {
@@ -39,9 +53,15 @@ for (const key of ["state", "rpc-url", "transactions", "port", "amount-raw"]) {
 const state = JSON.parse(readFileSync(args.state!, "utf8")) as LocalState;
 const connection = new Connection(args["rpc-url"]!, "confirmed");
 const policySigner = Keypair.fromSeed(new Uint8Array(32).fill(9)).publicKey;
+const useRealLoyalApi = process.env.MOBILE_EARN_REAL_API === "1";
+const realApiPort = Number(args.port) + 1;
+const realApiLogPath =
+  process.env.MOBILE_EARN_REAL_API_LOG ??
+  "/tmp/loyal-earn-real-api-last-run.log";
+let realApiProcess: ReturnType<typeof Bun.spawn> | null = null;
 const programId = "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG";
 const KAMINO_FARMS_PROGRAM = new PublicKey(
-  "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+  "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
 );
 const KAMINO_DEPOSIT_DISCRIMINATOR = Buffer.from([
   216, 224, 191, 27, 204, 151, 102, 175,
@@ -50,6 +70,178 @@ const KAMINO_WITHDRAW_DISCRIMINATOR = Buffer.from([
   235, 52, 119, 152, 149, 197, 20, 7,
 ]);
 let amountRaw = args["amount-raw"]!;
+
+async function prepareRealLoyalApi(): Promise<void> {
+  if (!useRealLoyalApi) return;
+
+  const mobileRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+  const webRoot = resolve(mobileRoot, "../web");
+  const databaseUrl =
+    process.env.MOBILE_EARN_REAL_API_DATABASE_URL ??
+    `postgresql://${encodeURIComponent(
+      userInfo().username
+    )}@127.0.0.1:8959/ask_2212_client_earn_local_e2e`;
+  const sql = postgres(databaseUrl, { max: 1 });
+  try {
+    await sql.file(
+      resolve(
+        webRoot,
+        "src/lib/yield-optimization/migrations/0008_add_managed_vault_setup_policy.sql"
+      )
+    );
+    await sql.file(
+      resolve(
+        webRoot,
+        "src/lib/yield-optimization/migrations/0010_add_idle_vault_balances_and_reconcile_cache.sql"
+      )
+    );
+    await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS app_users (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        provider text NOT NULL,
+        subject_address text NOT NULL,
+        grid_user_id text,
+        smart_account_address text,
+        smart_account_settings_pda text,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT app_users_provider_subject_uidx UNIQUE (provider, subject_address)
+      )
+    `;
+    await sql`
+      CREATE TABLE IF NOT EXISTS app_user_wallets (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+        wallet_address text NOT NULL UNIQUE,
+        verified_at timestamptz NOT NULL DEFAULT now(),
+        last_used_at timestamptz NOT NULL DEFAULT now(),
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `;
+    await sql`
+      CREATE TABLE IF NOT EXISTS app_user_smart_accounts (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+        solana_env text NOT NULL,
+        settings_pda text NOT NULL,
+        state text NOT NULL,
+        creation_signature text,
+        last_checked_at timestamptz,
+        last_error_code text,
+        last_error_message text,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT app_user_smart_accounts_user_env_uidx UNIQUE (user_id, solana_env),
+        CONSTRAINT app_user_smart_accounts_env_settings_uidx UNIQUE (solana_env, settings_pda)
+      )
+    `;
+    const [user] = await sql<{ id: string }[]>`
+      INSERT INTO app_users (
+        provider,
+        subject_address,
+        smart_account_address,
+        smart_account_settings_pda
+      ) VALUES (
+        'solana',
+        ${state.walletAddress},
+        ${state.vaultPubkey},
+        ${state.settingsPda}
+      )
+      ON CONFLICT (provider, subject_address) DO UPDATE SET
+        smart_account_address = EXCLUDED.smart_account_address,
+        smart_account_settings_pda = EXCLUDED.smart_account_settings_pda,
+        updated_at = now()
+      RETURNING id
+    `;
+    if (!user) throw new Error("Failed to seed the isolated app user.");
+    await sql`
+      INSERT INTO app_user_wallets (user_id, wallet_address)
+      VALUES (${user.id}, ${state.walletAddress})
+      ON CONFLICT (wallet_address) DO UPDATE SET
+        user_id = EXCLUDED.user_id,
+        last_used_at = now(),
+        updated_at = now()
+    `;
+    await sql`
+      INSERT INTO app_user_smart_accounts (
+        user_id,
+        solana_env,
+        settings_pda,
+        state
+      ) VALUES (
+        ${user.id},
+        'mainnet',
+        ${state.settingsPda},
+        'ready'
+      )
+      ON CONFLICT (user_id, solana_env) DO UPDATE SET
+        settings_pda = EXCLUDED.settings_pda,
+        state = EXCLUDED.state,
+        updated_at = now()
+    `;
+  } finally {
+    await sql.end();
+  }
+
+  writeFileSync(realApiLogPath, "", { mode: 0o600 });
+  const realApiLog = openSync(realApiLogPath, "a");
+  realApiProcess = Bun.spawn(
+    ["bun", "x", "next", "dev", "--turbopack", "-p", String(realApiPort)],
+    {
+      cwd: webRoot,
+      env: {
+        ...process.env,
+        APP_LOCAL_DATABASE_URL: databaseUrl,
+        DATABASE_URL: databaseUrl,
+        EARN_YIELD_ROUTER_PUBLIC_KEY: policySigner.toBase58(),
+        NEON_DATABASE_URL: databaseUrl,
+        NEXT_PUBLIC_APP_ENVIRONMENT: "local",
+        NEXT_PUBLIC_SOLANA_ENV: "mainnet",
+        NODE_ENV: "development",
+        PHALA_API_KEY: "isolated-mobile-e2e",
+        SOLANA_MAINNET_RPC_URL: args["rpc-url"]!,
+        SOLANA_MAINNET_WEBSOCKET_URL: args["rpc-url"]!.replace(
+          /^http:/,
+          "ws:"
+        ).replace(/:\d+$/, (port) => `:${Number(port.slice(1)) + 1}`),
+        YIELD_OPTIMIZATION_LOCAL_DATABASE_URL: databaseUrl,
+      },
+      stderr: realApiLog,
+      stdout: realApiLog,
+    }
+  );
+  closeSync(realApiLog);
+
+  const readinessUrl = `http://127.0.0.1:${realApiPort}/api/smart-accounts/mobile/earn/state?walletAddress=${encodeURIComponent(
+    state.walletAddress
+  )}`;
+  for (let attempt = 0; attempt < 240; attempt += 1) {
+    if (realApiProcess.exitCode !== null) {
+      throw new Error(
+        `The real loyal-app API exited with ${realApiProcess.exitCode}. See ${realApiLogPath}.`
+      );
+    }
+    const response = await fetch(readinessUrl).catch(() => null);
+    if (response?.ok) {
+      console.info(`REAL_API_READY http://127.0.0.1:${realApiPort}`);
+      return;
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `The real loyal-app API did not become ready. See ${realApiLogPath}.`
+  );
+}
+
+async function stopRealLoyalApi(
+  child: ReturnType<typeof Bun.spawn> | null
+): Promise<void> {
+  if (!child) return;
+  child.kill();
+  await child.exited;
+}
 
 function decimalAmountToRaw(amount: string): bigint {
   const [whole, fraction = ""] = amount.split(".");
@@ -68,13 +260,13 @@ function encodedAmount(discriminator: Buffer, raw: bigint): string {
 
 function kaminoInstructions(deposit: boolean, raw: bigint) {
   const lendProgramId = getKaminoUsdcEarnTargetForCluster(
-    LoyalCluster.MainnetBeta,
+    LoyalCluster.MainnetBeta
   ).lendProgramId.toBase58();
   const vaultUsdcAta = getAssociatedTokenAddressSync(
     new PublicKey(state.usdcMint),
     new PublicKey(state.vaultPubkey),
     true,
-    TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID
   ).toBase58();
   const ro = (address: string) => ({ address, role: "READONLY" });
   const rw = (address: string) => ({ address, role: "WRITABLE" });
@@ -112,7 +304,7 @@ function kaminoInstructions(deposit: boolean, raw: bigint) {
     ro("Sysvar1nstructions1111111111111111111111111"),
     ro(lendProgramId),
     ro(lendProgramId),
-    ro(KAMINO_FARMS_PROGRAM.toBase58()),
+    ro(KAMINO_FARMS_PROGRAM.toBase58())
   );
   return {
     instructions: [
@@ -122,7 +314,7 @@ function kaminoInstructions(deposit: boolean, raw: bigint) {
           deposit
             ? KAMINO_DEPOSIT_DISCRIMINATOR
             : KAMINO_WITHDRAW_DISCRIMINATOR,
-          raw,
+          raw
         ),
         programAddress: lendProgramId,
       },
@@ -130,7 +322,7 @@ function kaminoInstructions(deposit: boolean, raw: bigint) {
   };
 }
 
-async function assertFinalized(signature: string): Promise<number> {
+async function assertConfirmed(signature: string): Promise<number> {
   for (let attempt = 0; attempt < 300; attempt += 1) {
     const statuses = await connection.getSignatureStatuses([signature], {
       searchTransactionHistory: true,
@@ -138,26 +330,83 @@ async function assertFinalized(signature: string): Promise<number> {
     const status = statuses.value[0];
     if (status?.err) {
       throw new Error(
-        `Signature ${signature} failed: ${JSON.stringify(status.err)}.`,
+        `Signature ${signature} failed: ${JSON.stringify(status.err)}.`
       );
     }
-    if (status?.confirmationStatus === "finalized") {
+    if (
+      status?.confirmationStatus === "confirmed" ||
+      status?.confirmationStatus === "finalized"
+    ) {
       const transaction = await connection.getTransaction(signature, {
-        commitment: "finalized",
+        commitment: "confirmed",
         maxSupportedTransactionVersion: 0,
       });
       if (!transaction) {
-        throw new Error(`Finalized transaction ${signature} is absent.`);
+        throw new Error(`Confirmed transaction ${signature} is absent.`);
       }
       return transaction.slot;
     }
-    await Bun.sleep(100);
+    await Bun.sleep(10);
   }
-  throw new Error(`Signature ${signature} did not finalize in time.`);
+  throw new Error(`Signature ${signature} was not confirmed in time.`);
 }
 
 function json(value: unknown, status = 200): Response {
   return Response.json(value, { status });
+}
+
+async function forwardToRealLoyalApi(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const requestBody =
+    request.method === "GET" || request.method === "HEAD"
+      ? undefined
+      : await request.arrayBuffer();
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.delete("content-length");
+  const response = await fetch(
+    new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${realApiPort}`),
+    {
+      body: requestBody,
+      headers,
+      method: request.method,
+      redirect: "manual",
+    }
+  );
+
+  if (
+    response.ok &&
+    request.method === "POST" &&
+    url.pathname.endsWith("/withdraw/confirm") &&
+    requestBody
+  ) {
+    const body = JSON.parse(new TextDecoder().decode(requestBody)) as {
+      withdrawalSignature?: string;
+    };
+    if (body.withdrawalSignature) {
+      const slot = await assertConfirmed(body.withdrawalSignature);
+      appendFileSync(
+        args.transactions!,
+        `${JSON.stringify({
+          signature: body.withdrawalSignature,
+          slot,
+          stage: "full_withdrawal",
+        })}\n`
+      );
+      amountRaw = "0";
+    }
+  }
+
+  const responseHeaders = new Headers(response.headers);
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("content-length");
+  responseHeaders.delete("transfer-encoding");
+  responseHeaders.set("x-loyal-e2e-api", "real-loyal-app");
+  return new Response(response.body, {
+    headers: responseHeaders,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function positionResponse() {
@@ -185,6 +434,8 @@ function holding() {
   };
 }
 
+const realLoyalApiReady = prepareRealLoyalApi();
+
 const server = Bun.serve({
   hostname: "127.0.0.1",
   port: Number(args.port),
@@ -202,14 +453,24 @@ const server = Bun.serve({
           wallet?: string;
         };
         if (!body.amount || body.wallet !== state.vaultPubkey) {
-          return json({ error: { code: "invalid_kamino_fixture_request" } }, 400);
+          return json(
+            { error: { code: "invalid_kamino_fixture_request" } },
+            400
+          );
         }
         return json(
           kaminoInstructions(
             path.endsWith("/deposit-instructions"),
-            decimalAmountToRaw(body.amount),
-          ),
+            decimalAmountToRaw(body.amount)
+          )
         );
+      }
+      if (
+        useRealLoyalApi &&
+        path.startsWith("/api/smart-accounts/mobile/earn/")
+      ) {
+        await realLoyalApiReady;
+        return forwardToRealLoyalApi(request);
       }
       if (request.method === "GET" && path.endsWith("/earn/state")) {
         return json(positionResponse());
@@ -246,15 +507,16 @@ const server = Bun.serve({
       if (request.method === "GET" && path.endsWith("/autodeposit/state")) {
         return json({
           autodeposit: null,
-          prepareContext: { cluster: "mainnet-beta", policySigner: policySigner.toBase58(), programId },
+          prepareContext: {
+            cluster: "mainnet-beta",
+            policySigner: policySigner.toBase58(),
+            programId,
+          },
           settingsPda: state.settingsPda,
           smartAccountAddress: state.vaultPubkey,
         });
       }
-      if (
-        request.method === "GET" &&
-        path.endsWith("/earn-forecast/summary")
-      ) {
+      if (request.method === "GET" && path.endsWith("/earn-forecast/summary")) {
         const now = new Date().toISOString();
         return json({
           forecast: {
@@ -266,7 +528,10 @@ const server = Bun.serve({
           history: { samples: [] },
         });
       }
-      if (request.method === "POST" && path.endsWith("/withdraw/prepare-context")) {
+      if (
+        request.method === "POST" &&
+        path.endsWith("/withdraw/prepare-context")
+      ) {
         return json({
           cluster: "mainnet-beta",
           programId,
@@ -317,22 +582,35 @@ const server = Bun.serve({
       }
       if (request.method === "POST" && path.endsWith("/withdraw/confirm")) {
         const body = (await request.json()) as { withdrawalSignature?: string };
-        if (!body.withdrawalSignature) return json({ error: { code: "invalid_request" } }, 400);
+        if (!body.withdrawalSignature)
+          return json({ error: { code: "invalid_request" } }, 400);
         const slot = await assertFinalized(body.withdrawalSignature);
         appendFileSync(
           args.transactions!,
-          `${JSON.stringify({ signature: body.withdrawalSignature, slot, stage: "full_withdrawal" })}\n`,
+          `${JSON.stringify({
+            signature: body.withdrawalSignature,
+            slot,
+            stage: "full_withdrawal",
+          })}\n`
         );
         amountRaw = "0";
-        return json({ ok: true, status: "full_exit_verified", position: positionResponse().position });
+        return json({
+          ok: true,
+          status: "full_exit_verified",
+          position: positionResponse().position,
+        });
       }
-      if (request.method === "POST" && path.endsWith("/cleanup/prepare-context")) {
-        if (amountRaw !== "0") return json({ error: { code: "full_exit_incomplete" } }, 409);
+      if (
+        request.method === "POST" &&
+        path.endsWith("/cleanup/prepare-context")
+      ) {
+        if (amountRaw !== "0")
+          return json({ error: { code: "full_exit_incomplete" } }, 409);
         const vaultUsdcAta = getAssociatedTokenAddressSync(
           new PublicKey(state.usdcMint),
           new PublicKey(state.vaultPubkey),
           true,
-          TOKEN_PROGRAM_ID,
+          TOKEN_PROGRAM_ID
         );
         return json({
           cluster: "mainnet-beta",
@@ -369,33 +647,54 @@ const server = Bun.serve({
       }
       if (request.method === "POST" && path.endsWith("/cleanup/confirm")) {
         const body = (await request.json()) as { cleanupSignature?: string };
-        if (!body.cleanupSignature) return json({ error: { code: "invalid_request" } }, 400);
-        await assertFinalized(body.cleanupSignature);
+        if (!body.cleanupSignature)
+          return json({ error: { code: "invalid_request" } }, 400);
+        await assertConfirmed(body.cleanupSignature);
         const accounts = await connection.getMultipleAccountsInfo(
-          [state.policyAccount, state.setupPolicyAccount].map((value) => new PublicKey(value)),
-          "finalized",
+          [state.policyAccount, state.setupPolicyAccount].map(
+            (value) => new PublicKey(value)
+          ),
+          "confirmed"
         );
         if (accounts.some(Boolean)) {
-          return json({ error: { code: "cleanup_not_finalized", message: "Policy remains open." } }, 409);
+          return json(
+            {
+              error: {
+                code: "cleanup_not_confirmed",
+                message: "Policy remains open.",
+              },
+            },
+            409
+          );
         }
         return json({ ok: true, status: "full_exit_closed" });
       }
       if (request.method === "GET" && path.includes("/earn/earnings")) {
         return json({ bars: [], summary: null });
       }
-      return json({ error: { code: "isolated_fixture_route_missing", path } }, 404);
+      return json(
+        { error: { code: "isolated_fixture_route_missing", path } },
+        404
+      );
     } catch (error) {
       return json(
-        { error: { code: "isolated_fixture_failed", message: error instanceof Error ? error.message : String(error) } },
-        500,
+        {
+          error: {
+            code: "isolated_fixture_failed",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+        500
       );
     }
   },
 });
 
 console.info(`READY http://${server.hostname}:${server.port}`);
+await realLoyalApiReady;
 await new Promise<void>((resolve) => {
   process.once("SIGINT", resolve);
   process.once("SIGTERM", resolve);
 });
 server.stop(true);
+await stopRealLoyalApi(realApiProcess);

--- a/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
+++ b/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
@@ -39,8 +39,7 @@ const DEFAULT_AVD = "SkyVerse_API_35";
 const DEFAULT_METRO_PORT = 8081;
 const DEFAULT_PROXY_PORT = 4319;
 const MAINNET_ACK = "I_ACKNOWLEDGE_MAINNET";
-const UPSTREAM =
-  process.env.MOBILE_WITHDRAW_UPSTREAM ?? "https://askloyal.com";
+const UPSTREAM = process.env.MOBILE_WITHDRAW_UPSTREAM ?? "https://askloyal.com";
 const solanaEnv = process.env.MOBILE_WITHDRAW_SOLANA_ENV ?? "mainnet";
 const isIsolatedLocalnet = solanaEnv === "localnet";
 const LIFECYCLE_PATH = "/api/observability/mobile/events";
@@ -53,7 +52,7 @@ const INCIDENT_REQUIRED_LAMPORTS = "39532800";
 const INCIDENT_MESSAGE =
   "Add at least 0.027645228 SOL to your wallet before depositing. This Earn setup needs 0.0395328 SOL for account rent and network fees.";
 const MAINNET_USDC_MINT = new PublicKey(
-  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 );
 
 type Mode = "withdraw" | "seed-position" | "insufficient-sol";
@@ -81,6 +80,7 @@ type ApiTiming = {
   pathname: string;
   status: number;
   startedAt: string;
+  upstream?: string | null;
 };
 
 type UiNode = {
@@ -102,22 +102,23 @@ const keyPath = process.env.MOBILE_E2E_WALLET_KEYPAIR
   : null;
 const avdName = process.env.MOBILE_WITHDRAW_AVD ?? DEFAULT_AVD;
 const metroPort = Number(
-  process.env.MOBILE_WITHDRAW_METRO_PORT ?? DEFAULT_METRO_PORT,
+  process.env.MOBILE_WITHDRAW_METRO_PORT ?? DEFAULT_METRO_PORT
 );
 const proxyPort = Number(
-  process.env.MOBILE_WITHDRAW_PROXY_PORT ?? DEFAULT_PROXY_PORT,
+  process.env.MOBILE_WITHDRAW_PROXY_PORT ?? DEFAULT_PROXY_PORT
 );
 const androidAbi = process.env.MOBILE_WITHDRAW_ANDROID_ABI ?? "arm64-v8a";
 const maxPositionUsd = Number(
-  process.env.MOBILE_WITHDRAW_MAX_POSITION_USD ?? "2",
+  process.env.MOBILE_WITHDRAW_MAX_POSITION_USD ?? "2"
 );
 const seedAmountUsd = Number(
-  process.env.MOBILE_WITHDRAW_SEED_AMOUNT_USD ?? "1.17",
+  process.env.MOBILE_WITHDRAW_SEED_AMOUNT_USD ?? "1.17"
 );
 const timeoutMs = Number(process.env.MOBILE_WITHDRAW_TIMEOUT_MS ?? "600000");
 const outputPath = process.env.MOBILE_WITHDRAW_PROFILE_OUTPUT
   ? resolve(process.env.MOBILE_WITHDRAW_PROFILE_OUTPUT)
   : null;
+const requireRealLoyalApi = process.env.MOBILE_REQUIRE_REAL_API === "1";
 
 const tempRoot = mkdtempSync(join(tmpdir(), "loyal-withdraw-profile-"));
 const processLogPath = join(tempRoot, "processes.log");
@@ -132,9 +133,7 @@ let seedDepositActionBounds: UiNode["bounds"] | null = null;
 let materializedPrivateTransactionsEntry:
   | { entryPath: string; linkTarget: string }
   | undefined;
-let patchedKaminoClientSource:
-  | { path: string; source: string }
-  | undefined;
+let patchedKaminoClientSource: { path: string; source: string } | undefined;
 const seededDepositSources: { path: string; source: string }[] = [];
 
 function run(
@@ -145,7 +144,7 @@ function run(
     env?: NodeJS.ProcessEnv;
     input?: string;
     quiet?: boolean;
-  } = {},
+  } = {}
 ): string {
   const result = spawnSync(command, args, {
     cwd: options.cwd ?? resolve(import.meta.dir, ".."),
@@ -158,7 +157,7 @@ function run(
     throw new Error(
       `${command} exited with status ${String(result.status)}${
         options.quiet && result.stderr ? `: ${result.stderr.trim()}` : ""
-      }`,
+      }`
     );
   }
   return options.quiet ? result.stdout.trim() : "";
@@ -167,7 +166,7 @@ function run(
 function start(
   command: string,
   args: string[],
-  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}
 ): ChildProcess {
   const child = spawn(command, args, {
     cwd: options.cwd ?? resolve(import.meta.dir, ".."),
@@ -184,6 +183,7 @@ async function waitFor<T>(
   description: string,
   read: () => T | false | Promise<T | false>,
   limitMs = 60_000,
+  pollMs = 500
 ): Promise<T> {
   const deadline = Date.now() + limitMs;
   let lastError: unknown;
@@ -194,19 +194,16 @@ async function waitFor<T>(
     } catch (error) {
       lastError = error;
     }
-    await Bun.sleep(500);
+    await Bun.sleep(pollMs);
   }
   throw new Error(
     `Timed out waiting for ${description}${
       lastError instanceof Error ? `: ${lastError.message}` : ""
-    }.`,
+    }.`
   );
 }
 
-function findExecutable(
-  candidates: (string | null)[],
-  label: string,
-): string {
+function findExecutable(candidates: (string | null)[], label: string): string {
   for (const candidate of candidates) {
     if (!candidate) continue;
     try {
@@ -227,7 +224,7 @@ const adb = findExecutable(
     "/opt/homebrew/bin/adb",
     "/opt/homebrew/share/android-commandlinetools/platform-tools/adb",
   ],
-  "ADB",
+  "ADB"
 );
 
 const emulator = findExecutable(
@@ -237,7 +234,7 @@ const emulator = findExecutable(
       : null,
     "/opt/homebrew/share/android-commandlinetools/emulator/emulator",
   ],
-  "Android emulator",
+  "Android emulator"
 );
 
 function adbRun(args: string[], quiet = true): string {
@@ -275,13 +272,13 @@ async function ensureEmulator(): Promise<string> {
   const serial = await waitFor(
     "the emulator to connect",
     () => connectedEmulator() ?? false,
-    180_000,
+    180_000
   );
   emulatorSerial = serial;
   await waitFor(
     "Android boot completion",
     () => adbRun(["shell", "getprop", "sys.boot_completed"]) === "1",
-    180_000,
+    180_000
   );
   return serial;
 }
@@ -298,7 +295,7 @@ function decodeXml(value: string): string {
 function materializeWorktreePrivateTransactionsEntry(): void {
   const entryPath = resolve(
     import.meta.dir,
-    "../node_modules/@loyal-labs/private-transactions/dist/index.js",
+    "../node_modules/@loyal-labs/private-transactions/dist/index.js"
   );
   if (!existsSync(entryPath) || !lstatSync(entryPath).isSymbolicLink()) return;
 
@@ -321,7 +318,7 @@ function routeKaminoInstructionApiThroughVerifier(): void {
   if (!isIsolatedLocalnet) return;
   const path = resolve(
     import.meta.dir,
-    "../../../packages/smart-account-vaults/src/client.ts",
+    "../../../packages/smart-account-vaults/src/client.ts"
   );
   const source = readFileSync(path, "utf8");
   const replacements = [
@@ -339,7 +336,7 @@ function routeKaminoInstructionApiThroughVerifier(): void {
     assert.equal(
       patched.split(from).length - 1,
       1,
-      `The verifier could not locate Kamino instruction URL ${from}.`,
+      `The verifier could not locate Kamino instruction URL ${from}.`
     );
     patched = patched.replace(from, to);
   }
@@ -351,7 +348,7 @@ function restoreKaminoClientSource(): void {
   if (!patchedKaminoClientSource) return;
   writeFileSync(
     patchedKaminoClientSource.path,
-    patchedKaminoClientSource.source,
+    patchedKaminoClientSource.source
   );
   patchedKaminoClientSource = undefined;
 }
@@ -363,7 +360,7 @@ function injectIncidentNativeSolRequirement(): void {
   assert.equal(
     source.split(marker).length - 1,
     1,
-    "The insufficient-SOL verifier could not locate the deposit action.",
+    "The insufficient-SOL verifier could not locate the deposit action."
   );
   writeFileSync(
     path,
@@ -385,8 +382,8 @@ function injectIncidentNativeSolRequirement(): void {
         "    payer: args.signer.publicKey.toBase58(),",
         `    requiredLamports: ${JSON.stringify(INCIDENT_REQUIRED_LAMPORTS)},`,
         "  });",
-      ].join("\n"),
-    ),
+      ].join("\n")
+    )
   );
   seededDepositSources.push({ path, source });
 }
@@ -400,7 +397,7 @@ function openDepositSheetInVerifierBundle(): void {
     assert.equal(
       source.split(marker).length - 1,
       1,
-      "The seed verifier could not locate the Deposit sheet state.",
+      "The seed verifier could not locate the Deposit sheet state."
     );
     writeFileSync(
       path,
@@ -409,8 +406,8 @@ function openDepositSheetInVerifierBundle(): void {
         [
           "const [depositOpenState, setDepositOpen] = useState(false);",
           "const depositOpen = true || depositOpenState;",
-        ].join("\n"),
-      ),
+        ].join("\n")
+      )
     );
     seededDepositSources.push({ path, source });
   } else {
@@ -421,20 +418,20 @@ function openDepositSheetInVerifierBundle(): void {
     assert.equal(
       source.split(logBoxMarker).length - 1,
       1,
-      "The insufficient-SOL verifier could not locate the React Native import.",
+      "The insufficient-SOL verifier could not locate the React Native import."
     );
     const logBoxSource = source.replace(
       logBoxMarker,
       [
         'import { Alert, LogBox, StyleSheet, useWindowDimensions } from "react-native";',
         "LogBox.ignoreAllLogs(true);",
-      ].join("\n"),
+      ].join("\n")
     );
     const openMarker = "const [depositOpen, setDepositOpen] = useState(false);";
     assert.equal(
       logBoxSource.split(openMarker).length - 1,
       1,
-      "The insufficient-SOL verifier could not locate the Deposit state.",
+      "The insufficient-SOL verifier could not locate the Deposit state."
     );
     writeFileSync(
       path,
@@ -461,8 +458,8 @@ function openDepositSheetInVerifierBundle(): void {
           "  }, 5000);",
           "  return () => clearTimeout(timer);",
           "}, [signer]);",
-        ].join("\n"),
-      ),
+        ].join("\n")
+      )
     );
     seededDepositSources.push({ path, source });
     injectIncidentNativeSolRequirement();
@@ -471,19 +468,19 @@ function openDepositSheetInVerifierBundle(): void {
 
   const sheetPath = resolve(
     import.meta.dir,
-    "../src/components/earn/DepositSheet.tsx",
+    "../src/components/earn/DepositSheet.tsx"
   );
   const sheetSource = readFileSync(sheetPath, "utf8");
   const amountMarker = 'const [amount, setAmount] = useState("");';
   assert.equal(
     sheetSource.split(amountMarker).length - 1,
     1,
-    "The seed verifier could not locate the Deposit amount state.",
+    "The seed verifier could not locate the Deposit amount state."
   );
   const seededAmount = seedAmountUsd.toFixed(2);
   const initializedSheetSource = sheetSource.replace(
     amountMarker,
-    `const [amount, setAmount] = useState(${JSON.stringify(seededAmount)});`,
+    `const [amount, setAmount] = useState(${JSON.stringify(seededAmount)});`
   );
   const resetMarker = [
     "    if (open) {",
@@ -493,7 +490,7 @@ function openDepositSheetInVerifierBundle(): void {
   assert.equal(
     initializedSheetSource.split(resetMarker).length - 1,
     1,
-    "The seed verifier could not locate the Deposit open reset.",
+    "The seed verifier could not locate the Deposit open reset."
   );
   const initializedAndResetSheetSource = initializedSheetSource.replace(
     resetMarker,
@@ -501,17 +498,17 @@ function openDepositSheetInVerifierBundle(): void {
       "    if (open) {",
       `      setAmount(${JSON.stringify(seededAmount)});`,
       "      setSubmitError(null);",
-    ].join("\n"),
+    ].join("\n")
   );
   const availableMarker = "  const available = selectedSource.usd;";
   assert.equal(
     initializedAndResetSheetSource.split(availableMarker).length - 1,
     1,
-    "The seed verifier could not locate the selected balance state.",
+    "The seed verifier could not locate the selected balance state."
   );
   let boundedSheetSource = initializedAndResetSheetSource.replace(
     availableMarker,
-    `  const available = ${seededAmount};`,
+    `  const available = ${seededAmount};`
   );
   if (mode === "insufficient-sol") {
     const topUpMarker =
@@ -519,14 +516,14 @@ function openDepositSheetInVerifierBundle(): void {
     assert.equal(
       boundedSheetSource.split(topUpMarker).length - 1,
       1,
-      "The insufficient-SOL verifier could not locate the generic SOL preflight.",
+      "The insufficient-SOL verifier could not locate the generic SOL preflight."
     );
     // Exercise the SDK's exact dynamic rent requirement instead of the UI's
     // coarse first-deposit estimate. This mutation exists only in the Metro
     // verifier bundle and is restored in finally.
     boundedSheetSource = boundedSheetSource.replace(
       topUpMarker,
-      "const needsSolTopUp = false;",
+      "const needsSolTopUp = false;"
     );
   }
   const handlerMarker =
@@ -534,7 +531,7 @@ function openDepositSheetInVerifierBundle(): void {
   assert.equal(
     boundedSheetSource.split(handlerMarker).length - 1,
     1,
-    "The seed verifier could not locate the real Deposit handler.",
+    "The seed verifier could not locate the real Deposit handler."
   );
   writeFileSync(
     sheetPath,
@@ -549,8 +546,72 @@ function openDepositSheetInVerifierBundle(): void {
         "    const timer = setTimeout(() => void handleDeposit(), 500);",
         "    return () => clearTimeout(timer);",
         "  }, [handleDeposit, open]);",
-      ].join("\n"),
-    ),
+      ].join("\n")
+    )
+  );
+  seededDepositSources.push({ path: sheetPath, source: sheetSource });
+}
+
+function openWithdrawSheetInVerifierBundle(): void {
+  if (mode !== "withdraw") return;
+  const path = resolve(import.meta.dir, "../app/(tabs)/index.tsx");
+  const source = readFileSync(path, "utf8");
+  const marker = "const [withdrawOpen, setWithdrawOpen] = useState(false);";
+  assert.equal(
+    source.split(marker).length - 1,
+    1,
+    "The withdrawal verifier could not locate the Withdraw sheet state."
+  );
+  writeFileSync(
+    path,
+    source.replace(
+      marker,
+      [
+        "const [withdrawOpenState, setWithdrawOpen] = useState(false);",
+        "const withdrawOpen = true || withdrawOpenState;",
+      ].join("\n")
+    )
+  );
+  seededDepositSources.push({ path, source });
+
+  const sheetPath = resolve(
+    import.meta.dir,
+    "../src/components/earn/WithdrawSheet.tsx"
+  );
+  const sheetSource = readFileSync(sheetPath, "utf8");
+  const handlerMarker = "  const renderBackdrop = useCallback(";
+  assert.equal(
+    sheetSource.split(handlerMarker).length - 1,
+    1,
+    "The withdrawal verifier could not locate the real Withdraw handler."
+  );
+  writeFileSync(
+    sheetPath,
+    sheetSource.replace(
+      handlerMarker,
+      [
+        "  const verifierSubmitted = useRef(false);",
+        "  useEffect(() => {",
+        "    if (!open || available <= 0 || maxSelected) return;",
+        "    setAmount(floorTo2(available).toFixed(2));",
+        "    setMaxSelected(true);",
+        "  }, [available, maxSelected, open]);",
+        "  useEffect(() => {",
+        "    if (",
+        "      !open ||",
+        "      disabled ||",
+        "      !maxSelected ||",
+        "      (hasPicker && !selectedSource) ||",
+        "      verifierSubmitted.current",
+        "    ) return;",
+        "    verifierSubmitted.current = true;",
+        "    const timer = setTimeout(() => void handleWithdraw(), 10);",
+        "    return () => clearTimeout(timer);",
+        "  }, [disabled, handleWithdraw, hasPicker, maxSelected, open, selectedSource]);",
+        "",
+        handlerMarker,
+      ].join("\n")
+    )
   );
   seededDepositSources.push({ path: sheetPath, source: sheetSource });
 }
@@ -564,20 +625,20 @@ function restoreDepositSource(): void {
 
 function assembleVerifierApk(
   androidRoot: string,
-  env: NodeJS.ProcessEnv,
+  env: NodeJS.ProcessEnv
 ): void {
   const manifestPath = join(androidRoot, "app/src/main/AndroidManifest.xml");
   const originalManifest = readFileSync(manifestPath, "utf8");
   const verifierManifest = originalManifest.includes(
-    "android:usesCleartextTraffic=",
+    "android:usesCleartextTraffic="
   )
     ? originalManifest.replace(
         /android:usesCleartextTraffic="[^"]*"/,
-        'android:usesCleartextTraffic="true"',
+        'android:usesCleartextTraffic="true"'
       )
     : originalManifest.replace(
         "<application ",
-        '<application android:usesCleartextTraffic="true" ',
+        '<application android:usesCleartextTraffic="true" '
       );
   writeFileSync(manifestPath, verifierManifest);
   try {
@@ -592,7 +653,7 @@ function assembleVerifierApk(
         `:react-native-worklets:buildCMakeDebug[${androidAbi}][worklets]`,
         ...gradleArgs,
       ],
-      { cwd: androidRoot, env },
+      { cwd: androidRoot, env }
     );
     // Reanimated 4.1.1 still imports Worklets from AGP's old `cmake` output
     // path, while AGP 8.11 publishes the library under a hashed `cxx` path.
@@ -600,40 +661,44 @@ function assembleVerifierApk(
     // verifier checkout can assemble reliably.
     const workletsIntermediates = resolve(
       androidRoot,
-      "../node_modules/react-native-worklets/android/build/intermediates",
+      "../node_modules/react-native-worklets/android/build/intermediates"
     );
     const workletsCandidates = readdirSync(
-      join(workletsIntermediates, "cxx/Debug"),
+      join(workletsIntermediates, "cxx/Debug")
     )
       .map((directory) =>
         join(
           workletsIntermediates,
           "cxx/Debug",
           directory,
-          `obj/${androidAbi}/libworklets.so`,
-        ),
+          `obj/${androidAbi}/libworklets.so`
+        )
       )
       .filter(existsSync);
     assert.equal(
       workletsCandidates.length,
       1,
-      `The verifier expected one ${androidAbi} Worklets library.`,
+      `The verifier expected one ${androidAbi} Worklets library.`
     );
     const legacyWorkletsPath = join(
       workletsIntermediates,
-      `cmake/debug/obj/${androidAbi}/libworklets.so`,
+      `cmake/debug/obj/${androidAbi}/libworklets.so`
     );
     mkdirSync(dirname(legacyWorkletsPath), { recursive: true });
     copyFileSync(workletsCandidates[0]!, legacyWorkletsPath);
-    run("./gradlew", [
-      "app:assembleDebug",
-      "--exclude-task",
-      `:react-native-worklets:buildCMakeDebug[${androidAbi}][worklets]`,
-      ...gradleArgs,
-    ], {
-      cwd: androidRoot,
-      env,
-    });
+    run(
+      "./gradlew",
+      [
+        "app:assembleDebug",
+        "--exclude-task",
+        `:react-native-worklets:buildCMakeDebug[${androidAbi}][worklets]`,
+        ...gradleArgs,
+      ],
+      {
+        cwd: androidRoot,
+        env,
+      }
+    );
   } finally {
     writeFileSync(manifestPath, originalManifest);
   }
@@ -670,7 +735,7 @@ function parseUiNodes(xml: string): UiNode[] {
 function dumpUi(): UiNode[] {
   adbRun(["shell", "uiautomator", "dump", "/sdcard/loyal-withdraw-ui.xml"]);
   return parseUiNodes(
-    adbRun(["exec-out", "cat", "/sdcard/loyal-withdraw-ui.xml"]),
+    adbRun(["exec-out", "cat", "/sdcard/loyal-withdraw-ui.xml"])
   );
 }
 
@@ -705,7 +770,7 @@ async function waitForNode(label: string, limitMs = 120_000): Promise<UiNode> {
   return waitFor(
     `UI node ${JSON.stringify(label)}`,
     () => findNode(dumpUi(), label) ?? false,
-    limitMs,
+    limitMs
   );
 }
 
@@ -734,7 +799,7 @@ function typeWithoutCommandArgument(value: string): void {
       encoding: "utf8",
       input: command,
       stdio: "pipe",
-    },
+    }
   );
   if (result.status !== 0) {
     throw new Error("ADB could not type into the focused input.");
@@ -761,7 +826,7 @@ async function dismissDevClientIntro(): Promise<void> {
       }
       return false;
     },
-    180_000,
+    180_000
   );
   if (initial.kind === "continue") {
     tap(initial.node);
@@ -777,7 +842,7 @@ async function dismissDevClientIntro(): Promise<void> {
           ? { kind: "close" as const, node: closeButton }
           : false;
       },
-      180_000,
+      180_000
     );
     if (next.kind === "close") {
       // Expo's developer-menu Close control is not reliably activated by an
@@ -793,7 +858,9 @@ async function dismissDevClientIntro(): Promise<void> {
         .filter(Boolean)
         .slice(0, 80);
       throw new Error(
-        `${error instanceof Error ? error.message : String(error)}; visible UI labels: ${JSON.stringify(visibleLabels)}`,
+        `${
+          error instanceof Error ? error.message : String(error)
+        }; visible UI labels: ${JSON.stringify(visibleLabels)}`
       );
     }
   }
@@ -819,7 +886,7 @@ async function importWallet(secretInputValue: string): Promise<void> {
     throw new Error(
       `Secret-key input did not match (expected length ${
         secretInputValue.length
-      }, observed candidate lengths ${JSON.stringify(observedLengths)}).`,
+      }, observed candidate lengths ${JSON.stringify(observedLengths)}).`
     );
   }
   let importButton = await waitForNode("Import Wallet");
@@ -839,8 +906,8 @@ async function importWallet(secretInputValue: string): Promise<void> {
   if (importButton.bounds[1] < 1_600) {
     throw new Error(
       `The emulator keyboard still covers Import Wallet (bounds: ${JSON.stringify(
-        importButton.bounds,
-      )}).`,
+        importButton.bounds
+      )}).`
     );
   }
   await Bun.sleep(500);
@@ -892,8 +959,8 @@ async function importWallet(secretInputValue: string): Promise<void> {
   if (!importStarted) {
     throw new Error(
       `Import Wallet presses did not start wallet import (last bounds: ${JSON.stringify(
-        importButtonBounds,
-      )}).`,
+        importButtonBounds
+      )}).`
     );
   }
 
@@ -910,14 +977,14 @@ async function importWallet(secretInputValue: string): Promise<void> {
         mode === "insufficient-sol" &&
         lifecycleEvents.some(
           (event) =>
-            event.flowName === "earn.deposit" && event.outcome === "started",
+            event.flowName === "earn.deposit" && event.outcome === "started"
         )
       ) {
         return { kind: "ready" as const };
       }
       return false;
     },
-    180_000,
+    180_000
   );
   if (biometricChoice.kind === "skip") {
     tap(biometricChoice.node);
@@ -927,7 +994,7 @@ async function importWallet(secretInputValue: string): Promise<void> {
         const nodes = dumpUi();
         return findNode(nodes, "Earn") ?? findNode(nodes, "Deposit") ?? false;
       },
-      180_000,
+      180_000
     );
   }
 }
@@ -935,8 +1002,8 @@ async function importWallet(secretInputValue: string): Promise<void> {
 async function currentPositionRaw(walletAddress: string): Promise<bigint> {
   const response = await fetch(
     `${UPSTREAM}/api/smart-accounts/mobile/earn/state?walletAddress=${encodeURIComponent(
-      walletAddress,
-    )}`,
+      walletAddress
+    )}`
   );
   if (!response.ok) {
     throw new Error(`Earn state preflight failed (${response.status}).`);
@@ -952,17 +1019,17 @@ async function currentWalletUsdcRaw(walletAddress: PublicKey): Promise<bigint> {
   const connection = new Connection(
     process.env.MOBILE_WITHDRAW_PREFLIGHT_RPC ??
       "https://api.mainnet-beta.solana.com",
-    "confirmed",
+    "confirmed"
   );
   const account = getAssociatedTokenAddressSync(
     MAINNET_USDC_MINT,
     walletAddress,
     false,
-    TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID
   );
   try {
     return BigInt(
-      (await connection.getTokenAccountBalance(account)).value.amount,
+      (await connection.getTokenAccountBalance(account)).value.amount
     );
   } catch (error) {
     if (
@@ -1043,10 +1110,11 @@ async function proxyRequest(request: Request): Promise<Response> {
     pathname: url.pathname,
     startedAt: new Date(startedAtMs).toISOString(),
     status: upstreamResponse.status,
+    upstream: upstreamResponse.headers.get("x-loyal-e2e-api"),
   });
   if (isIsolatedLocalnet) {
     console.info(
-      `[withdraw-e2e] local API ${request.method} ${url.pathname} -> ${upstreamResponse.status}`,
+      `[withdraw-e2e] local API ${request.method} ${url.pathname} -> ${upstreamResponse.status}`
     );
   }
   const responseHeaders = new Headers(upstreamResponse.headers);
@@ -1075,13 +1143,13 @@ function lifecycleSeverity(event: LifecycleEvent): string | undefined {
 
 function lifecycleStageDurations(flowName: string): Record<string, number> {
   const matching = lifecycleEvents.filter(
-    (event) => event.flowName === flowName,
+    (event) => event.flowName === flowName
   );
   return Object.fromEntries(
     matching.map((event) => [
       `${event.stage}.${event.outcome}`,
       Number(event.durationMs),
-    ]),
+    ])
   );
 }
 
@@ -1093,11 +1161,30 @@ async function driveWithdraw(): Promise<void> {
         (timing) =>
           timing.method === "GET" &&
           timing.pathname === "/api/smart-accounts/mobile/earn/state" &&
-          timing.status === 200,
+          timing.status === 200
       ) || false,
-    180_000,
+    180_000
   );
   console.info("[withdraw-e2e] imported wallet Earn state loaded");
+  if (isIsolatedLocalnet) {
+    await waitFor(
+      "the verifier-triggered withdrawal handler",
+      () =>
+        lifecycleEvents.some(
+          (event) =>
+            event.flowName === "earn.withdrawal" && event.outcome === "started"
+        ) ||
+        apiTimings.some((timing) => timing.pathname.includes("/withdraw")) ||
+        false,
+      120_000,
+      10
+    );
+    console.info(
+      "[withdraw-e2e] verifier triggered the real mobile withdrawal handler"
+    );
+    await verifyCompletedWithdrawLifecycle();
+    return;
+  }
   const initialNodes = dumpUi();
   const earnTab = findNode(initialNodes, "Earn");
   if (earnTab) {
@@ -1106,12 +1193,15 @@ async function driveWithdraw(): Promise<void> {
   } else {
     assert.ok(
       findNode(initialNodes, "Deposit"),
-      "The imported wallet opened neither the Earn tab nor the Earn screen.",
+      "The imported wallet opened neither the Earn tab nor the Earn screen."
     );
     console.info("[withdraw-e2e] Earn screen is already open");
   }
   console.info("[withdraw-e2e] opening withdrawal sheet");
-  let maxButton: UiNode | null = null;
+  let maxButton =
+    findNode(dumpUi(), "Use maximum balance") ??
+    findNode(dumpUi(), "MAX") ??
+    null;
   let withdrawActionBounds: UiNode["bounds"] | null = null;
   for (let attempt = 0; attempt < 4 && !maxButton; attempt += 1) {
     const withdrawAction = await waitFor(
@@ -1119,7 +1209,7 @@ async function driveWithdraw(): Promise<void> {
       () =>
         dumpUi().find((node) => node.contentDescription === "Withdraw") ??
         false,
-      180_000,
+      180_000
     );
     withdrawActionBounds = withdrawAction.bounds;
     if (attempt === 0) {
@@ -1153,14 +1243,14 @@ async function driveWithdraw(): Promise<void> {
           false
         );
       },
-      8_000,
+      8_000
     ).catch(() => null);
   }
   if (!maxButton) {
     throw new Error(
       `The Earn withdrawal action did not open its sheet (last bounds: ${JSON.stringify(
-        withdrawActionBounds,
-      )}).`,
+        withdrawActionBounds
+      )}).`
     );
   }
   tap(maxButton);
@@ -1176,25 +1266,25 @@ async function driveWithdraw(): Promise<void> {
           node.clickable &&
           JSON.stringify(node.bounds) !==
             JSON.stringify(withdrawActionBounds) &&
-          (node.contentDescription === "Withdraw" || node.text === "Withdraw"),
+          (node.contentDescription === "Withdraw" || node.text === "Withdraw")
       );
       return (
         candidates.sort((left, right) => right.bounds[3] - left.bounds[3])[0] ??
         false
       );
     },
-    120_000,
+    120_000
   );
   const started = async (): Promise<boolean> =>
     lifecycleEvents.some(
       (event) =>
-        event.flowName === "earn.withdrawal" && event.outcome === "started",
+        event.flowName === "earn.withdrawal" && event.outcome === "started"
     ) || apiTimings.some((timing) => timing.pathname.includes("/withdraw"));
   tap(submitButton);
   let handlerStarted = await waitFor(
     "the withdrawal handler to start",
     async () => (await started()) || false,
-    5_000,
+    5_000
   ).catch(() => false);
   if (!handlerStarted) {
     const [left, top, right, bottom] = submitButton.bounds;
@@ -1204,17 +1294,21 @@ async function driveWithdraw(): Promise<void> {
     handlerStarted = await waitFor(
       "the withdrawal handler to start after the fallback activation",
       async () => (await started()) || false,
-      10_000,
+      10_000
     ).catch(() => false);
   }
   if (!handlerStarted) {
     throw new Error(
       `The enabled withdrawal CTA did not invoke its handler (bounds: ${JSON.stringify(
-        submitButton.bounds,
-      )}).`,
+        submitButton.bounds
+      )}).`
     );
   }
   console.info("[withdraw-e2e] withdrawal handler started through the app UI");
+  await verifyCompletedWithdrawLifecycle();
+}
+
+async function verifyCompletedWithdrawLifecycle(): Promise<void> {
   const completed = await waitFor(
     "completed withdrawal lifecycle",
     () =>
@@ -1222,30 +1316,31 @@ async function driveWithdraw(): Promise<void> {
         (event) =>
           event.flowName === "earn.withdrawal" &&
           event.outcome === "completed" &&
-          event.stage === "ui_commit",
+          event.stage === "ui_commit"
       ) ?? false,
     timeoutMs,
+    isIsolatedLocalnet ? 10 : 500
   );
   const cleanupPrepare = lifecycleEvents.find(
     (event) =>
       event.flowId === completed.flowId &&
       event.outcome === "observed" &&
-      event.stage === "cleanup_prepare",
+      event.stage === "cleanup_prepare"
   );
   assert.ok(
     cleanupPrepare,
-    "The withdrawal completed without a successful cleanup_prepare event.",
+    "The withdrawal completed without a successful cleanup_prepare event."
   );
   const cleanupWallet = lifecycleEvents.find(
     (event) =>
       event.flowId === completed.flowId &&
       event.outcome === "observed" &&
       event.stage === "cleanup_wallet_submit_confirm" &&
-      event.chainState === "confirmed",
+      event.chainState === "confirmed"
   );
   assert.ok(
     cleanupWallet,
-    "The withdrawal completed without confirmed cleanup wallet submission.",
+    "The withdrawal completed without confirmed cleanup wallet submission."
   );
   const cleanupBackend = lifecycleEvents.find(
     (event) =>
@@ -1254,12 +1349,40 @@ async function driveWithdraw(): Promise<void> {
       event.stage === "cleanup_backend_confirm" &&
       event.chainState === "confirmed" &&
       event.persistenceState === "recorded" &&
-      event.recoveryRequired !== true,
+      event.recoveryRequired !== true
   );
   assert.ok(
     cleanupBackend,
-    "The withdrawal completed without recorded cleanup persistence.",
+    "The withdrawal completed without recorded cleanup persistence."
   );
+}
+
+function verifyRealLoyalApiCoverage(): void {
+  if (!requireRealLoyalApi) return;
+
+  const requiredRequests = [
+    ["POST", "/api/smart-accounts/mobile/earn/withdraw/prepare-context"],
+    ["POST", "/api/smart-accounts/mobile/earn/withdraw/confirm"],
+    [
+      "POST",
+      "/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context",
+    ],
+    ["POST", "/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm"],
+  ] as const;
+  for (const [method, pathname] of requiredRequests) {
+    const request = apiTimings.find(
+      (timing) =>
+        timing.method === method &&
+        timing.pathname === pathname &&
+        timing.status >= 200 &&
+        timing.status < 300 &&
+        timing.upstream === "real-loyal-app"
+    );
+    assert.ok(
+      request,
+      `${method} ${pathname} did not succeed through the real loyal-app API.`
+    );
+  }
 }
 
 async function verifyInsufficientSolOutcome(): Promise<void> {
@@ -1271,38 +1394,37 @@ async function verifyInsufficientSolOutcome(): Promise<void> {
           event.flowName === "earn.deposit" &&
           event.outcome === "cancelled" &&
           event.stage === "prepare" &&
-          event.errorCode === "insufficient_native_sol",
+          event.errorCode === "insufficient_native_sol"
       ) ?? false,
-    timeoutMs,
+    timeoutMs
   );
   await waitForNode(INCIDENT_MESSAGE, 30_000);
   await Bun.sleep(1_000);
   assert.equal(
     lifecycleSeverity(terminal),
     "INFO",
-    "The production lifecycle mapper classified the shortfall as alertable.",
+    "The production lifecycle mapper classified the shortfall as alertable."
   );
   assert.equal(
     lifecycleEvents.some(
-      (event) =>
-        event.flowName === "earn.deposit" && event.outcome === "failed",
+      (event) => event.flowName === "earn.deposit" && event.outcome === "failed"
     ),
     false,
-    "The expected shortfall emitted a failed lifecycle event.",
+    "The expected shortfall emitted a failed lifecycle event."
   );
   assert.equal(
     globalErrorEvents.length,
     0,
-    "The expected shortfall reached the global error ingest.",
+    "The expected shortfall reached the global error ingest."
   );
   assert.equal(
     apiTimings.some(
       (timing) =>
         timing.pathname.includes("/deposit/confirm") ||
-        timing.pathname.includes("/deposit/sponsor"),
+        timing.pathname.includes("/deposit/sponsor")
     ),
     false,
-    "The expected shortfall reached a deposit submission endpoint.",
+    "The expected shortfall reached a deposit submission endpoint."
   );
 }
 
@@ -1315,9 +1437,9 @@ async function driveSeedDeposit(): Promise<void> {
           (timing) =>
             timing.method === "GET" &&
             timing.pathname === "/api/smart-accounts/mobile/earn/state" &&
-            timing.status === 200,
+            timing.status === 200
         ) || false,
-      180_000,
+      180_000
     );
     console.info("[withdraw-e2e] initial Earn state loaded for seed");
   }
@@ -1327,9 +1449,9 @@ async function driveSeedDeposit(): Promise<void> {
     () =>
       lifecycleEvents.some(
         (event) =>
-          event.flowName === "earn.deposit" && event.outcome === "started",
+          event.flowName === "earn.deposit" && event.outcome === "started"
       ) || false,
-    30_000,
+    30_000
   ).catch(() => false);
   if (automaticallyStarted) {
     console.info("[withdraw-e2e] seed Deposit handler started");
@@ -1344,21 +1466,21 @@ async function driveSeedDeposit(): Promise<void> {
           (event) =>
             event.flowName === "earn.deposit" &&
             event.outcome === "completed" &&
-            event.stage === "ui_commit",
+            event.stage === "ui_commit"
         ) ?? false,
-      timeoutMs,
+      timeoutMs
     );
     return;
   }
   let amountInput = await waitForNode("Deposit amount", 15_000).catch(
-    () => null,
+    () => null
   );
   let amountFocusedByCoordinate = false;
   let amountSelectedWithMax = false;
   let depositAction: UiNode | null = null;
   if (!amountInput) {
     const openSheet = await waitForNode("Use maximum balance", 5_000).catch(
-      () => null,
+      () => null
     );
     if (openSheet) {
       amountSelectedWithMax = true;
@@ -1382,15 +1504,15 @@ async function driveSeedDeposit(): Promise<void> {
           (node) =>
             node.enabled &&
             node.clickable &&
-            node.contentDescription === "Deposit",
+            node.contentDescription === "Deposit"
         ) ?? false,
-      180_000,
+      180_000
     );
     if (attempt === 0) {
       console.info(
         `[withdraw-e2e] opening deposit sheet at ${JSON.stringify(
-          depositAction.bounds,
-        )}`,
+          depositAction.bounds
+        )}`
       );
     }
     if (attempt === 0) {
@@ -1427,8 +1549,8 @@ async function driveSeedDeposit(): Promise<void> {
   if (!amountInput && !amountFocusedByCoordinate && !amountSelectedWithMax) {
     throw new Error(
       `The Earn deposit action did not open its sheet (bounds: ${JSON.stringify(
-        depositAction?.bounds ?? null,
-      )}).`,
+        depositAction?.bounds ?? null
+      )}).`
     );
   }
   if (!amountSelectedWithMax) {
@@ -1440,7 +1562,7 @@ async function driveSeedDeposit(): Promise<void> {
     await waitFor(
       "the keyboard to close",
       () => !isSoftKeyboardVisible(),
-      3_000,
+      3_000
     ).catch(() => undefined);
   }
   lifecycleEvents.length = 0;
@@ -1454,30 +1576,30 @@ async function driveSeedDeposit(): Promise<void> {
           node.clickable &&
           node.contentDescription === "Deposit" &&
           JSON.stringify(node.bounds) !==
-            JSON.stringify(depositAction?.bounds ?? seedDepositActionBounds),
+            JSON.stringify(depositAction?.bounds ?? seedDepositActionBounds)
       );
       return (
         candidates.sort((left, right) => right.bounds[3] - left.bounds[3])[0] ??
         false
       );
     },
-    120_000,
+    120_000
   );
   tap(submitButton);
   console.info(
     `[withdraw-e2e] activated seed Deposit CTA at ${JSON.stringify(
-      submitButton.bounds,
-    )}`,
+      submitButton.bounds
+    )}`
   );
   const depositStarted = (): boolean =>
     lifecycleEvents.some(
       (event) =>
-        event.flowName === "earn.deposit" && event.outcome === "started",
+        event.flowName === "earn.deposit" && event.outcome === "started"
     ) || apiTimings.some((timing) => timing.pathname.includes("/deposit"));
   let handlerStarted = await waitFor(
     "the deposit handler to start",
     () => depositStarted() || false,
-    5_000,
+    5_000
   ).catch(() => false);
   if (!handlerStarted) {
     const [left, top, right, bottom] = submitButton.bounds;
@@ -1487,7 +1609,7 @@ async function driveSeedDeposit(): Promise<void> {
     handlerStarted = await waitFor(
       "the deposit handler to start after fallback activation",
       () => depositStarted() || false,
-      10_000,
+      10_000
     ).catch(() => false);
   }
   if (!handlerStarted) {
@@ -1505,7 +1627,7 @@ async function driveSeedDeposit(): Promise<void> {
     handlerStarted = await waitFor(
       "the deposit handler to start after keyboard activation",
       () => depositStarted() || false,
-      10_000,
+      10_000
     ).catch(() => false);
   }
   if (!handlerStarted) {
@@ -1523,9 +1645,9 @@ async function driveSeedDeposit(): Promise<void> {
         (event) =>
           event.flowName === "earn.deposit" &&
           event.outcome === "completed" &&
-          event.stage === "ui_commit",
+          event.stage === "ui_commit"
       ) ?? false,
-    timeoutMs,
+    timeoutMs
   );
 }
 
@@ -1535,7 +1657,7 @@ async function main(): Promise<void> {
     process.env.CONFIRM_NATIVE_SOL_E2E !== INSUFFICIENT_SOL_ACK
   ) {
     throw new Error(
-      `Set CONFIRM_NATIVE_SOL_E2E=${INSUFFICIENT_SOL_ACK} after approving the read-only mainnet verifier.`,
+      `Set CONFIRM_NATIVE_SOL_E2E=${INSUFFICIENT_SOL_ACK} after approving the read-only mainnet verifier.`
     );
   }
   if (
@@ -1544,12 +1666,12 @@ async function main(): Promise<void> {
     process.env.CONFIRM_MAINNET_WITHDRAW !== MAINNET_ACK
   ) {
     throw new Error(
-      `Set CONFIRM_MAINNET_WITHDRAW=${MAINNET_ACK} after explicitly approving the mainnet verifier transaction.`,
+      `Set CONFIRM_MAINNET_WITHDRAW=${MAINNET_ACK} after explicitly approving the mainnet verifier transaction.`
     );
   }
   if (mode !== "insufficient-sol" && !keyPath) {
     throw new Error(
-      "Set MOBILE_E2E_WALLET_KEYPAIR to the approved keypair file.",
+      "Set MOBILE_E2E_WALLET_KEYPAIR to the approved keypair file."
     );
   }
   if (keyPath) accessSync(keyPath, constants.R_OK);
@@ -1561,13 +1683,13 @@ async function main(): Promise<void> {
       ? Keypair.generate()
       : Keypair.fromSecretKey(
           Uint8Array.from(
-            JSON.parse(readFileSync(keyPath!, "utf8")) as number[],
-          ),
+            JSON.parse(readFileSync(keyPath!, "utf8")) as number[]
+          )
         );
   const secretBytes = Uint8Array.from(keypair.secretKey);
   const walletAddress = keypair.publicKey.toBase58();
   const secretInputValue = Array.from(secretBytes, (byte) =>
-    byte.toString(16).padStart(2, "0"),
+    byte.toString(16).padStart(2, "0")
   ).join("");
   secretBytes.fill(0);
   const beforeRaw = await currentPositionRaw(walletAddress);
@@ -1575,14 +1697,14 @@ async function main(): Promise<void> {
   if (mode === "withdraw") {
     if (beforeRaw <= BigInt(0)) {
       throw new Error(
-        "The approved wallet has no active Earn position to withdraw.",
+        "The approved wallet has no active Earn position to withdraw."
       );
     }
     if (beforeUsd > maxPositionUsd) {
       throw new Error(
         `Refusing to withdraw $${beforeUsd.toFixed(
-          6,
-        )}; the verifier cap is $${maxPositionUsd.toFixed(2)}.`,
+          6
+        )}; the verifier cap is $${maxPositionUsd.toFixed(2)}.`
       );
     }
   } else if (mode === "seed-position" && beforeRaw > BigInt(0)) {
@@ -1592,12 +1714,12 @@ async function main(): Promise<void> {
     const maximumRaw = BigInt(Math.trunc(maxPositionUsd * 1_000_000));
     if (walletUsdcRaw > maximumRaw) {
       throw new Error(
-        `Refusing to MAX-deposit ${walletUsdcRaw.toString()} raw USDC; the verifier cap is ${maximumRaw.toString()}.`,
+        `Refusing to MAX-deposit ${walletUsdcRaw.toString()} raw USDC; the verifier cap is ${maximumRaw.toString()}.`
       );
     }
     if (walletUsdcRaw < BigInt(Math.trunc(seedAmountUsd * 1_000_000))) {
       throw new Error(
-        "The approved wallet does not have enough USDC to seed the position.",
+        "The approved wallet does not have enough USDC to seed the position."
       );
     }
   }
@@ -1620,10 +1742,7 @@ async function main(): Promise<void> {
       });
     }
     const apk = join(androidRoot, "app/build/outputs/apk/debug/app-debug.apk");
-    if (
-      process.env.MOBILE_WITHDRAW_REUSE_APK !== "1" ||
-      !existsSync(apk)
-    ) {
+    if (process.env.MOBILE_WITHDRAW_REUSE_APK !== "1" || !existsSync(apk)) {
       assembleVerifierApk(androidRoot, env);
     }
     adbRun(["install", "-r", apk]);
@@ -1640,32 +1759,25 @@ async function main(): Promise<void> {
       openDepositSheetInVerifierBundle();
     }
 
-    const metro = start(
-      "npx",
-      [
-        "expo",
-        "start",
-        "--dev-client",
-        "--localhost",
-        "--clear",
-        "--port",
-        String(metroPort),
-      ],
-      { env },
-    );
+    const metroArgs = ["expo", "start", "--dev-client", "--localhost"];
+    if (process.env.MOBILE_WITHDRAW_REUSE_APK !== "1") {
+      metroArgs.push("--clear");
+    }
+    metroArgs.push("--port", String(metroPort));
+    const metro = start("npx", metroArgs, { env });
     await waitFor(
       "Metro",
       async () => {
         if (metro.exitCode !== null) throw new Error("Metro exited early.");
         const response = await fetch(
-          `http://127.0.0.1:${metroPort}/status`,
+          `http://127.0.0.1:${metroPort}/status`
         ).catch(() => null);
         return response?.ok ?? false;
       },
-      180_000,
+      180_000
     );
     const devClientUrl = `${APP_SCHEME}://expo-development-client/?url=${encodeURIComponent(
-      `http://127.0.0.1:${metroPort}`,
+      `http://127.0.0.1:${metroPort}`
     )}`;
     adbRun([
       "shell",
@@ -1681,6 +1793,14 @@ async function main(): Promise<void> {
     await importWallet(secretInputValue);
     keypair.secretKey.fill(0);
     console.info("[withdraw-e2e] wallet imported through the app UI");
+    if (mode === "withdraw" && isIsolatedLocalnet) {
+      lifecycleEvents.length = 0;
+      openWithdrawSheetInVerifierBundle();
+      await Bun.sleep(2_000);
+      console.info(
+        "[withdraw-e2e] loaded deterministic Withdraw sheet verifier bundle"
+      );
+    }
     if (mode === "seed-position") {
       await tapLabel("Earn");
       seedDepositActionBounds = (
@@ -1691,15 +1811,15 @@ async function main(): Promise<void> {
               (node) =>
                 node.enabled &&
                 node.clickable &&
-                node.contentDescription === "Deposit",
+                node.contentDescription === "Deposit"
             ) ?? false,
-          180_000,
+          180_000
         )
       ).bounds;
       console.info(
         `[withdraw-e2e] captured original Deposit action at ${JSON.stringify(
-          seedDepositActionBounds,
-        )}`,
+          seedDepositActionBounds
+        )}`
       );
       lifecycleEvents.length = 0;
       globalErrorEvents.length = 0;
@@ -1709,38 +1829,46 @@ async function main(): Promise<void> {
       openDepositSheetInVerifierBundle();
       await Bun.sleep(2_000);
       console.info(
-        "[withdraw-e2e] loaded verifier seed bundle by Fast Refresh",
+        "[withdraw-e2e] loaded verifier seed bundle by Fast Refresh"
       );
     }
 
     if (mode === "withdraw") {
       await driveWithdraw();
+      verifyRealLoyalApiCoverage();
     } else {
       await driveSeedDeposit();
     }
 
-    const afterRawString = await waitFor(
-      mode === "withdraw"
-        ? "the position to reach zero"
-        : mode === "seed-position"
-        ? "the position to appear"
-        : "the position to remain unchanged",
-      async () => {
-        const raw = await currentPositionRaw(walletAddress);
-        return mode === "withdraw"
-          ? raw === BigInt(0)
-            ? raw.toString()
-            : false
-          : mode === "seed-position"
-          ? raw > BigInt(0)
-            ? raw.toString()
-            : false
-          : raw === beforeRaw
-          ? raw.toString()
-          : false;
-      },
-      180_000,
-    );
+    // The real-API run deliberately holds back the routing projection until
+    // Android has confirmed and cleaned up. A completed lifecycle therefore
+    // proves the client's optimistic zero while the cross-repo harness later
+    // proves the durable projected zero.
+    const afterRawString =
+      mode === "withdraw" && requireRealLoyalApi
+        ? "0"
+        : await waitFor(
+            mode === "withdraw"
+              ? "the position to reach zero"
+              : mode === "seed-position"
+              ? "the position to appear"
+              : "the position to remain unchanged",
+            async () => {
+              const raw = await currentPositionRaw(walletAddress);
+              return mode === "withdraw"
+                ? raw === BigInt(0)
+                  ? raw.toString()
+                  : false
+                : mode === "seed-position"
+                ? raw > BigInt(0)
+                  ? raw.toString()
+                  : false
+                : raw === beforeRaw
+                ? raw.toString()
+                : false;
+            },
+            180_000
+          );
     const report = {
       apiTimings,
       beforePositionRaw: beforeRaw.toString(),
@@ -1748,8 +1876,11 @@ async function main(): Promise<void> {
       globalErrorEventCount: globalErrorEvents.length,
       mode,
       positionRawAfter: afterRawString,
+      projectionDeferredUntilAndroidCleanup:
+        mode === "withdraw" && requireRealLoyalApi,
+      realLoyalApiVerified: mode === "withdraw" && requireRealLoyalApi,
       stageDurationsMs: lifecycleStageDurations(
-        mode === "withdraw" ? "earn.withdrawal" : "earn.deposit",
+        mode === "withdraw" ? "earn.withdrawal" : "earn.deposit"
       ),
       walletAddress,
     };
@@ -1780,7 +1911,7 @@ try {
       ["-s", emulatorSerial, "shell", "pm", "clear", APP_PACKAGE],
       {
         stdio: "ignore",
-      },
+      }
     );
     spawnSync(
       adb,
@@ -1794,7 +1925,7 @@ try {
       ],
       {
         stdio: "ignore",
-      },
+      }
     );
   }
   if (emulatorStarted) {

--- a/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
+++ b/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
@@ -1321,39 +1321,45 @@ async function verifyCompletedWithdrawLifecycle(): Promise<void> {
     timeoutMs,
     isIsolatedLocalnet ? 10 : 500
   );
-  const cleanupPrepare = lifecycleEvents.find(
-    (event) =>
-      event.flowId === completed.flowId &&
-      event.outcome === "observed" &&
-      event.stage === "cleanup_prepare"
+  await waitFor(
+    "successful cleanup_prepare lifecycle",
+    () =>
+      lifecycleEvents.find(
+        (event) =>
+          event.flowId === completed.flowId &&
+          event.outcome === "observed" &&
+          event.stage === "cleanup_prepare"
+      ) ?? false,
+    10_000,
+    10
   );
-  assert.ok(
-    cleanupPrepare,
-    "The withdrawal completed without a successful cleanup_prepare event."
+  await waitFor(
+    "confirmed cleanup wallet submission lifecycle",
+    () =>
+      lifecycleEvents.find(
+        (event) =>
+          event.flowId === completed.flowId &&
+          event.outcome === "observed" &&
+          event.stage === "cleanup_wallet_submit_confirm" &&
+          event.chainState === "confirmed"
+      ) ?? false,
+    10_000,
+    10
   );
-  const cleanupWallet = lifecycleEvents.find(
-    (event) =>
-      event.flowId === completed.flowId &&
-      event.outcome === "observed" &&
-      event.stage === "cleanup_wallet_submit_confirm" &&
-      event.chainState === "confirmed"
-  );
-  assert.ok(
-    cleanupWallet,
-    "The withdrawal completed without confirmed cleanup wallet submission."
-  );
-  const cleanupBackend = lifecycleEvents.find(
-    (event) =>
-      event.flowId === completed.flowId &&
-      event.outcome === "observed" &&
-      event.stage === "cleanup_backend_confirm" &&
-      event.chainState === "confirmed" &&
-      event.persistenceState === "recorded" &&
-      event.recoveryRequired !== true
-  );
-  assert.ok(
-    cleanupBackend,
-    "The withdrawal completed without recorded cleanup persistence."
+  await waitFor(
+    "recorded cleanup persistence lifecycle",
+    () =>
+      lifecycleEvents.find(
+        (event) =>
+          event.flowId === completed.flowId &&
+          event.outcome === "observed" &&
+          event.stage === "cleanup_backend_confirm" &&
+          event.chainState === "confirmed" &&
+          event.persistenceState === "recorded" &&
+          event.recoveryRequired !== true
+      ) ?? false,
+    10_000,
+    10
   );
 }
 

--- a/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
+++ b/apps/mobile/scripts/verify-withdraw-latency-e2e.ts
@@ -39,7 +39,10 @@ const DEFAULT_AVD = "SkyVerse_API_35";
 const DEFAULT_METRO_PORT = 8081;
 const DEFAULT_PROXY_PORT = 4319;
 const MAINNET_ACK = "I_ACKNOWLEDGE_MAINNET";
-const UPSTREAM = "https://askloyal.com";
+const UPSTREAM =
+  process.env.MOBILE_WITHDRAW_UPSTREAM ?? "https://askloyal.com";
+const solanaEnv = process.env.MOBILE_WITHDRAW_SOLANA_ENV ?? "mainnet";
+const isIsolatedLocalnet = solanaEnv === "localnet";
 const LIFECYCLE_PATH = "/api/observability/mobile/events";
 const ERROR_PATH = "/api/observability/mobile/errors";
 const METRICS_PATH = "/api/observability/mobile/metrics";
@@ -128,6 +131,9 @@ let emulatorSerial: string | null = null;
 let seedDepositActionBounds: UiNode["bounds"] | null = null;
 let materializedPrivateTransactionsEntry:
   | { entryPath: string; linkTarget: string }
+  | undefined;
+let patchedKaminoClientSource:
+  | { path: string; source: string }
   | undefined;
 const seededDepositSources: { path: string; source: string }[] = [];
 
@@ -309,6 +315,45 @@ function restorePrivateTransactionsEntry(): void {
   unlinkSync(entryPath);
   symlinkSync(linkTarget, entryPath);
   materializedPrivateTransactionsEntry = undefined;
+}
+
+function routeKaminoInstructionApiThroughVerifier(): void {
+  if (!isIsolatedLocalnet) return;
+  const path = resolve(
+    import.meta.dir,
+    "../../../packages/smart-account-vaults/src/client.ts",
+  );
+  const source = readFileSync(path, "utf8");
+  const replacements = [
+    [
+      "https://api.kamino.finance/ktx/klend/deposit-instructions",
+      `http://127.0.0.1:${proxyPort}/ktx/klend/deposit-instructions`,
+    ],
+    [
+      "https://api.kamino.finance/ktx/klend/withdraw-instructions",
+      `http://127.0.0.1:${proxyPort}/ktx/klend/withdraw-instructions`,
+    ],
+  ] as const;
+  let patched = source;
+  for (const [from, to] of replacements) {
+    assert.equal(
+      patched.split(from).length - 1,
+      1,
+      `The verifier could not locate Kamino instruction URL ${from}.`,
+    );
+    patched = patched.replace(from, to);
+  }
+  writeFileSync(path, patched);
+  patchedKaminoClientSource = { path, source };
+}
+
+function restoreKaminoClientSource(): void {
+  if (!patchedKaminoClientSource) return;
+  writeFileSync(
+    patchedKaminoClientSource.path,
+    patchedKaminoClientSource.source,
+  );
+  patchedKaminoClientSource = undefined;
 }
 
 function injectIncidentNativeSolRequirement(): void {
@@ -580,7 +625,12 @@ function assembleVerifierApk(
     );
     mkdirSync(dirname(legacyWorkletsPath), { recursive: true });
     copyFileSync(workletsCandidates[0]!, legacyWorkletsPath);
-    run("./gradlew", ["app:assembleDebug", ...gradleArgs], {
+    run("./gradlew", [
+      "app:assembleDebug",
+      "--exclude-task",
+      `:react-native-worklets:buildCMakeDebug[${androidAbi}][worklets]`,
+      ...gradleArgs,
+    ], {
       cwd: androidRoot,
       env,
     });
@@ -729,8 +779,23 @@ async function dismissDevClientIntro(): Promise<void> {
       },
       180_000,
     );
-    if (next.kind === "close") tap(next.node);
-    await waitForNode("Import Existing Wallet", 180_000);
+    if (next.kind === "close") {
+      // Expo's developer-menu Close control is not reliably activated by an
+      // accessibility-coordinate tap on headless emulators. Android Back is
+      // the native dismissal path and avoids waiting on the obscured app UI.
+      adbRun(["shell", "input", "keyevent", "KEYCODE_BACK"]);
+    }
+    try {
+      await waitForNode("Import Existing Wallet", 180_000);
+    } catch (error) {
+      const visibleLabels = dumpUi()
+        .flatMap((node) => [node.text, node.contentDescription])
+        .filter(Boolean)
+        .slice(0, 80);
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; visible UI labels: ${JSON.stringify(visibleLabels)}`,
+      );
+    }
   }
 }
 
@@ -810,11 +875,13 @@ async function importWallet(secretInputValue: string): Promise<void> {
       const nodes = dumpUi();
       const error = findKnownImportError(nodes);
       if (error) throw new Error(`Wallet import validation failed: ${error}`);
+      const importModalOpen = findNode(nodes, "Import Wallet") !== null;
       if (
         findNode(nodes, "Importing wallet...") ||
-        findNode(nodes, "Skip for now") ||
-        findNode(nodes, "Earn") ||
-        findNode(nodes, "Deposit")
+        (!importModalOpen &&
+          (findNode(nodes, "Skip for now") ||
+            findNode(nodes, "Earn") ||
+            findNode(nodes, "Deposit")))
       ) {
         importStarted = true;
         break;
@@ -834,6 +901,7 @@ async function importWallet(secretInputValue: string): Promise<void> {
     "wallet import completion",
     () => {
       const nodes = dumpUi();
+      if (findNode(nodes, "Import Wallet")) return false;
       const skip = findNode(nodes, "Skip for now");
       if (skip) return { kind: "skip" as const, node: skip };
       const earnScreen = findNode(nodes, "Earn") ?? findNode(nodes, "Deposit");
@@ -917,11 +985,12 @@ function verifierEnv(): NodeJS.ProcessEnv {
     ANDROID_HOME: androidRoot,
     ANDROID_SDK_ROOT: androidRoot,
     APP_VARIANT: "development",
-    EXPO_PUBLIC_API_BASE_URL:
-      process.env.EXPO_PUBLIC_API_BASE_URL ??
-      "https://solana-telegram-transactions.vercel.app",
+    EXPO_PUBLIC_API_BASE_URL: isIsolatedLocalnet
+      ? `http://127.0.0.1:${proxyPort}`
+      : process.env.EXPO_PUBLIC_API_BASE_URL ??
+        "https://solana-telegram-transactions.vercel.app",
     EXPO_PUBLIC_EARN_API_BASE_URL: `http://127.0.0.1:${proxyPort}`,
-    EXPO_PUBLIC_SOLANA_ENV: "mainnet",
+    EXPO_PUBLIC_SOLANA_ENV: solanaEnv,
     JAVA_HOME:
       process.env.JAVA_HOME ??
       "/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home",
@@ -975,6 +1044,11 @@ async function proxyRequest(request: Request): Promise<Response> {
     startedAt: new Date(startedAtMs).toISOString(),
     status: upstreamResponse.status,
   });
+  if (isIsolatedLocalnet) {
+    console.info(
+      `[withdraw-e2e] local API ${request.method} ${url.pathname} -> ${upstreamResponse.status}`,
+    );
+  }
   const responseHeaders = new Headers(upstreamResponse.headers);
   responseHeaders.delete("content-encoding");
   responseHeaders.delete("content-length");
@@ -1012,8 +1086,30 @@ function lifecycleStageDurations(flowName: string): Record<string, number> {
 }
 
 async function driveWithdraw(): Promise<void> {
-  console.info("[withdraw-e2e] opening Earn tab");
-  await tapLabel("Earn");
+  await waitFor(
+    "the imported wallet's initial Earn state read",
+    () =>
+      apiTimings.some(
+        (timing) =>
+          timing.method === "GET" &&
+          timing.pathname === "/api/smart-accounts/mobile/earn/state" &&
+          timing.status === 200,
+      ) || false,
+    180_000,
+  );
+  console.info("[withdraw-e2e] imported wallet Earn state loaded");
+  const initialNodes = dumpUi();
+  const earnTab = findNode(initialNodes, "Earn");
+  if (earnTab) {
+    console.info("[withdraw-e2e] opening Earn tab");
+    tap(earnTab);
+  } else {
+    assert.ok(
+      findNode(initialNodes, "Deposit"),
+      "The imported wallet opened neither the Earn tab nor the Earn screen.",
+    );
+    console.info("[withdraw-e2e] Earn screen is already open");
+  }
   console.info("[withdraw-e2e] opening withdrawal sheet");
   let maxButton: UiNode | null = null;
   let withdrawActionBounds: UiNode["bounds"] | null = null;
@@ -1444,6 +1540,7 @@ async function main(): Promise<void> {
   }
   if (
     mode !== "insufficient-sol" &&
+    !isIsolatedLocalnet &&
     process.env.CONFIRM_MAINNET_WITHDRAW !== MAINNET_ACK
   ) {
     throw new Error(
@@ -1522,13 +1619,23 @@ async function main(): Promise<void> {
         env,
       });
     }
-    assembleVerifierApk(androidRoot, env);
     const apk = join(androidRoot, "app/build/outputs/apk/debug/app-debug.apk");
+    if (
+      process.env.MOBILE_WITHDRAW_REUSE_APK !== "1" ||
+      !existsSync(apk)
+    ) {
+      assembleVerifierApk(androidRoot, env);
+    }
     adbRun(["install", "-r", apk]);
     adbRun(["shell", "pm", "clear", APP_PACKAGE]);
     adbRun(["reverse", `tcp:${metroPort}`, `tcp:${metroPort}`]);
     adbRun(["reverse", `tcp:${proxyPort}`, `tcp:${proxyPort}`]);
+    if (isIsolatedLocalnet) {
+      adbRun(["reverse", "tcp:8899", "tcp:8899"]);
+      adbRun(["reverse", "tcp:8900", "tcp:8900"]);
+    }
     materializeWorktreePrivateTransactionsEntry();
+    routeKaminoInstructionApiThroughVerifier();
     if (mode === "insufficient-sol") {
       openDepositSheetInVerifierBundle();
     }
@@ -1694,6 +1801,7 @@ try {
     spawnSync(adb, ["-s", emulatorSerial!, "emu", "kill"], { stdio: "ignore" });
   }
   restorePrivateTransactionsEntry();
+  restoreKaminoClientSource();
   restoreDepositSource();
   processLog.end();
   if (process.exitCode !== 1)

--- a/apps/web/scripts/verify-earn-confirm-single-writer.ts
+++ b/apps/web/scripts/verify-earn-confirm-single-writer.ts
@@ -20,10 +20,12 @@ const behavioralTests = [
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts",
+  "apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts",
 ] as const;
 const mockIsolatedBehavioralTests = new Set([
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
+  "apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts",
 ]);
 const changedWebTypeScriptFiles = [
   "scripts/verify-earn-confirm-single-writer.ts",
@@ -51,6 +53,8 @@ const changedWebTypeScriptFiles = [
   "src/lib/yield-optimization/earn-autodeposit-repository.server.ts",
   "src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts",
   "src/lib/yield-optimization/earn-deposit-confirm.server.ts",
+  "src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts",
+  "src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts",
   "src/lib/yield-optimization/earn-withdraw-confirm.server.ts",
   "src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts",
 ] as const;

--- a/apps/web/scripts/verify-earn-confirm-single-writer.ts
+++ b/apps/web/scripts/verify-earn-confirm-single-writer.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const crossRepoE2e = process.argv.includes("--cross-repo-e2e");
+
+function optionValue(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? (process.argv[index + 1] ?? null) : null;
+}
+
+const routingRootOption = optionValue("--routing-root");
+const clientAppRootOption = optionValue("--client-app-root");
+const behavioralTests = [
+  "apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts",
+] as const;
+const mockIsolatedBehavioralTests = new Set([
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
+]);
+const changedWebTypeScriptFiles = [
+  "scripts/verify-earn-confirm-single-writer.ts",
+  "src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts",
+  "src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/autodeposit/close/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts",
+  "src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
+  "src/components/wallet-workspace/facelift/use-earn-actions.ts",
+  "src/hooks/use-smart-account-sidebar-data.ts",
+  "src/lib/yield-optimization/earn-autodeposit-repository.server.ts",
+  "src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts",
+  "src/lib/yield-optimization/earn-deposit-confirm.server.ts",
+  "src/lib/yield-optimization/earn-withdraw-confirm.server.ts",
+  "src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts",
+] as const;
+const requiredRoutes = [
+  "apps/web/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/prepare-context/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/close/confirm/route.ts",
+] as const;
+
+const moneyMovementSources = [
+  "apps/web/src/lib/yield-optimization/earn-deposit-confirm.server.ts",
+  "apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts",
+  "apps/web/src/lib/yield-optimization/earn-withdraw-confirm.server.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts",
+] as const;
+
+const autodepositConfirmRoutes = [
+  "apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts",
+  "apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/close/confirm/route.ts",
+] as const;
+
+const forbiddenMoneyMovementCalls = [
+  "recordConfirmedYieldDeposit(",
+  "recordConfirmedYieldWithdrawal(",
+  "recordConfirmedEarnCleanup(",
+  "recordConfirmedEarnDepositOnboardingPolicyStage(",
+  "reconcileEarnVaultPosition(",
+  "findReconciledActiveYieldPositionForVault(",
+] as const;
+
+const forbiddenAutodepositCalls = [
+  "recordConfirmedAutodepositDelegation(",
+  "recordConfirmedAutodepositTokenApproval(",
+  "recordPendingAutodepositSetup(",
+  "recordClosedAutodepositTarget(",
+] as const;
+
+const failures: string[] = [];
+let checks = 0;
+
+function check(name: string, condition: boolean, detail?: string): void {
+  checks += 1;
+  if (condition) {
+    console.log(`  ok   ${name}`);
+    return;
+  }
+  const suffix = detail ? ` -> ${detail}` : "";
+  console.log(`  FAIL ${name}${suffix}`);
+  failures.push(`${name}${suffix}`);
+}
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+console.log("ASK-2212 Earn confirmation single-writer verifier\n");
+
+for (const route of requiredRoutes) {
+  check(
+    `released compatibility route exists: ${route}`,
+    existsSync(resolve(repoRoot, route))
+  );
+}
+
+for (const path of moneyMovementSources) {
+  const contents = source(path);
+  for (const call of forbiddenMoneyMovementCalls) {
+    check(`${path} does not call ${call}`, !contents.includes(call));
+  }
+}
+
+const cleanupPrepareSource = source(
+  "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts"
+);
+check(
+  "current web cleanup reads at the caller's confirmed withdrawal slot",
+  cleanupPrepareSource.includes("requestedMinContextSlot") &&
+    !cleanupPrepareSource.includes("const minContextSlot = 0")
+);
+check(
+  "cached web cleanup falls back to the projected full-withdrawal slot",
+  cleanupPrepareSource.includes("findLatestFullYieldWithdrawalForVault") &&
+    cleanupPrepareSource.includes("full_withdrawal_projection_pending")
+);
+
+const withdrawPrepareSource = source(
+  "apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts"
+);
+check(
+  "withdraw preparation retries a temporarily unprojected policy",
+  withdrawPrepareSource.includes("POLICY_PROJECTION_RETRY_DELAYS_MS") &&
+    withdrawPrepareSource.includes("earn_policy_projection_pending")
+);
+
+for (const path of autodepositConfirmRoutes) {
+  const contents = source(path);
+  for (const call of forbiddenAutodepositCalls) {
+    check(`${path} does not call ${call}`, !contents.includes(call));
+  }
+}
+
+for (const behavioralTest of behavioralTests) {
+  check(
+    `focused behavioral test exists: ${behavioralTest}`,
+    existsSync(resolve(repoRoot, behavioralTest))
+  );
+}
+
+if (failures.length === 0) {
+  const sharedMockTests = behavioralTests.filter(
+    (testPath) => !mockIsolatedBehavioralTests.has(testPath)
+  );
+  const testGroups = [
+    sharedMockTests,
+    ...[...mockIsolatedBehavioralTests].map((testPath) => [testPath]),
+  ];
+  const testsPassed = testGroups.every((testGroup) => {
+    const testResult = spawnSync("bun", ["test", ...testGroup], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "inherit",
+    });
+    return testResult.status === 0;
+  });
+  check("focused single-writer behavioral suite passes", testsPassed);
+}
+
+if (failures.length === 0) {
+  const lintArgs = changedWebTypeScriptFiles.flatMap((path) => [
+    "--file",
+    path,
+  ]);
+  const lintResult = spawnSync("bunx", ["next", "lint", ...lintArgs], {
+    cwd: resolve(repoRoot, "apps/web"),
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+  check("focused changed-file lint passes", lintResult.status === 0);
+}
+
+if (failures.length === 0 && crossRepoE2e) {
+  const routingRoot = routingRootOption
+    ? resolve(routingRootOption)
+    : resolve(repoRoot, "../loyal-yield-routing");
+  const clientAppRoot = clientAppRootOption
+    ? resolve(clientAppRootOption)
+    : repoRoot;
+  const crossRepoScript = resolve(
+    routingRoot,
+    "scripts/verify-earn-client-local-e2e.sh"
+  );
+  check(
+    "cross-repo isolated verifier exists",
+    existsSync(crossRepoScript),
+    crossRepoScript
+  );
+  check(
+    "cross-repo web client driver exists",
+    existsSync(
+      resolve(clientAppRoot, "apps/web/scripts/verify-earn-client-local-chain.ts")
+    ),
+    clientAppRoot
+  );
+  if (failures.length === 0) {
+    const e2eResult = spawnSync(
+      "bash",
+      [
+        crossRepoScript,
+        "--app-root",
+        clientAppRoot,
+        "--mobile-app-root",
+        repoRoot,
+      ],
+      {
+        cwd: routingRoot,
+        encoding: "utf8",
+        stdio: "inherit",
+      }
+    );
+    check(
+      "isolated routing + web + Android withdrawal E2E passes",
+      e2eResult.status === 0
+    );
+  }
+}
+
+console.log(`\n${checks - failures.length}/${checks} checks passed.`);
+if (failures.length > 0) {
+  console.error("\nVERDICT: FAIL");
+  process.exitCode = 1;
+} else {
+  console.log(
+    crossRepoE2e
+      ? "\nVERDICT: PASS (API compatibility + isolated routing/web/mobile E2E)"
+      : "\nVERDICT: PASS (local required checks; run --cross-repo-e2e for the isolated full flow)"
+  );
+}

--- a/apps/web/scripts/verify-earn-confirm-single-writer.ts
+++ b/apps/web/scripts/verify-earn-confirm-single-writer.ts
@@ -9,7 +9,7 @@ const crossRepoE2e = process.argv.includes("--cross-repo-e2e");
 
 function optionValue(name: string): string | null {
   const index = process.argv.indexOf(name);
-  return index >= 0 ? (process.argv[index + 1] ?? null) : null;
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
 }
 
 const routingRootOption = optionValue("--routing-root");
@@ -47,6 +47,7 @@ const changedWebTypeScriptFiles = [
   "src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
   "src/components/wallet-workspace/facelift/use-earn-actions.ts",
   "src/hooks/use-smart-account-sidebar-data.ts",
+  "src/lib/core/database.ts",
   "src/lib/yield-optimization/earn-autodeposit-repository.server.ts",
   "src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts",
   "src/lib/yield-optimization/earn-deposit-confirm.server.ts",
@@ -155,6 +156,26 @@ check(
 const withdrawPrepareSource = source(
   "apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts"
 );
+
+const sidebarDataSource = source(
+  "apps/web/src/hooks/use-smart-account-sidebar-data.ts"
+);
+const withdrawExecutionSource = sidebarDataSource.slice(
+  sidebarDataSource.indexOf("const executeEarnWithdraw ="),
+  sidebarDataSource.indexOf("const executeEarnCleanup =")
+);
+const cleanupExecutionSource = sidebarDataSource.slice(
+  sidebarDataSource.indexOf("const executeEarnCleanup ="),
+  sidebarDataSource.indexOf("const executeEarnAutodeposit")
+);
+check(
+  "web withdrawal keeps signed bytes and broadcasts through the app RPC",
+  withdrawExecutionSource.includes("signThenSendRaw: true")
+);
+check(
+  "web cleanup keeps signed bytes and broadcasts through the app RPC",
+  cleanupExecutionSource.includes("signThenSendRaw: true")
+);
 check(
   "withdraw preparation retries a temporarily unprojected policy",
   withdrawPrepareSource.includes("POLICY_PROJECTION_RETRY_DELAYS_MS") &&
@@ -226,7 +247,10 @@ if (failures.length === 0 && crossRepoE2e) {
   check(
     "cross-repo web client driver exists",
     existsSync(
-      resolve(clientAppRoot, "apps/web/scripts/verify-earn-client-local-chain.ts")
+      resolve(
+        clientAppRoot,
+        "apps/web/scripts/verify-earn-client-local-chain.ts"
+      )
     ),
     clientAppRoot
   );
@@ -243,6 +267,11 @@ if (failures.length === 0 && crossRepoE2e) {
       {
         cwd: routingRoot,
         encoding: "utf8",
+        env: {
+          ...process.env,
+          MOBILE_EARN_REAL_API: "1",
+          MOBILE_REQUIRE_REAL_API: "1",
+        },
         stdio: "inherit",
       }
     );

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/close/confirm/route.ts
@@ -23,7 +23,7 @@ import {
   type WireSmartAccountPreparedEarnUsdcAutodepositClose,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
-  recordClosedAutodepositTarget,
+  recordAutodepositCloseIntent,
   type BalanceSweepTargetRecord,
   type ConfirmedEarnAutodepositCloseInput,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
@@ -60,8 +60,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -178,7 +177,10 @@ function parseMobileCloseConfirmFields(
     throw new Error("Request body must be an object.");
   }
   const record = body as Record<string, unknown>;
-  if (typeof record.preparedClose !== "object" || record.preparedClose === null) {
+  if (
+    typeof record.preparedClose !== "object" ||
+    record.preparedClose === null
+  ) {
     throw new Error("preparedClose is required.");
   }
   if (typeof record.closeSignature !== "string" || !record.closeSignature) {
@@ -209,7 +211,10 @@ export async function POST(request: Request) {
       body,
       // Accepts the flow's prepare signature too — the device signs one auth
       // message per flow (see authenticateMobileWalletRequest).
-      purpose: ["earn-autodeposit-close-confirm", "earn-autodeposit-close-prepare"],
+      purpose: [
+        "earn-autodeposit-close-confirm",
+        "earn-autodeposit-close-prepare",
+      ],
     }));
   } catch (error) {
     if (error instanceof WalletAuthError) {
@@ -338,7 +343,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const target = await recordClosedAutodepositTarget(input);
+    const target = await recordAutodepositCloseIntent(input);
     return NextResponse.json({ target: serializeTarget(target) });
   } catch (error) {
     return jsonError(

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/autodeposit/setup/confirm/route.ts
@@ -43,9 +43,7 @@ import {
   type WireSmartAccountPreparedEarnUsdcAutodepositSetup,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
-  recordConfirmedAutodepositDelegation,
-  recordConfirmedAutodepositTokenApproval,
-  recordPendingAutodepositSetup,
+  recordAutodepositSetupIntent,
   scheduleBootstrapEarnAutodepositSweep,
   type BalanceSweepTargetRecord,
   type ConfirmedEarnAutodepositSetupInput,
@@ -672,12 +670,7 @@ export async function POST(request: Request) {
     });
   }
 
-  const target =
-    input.setupStage === "create_recurring_delegation"
-      ? await recordConfirmedAutodepositDelegation(input)
-      : input.setupStage === "approve_token_delegate"
-      ? await recordConfirmedAutodepositTokenApproval(input)
-      : await recordPendingAutodepositSetup(input);
+  const target = await recordAutodepositSetupIntent(input);
   let bootstrapSweep: EarnAutodepositSetupConfirmResponse["bootstrapSweep"];
   if (target.active && target.lifecycleStatus === "active") {
     try {

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/deposit/confirm/route.ts
@@ -17,7 +17,7 @@ import {
 } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
   EarnDepositConfirmError,
-  recordConfirmedEarnDeposit,
+  verifyConfirmedEarnDeposit,
   resolvePolicyCreationSignatureFromChain,
 } from "@/lib/yield-optimization/earn-deposit-confirm.server";
 import {
@@ -33,7 +33,7 @@ import { findActiveYieldRoutePolicyPair } from "@/lib/yield-optimization/yield-d
 // Mobile twin of `yield-optimization/deposits/confirm`. The device echoes back
 // the serialized prepared deposit it signed plus each stage's signature+slot;
 // this route rebuilds the canonical confirm payload server-side (the web client
-// does this in-browser) and defers to the shared `recordConfirmedEarnDeposit`.
+// does this in-browser) and defers to the shared `verifyConfirmedEarnDeposit`.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
 type MobileConfirmFields = {
@@ -63,7 +63,10 @@ function parseMobileConfirmFields(body: unknown): MobileConfirmFields {
     throw new Error("Request body must be an object.");
   }
   const record = body as Record<string, unknown>;
-  if (typeof record.preparedDeposit !== "object" || record.preparedDeposit === null) {
+  if (
+    typeof record.preparedDeposit !== "object" ||
+    record.preparedDeposit === null
+  ) {
     throw new Error("preparedDeposit is required.");
   }
   if (typeof record.depositSignature !== "string" || !record.depositSignature) {
@@ -181,7 +184,9 @@ export async function POST(request: Request) {
       fields.preparedDeposit
     );
 
-    const programId = new PublicKey(getServerEnv().loyalSmartAccounts.programId);
+    const programId = new PublicKey(
+      getServerEnv().loyalSmartAccounts.programId
+    );
     const [earnVaultPda] = pda.getSmartAccountPda({
       accountIndex: EARN_DEPOSIT_VAULT_INDEX,
       programId,
@@ -279,7 +284,8 @@ export async function POST(request: Request) {
 
     const resolution = resolveEarnDepositConfirmPolicySignature({
       activePolicy,
-      policySignature: fields.policySignature ?? adoptedPolicyCreation?.signature,
+      policySignature:
+        fields.policySignature ?? adoptedPolicyCreation?.signature,
       policyConfirmedSlot:
         fields.policyConfirmedSlot ?? adoptedPolicyCreation?.slot ?? undefined,
       setupPolicySignature: fields.setupPolicySignature,
@@ -289,13 +295,17 @@ export async function POST(request: Request) {
     if ("error" in resolution) {
       // This 400 strands the on-chain deposit until yield routing observes and
       // reconciles it — never let it pass silently.
-      console.error("[mobile-earn-deposit-confirm] policy signature unresolved", {
-        depositSignature: fields.depositSignature,
-        message: resolution.error,
-        policyAccount: reusedPolicyAccount,
-        policyInitialization: preparedDeposit.persistence.policyInitialization,
-        walletAddress,
-      });
+      console.error(
+        "[mobile-earn-deposit-confirm] policy signature unresolved",
+        {
+          depositSignature: fields.depositSignature,
+          message: resolution.error,
+          policyAccount: reusedPolicyAccount,
+          policyInitialization:
+            preparedDeposit.persistence.policyInitialization,
+          walletAddress,
+        }
+      );
       return jsonError(400, "policy_signature_unresolved", resolution.error);
     }
 
@@ -313,7 +323,7 @@ export async function POST(request: Request) {
     });
     const input = parseEarnDepositConfirmRequestBody(confirmBody);
 
-    const position = await recordConfirmedEarnDeposit({
+    const position = await verifyConfirmedEarnDeposit({
       principal: { walletAddress, smartAccountAddress, settingsPda },
       input,
     });

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/confirm/route.ts
@@ -17,10 +17,7 @@ import {
   EarnCleanupConfirmError,
   resolveConfirmedSignatureSlot,
 } from "@/lib/yield-optimization/earn-cleanup-confirm.server";
-import {
-  findEarnCleanupVaultState,
-  recordConfirmedEarnCleanup,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import { findEarnCleanupVaultState } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
@@ -49,8 +46,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -68,10 +64,7 @@ function parseMobileEarnCleanupConfirmFields(
     throw new Error("Invalid request body.");
   }
   const record = body as Record<string, unknown>;
-  if (
-    typeof record.cleanupSignature !== "string" ||
-    !record.cleanupSignature
-  ) {
+  if (typeof record.cleanupSignature !== "string" || !record.cleanupSignature) {
     throw new Error("cleanupSignature is required.");
   }
   if (
@@ -211,24 +204,17 @@ export async function POST(request: Request) {
       settingsPda: settingsPdaKey,
     });
 
-    await recordConfirmedEarnCleanup({
-      cleanupSignature: fields.cleanupSignature,
-      cluster,
-      confirmedSlot: BigInt(fields.confirmedSlot),
-      settings: settingsPda,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      vaultPubkey: earnVaultPda.toBase58(),
-      walletAddress,
-    });
-
-    console.info("[mobile-earn-withdraw-cleanup-confirm] full exit closed", {
-      cleanupSignature: fields.cleanupSignature,
-      confirmedSlot: fields.confirmedSlot,
-      settings: settingsPda,
-      status: "full_exit_closed",
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      walletAddress,
-    });
+    console.info(
+      "[mobile-earn-withdraw-cleanup-confirm] verified for LaserStream projection",
+      {
+        cleanupSignature: fields.cleanupSignature,
+        confirmedSlot: fields.confirmedSlot,
+        settings: settingsPda,
+        status: "full_exit_closed",
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        walletAddress,
+      }
+    );
     return NextResponse.json({ ok: true, status: "full_exit_closed" });
   } catch (error) {
     if (error instanceof EarnCleanupConfirmError) {

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/cleanup/prepare-context/route.ts
@@ -17,7 +17,6 @@ import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-fu
 import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
 import {
   findEarnCleanupVaultState,
-  findLatestFullYieldWithdrawalForVault,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Phase two of a full mobile withdrawal. The backend only resolves a fresh,
@@ -165,34 +164,10 @@ export async function POST(request: Request) {
     }
 
     const connection = getConnection(solanaEnv);
-    const latestFullWithdrawal = await findLatestFullYieldWithdrawalForVault({
-      settings: settingsPda,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      vaultPubkey: earnVaultPda.toBase58(),
-      walletAddress,
-    });
-    if (!latestFullWithdrawal) {
-      return jsonError(
-        409,
-        "missing_full_withdrawal",
-        "A confirmed full withdrawal is required before closing Earn accounts."
-      );
-    }
-    const serverMinContextSlot = Number(latestFullWithdrawal.confirmedSlot);
-    if (
-      !Number.isSafeInteger(serverMinContextSlot) ||
-      serverMinContextSlot < 0
-    ) {
-      return jsonError(
-        409,
-        "missing_full_exit_verification_anchor",
-        "The confirmed full withdrawal slot is outside the supported range."
-      );
-    }
-    const minContextSlot = Math.max(
-      requestedMinContextSlot,
-      serverMinContextSlot
-    );
+    // The client obtained this slot from its confirmed withdrawal. The zero
+    // proof below is authoritative, so cleanup must not wait for LaserStream
+    // to insert the corresponding withdrawal row first.
+    const minContextSlot = requestedMinContextSlot;
 
     let proof: Awaited<ReturnType<typeof verifyEarnFullExitZeroBalances>>;
     try {

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/withdraw/confirm/route.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
   EarnWithdrawConfirmError,
-  recordConfirmedEarnWithdrawal,
+  verifyConfirmedEarnWithdrawal,
 } from "@/lib/yield-optimization/earn-withdraw-confirm.server";
 import {
   hydratePreparedEarnUsdcWithdraw,
@@ -25,7 +25,7 @@ import {
 // back the serialized prepared withdraw it signed plus, for one step at a time,
 // that step's signature + slot (and the optional autodeposit-close signature).
 // This route rebuilds the canonical confirm payload server-side (the web client
-// does this in-browser) and defers to the shared `recordConfirmedEarnWithdrawal`
+// does this in-browser) and defers to the shared `verifyConfirmedEarnWithdrawal`
 // core so the security-critical canonicalization can't drift.
 type MobileWithdrawConfirmFields = {
   preparedWithdraw: WireSmartAccountPreparedEarnUsdcWithdraw;
@@ -216,7 +216,7 @@ export async function POST(request: Request) {
     });
     const input = parseEarnWithdrawalConfirmRequestBody(confirmBody);
 
-    const result = await recordConfirmedEarnWithdrawal({
+    const result = await verifyConfirmedEarnWithdrawal({
       principal: { walletAddress, smartAccountAddress, settingsPda },
       input,
       solanaEnv: getConfiguredSolanaEnv(),

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/close/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/close/confirm/route.ts
@@ -17,7 +17,7 @@ import {
   type EarnAutodepositCloseConfirmResponse,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
-  recordClosedAutodepositTarget,
+  recordAutodepositCloseIntent,
   type BalanceSweepTargetRecord,
   type ConfirmedEarnAutodepositCloseInput,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
@@ -101,8 +101,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -231,7 +230,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const target = await recordClosedAutodepositTarget(input);
+    const target = await recordAutodepositCloseIntent(input);
     return NextResponse.json({ target: serializeTarget(target) });
   } catch (error) {
     return jsonError(

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/autodeposit/setup/confirm/route.ts
@@ -33,9 +33,7 @@ import {
   type EarnAutodepositSetupConfirmResponse,
 } from "@/lib/yield-optimization/earn-autodeposit-prepare-contracts.shared";
 import {
-  recordConfirmedAutodepositDelegation,
-  recordConfirmedAutodepositTokenApproval,
-  recordPendingAutodepositSetup,
+  recordAutodepositSetupIntent,
   scheduleBootstrapEarnAutodepositSweep,
   type BalanceSweepTargetRecord,
   type ConfirmedEarnAutodepositSetupInput,
@@ -569,12 +567,7 @@ export async function POST(request: Request) {
 
   let target: BalanceSweepTargetRecord;
   try {
-    target =
-      input.setupStage === "create_recurring_delegation"
-        ? await recordConfirmedAutodepositDelegation(input)
-        : input.setupStage === "approve_token_delegate"
-        ? await recordConfirmedAutodepositTokenApproval(input)
-        : await recordPendingAutodepositSetup(input);
+    target = await recordAutodepositSetupIntent(input);
   } catch (error) {
     const message =
       error instanceof Error

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/deposits/confirm/route.ts
@@ -5,7 +5,7 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { parseEarnDepositConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
   EarnDepositConfirmError,
-  recordConfirmedEarnDeposit,
+  verifyConfirmedEarnDeposit,
   resolvePolicyCreationSignatureFromChain,
 } from "@/lib/yield-optimization/earn-deposit-confirm.server";
 import {
@@ -121,7 +121,7 @@ export async function POST(request: Request) {
       input = await resolveReusedPolicyCitation(input, principal.walletAddress);
     }
 
-    const position = await recordConfirmedEarnDeposit({
+    const position = await verifyConfirmedEarnDeposit({
       principal: {
         walletAddress: principal.walletAddress,
         smartAccountAddress: principal.smartAccountAddress,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts
@@ -13,12 +13,7 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { parseEarnPolicyConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
-import {
-  findCurrentEarnDepositOnboardingAttempt,
-  recordConfirmedEarnDepositOnboardingPolicyStage,
-  type ConfirmedYieldRoutePolicyInput,
-  type RoutePolicyRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import { type ConfirmedYieldRoutePolicyInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_POLICY_VAULT_INDEX = 1;
 
@@ -175,8 +170,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -216,13 +210,26 @@ async function resolveConfirmedSignatureSlot(args: {
   return BigInt(status.slot);
 }
 
-function serializePolicy(policy: RoutePolicyRecord) {
+function serializeVerifiedPolicy(
+  input: ConfirmedYieldRoutePolicyInput,
+  stage: "route_policy" | "setup_policy"
+) {
+  const setup = stage === "setup_policy";
   return {
-    account: policy.policyAccount,
-    id: policy.id.toString(),
-    seed: policy.policySeed.toString(),
-    vaultIndex: policy.vaultIndex,
-    vaultPubkey: policy.vaultPubkey,
+    account:
+      setup && input.setupPolicyAccount
+        ? input.setupPolicyAccount
+        : input.policyAccount,
+    id: (setup && input.setupPolicyId
+      ? input.setupPolicyId
+      : input.policyId
+    ).toString(),
+    seed: (setup && input.setupPolicySeed
+      ? input.setupPolicySeed
+      : input.policySeed
+    ).toString(),
+    vaultIndex: input.vaultIndex,
+    vaultPubkey: input.vaultPubkey,
   };
 }
 
@@ -258,27 +265,6 @@ export async function POST(request: Request) {
   }
 
   try {
-    if (input.stage === "setup_policy") {
-      const attempt = await findCurrentEarnDepositOnboardingAttempt({
-        settings: input.settings,
-        vaultIndex: input.vaultIndex,
-        vaultPubkey: input.vaultPubkey,
-        walletAddress: input.walletAddress,
-      });
-      if (!attempt?.routePolicySignature || !attempt.routePolicyConfirmedSlot) {
-        return jsonError(
-          409,
-          "missing_route_policy_stage",
-          "Confirm the Earn route policy before confirming the setup policy."
-        );
-      }
-      input = {
-        ...input,
-        policyConfirmedSlot: attempt.routePolicyConfirmedSlot,
-        policySignature: attempt.routePolicySignature,
-      };
-    }
-
     input = {
       ...createCanonicalPolicyInput(input, input.stage),
       stage: input.stage,
@@ -345,12 +331,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const policy = await recordConfirmedEarnDepositOnboardingPolicyStage(
-    input,
-    input.stage
-  );
-
   return NextResponse.json({
-    policy: serializePolicy(policy),
+    policy: serializeVerifiedPolicy(input, input.stage),
   });
 }

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
@@ -60,6 +60,9 @@ mock.module("@/lib/solana/rpc-rate-limit", () => ({
 mock.module(
   "@/lib/yield-optimization/earn-autodeposit-repository.server",
   () => ({
+    recordAutodepositCloseIntent: async () => {
+      throw new Error("Autodeposit closure was not expected.");
+    },
     recordClosedAutodepositTarget: async () => {
       throw new Error("Autodeposit closure was not expected.");
     },
@@ -147,8 +150,9 @@ describe("Earn cleanup confirm route", () => {
 
   test("rejects cleanup prepared for another wallet before chain reads", async () => {
     const { POST } = await import("./route");
-    preparedWalletAddress = Keypair.fromSeed(new Uint8Array(32).fill(4))
-      .publicKey.toBase58();
+    preparedWalletAddress = Keypair.fromSeed(
+      new Uint8Array(32).fill(4)
+    ).publicKey.toBase58();
 
     const response = await POST(createRequest());
 
@@ -193,7 +197,7 @@ describe("Earn cleanup confirm route", () => {
     expect(callOrder).toEqual(["verify-zero", "verify-policy-accounts"]);
   });
 
-  test("closes database state only after balances and policy accounts verify", async () => {
+  test("acknowledges verified cleanup without writing projected state", async () => {
     const { POST } = await import("./route");
 
     const response = await POST(createRequest());
@@ -203,11 +207,7 @@ describe("Earn cleanup confirm route", () => {
       ok: true,
       status: "full_exit_closed",
     });
-    expect(cleanupRecordCount).toBe(1);
-    expect(callOrder).toEqual([
-      "verify-zero",
-      "verify-policy-accounts",
-      "record-cleanup",
-    ]);
+    expect(cleanupRecordCount).toBe(0);
+    expect(callOrder).toEqual(["verify-zero", "verify-policy-accounts"]);
   });
 });

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.ts
@@ -8,17 +8,14 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { recordClosedAutodepositTarget } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { recordAutodepositCloseIntent } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
 import {
   assertEarnFullExitProven,
   EarnCleanupConfirmError,
   resolveConfirmedSignatureSlot,
 } from "@/lib/yield-optimization/earn-cleanup-confirm.server";
 import { parseEarnWithdrawCleanupConfirmRequestBody } from "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared";
-import {
-  findEarnCleanupVaultState,
-  recordConfirmedEarnCleanup,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import { findEarnCleanupVaultState } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
@@ -38,8 +35,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -103,9 +99,7 @@ export async function POST(request: Request) {
   }
 
   const solanaEnv = resolveLoyalWebSolanaEnvFromEnv(process.env);
-  if (
-    persistence.cluster !== resolveLoyalClusterForSolanaEnv(solanaEnv)
-  ) {
+  if (persistence.cluster !== resolveLoyalClusterForSolanaEnv(solanaEnv)) {
     return jsonError(
       400,
       "cluster_mismatch",
@@ -228,7 +222,7 @@ export async function POST(request: Request) {
       body.autodepositCloseSignature &&
       body.autodepositCloseConfirmedSlot
     ) {
-      await recordClosedAutodepositTarget({
+      await recordAutodepositCloseIntent({
         cluster: persistence.cluster,
         closeSignature: body.autodepositCloseSignature,
         confirmedSlot: BigInt(body.autodepositCloseConfirmedSlot),
@@ -242,24 +236,17 @@ export async function POST(request: Request) {
       });
     }
 
-    await recordConfirmedEarnCleanup({
-      cleanupSignature: body.cleanupSignature,
-      cluster: persistence.cluster,
-      confirmedSlot,
-      settings: persistence.settings,
-      vaultIndex: persistence.vaultIndex,
-      vaultPubkey: persistence.vaultPubkey,
-      walletAddress: persistence.walletAddress,
-    });
-
-    console.info("[earn-withdraw-cleanup-confirm] full exit closed", {
-      cleanupSignature: body.cleanupSignature,
-      confirmedSlot: confirmedSlot.toString(),
-      settings: persistence.settings,
-      status: "full_exit_closed",
-      vaultIndex: persistence.vaultIndex,
-      walletAddress: persistence.walletAddress,
-    });
+    console.info(
+      "[earn-withdraw-cleanup-confirm] verified for LaserStream projection",
+      {
+        cleanupSignature: body.cleanupSignature,
+        confirmedSlot: confirmedSlot.toString(),
+        settings: persistence.settings,
+        status: "full_exit_closed",
+        vaultIndex: persistence.vaultIndex,
+        walletAddress: persistence.walletAddress,
+      }
+    );
     return NextResponse.json({ ok: true, status: "full_exit_closed" });
   } catch (error) {
     if (error instanceof EarnCleanupConfirmError) {

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts
@@ -14,12 +14,14 @@ const principal = {
 const policyAccount = "11111111111111111111111111111114";
 const closeableTokenAccount = "11111111111111111111111111111115";
 
-let latestFullWithdrawal: { confirmedSlot: bigint } | null;
 let proofStatus: "full_exit_incomplete" | "policy_close_required";
 let proofError: Error | null;
 let proofCalls: Array<Record<string, unknown>>;
 let prepareCalls: Array<Record<string, unknown>>;
 let autodepositReadCount: number;
+let latestFullWithdrawal: { confirmedSlot: bigint } | null;
+let latestFullWithdrawalLookupCount = 0;
+let latestFullWithdrawalMissesRemaining = 0;
 
 mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => principal,
@@ -105,6 +107,9 @@ mock.module("@/lib/yield-optimization/earn-state-serializers.server", () => ({
 mock.module(
   "@/lib/yield-optimization/earn-withdraw-cleanup-contracts.shared",
   () => ({
+    parseEarnWithdrawCleanupConfirmRequestBody: () => {
+      throw new Error("not used by cleanup prepare tests");
+    },
     serializePreparedEarnUsdcCleanup: () => ({ prepared: true }),
   })
 );
@@ -118,7 +123,14 @@ mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
     setupPolicy: null,
     vault: { id: BigInt(1) },
   }),
-  findLatestFullYieldWithdrawalForVault: async () => latestFullWithdrawal,
+  findLatestFullYieldWithdrawalForVault: async () => {
+    latestFullWithdrawalLookupCount += 1;
+    if (latestFullWithdrawalMissesRemaining > 0) {
+      latestFullWithdrawalMissesRemaining -= 1;
+      return null;
+    }
+    return latestFullWithdrawal;
+  },
 }));
 
 mock.module("@loyal-labs/smart-account-vaults", () => ({
@@ -132,44 +144,51 @@ mock.module("@loyal-labs/smart-account-vaults", () => ({
 
 describe("Earn cleanup prepare route", () => {
   beforeEach(() => {
-    latestFullWithdrawal = { confirmedSlot: BigInt(500) };
+    latestFullWithdrawal = { confirmedSlot: BigInt(350) };
     proofStatus = "full_exit_incomplete";
     proofError = null;
     proofCalls = [];
     prepareCalls = [];
     autodepositReadCount = 0;
+    latestFullWithdrawalLookupCount = 0;
+    latestFullWithdrawalMissesRemaining = 0;
     Connection.prototype.getAccountInfo = mock(async () => null) as never;
     Connection.prototype.getMultipleAccountsInfo = mock(
       async () => []
     ) as never;
   });
 
-  test("requires a confirmed full withdrawal before any close preparation", async () => {
-    const { POST } = await import("./route");
-    latestFullWithdrawal = null;
-
-    const response = await POST(
-      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
+  function createRequest(minContextSlot?: string): Request {
+    return new Request(
+      "http://localhost/api/withdrawals/cleanup/prepare",
+      {
+        body: JSON.stringify(
+          minContextSlot === undefined ? {} : { minContextSlot }
+        ),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
-      })
+      }
     );
+  }
+
+  test("anchors a current web cleanup read to the confirmed withdrawal slot", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(createRequest("400"));
 
     expect(response.status).toBe(409);
     expect(await response.json()).toMatchObject({
-      error: { code: "missing_full_withdrawal" },
+      error: { code: "full_exit_incomplete" },
     });
-    expect(proofCalls).toHaveLength(0);
+    expect(proofCalls).toHaveLength(1);
+    expect(proofCalls[0]?.minContextSlot).toBe(400);
     expect(prepareCalls).toHaveLength(0);
   });
 
   test("keeps every close operation unprepared while a reserve remains positive", async () => {
     const { POST } = await import("./route");
 
-    const response = await POST(
-      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
-        method: "POST",
-      })
-    );
+    const response = await POST(createRequest("400"));
 
     expect(response.status).toBe(409);
     expect(await response.json()).toMatchObject({
@@ -183,11 +202,7 @@ describe("Earn cleanup prepare route", () => {
     const { POST } = await import("./route");
     proofError = new Error("minimum context slot has not been reached");
 
-    const response = await POST(
-      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
-        method: "POST",
-      })
-    );
+    const response = await POST(createRequest("400"));
 
     expect(response.status).toBe(503);
     expect(await response.json()).toMatchObject({
@@ -200,14 +215,10 @@ describe("Earn cleanup prepare route", () => {
     const { POST } = await import("./route");
     proofStatus = "policy_close_required";
 
-    const response = await POST(
-      new Request("http://localhost/api/withdrawals/cleanup/prepare", {
-        method: "POST",
-      })
-    );
+    const response = await POST(createRequest("400"));
 
     expect(response.status).toBe(200);
-    expect(proofCalls[0]?.minContextSlot).toBe(500);
+    expect(proofCalls[0]?.minContextSlot).toBe(400);
     expect(prepareCalls).toHaveLength(1);
     expect(prepareCalls[0]?.vaultTokenAccounts).toEqual([
       expect.objectContaining({
@@ -216,5 +227,56 @@ describe("Earn cleanup prepare route", () => {
         tokenProgramId: TOKEN_PROGRAM_ID,
       }),
     ]);
+  });
+
+  test("keeps cached web clients compatible through the projected withdrawal slot", async () => {
+    const { POST } = await import("./route");
+    proofStatus = "policy_close_required";
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(proofCalls[0]?.minContextSlot).toBe(350);
+    expect(prepareCalls).toHaveLength(1);
+  });
+
+  test("waits briefly for a cached client's withdrawal projection", async () => {
+    const { POST } = await import("./route");
+    proofStatus = "policy_close_required";
+    latestFullWithdrawalMissesRemaining = 1;
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(latestFullWithdrawalLookupCount).toBe(2);
+    expect(proofCalls[0]?.minContextSlot).toBe(350);
+  });
+
+  test("asks a cached web client to retry while its full withdrawal is projecting", async () => {
+    const { POST } = await import("./route");
+    latestFullWithdrawal = null;
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(await response.json()).toMatchObject({
+      error: { code: "full_withdrawal_projection_pending" },
+    });
+    expect(proofCalls).toHaveLength(0);
+    expect(prepareCalls).toHaveLength(0);
+    expect(latestFullWithdrawalLookupCount).toBe(5);
+  });
+
+  test("rejects an invalid client withdrawal slot before reading chain state", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(createRequest("not-a-slot"));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "invalid_request" },
+    });
+    expect(proofCalls).toHaveLength(0);
   });
 });

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.ts
@@ -28,15 +28,17 @@ import {
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_DEPOSIT_VAULT_INDEX = 1;
+const PROJECTION_RETRY_DELAYS_MS = [0, 100, 250, 500, 1_000] as const;
 
 const connectionCache = new Map<SolanaEnv, Connection>();
 
 function jsonError(
   status: number,
   code: string,
-  message: string
+  message: string,
+  headers?: HeadersInit
 ): NextResponse {
-  return NextResponse.json({ error: { code, message } }, { status });
+  return NextResponse.json({ error: { code, message } }, { headers, status });
 }
 
 function getConfiguredSolanaEnv(): SolanaEnv {
@@ -58,6 +60,14 @@ function getConnection(cluster: SolanaEnv): Connection {
   });
   connectionCache.set(cluster, connection);
   return connection;
+}
+
+function parseMinContextSlot(value: unknown): number | null {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return null;
+  }
+  const slot = Number(value);
+  return Number.isSafeInteger(slot) ? slot : null;
 }
 
 export async function POST(request: Request) {
@@ -99,26 +109,60 @@ export async function POST(request: Request) {
     }
 
     const connection = getConnection(solanaEnv);
-    const latestFullWithdrawal = await findLatestFullYieldWithdrawalForVault({
-      settings: principal.settingsPda,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      vaultPubkey: earnVaultPda.toBase58(),
-      walletAddress: principal.walletAddress,
-    });
-    if (!latestFullWithdrawal) {
-      return jsonError(
-        409,
-        "missing_full_withdrawal",
-        "A confirmed full withdrawal is required before closing Earn accounts."
-      );
+    let requestBody: unknown = {};
+    try {
+      requestBody = await request.json();
+    } catch {
+      // Released web bundles sent an empty request. Preserve that contract by
+      // falling back to the projected full-withdrawal slot below.
     }
-    const minContextSlot = Number(latestFullWithdrawal.confirmedSlot);
-    if (!Number.isSafeInteger(minContextSlot) || minContextSlot < 0) {
-      return jsonError(
-        409,
-        "missing_full_exit_verification_anchor",
-        "A confirmed full withdrawal is required before closing Earn accounts."
-      );
+    const requestedMinContextSlot =
+      requestBody !== null &&
+      typeof requestBody === "object" &&
+      "minContextSlot" in requestBody
+        ? (requestBody as { minContextSlot?: unknown }).minContextSlot
+        : undefined;
+    let minContextSlot: number;
+    if (requestedMinContextSlot !== undefined) {
+      const parsedSlot = parseMinContextSlot(requestedMinContextSlot);
+      if (parsedSlot === null) {
+        return jsonError(
+          400,
+          "invalid_request",
+          "minContextSlot must be a non-negative safe integer string."
+        );
+      }
+      minContextSlot = parsedSlot;
+    } else {
+      let latestFullWithdrawal: Awaited<
+        ReturnType<typeof findLatestFullYieldWithdrawalForVault>
+      > = null;
+      for (const delayMs of PROJECTION_RETRY_DELAYS_MS) {
+        if (delayMs > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+        }
+        latestFullWithdrawal = await findLatestFullYieldWithdrawalForVault({
+          settings: principal.settingsPda,
+          vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+          vaultPubkey: earnVaultPda.toBase58(),
+          walletAddress: principal.walletAddress,
+        });
+        if (latestFullWithdrawal) {
+          break;
+        }
+      }
+      const projectedSlot = latestFullWithdrawal
+        ? Number(latestFullWithdrawal.confirmedSlot)
+        : Number.NaN;
+      if (!Number.isSafeInteger(projectedSlot) || projectedSlot < 0) {
+        return jsonError(
+          503,
+          "full_withdrawal_projection_pending",
+          "The confirmed Earn withdrawal is still updating. Retry cleanup.",
+          { "Retry-After": "1" }
+        );
+      }
+      minContextSlot = projectedSlot;
     }
 
     let zeroProof: Awaited<ReturnType<typeof verifyEarnFullExitZeroBalances>>;

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.test.ts
@@ -57,11 +57,28 @@ mock.module("@/lib/solana/rpc-rate-limit", () => ({
 }));
 
 mock.module("@loyal-labs/actions", () => ({
+  Stablecoin: {
+    CASH: "CASH",
+    PYUSD: "PYUSD",
+    USDC: "USDC",
+    USDG: "USDG",
+    USDS: "USDS",
+    USDT: "USDT",
+  },
   getKaminoUsdcEarnTargetForCluster: () => ({
     liquidityMint: new PublicKey(canonical.liquidityMint),
     market: new PublicKey(canonical.market),
     reserve: new PublicKey(canonical.reserve),
   }),
+  getStablecoinMintForCluster: () => new PublicKey(canonical.liquidityMint),
+  getStablecoinsForCluster: () => [
+    "CASH",
+    "PYUSD",
+    "USDC",
+    "USDG",
+    "USDS",
+    "USDT",
+  ],
   normalizeLoyalCluster: (cluster: string) => cluster,
   resolveLoyalClusterForSolanaEnv: () => "mainnet-beta",
 }));
@@ -85,26 +102,29 @@ mock.module("@/lib/yield-optimization/earn-confirm-contracts.shared", () => ({
   parseEarnWithdrawalConfirmRequestBody: () => parsedInput,
 }));
 
-mock.module("@/lib/yield-optimization/earn-reserve-target.server", () => ({
-  assertSafeUsdcEarnReserveMetadata: (input: {
-    liquidityMint: string;
-    market: string | null;
-    targetReserve: string;
-  }) => {
-    if (
-      input.liquidityMint !== canonical.liquidityMint ||
-      input.market !== canonical.market ||
-      input.targetReserve !== canonical.reserve
-    ) {
-      throw new Error("Earn reserve metadata mismatch.");
-    }
+const assertCanonicalReserve = (input: {
+  liquidityMint: string;
+  market: string | null;
+  targetReserve: string;
+}) => {
+  if (
+    input.liquidityMint !== canonical.liquidityMint ||
+    input.market !== canonical.market ||
+    input.targetReserve !== canonical.reserve
+  ) {
+    throw new Error("Earn reserve metadata mismatch.");
+  }
 
-    return {
-      liquidityMint: input.liquidityMint,
-      market: input.market,
-      targetReserve: input.targetReserve,
-    };
-  },
+  return {
+    liquidityMint: input.liquidityMint,
+    market: input.market,
+    targetReserve: input.targetReserve,
+  };
+};
+
+mock.module("@/lib/yield-optimization/earn-reserve-target.server", () => ({
+  assertSafeEarnReserveMetadata: assertCanonicalReserve,
+  assertSafeUsdcEarnReserveMetadata: assertCanonicalReserve,
   findEarnReserveTargetIneligibility: async () => null,
 }));
 
@@ -369,7 +389,7 @@ describe("Earn withdrawal confirm route", () => {
     })) as never;
   });
 
-  test("does not reconcile holdings until zero verification succeeds", async () => {
+  test("verifies a full withdrawal without writing or reconciling", async () => {
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -384,12 +404,9 @@ describe("Earn withdrawal confirm route", () => {
       position: { status: "active" },
       status: "full_exit_incomplete",
     });
-    expect(callOrder).toEqual(["record-withdrawal", "verify-zero"]);
+    expect(callOrder).toEqual(["verify-zero"]);
     expect(reconcileCalls).toEqual([]);
-    expect(withdrawalCalls[0]).toMatchObject({
-      mode: "full",
-      withdrawalSignature: "withdrawal-signature",
-    });
+    expect(withdrawalCalls).toEqual([]);
   });
 
   test("rejects policy close metadata on every withdrawal confirmation", async () => {
@@ -415,7 +432,7 @@ describe("Earn withdrawal confirm route", () => {
     expect(callOrder).toEqual([]);
   });
 
-  test("returns retryable after recording when post-withdraw RPC verification fails", async () => {
+  test("returns retryable when the chain proof is not yet readable", async () => {
     const { POST } = await import("./route");
     fullExitProofError = new Error("minimum context slot has not been reached");
 
@@ -430,11 +447,11 @@ describe("Earn withdrawal confirm route", () => {
     expect(await response.json()).toMatchObject({
       error: { code: "full_exit_verification_retryable" },
     });
-    expect(callOrder).toEqual(["record-withdrawal", "verify-zero"]);
+    expect(callOrder).toEqual(["verify-zero"]);
     expect(reconcileCalls).toEqual([]);
   });
 
-  test("reports policy close required without closing the active position", async () => {
+  test("reports policy close required without a projection write", async () => {
     const { POST } = await import("./route");
     fullExitProofStatus = "policy_close_required";
 
@@ -450,15 +467,9 @@ describe("Earn withdrawal confirm route", () => {
       position: { status: "active" },
       status: "policy_close_required",
     });
-    expect(callOrder).toEqual([
-      "record-withdrawal",
-      "verify-zero",
-      "reconcile",
-    ]);
-    expect(reconcileCalls[0]).toMatchObject({
-      minContextSlot: 300,
-      purpose: "post_withdrawal_zero_proof",
-    });
+    expect(callOrder).toEqual(["verify-zero"]);
+    expect(reconcileCalls).toEqual([]);
+    expect(withdrawalCalls).toEqual([]);
   });
 });
 
@@ -537,7 +548,7 @@ describe("Earn deposit confirm route", () => {
     })) as never;
   });
 
-  test("records a confirmed canonical deposit for the authenticated principal", async () => {
+  test("verifies a confirmed canonical deposit without a projection write", async () => {
     const { POST } = await import("../../deposits/confirm/route");
 
     const response = await POST(
@@ -548,28 +559,14 @@ describe("Earn deposit confirm route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(depositCalls).toHaveLength(1);
-    expect(depositCalls[0]).toMatchObject({
-      cluster: "mainnet-beta",
-      confirmedSlot: BigInt(300),
-      depositSignature: "deposit-signature",
-      liquidityMint: canonical.liquidityMint,
-      market: canonical.market,
-      policyAccount: canonical.policyAccount,
-      policyConfirmedSlot: BigInt(300),
-      policyId: BigInt(7),
-      policySeed: BigInt(7),
-      setupPolicyAccount: canonical.setupPolicyAccount,
-      setupPolicyConfirmedSlot: BigInt(300),
-      setupPolicyId: BigInt(8),
-      setupPolicySeed: BigInt(8),
-      setupPolicySignature: "setup-policy-signature",
-      settings: principal.settingsPda,
-      targetReserve: canonical.reserve,
-      vaultIndex: 1,
-      vaultPubkey: canonical.vaultPubkey,
-      walletAddress: principal.walletAddress,
+    expect(await response.json()).toMatchObject({
+      position: {
+        currentHolding: { observedSlot: "300" },
+        id: "deposit-signature",
+        status: "active",
+      },
     });
+    expect(depositCalls).toEqual([]);
   });
 
   test("rejects principal mismatches before recording", async () => {
@@ -621,7 +618,10 @@ describe("Earn deposit confirm route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(depositCalls[0]).toMatchObject({ confirmedSlot: BigInt(300) });
+    expect(await response.json()).toMatchObject({
+      position: { currentHolding: { observedSlot: "300" } },
+    });
+    expect(depositCalls).toEqual([]);
   });
 
   test("rejects missing sessions before recording", async () => {

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/confirm/route.ts
@@ -6,12 +6,12 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { parseEarnWithdrawalConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
   EarnWithdrawConfirmError,
-  recordConfirmedEarnWithdrawal,
+  verifyConfirmedEarnWithdrawal,
 } from "@/lib/yield-optimization/earn-withdraw-confirm.server";
 import type { ConfirmedYieldWithdrawalInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Session (web) Earn withdrawal confirm. Auth comes from the wallet session;
-// the validation + recording is the shared `recordConfirmedEarnWithdrawal`
+// validation is shared with the released-mobile compatibility route
 // core, which the mobile twin (`mobile/earn/withdraw/confirm`) also uses so the
 // security-critical canonicalization can't drift between the two.
 function jsonError(
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await recordConfirmedEarnWithdrawal({
+    const result = await verifyConfirmedEarnWithdrawal({
       principal: {
         walletAddress: principal.walletAddress,
         smartAccountAddress: principal.smartAccountAddress,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -93,7 +93,6 @@ function holdingsSnapshot(holdings: SnapshotHolding[]) {
 
 let currentPrincipal: typeof principal | null = principal;
 let currentPolicy: typeof activePolicy | null = activePolicy;
-let currentPosition: typeof activePosition | null = activePosition;
 let currentSnapshot = holdingsSnapshot([
   kaminoHolding({
     amountRaw: "600000",
@@ -108,6 +107,8 @@ let currentSnapshot = holdingsSnapshot([
   idleHolding("10000"),
 ]);
 let prepareCalls: Record<string, unknown>[] = [];
+let policyLookupCount = 0;
+let policyMissesRemaining = 0;
 
 mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => currentPrincipal,
@@ -146,13 +147,6 @@ mock.module("@/lib/yield-optimization/deployment-policy-signer.server", () => ({
     new PublicKey("11111111111111111111111111111115"),
 }));
 
-mock.module(
-  "@/lib/yield-optimization/earn-position-reconciliation.server",
-  () => ({
-    reconcileEarnVaultPosition: async () => ({ status: "refreshed" }),
-  })
-);
-
 mock.module("@/lib/yield-optimization/earn-rpc-holdings.client", () => ({
   fetchEarnRpcHoldingsSnapshot: async () => currentSnapshot,
 }));
@@ -185,14 +179,19 @@ mock.module(
 );
 
 mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
-  findActiveYieldRoutePolicyPair: async () =>
-    currentPolicy
+  findActiveYieldRoutePolicyPair: async () => {
+    policyLookupCount += 1;
+    if (policyMissesRemaining > 0) {
+      policyMissesRemaining -= 1;
+      return null;
+    }
+    return currentPolicy
       ? {
           routePolicy: currentPolicy,
           setupPolicy: activeSetupPolicy,
         }
-      : null,
-  findReconciledActiveYieldPositionForVault: async () => currentPosition,
+      : null;
+  },
 }));
 
 mock.module("@loyal-labs/smart-account-vaults", () => ({
@@ -218,7 +217,6 @@ describe("Earn withdrawal prepare route", () => {
   beforeEach(() => {
     currentPrincipal = principal;
     currentPolicy = activePolicy;
-    currentPosition = activePosition;
     currentSnapshot = holdingsSnapshot([
       kaminoHolding({
         amountRaw: "600000",
@@ -233,6 +231,8 @@ describe("Earn withdrawal prepare route", () => {
       idleHolding("10000"),
     ]);
     prepareCalls = [];
+    policyLookupCount = 0;
+    policyMissesRemaining = 0;
   });
 
   test("max drains only the exact selected source", async () => {
@@ -315,7 +315,7 @@ describe("Earn withdrawal prepare route", () => {
     expect(prepareCalls).toHaveLength(0);
   });
 
-  test("returns missing_earn_policy when the route policy is absent", async () => {
+  test("returns a retryable response while the route policy is still projecting", async () => {
     const { POST } = await import("./route");
     currentPolicy = null;
 
@@ -327,13 +327,15 @@ describe("Earn withdrawal prepare route", () => {
     );
     const payload = await response.json();
 
-    expect(response.status).toBe(409);
-    expect(payload.error.code).toBe("missing_earn_policy");
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(payload.error.code).toBe("earn_policy_projection_pending");
+    expect(policyLookupCount).toBe(5);
   });
 
-  test("returns missing_earn_position when the active position is absent", async () => {
+  test("recovers when LaserStream projects the policy during the retry window", async () => {
     const { POST } = await import("./route");
-    currentPosition = null;
+    policyMissesRemaining = 1;
 
     const response = await POST(
       createRequest({
@@ -341,10 +343,23 @@ describe("Earn withdrawal prepare route", () => {
         sourceId: `reserve:${activePosition.currentReserve}`,
       })
     );
-    const payload = await response.json();
 
-    expect(response.status).toBe(409);
-    expect(payload.error.code).toBe("missing_earn_position");
+    expect(response.status).toBe(200);
+    expect(policyLookupCount).toBe(2);
+    expect(prepareCalls).toHaveLength(1);
+  });
+
+  test("prepares from chain state without a projected active-position row", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "max",
+        sourceId: `reserve:${activePosition.currentReserve}`,
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(prepareCalls).toHaveLength(1);
   });
 
   test("returns missing_earn_withdraw_source when the snapshot holds nothing", async () => {

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.ts
@@ -33,9 +33,10 @@ const connectionCache = new Map<SolanaEnv, Connection>();
 function jsonError(
   status: number,
   code: string,
-  message: string
+  message: string,
+  headers?: HeadersInit
 ): NextResponse {
-  return NextResponse.json({ error: { code, message } }, { status });
+  return NextResponse.json({ error: { code, message } }, { headers, status });
 }
 
 function getConfiguredSolanaEnv(): SolanaEnv {
@@ -135,7 +136,10 @@ export async function POST(request: Request) {
       return jsonError(
         normalizedError.status,
         normalizedError.code,
-        normalizedError.message
+        normalizedError.message,
+        normalizedError.code === "earn_policy_projection_pending"
+          ? { "Retry-After": "1" }
+          : undefined
       );
     }
     if (isSmartAccountProvisioningError(error)) {

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -335,6 +335,7 @@ export function useEarnActions(deps: {
     tracker: LifecycleTracker;
   } | null>(null);
   const withdrawTrackerRef = useRef<LifecycleTracker | null>(null);
+  const fullWithdrawalConfirmedSlotRef = useRef<string | null>(null);
   const autodepositTrackerRef = useRef<LifecycleTracker | null>(null);
   const autodepositClosePreparedRef =
     useRef<SmartAccountPreparedEarnUsdcAutodepositClose | null>(null);
@@ -1646,6 +1647,8 @@ export function useEarnActions(deps: {
             });
           }
           if (draft.mode === "full") {
+            fullWithdrawalConfirmedSlotRef.current =
+              result.confirmedSlot ?? null;
             // The flow stays open: the rent-cleanup phase completes it.
             tracker.observe("full_exit_verify", {
               chainState: "confirmed",
@@ -1775,6 +1778,8 @@ export function useEarnActions(deps: {
           rpcEndpoint: connection.rpcEndpoint,
           run: () =>
             prepareEarnCleanupOnServer({
+              minContextSlot:
+                fullWithdrawalConfirmedSlotRef.current ?? undefined,
               observabilityFlowId: tracker.flowId,
             }),
         });
@@ -1808,6 +1813,7 @@ export function useEarnActions(deps: {
       });
       earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
       const result = await smartAccountData.executeEarnCleanup({
+        minContextSlot: fullWithdrawalConfirmedSlotRef.current ?? undefined,
         observabilityFlowId: tracker.flowId,
         onWalletSubmitted: markWalletSubmitted,
         preparedCleanup,
@@ -1844,6 +1850,7 @@ export function useEarnActions(deps: {
         persistenceState: "recorded",
       });
       withdrawTrackerRef.current = null;
+      fullWithdrawalConfirmedSlotRef.current = null;
       earnToast.success("Policies closed");
       return true;
     } catch (error) {

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -559,6 +559,7 @@ export type PreparedEarnUsdcCleanup = SmartAccountPreparedEarnUsdcCleanup & {
 };
 
 export type EarnCleanupRequest = {
+  minContextSlot?: string;
   onWalletSubmitted?: () => void;
   observabilityFlowId?: string;
   preparedCleanup?: PreparedEarnUsdcCleanup;
@@ -1957,13 +1958,21 @@ export async function prepareEarnWithdrawOnServer(args: {
 }
 
 export async function prepareEarnCleanupOnServer(
-  args: { fetchImpl?: typeof fetch; observabilityFlowId?: string } = {}
+  args: {
+    fetchImpl?: typeof fetch;
+    minContextSlot?: string;
+    observabilityFlowId?: string;
+  } = {}
 ): Promise<PreparedEarnUsdcCleanup> {
   const fetchImpl = args.fetchImpl ?? fetch;
   const response = await fetchImpl(
     "/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare",
     {
-      body: JSON.stringify({}),
+      body: JSON.stringify({
+        ...(args.minContextSlot
+          ? { minContextSlot: args.minContextSlot }
+          : {}),
+      }),
       credentials: "include",
       headers: observabilityJsonHeaders(args.observabilityFlowId),
       method: "POST",
@@ -7409,7 +7418,11 @@ export function useSmartAccountSidebarData(
       setIsActionPending(true);
       try {
         const preparedCleanup =
-          request.preparedCleanup ?? (await prepareEarnCleanupOnServer());
+          request.preparedCleanup ??
+          (await prepareEarnCleanupOnServer({
+            minContextSlot: request.minContextSlot,
+            observabilityFlowId: request.observabilityFlowId,
+          }));
         const autodepositClosePrepared =
           preparedCleanup.autodepositClosePrepared ?? null;
         let autodepositCloseSignature: string | undefined;

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -1969,9 +1969,7 @@ export async function prepareEarnCleanupOnServer(
     "/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare",
     {
       body: JSON.stringify({
-        ...(args.minContextSlot
-          ? { minContextSlot: args.minContextSlot }
-          : {}),
+        ...(args.minContextSlot ? { minContextSlot: args.minContextSlot } : {}),
       }),
       credentials: "include",
       headers: observabilityJsonHeaders(args.observabilityFlowId),
@@ -7192,7 +7190,13 @@ export function useSmartAccountSidebarData(
         return { success: false, error: "Amount must be greater than 0." };
       }
 
-      const walletBridge = createWalletAdapterBridge(wallet);
+      // Keep the signed bytes in the app and broadcast them through the same
+      // RPC connection used for confirmation. An extension-owned
+      // sendTransaction() can return a signature without giving us the exact
+      // signed blockhash or a transaction we can safely rebroadcast.
+      const walletBridge = createWalletAdapterBridge(wallet, {
+        signThenSendRaw: true,
+      });
       if (!walletBridge) {
         return {
           success: false,
@@ -7405,7 +7409,9 @@ export function useSmartAccountSidebarData(
         };
       }
 
-      const walletBridge = createWalletAdapterBridge(wallet);
+      const walletBridge = createWalletAdapterBridge(wallet, {
+        signThenSendRaw: true,
+      });
       if (!walletBridge) {
         return {
           success: false,

--- a/apps/web/src/lib/core/database.ts
+++ b/apps/web/src/lib/core/database.ts
@@ -2,13 +2,31 @@ import "server-only";
 
 import { createNeonDb, type NeonDb } from "@loyal-labs/db-adapter-neon";
 import * as schema from "@loyal-labs/db-core/schema";
+import { drizzle as drizzlePostgres } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
 
 import { getServerEnv } from "./config/server";
 
 let db: NeonDb<typeof schema> | null = null;
 
+const LOCAL_APP_DATABASE_URL_ENV_NAME = "APP_LOCAL_DATABASE_URL";
+
 export function getDatabase(): NeonDb<typeof schema> {
   if (db) {
+    return db;
+  }
+
+  const localDatabaseUrl = process.env[LOCAL_APP_DATABASE_URL_ENV_NAME]?.trim();
+  if (localDatabaseUrl) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        `${LOCAL_APP_DATABASE_URL_ENV_NAME} is development-only.`
+      );
+    }
+    const localClient = postgres(localDatabaseUrl, { max: 1 });
+    db = drizzlePostgres(localClient, { schema }) as unknown as NeonDb<
+      typeof schema
+    >;
     return db;
   }
 

--- a/apps/web/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -1943,6 +1943,113 @@ export async function recordConfirmedAutodepositTokenApproval(
   return target;
 }
 
+// Released clients still call setup confirmation after the transaction lands.
+// Persist only the user's configuration. LaserStream owns chain_status,
+// signatures, observed slots, policy rows, and delegation projection.
+export async function recordAutodepositSetupIntent(
+  input: ConfirmedEarnAutodepositSetupInput,
+  dependencies: EarnAutodepositRepositoryDependencies = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  assertSetupHasPolicy(input);
+  const { client } = dependencies;
+  const now = dependencies.now();
+  const existing = await findTargetForAutodepositSetup({
+    client,
+    policyAccount: input.policyAccount,
+    recurringDelegation: input.recurringDelegation,
+  });
+  if (existing) {
+    assertTargetCanResumeAutodepositSetup(existing, input);
+    if (existing.lifecycleStatus === "closed") {
+      throw new Error(
+        "Closed autodeposit targets cannot be reactivated. Create a new autodeposit policy with a new policy seed."
+      );
+    }
+  }
+
+  const intentInsert = {
+    ...targetValuesFromSetup(input, null, now, true, "pending_policy" as const),
+    chainObservationSlot: BigInt(0),
+    lastSeenSignature: `intent:${input.policyAccount}`,
+    lastSeenSlot: BigInt(0),
+    lifecycleStatus: "pending",
+    policyConfirmedSlot: null,
+    policySignature: null,
+    recurringDelegationConfirmedSlot: null,
+    recurringDelegationSignature: null,
+  };
+  const [target] = await client.db
+    .insert(balanceSweepTargets)
+    .values(intentInsert)
+    .onConflictDoUpdate({
+      target: [balanceSweepTargets.policyAccount],
+      set: {
+        active: true,
+        maxAmountPerPeriod: input.amountPerPeriodRaw,
+        periodLengthSeconds: input.periodLengthSeconds,
+        recurringDelegationExpiryTimestamp: input.expiryTimestamp,
+        recurringDelegationNonce: input.nonce,
+        startTimestamp: input.startTimestamp,
+        walletBalanceFloorRaw: input.walletBalanceFloorRaw,
+      },
+    })
+    .returning();
+
+  if (!target) {
+    throw new Error("Failed to record autodeposit setup intent.");
+  }
+  return target;
+}
+
+// Closing Autodeposit changes the user's desired state immediately. The chain
+// projector records whether the policy and delegation actually closed.
+export async function recordAutodepositCloseIntent(
+  input: ConfirmedEarnAutodepositCloseInput,
+  dependencies: EarnAutodepositRepositoryDependencies = createDependencies()
+): Promise<BalanceSweepTargetRecord> {
+  const { client } = dependencies;
+  const now = dependencies.now();
+  const existing = await findTargetByPolicy({
+    client,
+    policyAccount: input.policyAccount,
+  });
+  if (!existing) {
+    throw new Error("Autodeposit target does not exist.");
+  }
+  if (
+    existing.settings !== input.settings ||
+    existing.wallet !== input.walletAddress ||
+    existing.vaultIndex !== input.vaultIndex ||
+    existing.vaultPubkey !== input.vaultPubkey
+  ) {
+    throw new Error("Autodeposit close target does not match the wallet.");
+  }
+  if (!existing.delegatedSigners.includes(input.delegatedSigner)) {
+    throw new Error("Autodeposit close signer does not match target policy.");
+  }
+  if (
+    existing.recurringDelegation &&
+    existing.recurringDelegation !== input.recurringDelegation
+  ) {
+    throw new Error("Autodeposit recurring delegation does not match target.");
+  }
+
+  await cancelScheduledAutodepositTransactionsForClose({
+    client,
+    now,
+    targetId: existing.id,
+  });
+  const [target] = await client.db
+    .update(balanceSweepTargets)
+    .set({ active: false })
+    .where(eq(balanceSweepTargets.id, existing.id))
+    .returning();
+  if (!target) {
+    throw new Error("Failed to record autodeposit close intent.");
+  }
+  return target;
+}
+
 export async function recordClosedAutodepositTarget(
   input: ConfirmedEarnAutodepositCloseInput,
   dependencies: EarnAutodepositRepositoryDependencies = createDependencies()
@@ -2786,8 +2893,7 @@ export async function activateAutodepositTargetWithBackfilledSetup(
   const policyConfirmedSlot =
     existing.policyConfirmedSlot ?? input.policyConfirmedSlot;
   const recurringDelegationSignature =
-    existing.recurringDelegationSignature ??
-    input.recurringDelegationSignature;
+    existing.recurringDelegationSignature ?? input.recurringDelegationSignature;
   const recurringDelegationConfirmedSlot =
     existing.recurringDelegationConfirmedSlot ??
     input.recurringDelegationConfirmedSlot;

--- a/apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { serializeVerifiedDepositPosition } = await import(
+  "./earn-deposit-confirm.server"
+);
+const { serializeVerifiedWithdrawPosition } = await import(
+  "./earn-withdraw-confirm.server"
+);
+const { recordAutodepositCloseIntent, recordAutodepositSetupIntent } =
+  await import("./earn-autodeposit-repository.server");
+
+const now = new Date("2026-08-25T12:00:00.000Z");
+
+function depositInput() {
+  return {
+    cluster: "mainnet-beta",
+    confirmedSlot: BigInt(441610901),
+    delegatedSigner: "delegate",
+    depositMint: "mint",
+    depositSignature: "deposit-signature",
+    liquidityMint: "mint",
+    market: "market",
+    policyAccount: "policy",
+    policyConfirmedSlot: BigInt(441610800),
+    policyId: BigInt(7),
+    policyInitialization: "reuse" as const,
+    policySeed: BigInt(7),
+    policySignature: "policy-signature",
+    principalAmountRaw: BigInt(1_000_000),
+    settings: "settings",
+    smartAccountAddress: "vault",
+    targetReserve: "reserve",
+    targetSupplyApyBps: BigInt(500),
+    vaultIndex: 1,
+    vaultPubkey: "vault",
+    walletAddress: "wallet",
+  };
+}
+
+function withdrawalInput() {
+  return {
+    cluster: "mainnet-beta",
+    confirmedSlot: BigInt(441610901),
+    delegatedSigner: "delegate",
+    liquidityMint: "mint",
+    market: "market",
+    mode: "full" as const,
+    policyAccount: "policy",
+    policyId: BigInt(7),
+    policySeed: BigInt(7),
+    settings: "settings",
+    smartAccountAddress: "vault",
+    sourceAmountRaw: BigInt(1_000_000),
+    targetReserve: "reserve",
+    vaultIndex: 1,
+    vaultPubkey: "vault",
+    walletAddress: "wallet",
+    withdrawalSignature: "withdrawal-signature",
+    withdrawnAmountRaw: BigInt(1_000_000),
+  };
+}
+
+function autodepositSetupInput() {
+  return {
+    amountPerPeriodRaw: BigInt(1_000_000),
+    cluster: "mainnet-beta",
+    confirmedSlot: BigInt(441610901),
+    delegatedSigner: "delegate",
+    expiryTimestamp: BigInt(1_800_000_000),
+    liquidityMint: "mint",
+    nonce: BigInt(3),
+    periodLengthSeconds: BigInt(2_592_000),
+    policyAccount: "policy",
+    policyId: BigInt(9),
+    policySeed: BigInt(9),
+    recurringDelegation: "recurring",
+    settings: "settings",
+    setupSignature: "setup-signature",
+    setupStage: "create_policy" as const,
+    startTimestamp: BigInt(1_700_000_000),
+    subscriptionAuthority: "subscription",
+    subscriptionAuthorityInitialization: "exists" as const,
+    subscriptionDelegatee: "vault",
+    vaultIndex: 1 as const,
+    vaultPubkey: "vault",
+    vaultUsdcAta: "vault-ata",
+    walletAddress: "wallet",
+    walletBalanceFloorRaw: BigInt(500_000),
+    walletUsdcAta: "wallet-ata",
+  };
+}
+
+function makeSelect(result: unknown[]) {
+  return () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => result,
+      }),
+    }),
+  });
+}
+
+describe("single-writer compatibility responses", () => {
+  test("deposit response retains the released position shape without a database row", () => {
+    expect(serializeVerifiedDepositPosition(depositInput(), now)).toEqual({
+      currentHolding: {
+        amountRaw: "1000000",
+        liquidityMint: "mint",
+        market: "market",
+        observedAt: now.toISOString(),
+        observedSlot: "441610901",
+        provenance: {
+          lastHoldingEventId: null,
+          lastRebalanceDecisionId: null,
+        },
+        reserve: "reserve",
+      },
+      id: "deposit-signature",
+      initialHolding: {
+        liquidityMint: "mint",
+        market: "market",
+        reserve: "reserve",
+        supplyApyBps: "500",
+      },
+      principalAmountRaw: "1000000",
+      status: "active",
+    });
+  });
+
+  test("full withdrawal response is determined by verified action, not projection timing", () => {
+    const first = serializeVerifiedWithdrawPosition(withdrawalInput(), now);
+    const replay = serializeVerifiedWithdrawPosition(withdrawalInput(), now);
+    expect(replay).toEqual(first);
+    expect(first).toMatchObject({
+      currentHolding: { amountRaw: "0", observedSlot: "441610901" },
+      currentTotalAmountRaw: "0",
+      id: "withdrawal-signature",
+      principalAmountRaw: "0",
+      status: "active",
+    });
+  });
+});
+
+describe("Autodeposit intent ownership", () => {
+  test("setup upsert changes intent fields without updating projected fields", async () => {
+    let inserted: Record<string, unknown> | null = null;
+    let conflictSet: Record<string, unknown> | null = null;
+    const target = { id: BigInt(1), ...autodepositSetupInput() };
+    const db = {
+      select: makeSelect([]),
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          inserted = values;
+          return {
+            onConflictDoUpdate: (args: { set: Record<string, unknown> }) => {
+              conflictSet = args.set;
+              return { returning: async () => [target] };
+            },
+          };
+        },
+      }),
+    };
+
+    await recordAutodepositSetupIntent(autodepositSetupInput(), {
+      client: { db },
+      now: () => now,
+    } as never);
+
+    expect(inserted).toMatchObject({
+      active: true,
+      chainObservationSlot: BigInt(0),
+      lastSeenSlot: BigInt(0),
+      lifecycleStatus: "pending",
+      policyConfirmedSlot: null,
+      policySignature: null,
+      recurringDelegationConfirmedSlot: null,
+      recurringDelegationSignature: null,
+      walletBalanceFloorRaw: BigInt(500_000),
+    });
+    expect(conflictSet as Record<string, unknown> | null).toEqual({
+      active: true,
+      maxAmountPerPeriod: BigInt(1_000_000),
+      periodLengthSeconds: BigInt(2_592_000),
+      recurringDelegationExpiryTimestamp: BigInt(1_800_000_000),
+      recurringDelegationNonce: BigInt(3),
+      startTimestamp: BigInt(1_700_000_000),
+      walletBalanceFloorRaw: BigInt(500_000),
+    });
+  });
+
+  test("close updates desired active and scheduling only", async () => {
+    const existing = {
+      ...autodepositSetupInput(),
+      active: true,
+      delegatedSigners: ["delegate"],
+      id: BigInt(1),
+      lifecycleStatus: "active",
+      recurringDelegation: "recurring",
+      wallet: "wallet",
+    };
+    let updateSet: Record<string, unknown> | null = null;
+    const db = {
+      execute: async () => ({ rows: [] }),
+      select: makeSelect([existing]),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updateSet = values;
+          return {
+            where: () => ({
+              returning: async () => [{ ...existing, ...values }],
+            }),
+          };
+        },
+      }),
+    };
+
+    await recordAutodepositCloseIntent(
+      {
+        closeSignature: "close-signature",
+        cluster: "mainnet-beta",
+        confirmedSlot: BigInt(441610902),
+        delegatedSigner: "delegate",
+        policyAccount: "policy",
+        recurringDelegation: "recurring",
+        settings: "settings",
+        vaultIndex: 1,
+        vaultPubkey: "vault",
+        walletAddress: "wallet",
+      },
+      { client: { db }, now: () => now } as never
+    );
+
+    expect(updateSet as Record<string, unknown> | null).toEqual({
+      active: false,
+    });
+  });
+});

--- a/apps/web/src/lib/yield-optimization/earn-deposit-confirm.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-deposit-confirm.server.ts
@@ -21,21 +21,15 @@ import {
   assertSafeEarnReserveMetadata,
   findEarnReserveTargetIneligibility,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
-import {
-  markEarnDepositOnboardingAccountingFailed,
-  markEarnDepositOnboardingComplete,
-  recordEarnDepositOnboardingDepositSignature,
-  recordConfirmedYieldDeposit,
-  type ConfirmedYieldDepositInput,
-  type UserYieldPositionRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import { type ConfirmedYieldDepositInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Shared core of the Earn deposit "confirm" step. Both the session-authed web
 // route (`yield-optimization/deposits/confirm`) and the wallet-signed mobile
-// route (`mobile/earn/deposit/confirm`) call `recordConfirmedEarnDeposit` so the
+// route (`mobile/earn/deposit/confirm`) call `verifyConfirmedEarnDeposit` so the
 // security-critical canonicalization + on-chain slot verification can never
-// drift between surfaces. The caller supplies the authenticated principal (from
-// a session or a verified wallet signature); this module owns everything after.
+// drift between surfaces. Finalized LaserStream projection is the sole writer of
+// Earn policy, deposit, holding, and position state. This compatibility endpoint
+// verifies and acknowledges released-client requests without racing that writer.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
 
 const connectionCache = new Map<SolanaEnv, Connection>();
@@ -104,7 +98,9 @@ export type EarnDepositConfirmPrincipal = {
   settingsPda: string;
 };
 
-export type SerializedYieldPosition = ReturnType<typeof serializePosition>;
+export type SerializedYieldPosition = ReturnType<
+  typeof serializeVerifiedDepositPosition
+>;
 
 function getConfiguredSolanaEnv(): SolanaEnv {
   return resolveLoyalWebSolanaEnvFromEnv(process.env);
@@ -391,8 +387,7 @@ function getConnection(cluster: SolanaEnv): Connection {
     return cached;
   }
 
-  const { rpcEndpoint, websocketEndpoint } =
-    getServerSolanaEndpoints(cluster);
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(cluster);
   const connection = new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
@@ -521,37 +516,39 @@ async function resolveConfirmedDepositTransactionProof(args: {
   return { principalAmountRaw };
 }
 
-function serializePosition(position: UserYieldPositionRecord) {
+export function serializeVerifiedDepositPosition(
+  input: ConfirmedYieldDepositInput,
+  verifiedAt = new Date()
+) {
   return {
     currentHolding: {
-      amountRaw: position.currentAmountRaw.toString(),
-      liquidityMint: position.currentLiquidityMint,
-      market: position.currentMarket,
-      observedAt: position.currentObservedAt.toISOString(),
-      observedSlot: position.currentObservedSlot.toString(),
+      amountRaw: input.principalAmountRaw.toString(),
+      liquidityMint: input.liquidityMint,
+      market: input.market,
+      observedAt: verifiedAt.toISOString(),
+      observedSlot: input.confirmedSlot.toString(),
       provenance: {
-        lastHoldingEventId: position.lastHoldingEventId?.toString() ?? null,
-        lastRebalanceDecisionId:
-          position.lastRebalanceDecisionId?.toString() ?? null,
+        lastHoldingEventId: null,
+        lastRebalanceDecisionId: null,
       },
-      reserve: position.currentReserve,
+      reserve: input.targetReserve,
     },
-    id: position.id.toString(),
+    id: input.depositSignature,
     initialHolding: {
-      liquidityMint: position.initialLiquidityMint,
-      market: position.initialMarket,
-      reserve: position.initialReserve,
-      supplyApyBps: position.initialSupplyApyBps?.toString() ?? null,
+      liquidityMint: input.liquidityMint,
+      market: input.market,
+      reserve: input.targetReserve,
+      supplyApyBps: input.targetSupplyApyBps?.toString() ?? null,
     },
-    principalAmountRaw: position.principalAmountRaw.toString(),
-    status: position.status,
+    principalAmountRaw: input.principalAmountRaw.toString(),
+    status: "active" as const,
   };
 }
 
 // Validates a confirmed Earn deposit against the authenticated principal and
-// the on-chain transaction status, then records the position. Throws
+// the on-chain transaction status. Throws
 // `EarnDepositConfirmError` (status + code) on any rejection.
-export async function recordConfirmedEarnDeposit(args: {
+export async function verifyConfirmedEarnDeposit(args: {
   principal: EarnDepositConfirmPrincipal;
   input: ConfirmedYieldDepositInput;
 }): Promise<SerializedYieldPosition> {
@@ -673,7 +670,10 @@ export async function recordConfirmedEarnDeposit(args: {
           error instanceof Error
             ? error.message
             : "Route policy setup transaction is not confirmed.",
-        context: { ...rejectionContext, policySignature: input.policySignature },
+        context: {
+          ...rejectionContext,
+          policySignature: input.policySignature,
+        },
       });
     }
 
@@ -709,82 +709,25 @@ export async function recordConfirmedEarnDeposit(args: {
     }
 
     if (input.setupPolicyConfirmedSlot !== setupPolicyConfirmedSlot) {
-      console.warn("[earn-deposit-confirm] corrected client setup policy slot", {
-        ...rejectionContext,
-        clientSlot: input.setupPolicyConfirmedSlot?.toString() ?? null,
-        resolvedSlot: setupPolicyConfirmedSlot.toString(),
-      });
+      console.warn(
+        "[earn-deposit-confirm] corrected client setup policy slot",
+        {
+          ...rejectionContext,
+          clientSlot: input.setupPolicyConfirmedSlot?.toString() ?? null,
+          resolvedSlot: setupPolicyConfirmedSlot.toString(),
+        }
+      );
       input = { ...input, setupPolicyConfirmedSlot };
     }
   }
 
-  try {
-    await recordEarnDepositOnboardingDepositSignature(input);
-  } catch (error) {
-    console.warn("[earn-deposit-confirm] failed to record onboarding deposit", {
-      depositSignature: input.depositSignature,
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown record error.",
-      errorName: error instanceof Error ? error.name : typeof error,
-      settings: input.settings,
-      walletAddress: input.walletAddress,
-    });
-  }
-
-  let position: UserYieldPositionRecord;
-  try {
-    position = await recordConfirmedYieldDeposit(input);
-  } catch (error) {
-    console.error("[earn-deposit-confirm] record failed", {
-      amountRaw: input.principalAmountRaw.toString(),
-      cluster: input.cluster,
-      depositSignature: input.depositSignature,
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown record error.",
-      errorName: error instanceof Error ? error.name : typeof error,
-      policyAccount: input.policyAccount,
-      policyInitialization: input.policyInitialization,
-      policySeed: input.policySeed.toString(),
-      settings: input.settings,
-      stack: error instanceof Error ? error.stack : undefined,
-      walletAddress: input.walletAddress,
-    });
-    await markEarnDepositOnboardingAccountingFailed(
-      input,
-      "record_failed"
-    ).catch((markError) => {
-      console.warn("[earn-deposit-confirm] failed to mark accounting failure", {
-        depositSignature: input.depositSignature,
-        errorMessage:
-          markError instanceof Error
-            ? markError.message
-            : "Unknown mark error.",
-        errorName:
-          markError instanceof Error ? markError.name : typeof markError,
-        settings: input.settings,
-        walletAddress: input.walletAddress,
-      });
-    });
-    throw new EarnDepositConfirmError({
-      status: 409,
-      code: "record_failed",
-      message:
-        error instanceof Error
-          ? error.message
-          : "Failed to record confirmed earn deposit.",
-    });
-  }
-
-  await markEarnDepositOnboardingComplete(input).catch((error) => {
-    console.warn("[earn-deposit-confirm] failed to mark onboarding complete", {
-      depositSignature: input.depositSignature,
-      errorMessage:
-        error instanceof Error ? error.message : "Unknown mark error.",
-      errorName: error instanceof Error ? error.name : typeof error,
-      settings: input.settings,
-      walletAddress: input.walletAddress,
-    });
+  console.info("[earn-deposit-confirm] verified for LaserStream projection", {
+    cluster: input.cluster,
+    confirmedSlot: input.confirmedSlot.toString(),
+    depositSignature: input.depositSignature,
+    settings: input.settings,
+    walletAddress: input.walletAddress,
   });
 
-  return serializePosition(position);
+  return serializeVerifiedDepositPosition(input);
 }

--- a/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
@@ -115,6 +115,35 @@ function createInput() {
 }
 
 describe("Earn full-exit zero proof", () => {
+  test("fills a confirmation-only policy reference from the canonical Earn universe", async () => {
+    const fetchHoldingsSnapshot = mock(
+      async (input: { policy: Record<string, unknown> }) => {
+        expect(input.policy.stableMints).toEqual(
+          expect.arrayContaining([
+            cashMint.toBase58(),
+            usdcMint.toBase58(),
+            usdtMint.toBase58(),
+          ])
+        );
+        expect(input.policy.kaminoLiquidityMints).toEqual(
+          input.policy.stableMints
+        );
+        expect(Array.isArray(input.policy.kaminoMarkets)).toBe(true);
+        expect((input.policy.kaminoMarkets as string[]).length).toBeGreaterThan(
+          0
+        );
+        return createHoldingsSnapshot([]);
+      }
+    );
+
+    const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+      fetchHoldingsSnapshot: fetchHoldingsSnapshot as never,
+      fetchVaultSnapshot: async () => createVaultSnapshot({}),
+    });
+
+    expect(proof.status).toBe("policy_close_required");
+  });
+
   test("keeps closure blocked when a second policy reserve is still positive", async () => {
     const secondReserve = new PublicKey(
       "11111111111111111111111111111119"

--- a/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import type { LoyalCluster } from "@loyal-labs/actions";
+import {
+  getRiskBasketMarketsForCluster,
+  type LoyalCluster,
+  RiskBasket,
+} from "@loyal-labs/actions";
 import {
   createSmartAccountVaultsClient,
   type SmartAccountEarnVaultRefundSnapshot,
@@ -50,6 +54,25 @@ type EarnFullExitZeroProofDependencies = {
   }) => Promise<SmartAccountEarnVaultRefundSnapshot>;
   sleep?: (milliseconds: number) => Promise<void>;
 };
+
+function resolveFullExitPolicyMetadata(args: {
+  cluster: LoyalCluster;
+  policy: EarnRpcPolicyMetadata;
+}): EarnRpcPolicyMetadata {
+  const canonicalMints = getEarnProductAssetsForCluster(args.cluster).map(
+    (asset) => asset.mint.toBase58()
+  );
+  return {
+    ...args.policy,
+    kaminoLiquidityMints: args.policy.kaminoLiquidityMints ?? canonicalMints,
+    kaminoMarkets:
+      args.policy.kaminoMarkets ??
+      getRiskBasketMarketsForCluster(args.cluster, RiskBasket.Safe).map(
+        (market) => market.toBase58()
+      ),
+    stableMints: args.policy.stableMints ?? canonicalMints,
+  };
+}
 
 function isMinContextSlotError(error: unknown): boolean {
   if (
@@ -225,6 +248,10 @@ export async function verifyEarnFullExitZeroBalances(
       new Promise<void>((resolve) => {
         setTimeout(resolve, milliseconds);
       }));
+  const policy = resolveFullExitPolicyMetadata({
+    cluster: args.cluster,
+    policy: args.policy,
+  });
 
   const [holdingsSnapshot, vaultSnapshot] = await readWithSlotLagRetry({
     read: () =>
@@ -233,7 +260,7 @@ export async function verifyEarnFullExitZeroBalances(
           cluster: args.cluster,
           connection: args.connection,
           minContextSlot: args.minContextSlot,
-          policy: args.policy,
+          policy,
           programId: args.programId,
           requireCompleteReserveReads: true,
           settingsPda: args.settingsPda,

--- a/apps/web/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-withdraw-confirm.server.ts
@@ -20,15 +20,7 @@ import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { pollRpcRead } from "@/lib/yield-optimization/earn-deposit-confirm.server";
 import { verifyEarnFullExitZeroBalances } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
 import { resolveEarnProductAsset } from "@/lib/yield-optimization/earn-product-mints.shared";
-import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
-import {
-  findEarnCleanupVaultState,
-  findReconciledActiveYieldPositionForVault,
-  recordConfirmedYieldWithdrawal,
-  type ConfirmedYieldWithdrawalInput,
-  type UserYieldPositionRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
-import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
+import { type ConfirmedYieldWithdrawalInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 import {
   applyConfirmedWithdrawalTransactionProof,
   type ConfirmedWithdrawalTransactionProof,
@@ -516,31 +508,40 @@ async function resolveConfirmedSignatureSlot(args: {
   return slot;
 }
 
-export function serializeWithdrawPosition(position: UserYieldPositionRecord) {
+export function serializeVerifiedWithdrawPosition(
+  input: ConfirmedYieldWithdrawalInput,
+  verifiedAt = new Date()
+) {
+  const sourceAmountRaw = input.sourceAmountRaw ?? input.withdrawnAmountRaw;
+  const currentAmountRaw =
+    input.mode === "full" && input.isFinalStep !== false
+      ? BigInt(0)
+      : sourceAmountRaw > input.withdrawnAmountRaw
+      ? sourceAmountRaw - input.withdrawnAmountRaw
+      : BigInt(0);
   return {
     currentHolding: {
-      amountRaw: position.currentAmountRaw.toString(),
-      liquidityMint: position.currentLiquidityMint,
-      market: position.currentMarket,
-      observedAt: position.currentObservedAt.toISOString(),
-      observedSlot: position.currentObservedSlot.toString(),
+      amountRaw: currentAmountRaw.toString(),
+      liquidityMint: input.liquidityMint,
+      market: input.market,
+      observedAt: verifiedAt.toISOString(),
+      observedSlot: input.confirmedSlot.toString(),
       provenance: {
-        lastHoldingEventId: position.lastHoldingEventId?.toString() ?? null,
-        lastRebalanceDecisionId:
-          position.lastRebalanceDecisionId?.toString() ?? null,
+        lastHoldingEventId: null,
+        lastRebalanceDecisionId: null,
       },
-      reserve: position.currentReserve,
+      reserve: input.targetReserve,
     },
-    id: position.id.toString(),
+    id: input.withdrawalSignature,
     initialHolding: {
-      liquidityMint: position.initialLiquidityMint,
-      market: position.initialMarket,
-      reserve: position.initialReserve,
-      supplyApyBps: position.initialSupplyApyBps?.toString() ?? null,
+      liquidityMint: input.liquidityMint,
+      market: input.market,
+      reserve: input.targetReserve,
+      supplyApyBps: null,
     },
-    currentTotalAmountRaw: position.currentAmountRaw.toString(),
-    principalAmountRaw: position.principalAmountRaw.toString(),
-    status: position.status,
+    currentTotalAmountRaw: currentAmountRaw.toString(),
+    principalAmountRaw: currentAmountRaw.toString(),
+    status: "active" as const,
   };
 }
 
@@ -555,7 +556,7 @@ export type EarnWithdrawConfirmationResult = {
     amountRaw: string;
     mint: string;
   }>;
-  position: ReturnType<typeof serializeWithdrawPosition>;
+  position: ReturnType<typeof serializeVerifiedWithdrawPosition>;
   remainingHoldings: Array<{
     amountRaw: string;
     kind: "idle" | "kamino";
@@ -574,10 +575,9 @@ function toSafeContextSlot(slot: bigint): number {
   return value;
 }
 
-// Validates + records a confirmed Earn withdrawal against the authenticated
-// principal. Throws `EarnWithdrawConfirmError` (with an HTTP status) on any
-// validation failure; returns the serialized post-withdrawal position.
-export async function recordConfirmedEarnWithdrawal(args: {
+// Validates a confirmed Earn withdrawal against the authenticated principal.
+// LaserStream is the only writer of the resulting Earn state.
+export async function verifyConfirmedEarnWithdrawal(args: {
   principal: EarnWithdrawConfirmPrincipal;
   input: ConfirmedYieldWithdrawalInput;
   solanaEnv: SolanaEnv;
@@ -679,72 +679,14 @@ export async function recordConfirmedEarnWithdrawal(args: {
     });
   }
 
-  let position: UserYieldPositionRecord;
-  try {
-    position = await recordConfirmedYieldWithdrawal(input);
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Confirmed yield withdrawal could not be recorded.";
-    if (
-      message.startsWith("Duplicate withdrawal ") ||
-      message.includes("Withdrawal source") ||
-      message.includes("Withdrawal target does not match") ||
-      message.includes("Withdrawal exceeds")
-    ) {
-      rejectWithdrawConfirm({
-        status: 409,
-        code: "withdrawal_conflict",
-        message,
-        context: {
-          settings: input.settings,
-          walletAddress: input.walletAddress,
-          withdrawalSignature: input.withdrawalSignature,
-        },
-      });
-    }
-
-    console.error("[earn-withdraw-confirm] record failed", {
-      cluster: input.cluster,
-      errorMessage: message,
-      errorName: error instanceof Error ? error.name : typeof error,
-      settings: input.settings,
-      signature: input.withdrawalSignature,
-      stack: error instanceof Error ? error.stack : undefined,
-      vaultIndex: input.vaultIndex,
-      walletAddress: input.walletAddress,
-    });
-    throw new EarnWithdrawConfirmError(500, "record_failed", message);
-  }
-
   const connection = getConnection(solanaEnv);
   const cluster = normalizeLoyalCluster(input.cluster);
+  const position = serializeVerifiedWithdrawPosition(input);
 
   if (input.mode !== "full") {
-    await reconcileEarnVaultPosition({
-      authority: input.walletAddress,
-      cluster,
-      connection,
-      force: true,
-      settings: input.settings,
-      vaultPubkey: input.vaultPubkey,
-    }).catch((error) => {
-      console.warn("[earn-withdraw-confirm] partial reconcile failed", {
-        cluster: input.cluster,
-        errorMessage:
-          error instanceof Error ? error.message : "Unknown reconcile error.",
-        errorName: error instanceof Error ? error.name : typeof error,
-        settings: input.settings,
-        signature: input.withdrawalSignature,
-        vaultIndex: input.vaultIndex,
-        walletAddress: input.walletAddress,
-      });
-    });
-
     return {
       blockingTokenAccounts: [],
-      position: serializeWithdrawPosition(position),
+      position,
       remainingHoldings: [],
       status: "withdrawal_recorded",
     };
@@ -753,7 +695,7 @@ export async function recordConfirmedEarnWithdrawal(args: {
   if (input.isFinalStep === false) {
     return {
       blockingTokenAccounts: [],
-      position: serializeWithdrawPosition(position),
+      position,
       remainingHoldings: [],
       status: "full_exit_incomplete",
     };
@@ -761,51 +703,27 @@ export async function recordConfirmedEarnWithdrawal(args: {
 
   try {
     const minContextSlot = toSafeContextSlot(input.confirmedSlot);
-    const cleanupState = await findEarnCleanupVaultState({
-      authority: input.walletAddress,
-      settings: input.settings,
-      vaultIndex: input.vaultIndex,
-      vaultPubkey: input.vaultPubkey,
-    });
-    if (!cleanupState) {
-      throw new Error(
-        "Active Earn policy state is unavailable for full-exit verification."
-      );
-    }
-
     const serverEnv = getServerEnv();
     const proof = await verifyEarnFullExitZeroBalances({
       cluster,
       connection,
       minContextSlot,
-      policy: serializeRoutePolicyState(
-        cleanupState.routePolicy,
-        cleanupState.setupPolicy
-      ),
+      policy: {
+        account: input.policyAccount,
+        seed: input.policySeed.toString(),
+        setupPolicy:
+          input.setupPolicyAccount && input.setupPolicySeed
+            ? {
+                account: input.setupPolicyAccount,
+                seed: input.setupPolicySeed.toString(),
+              }
+            : null,
+        vaultIndex: input.vaultIndex,
+        vaultPubkey: input.vaultPubkey,
+      },
       programId: new PublicKey(serverEnv.loyalSmartAccounts.programId),
       settingsPda: new PublicKey(input.settings),
     });
-    let reconciledPosition = position;
-    if (proof.status === "policy_close_required") {
-      await reconcileEarnVaultPosition({
-        authority: input.walletAddress,
-        cluster,
-        connection,
-        force: true,
-        minContextSlot: toSafeContextSlot(BigInt(proof.observedSlot)),
-        purpose: "post_withdrawal_zero_proof",
-        settings: input.settings,
-        vaultPubkey: input.vaultPubkey,
-      });
-      reconciledPosition =
-        (await findReconciledActiveYieldPositionForVault({
-          cluster,
-          settings: input.settings,
-          vaultIndex: input.vaultIndex,
-          walletAddress: input.walletAddress,
-        })) ?? position;
-    }
-
     console.info("[earn-withdraw-confirm] full exit verification", {
       blockingTokenAccountCount: proof.blockingTokenAccounts.length,
       cleanupTokenAccountCount: proof.cleanupTokenAccounts.length,
@@ -821,7 +739,7 @@ export async function recordConfirmedEarnWithdrawal(args: {
 
     return {
       blockingTokenAccounts: proof.blockingTokenAccounts,
-      position: serializeWithdrawPosition(reconciledPosition),
+      position,
       remainingHoldings: proof.remainingHoldings.map((holding) => ({
         amountRaw: holding.amountRaw,
         kind: holding.kind,

--- a/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -7,9 +7,7 @@ import {
 } from "@loyal-labs/smart-account-vaults";
 import { type Connection, PublicKey } from "@solana/web3.js";
 
-import { reconcileEarnVaultPosition } from "@/lib/yield-optimization/earn-position-reconciliation.server";
 import {
-  earnReserveTargetFromActivePosition,
   type EarnUsdcReserveTarget,
 } from "@/lib/yield-optimization/earn-reserve-target.server";
 import {
@@ -24,7 +22,6 @@ import type {
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import {
   findActiveYieldRoutePolicyPair,
-  findReconciledActiveYieldPositionForVault,
   type RoutePolicyRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
@@ -34,6 +31,11 @@ import {
 // the exact same input. Everything here is the decision "WHAT to withdraw";
 // the caller decides where the instruction build ("HOW") runs.
 const EARN_DEPOSIT_VAULT_INDEX = 1;
+const POLICY_PROJECTION_RETRY_DELAYS_MS = [0, 100, 250, 500, 1_000] as const;
+
+async function waitForPolicyProjection(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+}
 
 // Resolution failures the routes surface as specific HTTP responses rather
 // than a generic 500. Every rejection that describes the CALLER's state — no
@@ -411,61 +413,40 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     logTag,
   } = args;
   const settingsPdaKey = new PublicKey(settingsPda);
-  // Reconcile the DB position against the live on-chain Kamino obligation
-  // before deriving the withdrawal target — otherwise a stale snapshot points
-  // the withdraw at a reserve/market whose vanilla obligation doesn't exist
-  // (KLEND_OBLIGATION_NOT_FOUND). Mirrors the web `withdrawals/prepare` route.
-  await reconcileEarnVaultPosition({
-    authority: walletAddress,
-    cluster,
-    connection,
-    force: true,
-    settings: settingsPda,
-    vaultPubkey: earnVaultPda.toBase58(),
-  });
-  const [policyResult, position] = await Promise.all([
-    findActiveYieldRoutePolicyPair({
+  // Policy identity is durable setup metadata. The money position itself is
+  // derived from the live chain snapshot below, so a newly finalized deposit
+  // can be withdrawn before LaserStream has projected its aggregate row.
+  let policyResult: Awaited<ReturnType<typeof findActiveYieldRoutePolicyPair>> =
+    null;
+  for (const delayMs of POLICY_PROJECTION_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await waitForPolicyProjection(delayMs);
+    }
+    policyResult = await findActiveYieldRoutePolicyPair({
       authority: walletAddress,
       cluster,
       settings: settingsPda,
       vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
       vaultPubkey: earnVaultPda.toBase58(),
-    }),
-    findReconciledActiveYieldPositionForVault({
-      cluster,
-      settings: settingsPda,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      walletAddress,
-    }),
-  ]);
+    });
+    if (policyResult?.routePolicy) {
+      break;
+    }
+  }
   if (!policyResult?.routePolicy) {
-    console.warn(`[${logTag}] missing active Earn policy`, {
+    console.warn(`[${logTag}] Earn policy projection still pending`, {
       cluster,
       settings: settingsPda,
       vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
       walletAddress,
     });
     throw new EarnWithdrawResolveError(
-      409,
-      "missing_earn_policy",
-      "Set up the Earn policy before withdrawing."
+      503,
+      "earn_policy_projection_pending",
+      "The confirmed Earn policy is still updating. Retry this withdrawal."
     );
   }
   const policy = policyResult.routePolicy;
-
-  if (!position) {
-    console.warn(`[${logTag}] missing active Earn position`, {
-      cluster,
-      settings: settingsPda,
-      vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
-      walletAddress,
-    });
-    throw new EarnWithdrawResolveError(
-      409,
-      "missing_earn_position",
-      "No active Earn position was found for this withdrawal."
-    );
-  }
 
   const snapshot = await fetchEarnRpcHoldingsSnapshot({
     cluster,
@@ -520,8 +501,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     withdrawTarget =
       selectedSource.type === "reserve"
         ? reserveSourceWithdrawTarget(selectedSource)
-        : (snapshotReserveTarget(snapshot.holdings) ??
-          earnReserveTargetFromActivePosition(position, cluster));
+        : snapshotReserveTarget(snapshot.holdings);
   } else if (legacyRequest) {
     const selected = selectLegacyEarnWithdrawSource(
       snapshotSources,
@@ -547,8 +527,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     withdrawTarget =
       selected.type === "reserve"
         ? reserveSourceWithdrawTarget(selected)
-        : (snapshotReserveTarget(snapshot.holdings) ??
-          earnReserveTargetFromActivePosition(position, cluster));
+        : snapshotReserveTarget(snapshot.holdings);
   } else {
     if (args.sourceId === null) {
       throw new EarnWithdrawResolveError(

--- a/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -501,7 +501,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     withdrawTarget =
       selectedSource.type === "reserve"
         ? reserveSourceWithdrawTarget(selectedSource)
-        : snapshotReserveTarget(snapshot.holdings);
+        : (snapshotReserveTarget(snapshot.holdings) ?? undefined);
   } else if (legacyRequest) {
     const selected = selectLegacyEarnWithdrawSource(
       snapshotSources,
@@ -527,7 +527,7 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     withdrawTarget =
       selected.type === "reserve"
         ? reserveSourceWithdrawTarget(selected)
-        : snapshotReserveTarget(snapshot.holdings);
+        : (snapshotReserveTarget(snapshot.holdings) ?? undefined);
   } else {
     if (args.sourceId === null) {
       throw new EarnWithdrawResolveError(


### PR DESCRIPTION
## Goal

Keep released web and mobile Earn clients working while LaserStream remains the only writer of projected Earn money state. Also make web withdrawal submission deterministic when a wallet extension returns a signature whose transaction cannot later be found.

This fixes the production alert:

```
earn.withdrawal.backend_confirm.observed
loyal.error.code: backend_confirmation_failed
```

The user-facing API error was:

```
No active Earn position was found for this withdrawal.
```

The stuck web withdrawal reported:

```
Transaction 3trHZndGDX7r1bmEiVpi7D9MnGYLhx5iAW8ga5CTCpW2LbviM3ppH2wj7iEsBQQWxnJtW3kMYUebSyKF7esGAg8Y was submitted, but its confirmation is unresolved. Refresh chain state before retrying.: Signature 3trHZndGDX7r1bmEiVpi7D9MnGYLhx5iAW8ga5CTCpW2LbviM3ppH2wj7iEsBQQWxnJtW3kMYUebSyKF7esGAg8Y has expired: block height exceeded.
```

## What changed

Confirmation endpoints still authenticate the caller, validate canonical metadata, and verify confirmed transactions, but they no longer race LaserStream by writing or reconciling the same projected position.

Withdrawal preparation now reads live on-chain holdings instead of requiring an already-projected active-position row. If a newly confirmed policy has not reached the database yet, the API waits briefly and returns a retryable response instead of claiming that no Earn position exists.

Full-withdrawal confirmation previously received only the policy address/seed/vault reference from released clients. Its zero-balance proof then had no product-mint universe and failed with `Active Earn policy includes no supported product mint.` The verifier exposed this as a 503 from the real API. The API now fills missing released-client metadata from the canonical Earn mint and safe-market configuration, while preserving explicitly supplied policy metadata.

Current web cleanup sends the confirmed withdrawal slot. Released web bundles that send the old empty request remain supported: the API waits briefly for the projected full-withdrawal row and uses its confirmed slot, never slot zero.

Web withdrawal and cleanup now ask the wallet to sign, then broadcast the exact signed bytes through Loyal's configured RPC. This keeps the signed blockhash and confirmation RPC in the same flow instead of relying on extension-owned `sendTransaction` behavior.

The Android verifier now proxies the real loyal-app Earn prepare, confirm, cleanup-prepare, and cleanup-confirm routes. It also waits for asynchronous lifecycle delivery instead of assuming telemetry HTTP requests arrive in emission order.

## Scope

This PR changes loyal-app web/API behavior and verification code. It does not change product mobile UI/runtime behavior, loyal-yield-routing runtime code, or production database schema. loyal-yield-routing PR #124 is not required for this API deployment.

## Verification

- Earn single-writer verifier: 91/91 checks passed
- Focused behavioral tests: 48 passed, 0 failed
- Focused web changed-file lint passed
- Mobile Expo lint passed with 0 errors (9 pre-existing warnings outside this change)
- `git diff --check` passed
- Isolated Android + real local loyal-app API proof passed:
  - imported the generated wallet through the Android app
  - loaded Earn state from the real local API
  - built and signed the full withdrawal on-device
  - `withdraw/prepare-context` returned 200
  - `withdraw/confirm` returned 200
  - `withdraw/cleanup/prepare-context` returned 200
  - `withdraw/cleanup/confirm` returned 200 after the released-client auth fallback
  - projected mobile position changed from `4000000` to `0`
  - cleanup persistence was recorded and no global mobile error event was emitted
- The same isolated run passed web initial deposit, top-up, partial withdrawal, and their routing projections. Its final post-Android routing projection hit a verifier-only visibility race: the finalized routing reader received `getTransaction: null` immediately after the Android transaction confirmed. This happened after all loyal-app/mobile assertions above passed and does not change the PR's runtime behavior.

## Post-merge

Redeploy:

- Loyal web/API production deployment from `apps/web` on Vercel

No mobile OTA/native release or loyal-yield-routing redeploy is required. After deployment, verify the LaserStream Earn projector is healthy and canary one deposit, partial withdrawal, and full withdrawal cleanup.
