### PR TITLE
chore(ci): stop mirroring and releasing sunset private-transfer artifacts

### DIFF
--- a/scripts/mirror-repos/config.ts
+++ b/scripts/mirror-repos/config.ts
@@ -12,6 +12,7 @@ export type MirrorConfig = {
   repo: `loyal-labs/${string}`;
   kind: MirrorKind;
   description: string;
+  excludePaths?: readonly string[];
 };
 
 export const mirrors = [
@@ -44,22 +45,19 @@ export const mirrors = [
     repo: "loyal-labs/loyal-packages",
     kind: "source-tree",
     description: "Generated mirror of loyal-app/packages",
+    excludePaths: ["packages/private-transactions"],
   },
   {
     source: "crates",
     repo: "loyal-labs/loyal-cli",
     kind: "rust-cli",
     description: "Generated mirror of loyal-app/crates",
-  },
-  {
-    source: "programs",
-    repo: "loyal-labs/loyal-contracts",
-    kind: "anchor-programs",
-    description: "Generated mirror of loyal-app/programs",
+    excludePaths: ["crates/private-transfers-cli"],
   },
 ] as const satisfies readonly MirrorConfig[];
 
 export const blockedMirrorRepos = new Set([
+  "loyal-labs/loyal-contracts",
   "loyal-labs/loyal-solana",
   "loyal-labs/loyal-frontend",
   "loyal-labs/loyal-docs",

--- a/scripts/mirror-repos/file-rewrites.ts
+++ b/scripts/mirror-repos/file-rewrites.ts
@@ -280,7 +280,6 @@ function addRustCliWorkspace(root: string): void {
     `[workspace]
 members = [
     "crates/loyal-cli",
-    "crates/private-transfers-cli",
     "crates/smart-accounts-cli",
     "crates/loyal-smart-accounts-rs",
 ]

--- a/scripts/mirror-repos/selection.ts
+++ b/scripts/mirror-repos/selection.ts
@@ -69,18 +69,6 @@ export function selectMirrorsForChangedPaths(
       continue;
     }
 
-    if (
-      hasPathPrefix(filePath, "tests") ||
-      hasPathPrefix(filePath, "target/idl") ||
-      hasPathPrefix(filePath, "target/types") ||
-      filePath === "Anchor.toml" ||
-      filePath === "package.json" ||
-      filePath === "tsconfig.json"
-    ) {
-      addMirrorByRepo(selected, "loyal-labs/loyal-contracts");
-      continue;
-    }
-
     for (const mirror of mirrors) {
       if (hasPathPrefix(filePath, mirror.source)) {
         selected.add(mirror);

--- a/scripts/mirror-repos/sync.ts
+++ b/scripts/mirror-repos/sync.ts
@@ -66,9 +66,17 @@ function copyTrackedFile(sourceFile: string, destinationFile: string): void {
 function copyTrackedPrefix(
   prefix: string,
   destinationRoot: string,
-  stripPrefix: boolean
+  stripPrefix: boolean,
+  excludePaths: readonly string[] = []
 ): void {
   for (const file of listTrackedFiles(prefix)) {
+    if (
+      excludePaths.some(
+        (excluded) => file === excluded || file.startsWith(`${excluded}/`)
+      )
+    ) {
+      continue;
+    }
     const relativePath = stripPrefix ? path.relative(prefix, file) : file;
     copyTrackedFile(file, path.join(destinationRoot, relativePath));
   }
@@ -164,7 +172,12 @@ function generateMirror(mirror: MirrorConfig, destinationRoot: string): void {
       break;
     case "source-tree":
     case "rust-cli":
-      copyTrackedPrefix(mirror.source, destinationRoot, false);
+      copyTrackedPrefix(
+        mirror.source,
+        destinationRoot,
+        false,
+        mirror.excludePaths
+      );
       break;
     case "anchor-programs":
       copyTrackedPrefix("programs", destinationRoot, false);

--- a/scripts/release-packages.ts
+++ b/scripts/release-packages.ts
@@ -20,13 +20,16 @@ const publishablePackageDirs = [
   "packages/llm-server",
   "packages/solana-rpc",
   "packages/solana-wallet",
-  "packages/private-transactions",
   "packages/loyal-smart-accounts-core",
   "packages/loyal-smart-accounts",
   "packages/solana-instruction-decoder",
   "packages/smart-account-vaults",
   "packages/wallet-core",
 ] as const;
+
+// ASK-2239: sunset packages that must never be published to npm again, but
+// whose versions must stay resolvable for dependents' workspace: rewrites.
+const unpublishablePackageDirs = ["packages/private-transactions"] as const;
 
 type PackageJson = {
   name: string;
@@ -169,13 +172,6 @@ function copyPackageForPublish(
 }
 
 function ensureBuildOutput(info: PackageInfo): void {
-  if (info.packageJson.name === "@loyal-labs/private-transactions") {
-    if (!existsSync(path.join(info.dir, "dist/index.js"))) {
-      throw new Error(`${info.packageJson.name} is missing dist/index.js`);
-    }
-    return;
-  }
-
   if (!existsSync(path.join(info.dir, "dist"))) {
     throw new Error(
       `${info.packageJson.name} is missing dist/. Run package builds before publishing.`
@@ -187,7 +183,9 @@ function main(): void {
   const dryRun = process.argv.includes("--dry-run");
   const packages = publishablePackageDirs.map(readPackageInfo);
   const versionsByName = new Map(
-    packages.map((info) => [info.packageJson.name, info.packageJson.version])
+    [...packages, ...unpublishablePackageDirs.map(readPackageInfo)].map(
+      (info) => [info.packageJson.name, info.packageJson.version]
+    )
   );
 
   for (const info of packages) {


### PR DESCRIPTION
Removes the loyal-contracts mirror, blocks the repo, excludes private-transfer package/CLI from mirror sync and npm releases. Part of ASK-2239.