### PR TITLE
feat(web): trending-on-focus token search with fast abortable typeahead

### DIFF
--- a/apps/web/src/components/wallet-sidebar/index.tsx
+++ b/apps/web/src/components/wallet-sidebar/index.tsx
@@ -203,7 +203,7 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
     [props.smartAccountData.approvals, selectedApprovalId]
   );
 
-  const { tokens: popularTokens, search: searchTokens } = usePopularTokens({
+  const { search: searchTokens } = usePopularTokens({
     enabled: shouldLoadPopularTokens,
   });
 
@@ -242,14 +242,10 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
     return tokens;
   }, [props.walletDesktopData.positions]);
 
-  // Merge user's held tokens with popular tokens for swap target selection
-  const swapTargetTokens = useMemo<SwapToken[]>(() => {
-    const heldMints = new Set(derivedTokens.map((t) => t.mint).filter(Boolean));
-    const extras = popularTokens.filter(
-      (t) => t.mint && !heldMints.has(t.mint)
-    );
-    return [...derivedTokens, ...extras];
-  }, [derivedTokens, popularTokens]);
+  // Held tokens only: the selector renders the trending list as its own
+  // section, so inlining popular tokens here would both empty that section
+  // (they'd count as owned) and mislabel them "Your tokens".
+  const swapTargetTokens = derivedTokens;
   const selectedVaultSwapTokens = useMemo<SwapToken[]>(
     () =>
       selectedVault
@@ -260,15 +256,7 @@ export function HeroRightSidebar(props: HeroRightSidebarProps) {
         : [],
     [selectedVault]
   );
-  const vaultSwapTargetTokens = useMemo<SwapToken[]>(() => {
-    const heldMints = new Set(
-      selectedVaultSwapTokens.map((token) => token.mint).filter(Boolean)
-    );
-    const extras = popularTokens.filter(
-      (token) => token.mint && !heldMints.has(token.mint)
-    );
-    return [...selectedVaultSwapTokens, ...extras];
-  }, [popularTokens, selectedVaultSwapTokens]);
+  const vaultSwapTargetTokens = selectedVaultSwapTokens;
   const executeVaultSwap = props.smartAccountData.executeVaultSwap;
   const selectedVaultSwapExecutionContext = useMemo<
     SwapExecutionContext | undefined

--- a/apps/web/src/components/wallet-sidebar/shared.tsx
+++ b/apps/web/src/components/wallet-sidebar/shared.tsx
@@ -5,10 +5,14 @@ import { ArrowRight, Search, X } from "lucide-react";
 export function SearchInput({
   value,
   onChange,
+  onFocus,
+  onKeyDown,
   placeholder = "Search",
 }: {
   value: string;
   onChange: (v: string) => void;
+  onFocus?: () => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
 }) {
   return (
@@ -30,6 +34,8 @@ export function SearchInput({
         />
         <input
           onChange={(e) => onChange(e.target.value)}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           style={{
             flex: 1,

--- a/apps/web/src/components/wallet-sidebar/token-select-view.tsx
+++ b/apps/web/src/components/wallet-sidebar/token-select-view.tsx
@@ -2,17 +2,52 @@
 
 import Image from "next/image";
 import { ArrowLeft } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
+
+import {
+  getCachedTrendingTokens,
+  prefetchTrendingTokens,
+  rankSearchResults,
+  searchTokens,
+  type TokenSearchResult,
+} from "@/lib/market/token-search.client";
 
 import { SearchInput } from "./shared";
 import type { SwapToken } from "./types";
 
+// Typeahead is user-perceived latency; debounce only long enough to collapse a
+// burst of keystrokes into a single request.
+const SEARCH_DEBOUNCE_MS = 120;
+// Remote search and trending only kick in from 2 chars, as before.
+const MIN_SEARCH_LENGTH = 2;
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-geist-sans), sans-serif",
+        fontSize: "11px",
+        fontWeight: 600,
+        lineHeight: "16px",
+        letterSpacing: "0.06em",
+        textTransform: "uppercase",
+        color: "rgba(60, 60, 67, 0.6)",
+        padding: "12px 12px 4px",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
 function SelectableTokenRow({
   token,
+  isActive,
   isSelected,
   onClick,
 }: {
   token: SwapToken;
+  isActive: boolean;
   isSelected: boolean;
   onClick: () => void;
 }) {
@@ -30,9 +65,11 @@ function SelectableTokenRow({
         borderRadius: "16px",
         width: "100%",
         overflow: "visible",
-        background: isSelected
-          ? "rgba(0, 0, 0, 0.04)"
-          : hovered
+        // The keyboard-active suggestion reads slightly stronger than hover or
+        // the already-selected token so Enter's target is never ambiguous.
+        background: isActive
+          ? "rgba(0, 0, 0, 0.06)"
+          : isSelected || hovered
           ? "rgba(0, 0, 0, 0.04)"
           : "transparent",
         transition: "background-color 0.15s ease",
@@ -193,49 +230,163 @@ export function TokenSelectView({
   onBack: () => void;
   onClose: () => void;
   tokens: SwapToken[];
+  /**
+   * Opts this picker into remote token search (and therefore trending).
+   * Search is run in here via `searchTokens`, so the callback itself is unused
+   * beyond acting as the flag — kept so existing callers keep compiling.
+   */
   onSearch?: (query: string) => Promise<SwapToken[]>;
   isTokenSelected?: (token: SwapToken) => boolean;
 }) {
+  const remoteSearchEnabled = Boolean(onSearch);
   const [search, setSearch] = useState("");
-  const [searchResults, setSearchResults] = useState<SwapToken[]>([]);
+  const [remoteResults, setRemoteResults] = useState<TokenSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  // Hydrated from cache so a warm picker paints trending on the first render.
+  const [trending, setTrending] = useState<TokenSearchResult[]>(() =>
+    remoteSearchEnabled ? getCachedTrendingTokens() ?? [] : []
+  );
+  const [isTrendingLoading, setIsTrendingLoading] = useState(
+    remoteSearchEnabled && !getCachedTrendingTokens()
+  );
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchAbortRef = useRef<AbortController | null>(null);
 
-  const query = search.toLowerCase();
+  // Warm trending on mount; focus re-runs it, which is free while fresh and
+  // revalidates in the background once the cached list goes stale.
+  useEffect(() => {
+    if (!remoteSearchEnabled) return;
+
+    let cancelled = false;
+    setIsTrendingLoading(!getCachedTrendingTokens());
+    void prefetchTrendingTokens()
+      .then((result) => {
+        if (cancelled) return;
+        setTrending(result);
+        setIsTrendingLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setIsTrendingLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [remoteSearchEnabled]);
+
+  const query = search.trim().toLowerCase();
+  const hasQuery = query.length >= MIN_SEARCH_LENGTH;
+
   const localFiltered = tokens.filter(
     (t) =>
       t.symbol.toLowerCase().includes(query) ||
       (t.mint && t.mint.toLowerCase().includes(query))
   );
 
-  // Debounced remote search when local results are sparse
+  // Debounced remote typeahead. Each keystroke aborts the in-flight request,
+  // previous results stay painted while a newer one runs, and a response only
+  // commits if its query is still the one in the input.
   useEffect(() => {
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    if (!onSearch || search.length < 2) {
-      setSearchResults([]);
+    if (!remoteSearchEnabled || !hasQuery) {
+      setRemoteResults([]);
       setIsSearching(false);
       return;
     }
+
     setIsSearching(true);
     searchTimerRef.current = setTimeout(() => {
-      void onSearch(search)
+      const controller = new AbortController();
+      searchAbortRef.current = controller;
+      void searchTokens(search, controller.signal)
         .then((results) => {
-          // Exclude tokens already in local list
+          if (controller.signal.aborted) return;
+          // Keep the picker's verified-only contract and drop owned tokens.
           const localMints = new Set(tokens.map((t) => t.mint).filter(Boolean));
-          setSearchResults(
-            results.filter((t) => t.mint && !localMints.has(t.mint))
+          setRemoteResults(
+            results.filter(
+              (t) => t.mint && t.isVerified && !localMints.has(t.mint)
+            )
           );
         })
-        .catch(() => setSearchResults([]))
-        .finally(() => setIsSearching(false));
-    }, 300);
+        .catch(() => {
+          if (!controller.signal.aborted) setRemoteResults([]);
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setIsSearching(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+
     return () => {
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+      searchAbortRef.current?.abort();
     };
-  }, [search, onSearch, tokens]);
+  }, [search, hasQuery, remoteSearchEnabled, tokens]);
 
-  const allResults =
-    search.length >= 2 ? [...localFiltered, ...searchResults] : localFiltered;
+  // Trending only complements an empty query, and hides tokens already listed.
+  // Mock positions carry no mint, so symbol is the fallback identity.
+  const showTrending = remoteSearchEnabled && query.length === 0;
+  const ownedKeys = new Set(
+    tokens.flatMap((t) => [
+      ...(t.mint ? [t.mint.toLowerCase()] : []),
+      t.symbol.toLowerCase(),
+    ])
+  );
+  const trendingRows = showTrending
+    ? trending.filter(
+        (t) =>
+          !ownedKeys.has(t.mint.toLowerCase()) &&
+          !ownedKeys.has(t.symbol.toLowerCase())
+      )
+    : [];
+
+  // Owned matches stay first in their incoming order; remote hits are ranked
+  // behind them so a token the user holds always wins the top suggestion.
+  const sections: { label: string | null; tokens: SwapToken[] }[] = showTrending
+    ? [
+        ...(localFiltered.length > 0
+          ? [{ label: "Your tokens", tokens: localFiltered }]
+          : []),
+        ...(trendingRows.length > 0
+          ? [{ label: "Trending", tokens: trendingRows }]
+          : []),
+      ]
+    : [
+        {
+          label: null,
+          tokens: [
+            ...localFiltered,
+            ...rankSearchResults(query, remoteResults),
+          ],
+        },
+      ];
+
+  const rows = sections.flatMap((section) =>
+    section.tokens.map((token) => ({ label: section.label, token }))
+  );
+  const activeToken = hasQuery ? rows[0]?.token : undefined;
+
+  // Typeahead: Enter and Tab both commit the active (top-ranked) suggestion
+  // without rewriting the query the user typed.
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (!hasQuery || !activeToken) return;
+    if (event.key !== "Enter" && event.key !== "Tab") return;
+    // Don't swallow keys an IME is still composing with, and keep Tab from
+    // also moving focus after the commit.
+    if (event.nativeEvent.isComposing) return;
+    event.preventDefault();
+
+    onSelect(activeToken);
+    onBack();
+  };
+
+  const handleSearchFocus = () => {
+    if (!remoteSearchEnabled) return;
+    void prefetchTrendingTokens()
+      .then((result) => setTrending(result))
+      .catch(() => {});
+  };
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
@@ -280,7 +431,12 @@ export function TokenSelectView({
           <ArrowLeft size={24} />
         </button>
       </div>
-      <SearchInput onChange={setSearch} value={search} />
+      <SearchInput
+        onChange={setSearch}
+        onFocus={handleSearchFocus}
+        onKeyDown={handleSearchKeyDown}
+        value={search}
+      />
       <div
         style={{
           flex: 1,
@@ -290,23 +446,28 @@ export function TokenSelectView({
           padding: "0 8px",
         }}
       >
-        {allResults.map((token, i) => (
-          <SelectableTokenRow
-            isSelected={
-              isTokenSelected?.(token) ??
-              (token.mint
-                ? token.mint === currentToken.mint
-                : token.symbol === currentToken.symbol)
-            }
-            key={token.mint ?? `${token.symbol}-${i}`}
-            onClick={() => {
-              onSelect(token);
-              onBack();
-            }}
-            token={token}
-          />
+        {rows.map((row, i) => (
+          <Fragment key={row.token.mint ?? `${row.token.symbol}-${i}`}>
+            {row.label && rows[i - 1]?.label !== row.label && (
+              <SectionLabel>{row.label}</SectionLabel>
+            )}
+            <SelectableTokenRow
+              isActive={row.token === activeToken}
+              isSelected={
+                isTokenSelected?.(row.token) ??
+                (row.token.mint
+                  ? row.token.mint === currentToken.mint
+                  : row.token.symbol === currentToken.symbol)
+              }
+              onClick={() => {
+                onSelect(row.token);
+                onBack();
+              }}
+              token={row.token}
+            />
+          </Fragment>
         ))}
-        {isSearching && allResults.length === 0 && (
+        {rows.length === 0 && (
           <div
             style={{
               padding: "32px 20px",
@@ -316,20 +477,11 @@ export function TokenSelectView({
               color: "rgba(60, 60, 67, 0.6)",
             }}
           >
-            Searching...
-          </div>
-        )}
-        {!isSearching && allResults.length === 0 && (
-          <div
-            style={{
-              padding: "32px 20px",
-              textAlign: "center",
-              fontFamily: "var(--font-geist-sans), sans-serif",
-              fontSize: "14px",
-              color: "rgba(60, 60, 67, 0.6)",
-            }}
-          >
-            No tokens found
+            {isSearching
+              ? "Searching..."
+              : showTrending && isTrendingLoading
+              ? "Loading..."
+              : "No tokens found"}
           </div>
         )}
       </div>

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -233,20 +233,21 @@ export function CryptoPage({
     () => new Set(earnProductAssets.map((asset) => asset.mint)),
     [earnProductAssets]
   );
+  // Receive-side picker list: held tokens plus Earn stables nothing else lists.
+  // Trending tokens are no longer inlined here — the selector renders them as
+  // its own "Trending" section and would otherwise list them twice. They still
+  // count as listed, so a trending Earn stable is not synthesized below.
   const swapTargetTokens = useMemo<SwapToken[]>(() => {
     const heldMints = new Set(
       derivedTokens.map((token) => token.mint).filter(Boolean)
     );
-    const extras = popularTokens.filter(
-      (token) => token.mint && !heldMints.has(token.mint)
-    );
-    // Earn stables missing from held+popular (e.g. CASH) still belong in
+    // Earn stables missing from held+trending (e.g. CASH) still belong in
     // the receive list: synthesize them from the canonical product assets.
     // The picker price is indicative only (quotes come by mint), so a flat
     // $1 for a USD stable is fine.
     const listedMints = new Set([
       ...heldMints,
-      ...extras.map((token) => token.mint),
+      ...popularTokens.map((token) => token.mint),
     ]);
     const missingEarnStables = earnProductAssets
       .filter((asset) => !listedMints.has(asset.mint))
@@ -266,7 +267,7 @@ export function CryptoPage({
         ? 1
         : 2;
 
-    return [...derivedTokens, ...extras, ...missingEarnStables].sort(
+    return [...derivedTokens, ...missingEarnStables].sort(
       (a, b) => rank(a) - rank(b)
     );
   }, [derivedTokens, earnEligibleMints, earnProductAssets, popularTokens]);

--- a/apps/web/src/components/wallet-workspace/facelift/swap-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/swap-pane.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { Search } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 
 import { sanitizeBucksAmountInput } from "@/components/wallet-sidebar/earn-detail-view";
 import type { SwapToken } from "@/components/wallet-sidebar/types";
@@ -24,9 +31,22 @@ import { usePublicEnv } from "@/contexts/public-env-context";
 import { useSwap } from "@/hooks/use-swap";
 import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
 import { trackWalletSwapPressed } from "@/lib/core/analytics";
+import {
+  getCachedTrendingTokens,
+  prefetchTrendingTokens,
+  rankSearchResults,
+  searchTokens,
+  type TokenSearchResult,
+} from "@/lib/market/token-search.client";
 import { getTokenIconUrl } from "@/lib/token-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
+
+// Typeahead cadence: two characters before a remote search starts (as the OG
+// token-select did), after a debounce short enough to stay attached to the
+// keystrokes.
+const SEARCH_DEBOUNCE_MS = 120;
+const SEARCH_MIN_QUERY_LENGTH = 2;
 
 // $63.83 / $0.99866 — two decimals above a dollar, significant digits below.
 function formatTokenPrice(price: number): string {
@@ -608,10 +628,32 @@ export function SwapPane({
   );
 }
 
+// `rankSearchResults` tiers on the richer `TokenSearchResult` shape, so held
+// tokens are lifted into it: `mcap: null` keeps their own list order within a
+// tier, and a missing mint becomes "" so it can never mint-match.
+function toSelectorToken(
+  token: SwapToken,
+  nameByMint: Record<string, string>
+): TokenSearchResult {
+  return {
+    balance: token.balance,
+    icon: token.icon,
+    isVerified: true,
+    mint: token.mint ?? "",
+    mcap: null,
+    name: (token.mint ? nameByMint[token.mint] : undefined) ?? token.symbol,
+    price: token.price,
+    symbol: token.symbol,
+  };
+}
+
 // Token selector (Figma 4819:414935 right pane / 4819:413827 <1204 overlay):
-// search + token list with prices. Local filter over the passed list plus the
-// OG token-select's debounced remote Jupiter search merged in (deduped by
-// mint). Held tokens surface their portfolio names via nameByMint.
+// search + token list with prices. The local filter over the passed list stays
+// instant; a debounced remote Jupiter search merges into it (deduped by mint)
+// and the merged rows are tiered by rankSearchResults. An empty query lists
+// trending tokens above the holdings, and while a typeahead is live the
+// top-ranked row is the active suggestion (Enter/Tab commit it). Held tokens
+// surface their portfolio names via nameByMint.
 export function SwapTokenSelectPane({
   earnEligibleMints,
   nameByMint,
@@ -626,6 +668,14 @@ export function SwapTokenSelectPane({
   earnEligibleMints?: ReadonlySet<string>;
   nameByMint: Record<string, string>;
   onClose: () => void;
+  /**
+   * Opt-in to the remote search and the Trending section. Presence is the
+   * switch: the request lifecycle (debounce, abort, stale guarding) is owned
+   * here and calls `searchTokens` directly, so the callback itself is never
+   * invoked — it stays accepted for callers passing `usePopularTokens().search`.
+   * Selectors that pass none (Send's asset picker, swap's from side) stay
+   * holdings-only.
+   */
   onSearch?: (query: string) => Promise<SwapToken[]>;
   onSelect: (token: SwapToken) => void;
   side: "from" | "to";
@@ -634,11 +684,25 @@ export function SwapTokenSelectPane({
   tokens: SwapToken[];
 }) {
   const [search, setSearch] = useState("");
-  const [searchResults, setSearchResults] = useState<SwapToken[]>([]);
-  const searchTimerRef = useRef<number | null>(null);
+  // Superseded results stay painted until the next set commits.
+  const [searchResults, setSearchResults] = useState<TokenSearchResult[]>([]);
+  const [trending, setTrending] = useState<TokenSearchResult[]>(() =>
+    onSearch ? getCachedTrendingTokens() ?? [] : []
+  );
+  const [activeIndex, setActiveIndex] = useState(0);
+  const searchAbortRef = useRef<AbortController | null>(null);
   const { isBalanceHidden } = useBalanceVisibility();
 
-  const query = search.trim().toLowerCase();
+  // Raw (case-preserved) for the remote search and ranking — base58 mints are
+  // case-sensitive — lowercased for the local symbol/name filter.
+  const rawQuery = search.trim();
+  const query = rawQuery.toLowerCase();
+  const isRemoteSearchEnabled = Boolean(onSearch);
+  // Read back when a response lands, so a late resolver can't commit for a
+  // query the user has already moved past.
+  const latestQueryRef = useRef(rawQuery);
+  latestQueryRef.current = rawQuery;
+
   const localFiltered = useMemo(
     () =>
       tokens.filter((token) => {
@@ -655,32 +719,189 @@ export function SwapTokenSelectPane({
     [nameByMint, query, tokens]
   );
 
-  useEffect(() => {
-    if (searchTimerRef.current !== null) {
-      window.clearTimeout(searchTimerRef.current);
+  const heldMints = useMemo(
+    () => new Set(tokens.map((token) => token.mint).filter(Boolean)),
+    [tokens]
+  );
+  const ownedTokens = useMemo(
+    () => localFiltered.map((token) => toSelectorToken(token, nameByMint)),
+    [localFiltered, nameByMint]
+  );
+  const remoteTokens = useMemo(
+    () => searchResults.filter((token) => !heldMints.has(token.mint)),
+    [heldMints, searchResults]
+  );
+  // Trending fills an empty query only, and never repeats a held token.
+  const trendingRows = useMemo(() => {
+    if (!isRemoteSearchEnabled || query) {
+      return [];
     }
-    if (!onSearch || search.trim().length < 2) {
+    return trending.filter((token) => !heldMints.has(token.mint));
+  }, [heldMints, isRemoteSearchEnabled, query, trending]);
+
+  // With a query the merged rows are tiered (exact symbol, then symbol/name
+  // prefix, then mint); empty keeps the holdings order — ranking by mcap would
+  // reshuffle the user's own assets.
+  const list = useMemo(() => {
+    if (!query) {
+      return [...trendingRows, ...ownedTokens];
+    }
+    return rankSearchResults(rawQuery, [...ownedTokens, ...remoteTokens]);
+  }, [ownedTokens, query, rawQuery, remoteTokens, trendingRows]);
+
+  const activeSuggestion =
+    query.length >= SEARCH_MIN_QUERY_LENGTH && list.length > 0
+      ? Math.min(activeIndex, list.length - 1)
+      : null;
+  const activeToken = activeSuggestion === null ? null : list[activeSuggestion];
+
+  // Trending warms on mount and again on focus (the pane can sit open long
+  // enough for the cache to go stale); the sync cache read paints instantly
+  // and the prefetch promise fills it in.
+  const refreshTrending = useCallback(() => {
+    if (!isRemoteSearchEnabled) {
+      return;
+    }
+    const cached = getCachedTrendingTokens();
+    if (cached) {
+      setTrending(cached);
+    }
+    void prefetchTrendingTokens()
+      .then((result) => setTrending(result))
+      .catch(() => {});
+  }, [isRemoteSearchEnabled]);
+
+  useEffect(() => {
+    refreshTrending();
+  }, [refreshTrending]);
+
+  // Debounced remote search. Each keystroke aborts the request before it; a
+  // failed or aborted one leaves the previous results on screen.
+  useEffect(() => {
+    if (!isRemoteSearchEnabled || rawQuery.length < SEARCH_MIN_QUERY_LENGTH) {
+      searchAbortRef.current?.abort();
+      searchAbortRef.current = null;
       setSearchResults([]);
       return;
     }
-    searchTimerRef.current = window.setTimeout(() => {
-      void onSearch(search.trim()).then((results) => {
-        const localMints = new Set(
-          tokens.map((token) => token.mint).filter(Boolean)
-        );
-        setSearchResults(
-          results.filter((token) => token.mint && !localMints.has(token.mint))
-        );
-      });
-    }, 300);
+    let isCurrent = true;
+    const timer = window.setTimeout(() => {
+      const controller = new AbortController();
+      searchAbortRef.current = controller;
+      void searchTokens(rawQuery, controller.signal)
+        .then((results) => {
+          if (!isCurrent || latestQueryRef.current !== rawQuery) {
+            return;
+          }
+          setSearchResults(results.filter((token) => token.isVerified));
+        })
+        .catch(() => {});
+    }, SEARCH_DEBOUNCE_MS);
     return () => {
-      if (searchTimerRef.current !== null) {
-        window.clearTimeout(searchTimerRef.current);
-      }
+      isCurrent = false;
+      window.clearTimeout(timer);
+      searchAbortRef.current?.abort();
     };
-  }, [onSearch, search, tokens]);
+  }, [isRemoteSearchEnabled, rawQuery]);
 
-  const list = [...localFiltered, ...searchResults];
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Don't swallow keys an IME is still composing with.
+    if (event.nativeEvent.isComposing || activeSuggestion === null) {
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        Math.max(
+          0,
+          Math.min(
+            list.length - 1,
+            current + (event.key === "ArrowDown" ? 1 : -1)
+          )
+        )
+      );
+      return;
+    }
+    // Enter/Tab commit the highlighted suggestion straight away; the input
+    // keeps whatever the user typed.
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      onSelect(list[activeSuggestion]);
+    }
+  };
+
+  const renderTokenRow = (token: TokenSearchResult) => (
+    <button
+      className={`t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-accent ${
+        token === activeToken ? "bg-accent" : ""
+      }`}
+      key={token.mint || token.symbol}
+      onClick={() => onSelect(token)}
+      type="button"
+    >
+      <span className="flex shrink-0 items-center py-2 pr-3">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt=""
+          className="size-11 rounded-full object-cover"
+          src={token.icon || getTokenIconUrl(token.symbol)}
+        />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
+            {(token.mint ? nameByMint[token.mint] : undefined) ?? token.symbol}
+          </span>
+          {side === "to" && token.mint && earnEligibleMints?.has(token.mint) ? (
+            <span className="shrink-0 rounded-md bg-positive/[0.14] px-1.5 py-0.5 font-medium text-[11px] text-positive leading-3">
+              Can earn
+            </span>
+          ) : null}
+        </span>
+        <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+          {token.symbol}
+        </span>
+      </span>
+      {side === "from" ? (
+        // Figma 4852:39653 — the source side lists what you hold:
+        // USD value on top (gray fraction), token amount below.
+        <span className="flex shrink-0 flex-col items-end justify-center gap-0.5 py-[11px] pl-3">
+          <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
+            <ScrambleText
+              isHidden={isBalanceHidden}
+              text={splitUsdBalance(token.balance * token.price).balanceWhole}
+            />
+            <span className="text-tertiary">
+              <ScrambleText
+                isHidden={isBalanceHidden}
+                text={
+                  splitUsdBalance(token.balance * token.price).balanceFraction
+                }
+              />
+            </span>
+          </span>
+          <span className="whitespace-nowrap text-right text-[13px] leading-4 text-muted-foreground">
+            <ScrambleText
+              isHidden={isBalanceHidden}
+              text={formatTokenAmount(token.balance)}
+            />
+          </span>
+        </span>
+      ) : (
+        <span className="flex shrink-0 items-center justify-end pl-3">
+          <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
+            ${formatTokenPrice(token.price)}
+          </span>
+        </span>
+      )}
+    </button>
+  );
+
+  const renderSectionLabel = (label: string) => (
+    <p className="px-4 pb-1 pt-2 text-[13px] leading-4 text-muted-foreground">
+      {label}
+    </p>
+  );
 
   return (
     <div className="flex h-full w-full min-w-0 flex-col">
@@ -713,7 +934,12 @@ export function SwapTokenSelectPane({
           />
           <input
             className="min-w-0 flex-1 bg-transparent py-3 text-[16px] text-foreground leading-5 outline-none placeholder:text-muted-foreground"
-            onChange={(event) => setSearch(event.target.value)}
+            onChange={(event) => {
+              setSearch(event.target.value);
+              setActiveIndex(0);
+            }}
+            onFocus={refreshTrending}
+            onKeyDown={handleSearchKeyDown}
             placeholder="Search assets"
             type="text"
             value={search}
@@ -725,78 +951,17 @@ export function SwapTokenSelectPane({
           <p className="px-4 py-8 text-center text-[14px] leading-5 text-muted-foreground">
             No tokens found
           </p>
+        ) : query ? (
+          list.map(renderTokenRow)
+        ) : trendingRows.length > 0 ? (
+          <>
+            {renderSectionLabel("Trending")}
+            {trendingRows.map(renderTokenRow)}
+            {renderSectionLabel("Your assets")}
+            {ownedTokens.map(renderTokenRow)}
+          </>
         ) : (
-          list.map((token) => (
-            <button
-              className="t-hover flex w-full shrink-0 items-center rounded-2xl px-4 text-left hover:bg-accent"
-              key={token.mint ?? token.symbol}
-              onClick={() => onSelect(token)}
-              type="button"
-            >
-              <span className="flex shrink-0 items-center py-2 pr-3">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt=""
-                  className="size-11 rounded-full object-cover"
-                  src={token.icon || getTokenIconUrl(token.symbol)}
-                />
-              </span>
-              <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                <span className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
-                    {(token.mint ? nameByMint[token.mint] : undefined) ??
-                      token.symbol}
-                  </span>
-                  {side === "to" &&
-                  token.mint &&
-                  earnEligibleMints?.has(token.mint) ? (
-                    <span className="shrink-0 rounded-md bg-positive/[0.14] px-1.5 py-0.5 font-medium text-[11px] text-positive leading-3">
-                      Can earn
-                    </span>
-                  ) : null}
-                </span>
-                <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
-                  {token.symbol}
-                </span>
-              </span>
-              {side === "from" ? (
-                // Figma 4852:39653 — the source side lists what you hold:
-                // USD value on top (gray fraction), token amount below.
-                <span className="flex shrink-0 flex-col items-end justify-center gap-0.5 py-[11px] pl-3">
-                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
-                    <ScrambleText
-                      isHidden={isBalanceHidden}
-                      text={
-                        splitUsdBalance(token.balance * token.price)
-                          .balanceWhole
-                      }
-                    />
-                    <span className="text-tertiary">
-                      <ScrambleText
-                        isHidden={isBalanceHidden}
-                        text={
-                          splitUsdBalance(token.balance * token.price)
-                            .balanceFraction
-                        }
-                      />
-                    </span>
-                  </span>
-                  <span className="whitespace-nowrap text-right text-[13px] leading-4 text-muted-foreground">
-                    <ScrambleText
-                      isHidden={isBalanceHidden}
-                      text={formatTokenAmount(token.balance)}
-                    />
-                  </span>
-                </span>
-              ) : (
-                <span className="flex shrink-0 items-center justify-end pl-3">
-                  <span className="whitespace-nowrap text-right font-medium text-[16px] text-foreground leading-5">
-                    ${formatTokenPrice(token.price)}
-                  </span>
-                </span>
-              )}
-            </button>
-          ))
+          ownedTokens.map(renderTokenRow)
         )}
       </div>
     </div>

--- a/apps/web/src/hooks/use-popular-tokens.ts
+++ b/apps/web/src/hooks/use-popular-tokens.ts
@@ -4,166 +4,36 @@ import type { SwapToken } from "@loyal-labs/wallet-core/types";
 import { useCallback, useEffect, useState } from "react";
 
 import {
-  readClientCacheEntry,
-  writeClientCache,
-} from "@/lib/client-cache/client-cache";
+  getCachedTrendingTokens,
+  prefetchTrendingTokens,
+  resetTokenSearchCacheForTests,
+  searchTokens,
+} from "@/lib/market/token-search.client";
 
-const JUPITER_SEARCH_URL = "https://lite-api.jup.ag/tokens/v2/search";
-
-const POPULAR_TOKENS_CACHE_KEY = "loyal.popularTokens.v1";
-const POPULAR_TOKENS_CACHE_VERSION = 1;
-// Jupiter's verified-token registry is mainnet data regardless of the
-// selected Solana cluster, so the persisted cache is env-independent.
-const POPULAR_TOKENS_CACHE_SCOPE = "global";
-// Token identity (mint/symbol/icon/decimals) is effectively immutable; the
-// price field is only indicative in pickers (quotes come from the Jupiter
-// quote API), so serving a stale list is safe.
-const POPULAR_TOKENS_FRESH_MS = 60 * 60 * 1000;
-const POPULAR_TOKENS_PERSIST_TTL_MS = 24 * 60 * 60 * 1000;
-
-const POPULAR_SYMBOLS = [
-  "USDC",
-  "USDT",
-  "JUP",
-  "BONK",
-  "RAY",
-  "WIF",
-  "PYTH",
-  "JTO",
-  "ORCA",
-  "RENDER",
-];
-
-type JupiterSearchResult = {
-  id: string;
-  name: string;
-  symbol: string;
-  decimals: number;
-  icon: string | null;
-  usdPrice: number | null;
-  isVerified: boolean;
-  mcap: number | null;
-};
-
-function toSwapToken(t: JupiterSearchResult): SwapToken {
-  return {
-    mint: t.id,
-    symbol: t.symbol,
-    icon: t.icon ?? "",
-    price: t.usdPrice ?? 0,
-    balance: 0,
-  };
-}
-
-async function searchJupiterToken(
-  query: string
-): Promise<JupiterSearchResult[]> {
-  const res = await fetch(
-    `${JUPITER_SEARCH_URL}?query=${encodeURIComponent(
-      query
-    )}&tags=verified&limit=10`
-  );
-  if (!res.ok) return [];
-  return res.json();
-}
-
-function isSwapTokenArray(data: unknown): data is SwapToken[] {
-  return (
-    Array.isArray(data) &&
-    data.every(
-      (t) =>
-        typeof t === "object" &&
-        t !== null &&
-        typeof (t as SwapToken).mint === "string" &&
-        typeof (t as SwapToken).symbol === "string" &&
-        typeof (t as SwapToken).icon === "string" &&
-        typeof (t as SwapToken).price === "number" &&
-        typeof (t as SwapToken).balance === "number"
-    )
-  );
-}
-
-function readPersistedPopularTokens() {
-  return readClientCacheEntry<SwapToken[]>({
-    key: POPULAR_TOKENS_CACHE_KEY,
-    version: POPULAR_TOKENS_CACHE_VERSION,
-    solanaEnv: POPULAR_TOKENS_CACHE_SCOPE,
-    validate: isSwapTokenArray,
-  });
-}
-
-let popularCache: SwapToken[] | null = null;
-let popularInflight: Promise<SwapToken[]> | null = null;
-
-function loadPopularTokensFromNetwork(): Promise<SwapToken[]> {
-  if (popularInflight) return popularInflight;
-
-  popularInflight = Promise.all(
-    POPULAR_SYMBOLS.map(async (symbol) => {
-      try {
-        const tokens = await searchJupiterToken(symbol);
-        // Pick exact symbol match with highest mcap
-        const exact = tokens
-          .filter(
-            (t) =>
-              t.symbol.toUpperCase() === symbol.toUpperCase() && t.isVerified
-          )
-          .sort((a, b) => (b.mcap ?? 0) - (a.mcap ?? 0));
-        return exact[0] ? toSwapToken(exact[0]) : null;
-      } catch {
-        return null;
-      }
-    })
-  )
-    .then((results) => {
-      popularCache = results.filter((t): t is SwapToken => t !== null);
-      // Only persist complete lists so a partial outage never pins a
-      // degraded picker for the full TTL.
-      if (popularCache.length === POPULAR_SYMBOLS.length) {
-        writeClientCache({
-          key: POPULAR_TOKENS_CACHE_KEY,
-          version: POPULAR_TOKENS_CACHE_VERSION,
-          solanaEnv: POPULAR_TOKENS_CACHE_SCOPE,
-          data: popularCache,
-          ttlMs: POPULAR_TOKENS_PERSIST_TTL_MS,
-        });
-      }
-      return popularCache;
-    })
-    .finally(() => {
-      popularInflight = null;
-    });
-
-  return popularInflight;
-}
-
+/**
+ * Trending tokens for the swap pickers. The non-hook fetching/caching logic
+ * lives in `@/lib/market/token-search.client` so non-React callers share the
+ * same cache; this module is the React binding.
+ */
 export async function fetchPopularTokens(): Promise<SwapToken[]> {
-  if (popularCache) return popularCache;
-  if (popularInflight) return popularInflight;
-
-  const persisted = readPersistedPopularTokens();
-  if (persisted) {
-    popularCache = persisted.data;
-    if (Date.now() - persisted.savedAt >= POPULAR_TOKENS_FRESH_MS) {
-      // Stale but usable: serve instantly and revalidate in the background
-      // for the next consumer.
-      void loadPopularTokensFromNetwork().catch(() => {});
-    }
-    return popularCache;
-  }
-
-  return loadPopularTokensFromNetwork();
+  // `TokenSearchResult` extends `SwapToken`, so the richer list satisfies the
+  // original contract without a mapping pass.
+  return prefetchTrendingTokens();
 }
 
 export function resetPopularTokensCacheForTests() {
-  popularCache = null;
-  popularInflight = null;
+  resetTokenSearchCacheForTests();
 }
 
 export function usePopularTokens(options: { enabled?: boolean } = {}) {
   const enabled = options.enabled ?? true;
-  const [tokens, setTokens] = useState<SwapToken[]>(popularCache ?? []);
-  const [isLoading, setIsLoading] = useState(enabled && !popularCache);
+  // Synchronously hydrate from cache so a warm picker paints on first render.
+  const [tokens, setTokens] = useState<SwapToken[]>(
+    getCachedTrendingTokens() ?? []
+  );
+  const [isLoading, setIsLoading] = useState(
+    enabled && !getCachedTrendingTokens()
+  );
 
   useEffect(() => {
     if (!enabled) {
@@ -172,7 +42,7 @@ export function usePopularTokens(options: { enabled?: boolean } = {}) {
     }
 
     let cancelled = false;
-    setIsLoading(!popularCache);
+    setIsLoading(!getCachedTrendingTokens());
     void fetchPopularTokens()
       .then((result) => {
         if (!cancelled) setTokens(result);
@@ -188,8 +58,7 @@ export function usePopularTokens(options: { enabled?: boolean } = {}) {
   const search = useCallback(async (query: string): Promise<SwapToken[]> => {
     if (!query || query.length < 2) return [];
     try {
-      const results = await searchJupiterToken(query);
-      return results.filter((t) => t.isVerified).map(toSwapToken);
+      return (await searchTokens(query)).filter((t) => t.isVerified);
     } catch {
       return [];
     }

--- a/apps/web/src/lib/market/token-search.client.ts
+++ b/apps/web/src/lib/market/token-search.client.ts
@@ -1,0 +1,350 @@
+"use client";
+
+import type { SwapToken } from "@loyal-labs/wallet-core/types";
+
+import {
+  readClientCacheEntry,
+  writeClientCache,
+} from "@/lib/client-cache/client-cache";
+
+/**
+ * Jupiter search hit enriched with the display/quality fields the shared
+ * `SwapToken` type drops. Still assignable to `SwapToken`, so token pickers
+ * that only read mint/symbol/icon/price keep working unchanged.
+ */
+export type TokenSearchResult = Omit<SwapToken, "mint"> & {
+  /** Jupiter always returns a mint (`id`) for search hits, so this is required. */
+  mint: string;
+  name: string;
+  isVerified: boolean;
+  mcap: number | null;
+};
+
+const JUPITER_SEARCH_URL = "https://lite-api.jup.ag/tokens/v2/search";
+const JUPITER_SEARCH_LIMIT = 10;
+// Typeahead requests are user-perceived latency; past this the user has already
+// kept typing, so the result would be discarded anyway.
+const SEARCH_TIMEOUT_MS = 8 * 1000;
+const SEARCH_CACHE_LIMIT = 50;
+const SEARCH_FRESH_MS = 5 * 60 * 1000;
+
+type JupiterSearchResult = {
+  id: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  icon: string | null;
+  usdPrice: number | null;
+  isVerified: boolean;
+  mcap: number | null;
+};
+
+function toTokenSearchResult(t: JupiterSearchResult): TokenSearchResult {
+  return {
+    mint: t.id,
+    symbol: t.symbol,
+    name: t.name,
+    icon: t.icon ?? "",
+    price: t.usdPrice ?? 0,
+    balance: 0,
+    isVerified: t.isVerified,
+    mcap: t.mcap,
+  };
+}
+
+function isJupiterSearchResultArray(
+  data: unknown
+): data is JupiterSearchResult[] {
+  return (
+    Array.isArray(data) &&
+    data.every(
+      (t) =>
+        typeof t === "object" &&
+        t !== null &&
+        typeof (t as JupiterSearchResult).id === "string" &&
+        typeof (t as JupiterSearchResult).symbol === "string" &&
+        typeof (t as JupiterSearchResult).isVerified === "boolean"
+    )
+  );
+}
+
+function composeRequestSignal(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+/**
+ * Rejects as soon as `signal` aborts, even when `promise` is shared with other
+ * callers (in-flight dedup) and therefore outlives this one.
+ */
+function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+async function fetchJupiterSearch(
+  query: string,
+  signal?: AbortSignal
+): Promise<TokenSearchResult[]> {
+  const res = await fetch(
+    `${JUPITER_SEARCH_URL}?query=${encodeURIComponent(
+      query
+    )}&tags=verified&limit=${JUPITER_SEARCH_LIMIT}`,
+    { signal: composeRequestSignal(signal) }
+  );
+  if (!res.ok) throw new Error(`Token search failed: ${res.status}`);
+  const data: unknown = await res.json();
+  if (!isJupiterSearchResultArray(data)) return [];
+  return data.map(toTokenSearchResult);
+}
+
+// LRU keyed by normalized query. Insertion order doubles as recency, so
+// re-inserting on read keeps hot queries at the tail for eviction.
+let searchCache = new Map<
+  string,
+  { expiresAt: number; value: TokenSearchResult[] }
+>();
+let searchInflight = new Map<string, Promise<TokenSearchResult[]>>();
+
+function setSearchCacheEntry(key: string, value: TokenSearchResult[]) {
+  searchCache.delete(key);
+  searchCache.set(key, {
+    expiresAt: Date.now() + SEARCH_FRESH_MS,
+    value,
+  });
+  while (searchCache.size > SEARCH_CACHE_LIMIT) {
+    const oldest = searchCache.keys().next();
+    if (oldest.done) break;
+    searchCache.delete(oldest.value);
+  }
+}
+
+/**
+ * Searches verified Jupiter tokens for a free-text query.
+ *
+ * Results are returned in Jupiter's own relevance order; use
+ * `rankSearchResults` when a caller needs deterministic tiering.
+ *
+ * The first caller's signal is the one wired into the fetch, so an abort
+ * genuinely cancels the in-flight request. Late joiners share that request and
+ * observe the same cancellation — acceptable for typeahead, where a superseded
+ * query is exactly the one being abandoned. An aborted or failed request is
+ * never cached, so the next call starts clean.
+ */
+export async function searchTokens(
+  query: string,
+  signal?: AbortSignal
+): Promise<TokenSearchResult[]> {
+  const key = query.trim().toLowerCase();
+  if (!key) return [];
+
+  const now = Date.now();
+  const cached = searchCache.get(key);
+  if (cached) {
+    searchCache.delete(key);
+    if (cached.expiresAt > now) {
+      searchCache.set(key, cached);
+      return cached.value;
+    }
+  }
+
+  const existing = searchInflight.get(key);
+  if (existing) return withAbort(existing, signal);
+
+  // Written once per request on the shared promise, so a rejected (aborted or
+  // failed) request never reaches the cache.
+  // Fetch with the raw (case-preserved) query: base58 mint addresses are
+  // case-sensitive, so lowercasing here would break paste-a-mint search.
+  const request = fetchJupiterSearch(query.trim(), signal)
+    .then((value) => {
+      setSearchCacheEntry(key, value);
+      return value;
+    })
+    .finally(() => {
+      searchInflight.delete(key);
+    });
+  searchInflight.set(key, request);
+  return withAbort(request, signal);
+}
+
+const TRENDING_TOKENS_CACHE_VERSION = 2;
+// Jupiter's verified-token registry is mainnet data regardless of the
+// selected Solana cluster, so the persisted cache is env-independent.
+const TRENDING_TOKENS_CACHE_SCOPE = "global";
+// v2 widens the stored shape from `SwapToken` to `TokenSearchResult`.
+const TRENDING_TOKENS_CACHE_KEY = `loyal.popularTokens.v${TRENDING_TOKENS_CACHE_VERSION}`;
+// Token identity (mint/symbol/icon/decimals) is effectively immutable; the
+// price field is only indicative in pickers (quotes come from the Jupiter
+// quote API), so serving a stale list is safe.
+const TRENDING_TOKENS_FRESH_MS = 60 * 60 * 1000;
+const TRENDING_TOKENS_PERSIST_TTL_MS = 24 * 60 * 60 * 1000;
+
+const TRENDING_SYMBOLS = [
+  "USDC",
+  "USDT",
+  "JUP",
+  "BONK",
+  "RAY",
+  "WIF",
+  "PYTH",
+  "JTO",
+  "ORCA",
+  "RENDER",
+];
+
+function isTokenSearchResultArray(data: unknown): data is TokenSearchResult[] {
+  return (
+    Array.isArray(data) &&
+    data.every(
+      (t) =>
+        typeof t === "object" &&
+        t !== null &&
+        typeof (t as TokenSearchResult).mint === "string" &&
+        typeof (t as TokenSearchResult).symbol === "string" &&
+        typeof (t as TokenSearchResult).name === "string" &&
+        typeof (t as TokenSearchResult).icon === "string" &&
+        typeof (t as TokenSearchResult).price === "number" &&
+        typeof (t as TokenSearchResult).balance === "number" &&
+        typeof (t as TokenSearchResult).isVerified === "boolean"
+    )
+  );
+}
+
+function readPersistedTrendingTokens() {
+  return readClientCacheEntry<TokenSearchResult[]>({
+    key: TRENDING_TOKENS_CACHE_KEY,
+    version: TRENDING_TOKENS_CACHE_VERSION,
+    solanaEnv: TRENDING_TOKENS_CACHE_SCOPE,
+    validate: isTokenSearchResultArray,
+  });
+}
+
+let trendingCache: TokenSearchResult[] | null = null;
+let trendingInflight: Promise<TokenSearchResult[]> | null = null;
+
+function loadTrendingTokensFromNetwork(): Promise<TokenSearchResult[]> {
+  if (trendingInflight) return trendingInflight;
+
+  trendingInflight = Promise.all(
+    TRENDING_SYMBOLS.map(async (symbol) => {
+      try {
+        const tokens = await fetchJupiterSearch(symbol);
+        // Pick exact symbol match with highest mcap
+        const exact = tokens
+          .filter(
+            (t) =>
+              t.symbol.toUpperCase() === symbol.toUpperCase() && t.isVerified
+          )
+          .sort((a, b) => (b.mcap ?? 0) - (a.mcap ?? 0));
+        return exact[0] ?? null;
+      } catch {
+        return null;
+      }
+    })
+  )
+    .then((results) => {
+      trendingCache = results.filter((t): t is TokenSearchResult => t !== null);
+      // Only persist complete lists so a partial outage never pins a
+      // degraded picker for the full TTL.
+      if (trendingCache.length === TRENDING_SYMBOLS.length) {
+        writeClientCache({
+          key: TRENDING_TOKENS_CACHE_KEY,
+          version: TRENDING_TOKENS_CACHE_VERSION,
+          solanaEnv: TRENDING_TOKENS_CACHE_SCOPE,
+          data: trendingCache,
+          ttlMs: TRENDING_TOKENS_PERSIST_TTL_MS,
+        });
+      }
+      return trendingCache;
+    })
+    .finally(() => {
+      trendingInflight = null;
+    });
+
+  return trendingInflight;
+}
+
+/**
+ * Warms the trending-token list. Safe to call repeatedly: concurrent calls
+ * share one request, and a fresh cache or a persisted list is returned without
+ * touching the network (a stale-but-valid list revalidates in the background).
+ */
+export async function prefetchTrendingTokens(): Promise<TokenSearchResult[]> {
+  if (trendingCache) return trendingCache;
+  if (trendingInflight) return trendingInflight;
+
+  const persisted = readPersistedTrendingTokens();
+  if (persisted) {
+    trendingCache = persisted.data;
+    if (Date.now() - persisted.savedAt >= TRENDING_TOKENS_FRESH_MS) {
+      // Stale but usable: serve instantly and revalidate in the background
+      // for the next consumer.
+      void loadTrendingTokensFromNetwork().catch(() => {});
+    }
+    return trendingCache;
+  }
+
+  return loadTrendingTokensFromNetwork();
+}
+
+/**
+ * Synchronous read of the trending list for instant paint (e.g. on input
+ * focus). Reads memory first, then localStorage; never touches the network and
+ * does not promote the persisted list into memory, so `prefetchTrendingTokens`
+ * still sees the saved timestamp and can revalidate a stale list.
+ */
+export function getCachedTrendingTokens(): TokenSearchResult[] | null {
+  if (trendingCache) return trendingCache;
+  return readPersistedTrendingTokens()?.data ?? null;
+}
+
+/**
+ * Orders results into tiers: exact symbol match, symbol prefix, name prefix,
+ * exact mint match, then everything else. Within a tier, higher mcap wins.
+ * Mint matching uses the raw (case-sensitive) query because base58 addresses
+ * are case-sensitive; symbol/name matching is case-insensitive.
+ *
+ * `Array#sort` is stable, so equal mcap preserves the caller's order.
+ */
+export function rankSearchResults(
+  query: string,
+  results: TokenSearchResult[]
+): TokenSearchResult[] {
+  const symbol = query.trim().toLowerCase();
+  const name = symbol;
+  const mint = query.trim();
+
+  const tier = (t: TokenSearchResult) => {
+    if (t.symbol.toLowerCase() === symbol) return 0;
+    if (t.symbol.toLowerCase().startsWith(symbol)) return 1;
+    if (name && t.name.toLowerCase().startsWith(name)) return 2;
+    if (mint && t.mint === mint) return 3;
+    return 4;
+  };
+
+  return [...results].sort(
+    (a, b) => tier(a) - tier(b) || (b.mcap ?? 0) - (a.mcap ?? 0)
+  );
+}
+
+export function resetTokenSearchCacheForTests() {
+  searchCache = new Map();
+  searchInflight = new Map();
+  trendingCache = null;
+  trendingInflight = null;
+}


### PR DESCRIPTION
On input focus the token selector now instantly shows a Trending section (prefetched + cached); typing runs a 120ms-debounced, abortable, stale-guarded Jupiter search with tiered ranking and keyboard typeahead (top suggestion highlighted, Enter/Tab selects, IME-aware). Adds a shared search client with LRU cache, in-flight dedup, and timeout; refactors use-popular-tokens into a thin binding; updates both selectors (wallet-sidebar + facelift swap pane) and their callers.

Implemented by GLM flash subagents from a luna exploration plan; reviewed (Opus) with 3 findings fixed: raw-case mint queries, trending double-inline in sidebar caller, IME/preventDefault on typeahead commit. tsc, ESLint, prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wKjdNRAnqgGiZRKntZMPX