### PR TITLE
feat(admin): add Backyard vault macroview

### DIFF
--- a/apps/admin/src/app/(admin)/vault-integrations/backyard/backyard-vault-data.ts
+++ b/apps/admin/src/app/(admin)/vault-integrations/backyard/backyard-vault-data.ts
@@ -1,0 +1,260 @@
+import "server-only";
+
+import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.server";
+
+const MANIFEST = {
+  adaptor: "FSj27QT2PtP7365pQRtgSAwSwk5h2m2ATCBoXQjwTSxW",
+  squadsSettings: "5YQ78RwqukvCcykpmjmgRFmbEUeAgLpuVDxx1xNZnHD6",
+  squadsVault: "ST999VUTo5QExYEX9bz1oDDoKGkjXG9zpphy4Hj7VWh",
+  voltrProgram: "vVoLTRjQmtFpiYoegx285Ze4gsLJ8ZxgFKVcuvmG1a8",
+  voltrVault: "HXtk15EA5pBg3rSKxBm8sWPExScPkTknSRp37fXNHgNA",
+  vaultCapRaw: BigInt("1000000000000"),
+  withdrawalWaitSeconds: 600,
+} as const;
+
+type DashboardRow = {
+  collateral_raw: string | null;
+  collateral_value_usd_micros: string | null;
+  debt_raw: string | null;
+  debt_value_usd_micros: string | null;
+  equity_usd_micros: string | null;
+  forecast_apy_bps: string | null;
+  ltv_bps: string | null;
+  observed_at: Date | string | null;
+  route_key: string;
+  state: unknown;
+  strategy_key: string | null;
+};
+
+type OperationRow = {
+  action: string;
+  amount_raw: string | null;
+  created_at: Date | string;
+  status: string;
+  transaction_signature: string | null;
+};
+
+type VaultSettings = Array<{ key: string; value: string }>;
+
+export type BackyardVaultData =
+  | { available: false; error: string; observedAt: string }
+  | {
+      available: true;
+      aumUsdMicros: bigint | null;
+      currentPosition: {
+        collateralRaw: bigint | null;
+        debtRaw: bigint | null;
+        ltvBps: bigint | null;
+        strategy: string | null;
+      };
+      history: OperationRow[];
+      navUsdMicros: bigint | null;
+      observedAt: string;
+      projectedApyBps: bigint | null;
+      report: {
+        fresh: boolean | null;
+        observedAt: string | null;
+        slot: bigint | null;
+      };
+      routeStatus: string | null;
+      settings: VaultSettings;
+      squadsIdleRaw: bigint | null;
+      voltrIdleRaw: bigint | null;
+      vaultCapRaw: bigint;
+      withdrawalWaitSeconds: number;
+    };
+
+function toBigInt(value: string | null) {
+  return value === null ? null : BigInt(value);
+}
+
+function toIso(value: Date | string | null) {
+  return value ? new Date(value).toISOString() : null;
+}
+
+function scalarSettings(value: unknown): VaultSettings {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  return Object.entries(value)
+    .filter(([, nested]) =>
+      ["string", "number", "boolean"].includes(typeof nested)
+    )
+    .slice(0, 12)
+    .map(([key, nested]) => ({ key, value: String(nested) }));
+}
+
+function projectedValue(state: Record<string, unknown> | null, keys: string[]) {
+  if (!state) return null;
+  const groups = [
+    state,
+    state.snapshot,
+    state.observation,
+    state.balances,
+    state.report,
+  ].filter(
+    (value): value is Record<string, unknown> =>
+      Boolean(value) && typeof value === "object" && !Array.isArray(value)
+  );
+  for (const group of groups) {
+    for (const key of keys) {
+      const value = group[key];
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "bigint"
+      )
+        return value;
+    }
+  }
+  return null;
+}
+
+function projectedBigInt(
+  state: Record<string, unknown> | null,
+  keys: string[]
+) {
+  const value = projectedValue(state, keys);
+  try {
+    return value === null ? null : BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function projectedBoolean(
+  state: Record<string, unknown> | null,
+  keys: string[]
+) {
+  if (!state) return null;
+  const groups = [
+    state,
+    state.snapshot,
+    state.observation,
+    state.balances,
+    state.report,
+  ].filter(
+    (value): value is Record<string, unknown> =>
+      Boolean(value) && typeof value === "object" && !Array.isArray(value)
+  );
+  for (const group of groups) {
+    for (const key of keys) {
+      if (typeof group[key] === "boolean") return group[key];
+    }
+  }
+  return null;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "The Backyard RWA projection could not be loaded.";
+}
+
+export async function getBackyardVaultData(): Promise<BackyardVaultData> {
+  const observedAt = new Date().toISOString();
+
+  try {
+    const sql = getYieldNeonSql();
+    const rows = (await sql.query(`
+      SELECT route.route_key, route.state,
+        snapshot.strategy_key, snapshot.collateral_raw::text,
+        snapshot.debt_raw::text, snapshot.equity_usd_micros::text,
+        snapshot.collateral_value_usd_micros::text,
+        snapshot.debt_value_usd_micros::text, snapshot.ltv_bps::text,
+        snapshot.forecast_apy_bps::text, snapshot.observed_at
+      FROM loyal_yield.multiply_route_states AS route
+      LEFT JOIN LATERAL (
+        SELECT * FROM loyal_yield.multiply_position_snapshots
+        WHERE route_key = route.route_key
+        ORDER BY observed_at DESC, id DESC
+        LIMIT 1
+      ) AS snapshot ON true
+      WHERE route.state ->> 'engineVersion' = 'backyard_rwa_v1'
+      ORDER BY snapshot.observed_at DESC NULLS LAST, route.updated_at DESC
+      LIMIT 1
+    `)) as unknown as DashboardRow[];
+    const row = rows[0];
+
+    if (!row) {
+      return {
+        available: false,
+        error:
+          "No Backyard RWA route projection exists yet. The page will populate after the Go worker records its first observation.",
+        observedAt,
+      };
+    }
+
+    const history = (await sql.query(
+      `
+      SELECT action, status, expected_effects -> 'decision' ->> 'amountRaw' AS amount_raw,
+        transaction_signature, created_at
+      FROM loyal_yield.multiply_operations
+      WHERE route_key = $1 AND engine_version = 'backyard_rwa_v1'
+      ORDER BY created_at DESC, operation_id DESC
+      LIMIT 20
+    `,
+      [row.route_key]
+    )) as unknown as OperationRow[];
+
+    const state = row.state as Record<string, unknown> | null;
+    const routeSettings = scalarSettings(state?.vaultSettings);
+    const observedSnapshotAt = toIso(row.observed_at);
+    // Position equity is only one NAV component. Never present it as vault
+    // AUM or adaptor NAV when idle balances/report state are unavailable.
+    const aumUsdMicros = projectedBigInt(state, [
+      "aumUsdMicros",
+      "aum_usd_micros",
+      "aumRaw",
+    ]);
+    const navUsdMicros = projectedBigInt(state, [
+      "navUsdMicros",
+      "nav_usd_micros",
+      "reportedNavRaw",
+      "navRaw",
+    ]);
+
+    return {
+      available: true,
+      aumUsdMicros,
+      currentPosition: {
+        collateralRaw: toBigInt(row.collateral_raw),
+        debtRaw: toBigInt(row.debt_raw),
+        ltvBps: toBigInt(row.ltv_bps),
+        strategy: row.strategy_key,
+      },
+      history,
+      navUsdMicros,
+      observedAt: observedSnapshotAt ?? observedAt,
+      projectedApyBps: toBigInt(row.forecast_apy_bps),
+      report: {
+        fresh: projectedBoolean(state, ["fresh", "navFresh"]),
+        observedAt:
+          String(
+            projectedValue(state, ["reportObservedAt", "navObservedAt"]) ?? ""
+          ) || null,
+        slot: projectedBigInt(state, ["reportSlot", "navSlot", "slot"]),
+      },
+      routeStatus:
+        String(projectedValue(state, ["routeStatus", "status"]) ?? "") || null,
+      settings: [
+        { key: "Voltr vault", value: MANIFEST.voltrVault },
+        { key: "Voltr program", value: MANIFEST.voltrProgram },
+        { key: "Squads vault", value: MANIFEST.squadsVault },
+        { key: "Squads settings", value: MANIFEST.squadsSettings },
+        { key: "Adaptor", value: MANIFEST.adaptor },
+        ...routeSettings,
+      ],
+      squadsIdleRaw: projectedBigInt(state, [
+        "squadsIdleRaw",
+        "squads_idle_raw",
+      ]),
+      voltrIdleRaw: projectedBigInt(state, ["voltrIdleRaw", "voltr_idle_raw"]),
+      vaultCapRaw: MANIFEST.vaultCapRaw,
+      withdrawalWaitSeconds: MANIFEST.withdrawalWaitSeconds,
+    };
+  } catch (error) {
+    return { available: false, error: errorMessage(error), observedAt };
+  }
+}

--- a/apps/admin/src/app/(admin)/vault-integrations/backyard/page.tsx
+++ b/apps/admin/src/app/(admin)/vault-integrations/backyard/page.tsx
@@ -1,0 +1,330 @@
+import {
+  AddressLink,
+  ShortAddressText,
+} from "@/components/blockchain/address-link";
+import { PageContainer } from "@/components/layout/page-container";
+import { SectionHeader } from "@/components/layout/section-header";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { requireAdminSession } from "@/lib/require-admin-session";
+
+import { getBackyardVaultData } from "./backyard-vault-data";
+
+export const dynamic = "force-dynamic";
+
+function formatUsdMicros(value: bigint | null) {
+  if (value === null) return "—";
+  const cents = (value + BigInt(5_000)) / BigInt(10_000);
+  const whole = cents / BigInt(100);
+  return `$${whole.toString().replace(/\\B(?=(\\d{3})+(?!\\d))/g, ",")}.${(
+    cents % BigInt(100)
+  )
+    .toString()
+    .padStart(2, "0")}`;
+}
+
+function formatBps(value: bigint | null) {
+  if (value === null) return "—";
+  return `${(Number(value) / 100).toFixed(2)}%`;
+}
+
+function formatRaw(value: bigint | null) {
+  if (value === null) return "Unavailable";
+  const whole = value / BigInt(1_000_000);
+  const fraction = ((value % BigInt(1_000_000)) / BigInt(10_000))
+    .toString()
+    .padStart(2, "0");
+  return `${whole
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}.${fraction}`;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function actionKind(action: string) {
+  if (action.includes("ALLOCATE") || action.includes("OPEN"))
+    return "Deposit / deploy";
+  if (
+    action.includes("DELEVER") ||
+    action.includes("STAGE") ||
+    action.includes("RESTORE")
+  )
+    return "Withdrawal / restore";
+  return action.replaceAll("_", " ");
+}
+
+export default async function BackyardVaultPage() {
+  await requireAdminSession();
+  const data = await getBackyardVaultData();
+
+  return (
+    <PageContainer className="max-w-6xl space-y-6">
+      <SectionHeader
+        breadcrumbs={[{ label: "Vault integrations" }, { label: "Backyard" }]}
+        subtitle="Read-only view of the Voltr vault, its bound Squads smart account, and the Backyard RWA worker projection."
+        title="Backyard vault"
+      />
+
+      {!data.available ? (
+        <Card>
+          <CardHeader>
+            <Badge variant="outline">Awaiting projection</Badge>
+            <CardTitle className="text-base">No live vault snapshot</CardTitle>
+            <CardDescription>{formatDate(data.observedAt)} UTC</CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {data.error}
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <section className="grid gap-4 md:grid-cols-3">
+            <Metric
+              title="Current AUM"
+              value={formatUsdMicros(data.aumUsdMicros)}
+              description="Latest worker valuation"
+            />
+            <Metric
+              title="Reported NAV"
+              value={formatUsdMicros(data.navUsdMicros)}
+              description={`Observed ${formatDate(data.observedAt)} UTC`}
+            />
+            <Metric
+              title="Forecast APY"
+              value={formatBps(data.projectedApyBps)}
+              description="Latest route snapshot; not a promise"
+            />
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardDescription>Current route position</CardDescription>
+                <CardTitle className="text-base">
+                  {data.currentPosition.strategy ?? "No funded position"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-3 gap-3 text-sm">
+                <div>
+                  <p className="text-muted-foreground">Collateral</p>
+                  <p className="font-medium tabular-nums">
+                    {formatRaw(data.currentPosition.collateralRaw)} PRIME
+                  </p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Debt</p>
+                  <p className="font-medium tabular-nums">
+                    {formatRaw(data.currentPosition.debtRaw)} USDC
+                  </p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">LTV</p>
+                  <p className="font-medium tabular-nums">
+                    {formatBps(data.currentPosition.ltvBps)}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardDescription>Bound accounts</CardDescription>
+                <CardTitle className="text-base">Voltr + Squads</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {data.settings.slice(0, 5).map((setting) => (
+                  <p key={setting.key} className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">{setting.key}</span>
+                    <AddressLink address={setting.value} />
+                  </p>
+                ))}
+              </CardContent>
+            </Card>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-3">
+            <Metric
+              title="Voltr idle"
+              value={`${formatRaw(data.voltrIdleRaw)} USDC`}
+              description="Strategy idle balance projected by worker"
+            />
+            <Metric
+              title="Squads idle"
+              value={`${formatRaw(data.squadsIdleRaw)} USDC`}
+              description="Smart-account idle balance projected by worker"
+            />
+            <Metric
+              title="Withdrawal wait"
+              value={`${data.withdrawalWaitSeconds}s`}
+              description={`Vault cap ${formatRaw(data.vaultCapRaw)} USDC`}
+            />
+          </section>
+
+          <Card>
+            <CardHeader>
+              <CardDescription>Route and NAV report</CardDescription>
+              <CardTitle className="text-base">
+                {data.routeStatus ?? "Route status unavailable"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground">
+              <span>
+                Report slot:{" "}
+                {data.report.slot?.toLocaleString("en-US") ?? "Unavailable"}
+              </span>
+              <span>
+                Report time:{" "}
+                {data.report.observedAt
+                  ? `${formatDate(data.report.observedAt)} UTC`
+                  : "Unavailable"}
+              </span>
+              <span>
+                Freshness:{" "}
+                {data.report.fresh === null
+                  ? "Unavailable"
+                  : data.report.fresh
+                  ? "Fresh"
+                  : "Stale"}
+              </span>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardDescription>Vault settings</CardDescription>
+              <CardTitle className="text-base">
+                Configuration observed by the worker
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-2 text-sm md:grid-cols-2">
+              {data.settings.slice(5).length ? (
+                data.settings.slice(5).map((setting) => (
+                  <p
+                    key={setting.key}
+                    className="flex justify-between gap-4 rounded border p-2"
+                  >
+                    <span className="text-muted-foreground">{setting.key}</span>
+                    <span className="font-mono text-xs">{setting.value}</span>
+                  </p>
+                ))
+              ) : (
+                <p className="text-muted-foreground">
+                  Fee and admin settings are unavailable until projected by the
+                  worker.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardDescription>Recent worker journal</CardDescription>
+              <CardTitle className="text-base">
+                Capital decisions and execution steps
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Time</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Amount</TableHead>
+                    <TableHead>Transaction</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.history.length ? (
+                    data.history.map((item, index) => (
+                      <TableRow key={`${item.created_at}-${index}`}>
+                        <TableCell>
+                          {formatDate(String(item.created_at))} UTC
+                        </TableCell>
+                        <TableCell>{actionKind(item.action)}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              item.status === "reconciled"
+                                ? "outline"
+                                : "secondary"
+                            }
+                          >
+                            {item.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="tabular-nums">
+                          {item.amount_raw
+                            ? formatRaw(BigInt(item.amount_raw))
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          {item.transaction_signature ? (
+                            <ShortAddressText
+                              address={item.transaction_signature}
+                            />
+                          ) : (
+                            "—"
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-muted-foreground">
+                        No worker decisions or execution steps recorded yet.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </PageContainer>
+  );
+}
+
+function Metric({
+  description,
+  title,
+  value,
+}: {
+  description: string;
+  title: string;
+  value: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardDescription>{description}</CardDescription>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-semibold tabular-nums tracking-tight">
+          {value}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/components/app-sidebar.tsx
+++ b/apps/admin/src/components/app-sidebar.tsx
@@ -73,6 +73,16 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
+    label: "Vault integrations",
+    items: [
+      {
+        href: "/vault-integrations/backyard",
+        icon: LandmarkIcon,
+        label: "Backyard vault",
+      },
+    ],
+  },
+  {
     label: "Mobile",
     items: [
       { href: "/dapps", icon: AppWindowIcon, label: "dApps" },


### PR DESCRIPTION
Adds a read-only Backyard vault integration page for the Voltr vault, bound Squads account, worker projection, and recent movement history. Adds the page to the admin navigation so operators can inspect the integration from one focused macroview.