### PR TITLE
fix(observability): classify invalid SIWS proofs

### DIFF
--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -178,6 +178,9 @@ export const LIFECYCLE_ERROR_CODES = [
   "invalid_wallet_origin",
   "invalid_wallet_proof_kind",
   "invalid_wallet_signature",
+  // A Sign In With Solana proof reached the backend but did not match the
+  // issued challenge or failed signature verification.
+  "invalid_wallet_signin",
   "wallet_auth_completion_in_progress",
   "smart_account_sponsor_not_configured",
   "smart_account_provisioning_failed",


### PR DESCRIPTION
Fixes the ClickStack alert `auth.smart_account_provisioning.proof_verify.failed` being mislabeled as `loyal.error.code=unexpected_error`: the change adds `invalid_wallet_signin` to the bounded lifecycle vocabulary so the wallet completion route preserves the real backend error without changing authentication behavior or logging sensitive proof data.

Verified with a focused Bun assertion and commitlint; the local frontend build was intentionally skipped per repository policy, so post-merge we should rely on PR checks and confirm new SIWS verification failures appear in ClickStack as `invalid_wallet_signin`.