### PR TITLE
fix(mobile): bound Earn transaction rebroadcasting

### DIFF
--- a/apps/mobile/src/lib/solana/earn/__tests__/send-prepared.test.ts
+++ b/apps/mobile/src/lib/solana/earn/__tests__/send-prepared.test.ts
@@ -1,0 +1,133 @@
+import {
+  type Connection,
+  Keypair,
+  SystemProgram,
+} from "@solana/web3.js";
+
+import { LocalKeypairSigner } from "@/lib/wallet/signer";
+
+import {
+  REBROADCAST_INTERVAL_MS,
+  REBROADCAST_MAX_RESENDS,
+  signAndSendPreparedOperations,
+} from "../send-prepared";
+
+const payer = Keypair.generate();
+const signer = new LocalKeypairSigner(payer);
+const operation = {
+  payer: payer.publicKey,
+  instructions: [
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: Keypair.generate().publicKey,
+      lamports: 1,
+    }),
+  ],
+  lookupTableAccounts: [],
+};
+
+// A pending signature that never confirms, then expires — the exact case the
+// old loop turned into an unbounded stream of paid resends.
+function makeConnection(overrides: Partial<Connection> = {}) {
+  let sends = 0;
+  const connection = {
+    getLatestBlockhash: jest.fn().mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 100,
+    }),
+    sendRawTransaction: jest.fn(async () => `sig-${++sends}`),
+    confirmTransaction: jest.fn(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(
+            () => reject(new Error("Signature has expired")),
+            REBROADCAST_INTERVAL_MS * (REBROADCAST_MAX_RESENDS + 5),
+          );
+        }),
+    ),
+    getSignatureStatuses: jest.fn().mockResolvedValue({ value: [null] }),
+    ...overrides,
+  };
+  return connection as unknown as Connection & typeof connection;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function settle<T>(promise: Promise<T>) {
+  const outcome = promise.then(
+    (value) => ({ ok: true as const, value }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+  await jest.runAllTimersAsync();
+  return outcome;
+}
+
+describe("signAndSendPreparedOperations rebroadcast bounds", () => {
+  test("a pending tx sends at most 1 + REBROADCAST_MAX_RESENDS times", async () => {
+    const connection = makeConnection();
+    const result = await settle(
+      signAndSendPreparedOperations({
+        connection,
+        signer,
+        operations: [operation],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(connection.sendRawTransaction).toHaveBeenCalledTimes(
+      1 + REBROADCAST_MAX_RESENDS,
+    );
+  });
+
+  test("send-all-before-confirm stops every loop once a confirm fails", async () => {
+    const connection = makeConnection({
+      confirmTransaction: jest
+        .fn()
+        .mockRejectedValue(new Error("Signature has expired")),
+    } as Partial<Connection>);
+    const result = await settle(
+      signAndSendPreparedOperations({
+        connection,
+        signer,
+        operations: [operation, operation],
+        sendMode: "send-all-before-confirm",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    // Two first-sends; the stop() in `finally` must win before any timer fires.
+    expect(connection.sendRawTransaction).toHaveBeenCalledTimes(2);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test("stops resending as soon as confirmation lands", async () => {
+    const connection = makeConnection({
+      confirmTransaction: jest.fn(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () => resolve({ context: { slot: 7 }, value: { err: null } }),
+              REBROADCAST_INTERVAL_MS * 2 + 1,
+            );
+          }),
+      ),
+      getSignatureStatuses: jest.fn().mockResolvedValue({
+        value: [{ slot: 7, err: null, confirmationStatus: "confirmed" }],
+      }),
+    } as Partial<Connection>);
+    const result = await settle(
+      signAndSendPreparedOperations({
+        connection,
+        signer,
+        operations: [operation],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(connection.sendRawTransaction).toHaveBeenCalledTimes(3);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/mobile/src/lib/solana/earn/send-prepared.ts
+++ b/apps/mobile/src/lib/solana/earn/send-prepared.ts
@@ -40,8 +40,15 @@ const PRIORITY_FEE_MICRO_LAMPORTS = 100_000;
 // the RPC would reject it anyway. When that happens, send without the fee:
 // landing slowly beats not signing at all.
 const MAX_TRANSACTION_BYTES = 1232;
-// How often to re-broadcast the signed tx while waiting for confirmation.
-const REBROADCAST_INTERVAL_MS = 2000;
+// Rebroadcast cadence and hard ceilings. Every resend is a paid Helius
+// `sendTransactionWithStake` call, and an uncapped 2s loop burned ~269K
+// credits/day (ASK-2258). With the priority fee above, a 4s cadence still
+// keeps the tx in front of leaders; the count/time caps guarantee a stuck
+// confirmation (or an orphaned batch loop) can never resend forever. The
+// 60s deadline matches blockhash validity — past it, resends are dead weight.
+export const REBROADCAST_INTERVAL_MS = 4000;
+export const REBROADCAST_MAX_RESENDS = 10;
+export const REBROADCAST_MAX_ELAPSED_MS = 60_000;
 
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -170,11 +177,11 @@ type InFlightTransaction = {
   stop: () => Promise<void>;
 };
 
-// Sends an already-signed transaction and keeps re-broadcasting it until
-// `stop()` — under load, RPCs drop a pending tx and `confirmTransaction` never
-// re-sends; it just waits out the blockhash and reports expiry. Re-broadcasting
-// the signed raw tx every couple seconds keeps it in front of leaders until it
-// lands.
+// Sends an already-signed transaction and re-broadcasts it until `stop()` or
+// the resend caps — under load, RPCs drop a pending tx and `confirmTransaction`
+// never re-sends; it just waits out the blockhash and reports expiry.
+// Re-broadcasting the signed raw tx keeps it in front of leaders until it
+// lands. Callers stop the loop on confirmation, on-chain failure, or expiry.
 async function startSendingSignedTransaction(
   connection: Connection,
   transaction: VersionedTransaction,
@@ -188,6 +195,7 @@ async function startSendingSignedTransaction(
   });
 
   let rebroadcasting = true;
+  const deadline = Date.now() + REBROADCAST_MAX_ELAPSED_MS;
   let wakeRebroadcast: (() => void) | null = null;
   const waitForRebroadcast = (): Promise<void> =>
     new Promise((resolve) => {
@@ -202,9 +210,9 @@ async function startSendingSignedTransaction(
       };
     });
   const rebroadcast = (async () => {
-    while (rebroadcasting) {
+    for (let resend = 0; resend < REBROADCAST_MAX_RESENDS; resend++) {
       await waitForRebroadcast();
-      if (!rebroadcasting) {
+      if (!rebroadcasting || Date.now() >= deadline) {
         return;
       }
       try {


### PR DESCRIPTION
Caps the mobile Earn rebroadcast loop at 10 resends / 60s on a 4s cadence, stopping on confirmation, on-chain failure, or expiry, so a pending tx can no longer generate unbounded Helius sendTransactionWithStake calls (ASK-2258).