### PR TITLE
feat(web): deposit from evm chains via privy deposit address

### DIFF
--- a/apps/telegram/drizzle/0030_evm_deposit_address.sql
+++ b/apps/telegram/drizzle/0030_evm_deposit_address.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_user_wallets" ADD COLUMN "evm_deposit_address" text;

--- a/apps/telegram/drizzle/meta/0030_snapshot.json
+++ b/apps/telegram/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,5413 @@
+{
+  "id": "1670caa8-44c4-4e79-bb93-828501793ef5",
+  "prevId": "49e3c493-aaa6-497e-884a-e5f848860cce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_telegram_id_idx": {
+          "name": "admins_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_captcha_keys": {
+      "name": "app_captcha_keys",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_chat_messages": {
+      "name": "app_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chat_messages_chat_client_message_uidx": {
+          "name": "app_chat_messages_chat_client_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"client_message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_role_turn_uidx": {
+          "name": "app_chat_messages_chat_role_turn_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chat_messages\".\"turn_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chat_messages_chat_created_idx": {
+          "name": "app_chat_messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chat_messages_chat_id_app_chats_id_fk": {
+          "name": "app_chat_messages_chat_id_app_chats_id_fk",
+          "tableFrom": "app_chat_messages",
+          "tableTo": "app_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_chat_messages_role_check": {
+          "name": "app_chat_messages_role_check",
+          "value": "\"app_chat_messages\".\"role\" IN ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_chats": {
+      "name": "app_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_chat_id": {
+          "name": "client_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_chats_user_client_chat_uidx": {
+          "name": "app_chats_user_client_chat_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_chats\".\"client_chat_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_chats_user_last_message_idx": {
+          "name": "app_chats_user_last_message_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_chats_user_id_app_users_id_fk": {
+          "name": "app_chats_user_id_app_users_id_fk",
+          "tableFrom": "app_chats",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_settings_change_requests": {
+      "name": "app_smart_account_settings_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_address": {
+          "name": "signer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_index": {
+          "name": "transaction_index",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_slot": {
+          "name": "confirmed_slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_settings_change_req_idem_uidx": {
+          "name": "app_smart_account_settings_change_req_idem_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_settings_idx": {
+          "name": "app_smart_account_settings_change_req_settings_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_signer_idx": {
+          "name": "app_smart_account_settings_change_req_signer_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_status_idx": {
+          "name": "app_smart_account_settings_change_req_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_settings_change_req_user_idx": {
+          "name": "app_smart_account_settings_change_req_user_idx",
+          "columns": [
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_smart_account_settings_change_requests_requested_by_user_id_app_users_id_fk": {
+          "name": "app_smart_account_settings_change_requests_requested_by_user_id_app_users_id_fk",
+          "tableFrom": "app_smart_account_settings_change_requests",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_settings_change_req_solana_env_check": {
+          "name": "app_smart_account_settings_change_req_solana_env_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_smart_account_settings_change_req_scope_check": {
+          "name": "app_smart_account_settings_change_req_scope_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"scope\" IN ('root_settings')"
+        },
+        "app_smart_account_settings_change_req_action_check": {
+          "name": "app_smart_account_settings_change_req_action_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"action\" IN ('add_root_signer', 'remove_root_signer')"
+        },
+        "app_smart_account_settings_change_req_status_check": {
+          "name": "app_smart_account_settings_change_req_status_check",
+          "value": "\"app_smart_account_settings_change_requests\".\"status\" IN ('draft', 'submitted', 'confirmed', 'failed', 'canceled', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_signers": {
+      "name": "app_smart_account_signers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_address": {
+          "name": "signer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_mask": {
+          "name": "permission_mask",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_signature": {
+          "name": "source_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_slot": {
+          "name": "source_slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_signers_env_settings_scope_signer_uidx": {
+          "name": "app_smart_account_signers_env_settings_scope_signer_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_env_signer_state_idx": {
+          "name": "app_smart_account_signers_env_signer_state_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_settings_idx": {
+          "name": "app_smart_account_signers_settings_idx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_signers_user_idx": {
+          "name": "app_smart_account_signers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_smart_account_signers_user_id_app_users_id_fk": {
+          "name": "app_smart_account_signers_user_id_app_users_id_fk",
+          "tableFrom": "app_smart_account_signers",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_signers_solana_env_check": {
+          "name": "app_smart_account_signers_solana_env_check",
+          "value": "\"app_smart_account_signers\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_smart_account_signers_scope_check": {
+          "name": "app_smart_account_signers_scope_check",
+          "value": "\"app_smart_account_signers\".\"scope\" IN ('root_settings')"
+        },
+        "app_smart_account_signers_state_check": {
+          "name": "app_smart_account_signers_state_check",
+          "value": "\"app_smart_account_signers\".\"state\" IN ('active', 'removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_smart_account_sponsorship_transactions": {
+      "name": "app_smart_account_sponsorship_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_smart_account_sponsorship_tx_env_signature_uidx": {
+          "name": "app_smart_account_sponsorship_tx_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_occurred_at_idx": {
+          "name": "app_smart_account_sponsorship_tx_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_user_address_idx": {
+          "name": "app_smart_account_sponsorship_tx_user_address_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_smart_account_sponsorship_tx_smart_account_idx": {
+          "name": "app_smart_account_sponsorship_tx_smart_account_idx",
+          "columns": [
+            {
+              "expression": "smart_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_smart_account_sponsorship_tx_solana_env_check": {
+          "name": "app_smart_account_sponsorship_tx_solana_env_check",
+          "value": "\"app_smart_account_sponsorship_transactions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_smart_accounts": {
+      "name": "app_user_smart_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_signature": {
+          "name": "creation_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_smart_accounts_user_env_uidx": {
+          "name": "app_user_smart_accounts_user_env_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_env_settings_uidx": {
+          "name": "app_user_smart_accounts_env_settings_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_pda",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_smart_accounts_user_id_idx": {
+          "name": "app_user_smart_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_smart_accounts_user_id_app_users_id_fk": {
+          "name": "app_user_smart_accounts_user_id_app_users_id_fk",
+          "tableFrom": "app_user_smart_accounts",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_user_smart_accounts_solana_env_check": {
+          "name": "app_user_smart_accounts_solana_env_check",
+          "value": "\"app_user_smart_accounts\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_user_smart_accounts_state_check": {
+          "name": "app_user_smart_accounts_state_check",
+          "value": "\"app_user_smart_accounts\".\"state\" IN ('provisioning', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_wallets": {
+      "name": "app_user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evm_deposit_address": {
+          "name": "evm_deposit_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_user_wallets_wallet_address_uidx": {
+          "name": "app_user_wallets_wallet_address_uidx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_wallets_user_id_app_users_id_fk": {
+          "name": "app_user_wallets_user_id_app_users_id_fk",
+          "tableFrom": "app_user_wallets",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_users": {
+      "name": "app_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_address": {
+          "name": "subject_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grid_user_id": {
+          "name": "grid_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_settings_pda": {
+          "name": "smart_account_settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_users_provider_subject_uidx": {
+          "name": "app_users_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_users_provider_check": {
+          "name": "app_users_provider_check",
+          "value": "\"app_users\".\"provider\" IN ('solana')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_wallet_auth_completions": {
+      "name": "app_wallet_auth_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_hash": {
+          "name": "challenge_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_account_address": {
+          "name": "smart_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioning_outcome": {
+          "name": "provisioning_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_wallet_auth_completions_challenge_hash_uidx": {
+          "name": "app_wallet_auth_completions_challenge_hash_uidx",
+          "columns": [
+            {
+              "expression": "challenge_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_wallet_address_idx": {
+          "name": "app_wallet_auth_completions_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_state_idx": {
+          "name": "app_wallet_auth_completions_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_wallet_auth_completions_user_id_idx": {
+          "name": "app_wallet_auth_completions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_wallet_auth_completions_user_id_app_users_id_fk": {
+          "name": "app_wallet_auth_completions_user_id_app_users_id_fk",
+          "tableFrom": "app_wallet_auth_completions",
+          "tableTo": "app_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_wallet_auth_completions_solana_env_check": {
+          "name": "app_wallet_auth_completions_solana_env_check",
+          "value": "\"app_wallet_auth_completions\".\"solana_env\" IN ('mainnet', 'testnet', 'devnet', 'localnet')"
+        },
+        "app_wallet_auth_completions_state_check": {
+          "name": "app_wallet_auth_completions_state_check",
+          "value": "\"app_wallet_auth_completions\".\"state\" IN ('processing', 'completed', 'failed')"
+        },
+        "app_wallet_auth_completions_provisioning_outcome_check": {
+          "name": "app_wallet_auth_completions_provisioning_outcome_check",
+          "value": "\"app_wallet_auth_completions\".\"provisioning_outcome\" IS NULL OR \"app_wallet_auth_completions\".\"provisioning_outcome\" IN ('existing_ready', 'delegated_root_signer', 'reconciled_ready', 'sponsored_existing_record', 'sponsored_new_record', 'retried_failed_record')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_messages": {
+      "name": "bot_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_content": {
+          "name": "encrypted_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_messages_thread_created_idx": {
+          "name": "bot_messages_thread_created_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_messages_telegram_id_idx": {
+          "name": "bot_messages_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_messages_thread_id_bot_threads_id_fk": {
+          "name": "bot_messages_thread_id_bot_threads_id_fk",
+          "tableFrom": "bot_messages",
+          "tableTo": "bot_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_threads": {
+      "name": "bot_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_thread_id": {
+          "name": "telegram_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_threads_user_id_idx": {
+          "name": "bot_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_telegram_unique_idx": {
+          "name": "bot_threads_telegram_unique_idx",
+          "columns": [
+            {
+              "expression": "telegram_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_threads_status_idx": {
+          "name": "bot_threads_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_threads_user_id_users_id_fk": {
+          "name": "bot_threads_user_id_users_id_fk",
+          "tableFrom": "bot_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_connections": {
+      "name": "business_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_connection_id": {
+          "name": "business_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_chat_id": {
+          "name": "user_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_connections_user_id_idx": {
+          "name": "business_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_connections_is_enabled_idx": {
+          "name": "business_connections_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_connections_user_id_users_id_fk": {
+          "name": "business_connections_user_id_users_id_fk",
+          "tableFrom": "business_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_by": {
+          "name": "activated_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "parser_type": {
+          "name": "parser_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "summary_notifications_enabled": {
+          "name": "summary_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summary_notification_time_hours": {
+          "name": "summary_notification_time_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 24
+        },
+        "summary_notification_message_count": {
+          "name": "summary_notification_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_chat_id_idx": {
+          "name": "communities_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_idx": {
+          "name": "communities_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_is_active_parser_type_idx": {
+          "name": "communities_is_active_parser_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parser_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "communities_summary_notification_time_hours_check": {
+          "name": "communities_summary_notification_time_hours_check",
+          "value": "\"communities\".\"summary_notification_time_hours\" IS NULL OR \"communities\".\"summary_notification_time_hours\" IN (24, 48)"
+        },
+        "communities_parser_type_check": {
+          "name": "communities_parser_type_check",
+          "value": "\"communities\".\"parser_type\" IN ('bot', 'userbot')"
+        },
+        "communities_summary_notification_message_count_check": {
+          "name": "communities_summary_notification_message_count_check",
+          "value": "\"communities\".\"summary_notification_message_count\" IS NULL OR \"communities\".\"summary_notification_message_count\" IN (500, 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_members_unique_idx": {
+          "name": "community_members_unique_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_members_user_id_idx": {
+          "name": "community_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_users_id_fk": {
+          "name": "community_members_user_id_users_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.earn_yield_push_state": {
+      "name": "earn_yield_push_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_pushed_earned_usd": {
+          "name": "last_pushed_earned_usd",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_pushed_at": {
+          "name": "last_pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_campaigns": {
+          "name": "sent_campaigns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "earn_yield_push_state_wallet_uidx": {
+          "name": "earn_yield_push_state_wallet_uidx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_app_statuses": {
+      "name": "feature_app_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_app_statuses_feature_app_idx": {
+          "name": "feature_app_statuses_feature_app_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_app_statuses_feature_id_feature_registry_id_fk": {
+          "name": "feature_app_statuses_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_app_statuses",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_app_statuses_app_check": {
+          "name": "feature_app_statuses_app_check",
+          "value": "\"feature_app_statuses\".\"app\" IN ('telegram_miniapp', 'website', 'mobile', 'extension')"
+        },
+        "feature_app_statuses_status_check": {
+          "name": "feature_app_statuses_status_check",
+          "value": "\"feature_app_statuses\".\"status\" IN ('missing', 'planned', 'in_progress', 'implemented', 'live')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_evidence": {
+      "name": "feature_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_app_status_id": {
+          "name": "feature_app_status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_evidence_feature_app_status_id_idx": {
+          "name": "feature_evidence_feature_app_status_id_idx",
+          "columns": [
+            {
+              "expression": "feature_app_status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk": {
+          "name": "feature_evidence_feature_app_status_id_feature_app_statuses_id_fk",
+          "tableFrom": "feature_evidence",
+          "tableTo": "feature_app_statuses",
+          "columnsFrom": [
+            "feature_app_status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_evidence_type_check": {
+          "name": "feature_evidence_type_check",
+          "value": "\"feature_evidence\".\"type\" IN ('path', 'branch', 'pr', 'linear', 'commit', 'doc')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feature_flag_links": {
+      "name": "feature_flag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flag_links_unique_idx": {
+          "name": "feature_flag_links_unique_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_flag_links_feature_id_feature_registry_id_fk": {
+          "name": "feature_flag_links_feature_id_feature_registry_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "feature_registry",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feature_flag_links_flag_id_runtime_flags_id_fk": {
+          "name": "feature_flag_links_flag_id_runtime_flags_id_fk",
+          "tableFrom": "feature_flag_links",
+          "tableTo": "runtime_flags",
+          "columnsFrom": [
+            "flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_registry": {
+      "name": "feature_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_registry_key_idx": {
+          "name": "feature_registry_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gasless_claim_transactions": {
+      "name": "gasless_claim_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solana_env": {
+          "name": "solana_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_lamports": {
+          "name": "spent_lamports",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gasless_claim_transactions_env_signature_uidx": {
+          "name": "gasless_claim_transactions_env_signature_uidx",
+          "columns": [
+            {
+              "expression": "solana_env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_occurred_at_idx": {
+          "name": "gasless_claim_transactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_type_occurred_at_idx": {
+          "name": "gasless_claim_transactions_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gasless_claim_transactions_recipient_address_idx": {
+          "name": "gasless_claim_transactions_recipient_address_idx",
+          "columns": [
+            {
+              "expression": "recipient_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gasless_claim_transactions_type_check": {
+          "name": "gasless_claim_transactions_type_check",
+          "value": "\"gasless_claim_transactions\".\"transaction_type\" IN ('store', 'verify_telegram_init_data', 'top_up_to_0_01_sol')"
+        },
+        "gasless_claim_transactions_solana_env_check": {
+          "name": "gasless_claim_transactions_solana_env_check",
+          "value": "\"gasless_claim_transactions\".\"solana_env\" IN ('mainnet', 'devnet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_addresses": {
+      "name": "helius_webhook_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhook_addresses_address_unique": {
+          "name": "helius_webhook_addresses_address_unique",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_wallet_idx": {
+          "name": "helius_webhook_addresses_wallet_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "helius_webhook_addresses_webhook_idx": {
+          "name": "helius_webhook_addresses_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk": {
+          "name": "helius_webhook_addresses_webhook_id_helius_webhooks_id_fk",
+          "tableFrom": "helius_webhook_addresses",
+          "tableTo": "helius_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhook_deliveries": {
+      "name": "helius_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helius_webhook_deliveries_signature_wallet_public_key_pk": {
+          "name": "helius_webhook_deliveries_signature_wallet_public_key_pk",
+          "columns": [
+            "signature",
+            "wallet_public_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helius_webhooks": {
+      "name": "helius_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "helius_webhook_id": {
+          "name": "helius_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "address_count": {
+          "name": "address_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "helius_webhooks_helius_id_unique": {
+          "name": "helius_webhooks_helius_id_unique",
+          "columns": [
+            {
+              "expression": "helius_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_articles": {
+      "name": "library_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_time": {
+          "name": "read_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_articles_section_order_idx": {
+          "name": "library_articles_section_order_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_articles_featured_idx": {
+          "name": "library_articles_featured_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_articles_section_id_library_sections_id_fk": {
+          "name": "library_articles_section_id_library_sections_id_fk",
+          "tableFrom": "library_articles",
+          "tableTo": "library_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sections": {
+      "name": "library_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sections_active_order_idx": {
+          "name": "library_sections_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loyal_stats_snapshots": {
+      "name": "loyal_stats_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_key": {
+          "name": "snapshot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "total_aum_raw": {
+          "name": "total_aum_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_optimized_volume_raw": {
+          "name": "total_optimized_volume_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_principal_raw": {
+          "name": "active_principal_raw",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "unique_earn_users": {
+          "name": "unique_earn_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_earn_policies": {
+          "name": "unique_earn_policies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_autodeposit_policies": {
+          "name": "active_autodeposit_policies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "earn_aum_series": {
+          "name": "earn_aum_series",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loyal_stats_snapshots_key_uidx": {
+          "name": "loyal_stats_snapshots_key_uidx",
+          "columns": [
+            {
+              "expression": "snapshot_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "loyal_stats_snapshots_current_key_check": {
+          "name": "loyal_stats_snapshots_current_key_check",
+          "value": "\"loyal_stats_snapshots\".\"snapshot_key\" = 'current'"
+        },
+        "loyal_stats_snapshots_nonnegative_check": {
+          "name": "loyal_stats_snapshots_nonnegative_check",
+          "value": "\"loyal_stats_snapshots\".\"total_aum_raw\" >= 0 AND \"loyal_stats_snapshots\".\"total_users\" >= 0 AND \"loyal_stats_snapshots\".\"total_optimized_volume_raw\" >= 0 AND \"loyal_stats_snapshots\".\"active_principal_raw\" >= 0 AND \"loyal_stats_snapshots\".\"unique_earn_users\" >= 0 AND \"loyal_stats_snapshots\".\"unique_earn_policies\" >= 0 AND \"loyal_stats_snapshots\".\"active_autodeposit_policies\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_community_created_idx": {
+          "name": "messages_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_community_telegram_id_idx": {
+          "name": "messages_community_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_community_id_communities_id_fk": {
+          "name": "messages_community_id_communities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_analytics_sync_state": {
+      "name": "private_transfer_analytics_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_key": {
+          "name": "sync_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backfill_cursor": {
+          "name": "backfill_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_seen_signature": {
+          "name": "latest_seen_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_completed_at": {
+          "name": "backfill_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_started_at": {
+          "name": "last_run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_finished_at": {
+          "name": "last_run_finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_analytics_sync_state_sync_key_uidx": {
+          "name": "private_transfer_analytics_sync_state_sync_key_uidx",
+          "columns": [
+            {
+              "expression": "sync_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_modify_balance_events": {
+      "name": "private_transfer_modify_balance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_index": {
+          "name": "instruction_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_modify_balance_events_signature_instruction_uidx": {
+          "name": "private_transfer_modify_balance_events_signature_instruction_uidx",
+          "columns": [
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instruction_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_token_mint_idx": {
+          "name": "private_transfer_modify_balance_events_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_flow_occurred_at_idx": {
+          "name": "private_transfer_modify_balance_events_flow_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "flow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_modify_balance_events_vault_address_idx": {
+          "name": "private_transfer_modify_balance_events_vault_address_idx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "private_transfer_modify_balance_events_flow_check": {
+          "name": "private_transfer_modify_balance_events_flow_check",
+          "value": "\"private_transfer_modify_balance_events\".\"flow\" IN ('shield', 'unshield')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_token_catalog": {
+      "name": "private_transfer_token_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_price_usd": {
+          "name": "last_price_usd",
+          "type": "numeric(30, 12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_token_catalog_token_mint_uidx": {
+          "name": "private_transfer_token_catalog_token_mint_uidx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_transfer_vault_holdings": {
+      "name": "private_transfer_vault_holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_account_address": {
+          "name": "token_account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_mint": {
+          "name": "token_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "private_transfer_vault_holdings_vault_address_uidx": {
+          "name": "private_transfer_vault_holdings_vault_address_uidx",
+          "columns": [
+            {
+              "expression": "vault_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_account_address_uidx": {
+          "name": "private_transfer_vault_holdings_token_account_address_uidx",
+          "columns": [
+            {
+              "expression": "token_account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "private_transfer_vault_holdings_token_mint_idx": {
+          "name": "private_transfer_vault_holdings_token_mint_idx",
+          "columns": [
+            {
+              "expression": "token_mint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_sends": {
+      "name": "push_notification_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_count": {
+          "name": "requested_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ticket_count": {
+          "name": "ticket_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_ok_count": {
+          "name": "receipt_ok_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_error_count": {
+          "name": "receipt_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_not_registered_count": {
+          "name": "device_not_registered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipts_checked_at": {
+          "name": "receipts_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_sends_created_at_idx": {
+          "name": "push_notification_sends_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_sends_status_idx": {
+          "name": "push_notification_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "push_notification_sends_audience_check": {
+          "name": "push_notification_sends_audience_check",
+          "value": "\"push_notification_sends\".\"audience\" IN ('all', 'platform', 'wallet')"
+        },
+        "push_notification_sends_status_check": {
+          "name": "push_notification_sends_status_check",
+          "value": "\"push_notification_sends\".\"status\" IN ('sending', 'sent', 'receipt_checked', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tickets": {
+      "name": "push_notification_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_status": {
+          "name": "ticket_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_message": {
+          "name": "ticket_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_error": {
+          "name": "ticket_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_status": {
+          "name": "receipt_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_message": {
+          "name": "receipt_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_error": {
+          "name": "receipt_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_tickets_send_id_idx": {
+          "name": "push_notification_tickets_send_id_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_ticket_id_idx": {
+          "name": "push_notification_tickets_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tickets_token_idx": {
+          "name": "push_notification_tickets_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tickets_send_id_push_notification_sends_id_fk": {
+          "name": "push_notification_tickets_send_id_push_notification_sends_id_fk",
+          "tableFrom": "push_notification_tickets",
+          "tableTo": "push_notification_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_telegram_user_id_idx": {
+          "name": "push_tokens_telegram_user_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_wallet_public_key_idx": {
+          "name": "push_tokens_wallet_public_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_flags": {
+      "name": "runtime_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_environments": {
+          "name": "target_environments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"development\",\"preview\",\"production\"]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_flags_key_idx": {
+          "name": "runtime_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_flags_audience_check": {
+          "name": "runtime_flags_audience_check",
+          "value": "\"runtime_flags\".\"audience\" IN ('all', 'public', 'team')"
+        },
+        "runtime_flags_target_environments_check": {
+          "name": "runtime_flags_target_environments_check",
+          "value": "jsonb_typeof(\"runtime_flags\".\"target_environments\") = 'array' AND \"runtime_flags\".\"target_environments\" <@ '[\"development\",\"preview\",\"production\"]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.summaries": {
+      "name": "summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_title": {
+          "name": "chat_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oneliner": {
+          "name": "oneliner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_key": {
+          "name": "trigger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_sent_at": {
+          "name": "notification_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_claimed_at": {
+          "name": "notification_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summaries_community_created_idx": {
+          "name": "summaries_community_created_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_community_trigger_key_uidx": {
+          "name": "summaries_community_trigger_key_uidx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"summaries\".\"trigger_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_trigger_key_idx": {
+          "name": "summaries_trigger_key_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summaries_notification_sent_idx": {
+          "name": "summaries_notification_sent_idx",
+          "columns": [
+            {
+              "expression": "trigger_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summaries_community_id_communities_id_fk": {
+          "name": "summaries_community_id_communities_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.summary_votes": {
+      "name": "summary_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "summary_votes_summary_user_uidx": {
+          "name": "summary_votes_summary_user_uidx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_votes_summary_action_idx": {
+          "name": "summary_votes_summary_action_idx",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "summary_votes_user_id_users_id_fk": {
+          "name": "summary_votes_user_id_users_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "summary_votes_summary_id_summaries_id_fk": {
+          "name": "summary_votes_summary_id_summaries_id_fk",
+          "tableFrom": "summary_votes",
+          "tableTo": "summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "summary_votes_action_check": {
+          "name": "summary_votes_action_check",
+          "value": "\"summary_votes\".\"action\" IN ('LIKE', 'DISLIKE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_command_receipts": {
+      "name": "telegram_command_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_update_id": {
+          "name": "telegram_update_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "telegram_message_id": {
+          "name": "telegram_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_command_receipts_update_uidx": {
+          "name": "telegram_command_receipts_update_uidx",
+          "columns": [
+            {
+              "expression": "telegram_update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_command_receipts_status_created_idx": {
+          "name": "telegram_command_receipts_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "telegram_command_receipts_status_check": {
+          "name": "telegram_command_receipts_status_check",
+          "value": "\"telegram_command_receipts\".\"status\" IN ('processing', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_helper_message_cleanup": {
+      "name": "telegram_helper_message_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_after": {
+          "name": "delete_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_helper_message_cleanup_delete_after_idx": {
+          "name": "telegram_helper_message_cleanup_delete_after_idx",
+          "columns": [
+            {
+              "expression": "delete_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_helper_message_cleanup_chat_message_uidx": {
+          "name": "telegram_helper_message_cleanup_chat_message_uidx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trusted_dapps": {
+      "name": "trusted_dapps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trusted_dapps_origin_uidx": {
+          "name": "trusted_dapps_origin_uidx",
+          "columns": [
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_order_idx": {
+          "name": "trusted_dapps_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trusted_dapps_active_category_order_idx": {
+          "name": "trusted_dapps_active_category_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'phala/gpt-oss-120b'"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_telegram_id_idx": {
+          "name": "users_telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_push_sync_state": {
+      "name": "wallet_push_sync_state",
+      "schema": "",
+      "columns": {
+        "wallet_public_key": {
+          "name": "wallet_public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_signature": {
+          "name": "last_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/telegram/drizzle/meta/_journal.json
+++ b/apps/telegram/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1788364024058,
       "tag": "0029_privy_user_email",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1788427297930,
+      "tag": "0030_evm_deposit_address",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -65,7 +65,18 @@ users are asked to link an email right after sign-in. Without the Privy env,
 the legacy SIWS flow is used.
 
 Wallet sign-in provisions or reconciles the sponsored smart account before the
-session cookie is issued. The HttpOnly wallet session cookie uses a 7 day TTL
+session cookie is issued.
+
+### Deposit from other chains (Privy embedded wallets only)
+
+`/api/funding/evm-deposit-address` returns a permanent `0x` address per
+embedded Solana wallet (stored on `app_user_wallets.evm_deposit_address`).
+USDC/USDT/ETH sent there on Ethereum, Base, Arbitrum or Polygon is bridged by
+Privy and delivered as USDC to the user's Solana wallet; the app pays bridge
+gas (Privy dashboard: swaps + app-pays sponsorship on those chains). First
+call is two-step: `GET` returns the Privy request to sign, the browser signs it
+with the user's Privy key (`useAuthorizationSignature`), `POST` forwards the
+signature. External wallets get 409. UI: Receive sheet → "Other chains". The HttpOnly wallet session cookie uses a 7 day TTL
 and refreshes locally once it is at least 24 hours old.
 
 ## Development

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
     "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1",
     "@neondatabase/serverless": "^1.0.2",
     "@number-flow/react": "^0.6.0",
-    "@privy-io/node": "0.20.0",
+    "@privy-io/node": "0.32.0",
     "@privy-io/react-auth": "3.35.2",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/apps/web/src/app/api/funding/evm-deposit-address/route.ts
+++ b/apps/web/src/app/api/funding/evm-deposit-address/route.ts
@@ -7,6 +7,7 @@ import {
   EVM_DEPOSIT_ASSETS,
   EVM_DEPOSIT_CHAINS,
   EVM_DEPOSIT_MIN_USD_ETHEREUM,
+  EVM_DEPOSIT_SIGN_WINDOW_MS,
   findEvmDepositAddress,
   resolveEmbeddedWalletId,
 } from "@/features/funding/server/evm-deposit";
@@ -18,7 +19,10 @@ import { getServerEnv } from "@/lib/core/config/server";
 
 // Two-step: GET returns the stored address, or the Privy request the user must
 // sign; POST takes that signature and creates the address.
-const bodySchema = z.object({ signature: z.string().min(1) });
+const bodySchema = z.object({
+  signature: z.string().min(1),
+  requestExpiry: z.number().int().positive(),
+});
 
 function meta() {
   return {
@@ -64,9 +68,11 @@ export function GET(request: Request) {
     }
     const walletId = await resolveEmbeddedWalletId(p.walletAddress);
     const { privyAppId } = getServerEnv();
+    const requestExpiry = Date.now() + EVM_DEPOSIT_SIGN_WINDOW_MS;
     return Response.json({
       address: null,
-      toSign: buildEvmDepositRequest(walletId, privyAppId ?? ""),
+      toSign: buildEvmDepositRequest(walletId, privyAppId ?? "", requestExpiry),
+      requestExpiry,
       ...meta(),
     });
   });
@@ -92,6 +98,7 @@ export function POST(request: Request) {
       walletId,
       appId: privyAppId ?? "",
       signature: parsed.data.signature,
+      requestExpiry: parsed.data.requestExpiry,
     });
     return Response.json({ address, ...meta() });
   });

--- a/apps/web/src/app/api/funding/evm-deposit-address/route.ts
+++ b/apps/web/src/app/api/funding/evm-deposit-address/route.ts
@@ -1,21 +1,37 @@
 import { z } from "zod";
 
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import {
+  buildEvmDepositRequest,
+  createEvmDepositAddress,
   EVM_DEPOSIT_ASSETS,
   EVM_DEPOSIT_CHAINS,
   EVM_DEPOSIT_MIN_USD_ETHEREUM,
-  getOrCreateEvmDepositAddress,
+  findEvmDepositAddress,
+  resolveEmbeddedWalletId,
 } from "@/features/funding/server/evm-deposit";
-import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
 import {
   isAuthGatewayError,
   resolveAuthenticatedPrincipalFromRequest,
 } from "@/features/identity/server/auth-session";
+import { getServerEnv } from "@/lib/core/config/server";
 
-const bodySchema = z.object({ privyAccessToken: z.string().min(1) });
+// Two-step: GET returns the stored address, or the Privy request the user must
+// sign; POST takes that signature and creates the address.
+const bodySchema = z.object({ signature: z.string().min(1) });
 
-// Returns (creating on first call) the user's cross-chain deposit address.
-export async function POST(request: Request) {
+function meta() {
+  return {
+    chains: EVM_DEPOSIT_CHAINS,
+    assets: EVM_DEPOSIT_ASSETS,
+    minimums: { ethereum: EVM_DEPOSIT_MIN_USD_ETHEREUM },
+  };
+}
+
+async function withPrincipal(
+  request: Request,
+  fn: (p: { userId: string; walletAddress: string }) => Promise<Response>
+) {
   try {
     const principal = await resolveAuthenticatedPrincipalFromRequest(request);
     if (!principal) {
@@ -24,29 +40,10 @@ export async function POST(request: Request) {
         { status: 401 }
       );
     }
-    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
-    if (!parsed.success) {
-      return Response.json(
-        {
-          error: {
-            code: "invalid_body",
-            message: "privyAccessToken required.",
-          },
-        },
-        { status: 400 }
-      );
-    }
     const user = await getOrCreateCurrentUser(principal);
-    const address = await getOrCreateEvmDepositAddress({
+    return await fn({
       userId: user.id,
       walletAddress: principal.walletAddress,
-      privyAccessToken: parsed.data.privyAccessToken,
-    });
-    return Response.json({
-      address,
-      chains: EVM_DEPOSIT_CHAINS,
-      assets: EVM_DEPOSIT_ASSETS,
-      minimums: { ethereum: EVM_DEPOSIT_MIN_USD_ETHEREUM },
     });
   } catch (error) {
     if (isAuthGatewayError(error)) {
@@ -57,4 +54,45 @@ export async function POST(request: Request) {
     }
     throw error;
   }
+}
+
+export function GET(request: Request) {
+  return withPrincipal(request, async (p) => {
+    const row = await findEvmDepositAddress(p);
+    if (row.evmDepositAddress) {
+      return Response.json({ address: row.evmDepositAddress, ...meta() });
+    }
+    const walletId = await resolveEmbeddedWalletId(p.walletAddress);
+    const { privyAppId } = getServerEnv();
+    return Response.json({
+      address: null,
+      toSign: buildEvmDepositRequest(walletId, privyAppId ?? ""),
+      ...meta(),
+    });
+  });
+}
+
+export function POST(request: Request) {
+  return withPrincipal(request, async (p) => {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return Response.json(
+        { error: { code: "invalid_body", message: "signature required." } },
+        { status: 400 }
+      );
+    }
+    const row = await findEvmDepositAddress(p);
+    if (row.evmDepositAddress) {
+      return Response.json({ address: row.evmDepositAddress, ...meta() });
+    }
+    const walletId = await resolveEmbeddedWalletId(p.walletAddress);
+    const { privyAppId } = getServerEnv();
+    const address = await createEvmDepositAddress({
+      rowId: row.id,
+      walletId,
+      appId: privyAppId ?? "",
+      signature: parsed.data.signature,
+    });
+    return Response.json({ address, ...meta() });
+  });
 }

--- a/apps/web/src/app/api/funding/evm-deposit-address/route.ts
+++ b/apps/web/src/app/api/funding/evm-deposit-address/route.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import {
+  EVM_DEPOSIT_ASSETS,
+  EVM_DEPOSIT_CHAINS,
+  EVM_DEPOSIT_MIN_USD_ETHEREUM,
+  getOrCreateEvmDepositAddress,
+} from "@/features/funding/server/evm-deposit";
+import { getOrCreateCurrentUser } from "@/features/chat/server/app-user";
+import {
+  isAuthGatewayError,
+  resolveAuthenticatedPrincipalFromRequest,
+} from "@/features/identity/server/auth-session";
+
+const bodySchema = z.object({ privyAccessToken: z.string().min(1) });
+
+// Returns (creating on first call) the user's cross-chain deposit address.
+export async function POST(request: Request) {
+  try {
+    const principal = await resolveAuthenticatedPrincipalFromRequest(request);
+    if (!principal) {
+      return Response.json(
+        { error: { code: "unauthenticated", message: "Sign in first." } },
+        { status: 401 }
+      );
+    }
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return Response.json(
+        {
+          error: {
+            code: "invalid_body",
+            message: "privyAccessToken required.",
+          },
+        },
+        { status: 400 }
+      );
+    }
+    const user = await getOrCreateCurrentUser(principal);
+    const address = await getOrCreateEvmDepositAddress({
+      userId: user.id,
+      walletAddress: principal.walletAddress,
+      privyAccessToken: parsed.data.privyAccessToken,
+    });
+    return Response.json({
+      address,
+      chains: EVM_DEPOSIT_CHAINS,
+      assets: EVM_DEPOSIT_ASSETS,
+      minimums: { ethereum: EVM_DEPOSIT_MIN_USD_ETHEREUM },
+    });
+  } catch (error) {
+    if (isAuthGatewayError(error)) {
+      return Response.json(
+        { error: { code: error.code, message: error.message } },
+        { status: error.status }
+      );
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2880,6 +2880,43 @@ cap-widget {
   }
 }
 
+/* Same recipe, small form: the Receive sheet's Solana / Other-chains bodies
+   share one grid cell; the inactive one is display:none-free so it can
+   slide out, and pointer-events off so it never catches clicks. */
+.t-receive-pages .t-receive-page {
+  opacity: 0;
+  transform: translateX(var(--t-page-from-x, 0px));
+  filter: blur(var(--page-blur));
+  pointer-events: none;
+  transition: opacity var(--page-fade-dur) var(--page-fade-ease),
+    transform var(--page-slide-dur) var(--page-slide-ease),
+    filter var(--page-slide-dur) var(--page-slide-ease);
+}
+.t-receive-pages .t-receive-page[data-page-id="1"] {
+  --t-page-from-x: calc(var(--page-slide-distance) * -1);
+}
+.t-receive-pages .t-receive-page[data-page-id="2"] {
+  --t-page-from-x: var(--page-slide-distance);
+}
+.t-receive-pages[data-page="1"] .t-receive-page[data-page-id="1"],
+.t-receive-pages[data-page="2"] .t-receive-page[data-page-id="2"] {
+  opacity: 1;
+  transform: translateX(0);
+  filter: blur(0);
+  pointer-events: auto;
+}
+/* The skeleton overlay is absolute (recipe); the content layer stays
+   in-flow here so it sizes the card. */
+.t-receive-page .t-skel-content {
+  position: relative;
+  inset: auto;
+}
+@media (prefers-reduced-motion: reduce) {
+  .t-receive-pages .t-receive-page {
+    transition: none !important;
+  }
+}
+
 /* Facelift adaptation — a transaction arriving after a mutation pushes the
    list down and reveals: the accordion recipe's 0fr → 1fr track
    (frontend/transitions/accordion.md) grows the row's slot on the resize

--- a/apps/web/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/earn-chart-pane.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -18,6 +17,7 @@ import { useBalanceVisibility } from "@/components/wallet-workspace/facelift/bal
 import { readCssDurationMs } from "@/components/wallet-workspace/facelift/css-duration";
 import { EarnedChart } from "@/components/wallet-workspace/facelift/earned-chart";
 import { InfoTooltip } from "@/components/wallet-workspace/facelift/info-tooltip";
+import { SlidingTabs } from "@/components/wallet-workspace/facelift/sliding-tabs";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
 import { useEarnForecastApyStatus } from "@/components/wallet-workspace/facelift/use-earn-forecast-apy-status";
 import type { EarnPositionData } from "@/components/wallet-workspace/facelift/use-earn-position-data";
@@ -35,72 +35,6 @@ export type ChartTab = (typeof CHART_TABS)[number];
 // white active pill is one absolutely-positioned span that tweens between the
 // measured offset/width of the selected tab. First paint and resizes write
 // the position with transitions suspended so the pill snaps, never flies in.
-function ChartTabs({
-  activeTab,
-  onSelect,
-  tabs,
-}: {
-  activeTab: ChartTab;
-  onSelect: (tab: ChartTab) => void;
-  tabs: readonly ChartTab[];
-}) {
-  const barRef = useRef<HTMLDivElement>(null);
-  const pillRef = useRef<HTMLSpanElement>(null);
-  const hasPainted = useRef(false);
-
-  const movePillToActiveTab = useCallback((animate: boolean) => {
-    const bar = barRef.current;
-    const pill = pillRef.current;
-    const active = bar?.querySelector<HTMLButtonElement>(
-      '[aria-selected="true"]'
-    );
-    if (!(bar && pill && active)) {
-      return;
-    }
-    if (animate) {
-      pill.style.transform = `translateX(${active.offsetLeft}px)`;
-      pill.style.width = `${active.offsetWidth}px`;
-      return;
-    }
-    const previousTransition = pill.style.transition;
-    pill.style.transition = "none";
-    pill.style.transform = `translateX(${active.offsetLeft}px)`;
-    pill.style.width = `${active.offsetWidth}px`;
-    void pill.offsetWidth;
-    pill.style.transition = previousTransition;
-  }, []);
-
-  // Re-measure when the tab set changes too (Earned appears with a position).
-  useLayoutEffect(() => {
-    movePillToActiveTab(hasPainted.current);
-    hasPainted.current = true;
-  }, [activeTab, movePillToActiveTab, tabs.length]);
-
-  useEffect(() => {
-    const handleResize = () => movePillToActiveTab(false);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, [movePillToActiveTab]);
-
-  return (
-    <div className="t-tabs" ref={barRef} role="tablist">
-      <span aria-hidden="true" className="t-tabs-pill" ref={pillRef} />
-      {tabs.map((tab) => (
-        <button
-          aria-selected={activeTab === tab}
-          className="t-tab whitespace-nowrap font-medium text-[14px] leading-5"
-          key={tab}
-          onClick={() => onSelect(tab)}
-          role="tab"
-          type="button"
-        >
-          {tab}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 function ChartBody({
   activeTab,
   apy,
@@ -225,7 +159,7 @@ export function EarnChartCard({
               />
             </div>
           ) : (
-            <ChartTabs
+            <SlidingTabs
               activeTab={activeTab}
               onSelect={onSelectTab}
               tabs={visibleTabs}

--- a/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -5,10 +5,20 @@ import { useEffect, useState } from "react";
 
 import { copyTextToClipboard } from "@/components/wallet-workspace/facelift/copy-text";
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
+import { SlidingTabs } from "@/components/wallet-workspace/facelift/sliding-tabs";
 import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+import { useEvmDepositAddress } from "@/components/wallet-workspace/facelift/use-evm-deposit-address";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
+const TABS = ["Solana", "Other chains"] as const;
+type Tab = (typeof TABS)[number];
+const CHAIN_LABELS: Record<string, string> = {
+  ethereum: "Ethereum",
+  base: "Base",
+  arbitrum: "Arbitrum",
+  polygon: "Polygon",
+};
 
 // Facelift take on the OG Receive view (receive-content.tsx): Solana-only
 // warning, QR card with the mascot in the center and the raw address, and a
@@ -23,6 +33,15 @@ export function ReceiveSheet({
   walletAddress: string | null;
 }) {
   const [copied, setCopied] = useState(false);
+  const [tab, setTab] = useState<Tab>("Solana");
+  const evm = useEvmDepositAddress(walletAddress);
+  // Privy provisions the 0x address on first request; only ask once the
+  // user actually opens the tab.
+  useEffect(() => {
+    if (isOpen && tab === "Other chains") void evm.load();
+  }, [evm, isOpen, tab]);
+  const isEvmTab = tab === "Other chains";
+  const shownAddress = isEvmTab ? evm.info?.address ?? null : walletAddress;
 
   useEffect(() => {
     if (!isOpen) {
@@ -39,10 +58,10 @@ export function ReceiveSheet({
   }, [isOpen, onClose]);
 
   const handleCopy = () => {
-    if (!walletAddress) {
+    if (!shownAddress) {
       return;
     }
-    void copyTextToClipboard(walletAddress).then((didCopy) => {
+    void copyTextToClipboard(shownAddress).then((didCopy) => {
       if (didCopy) {
         setCopied(true);
         window.setTimeout(() => setCopied(false), 2000);
@@ -74,19 +93,35 @@ export function ReceiveSheet({
         </button>
       </header>
       <div className="flex w-full flex-col items-center gap-6 px-6 pt-2 pb-2">
-        <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
-          Use to receive tokens on the Solana network only. Other assets will
-          be lost forever.
-        </p>
+        {evm.eligible ? (
+          <SlidingTabs activeTab={tab} onSelect={setTab} tabs={TABS} />
+        ) : null}
+        {isEvmTab ? (
+          <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
+            Send USDC, USDT or ETH on{" "}
+            {(evm.info?.chains ?? [])
+              .map((c) => CHAIN_LABELS[c] ?? c)
+              .join(", ")}
+            . It arrives as USDC in your loyal wallet in a few minutes.
+            {evm.info?.minimums.ethereum
+              ? ` Minimum on Ethereum: $${evm.info.minimums.ethereum}.`
+              : null}
+          </p>
+        ) : (
+          <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
+            Use to receive tokens on the Solana network only. Other assets will
+            be lost forever.
+          </p>
+        )}
         <div className="flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-border p-8">
-          {walletAddress ? (
+          {shownAddress ? (
             <div className="relative">
               <QRCodeSVG
                 bgColor="transparent"
                 fgColor="var(--foreground)"
                 level="M"
                 size={192}
-                value={walletAddress}
+                value={shownAddress}
               />
               <span className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 flex h-8 w-10 items-center justify-center rounded bg-card p-0.5">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -102,14 +137,17 @@ export function ReceiveSheet({
             <div className="size-48 rounded-lg bg-accent" />
           )}
           <p className="break-all text-center text-[13px] leading-4 text-muted-foreground">
-            {walletAddress ?? "No wallet connected"}
+            {shownAddress ??
+              (isEvmTab
+                ? evm.error ?? "Preparing your deposit address…"
+                : "No wallet connected")}
           </p>
         </div>
       </div>
       <div className="w-full px-5 pt-2 pb-4">
         <button
           className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-40"
-          disabled={!walletAddress}
+          disabled={!shownAddress}
           onClick={handleCopy}
           type="button"
         >

--- a/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -115,6 +115,9 @@ export function ReceiveSheet({
               address={evm.info?.address ?? null}
               copy={
                 <>
+                  <span className="mr-1.5 inline-flex rounded-md bg-primary/[0.14] px-1.5 py-px align-middle font-medium text-[11px] text-primary uppercase leading-[13px] tracking-[0.06px]">
+                    Alpha
+                  </span>
                   Send USDC, USDT or ETH on{" "}
                   {(evm.info?.chains ?? EVM_CHAIN_FALLBACK)
                     .map((c) => CHAIN_LABELS[c] ?? c)
@@ -122,7 +125,8 @@ export function ReceiveSheet({
                   . It arrives as USDC in your loyal wallet in a few minutes.
                   {evm.info?.minimums.ethereum
                     ? ` Minimum on Ethereum: $${evm.info.minimums.ethereum}.`
-                    : null}
+                    : null}{" "}
+                  This is an early release; start with a small amount.
                 </>
               }
               error={evm.error}

--- a/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { QRCodeSVG } from "qrcode.react";
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 import { copyTextToClipboard } from "@/components/wallet-workspace/facelift/copy-text";
 import { SheetReveal } from "@/components/wallet-workspace/facelift/sheet-reveal";
@@ -13,6 +13,7 @@ import { useEvmDepositAddress } from "@/components/wallet-workspace/facelift/use
 const ASSET_BASE = "/wallet-workspace/facelift";
 const TABS = ["Solana", "Other chains"] as const;
 type Tab = (typeof TABS)[number];
+const EVM_CHAIN_FALLBACK = ["ethereum", "base", "arbitrum", "polygon"];
 const CHAIN_LABELS: Record<string, string> = {
   ethereum: "Ethereum",
   base: "Base",
@@ -96,32 +97,107 @@ export function ReceiveSheet({
         {evm.eligible ? (
           <SlidingTabs activeTab={tab} onSelect={setTab} tabs={TABS} />
         ) : null}
-        {isEvmTab ? (
-          <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
-            Send USDC, USDT or ETH on{" "}
-            {(evm.info?.chains ?? [])
-              .map((c) => CHAIN_LABELS[c] ?? c)
-              .join(", ")}
-            . It arrives as USDC in your loyal wallet in a few minutes.
-            {evm.info?.minimums.ethereum
-              ? ` Minimum on Ethereum: $${evm.info.minimums.ethereum}.`
-              : null}
-          </p>
-        ) : (
-          <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
-            Use to receive tokens on the Solana network only. Other assets will
-            be lost forever.
-          </p>
-        )}
-        <div className="flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-border p-8">
-          {shownAddress ? (
+        {/* transitions.dev "page side-by-side": both tab bodies share one
+            grid cell; the active one slides in from its side, the other
+            slides out the opposite way with a fade + blur. */}
+        <div
+          className="t-receive-pages grid w-full justify-items-center"
+          data-page={isEvmTab ? "2" : "1"}
+        >
+          <ReceiveBody
+            address={walletAddress}
+            copy="Use to receive tokens on the Solana network only. Other assets will be lost forever."
+            page="1"
+            placeholder="No wallet connected"
+          />
+          {evm.eligible ? (
+            <ReceiveBody
+              address={evm.info?.address ?? null}
+              copy={
+                <>
+                  Send USDC, USDT or ETH on{" "}
+                  {(evm.info?.chains ?? EVM_CHAIN_FALLBACK)
+                    .map((c) => CHAIN_LABELS[c] ?? c)
+                    .join(", ")}
+                  . It arrives as USDC in your loyal wallet in a few minutes.
+                  {evm.info?.minimums.ethereum
+                    ? ` Minimum on Ethereum: $${evm.info.minimums.ethereum}.`
+                    : null}
+                </>
+              }
+              error={evm.error}
+              loading={!evm.info && !evm.error}
+              page="2"
+              placeholder="Preparing your deposit address…"
+            />
+          ) : null}
+        </div>
+      </div>
+      <div className="w-full px-5 pt-2 pb-4">
+        <button
+          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-40"
+          disabled={!shownAddress}
+          onClick={handleCopy}
+          type="button"
+        >
+          <TextSwap text={copied ? "Copied!" : "Copy Address"} />
+        </button>
+      </div>
+    </SheetReveal>
+  );
+}
+
+function ReceiveBody({
+  address,
+  copy,
+  error,
+  loading = false,
+  page,
+  placeholder,
+}: {
+  address: string | null;
+  copy: ReactNode;
+  error?: string | null;
+  loading?: boolean;
+  page: "1" | "2";
+  placeholder: string;
+}) {
+  // transitions.dev "skeleton loader and reveal" on the QR + address slot:
+  // the skeleton pulses while Privy provisions the address, then both layers
+  // cross-fade. Solana's address is known at open, so it reveals at once.
+  const revealed = Boolean(address) || Boolean(error);
+  return (
+    <div
+      className="t-receive-page col-start-1 row-start-1 flex w-full flex-col items-center gap-6"
+      data-page-id={page}
+    >
+      <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
+        {copy}
+      </p>
+      <div
+        className={`t-skel flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-border p-8 ${
+          revealed ? "is-revealed" : ""
+        }`}
+        style={{ ["--pulse-count" as never]: "infinite" }}
+      >
+        <div
+          aria-hidden="true"
+          className={`t-skel-skeleton flex flex-col items-center gap-4 p-8 ${
+            loading ? "is-pulsing" : ""
+          }`}
+        >
+          <div className="size-48 rounded-lg bg-accent" />
+          <div className="h-8 w-40 rounded-md bg-accent" />
+        </div>
+        <div className="t-skel-content relative flex flex-col items-center gap-4">
+          {address ? (
             <div className="relative">
               <QRCodeSVG
                 bgColor="transparent"
                 fgColor="var(--foreground)"
                 level="M"
                 size={192}
-                value={shownAddress}
+                value={address}
               />
               <span className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 flex h-8 w-10 items-center justify-center rounded bg-card p-0.5">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -136,24 +212,15 @@ export function ReceiveSheet({
           ) : (
             <div className="size-48 rounded-lg bg-accent" />
           )}
-          <p className="break-all text-center text-[13px] leading-4 text-muted-foreground">
-            {shownAddress ??
-              (isEvmTab
-                ? evm.error ?? "Preparing your deposit address…"
-                : "No wallet connected")}
+          <p
+            className={`break-all text-center text-[13px] leading-4 ${
+              error ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {address ?? error ?? placeholder}
           </p>
         </div>
       </div>
-      <div className="w-full px-5 pt-2 pb-4">
-        <button
-          className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 enabled:hover:-translate-y-0.5 enabled:hover:bg-foreground/90 enabled:active:translate-y-0 disabled:opacity-40"
-          disabled={!shownAddress}
-          onClick={handleCopy}
-          type="button"
-        >
-          <TextSwap text={copied ? "Copied!" : "Copy Address"} />
-        </button>
-      </div>
-    </SheetReveal>
+    </div>
   );
 }

--- a/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -115,9 +115,6 @@ export function ReceiveSheet({
               address={evm.info?.address ?? null}
               copy={
                 <>
-                  <span className="mr-1.5 inline-flex rounded-md bg-primary/[0.14] px-1.5 py-px align-middle font-medium text-[11px] text-primary uppercase leading-[13px] tracking-[0.06px]">
-                    Alpha
-                  </span>
                   Send USDC, USDT or ETH on{" "}
                   {(evm.info?.chains ?? EVM_CHAIN_FALLBACK)
                     .map((c) => CHAIN_LABELS[c] ?? c)
@@ -125,12 +122,21 @@ export function ReceiveSheet({
                   . It arrives as USDC in your loyal wallet in a few minutes.
                   {evm.info?.minimums.ethereum
                     ? ` Minimum on Ethereum: $${evm.info.minimums.ethereum}.`
-                    : null}{" "}
-                  This is an early release; start with a small amount.
+                    : null}
                 </>
               }
               error={evm.error}
               loading={!evm.info && !evm.error}
+              notice={
+                <>
+                  <span className="flex h-5 shrink-0 items-center rounded-md bg-primary/[0.14] px-1.5 font-medium text-[11px] text-primary uppercase tracking-[0.06px]">
+                    Alpha
+                  </span>
+                  <span className="text-[13px] text-foreground leading-4">
+                    Early release. Start with a small amount.
+                  </span>
+                </>
+              }
               page="2"
               placeholder="Preparing your deposit address…"
             />
@@ -156,6 +162,7 @@ function ReceiveBody({
   copy,
   error,
   loading = false,
+  notice,
   page,
   placeholder,
 }: {
@@ -163,6 +170,7 @@ function ReceiveBody({
   copy: ReactNode;
   error?: string | null;
   loading?: boolean;
+  notice?: ReactNode;
   page: "1" | "2";
   placeholder: string;
 }) {
@@ -175,9 +183,14 @@ function ReceiveBody({
       className="t-receive-page col-start-1 row-start-1 flex w-full flex-col items-center gap-6"
       data-page-id={page}
     >
-      <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
-        {copy}
-      </p>
+      <div className="flex flex-col items-center gap-2">
+        {notice ? (
+          <div className="flex items-center gap-2">{notice}</div>
+        ) : null}
+        <p className="max-w-[300px] text-center text-[13px] leading-4 text-muted-foreground">
+          {copy}
+        </p>
+      </div>
       <div
         className={`t-skel flex w-full max-w-[280px] flex-col items-center gap-4 rounded-[20px] border border-border p-8 ${
           revealed ? "is-revealed" : ""

--- a/apps/web/src/components/wallet-workspace/facelift/sliding-tabs.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/sliding-tabs.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+
+// transitions.dev "tabs sliding": the active pill slides between options;
+// JS writes offsetLeft/offsetWidth, globals.css owns the tween.
+export function SlidingTabs<T extends string>({
+  activeTab,
+  onSelect,
+  tabs,
+}: {
+  activeTab: T;
+  onSelect: (tab: T) => void;
+  tabs: readonly T[];
+}) {
+  const barRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLSpanElement>(null);
+  const hasPainted = useRef(false);
+
+  const movePillToActiveTab = useCallback((animate: boolean) => {
+    const bar = barRef.current;
+    const pill = pillRef.current;
+    const active = bar?.querySelector<HTMLButtonElement>(
+      '[aria-selected="true"]'
+    );
+    if (!(bar && pill && active)) {
+      return;
+    }
+    if (animate) {
+      pill.style.transform = `translateX(${active.offsetLeft}px)`;
+      pill.style.width = `${active.offsetWidth}px`;
+      return;
+    }
+    const previousTransition = pill.style.transition;
+    pill.style.transition = "none";
+    pill.style.transform = `translateX(${active.offsetLeft}px)`;
+    pill.style.width = `${active.offsetWidth}px`;
+    void pill.offsetWidth;
+    pill.style.transition = previousTransition;
+  }, []);
+
+  // Re-measure when the tab set changes too (Earned appears with a position).
+  useLayoutEffect(() => {
+    movePillToActiveTab(hasPainted.current);
+    hasPainted.current = true;
+  }, [activeTab, movePillToActiveTab, tabs.length]);
+
+  useEffect(() => {
+    const handleResize = () => movePillToActiveTab(false);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [movePillToActiveTab]);
+
+  return (
+    <div className="t-tabs" ref={barRef} role="tablist">
+      <span aria-hidden="true" className="t-tabs-pill" ref={pillRef} />
+      {tabs.map((tab) => (
+        <button
+          aria-selected={activeTab === tab}
+          className="t-tab whitespace-nowrap font-medium text-[14px] leading-5"
+          key={tab}
+          onClick={() => onSelect(tab)}
+          role="tab"
+          type="button"
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { getAccessToken, usePrivy } from "@privy-io/react-auth";
+import { useCallback, useEffect, useState } from "react";
+
+import { usePublicEnv } from "@/contexts/public-env-context";
+
+export type EvmDepositInfo = {
+  address: string;
+  chains: readonly string[];
+  assets: readonly string[];
+  minimums: Record<string, number>;
+};
+
+/**
+ * Cross-chain deposit address for the signed-in user's Privy-embedded wallet.
+ * `eligible` is false for external wallets (Loyal extension, Phantom…); the
+ * address is fetched lazily on `load()` because Privy provisions it on first
+ * call and we only want that when the user opens the tab.
+ */
+export function useEvmDepositAddress(walletAddress: string | null) {
+  const { privyAppId } = usePublicEnv();
+  const { user } = usePrivy();
+  const [info, setInfo] = useState<EvmDepositInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const eligible =
+    Boolean(privyAppId) &&
+    Boolean(walletAddress) &&
+    (user?.linkedAccounts.some(
+      (a) =>
+        a.type === "wallet" &&
+        a.chainType === "solana" &&
+        a.walletClientType === "privy" &&
+        a.address === walletAddress
+    ) ??
+      false);
+
+  useEffect(() => {
+    setInfo(null);
+    setError(null);
+  }, [walletAddress]);
+
+  const load = useCallback(async () => {
+    if (!eligible || info || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const privyAccessToken = await getAccessToken();
+      if (!privyAccessToken) throw new Error("Not signed in with Privy.");
+      const res = await fetch("/api/funding/evm-deposit-address", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ privyAccessToken }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | (EvmDepositInfo & { error?: undefined })
+        | { error?: { message?: string } }
+        | null;
+      if (!res.ok || !body || body.error || !("address" in body)) {
+        throw new Error(
+          body?.error?.message ??
+            `Could not get a deposit address (${res.status}).`
+        );
+      }
+      setInfo(body);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [eligible, info, loading]);
+
+  return { eligible, info, error, loading, load };
+}

--- a/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { getAccessToken, usePrivy } from "@privy-io/react-auth";
-import { useCallback, useEffect, useState } from "react";
+import { useAuthorizationSignature, usePrivy } from "@privy-io/react-auth";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { usePublicEnv } from "@/contexts/public-env-context";
 
@@ -21,6 +21,7 @@ export type EvmDepositInfo = {
 export function useEvmDepositAddress(walletAddress: string | null) {
   const { privyAppId } = usePublicEnv();
   const { user } = usePrivy();
+  const { generateAuthorizationSignature } = useAuthorizationSignature();
   const [info, setInfo] = useState<EvmDepositInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -42,18 +43,49 @@ export function useEvmDepositAddress(walletAddress: string | null) {
     setError(null);
   }, [walletAddress]);
 
+  const attemptedRef = useRef(false);
+  useEffect(() => {
+    attemptedRef.current = false;
+  }, [walletAddress]);
+
   const load = useCallback(async () => {
-    if (!eligible || info || loading) return;
+    if (!eligible || info || loading || attemptedRef.current) return;
+    attemptedRef.current = true;
     setLoading(true);
     setError(null);
     try {
-      const privyAccessToken = await getAccessToken();
-      if (!privyAccessToken) throw new Error("Not signed in with Privy.");
+      const read = (await (
+        await fetch("/api/funding/evm-deposit-address", {
+          credentials: "include",
+        })
+      ).json()) as {
+        address?: string | null;
+        toSign?: unknown;
+        chains?: readonly string[];
+        assets?: readonly string[];
+        minimums?: Record<string, number>;
+        error?: { message?: string };
+      };
+      if (read.error) throw new Error(read.error.message ?? "Request failed.");
+      if (read.address) {
+        setInfo({
+          address: read.address,
+          chains: read.chains ?? [],
+          assets: read.assets ?? [],
+          minimums: read.minimums ?? {},
+        });
+        return;
+      }
+      // First time: the wallet is user-owned, so the user signs the exact
+      // Privy request with their key and the server forwards the signature.
+      const { signature } = await generateAuthorizationSignature(
+        read.toSign as Parameters<typeof generateAuthorizationSignature>[0]
+      );
       const res = await fetch("/api/funding/evm-deposit-address", {
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ privyAccessToken }),
+        body: JSON.stringify({ signature }),
       });
       const body = (await res.json().catch(() => null)) as
         | (EvmDepositInfo & { error?: undefined })
@@ -71,7 +103,7 @@ export function useEvmDepositAddress(walletAddress: string | null) {
     } finally {
       setLoading(false);
     }
-  }, [eligible, info, loading]);
+  }, [eligible, generateAuthorizationSignature, info, loading]);
 
   return { eligible, info, error, loading, load };
 }

--- a/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-evm-deposit-address.ts
@@ -61,6 +61,7 @@ export function useEvmDepositAddress(walletAddress: string | null) {
       ).json()) as {
         address?: string | null;
         toSign?: unknown;
+        requestExpiry?: number;
         chains?: readonly string[];
         assets?: readonly string[];
         minimums?: Record<string, number>;
@@ -85,7 +86,10 @@ export function useEvmDepositAddress(walletAddress: string | null) {
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ signature }),
+        body: JSON.stringify({
+          signature,
+          requestExpiry: read.requestExpiry,
+        }),
       });
       const body = (await res.json().catch(() => null)) as
         | (EvmDepositInfo & { error?: undefined })

--- a/apps/web/src/features/funding/server/evm-deposit.ts
+++ b/apps/web/src/features/funding/server/evm-deposit.ts
@@ -31,13 +31,48 @@ const SOURCE_ASSETS = EVM_DEPOSIT_CHAINS.flatMap((chain) =>
   ).map((asset) => ({ asset, chain }))
 );
 
-export async function getOrCreateEvmDepositAddress(args: {
+/**
+ * The exact Privy request the user must sign in the browser (the wallet is
+ * user-owned; with Privy as auth provider the server cannot mint a user key).
+ * Client and server both build it from here so the signed bytes match.
+ */
+export function buildEvmDepositRequest(walletId: string, appId: string) {
+  return {
+    version: 1 as const,
+    method: "POST" as const,
+    url: `https://api.privy.io/v1/wallets/${walletId}/deposit_accounts/crypto`,
+    body: {
+      type: "inline_route",
+      source: { mode: "include", values: SOURCE_ASSETS },
+      destination: { asset: "usdc", chain: "solana" },
+    },
+    headers: { "privy-app-id": appId },
+  };
+}
+
+export async function resolveEmbeddedWalletId(walletAddress: string) {
+  const privy = getPrivyClient();
+  let wallet;
+  try {
+    wallet = await privy
+      .wallets()
+      .getWalletByAddress({ address: walletAddress });
+  } catch {
+    wallet = null;
+  }
+  if (!wallet || wallet.chain_type !== "solana") {
+    throw new WalletAuthError(
+      "Deposits from other chains need a Loyal-created wallet.",
+      { code: "evm_deposit_external_wallet", status: 409 }
+    );
+  }
+  return wallet.id;
+}
+
+export async function findEvmDepositAddress(args: {
   userId: string;
   walletAddress: string;
-  /** Privy access token of the signed-in user; the wallet is user-owned so
-   *  Privy needs their signature to attach a deposit route to it. */
-  privyAccessToken: string;
-}): Promise<string> {
+}) {
   const db = getDatabase();
   const row = await db.query.appUserWallets.findFirst({
     where: and(
@@ -52,34 +87,25 @@ export async function getOrCreateEvmDepositAddress(args: {
       status: 403,
     });
   }
-  if (row.evmDepositAddress) return row.evmDepositAddress;
+  return row;
+}
 
+export async function createEvmDepositAddress(args: {
+  rowId: string;
+  walletId: string;
+  appId: string;
+  /** User's authorization signature over buildEvmDepositRequest(). */
+  signature: string;
+}): Promise<string> {
   const privy = getPrivyClient();
-  let wallet;
-  try {
-    wallet = await privy
-      .wallets()
-      .getWalletByAddress({ address: args.walletAddress });
-  } catch {
-    wallet = null;
-  }
-  if (!wallet || wallet.chain_type !== "solana") {
-    throw new WalletAuthError(
-      "Deposits from other chains need a Loyal-created wallet.",
-      { code: "evm_deposit_external_wallet", status: 409 }
-    );
-  }
-
+  const req = buildEvmDepositRequest(args.walletId, args.appId);
   // @privy-io/node@0.32 types predate the `asset`/`chain` aliases the API
   // and docs use (they want asset_address/caip2); the wire format is fine.
   const created = (await privy
     .wallets()
-    .depositAccounts.crypto.create(wallet.id, {
-      type: "inline_route",
-      source: { mode: "include", values: SOURCE_ASSETS },
-      destination: { asset: "usdc", chain: "solana" },
-      authorization_context: { user_jwts: [args.privyAccessToken] },
-      idempotency_key: `evm-deposit:${wallet.id}`,
+    .depositAccounts.crypto.create(args.walletId, {
+      ...req.body,
+      authorization_context: { signatures: [args.signature] },
     } as unknown as Parameters<ReturnType<typeof privy.wallets>["depositAccounts"]["crypto"]["create"]>[1])) as unknown as {
     deposit_accounts?: { deposit_address: string }[];
     deposit_addresses?: { deposit_address: string }[];
@@ -92,10 +118,9 @@ export async function getOrCreateEvmDepositAddress(args: {
       status: 502,
     });
   }
-
-  await db
+  await getDatabase()
     .update(appUserWallets)
     .set({ evmDepositAddress: evm.deposit_address, updatedAt: new Date() })
-    .where(eq(appUserWallets.id, row.id));
+    .where(eq(appUserWallets.id, args.rowId));
   return evm.deposit_address;
 }

--- a/apps/web/src/features/funding/server/evm-deposit.ts
+++ b/apps/web/src/features/funding/server/evm-deposit.ts
@@ -36,7 +36,12 @@ const SOURCE_ASSETS = EVM_DEPOSIT_CHAINS.flatMap((chain) =>
  * user-owned; with Privy as auth provider the server cannot mint a user key).
  * Client and server both build it from here so the signed bytes match.
  */
-export function buildEvmDepositRequest(walletId: string, appId: string) {
+export function buildEvmDepositRequest(
+  walletId: string,
+  appId: string,
+  /** Unix ms; must be identical when signing and when sending. */
+  requestExpiry: number
+) {
   return {
     version: 1 as const,
     method: "POST" as const,
@@ -46,9 +51,15 @@ export function buildEvmDepositRequest(walletId: string, appId: string) {
       source: { mode: "include", values: SOURCE_ASSETS },
       destination: { asset: "usdc", chain: "solana" },
     },
-    headers: { "privy-app-id": appId },
+    headers: {
+      "privy-app-id": appId,
+      "privy-request-expiry": String(requestExpiry),
+    },
   };
 }
+
+// Long enough for the user to approve in the Privy iframe.
+export const EVM_DEPOSIT_SIGN_WINDOW_MS = 10 * 60 * 1000;
 
 export async function resolveEmbeddedWalletId(walletAddress: string) {
   const privy = getPrivyClient();
@@ -96,9 +107,20 @@ export async function createEvmDepositAddress(args: {
   appId: string;
   /** User's authorization signature over buildEvmDepositRequest(). */
   signature: string;
+  requestExpiry: number;
 }): Promise<string> {
+  if (args.requestExpiry <= Date.now()) {
+    throw new WalletAuthError("Signature expired, try again.", {
+      code: "evm_deposit_signature_expired",
+      status: 400,
+    });
+  }
   const privy = getPrivyClient();
-  const req = buildEvmDepositRequest(args.walletId, args.appId);
+  const req = buildEvmDepositRequest(
+    args.walletId,
+    args.appId,
+    args.requestExpiry
+  );
   // @privy-io/node@0.32 types predate the `asset`/`chain` aliases the API
   // and docs use (they want asset_address/caip2); the wire format is fine.
   const created = (await privy
@@ -106,6 +128,7 @@ export async function createEvmDepositAddress(args: {
     .depositAccounts.crypto.create(args.walletId, {
       ...req.body,
       authorization_context: { signatures: [args.signature] },
+      request_expiry: args.requestExpiry,
     } as unknown as Parameters<ReturnType<typeof privy.wallets>["depositAccounts"]["crypto"]["create"]>[1])) as unknown as {
     deposit_accounts?: { deposit_address: string }[];
     deposit_addresses?: { deposit_address: string }[];

--- a/apps/web/src/features/funding/server/evm-deposit.ts
+++ b/apps/web/src/features/funding/server/evm-deposit.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { and, eq } from "drizzle-orm";
+import { appUserWallets } from "@loyal-labs/db-core/schema";
+
+import { getPrivyClient } from "@/features/identity/server/privy-auth";
+import { WalletAuthError } from "@/features/identity/server/wallet-auth-errors";
+import { getDatabase } from "@/lib/core/database";
+
+/**
+ * "Deposit from any chain" (ASK-2266): one Privy-provisioned 0x address per
+ * embedded Solana wallet. Anything sent there (USDC/USDT/ETH on the chains
+ * below) is bridged by Privy and lands as USDC in the user's Solana wallet.
+ * App pays the bridge gas, so this is only offered to Privy-native wallets.
+ */
+export const EVM_DEPOSIT_CHAINS = [
+  "ethereum",
+  "base",
+  "arbitrum",
+  "polygon",
+] as const;
+export const EVM_DEPOSIT_ASSETS = ["usdc", "usdt", "eth"] as const;
+// Ethereum L1 gas can spike to a few dollars per deposit; below this the
+// bridge eats the deposit. L2s are ~$0.01, no floor there.
+export const EVM_DEPOSIT_MIN_USD_ETHEREUM = 20;
+
+// Privy rejects eth on polygon; everything else is accepted on every chain.
+const SOURCE_ASSETS = EVM_DEPOSIT_CHAINS.flatMap((chain) =>
+  EVM_DEPOSIT_ASSETS.filter(
+    (asset) => !(asset === "eth" && chain === "polygon")
+  ).map((asset) => ({ asset, chain }))
+);
+
+export async function getOrCreateEvmDepositAddress(args: {
+  userId: string;
+  walletAddress: string;
+  /** Privy access token of the signed-in user; the wallet is user-owned so
+   *  Privy needs their signature to attach a deposit route to it. */
+  privyAccessToken: string;
+}): Promise<string> {
+  const db = getDatabase();
+  const row = await db.query.appUserWallets.findFirst({
+    where: and(
+      eq(appUserWallets.userId, args.userId),
+      eq(appUserWallets.walletAddress, args.walletAddress)
+    ),
+    columns: { id: true, evmDepositAddress: true },
+  });
+  if (!row) {
+    throw new WalletAuthError("Wallet is not attached to this user.", {
+      code: "invalid_wallet_principal",
+      status: 403,
+    });
+  }
+  if (row.evmDepositAddress) return row.evmDepositAddress;
+
+  const privy = getPrivyClient();
+  let wallet;
+  try {
+    wallet = await privy
+      .wallets()
+      .getWalletByAddress({ address: args.walletAddress });
+  } catch {
+    wallet = null;
+  }
+  if (!wallet || wallet.chain_type !== "solana") {
+    throw new WalletAuthError(
+      "Deposits from other chains need a Loyal-created wallet.",
+      { code: "evm_deposit_external_wallet", status: 409 }
+    );
+  }
+
+  // @privy-io/node@0.32 types predate the `asset`/`chain` aliases the API
+  // and docs use (they want asset_address/caip2); the wire format is fine.
+  const created = (await privy
+    .wallets()
+    .depositAccounts.crypto.create(wallet.id, {
+      type: "inline_route",
+      source: { mode: "include", values: SOURCE_ASSETS },
+      destination: { asset: "usdc", chain: "solana" },
+      authorization_context: { user_jwts: [args.privyAccessToken] },
+      idempotency_key: `evm-deposit:${wallet.id}`,
+    } as unknown as Parameters<ReturnType<typeof privy.wallets>["depositAccounts"]["crypto"]["create"]>[1])) as unknown as {
+    deposit_accounts?: { deposit_address: string }[];
+    deposit_addresses?: { deposit_address: string }[];
+  };
+  const routes = created.deposit_accounts ?? created.deposit_addresses ?? [];
+  const evm = routes.find((a) => a.deposit_address.startsWith("0x"));
+  if (!evm) {
+    throw new WalletAuthError("Privy returned no EVM deposit address.", {
+      code: "evm_deposit_unavailable",
+      status: 502,
+    });
+  }
+
+  await db
+    .update(appUserWallets)
+    .set({ evmDepositAddress: evm.deposit_address, updatedAt: new Date() })
+    .where(eq(appUserWallets.id, row.id));
+  return evm.deposit_address;
+}

--- a/apps/web/src/features/identity/server/privy-auth.ts
+++ b/apps/web/src/features/identity/server/privy-auth.ts
@@ -14,7 +14,7 @@ import { trackWalletOnboardingEvent } from "./wallet-onboarding-analytics";
 
 let privyClient: PrivyClient | null = null;
 
-function getPrivyClient(): PrivyClient {
+export function getPrivyClient(): PrivyClient {
   if (privyClient) return privyClient;
   const { privyAppId, privyAppSecret } = getServerEnv();
   if (!privyAppId || !privyAppSecret) {

--- a/bun.lock
+++ b/bun.lock
@@ -276,7 +276,7 @@
         "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1",
         "@neondatabase/serverless": "^1.0.2",
         "@number-flow/react": "^0.6.0",
-        "@privy-io/node": "0.20.0",
+        "@privy-io/node": "0.32.0",
         "@privy-io/react-auth": "3.35.2",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -6112,6 +6112,8 @@
     "loyal-public-dashboard/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
     "loyal-web-frontend/@number-flow/react": ["@number-flow/react@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-77Yfc9+zkV2UDSP8phhZzxJGuwxi/Tt1TikmipL+1r3e9GFKEYDZ1XwInj67NoSt3OnOB0KLvvcl3lfPZgBHVQ=="],
+
+    "loyal-web-frontend/@privy-io/node": ["@privy-io/node@0.32.0", "", { "dependencies": { "@hpke/chacha20poly1305": "^1.7.1", "@hpke/core": "^1.7.5", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0", "@scure/base": "^1.2.5", "canonicalize": "^2.1.0", "jose": "^6.1.0", "lru-cache": "^11.1.0", "svix": "^1.92.2" }, "peerDependencies": { "@solana/kit": "^5.1.0", "@x402/evm": "^2.3.0", "@x402/fetch": "^2.3.0", "@x402/svm": "^2.3.0", "viem": "^2.44.2" }, "optionalPeers": ["@solana/kit", "@x402/evm", "@x402/fetch", "@x402/svm", "viem"] }, "sha512-oUFRow2pEyOZEiq6ZGcq7/tcaSs8SldNQZu+T2i8yXs5faK5IDBTdELl1o11IkoCd+E6t4QDDJSEO5ZCqnykPA=="],
 
     "loyal-web-frontend/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 

--- a/packages/db-core/src/schema.ts
+++ b/packages/db-core/src/schema.ts
@@ -973,6 +973,8 @@ export const appUserWallets = pgTable(
       .notNull()
       .references(() => appUsers.id, { onDelete: "cascade" }),
     walletAddress: text("wallet_address").notNull(),
+    /** Privy crypto-deposit 0x address that auto-bridges into this wallet as USDC (ASK-2266). */
+    evmDepositAddress: text("evm_deposit_address"),
     verifiedAt: timestamp("verified_at", { withTimezone: true })
       .defaultNow()
       .notNull(),


### PR DESCRIPTION
Receive sheet gains an Other chains tab for Privy-embedded wallets: a permanent Privy 0x deposit address (USDC/USDT/ETH on Ethereum/Base/Arbitrum/Polygon → USDC on Solana, app pays bridge gas), created once via a user-signed Privy request and stored on app_user_wallets.evm_deposit_address. Address creation verified against Privy; the mainnet bridge itself is not yet canary-tested. Stacks on #755. Closes ASK-2266.