### PR TITLE
fix(earn): recover partial withdrawals from Kamino rounding

### DIFF
--- a/apps/mobile/src/lib/solana/earn/__tests__/withdraw.test.ts
+++ b/apps/mobile/src/lib/solana/earn/__tests__/withdraw.test.ts
@@ -445,10 +445,13 @@ describe("executeEarnWithdraw", () => {
       ...context,
       withdrawInput: { ...context.withdrawInput, mode: "partial" },
     });
-    // A plain error from the SDK build is a bug or a rejected input, not a
-    // transport blip: connection-retry throws it through unretried.
-    const semanticError = new Error(
-      "Kamino withdrawal simulation produced less liquidity than requested.",
+    // A semantic SDK error is not a transport blip: connection-retry throws
+    // it through unretried even when it carries a stable telemetry code.
+    const semanticError = Object.assign(
+      new Error(
+        "Kamino withdrawal simulation produced less liquidity than requested.",
+      ),
+      { code: "earn_withdraw_underfilled" },
     );
     prepareEarnUsdcWithdraw.mockRejectedValue(semanticError);
 

--- a/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
+++ b/apps/mobile/src/services/__tests__/lifecycle-rejection.test.ts
@@ -61,6 +61,26 @@ describe("wallet rejection classification", () => {
     expect(mapLifecycleErrorCode({ code: "unconfirmed_signature" })).toBe(
       "unconfirmed_signature",
     );
+    expect(mapLifecycleErrorCode({ code: "earn_withdraw_underfilled" })).toBe(
+      "earn_withdraw_underfilled",
+    );
+  });
+
+  it("emits a typed failure when bounded Earn withdrawal adjustment is exhausted", () => {
+    const sent = captureEnvelopes();
+    const error = Object.assign(new Error("withdrawal underfilled"), {
+      code: "earn_withdraw_underfilled",
+    });
+
+    newFlow().failFrom("prepare", error);
+
+    expect(sent).toEqual([
+      expect.objectContaining({
+        errorCode: "earn_withdraw_underfilled",
+        outcome: "failed",
+        stage: "prepare",
+      }),
+    ]);
   });
 
   it("emits cancelled, not failed, when the user declines the prompt", async () => {

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -355,6 +355,7 @@ type LifecycleErrorCode =
   | "unconfirmed_signature"
   | "backend_confirmation_failed"
   | "send_failed"
+  | "earn_withdraw_underfilled"
   | "insufficient_native_sol"
   | "wallet_rejected"
   | "wallet_account_mismatch"
@@ -483,6 +484,9 @@ export function mapLifecycleErrorCode(error: unknown): LifecycleErrorCode {
   if (error && typeof error === "object" && "code" in error) {
     const code = (error as { code?: unknown }).code;
     if (code === "unconfirmed_signature") return "unconfirmed_signature";
+    if (code === "earn_withdraw_underfilled") {
+      return "earn_withdraw_underfilled";
+    }
     return "request_failed";
   }
   // Only a connection-level TypeError is a failed request. Every other one is

--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -196,6 +196,9 @@ export const LIFECYCLE_ERROR_CODES = [
   "wallet_unavailable",
   "wallet_mismatch",
   "simulation_failed",
+  // Kamino KTX could not provide enough collateral to preserve the exact
+  // partial Earn withdrawal output after bounded rounding adjustments.
+  "earn_withdraw_underfilled",
   // The route's output fell below the quote's minimum-out (Jupiter 6001).
   "slippage_exceeded",
   "send_failed",

--- a/packages/smart-account-vaults/src/client.test.ts
+++ b/packages/smart-account-vaults/src/client.test.ts
@@ -1787,7 +1787,7 @@ describe("prepareEarnUsdcWithdraw", () => {
 
   test("[earn-withdraw-exact-output] preserves partial liquidity intent across a non-1 exchange rate", async () => {
     const requestedLiquidityAmountRaw = BigInt(100_000_000);
-    const collateralInstructionAmountRaw = BigInt(95_150_000);
+    const collateralInstructionAmountRaw = BigInt(95_238_096);
     const fetchMock = mockKaminoWithdrawInstruction({
       instructionAmountRaw: () => collateralInstructionAmountRaw,
     });
@@ -1807,6 +1807,14 @@ describe("prepareEarnUsdcWithdraw", () => {
     }));
     const client = createSmartAccountVaultsClient({
       connection: {
+        getAccountInfo: mock(async (account: PublicKey) =>
+          account.equals(kaminoReserve)
+            ? createSerializedKaminoReserveAccount({
+                collateralSupplyRaw: BigInt(100_000_000),
+                liquidityAvailableAmountRaw: BigInt(105_000_000),
+              })
+            : null
+        ),
         getLatestBlockhash: mock(async () => ({
           blockhash: "11111111111111111111111111111111",
           lastValidBlockHeight: 1,
@@ -1872,13 +1880,102 @@ describe("prepareEarnUsdcWithdraw", () => {
     });
   });
 
-  test("[earn-withdraw-exact-output] rejects an underfilled partial simulation before returning a transaction", async () => {
+  test("[earn-withdraw-exact-output] dynamically increases KTX collateral after a rounded-down simulation", async () => {
     const requestedLiquidityAmountRaw = BigInt(100_000_000);
-    mockKaminoWithdrawInstruction({
-      instructionAmountRaw: () => BigInt(95_150_000),
+    const requiredCollateralAmountRaw = BigInt(95_238_096);
+    const fetchMock = mockKaminoWithdrawInstruction({
+      instructionAmountRaw: () => requiredCollateralAmountRaw - BigInt(6),
+    });
+    let simulationCount = 0;
+    const simulateTransaction = mock(async () => {
+      simulationCount += 1;
+      return {
+        value: {
+          accounts: [
+            {
+              data: [
+                createSimulatedTokenAccountData(
+                  simulationCount === 1
+                    ? requestedLiquidityAmountRaw - BigInt(6)
+                    : requestedLiquidityAmountRaw + BigInt(1)
+                ),
+                "base64",
+              ],
+            },
+          ],
+          err: null,
+          logs: [],
+        },
+      };
     });
     const client = createSmartAccountVaultsClient({
       connection: {
+        getAccountInfo: mock(async (account: PublicKey) =>
+          account.equals(kaminoReserve)
+            ? createSerializedKaminoReserveAccount({
+                collateralSupplyRaw: BigInt(100_000_000),
+                liquidityAvailableAmountRaw: BigInt(105_000_000),
+              })
+            : null
+        ),
+        getLatestBlockhash: mock(async () => ({
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 1,
+        })),
+        getTokenAccountBalance: mock(async () => ({
+          context: { slot: 1 },
+          value: {
+            amount: "0",
+            decimals: 6,
+            uiAmount: 0,
+            uiAmountString: "0",
+          },
+        })),
+        simulateTransaction,
+      } as never,
+      programId,
+    });
+
+    const result = await client.prepareEarnUsdcWithdraw({
+      settingsPda,
+      walletAddress,
+      feePayer,
+      policySigner: backendSigner,
+      amountRaw: requestedLiquidityAmountRaw,
+      mode: "partial",
+      yieldRoutingPolicy: {
+        account: policyAccount,
+        seed: BigInt(7),
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(simulateTransaction).toHaveBeenCalledTimes(2);
+    expect(result.persistence).toMatchObject({
+      kaminoWithdrawAmountRaw: (
+        requiredCollateralAmountRaw + BigInt(1)
+      ).toString(),
+      requestedWithdrawAmountRaw: requestedLiquidityAmountRaw.toString(),
+      walletTransferAmountRaw: requestedLiquidityAmountRaw.toString(),
+      withdrawnAmountRaw: requestedLiquidityAmountRaw.toString(),
+    });
+  });
+
+  test("[earn-withdraw-exact-output] rejects an underfilled partial simulation with a typed error", async () => {
+    const requestedLiquidityAmountRaw = BigInt(100_000_000);
+    mockKaminoWithdrawInstruction({
+      instructionAmountRaw: () => BigInt(95_238_096),
+    });
+    const client = createSmartAccountVaultsClient({
+      connection: {
+        getAccountInfo: mock(async (account: PublicKey) =>
+          account.equals(kaminoReserve)
+            ? createSerializedKaminoReserveAccount({
+                collateralSupplyRaw: BigInt(100_000_000),
+                liquidityAvailableAmountRaw: BigInt(105_000_000),
+              })
+            : null
+        ),
         getLatestBlockhash: mock(async () => ({
           blockhash: "11111111111111111111111111111111",
           lastValidBlockHeight: 1,
@@ -1923,9 +2020,77 @@ describe("prepareEarnUsdcWithdraw", () => {
           seed: BigInt(7),
         },
       })
-    ).rejects.toThrow(
-      "Kamino withdrawal simulation produced less liquidity than requested."
-    );
+    ).rejects.toMatchObject({
+      code: "earn_withdraw_underfilled",
+      message:
+        "Kamino withdrawal simulation produced less liquidity than requested.",
+      name: "EarnWithdrawUnderfilledError",
+    });
+  });
+
+  test("[earn-withdraw-exact-output] bounds simulation-guided rounding adjustments", async () => {
+    const requestedLiquidityAmountRaw = BigInt(100_000_000);
+    const fetchMock = mockKaminoWithdrawInstruction({
+      instructionAmountRaw: () => BigInt(95_238_095),
+    });
+    const simulateTransaction = mock(async () => ({
+      value: {
+        accounts: [
+          {
+            data: [
+              createSimulatedTokenAccountData(BigInt(95_238_095)),
+              "base64",
+            ],
+          },
+        ],
+        err: null,
+        logs: [],
+      },
+    }));
+    const client = createSmartAccountVaultsClient({
+      connection: {
+        getAccountInfo: mock(async (account: PublicKey) =>
+          account.equals(kaminoReserve)
+            ? createSerializedKaminoReserveAccount({
+                collateralSupplyRaw: BigInt(100_000_000),
+                liquidityAvailableAmountRaw: BigInt(105_000_000),
+              })
+            : null
+        ),
+        getLatestBlockhash: mock(async () => ({
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 1,
+        })),
+        getTokenAccountBalance: mock(async () => ({
+          context: { slot: 1 },
+          value: {
+            amount: "0",
+            decimals: 6,
+            uiAmount: 0,
+            uiAmountString: "0",
+          },
+        })),
+        simulateTransaction,
+      } as never,
+      programId,
+    });
+
+    await expect(
+      client.prepareEarnUsdcWithdraw({
+        settingsPda,
+        walletAddress,
+        feePayer,
+        policySigner: backendSigner,
+        amountRaw: requestedLiquidityAmountRaw,
+        mode: "partial",
+        yieldRoutingPolicy: {
+          account: policyAccount,
+          seed: BigInt(7),
+        },
+      })
+    ).rejects.toMatchObject({ code: "earn_withdraw_underfilled" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(simulateTransaction).toHaveBeenCalledTimes(3);
   });
 
   test("[earn-withdraw-account-drift] retries AccountNotFound once and returns a typed error", async () => {

--- a/packages/smart-account-vaults/src/client.ts
+++ b/packages/smart-account-vaults/src/client.ts
@@ -193,6 +193,18 @@ export const EARN_POLICY_UPDATE_REQUIRED_CODE =
 export const EARN_WITHDRAW_REQUIRED_ACCOUNT_MISSING_CODE =
   "earn_withdraw_required_account_missing" as const;
 
+export const EARN_WITHDRAW_UNDERFILLED_CODE =
+  "earn_withdraw_underfilled" as const;
+
+export class EarnWithdrawUnderfilledError extends Error {
+  readonly code = EARN_WITHDRAW_UNDERFILLED_CODE;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "EarnWithdrawUnderfilledError";
+  }
+}
+
 export class EarnWithdrawRequiredAccountMissingError extends Error {
   readonly accountRole = "transaction_account" as const;
   readonly code = EARN_WITHDRAW_REQUIRED_ACCOUNT_MISSING_CODE;
@@ -8901,6 +8913,9 @@ export function createSmartAccountVaultsClient(
       instructions: TransactionInstruction[];
       kaminoWithdrawAmountRaw: bigint;
       lookupTableAddresses: PublicKey[];
+      reserveSnapshot: KaminoReserveSnapshot | null;
+      target: KaminoEarnTarget;
+      withdrawDiscriminator: readonly number[];
     };
 
     type ProvisionalWithdrawBatch = Omit<
@@ -8930,6 +8945,24 @@ export function createSmartAccountVaultsClient(
       instruction.data.length >= 16
         ? readUint64LE(instruction.data, 8)
         : fallback;
+
+    const replaceWithdrawInstructionAmountRaw = (
+      instruction: TransactionInstruction,
+      amountRaw: bigint
+    ): TransactionInstruction => {
+      if (instruction.data.length < 16) {
+        throw new EarnWithdrawUnderfilledError(
+          "Kamino returned a partial withdrawal instruction without an amount."
+        );
+      }
+      const data = Buffer.from(instruction.data);
+      data.writeBigUInt64LE(amountRaw, 8);
+      return new TransactionInstruction({
+        data,
+        keys: instruction.keys,
+        programId: instruction.programId,
+      });
+    };
 
     const chunkReserveWithdrawals = (
       withdrawals: ProvisionalReserveWithdrawal[]
@@ -9328,6 +9361,9 @@ export function createSmartAccountVaultsClient(
           ],
           kaminoWithdrawAmountRaw: stepKaminoWithdrawAmountRaw,
           lookupTableAddresses: kaminoWithdrawBundle.lookupTableAddresses,
+          reserveSnapshot,
+          target: plan.target,
+          withdrawDiscriminator: plan.target.withdrawDiscriminator,
         });
       }
 
@@ -9370,11 +9406,11 @@ export function createSmartAccountVaultsClient(
         (total, withdrawal) => total + withdrawal.amountRaw,
         BigInt(0)
       );
-      const batchKaminoWithdrawAmountRaw = batch.reduce(
+      let batchKaminoWithdrawAmountRaw = batch.reduce(
         (total, withdrawal) => total + withdrawal.kaminoWithdrawAmountRaw,
         BigInt(0)
       );
-      const batchExpectedRedeemedAmountRaw = batch.reduce(
+      let batchExpectedRedeemedAmountRaw = batch.reduce(
         (total, withdrawal) => total + withdrawal.expectedRedeemedAmountRaw,
         BigInt(0)
       );
@@ -9382,26 +9418,6 @@ export function createSmartAccountVaultsClient(
         isFinalExit && isFinalBatch
           ? fullWithdrawVaultUsdcRemainderRaw
           : BigInt(0);
-      const compiledWithdrawPrefix =
-        instructionsToSynchronousTransactionDetailsV2({
-          vaultPda,
-          members: [args.walletAddress],
-          transaction_instructions: batch.flatMap(
-            (withdrawal) => withdrawal.instructions
-          ),
-        });
-      const withdrawPrefixExecution =
-        await smartAccountsClient.features.execution.prepare.executeTransactionSyncV2(
-          {
-            feePayer: args.feePayer,
-            settingsPda: args.settingsPda,
-            accountIndex: EARN_DEPOSIT_VAULT_INDEX,
-            numSigners: 1,
-            instructions: compiledWithdrawPrefix.instructions,
-            instruction_accounts: compiledWithdrawPrefix.accounts,
-            memo: args.memo,
-          } as never
-        );
       // A prior full exit's cleanup closes the vault's USDC and collateral
       // ATAs while sweeps/rebalances can still land funds afterwards; klend's
       // withdraw requires both destination token accounts to exist, so
@@ -9453,35 +9469,146 @@ export function createSmartAccountVaultsClient(
             ? Promise.resolve(fullWithdrawVaultUsdcRemainderRaw)
             : getTokenAccountAmountOrZero(config.connection, vaultUsdcAta),
         ]);
-      const {
-        amountRaw: simulatedVaultUsdcAmountRaw,
-        lamportAccountLamports: simulatedVaultLamports,
-      } = await simulatePreparedTokenAccountAmount({
-        connection: config.connection,
-        lamportAccount: isFinalExit && isFinalBatch ? vaultPda : undefined,
-        prepared: freezePreparedOperation({
-          operation: "earnUsdcWithdrawPrefixSimulation",
-          payer: args.feePayer,
-          programId: smartAccountsClient.programId,
-          requiresConfirmation: false,
-          instructions: [
-            createAssociatedTokenAccountIdempotentInstruction(
-              args.feePayer,
-              walletUsdcAta,
-              args.walletAddress,
-              usdcMint,
-              liquidityTokenProgram
+      const simulateWithdrawPrefix = async () => {
+        const compiledWithdrawPrefix =
+          instructionsToSynchronousTransactionDetailsV2({
+            vaultPda,
+            members: [args.walletAddress],
+            transaction_instructions: batch.flatMap(
+              (withdrawal) => withdrawal.instructions
             ),
-            ...vaultAtaSetupInstructions,
-            ...withdrawPrefixExecution.instructions,
-          ],
-          lookupTableAccounts: dedupeLookupTableAccounts([
-            ...(withdrawPrefixExecution.lookupTableAccounts ?? []),
-            ...batchKaminoLookupTableAccounts,
-          ]),
-        }),
-        tokenAccount: vaultUsdcAta,
+          });
+        const withdrawPrefixExecution =
+          await smartAccountsClient.features.execution.prepare.executeTransactionSyncV2(
+            {
+              feePayer: args.feePayer,
+              settingsPda: args.settingsPda,
+              accountIndex: EARN_DEPOSIT_VAULT_INDEX,
+              numSigners: 1,
+              instructions: compiledWithdrawPrefix.instructions,
+              instruction_accounts: compiledWithdrawPrefix.accounts,
+              memo: args.memo,
+            } as never
+          );
+        return simulatePreparedTokenAccountAmount({
+          connection: config.connection,
+          lamportAccount: isFinalExit && isFinalBatch ? vaultPda : undefined,
+          prepared: freezePreparedOperation({
+            operation: "earnUsdcWithdrawPrefixSimulation",
+            payer: args.feePayer,
+            programId: smartAccountsClient.programId,
+            requiresConfirmation: false,
+            instructions: [
+              createAssociatedTokenAccountIdempotentInstruction(
+                args.feePayer,
+                walletUsdcAta,
+                args.walletAddress,
+                usdcMint,
+                liquidityTokenProgram
+              ),
+              ...vaultAtaSetupInstructions,
+              ...withdrawPrefixExecution.instructions,
+            ],
+            lookupTableAccounts: dedupeLookupTableAccounts([
+              ...(withdrawPrefixExecution.lookupTableAccounts ?? []),
+              ...batchKaminoLookupTableAccounts,
+            ]),
+          }),
+          tokenAccount: vaultUsdcAta,
+        });
+      };
+
+      let prefixSimulation = await simulateWithdrawPrefix();
+      let simulatedRedeemedOnlyAmountRaw = resolveSimulatedRedeemedAmountRaw({
+        currentVaultUsdcAmountRaw,
+        simulatedVaultUsdcAmountRaw: prefixSimulation.amountRaw,
       });
+      const maxRoundingAdjustmentAttempts = 2;
+      for (
+        let adjustmentAttempt = 0;
+        args.mode !== "full" &&
+        simulatedRedeemedOnlyAmountRaw < batchAmountRaw &&
+        adjustmentAttempt < maxRoundingAdjustmentAttempts;
+        adjustmentAttempt += 1
+      ) {
+        const withdrawal = batch.length === 1 ? batch[0]! : null;
+        if (!withdrawal) {
+          throw new EarnWithdrawUnderfilledError(
+            "Kamino could not safely adjust a split partial withdrawal."
+          );
+        }
+        if (!withdrawal.reserveSnapshot) {
+          withdrawal.reserveSnapshot = (
+            await resolveEarnPartialWithdrawAmounts({
+              connection: config.connection,
+              requestedWithdrawAmountRaw: withdrawal.amountRaw,
+              target: withdrawal.target,
+            })
+          ).snapshot;
+        }
+        const liquidityShortfallRaw =
+          batchAmountRaw - simulatedRedeemedOnlyAmountRaw;
+        const collateralAdjustmentRaw =
+          calculateKaminoCollateralAmountForRedeemableLiquidityRaw({
+            liquidityAmountRaw: liquidityShortfallRaw,
+            snapshot: withdrawal.reserveSnapshot,
+          }) + BigInt(1);
+        const adjustedCollateralAmountRaw =
+          withdrawal.kaminoWithdrawAmountRaw + collateralAdjustmentRaw;
+        let replacedInstructionCount = 0;
+        withdrawal.instructions = withdrawal.instructions.map((instruction) => {
+          if (
+            instruction.programId.equals(withdrawal.instruction.programId) &&
+            dataStartsWithDiscriminator(
+              instruction.data,
+              withdrawal.withdrawDiscriminator
+            )
+          ) {
+            replacedInstructionCount += 1;
+            return replaceWithdrawInstructionAmountRaw(
+              instruction,
+              adjustedCollateralAmountRaw
+            );
+          }
+          return instruction;
+        });
+        if (replacedInstructionCount !== 1) {
+          throw new EarnWithdrawUnderfilledError(
+            "Kamino returned an unsupported partial withdrawal instruction split."
+          );
+        }
+        withdrawal.instruction = replaceWithdrawInstructionAmountRaw(
+          withdrawal.instruction,
+          adjustedCollateralAmountRaw
+        );
+        withdrawal.kaminoWithdrawAmountRaw = adjustedCollateralAmountRaw;
+        withdrawal.expectedRedeemedAmountRaw =
+          calculateKaminoRedeemableLiquidityAmountRaw({
+            collateralAmountRaw: adjustedCollateralAmountRaw,
+            snapshot: withdrawal.reserveSnapshot,
+          });
+        prefixSimulation = await simulateWithdrawPrefix();
+        simulatedRedeemedOnlyAmountRaw = resolveSimulatedRedeemedAmountRaw({
+          currentVaultUsdcAmountRaw,
+          simulatedVaultUsdcAmountRaw: prefixSimulation.amountRaw,
+        });
+      }
+      if (
+        args.mode !== "full" &&
+        simulatedRedeemedOnlyAmountRaw < batchAmountRaw
+      ) {
+        throw new EarnWithdrawUnderfilledError(
+          "Kamino withdrawal simulation produced less liquidity than requested."
+        );
+      }
+      batchKaminoWithdrawAmountRaw = batch.reduce(
+        (total, withdrawal) => total + withdrawal.kaminoWithdrawAmountRaw,
+        BigInt(0)
+      );
+      batchExpectedRedeemedAmountRaw = batch.reduce(
+        (total, withdrawal) => total + withdrawal.expectedRedeemedAmountRaw,
+        BigInt(0)
+      );
       // Sweep what the vault will hold AFTER the withdraw prefix runs: klend's
       // v2 full withdraw closes the emptied obligation and refunds its rent
       // (~0.024 SOL) to the vault inside this same transaction, so the
@@ -9491,20 +9618,9 @@ export function createSmartAccountVaultsClient(
       // cleanup flow; the sweep can only undershoot, never overdraw.
       const vaultSweepLamports =
         isFinalExit && isFinalBatch
-          ? simulatedVaultLamports ?? fullWithdrawVaultSweepLamports
+          ? prefixSimulation.lamportAccountLamports ??
+            fullWithdrawVaultSweepLamports
           : BigInt(0);
-      const simulatedRedeemedOnlyAmountRaw = resolveSimulatedRedeemedAmountRaw({
-        currentVaultUsdcAmountRaw,
-        simulatedVaultUsdcAmountRaw,
-      });
-      if (
-        args.mode !== "full" &&
-        simulatedRedeemedOnlyAmountRaw < batchAmountRaw
-      ) {
-        throw new Error(
-          "Kamino withdrawal simulation produced less liquidity than requested."
-        );
-      }
       const redeemedTransferAmountRaw =
         simulatedRedeemedOnlyAmountRaw > BigInt(0)
           ? simulatedRedeemedOnlyAmountRaw


### PR DESCRIPTION
Fixes ASK-2243 by recovering mobile partial Earn withdrawals when Kamino rounds its collateral conversion down; the exact alert resolved is `Kamino withdrawal simulation produced less liquidity than requested.` The shared vault SDK now uses the observed simulation shortfall to calculate a bounded collateral adjustment, recompiles and re-simulates up to twice, still transfers exactly the user-requested amount, and emits `earn_withdraw_underfilled` if exact output cannot be guaranteed.

Scope is limited to partial-withdraw preparation plus the mobile/web telemetry contract; full exits are unchanged. Verification passed the Earn exact-output verifier, package typecheck/build, targeted SDK/mobile/observability tests, and Expo lint with no errors (nine existing warnings); an unsigned mainnet E2E against the affected reserve reproduced 10 initial underfills across 11 representative partial amounts and recovered all 10 in one adjustment without signing or submitting. After merge, monitor the original alert and the new typed failure code for any exhausted adjustments.
