### PR TITLE
fix(admin): show Backyard strategy receipt

### DIFF
--- a/apps/admin/src/app/(admin)/vault-integrations/backyard/backyard-vault-data.ts
+++ b/apps/admin/src/app/(admin)/vault-integrations/backyard/backyard-vault-data.ts
@@ -4,6 +4,7 @@ import { getYieldNeonSql } from "@/lib/yield-optimization/yield-neon-client.serv
 
 const MANIFEST = {
   adaptor: "FSj27QT2PtP7365pQRtgSAwSwk5h2m2ATCBoXQjwTSxW",
+  strategyReceipt: "4sycXz9Xwevedo6eiXR8QEhY8yrQrkNS4G1deY9tAD2Y",
   squadsSettings: "5YQ78RwqukvCcykpmjmgRFmbEUeAgLpuVDxx1xNZnHD6",
   squadsVault: "ST999VUTo5QExYEX9bz1oDDoKGkjXG9zpphy4Hj7VWh",
   voltrProgram: "vVoLTRjQmtFpiYoegx285Ze4gsLJ8ZxgFKVcuvmG1a8",
@@ -59,6 +60,7 @@ export type BackyardVaultData =
       routeStatus: string | null;
       settings: VaultSettings;
       squadsIdleRaw: bigint | null;
+      strategyIdleRaw: bigint | null;
       voltrIdleRaw: bigint | null;
       vaultCapRaw: bigint;
       withdrawalWaitSeconds: number;
@@ -244,11 +246,16 @@ export async function getBackyardVaultData(): Promise<BackyardVaultData> {
         { key: "Squads vault", value: MANIFEST.squadsVault },
         { key: "Squads settings", value: MANIFEST.squadsSettings },
         { key: "Adaptor", value: MANIFEST.adaptor },
+        { key: "Strategy receipt", value: MANIFEST.strategyReceipt },
         ...routeSettings,
       ],
       squadsIdleRaw: projectedBigInt(state, [
         "squadsIdleRaw",
         "squads_idle_raw",
+      ]),
+      strategyIdleRaw: projectedBigInt(state, [
+        "voltrStrategyIdleRaw",
+        "voltr_strategy_idle_raw",
       ]),
       voltrIdleRaw: projectedBigInt(state, ["voltrIdleRaw", "voltr_idle_raw"]),
       vaultCapRaw: MANIFEST.vaultCapRaw,

--- a/apps/admin/src/app/(admin)/vault-integrations/backyard/page.tsx
+++ b/apps/admin/src/app/(admin)/vault-integrations/backyard/page.tsx
@@ -98,7 +98,7 @@ export default async function BackyardVaultPage() {
         </Card>
       ) : (
         <>
-          <section className="grid gap-4 md:grid-cols-3">
+          <section className="grid gap-4 md:grid-cols-4">
             <Metric
               title="Current AUM"
               value={formatUsdMicros(data.aumUsdMicros)}
@@ -166,6 +166,11 @@ export default async function BackyardVaultPage() {
               title="Voltr idle"
               value={`${formatRaw(data.voltrIdleRaw)} USDC`}
               description="Strategy idle balance projected by worker"
+            />
+            <Metric
+              title="Strategy idle"
+              value={`${formatRaw(data.strategyIdleRaw)} USDC`}
+              description="Voltr strategy receipt custody"
             />
             <Metric
               title="Squads idle"


### PR DESCRIPTION
Add the missing Voltr strategy-idle balance and exact strategy receipt to the read-only Backyard vault macroview. The admin production build passes.