### PR TITLE
fix(autodeposit): validate bootstrap event ownership

### DIFF
--- a/apps/web/src/lib/yield-optimization/earn-autodeposit-event-id.shared.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autodeposit-event-id.shared.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX,
+  createBootstrapWalletBalanceEventId,
+  isAppAutodepositBootstrapEventSource,
+} from "./earn-autodeposit-event-id.shared";
+
+describe("createBootstrapWalletBalanceEventId", () => {
+  test("keeps App bootstrap events inside their reserved range", () => {
+    expect(createBootstrapWalletBalanceEventId(BigInt(1))).toBe(BigInt(-1));
+    expect(
+      createBootstrapWalletBalanceEventId(
+        APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX
+      )
+    ).toBe(-APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX);
+  });
+
+  test("recognizes bootstrap sources used by current and legacy mobile APIs", () => {
+    expect(
+      isAppAutodepositBootstrapEventSource(
+        "mobile_autodeposit_artifact_reconcile"
+      )
+    ).toBe(true);
+    expect(
+      isAppAutodepositBootstrapEventSource(
+        "laserstream_autodeposit_activation"
+      )
+    ).toBe(false);
+  });
+
+  test("rejects target IDs outside the reserved range", () => {
+    expect(() => createBootstrapWalletBalanceEventId(BigInt(0))).toThrow(
+      "outside the reserved App event ID range"
+    );
+    expect(() =>
+      createBootstrapWalletBalanceEventId(
+        APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX + BigInt(1)
+      )
+    ).toThrow("outside the reserved App event ID range");
+  });
+});

--- a/apps/web/src/lib/yield-optimization/earn-autodeposit-event-id.shared.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autodeposit-event-id.shared.ts
@@ -1,0 +1,24 @@
+export const APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX = BigInt("999999999999");
+
+export const APP_AUTODEPOSIT_BOOTSTRAP_EVENT_SOURCES = [
+  "app_autodeposit_artifact_reconcile",
+  "app_autodeposit_setup_confirm",
+  "mobile_autodeposit_artifact_reconcile",
+] as const;
+
+export function isAppAutodepositBootstrapEventSource(
+  source: string
+): boolean {
+  return APP_AUTODEPOSIT_BOOTSTRAP_EVENT_SOURCES.some(
+    (candidate) => candidate === source
+  );
+}
+
+export function createBootstrapWalletBalanceEventId(targetId: bigint): bigint {
+  if (targetId <= BigInt(0) || targetId > APP_AUTODEPOSIT_EVENT_TARGET_ID_MAX) {
+    throw new Error(
+      `Autodeposit target ID ${targetId.toString()} is outside the reserved App event ID range.`
+    );
+  }
+  return -targetId;
+}

--- a/apps/web/src/lib/yield-optimization/earn-autodeposit-load-state.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autodeposit-load-state.test.ts
@@ -236,11 +236,15 @@ function createFloorUpdateClient({
 }
 
 function createBootstrapClient({
+  conflictingEvent = null,
+  eventInserted = true,
   existingLot = null,
   existingProjection = [],
   insertedLot,
   scheduledSweep,
 }: {
+  conflictingEvent?: unknown | null;
+  eventInserted?: boolean;
   existingLot?: unknown | null;
   existingProjection?: unknown[];
   insertedLot?: unknown;
@@ -250,24 +254,19 @@ function createBootstrapClient({
   const executeSql: string[] = [];
   const insertValues: Record<string, unknown>[] = [];
   const slotId = BigInt(42);
-  let selectCallCount = 0;
-  const selectQuery = {
-    from() {
-      return selectQuery;
-    },
-    limit() {
-      selectCallCount += 1;
-      if (selectCallCount === 1) {
-        return existingProjection;
-      }
-      if (selectCallCount === 2) {
-        return existingLot ? [existingLot] : [];
-      }
-      return [];
-    },
-    where() {
-      return selectQuery;
-    },
+  const createSelectQuery = (rows: unknown[]) => {
+    const selectQuery = {
+      from() {
+        return selectQuery;
+      },
+      limit() {
+        return rows;
+      },
+      where() {
+        return selectQuery;
+      },
+    };
+    return selectQuery;
   };
   const insertQuery = {
     onConflictDoNothing() {
@@ -279,6 +278,9 @@ function createBootstrapClient({
     returning() {
       if (insertValues.length === 1) {
         return [insertValues[0]];
+      }
+      if (insertValues.length === 2 && eventInserted) {
+        return [insertValues[1]];
       }
       if (insertValues.length === 3 && insertedLot) {
         return [insertedLot];
@@ -304,8 +306,16 @@ function createBootstrapClient({
         insert() {
           return insertQuery;
         },
-        select() {
-          return selectQuery;
+        select(fields?: Record<string, unknown>) {
+          if (!fields || "amountRaw" in fields) {
+            return createSelectQuery(existingProjection);
+          }
+          if ("source" in fields && "targetId" in fields) {
+            return createSelectQuery(
+              conflictingEvent ? [conflictingEvent] : []
+            );
+          }
+          return createSelectQuery(existingLot ? [existingLot] : []);
         },
       },
     },
@@ -1457,6 +1467,94 @@ describe("Earn autodeposit load state", () => {
       sourceEventId: BigInt(-11),
       status: "open",
       targetId: BigInt(11),
+    });
+  });
+
+  test("legacy mobile setup cannot attach a bootstrap lot to a retained routing event", async () => {
+    const { scheduleBootstrapEarnAutodepositSweep } = await import(
+      "./earn-autodeposit-repository.server"
+    );
+    const { client, getInsertValues } = createBootstrapClient({
+      conflictingEvent: {
+        source: "laserstream_autodeposit_activation",
+        targetId: BigInt(1),
+      },
+      eventInserted: false,
+    });
+
+    await expect(
+      scheduleBootstrapEarnAutodepositSweep(
+        {
+          snapshot: {
+            accountDataHash: "hash",
+            amountRaw: BigInt(1_000_000_000),
+            mint: "mint",
+            observedAt: new Date("2026-06-16T00:00:00.000Z"),
+            observedSlot: BigInt(500),
+            owner: "wallet",
+            source: "app_autodeposit_setup_confirm",
+            sourceCommitment: "confirmed",
+          },
+          target: createRecord({
+            id: BigInt(2),
+            walletBalanceFloorRaw: BigInt(500_000_000),
+          }) as never,
+        },
+        {
+          client,
+          now: () => new Date("2026-06-16T00:05:00.000Z"),
+        } as never
+      )
+    ).rejects.toThrow(
+      "Autodeposit bootstrap event ID -2 for target 2 conflicts with target 1 from laserstream_autodeposit_activation."
+    );
+    expect(getInsertValues()).toHaveLength(2);
+  });
+
+  test("legacy mobile reconciliation can reuse its App-owned bootstrap event", async () => {
+    const { scheduleBootstrapEarnAutodepositSweep } = await import(
+      "./earn-autodeposit-repository.server"
+    );
+    const { client } = createBootstrapClient({
+      conflictingEvent: {
+        source: "mobile_autodeposit_artifact_reconcile",
+        targetId: BigInt(2),
+      },
+      eventInserted: false,
+      existingLot: {
+        id: BigInt(41),
+        scheduledSlotId: BigInt(42),
+        status: "suppressed",
+        targetId: BigInt(2),
+      },
+    });
+
+    const result = await scheduleBootstrapEarnAutodepositSweep(
+      {
+        snapshot: {
+          accountDataHash: "hash",
+          amountRaw: BigInt(1_000_000_000),
+          mint: "mint",
+          observedAt: new Date("2026-06-16T00:00:00.000Z"),
+          observedSlot: BigInt(500),
+          owner: "wallet",
+          source: "app_autodeposit_setup_confirm",
+          sourceCommitment: "confirmed",
+        },
+        target: createRecord({
+          id: BigInt(2),
+          walletBalanceFloorRaw: BigInt(500_000_000),
+        }) as never,
+      },
+      {
+        client,
+        now: () => new Date("2026-06-16T00:05:00.000Z"),
+      } as never
+    );
+
+    expect(result).toEqual({
+      reason: "bootstrap_sweep_already_closed",
+      status: "skipped",
     });
   });
 

--- a/apps/web/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-autodeposit-repository.server.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import { and, desc, eq, gte, inArray, ne, sql } from "drizzle-orm";
 
+import {
+  createBootstrapWalletBalanceEventId,
+  isAppAutodepositBootstrapEventSource,
+} from "./earn-autodeposit-event-id.shared";
 import type {
   ConfirmedEarnAutodepositCloseInput,
   ConfirmedEarnAutodepositSetupInput,
@@ -391,10 +395,6 @@ async function markSupersededAutodepositPolicyInactive(args: {
       lastSeenSlot: args.input.confirmedSlot,
     })
     .where(eq(balanceSweepPolicies.policyAccount, args.existing.policyAccount));
-}
-
-function createBootstrapWalletBalanceEventId(targetId: bigint): bigint {
-  return -targetId;
 }
 
 function addOneHour(date: Date): Date {
@@ -1072,6 +1072,12 @@ export async function scheduleBootstrapEarnAutodepositSweep(
   const { client } = dependencies;
   const now = dependencies.now();
   const { snapshot, target } = input;
+  const sourceEventId = createBootstrapWalletBalanceEventId(target.id);
+  if (!isAppAutodepositBootstrapEventSource(snapshot.source)) {
+    throw new Error(
+      `Autodeposit bootstrap source ${snapshot.source} cannot use the App event ID range.`
+    );
+  }
   const existingProjection = await client.db
     .select()
     .from(balanceSweepWalletBalancesCurrent)
@@ -1110,11 +1116,10 @@ export async function scheduleBootstrapEarnAutodepositSweep(
     };
   }
 
-  const sourceEventId = createBootstrapWalletBalanceEventId(target.id);
   const previousAmountRaw = existingProjection[0]?.amountRaw ?? null;
   const surplusRaw = snapshot.amountRaw - floorRaw;
 
-  await client.db
+  const insertedEvents = await client.db
     .insert(balanceSweepWalletBalanceEvents)
     .values({
       accountDataHash: snapshot.accountDataHash,
@@ -1144,7 +1149,31 @@ export async function scheduleBootstrapEarnAutodepositSweep(
     })
     .onConflictDoNothing({
       target: [balanceSweepWalletBalanceEvents.eventId],
-    });
+    })
+    .returning({ eventId: balanceSweepWalletBalanceEvents.eventId });
+
+  if (!insertedEvents[0]) {
+    const [conflictingEvent] = await client.db
+      .select({
+        source: balanceSweepWalletBalanceEvents.source,
+        targetId: balanceSweepWalletBalanceEvents.targetId,
+      })
+      .from(balanceSweepWalletBalanceEvents)
+      .where(eq(balanceSweepWalletBalanceEvents.eventId, sourceEventId))
+      .limit(1);
+    if (
+      !conflictingEvent ||
+      conflictingEvent.targetId !== target.id ||
+      !isAppAutodepositBootstrapEventSource(conflictingEvent.source)
+    ) {
+      const owner = conflictingEvent
+        ? `target ${conflictingEvent.targetId.toString()} from ${conflictingEvent.source}`
+        : "an event that could not be loaded";
+      throw new Error(
+        `Autodeposit bootstrap event ID ${sourceEventId.toString()} for target ${target.id.toString()} conflicts with ${owner}.`
+      );
+    }
+  }
 
   const [existingLot] = await client.db
     .select({
@@ -1152,11 +1181,17 @@ export async function scheduleBootstrapEarnAutodepositSweep(
       remainingAmountRaw: balanceSweepSurplusLots.remainingAmountRaw,
       scheduledSlotId: balanceSweepSurplusLots.scheduledSlotId,
       status: balanceSweepSurplusLots.status,
+      targetId: balanceSweepSurplusLots.targetId,
     })
     .from(balanceSweepSurplusLots)
     .where(eq(balanceSweepSurplusLots.sourceEventId, sourceEventId))
     .limit(1);
 
+  if (existingLot && existingLot.targetId !== target.id) {
+    throw new Error(
+      `Autodeposit bootstrap event ID ${sourceEventId.toString()} for target ${target.id.toString()} is linked to a lot for target ${existingLot.targetId.toString()}.`
+    );
+  }
   if (existingLot && existingLot.status === "open") {
     let slotId = existingLot.scheduledSlotId;
     if (!slotId) {
@@ -1254,11 +1289,17 @@ export async function scheduleBootstrapEarnAutodepositSweep(
       id: balanceSweepSurplusLots.id,
       scheduledSlotId: balanceSweepSurplusLots.scheduledSlotId,
       status: balanceSweepSurplusLots.status,
+      targetId: balanceSweepSurplusLots.targetId,
     })
     .from(balanceSweepSurplusLots)
     .where(eq(balanceSweepSurplusLots.sourceEventId, sourceEventId))
     .limit(1);
 
+  if (raceWinnerLot && raceWinnerLot.targetId !== target.id) {
+    throw new Error(
+      `Autodeposit bootstrap event ID ${sourceEventId.toString()} for target ${target.id.toString()} raced with a lot for target ${raceWinnerLot.targetId.toString()}.`
+    );
+  }
   if (raceWinnerLot?.status === "open") {
     const raceWinnerSlotId = raceWinnerLot.scheduledSlotId ?? slotId;
     if (!raceWinnerLot.scheduledSlotId) {


### PR DESCRIPTION
## Goal
Prevent App bootstrap events from silently reusing another producer's synthetic event ID. This is the App-side defense for the production alert: `duplicate key value violates unique constraint "balance_sweep_wallet_balance_events_pkey"`.

## Scope and implementation
The shared allocator reserves the App's `-targetId` range and rejects unsupported target IDs or sources. A conflicting insert now verifies that the existing event and any linked lot belong to the same target and an App-owned bootstrap source; otherwise bootstrap scheduling fails safely instead of associating another target's data.

Legacy mobile clients remain compatible: they use the existing mobile Autodeposit endpoints, do not send or consume event IDs, and the setup/state routes already contain bootstrap failures. Current and retired mobile reconciliation sources are explicitly accepted. The routing migration and cross-repository database contract are in loyal-labs/loyal-yield-routing#137.

## Verification
- `bun test src/lib/yield-optimization/earn-autodeposit-event-id.shared.test.ts src/lib/yield-optimization/earn-autodeposit-load-state.test.ts` (37 passed)
- `bun run lint` (passed with pre-existing warnings)
- `git diff --check`

## Post-merge
Deploy this guard before or alongside loyal-labs/loyal-yield-routing#137. No mobile release or client migration is required.
