### PR TITLE
feat(web): add account panel for privy linked accounts

### DIFF
--- a/apps/web/src/components/auth/add-email-nudge.tsx
+++ b/apps/web/src/components/auth/add-email-nudge.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { Mail, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { usePrivyAuth } from "@/components/auth/privy-session-sync";
+import { useAuthSession } from "@/contexts/auth-session-context";
+import { usePublicEnv } from "@/contexts/public-env-context";
+import { useCherryRuntime } from "@/features/cherry/client/runtime-context";
+
+// One-time nudge for users signed in through the legacy wallet flow (no Privy
+// user yet). "Add" runs the same wallet through Privy and asks for an email;
+// the cross remembers the dismissal. Expands/collapses on the accordion
+// recipe so it never snaps the layout.
+const DISMISSED_KEY = "loyal:add-email-nudge-dismissed";
+
+export function AddEmailNudge() {
+  const { privyAppId } = usePublicEnv();
+  const cherryRuntime = useCherryRuntime();
+  const { isHydrated, isAuthenticated } = useAuthSession();
+  const { ready, authenticated } = usePrivy();
+  const privyAuth = usePrivyAuth();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const eligible =
+    Boolean(privyAppId) &&
+    cherryRuntime.mode === "standalone" &&
+    isHydrated &&
+    isAuthenticated &&
+    ready &&
+    !authenticated;
+
+  useEffect(() => {
+    setIsOpen(eligible && localStorage.getItem(DISMISSED_KEY) !== "1");
+  }, [eligible]);
+
+  if (!privyAppId) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, "1");
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="t-acc w-full" data-open={isOpen ? "true" : "false"}>
+      <div className="t-acc-panel">
+        <div className="t-acc-panel-inner">
+          <div className="flex items-center rounded-2xl bg-accent py-1 pr-2 pl-4">
+            <span className="mr-3 flex size-11 shrink-0 items-center justify-center text-tertiary">
+              <Mail className="size-6" />
+            </span>
+            <span className="min-w-0 flex-1 py-2">
+              <span className="block font-medium text-[16px] text-foreground leading-5">
+                Add your email
+              </span>
+              <span className="block truncate text-muted-foreground text-[13px] leading-4">
+                Updates and recovery.
+              </span>
+            </span>
+            <button
+              className="t-hover ml-3 shrink-0 rounded-full bg-foreground px-4 py-2.5 font-medium text-[13px] text-background leading-4 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-40"
+              disabled={!privyAuth || privyAuth.step !== "idle"}
+              onClick={() => privyAuth?.addEmail()}
+              type="button"
+            >
+              Add
+            </button>
+            <button
+              aria-label="Dismiss"
+              className="t-hover ml-1 flex size-9 shrink-0 items-center justify-center rounded-3xl text-tertiary hover:bg-accent-selected"
+              onClick={dismiss}
+              type="button"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+          {/* Gap to whatever follows (room for the banner carousel dots on
+              mobile); inside the panel so it collapses too. */}
+          <div className="h-4" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/privy-account-panel.tsx
+++ b/apps/web/src/components/auth/privy-account-panel.tsx
@@ -13,6 +13,7 @@ import { useUpdateEmail } from "@privy-io/react-auth/ui";
 import { KeyRound, Mail, ShieldCheck, Wallet } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 
+import { usePrivyAuth } from "@/components/auth/privy-session-sync";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
@@ -44,6 +45,7 @@ function usePrivyAppConfig(appId: string | undefined) {
  */
 export function PrivyAccountPanel() {
   const { user: privyUser } = usePrivy();
+  const privyAuth = usePrivyAuth();
   const { user, refreshSession } = useAuthSession();
   const { privyAppId } = usePublicEnv();
   const [busy, setBusy] = useState(false);
@@ -77,7 +79,27 @@ export function PrivyAccountPanel() {
   const { exportWallet } = useExportWallet();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
 
-  if (!privyUser) return null;
+  if (!privyUser) {
+    // Legacy wallet session (signed in before Privy): one row that logs the
+    // same wallet into Privy and asks for an email.
+    return (
+      <div className="flex flex-col gap-1">
+        <Row
+          action="Add"
+          disabled={!privyAuth || privyAuth.step !== "idle"}
+          icon={<Mail className="size-6" />}
+          onClick={() => privyAuth?.addEmail()}
+          subtitle="For account updates and recovery."
+          title="Email"
+        />
+        {privyAuth?.error ? (
+          <p className="px-4 text-[13px] text-destructive leading-4">
+            {privyAuth.error}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
   const linked = privyUser.linkedAccounts;
   const email = linked.find((a) => a.type === "email");
   const google = linked.find((a) => a.type === "google_oauth");

--- a/apps/web/src/components/auth/privy-account-panel.tsx
+++ b/apps/web/src/components/auth/privy-account-panel.tsx
@@ -13,6 +13,7 @@ import { useUpdateEmail } from "@privy-io/react-auth/ui";
 import { KeyRound, Mail, ShieldCheck, Wallet } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 
+import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { useAuthSession } from "@/contexts/auth-session-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 
@@ -94,11 +95,11 @@ export function PrivyAccountPanel() {
   const mfaEnabled = (appConfig?.mfa_methods?.length ?? 0) > 0;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-1">
       <Row
         action={email ? (canUnlink ? "Remove" : "Change") : "Add"}
         disabled={busy}
-        icon={<Mail className="h-5 w-5" />}
+        icon={<Mail className="size-6" />}
         onClick={() =>
           email
             ? canUnlink
@@ -132,7 +133,7 @@ export function PrivyAccountPanel() {
         <Row
           action="Export"
           disabled={busy}
-          icon={<KeyRound className="h-5 w-5" />}
+          icon={<KeyRound className="size-6" />}
           onClick={() => exportWallet({ address: embedded.address })}
           subtitle="Copy the private key of your loyal wallet."
           title="Wallet key"
@@ -140,7 +141,7 @@ export function PrivyAccountPanel() {
       ) : (
         <Row
           disabled
-          icon={<Wallet className="h-5 w-5" />}
+          icon={<Wallet className="size-6" />}
           subtitle="Signed in with your own wallet."
           title="Wallet"
         />
@@ -149,7 +150,7 @@ export function PrivyAccountPanel() {
         <Row
           action={mfaOn ? "Manage" : "Enable"}
           disabled={busy}
-          icon={<ShieldCheck className="h-5 w-5" />}
+          icon={<ShieldCheck className="size-6" />}
           onClick={showMfaEnrollmentModal}
           subtitle={
             mfaOn
@@ -179,24 +180,30 @@ function Row({
   title: string;
 }) {
   const interactive = Boolean(onClick && action);
+  // Same row recipe as the sidebar links: t-hover + hover:bg-accent, 44px
+  // icon slot, tertiary icon. Static rows keep the layout but no hover.
   return (
     <button
-      className="flex w-full items-center gap-3 rounded-[20px] bg-secondary px-4 py-3 text-left transition enabled:hover:bg-secondary/80 disabled:cursor-default disabled:opacity-60"
+      className="t-hover flex w-full items-center rounded-2xl px-4 text-left enabled:hover:bg-accent disabled:cursor-default"
       disabled={disabled || !interactive}
       onClick={() => void onClick?.()}
       type="button"
     >
-      <span className="shrink-0 text-muted-foreground">{icon}</span>
-      <span className="min-w-0 flex-1">
-        <span className="block font-medium text-foreground text-sm">
+      <span className="mr-3 flex size-11 shrink-0 items-center justify-center text-tertiary">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 py-2">
+        <span className="block font-medium text-[16px] text-foreground leading-5">
           {title}
         </span>
-        <span className="block truncate text-muted-foreground text-xs">
+        <span className="block truncate text-muted-foreground text-[13px] leading-4">
           {subtitle}
         </span>
       </span>
       {action ? (
-        <span className="shrink-0 text-muted-foreground text-sm">{action}</span>
+        <span className="ml-3 shrink-0 rounded-full bg-accent px-4 py-2.5 text-center font-medium text-[13px] text-foreground leading-4">
+          <TextSwap text={action} />
+        </span>
       ) : null}
     </button>
   );
@@ -204,7 +211,7 @@ function Row({
 
 function GoogleMark() {
   return (
-    <svg aria-hidden="true" className="h-5 w-5" viewBox="0 0 24 24">
+    <svg aria-hidden="true" className="size-6" viewBox="0 0 24 24">
       <path
         d="M21.6 12.2c0-.7-.1-1.4-.2-2H12v3.9h5.4a4.6 4.6 0 0 1-2 3v2.5h3.2c1.9-1.7 3-4.3 3-7.4Z"
         fill="#4285F4"

--- a/apps/web/src/components/auth/privy-account-panel.tsx
+++ b/apps/web/src/components/auth/privy-account-panel.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import {
+  getIdentityToken,
+  useLinkAccount,
+  useMfaEnrollment,
+  usePrivy,
+  useUnlinkEmail,
+  useUnlinkOAuth,
+} from "@privy-io/react-auth";
+import { useExportWallet } from "@privy-io/react-auth/solana";
+import { useUpdateEmail } from "@privy-io/react-auth/ui";
+import { KeyRound, Mail, ShieldCheck, Wallet } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+
+import { useAuthSession } from "@/contexts/auth-session-context";
+import { usePublicEnv } from "@/contexts/public-env-context";
+
+type PrivyAppConfig = { google_oauth?: boolean; mfa_methods?: string[] };
+// Public, unauthenticated dashboard config; the SDK reads it but exposes no
+// hook. ponytail: one fetch per mount, no cache — the panel is rarely open.
+function usePrivyAppConfig(appId: string | undefined) {
+  const [config, setConfig] = useState<PrivyAppConfig | null>(null);
+  useEffect(() => {
+    if (!appId) return;
+    const ctrl = new AbortController();
+    fetch(`https://auth.privy.io/api/v1/apps/${appId}`, {
+      headers: { "privy-app-id": appId },
+      signal: ctrl.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((c) => c && setConfig(c as PrivyAppConfig))
+      .catch(() => undefined);
+    return () => ctrl.abort();
+  }, [appId]);
+  return config;
+}
+
+/**
+ * Account panel body when Privy is on: linked email / Google, embedded-wallet
+ * key export, MFA. Every Privy action runs in Privy's own modal; after a
+ * link/unlink the Loyal session is re-issued so `user.email` follows.
+ */
+export function PrivyAccountPanel() {
+  const { user: privyUser } = usePrivy();
+  const { user, refreshSession } = useAuthSession();
+  const { privyAppId } = usePublicEnv();
+  const [busy, setBusy] = useState(false);
+  const appConfig = usePrivyAppConfig(privyAppId);
+
+  const resync = useCallback(async () => {
+    if (!user?.walletAddress) return;
+    setBusy(true);
+    try {
+      const identityToken = await getIdentityToken();
+      if (!identityToken) return;
+      await fetch("/api/auth/privy/complete", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "content-type": "application/json",
+          "privy-id-token": identityToken,
+        },
+        body: JSON.stringify({ walletAddress: user.walletAddress }),
+      });
+      await refreshSession();
+    } finally {
+      setBusy(false);
+    }
+  }, [refreshSession, user?.walletAddress]);
+
+  const { linkEmail, linkGoogle } = useLinkAccount({ onSuccess: resync });
+  const { update: updateEmail } = useUpdateEmail();
+  const { unlink: unlinkEmail } = useUnlinkEmail();
+  const { unlink: unlinkOAuth } = useUnlinkOAuth();
+  const { exportWallet } = useExportWallet();
+  const { showMfaEnrollmentModal } = useMfaEnrollment();
+
+  if (!privyUser) return null;
+  const linked = privyUser.linkedAccounts;
+  const email = linked.find((a) => a.type === "email");
+  const google = linked.find((a) => a.type === "google_oauth");
+  const embedded = linked.find(
+    (a): a is Extract<typeof a, { type: "wallet" }> =>
+      a.type === "wallet" &&
+      a.chainType === "solana" &&
+      a.walletClientType === "privy"
+  );
+  // Privy refuses to unlink the last linked account; mirror that in the UI.
+  const canUnlink = linked.length > 1;
+  const mfaOn = privyUser.mfaMethods.length > 0;
+  // Dashboard toggles: rows for methods that are off would only error.
+  const googleEnabled = appConfig?.google_oauth === true;
+  const mfaEnabled = (appConfig?.mfa_methods?.length ?? 0) > 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Row
+        action={email ? (canUnlink ? "Remove" : "Change") : "Add"}
+        disabled={busy}
+        icon={<Mail className="h-5 w-5" />}
+        onClick={() =>
+          email
+            ? canUnlink
+              ? unlinkEmail({ address: email.address }).then(resync)
+              : updateEmail()
+            : linkEmail()
+        }
+        subtitle={email ? email.address : "For account updates and recovery."}
+        title="Email"
+      />
+      {google || googleEnabled ? (
+        <Row
+          action={google ? (canUnlink ? "Remove" : undefined) : "Link"}
+          disabled={busy}
+          icon={<GoogleMark />}
+          onClick={() =>
+            google
+              ? canUnlink
+                ? unlinkOAuth({
+                    provider: "google",
+                    subject: google.subject,
+                  }).then(resync)
+                : undefined
+              : linkGoogle()
+          }
+          subtitle={google ? google.email ?? "Linked" : "Sign in with Google."}
+          title="Google"
+        />
+      ) : null}
+      {embedded ? (
+        <Row
+          action="Export"
+          disabled={busy}
+          icon={<KeyRound className="h-5 w-5" />}
+          onClick={() => exportWallet({ address: embedded.address })}
+          subtitle="Copy the private key of your loyal wallet."
+          title="Wallet key"
+        />
+      ) : (
+        <Row
+          disabled
+          icon={<Wallet className="h-5 w-5" />}
+          subtitle="Signed in with your own wallet."
+          title="Wallet"
+        />
+      )}
+      {mfaEnabled || mfaOn ? (
+        <Row
+          action={mfaOn ? "Manage" : "Enable"}
+          disabled={busy}
+          icon={<ShieldCheck className="h-5 w-5" />}
+          onClick={showMfaEnrollmentModal}
+          subtitle={
+            mfaOn
+              ? "On — extra check before signing."
+              : "Extra check before signing."
+          }
+          title="Two-factor"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function Row({
+  action,
+  disabled,
+  icon,
+  onClick,
+  subtitle,
+  title,
+}: {
+  action?: string;
+  disabled?: boolean;
+  icon: ReactNode;
+  onClick?: () => unknown;
+  subtitle: string;
+  title: string;
+}) {
+  const interactive = Boolean(onClick && action);
+  return (
+    <button
+      className="flex w-full items-center gap-3 rounded-[20px] bg-secondary px-4 py-3 text-left transition enabled:hover:bg-secondary/80 disabled:cursor-default disabled:opacity-60"
+      disabled={disabled || !interactive}
+      onClick={() => void onClick?.()}
+      type="button"
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
+      <span className="min-w-0 flex-1">
+        <span className="block font-medium text-foreground text-sm">
+          {title}
+        </span>
+        <span className="block truncate text-muted-foreground text-xs">
+          {subtitle}
+        </span>
+      </span>
+      {action ? (
+        <span className="shrink-0 text-muted-foreground text-sm">{action}</span>
+      ) : null}
+    </button>
+  );
+}
+
+function GoogleMark() {
+  return (
+    <svg aria-hidden="true" className="h-5 w-5" viewBox="0 0 24 24">
+      <path
+        d="M21.6 12.2c0-.7-.1-1.4-.2-2H12v3.9h5.4a4.6 4.6 0 0 1-2 3v2.5h3.2c1.9-1.7 3-4.3 3-7.4Z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 22c2.7 0 5-.9 6.6-2.4l-3.2-2.5c-.9.6-2 1-3.4 1-2.6 0-4.8-1.8-5.6-4.1H3.1v2.6A10 10 0 0 0 12 22Z"
+        fill="#34A853"
+      />
+      <path
+        d="M6.4 14a6 6 0 0 1 0-3.9V7.5H3.1a10 10 0 0 0 0 9l3.3-2.5Z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 6c1.5 0 2.8.5 3.8 1.5l2.8-2.8A10 10 0 0 0 3.1 7.5L6.4 10c.8-2.3 3-4 5.6-4Z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/auth/privy-session-sync.tsx
+++ b/apps/web/src/components/auth/privy-session-sync.tsx
@@ -31,6 +31,9 @@ type PrivyAuthState = {
   step: Step;
   error: string | null;
   start: () => void;
+  // Signed in through the legacy wallet flow (no Privy user yet): log the
+  // same wallet into Privy, re-issue the session, then prompt for email.
+  addEmail: () => void;
 };
 
 const PrivyAuthContext = createContext<PrivyAuthState | null>(null);
@@ -82,7 +85,8 @@ function Inner({ children }: { children: ReactNode }) {
   const { createWallet } = useCreateWallet();
   const { ready: walletsReady, wallets: privyWallets } = useWallets();
   const adapter = useWallet();
-  const { isHydrated, isAuthenticated, refreshSession } = useAuthSession();
+  const { isHydrated, isAuthenticated, refreshSession, user } =
+    useAuthSession();
   const {
     openAccount: openSignInModal,
     close: closeSignInModal,
@@ -143,6 +147,17 @@ function Inner({ children }: { children: ReactNode }) {
     }
   }, [authenticated, login, setWantsSession]);
 
+  const addEmail = useCallback(() => {
+    if (authenticated) {
+      linkEmail();
+      return;
+    }
+    setError(null);
+    setWantsSession(true);
+    setStep("privy");
+    login({ loginMethods: ["wallet"], walletChainType: "solana-only" });
+  }, [authenticated, linkEmail, login, setWantsSession]);
+
   // "Connect" anywhere on the page goes straight to Privy while signed out;
   // signed in, the modal shows the Account view as before.
   useEffect(() => {
@@ -183,6 +198,20 @@ function Inner({ children }: { children: ReactNode }) {
       (embedded && "address" in embedded ? embedded.address : null);
     loginAddressRef.current = null;
 
+    // Add-email from a legacy session: Privy must have been logged in with
+    // the wallet that session is on, else we'd silently switch accounts.
+    if (user?.walletAddress) {
+      if (!linkedAddresses.has(user.walletAddress)) {
+        await logout();
+        const short = `${user.walletAddress.slice(
+          0,
+          4
+        )}…${user.walletAddress.slice(-4)}`;
+        throw new Error(`Sign in with ${short} to add an email.`);
+      }
+      address = user.walletAddress;
+    }
+
     if (!address) {
       setStep("creating_wallet");
       const { wallet } = await createWallet();
@@ -216,16 +245,18 @@ function Inner({ children }: { children: ReactNode }) {
     closeSignInModal,
     createWallet,
     linkEmail,
+    logout,
     privyUser,
     privyWallets,
     refreshSession,
     refreshUser,
+    user?.walletAddress,
   ]);
 
   // Sign-in: run once everything is ready, whichever order it arrives in.
   useEffect(() => {
     if (!wantsSession || !authenticated || !walletsReady || !privyUser) return;
-    if (isAuthenticated || runningRef.current) return;
+    if (runningRef.current) return;
     runningRef.current = true;
     void completeSignIn()
       .catch((e) => {
@@ -240,7 +271,6 @@ function Inner({ children }: { children: ReactNode }) {
   }, [
     authenticated,
     completeSignIn,
-    isAuthenticated,
     openSignInModal,
     privyUser,
     setWantsSession,
@@ -252,7 +282,6 @@ function Inner({ children }: { children: ReactNode }) {
   // disconnected (or on whatever it auto-connected to). Earn actions require
   // the connected wallet to equal the session wallet, so re-select the one
   // Privy says owns the address — same step completeSignIn does at login.
-  const { user } = useAuthSession();
   useEffect(() => {
     if (!isHydrated || !isAuthenticated || !walletsReady) return;
     const address = user?.walletAddress;
@@ -295,8 +324,8 @@ function Inner({ children }: { children: ReactNode }) {
   }, [authenticated, isAuthenticated, isHydrated, logout, ready, wantsSession]);
 
   const value = useMemo(
-    () => ({ ready, step, error, start }),
-    [ready, step, error, start]
+    () => ({ ready, step, error, start, addEmail }),
+    [ready, step, error, start, addEmail]
   );
   return (
     <PrivyAuthContext.Provider value={value}>

--- a/apps/web/src/components/auth/sign-in-modal.tsx
+++ b/apps/web/src/components/auth/sign-in-modal.tsx
@@ -69,7 +69,7 @@ function ConnectedView() {
 
         {address ? (
           <button
-            className="mt-4 flex w-full items-center gap-2 rounded-full bg-card px-4 py-3 text-left transition hover:bg-card/90"
+            className="t-hover mt-4 flex w-full items-center gap-2 rounded-full bg-card px-4 py-3 text-left hover:bg-accent-selected"
             onClick={handleCopy}
             title="Copy address"
             type="button"
@@ -94,7 +94,7 @@ function ConnectedView() {
         <div className="flex flex-col gap-2">
           {hasAuthSession ? (
             <button
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-4 font-medium text-background text-sm transition hover:bg-foreground/90"
+              className="t-hover flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-4 font-medium text-background text-sm hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
               onClick={async () => {
                 await Promise.allSettled([logout(), disconnect()]);
                 close();
@@ -107,7 +107,7 @@ function ConnectedView() {
           ) : null}
           {hasWalletConnection && !privyAppId ? (
             <button
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-destructive/15 px-4 font-medium text-destructive text-sm transition hover:bg-destructive/25"
+              className="t-hover flex h-12 w-full items-center justify-center gap-2 rounded-full bg-destructive/15 px-4 font-medium text-destructive text-sm hover:bg-destructive/25"
               onClick={async () => {
                 await disconnect();
                 close();
@@ -182,7 +182,7 @@ export function SignInModal() {
               </div>
             </>
           )}
-          <DialogClose className="absolute top-5 right-5 flex h-11 w-11 items-center justify-center rounded-full bg-accent text-muted-foreground transition hover:bg-accent-active hover:text-foreground">
+          <DialogClose className="t-hover absolute top-5 right-5 flex h-11 w-11 items-center justify-center rounded-full bg-accent text-muted-foreground hover:bg-accent-active hover:text-foreground">
             <XIcon className="size-4" />
             <span className="sr-only">Close</span>
           </DialogClose>

--- a/apps/web/src/components/auth/sign-in-modal.tsx
+++ b/apps/web/src/components/auth/sign-in-modal.tsx
@@ -21,6 +21,7 @@ import { useSignInModal } from "@/contexts/sign-in-modal-context";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { useCherryRuntime } from "@/features/cherry/client/runtime-context";
 
+import { PrivyAccountPanel } from "./privy-account-panel";
 import { PrivySignIn } from "./privy-sign-in";
 import { WalletSignIn } from "./wallet-sign-in";
 
@@ -84,6 +85,10 @@ function ConnectedView() {
           </button>
         ) : null}
       </div>
+
+      {privyAppId && cherryRuntime.mode === "standalone" ? (
+        <PrivyAccountPanel />
+      ) : null}
 
       {cherryRuntime.mode === "standalone" ? (
         <div className="flex flex-col gap-2">

--- a/apps/web/src/components/auth/sign-in-modal.tsx
+++ b/apps/web/src/components/auth/sign-in-modal.tsx
@@ -148,7 +148,18 @@ export function SignInModal() {
     <Dialog onOpenChange={handleOpenChange} open={isOpen}>
       <DialogPortal>
         <DialogOverlay className="t-modal-overlay" />
-        <DialogPrimitive.Content className="t-modal t-modal-center fixed top-[50%] left-[50%] z-[70] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-[32px] border border-border bg-card text-card-foreground shadow-[0_24px_70px_rgba(0,0,0,0.2)] outline-none sm:max-w-[480px]">
+        <DialogPrimitive.Content
+          className="t-modal t-modal-center fixed top-[50%] left-[50%] z-[70] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-[32px] border border-border bg-card text-card-foreground shadow-[0_24px_70px_rgba(0,0,0,0.2)] outline-none sm:max-w-[480px]"
+          // Privy's modals (login, link email, export key, MFA) stack on top
+          // of this one but pass pointer events through their backdrop, so a
+          // click on Privy's backdrop lands on our overlay and Radix reads it
+          // as an outside click. While Privy is up, nothing counts as outside.
+          onInteractOutside={(event) => {
+            if (document.querySelector("#privy-dialog")) {
+              event.preventDefault();
+            }
+          }}
+        >
           {hasAuthSession ? (
             <>
               <DialogHeader className="px-6 pt-6 pb-5 text-left">

--- a/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
@@ -167,7 +167,7 @@ export function FaceliftSidebar({
   // disconnect must stay clickable in that half-connected limbo to clear it.
   const canDisconnect = isAuthenticated || isWalletConnected;
   const { isBalanceHidden, toggleBalanceHidden } = useBalanceVisibility();
-  const { open: openSignIn } = useSignInModal();
+  const { open: openSignIn, openAccount } = useSignInModal();
   const { isDark, toggleTheme } = useTheme();
   const [isWalletMenuOpen, setIsWalletMenuOpen] = useState(false);
   const [isReceiveOpen, setIsReceiveOpen] = useState(false);
@@ -753,6 +753,22 @@ export function FaceliftSidebar({
             isOpen={cherryRuntime.mode === "standalone" && isWalletMenuOpen}
             origin="bottom-left"
           >
+            {publicEnv.privyAppId && isAuthenticated ? (
+              <button
+                className="t-hover flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left font-medium text-[16px] text-foreground leading-5 hover:bg-accent"
+                onClick={() => {
+                  setIsWalletMenuOpen(false);
+                  openAccount();
+                }}
+                type="button"
+              >
+                <ThemedIcon
+                  className="size-5 text-tertiary"
+                  src={`${ASSET_BASE}/icon-gear.svg`}
+                />
+                Account
+              </button>
+            ) : null}
             <button
               className="t-hover flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left font-medium text-[16px] text-foreground leading-5 enabled:hover:bg-accent disabled:text-tertiary"
               disabled={!canDisconnect}

--- a/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/sidebar.tsx
@@ -22,6 +22,7 @@ import { ReceiveSheet } from "@/components/wallet-workspace/facelift/receive-she
 import type { WorkspacePage } from "@/components/wallet-workspace/facelift/shell";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { AddEmailNudge } from "@/components/auth/add-email-nudge";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import { useAuthSession } from "@/contexts/auth-session-context";
@@ -414,6 +415,10 @@ export function FaceliftSidebar({
             </button>
           </div>
         </div>
+      </div>
+
+      <div className="w-full px-2">
+        <AddEmailNudge />
       </div>
 
       <nav className="flex w-full flex-1 flex-col py-2">

--- a/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
@@ -79,7 +79,7 @@ export function WalletHomePage({
   // whenever either side is live.
   const canDisconnect = isAuthenticated || isWalletConnected;
   const { isBalanceHidden, toggleBalanceHidden } = useBalanceVisibility();
-  const { open: openSignIn } = useSignInModal();
+  const { open: openSignIn, openAccount } = useSignInModal();
 
   const handleDisconnect = () => {
     void Promise.allSettled([logout(), disconnect()]);
@@ -247,6 +247,19 @@ export function WalletHomePage({
                     src={`${ASSET_BASE}/icon-globe.svg`}
                   />
                 </a>
+                {publicEnv.privyAppId && isAuthenticated ? (
+                  <button
+                    aria-label="Account settings"
+                    className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
+                    onClick={openAccount}
+                    type="button"
+                  >
+                    <ThemedIcon
+                      className="size-6 text-tertiary"
+                      src={`${ASSET_BASE}/icon-gear.svg`}
+                    />
+                  </button>
+                ) : null}
                 {cherryRuntime.mode === "standalone" ? (
                   <button
                     aria-label="Disconnect wallet"

--- a/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/wallet-home-page.tsx
@@ -21,6 +21,7 @@ import type { WorkspacePage } from "@/components/wallet-workspace/facelift/shell
 import { SplitAmount } from "@/components/wallet-workspace/facelift/sidebar";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
+import { AddEmailNudge } from "@/components/auth/add-email-nudge";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import { WalletHomeBanners } from "@/components/wallet-workspace/facelift/wallet-home-banners";
@@ -321,6 +322,9 @@ export function WalletHomePage({
               </div>
             </div>
 
+            <div className="w-full shrink-0 px-4">
+              <AddEmailNudge />
+            </div>
             <div className="min-h-0 w-full flex-1 px-4 py-2">
               <div className="grid h-full min-h-[400px] grid-cols-2 grid-rows-[repeat(3,minmax(0,1fr))] gap-2">
                 <WalletHomeBanners onSetUpAutodeposit={onSetUpAutodeposit} />


### PR DESCRIPTION
Account modal gains email / Google link+unlink, embedded-wallet key export and MFA rows (shown only when enabled in the Privy dashboard), reachable from the wallet menu; stacks on PR #755. Closes ASK-2264.