### PR TITLE
feat(web): add report-only content security policy for privy

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -46,6 +46,18 @@ describe("frame security headers", () => {
       expect(response.headers.get("content-security-policy")).toBeNull();
     }
   });
+
+  // Report-Only must never turn enforcing by accident: a bad allowlist would
+  // silently break wallet/RPC calls in prod. Enforcement is a deliberate flip.
+  test("ships the Privy CSP as report-only on app routes", async () => {
+    const response = await unstable_getResponseFromNextConfig({
+      url: "https://askloyal.com/app",
+      nextConfig,
+    });
+    const csp = response.headers.get("content-security-policy-report-only");
+    expect(csp).toContain("frame-src https://auth.privy.io");
+    expect(csp).toContain("report-uri /api/csp-report");
+  });
 });
 
 describe("earn banner asset caching", () => {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -35,11 +35,39 @@ function getGitInfo() {
 
 const { commitHash, branch } = getGitInfo();
 
+// Privy's recommended CSP (docs.privy.io/security/implementation-guide/
+// content-security-policy) plus what this app actually loads. Shipped as
+// Report-Only first: violations POST to /api/csp-report and nothing is
+// blocked. Flip to enforcing once the report stream is quiet.
+// ponytail: 'unsafe-inline'/'unsafe-eval' in script-src — Next inline
+// bootstrap + wallet-adapter libs need them; nonces are the upgrade path.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "child-src https://auth.privy.io https://verify.walletconnect.com https://verify.walletconnect.org",
+  "frame-src https://auth.privy.io https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com",
+  // Own API + Privy + Solana RPC/WS (Helius) + Jupiter + realtime + analytics.
+  "connect-src 'self' https://auth.privy.io https://api.privy.io https://*.rpc.privy.systems wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://explorer-api.walletconnect.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.mainnet-beta.solana.com https://api.devnet.solana.com https://api.jup.ag https://lite-api.jup.ag https://loyal-yield-realtime.onrender.com wss://loyal-yield-realtime.onrender.com https://api.mixpanel.com https://stats.askloyal.com",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  "report-uri /api/csp-report",
+].join("; ");
+
 const COMMON_SECURITY_HEADERS = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   {
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=()",
+  },
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: CONTENT_SECURITY_POLICY,
   },
 ] as const;
 

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -1,0 +1,33 @@
+import { reportServerError } from "@/features/observability/server";
+
+// Browser CSP violation reports (Content-Security-Policy-Report-Only in
+// next.config.ts). Forwarded to observability as a server error so they show
+// up next to everything else; never fails the caller.
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json().catch(() => null)) as {
+      "csp-report"?: Record<string, unknown>;
+    } | null;
+    const report = body?.["csp-report"];
+    if (report) {
+      const blocked = String(report["blocked-uri"] ?? "");
+      const directive = String(
+        report["effective-directive"] ?? report["violated-directive"] ?? ""
+      );
+      const doc = String(report["document-uri"] ?? "");
+      await reportServerError(
+        new Error(`CSP ${directive} blocked ${blocked} on ${doc}`),
+        {
+          method: "POST",
+          operation: "next.request.error",
+          pathname: "/api/csp-report",
+        }
+      );
+    }
+  } catch {
+    // best-effort
+  }
+  return new Response(null, { status: 204 });
+}


### PR DESCRIPTION
Ships Privy's recommended CSP as Content-Security-Policy-Report-Only with violations posted to /api/csp-report; enforce after a quiet week. Stacks on #755.