### PR TITLE
fix(observability): classify Earn SOL preflight failures

### DIFF
--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -850,8 +850,42 @@ export function useEarnActions(deps: {
       const interactionStartedAtMs = getBrowserPerformanceNow();
       let previewMetricSent = false;
       let walletSubmittedAtMs: number | null = null;
+      let walletSubmissionDiagnostics: {
+        executionMode?: "batch" | "sequential" | "single";
+        policyMode?: "create" | "reuse";
+      } = {};
+      const prepareWalletSubmission = (
+        diagnostics: typeof walletSubmissionDiagnostics
+      ) => {
+        walletSubmissionDiagnostics = diagnostics;
+      };
       const markWalletSubmitted = () => {
-        walletSubmittedAtMs ??= getBrowserPerformanceNow();
+        if (walletSubmittedAtMs !== null) {
+          return;
+        }
+        walletSubmittedAtMs = getBrowserPerformanceNow();
+        tracker.observe("wallet_submit_confirm", {
+          ...walletSubmissionDiagnostics,
+          chainState: "submitted",
+        });
+      };
+      const handleDepositPreflightFailure = (result: {
+        error?: string;
+        errorCode?: string;
+      }): boolean => {
+        if (result.errorCode !== "insufficient_native_sol") {
+          return false;
+        }
+        setDepositError(
+          result.error ?? "Add SOL to the connected wallet before signing."
+        );
+        tracker.fail("preflight", {
+          ...walletSubmissionDiagnostics,
+          chainState: "not_submitted",
+          errorCode: "insufficient_native_sol",
+        });
+        earnToast.error("More SOL required");
+        return true;
       };
 
       const commitDepositSuccess = (commit: {
@@ -1041,8 +1075,7 @@ export function useEarnActions(deps: {
         earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
 
         if (shouldBypassTopUpPreview) {
-          tracker.observe("wallet_submit_confirm", {
-            chainState: "submitted",
+          prepareWalletSubmission({
             executionMode: "single",
             policyMode: "reuse",
           });
@@ -1054,6 +1087,9 @@ export function useEarnActions(deps: {
             preparedDeposit,
           });
           if (!result.success) {
+            if (handleDepositPreflightFailure(result)) {
+              return false;
+            }
             if (result.status === "confirmation_record_failed") {
               tracker.fail("backend_confirm", {
                 chainState: "confirmed",
@@ -1091,8 +1127,7 @@ export function useEarnActions(deps: {
             executionMode: "batch",
             policyMode: "create",
           });
-          tracker.observe("wallet_submit_confirm", {
-            chainState: "submitted",
+          prepareWalletSubmission({
             executionMode: "batch",
             policyMode: "create",
           });
@@ -1123,6 +1158,9 @@ export function useEarnActions(deps: {
                 : {}),
             };
             if (!batchResult.success) {
+              if (handleDepositPreflightFailure(batchResult)) {
+                return false;
+              }
               if (batchResult.status === "confirmation_record_failed") {
                 tracker.fail("backend_confirm", {
                   chainState: "confirmed",
@@ -1164,9 +1202,9 @@ export function useEarnActions(deps: {
               executionMode: "sequential",
               policyMode: "create",
             });
-            tracker.observe("wallet_submit_confirm", {
-              chainState: "submitted",
+            prepareWalletSubmission({
               executionMode: "sequential",
+              policyMode: "create",
             });
             earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
             const result = await smartAccountData.executeEarnDepositPolicyStage(
@@ -1178,6 +1216,9 @@ export function useEarnActions(deps: {
               }
             );
             if (!result.success) {
+              if (handleDepositPreflightFailure(result)) {
+                return false;
+              }
               if (result.status === "confirmation_record_failed") {
                 tracker.fail("backend_confirm", {
                   chainState: "confirmed",
@@ -1216,9 +1257,9 @@ export function useEarnActions(deps: {
             continue;
           }
 
-          tracker.observe("wallet_submit_confirm", {
-            chainState: "submitted",
+          prepareWalletSubmission({
             executionMode: "sequential",
+            policyMode: "create",
           });
           earnToast.loading(CONFIRM_IN_WALLET_MESSAGE);
           const result = await smartAccountData.executeEarnDeposit({
@@ -1230,6 +1271,9 @@ export function useEarnActions(deps: {
             preparedDeposit,
           });
           if (!result.success) {
+            if (handleDepositPreflightFailure(result)) {
+              return false;
+            }
             if (result.status === "confirmation_record_failed") {
               tracker.fail("backend_confirm", {
                 chainState: "confirmed",

--- a/apps/web/src/features/observability/lifecycle-contract.ts
+++ b/apps/web/src/features/observability/lifecycle-contract.ts
@@ -96,6 +96,7 @@ export const LIFECYCLE_STAGES = {
     "review",
     "policy",
     "policy_finalize",
+    "preflight",
     "wallet_submit_confirm",
     "slot_resolve",
     "backend_confirm",

--- a/apps/web/src/features/observability/otlp.test.ts
+++ b/apps/web/src/features/observability/otlp.test.ts
@@ -39,6 +39,7 @@ function severityText(event: NormalizedLifecycleEvent): string | undefined {
 
 describe("lifecycle alert severity", () => {
   test.each([
+    "insufficient_native_sol",
     "wallet_account_mismatch",
     "wallet_authorization_expired",
     "wallet_connection_failed",

--- a/apps/web/src/features/observability/otlp.ts
+++ b/apps/web/src/features/observability/otlp.ts
@@ -31,7 +31,8 @@ function toUnixNano(timestamp: string): string {
   return (BigInt(Date.parse(timestamp)) * BigInt(1_000_000)).toString();
 }
 
-const EXPECTED_LOCAL_WALLET_FAILURES = new Set([
+const EXPECTED_LOCAL_FAILURES = new Set([
+  "insufficient_native_sol",
   "wallet_account_mismatch",
   "wallet_authorization_expired",
   "wallet_connection_failed",
@@ -60,7 +61,7 @@ export function isAlertableLifecycleEvent(
   ) {
     return true;
   }
-  if (event.errorCode && EXPECTED_LOCAL_WALLET_FAILURES.has(event.errorCode)) {
+  if (event.errorCode && EXPECTED_LOCAL_FAILURES.has(event.errorCode)) {
     return false;
   }
   if (event.errorCode !== "request_failed") return true;

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -501,6 +501,7 @@ export type EarnDepositResult = {
   confirmedSlot?: string;
   status?: "executed" | "confirmation_record_failed";
   error?: string;
+  errorCode?: "insufficient_native_sol";
 };
 
 export type EarnDepositBatchRequest = EarnDepositRequest & {
@@ -530,6 +531,7 @@ export type EarnDepositPolicyStageResult = {
   confirmedSlot?: string;
   status?: "confirmation_record_failed" | "executed";
   error?: string;
+  errorCode?: "insufficient_native_sol";
 };
 
 export type EarnWithdrawRequest = {
@@ -6423,7 +6425,11 @@ export function useSmartAccountSidebarData(
         request.preparedDeposit.nativeSolRequirement
       );
       if (nativeSolError) {
-        return { success: false, error: nativeSolError };
+        return {
+          success: false,
+          error: nativeSolError,
+          errorCode: "insufficient_native_sol",
+        };
       }
 
       const expectedEarnCluster = resolveEarnLoyalCluster(solanaEnv);
@@ -6624,7 +6630,11 @@ export function useSmartAccountSidebarData(
         request.preparedDeposit.nativeSolRequirement
       );
       if (nativeSolError) {
-        return { success: false, error: nativeSolError };
+        return {
+          success: false,
+          error: nativeSolError,
+          errorCode: "insufficient_native_sol",
+        };
       }
 
       setIsActionPending(true);
@@ -6966,7 +6976,11 @@ export function useSmartAccountSidebarData(
           preparedDeposit.nativeSolRequirement
         );
         if (nativeSolError) {
-          return { success: false, error: nativeSolError };
+          return {
+            success: false,
+            error: nativeSolError,
+            errorCode: "insufficient_native_sol",
+          };
         }
         console.log(
           "[executeEarnDeposit] prepared deposit; sending to wallet",


### PR DESCRIPTION
Stops the `earn.deposit.wallet_submit_confirm.failed` alert for expected insufficient-native-SOL rejections by emitting `insufficient_native_sol` at the `preflight` stage as ClickStack INFO, keeping `chainState` as `not_submitted`, and marking submission only from the actual wallet callback. Scope is web Earn deposit telemetry only; verified with targeted ESLint, 74 observability tests, the observability verifier, package builds, and web typecheck, with no post-merge action beyond monitoring ClickStack for the new informational event.