### PR TITLE
fix(earn): preserve exact withdraw max amount

### DIFF
--- a/apps/web/src/components/wallet-sidebar/earn-detail-view.tsx
+++ b/apps/web/src/components/wallet-sidebar/earn-detail-view.tsx
@@ -233,6 +233,7 @@ export type EarnWithdrawDraft = {
   // a wallet can hold USDC in a second Kamino market, and leaving one behind
   // strands it and fails the post-withdrawal zero proof.
   fullExitSources: EarnWithdrawSourceOption[];
+  isSourceMax?: boolean;
   mode: "partial" | "full";
   source: EarnWithdrawSourceOption;
   symbol: string;
@@ -339,6 +340,15 @@ function formatBucksAmount(value: number) {
     maximumFractionDigits: 2,
     minimumFractionDigits: 0,
   });
+}
+
+export function formatEarnWithdrawMaxAmountLabel(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "0";
+  }
+
+  const roundedToCents = value.toFixed(2);
+  return Number(roundedToCents) > 0 ? roundedToCents : value.toFixed(6);
 }
 
 // Sanitizes free-form amount typing. This helper never compares against a
@@ -3538,6 +3548,7 @@ export function EarnWithdrawView({
       fullExitSources: sourceOptions.filter(
         (source) => source.type === "reserve"
       ),
+      isSourceMax: !hasWithdrawAmount,
       mode: effectiveWithdrawMode,
       source: selectedSource,
       symbol: "USDC",

--- a/apps/web/src/components/wallet-sidebar/earn-withdraw-full-exit.test.ts
+++ b/apps/web/src/components/wallet-sidebar/earn-withdraw-full-exit.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { getEarnWithdrawDraftAmountRaw } from "@/components/wallet-workspace/facelift/earn-actions-support";
+
 import {
   deriveEarnWithdrawMode,
   type EarnWithdrawSourceOption,
+  formatEarnWithdrawMaxAmountLabel,
   selectEarnFullExitSources,
 } from "./earn-detail-view";
 
@@ -68,6 +71,44 @@ describe("Earn withdraw mode derivation", () => {
         sources: [secondReserve, reserveSource("dust", 0.000_001)],
       })
     ).toBe("partial");
+  });
+});
+
+describe("Earn withdraw MAX amounts", () => {
+  test("rounds a one-micro-unit Kamino shortfall to the displayed balance", () => {
+    expect(formatEarnWithdrawMaxAmountLabel(0.999_999)).toBe("1.00");
+  });
+
+  test("keeps sub-cent positions actionable", () => {
+    expect(formatEarnWithdrawMaxAmountLabel(0.001_585)).toBe("0.001585");
+  });
+
+  test("submits the exact selected source when its MAX label rounds up", () => {
+    const source = reserveSource("rounding", 0.999_999);
+
+    expect(
+      getEarnWithdrawDraftAmountRaw({
+        amountLabel: "1.00",
+        isSourceMax: true,
+        mode: "full",
+        source,
+        tokenDecimals: 6,
+      })
+    ).toBe(BigInt(999_999));
+  });
+
+  test("submits the exact selected source when other holdings make MAX partial", () => {
+    const source = reserveSource("rounding", 0.999_999);
+
+    expect(
+      getEarnWithdrawDraftAmountRaw({
+        amountLabel: "1.00",
+        isSourceMax: true,
+        mode: "partial",
+        source,
+        tokenDecimals: 6,
+      })
+    ).toBe(BigInt(999_999));
   });
 });
 

--- a/apps/web/src/components/wallet-workspace/facelift/earn-actions-support.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-actions-support.ts
@@ -168,9 +168,12 @@ export function isWalletCancellation(error: unknown): boolean {
 
 // app-wallet-workspace.tsx:3351-3357
 export function getEarnWithdrawDraftAmountRaw(
-  draft: EarnWithdrawDraft
+  draft: Pick<
+    EarnWithdrawDraft,
+    "amountLabel" | "isSourceMax" | "mode" | "source" | "tokenDecimals"
+  >
 ): bigint {
-  return draft.mode === "full"
+  return draft.isSourceMax || draft.mode === "full"
     ? BigInt(draft.source.amountRaw)
     : parseTokenAmountLabelToRaw(draft.amountLabel, draft.tokenDecimals);
 }

--- a/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/withdraw-pane.tsx
@@ -13,6 +13,7 @@ import {
   deriveEarnWithdrawMode,
   type EarnWithdrawDraft,
   type EarnWithdrawSourceOption,
+  formatEarnWithdrawMaxAmountLabel,
   sanitizeBucksAmountInput,
 } from "@/components/wallet-sidebar/earn-detail-view";
 import {
@@ -170,6 +171,7 @@ export function WithdrawPane({
   onBack: () => void;
 }) {
   const [amount, setAmount] = useState("");
+  const [maxSourceKey, setMaxSourceKey] = useState<string | null>(null);
   // Preselects the positions-row source that opened the screen; otherwise
   // defaults to the first eligible source (options[0] fallback below).
   const [selectedKey, setSelectedKey] = useState(initialSourceKey ?? "");
@@ -225,13 +227,19 @@ export function WithdrawPane({
     options[0] ??
     null;
   const fromBalance = splitUsdBalance(selectedOption?.usd ?? 0);
-
-  const amountUsd = Number.parseFloat(amount.replace(/,/g, "")) || 0;
+  const isSourceMax =
+    selectedOption !== null && maxSourceKey === selectedOption.key;
+  const amountInputValue = isSourceMax
+    ? formatEarnWithdrawMaxAmountLabel(selectedOption.usd)
+    : amount;
+  const typedAmountUsd =
+    Number.parseFloat(amountInputValue.replace(/,/g, "")) || 0;
+  const amountUsd = isSourceMax ? selectedOption.usd : typedAmountUsd;
   const amountLabel = amountUsd.toLocaleString("en-US", {
     maximumFractionDigits: 2,
   });
-  // Same mode derivation as the old workspace: compared against the floored
-  // TOTAL of all sources, so the visible max registers as a full exit.
+  // Same mode derivation as the old workspace: compare the exact selected
+  // source balance for MAX even when its two-decimal label rounds differently.
   const withdrawMode = deriveEarnWithdrawMode({ amount: amountUsd, sources });
   const fullExitSources = useMemo(
     () => sources.filter((source) => source.type === "reserve"),
@@ -263,9 +271,10 @@ export function WithdrawPane({
     data.actions.hasCleanupCandidate && sources.length === 0;
 
   const handleAmountChange = (rawValue: string) => {
-    const sanitized = sanitizeBucksAmountInput(rawValue, amount);
+    const sanitized = sanitizeBucksAmountInput(rawValue, amountInputValue);
     if (sanitized !== null) {
       setAmount(sanitized);
+      setMaxSourceKey(null);
     }
   };
   const selectSource = (key: string) => {
@@ -278,9 +287,10 @@ export function WithdrawPane({
     }
     const draft: EarnWithdrawDraft = {
       amount: amountUsd,
-      amountLabel: amount,
+      amountLabel: amountInputValue,
       destination: data.actions.depositSource,
       fullExitSources,
+      isSourceMax,
       mode: withdrawMode,
       source: draftSource,
       symbol: selectedSymbol,
@@ -377,7 +387,7 @@ export function WithdrawPane({
                     }}
                     placeholder="0"
                     type="text"
-                    value={amount}
+                    value={amountInputValue}
                   />
                 </span>
               </label>
@@ -503,17 +513,8 @@ export function WithdrawPane({
                 <button
                   className="t-hover min-w-16 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4 hover:bg-accent-active"
                   onClick={() => {
-                    const usd = selectedOption?.usd ?? 0;
-                    if (usd > 0) {
-                      // Floor to cents so the label never rounds above the
-                      // real balance (full exits withdraw the exact raw).
-                      // Sub-cent dust floors to $0.00 and blocks the exit;
-                      // use the exact 6-decimal amount so the position can
-                      // still close (ASK-2207).
-                      const floored = Math.floor(usd * 100) / 100;
-                      handleAmountChange(
-                        floored > 0 ? floored.toFixed(2) : usd.toFixed(6)
-                      );
+                    if (selectedOption && selectedOption.usd > 0) {
+                      setMaxSourceKey(selectedOption.key);
                     }
                   }}
                   type="button"


### PR DESCRIPTION
Fixes web Earn Withdraw MAX when Kamino’s exact balance is slightly below the two-decimal UI balance: the field now shows the correctly rounded amount while MAX remains explicit and submits the selected source’s exact raw balance for both full and source-local partial exits. Scope is limited to web Earn withdrawal amount selection; verified with the targeted 12-test withdrawal suite, web lint, `tsc --noEmit`, and Prettier, with no post-merge steps required.