### PR TITLE
fix(ci): exclude mobile e2e verifier from generated mirror

### DIFF
--- a/scripts/mirror-repos/config.ts
+++ b/scripts/mirror-repos/config.ts
@@ -32,6 +32,9 @@ export const mirrors = [
     repo: "loyal-labs/loyal-mobile",
     kind: "expo-app",
     description: "Generated mirror of loyal-app/mobile",
+    // Operator e2e verifier; hardcodes monorepo-relative package paths that
+    // trip the generated-mirror safety check.
+    excludePaths: ["apps/mobile/scripts/verify-withdraw-latency-e2e.ts"],
   },
   {
     source: "apps/extension",

--- a/scripts/mirror-repos/sync.ts
+++ b/scripts/mirror-repos/sync.ts
@@ -111,7 +111,12 @@ function generateMirror(mirror: MirrorConfig, destinationRoot: string): void {
     case "telegram-app":
     case "expo-app":
     case "wxt-extension":
-      copyTrackedPrefix(mirror.source, destinationRoot, true);
+      copyTrackedPrefix(
+        mirror.source,
+        destinationRoot,
+        true,
+        mirror.excludePaths
+      );
       break;
     case "source-tree":
     case "rust-cli":


### PR DESCRIPTION
The verifier script hardcodes monorepo-relative package paths and trips the mirror safety check when loyal-mobile regenerates. Unblocks mirror sync after ASK-2239.