### PR TITLE
fix(wallet): restore unshield-only exit on mobile, web, and extension

### DIFF
--- a/apps/extension/src/components/wallet/portfolio-content.tsx
+++ b/apps/extension/src/components/wallet/portfolio-content.tsx
@@ -7,6 +7,7 @@ import {
   Eye,
   EyeOff,
   Settings,
+  Shield,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 
@@ -119,6 +120,7 @@ export function PortfolioContent({
   onSend,
   onReceive,
   onSwap,
+  onUnshield,
   onSettings,
   tokenRows,
   transactionDetails,
@@ -141,6 +143,8 @@ export function PortfolioContent({
   onSend: () => void;
   onReceive: () => void;
   onSwap: () => void;
+  /** Only set when the wallet still holds shielded balances (ASK-2269). */
+  onUnshield?: () => void;
   onSettings: () => void;
   tokenRows: TokenRow[];
   transactionDetails: Record<string, TransactionDetail>;
@@ -513,6 +517,9 @@ export function PortfolioContent({
             { label: "Send", Icon: ArrowUpRight, action: onSend },
             { label: "Receive", Icon: ArrowDownLeft, action: onReceive },
             { label: "Swap", Icon: ArrowLeftRight, action: onSwap },
+            ...(onUnshield
+              ? [{ label: "Unshield", Icon: Shield, action: onUnshield }]
+              : []),
           ] as const
         ).map(({ label, Icon, action }) => (
           <button

--- a/apps/extension/src/components/wallet/unshield-content.tsx
+++ b/apps/extension/src/components/wallet/unshield-content.tsx
@@ -1,0 +1,244 @@
+import type {
+  ShieldedBalance,
+  UnshieldResult,
+} from "@loyal-labs/wallet-core/hooks";
+import { getTokenIconUrl } from "@loyal-labs/wallet-core/lib";
+import type { PortfolioPosition } from "@loyal-labs/solana-wallet";
+import { ExternalLink, X } from "lucide-react";
+import { useState } from "react";
+
+const font = "var(--font-geist-sans), sans-serif";
+const secondary = "rgba(60, 60, 67, 0.6)";
+
+// ponytail: shielded-only tokens have no portfolio position; known mints get
+// symbol/decimals here, anything else shows the raw amount + short mint.
+const KNOWN_TOKENS: Record<string, { symbol: string; decimals: number }> = {
+  So11111111111111111111111111111111111111112: { symbol: "SOL", decimals: 9 },
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: { symbol: "USDC", decimals: 6 },
+};
+
+function formatAmount(amountRaw: bigint, decimals: number): string {
+  const whole = amountRaw / 10n ** BigInt(decimals);
+  const fraction = (amountRaw % 10n ** BigInt(decimals))
+    .toString()
+    .padStart(decimals, "0")
+    .replace(/0+$/, "");
+  return fraction ? `${whole}.${fraction}` : whole.toString();
+}
+
+export function UnshieldContent({
+  balances,
+  positions,
+  executeUnshield,
+  loading,
+  error,
+  onClose,
+}: {
+  balances: ShieldedBalance[];
+  positions: PortfolioPosition[];
+  executeUnshield: (tokenMint: string) => Promise<UnshieldResult>;
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+}) {
+  const [activeMint, setActiveMint] = useState<string | null>(null);
+  const [signature, setSignature] = useState<string | null>(null);
+
+  const handleUnshield = async (tokenMint: string) => {
+    setActiveMint(tokenMint);
+    setSignature(null);
+    const result = await executeUnshield(tokenMint);
+    if (result.success && result.signature) setSignature(result.signature);
+    setActiveMint(null);
+  };
+
+  return (
+    <>
+      <style>{`
+        .unshield-close:hover { background: rgba(0, 0, 0, 0.08) !important; }
+        .unshield-btn:hover:not(:disabled) { background: rgba(0, 0, 0, 0.85) !important; }
+      `}</style>
+
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "8px",
+        }}
+      >
+        <div style={{ flex: 1, padding: "4px 0 4px 12px" }}>
+          <span
+            style={{
+              fontFamily: font,
+              fontSize: "18px",
+              fontWeight: 600,
+              lineHeight: "28px",
+              color: "#000",
+            }}
+          >
+            Unshield
+          </span>
+        </div>
+        <button
+          className="unshield-close"
+          onClick={onClose}
+          style={{
+            width: "36px",
+            height: "36px",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            background: "rgba(0, 0, 0, 0.04)",
+            border: "none",
+            borderRadius: "9999px",
+            cursor: "pointer",
+            transition: "all 0.2s ease",
+            color: "#3C3C43",
+            flexShrink: 0,
+          }}
+          type="button"
+        >
+          <X size={24} />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div
+        style={{ flex: 1, overflow: "auto", minHeight: 0, padding: "0 12px" }}
+      >
+        <p
+          style={{
+            fontFamily: font,
+            fontSize: "14px",
+            lineHeight: "20px",
+            color: secondary,
+            padding: "0 12px 12px",
+          }}
+        >
+          Shielded balances are being sunset. Move your full balance back to
+          your wallet.
+        </p>
+
+        {balances.length === 0 && (
+          <p
+            style={{
+              fontFamily: font,
+              fontSize: "14px",
+              color: secondary,
+              textAlign: "center",
+              padding: "24px 12px",
+            }}
+          >
+            No shielded balances.
+          </p>
+        )}
+
+        {balances.map(({ tokenMint, amountRaw }) => {
+          const position = positions.find((p) => p.asset.mint === tokenMint);
+          const known = KNOWN_TOKENS[tokenMint];
+          const symbol =
+            position?.asset.symbol ?? known?.symbol ?? tokenMint.slice(0, 4);
+          const decimals = position?.asset.decimals ?? known?.decimals ?? 0;
+          const icon = position?.asset.imageUrl || getTokenIconUrl(symbol);
+          const isActive = loading && activeMint === tokenMint;
+          return (
+            <div
+              key={tokenMint}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "12px",
+                padding: "8px 12px",
+                borderRadius: "16px",
+              }}
+            >
+              <img
+                alt={symbol}
+                height={40}
+                src={icon}
+                style={{ borderRadius: "9999px", objectFit: "cover" }}
+                width={40}
+              />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontFamily: font,
+                    fontSize: "16px",
+                    fontWeight: 500,
+                    color: "#000",
+                  }}
+                >
+                  {symbol}
+                </div>
+                <div
+                  style={{
+                    fontFamily: font,
+                    fontSize: "13px",
+                    color: secondary,
+                  }}
+                >
+                  {formatAmount(amountRaw, decimals)} shielded
+                </div>
+              </div>
+              <button
+                className="unshield-btn"
+                disabled={loading}
+                onClick={() => void handleUnshield(tokenMint)}
+                style={{
+                  padding: "8px 16px",
+                  background: "#000",
+                  border: "none",
+                  borderRadius: "9999px",
+                  cursor: loading ? "not-allowed" : "pointer",
+                  opacity: loading && !isActive ? 0.4 : 1,
+                  fontFamily: font,
+                  fontSize: "14px",
+                  color: "#fff",
+                  transition: "background 0.2s ease",
+                }}
+                type="button"
+              >
+                {isActive ? "Unshielding…" : "Unshield"}
+              </button>
+            </div>
+          );
+        })}
+
+        {error && (
+          <p
+            style={{
+              fontFamily: font,
+              fontSize: "13px",
+              color: "#F9363C",
+              padding: "12px",
+            }}
+          >
+            {error}
+          </p>
+        )}
+
+        {signature && (
+          <a
+            href={`https://explorer.solana.com/tx/${signature}`}
+            rel="noreferrer"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              fontFamily: font,
+              fontSize: "13px",
+              color: "#34C759",
+              padding: "12px",
+              textDecoration: "none",
+            }}
+            target="_blank"
+          >
+            Unshield confirmed. View in explorer <ExternalLink size={14} />
+          </a>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/extension/src/components/wallet/wallet-app.tsx
+++ b/apps/extension/src/components/wallet/wallet-app.tsx
@@ -39,6 +39,7 @@ import type { TokenRowActions } from "./token-row-item";
 import { SendContent } from "./send-content";
 import { ReceiveContent } from "./receive-content";
 import { SwapContent } from "./swap-content";
+import { UnshieldContent } from "./unshield-content";
 
 import { AllTokensView } from "./all-tokens-view";
 import { AllActivityView } from "./all-activity-view";
@@ -47,7 +48,7 @@ import { TokenSelectView } from "./token-select-view";
 import { TransactionDetailView } from "./transaction-detail-view";
 import { Settings } from "./settings";
 import { DappApprovalView } from "./dapp-approval-view";
-import { useWalletData } from "@loyal-labs/wallet-core/hooks";
+import { useUnshield, useWalletData } from "@loyal-labs/wallet-core/hooks";
 import { getTokenIconUrl } from "@loyal-labs/wallet-core/lib";
 import { useExtensionWalletDataClient } from "~/src/lib/wallet-data-client";
 import { fetchPriceChanges } from "~/src/lib/coingecko";
@@ -88,6 +89,7 @@ const TABS = [
   { id: "send", label: "Send", Icon: ArrowUpRight },
   { id: "receive", label: "Receive", Icon: ArrowDownLeft },
   { id: "swap", label: "Swap", Icon: ArrowLeftRight },
+  { id: "unshield", label: "Unshield", Icon: Shield },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -1186,6 +1188,8 @@ function WalletInterface() {
     client: walletDataClient,
     solanaEnv,
   });
+  // Exit-only path for the sunset private-transfer program (ASK-2269).
+  const unshield = useUnshield(signer, solanaEnv);
 
   // Navigation state
   const [activeTab, setActiveTab] = useState<TabId>("portfolio");
@@ -1452,6 +1456,11 @@ function WalletInterface() {
             onSend={() => handleTabChange("send")}
             onReceive={() => handleTabChange("receive")}
             onSwap={() => handleTabChange("swap")}
+            onUnshield={
+              unshield.balances.length > 0
+                ? () => handleTabChange("unshield")
+                : undefined
+            }
             onSettings={() => setShowSettings(true)}
             tokenRows={enrichedPortfolioRows}
             transactionDetails={transactionDetails}
@@ -1488,6 +1497,17 @@ function WalletInterface() {
             onClose={handleClose}
             onNavigate={handleNavigate}
             onDone={handleDone}
+          />
+        );
+      case "unshield":
+        return (
+          <UnshieldContent
+            balances={unshield.balances}
+            positions={positions}
+            executeUnshield={unshield.executeUnshield}
+            loading={unshield.loading}
+            error={unshield.error}
+            onClose={handleClose}
           />
         );
     }

--- a/apps/mobile/app/(tabs)/wallet.tsx
+++ b/apps/mobile/app/(tabs)/wallet.tsx
@@ -155,8 +155,9 @@ export default function WalletScreen() {
         : SOLANA_USDC_MINT_DEVNET,
     );
     for (const holding of tokenHoldings) mints.add(holding.mint);
+    for (const balance of shieldedBalances) mints.add(balance.tokenMint);
     return Array.from(mints);
-  }, [tokenHoldings]);
+  }, [tokenHoldings, shieldedBalances]);
   const tokenDetailsByMint = useTokenDetails(
     tokenDetailMints,
     tokenMarketRefreshKey,

--- a/apps/mobile/app/(tabs)/wallet.tsx
+++ b/apps/mobile/app/(tabs)/wallet.tsx
@@ -1,3 +1,4 @@
+import { useUnshield } from "@loyal-labs/wallet-core/hooks";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { ArrowDown, ArrowUp } from "lucide-react-native";
 import {
@@ -23,6 +24,7 @@ import { BalanceCard } from "@/components/wallet/BalanceCard";
 import { ReceiveSheet } from "@/components/wallet/ReceiveSheet";
 import { SendSheet } from "@/components/wallet/SendSheet";
 import { SwapSheet } from "@/components/wallet/SwapSheet";
+import { UnshieldSheet } from "@/components/wallet/UnshieldSheet";
 import { shouldShowWalletTopUp } from "@/components/wallet/wallet-screen-helpers";
 import {
   filterHoldingsByCategory,
@@ -101,6 +103,13 @@ export default function WalletScreen() {
   // screen / APY chart / web, not the position's raw reserve supply APY.
   const forecastSummary = useEarnForecast();
   const { signer, state } = useWallet();
+  // Legacy shielded balances (ASK-2269): the Unshield action only appears while
+  // the wallet still holds one.
+  const {
+    balances: shieldedBalances,
+    executeUnshield,
+    refreshBalances: refreshShieldedBalances,
+  } = useUnshield(signer, getSolanaEnv());
 
   const doFullRefresh = useCallback(
     async (reason: WalletRefreshReason) => {
@@ -255,6 +264,7 @@ export default function WalletScreen() {
   const [sendWithScanner, setSendWithScanner] = useState(false);
   const [isReceiveOpen, setIsReceiveOpen] = useState(false);
   const [isSwapOpen, setIsSwapOpen] = useState(false);
+  const [isUnshieldOpen, setIsUnshieldOpen] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [moreAnchor, setMoreAnchor] = useState<MoreActionsAnchor | null>(null);
   const moreButtonRef = useRef<ComponentRef<typeof MeasureView>>(null);
@@ -499,6 +509,16 @@ export default function WalletScreen() {
         onSwapComplete={handleSwapComplete}
       />
 
+      <UnshieldSheet
+        open={isUnshieldOpen}
+        onClose={() => setIsUnshieldOpen(false)}
+        balances={shieldedBalances}
+        executeUnshield={executeUnshield}
+        tokenHoldings={tokenHoldings}
+        tokenDetailsByMint={tokenDetailsByMint}
+        onUnshieldComplete={() => void requestRefresh("mutation")}
+      />
+
       <MoreActionsSheet
         open={isMoreOpen}
         onClose={() => setIsMoreOpen(false)}
@@ -515,6 +535,14 @@ export default function WalletScreen() {
           track(PORTFOLIO_EVENTS.openSwap);
           setIsSwapOpen(true);
         }}
+        onUnshield={
+          shieldedBalances.length > 0
+            ? () => {
+                void refreshShieldedBalances();
+                setIsUnshieldOpen(true);
+              }
+            : undefined
+        }
       />
 
       <BalanceBackgroundPicker

--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.8",
         "@lottiefiles/dotlottie-react": "^0.18.3",
+        "@loyal-labs/private-transactions": "0.2.11",
         "@loyal-labs/shared": "file:../../packages/shared",
         "@loyal-labs/solana-rpc": "file:../../packages/solana-rpc",
         "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1",
@@ -556,6 +557,8 @@
     "@lottiefiles/dotlottie-react": ["@lottiefiles/dotlottie-react@0.18.3", "", { "dependencies": { "@lottiefiles/dotlottie-web": "0.65.0" }, "peerDependencies": { "react": "^17 || ^18 || ^19" } }, "sha512-/6iVC4y9KCyPKS2gDUFp+omYndo3KPombAsZXB0h5sSyEO/+ydVppd5fIoHg2ogGAPOCPK97Y5Eos65JnyTjww=="],
 
     "@lottiefiles/dotlottie-web": ["@lottiefiles/dotlottie-web@0.65.0", "", {}, "sha512-D5ALEwZerjy+MkOv9mMjY7bxRfe7rQPWMtDl8hlNYLnrDKj4AzTaRztZ2u5hBHHiSfSc7TnA4MJgq+ktNZPpIg=="],
+
+    "@loyal-labs/private-transactions": ["@loyal-labs/private-transactions@0.2.11", "", { "peerDependencies": { "@coral-xyz/anchor": "^0.32.0", "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.95.0" } }, "sha512-bQkNIBix7TZ94ti8mCkTaK8j9DIJVQt/GBe5QVw19nQEDDxyBM31truYJXAweZqZJdG3jlBu9Xq7PySWLbLO6Q=="],
 
     "@loyal-labs/shared": ["@loyal-labs/shared@file:../../packages/shared", {}],
 

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -47,6 +47,7 @@ config.resolver.nodeModulesPaths = [
 ];
 config.resolver.extraNodeModules = {
   "@loyal-labs/solana-rpc": solanaRpcRoot,
+  "@loyal-labs/wallet-core/hooks": path.resolve(walletCoreRoot, "hooks/index.ts"),
   "@loyal-labs/wallet-core/lib": path.resolve(walletCoreRoot, "lib/index.ts"),
   "@loyal-labs/smart-account-vaults": smartAccountVaultsRoot,
   "@loyal-labs/actions": loyalActionsRoot,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
     "@gorhom/bottom-sheet": "^5.2.8",
     "@lottiefiles/dotlottie-react": "^0.18.3",
     "@loyal-labs/shared": "file:../../packages/shared",
+    "@loyal-labs/private-transactions": "0.2.11",
     "@loyal-labs/solana-rpc": "file:../../packages/solana-rpc",
     "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1",
     "@metaplex-foundation/beet": "0.7.1",

--- a/apps/mobile/src/components/wallet/UnshieldSheet.tsx
+++ b/apps/mobile/src/components/wallet/UnshieldSheet.tsx
@@ -1,31 +1,35 @@
 import {
   BottomSheetBackdrop,
   BottomSheetModal,
+  BottomSheetScrollView,
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
 import type { ShieldedBalance, UnshieldResult } from "@loyal-labs/wallet-core/hooks";
-import { X } from "lucide-react-native";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Image, Linking, StyleSheet } from "react-native";
+import * as Haptics from "expo-haptics";
+import { ArrowLeft, ChevronDown, X } from "lucide-react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Image, Linking } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import {
+  formatShieldedUsd,
+  resolveShieldedRow,
+  type ShieldedRow,
+} from "@/components/wallet/shielded-balance";
 import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
 import type { TokenDetailsByMint } from "@/hooks/wallet/useTokenDetails";
-import { NATIVE_SOL_DECIMALS, NATIVE_SOL_MINT } from "@/lib/solana/constants";
 import { getSolanaEnv } from "@/lib/solana/rpc/connection";
-import {
-  resolveTokenIcon,
-  resolveTokenSymbol,
-} from "@/lib/solana/token-holdings/resolve-token-info";
 import type { TokenHolding } from "@/lib/solana/token-holdings/types";
 import { Pressable, Text, View } from "@/tw";
 
-// Exit-only unshield for the sunset private-transfer program (ASK-2269): one
-// row per shielded token, full-balance unshield, no shield / private send.
+import SendErrorDog from "../../../assets/images/wallet/send_error_dog.svg";
+import SendSuccessDog from "../../../assets/images/wallet/send_success_dog.svg";
 
-const COLOR_CARD_BG = "#F2F2F7";
-const COLOR_ICON = "#3C3C43";
-const MUTED = "rgba(60, 60, 67, 0.6)";
+// Exit-only unshield for the sunset private-transfer program (ASK-2269):
+// review the full shielded balance of one token, then move it back to the
+// wallet. Mirrors SendSheet's confirm / result steps.
+
+const MUTED = "rgba(60,60,67,0.6)";
 
 type UnshieldSheetProps = {
   open: boolean;
@@ -34,8 +38,11 @@ type UnshieldSheetProps = {
   executeUnshield: (tokenMint: string) => Promise<UnshieldResult>;
   tokenHoldings: TokenHolding[];
   tokenDetailsByMint: TokenDetailsByMint;
+  initialMint?: string | null;
   onUnshieldComplete?: () => void;
 };
+
+type Phase = "confirm" | "pick" | "result";
 
 export function UnshieldSheet({
   open,
@@ -44,34 +51,50 @@ export function UnshieldSheet({
   executeUnshield,
   tokenHoldings,
   tokenDetailsByMint,
+  initialMint,
   onUnshieldComplete,
 }: UnshieldSheetProps) {
   const { sheetHeight, snapPoints } = useFixedSheetLayout(0.6);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  const insets = useSafeAreaInsets();
-  const [pendingMint, setPendingMint] = useState<string | null>(null);
-  const [result, setResult] = useState<UnshieldResult | null>(null);
+  const [phase, setPhase] = useState<Phase>("confirm");
+  const [selectedMint, setSelectedMint] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  // Captured before executing: the balance list drops the token on success.
+  const [outcome, setOutcome] = useState<{ row: ShieldedRow; result: UnshieldResult } | null>(null);
+
+  const rows = useMemo(
+    () => balances.map((b) => resolveShieldedRow(b, tokenHoldings, tokenDetailsByMint)),
+    [balances, tokenHoldings, tokenDetailsByMint],
+  );
+  const selected =
+    rows.find((r) => r.mint === (selectedMint ?? initialMint)) ?? rows[0] ?? null;
 
   useEffect(() => {
     if (open) {
-      setResult(null);
+      setPhase("confirm");
+      setSelectedMint(initialMint ?? null);
+      setOutcome(null);
       bottomSheetRef.current?.present();
     } else {
       bottomSheetRef.current?.dismiss();
     }
-  }, [open]);
+  }, [open, initialMint]);
 
-  const handleUnshield = useCallback(
-    async (tokenMint: string) => {
-      setPendingMint(tokenMint);
-      setResult(null);
-      const res = await executeUnshield(tokenMint);
-      setPendingMint(null);
-      setResult(res);
-      if (res.success) onUnshieldComplete?.();
-    },
-    [executeUnshield, onUnshieldComplete],
-  );
+  const handleUnshield = useCallback(async () => {
+    if (!selected || isPending) return;
+    void Haptics.selectionAsync();
+    setIsPending(true);
+    const result = await executeUnshield(selected.mint);
+    setIsPending(false);
+    setOutcome({ row: selected, result });
+    setPhase("result");
+    void Haptics.notificationAsync(
+      result.success
+        ? Haptics.NotificationFeedbackType.Success
+        : Haptics.NotificationFeedbackType.Error,
+    );
+    if (result.success) onUnshieldComplete?.();
+  }, [selected, isPending, executeUnshield, onUnshieldComplete]);
 
   const renderBackdrop = useCallback(
     (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
@@ -85,151 +108,340 @@ export function UnshieldSheet({
     [],
   );
 
-  const env = getSolanaEnv();
-  const explorerUrl = result?.signature
-    ? `https://solscan.io/tx/${result.signature}${env === "mainnet" ? "" : `?cluster=${env}`}`
-    : null;
-
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
       snapPoints={snapPoints}
       enableDynamicSizing={false}
-      enablePanDownToClose
+      enablePanDownToClose={!isPending}
       backdropComponent={renderBackdrop}
       onDismiss={onClose}
       handleComponent={null}
-      backgroundStyle={styles.sheetBackground}
+      backgroundStyle={{ borderTopLeftRadius: 38, borderTopRightRadius: 38 }}
     >
-      <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
-        <View className="flex-row items-center justify-between px-4 py-4">
-          <Pressable
-            onPress={onClose}
-            accessibilityRole="button"
-            accessibilityLabel="Close"
-            hitSlop={12}
-            style={styles.iconButton}
-          >
-            <X size={28} color={COLOR_ICON} strokeWidth={2} opacity={0.6} />
-          </Pressable>
-          <Text className="text-[17px] font-semibold text-black" style={{ lineHeight: 22 }}>
-            Unshield
-          </Text>
-          <View style={styles.iconButtonSpacer} />
-        </View>
-
-        <Text className="px-6 pb-4 text-center text-[14px]" style={{ lineHeight: 20, color: MUTED }}>
-          Private balances are being retired. Move each balance back to your wallet.
-        </Text>
-
-        <View className="px-4 gap-2">
-          {balances.map((balance) => {
-            const holding = tokenHoldings.find((h) => h.mint === balance.tokenMint);
-            const detail = tokenDetailsByMint[balance.tokenMint];
-            const decimals =
-              holding?.decimals ??
-              detail?.token.decimals ??
-              (balance.tokenMint === NATIVE_SOL_MINT ? NATIVE_SOL_DECIMALS : 6);
-            const symbol = resolveTokenSymbol({
-              mint: balance.tokenMint,
-              detailSymbol: detail?.token.symbol,
-              holdingSymbol: holding?.symbol,
-            });
-            const icon = resolveTokenIcon({
-              mint: balance.tokenMint,
-              imageUrl: holding?.imageUrl,
-              detailLogoUrl: detail?.token.logoUrl,
-            });
-            const amount = Number(balance.amountRaw) / 10 ** decimals;
-            const isPending = pendingMint === balance.tokenMint;
-            return (
-              <View key={balance.tokenMint} style={styles.row}>
-                <Image source={{ uri: icon }} style={styles.icon} />
-                <View className="flex-1">
-                  <Text className="text-[17px] font-medium text-black">{symbol}</Text>
-                  <Text className="text-[14px]" style={{ color: MUTED }}>
-                    {amount.toLocaleString("en-US", { maximumFractionDigits: decimals })}
-                  </Text>
-                </View>
-                <Pressable
-                  onPress={() => void handleUnshield(balance.tokenMint)}
-                  disabled={pendingMint !== null}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Unshield ${symbol}`}
-                  style={[styles.button, { opacity: pendingMint !== null && !isPending ? 0.4 : 1 }]}
-                >
-                  {isPending ? (
-                    <ActivityIndicator color="#fff" />
-                  ) : (
-                    <Text className="text-[15px] font-medium text-white">Unshield</Text>
-                  )}
-                </Pressable>
-              </View>
-            );
-          })}
-          {balances.length === 0 ? (
-            <Text className="py-6 text-center text-[14px]" style={{ color: MUTED }}>
-              No shielded balances left.
-            </Text>
-          ) : null}
-        </View>
-
-        <View className="px-4" style={{ paddingBottom: insets.bottom + 12, marginTop: "auto" }}>
-          {result?.error ? (
-            <Text className="text-center text-[14px] text-[#f97362]" style={{ lineHeight: 20 }}>
-              {result.error}
-            </Text>
-          ) : null}
-          {explorerUrl ? (
-            <Pressable onPress={() => void Linking.openURL(explorerUrl)} accessibilityRole="link">
-              <Text className="text-center text-[14px] text-[#24a148]" style={{ lineHeight: 20 }}>
-                Unshielded. View on Solscan
-              </Text>
-            </Pressable>
-          ) : null}
-        </View>
+      <BottomSheetView
+        style={{
+          height: sheetHeight,
+          backgroundColor: "#fff",
+          borderTopLeftRadius: 38,
+          borderTopRightRadius: 38,
+          overflow: "hidden",
+        }}
+      >
+        {phase === "pick" ? (
+          <>
+            <Toolbar title="Select asset" onBack={() => setPhase("confirm")} />
+            <BottomSheetScrollView style={{ flex: 1 }}>
+              {rows.map((row) => (
+                <TokenCell
+                  key={row.mint}
+                  row={row}
+                  onPress={() => {
+                    setSelectedMint(row.mint);
+                    setPhase("confirm");
+                  }}
+                />
+              ))}
+            </BottomSheetScrollView>
+          </>
+        ) : phase === "result" && outcome ? (
+          <ResultStep
+            row={outcome.row}
+            result={outcome.result}
+            onClose={onClose}
+            onRetry={() => setPhase("confirm")}
+          />
+        ) : (
+          <ConfirmStep
+            row={selected}
+            canPick={rows.length > 1}
+            isPending={isPending}
+            onPick={() => setPhase("pick")}
+            onClose={onClose}
+            onConfirm={() => void handleUnshield()}
+          />
+        )}
       </BottomSheetView>
     </BottomSheetModal>
   );
 }
 
-const styles = StyleSheet.create({
-  sheetBackground: {
-    backgroundColor: "#FFF",
-    borderTopLeftRadius: 38,
-    borderTopRightRadius: 38,
-  },
-  container: {
-    backgroundColor: "#FFF",
-    borderTopLeftRadius: 38,
-    borderTopRightRadius: 38,
-    overflow: "hidden",
-  },
-  iconButton: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: COLOR_CARD_BG,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  iconButtonSpacer: { width: 44, height: 44 },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    padding: 12,
-    borderRadius: 16,
-    backgroundColor: COLOR_CARD_BG,
-  },
-  icon: { width: 40, height: 40, borderRadius: 20, backgroundColor: "#fff" },
-  button: {
-    height: 40,
-    minWidth: 96,
-    paddingHorizontal: 16,
-    borderRadius: 12,
-    backgroundColor: "#000",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});
+function Toolbar({
+  title,
+  onBack,
+  onClose,
+}: {
+  title: string;
+  onBack?: () => void;
+  onClose?: () => void;
+}) {
+  return (
+    <View className="w-full" style={{ paddingVertical: 16 }}>
+      <View className="flex-row items-center justify-between px-4">
+        <Pressable
+          className="h-11 w-11 items-center justify-center rounded-full bg-[#f2f2f7]"
+          hitSlop={6}
+          onPress={onBack ?? onClose}
+          accessibilityRole="button"
+          accessibilityLabel={onBack ? "Back" : "Close"}
+        >
+          {onBack ? (
+            <ArrowLeft size={24} color={MUTED} strokeWidth={2} />
+          ) : (
+            <X size={24} color={MUTED} strokeWidth={2} />
+          )}
+        </Pressable>
+        <View
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+          }}
+        >
+          <Text className="text-[17px] font-semibold text-black" style={{ lineHeight: 22 }}>
+            {title}
+          </Text>
+        </View>
+        <View className="h-11 w-11" style={{ opacity: 0 }} />
+      </View>
+    </View>
+  );
+}
+
+function TokenCell({
+  row,
+  onPress,
+  showChevron,
+}: {
+  row: ShieldedRow;
+  onPress?: () => void;
+  showChevron?: boolean;
+}) {
+  return (
+    <Pressable
+      className="w-full flex-row items-center"
+      style={{ paddingHorizontal: 16 }}
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Select ${row.name}`}
+    >
+      <View style={{ paddingRight: 12, paddingVertical: 6 }}>
+        <Image
+          source={{ uri: row.icon }}
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+            borderWidth: 0.5,
+            borderColor: "rgba(0,0,0,0.08)",
+          }}
+        />
+      </View>
+      <View className="flex-1" style={{ paddingVertical: 8, gap: 2 }}>
+        <Text
+          className="text-[17px] font-medium text-black"
+          style={{ lineHeight: 22, letterSpacing: -0.187 }}
+          numberOfLines={1}
+        >
+          {row.name}
+        </Text>
+        <Text className="text-[15px] font-normal" style={{ color: MUTED, lineHeight: 20 }} numberOfLines={1}>
+          {row.amountText} {row.symbol} shielded
+        </Text>
+      </View>
+      <View className="flex-row items-center" style={{ paddingLeft: 12, gap: 4 }}>
+        {row.usd !== null ? (
+          <Text className="text-[17px] font-medium text-black" style={{ lineHeight: 22 }}>
+            {formatShieldedUsd(row.usd)}
+          </Text>
+        ) : null}
+        {showChevron ? <ChevronDown size={18} color="rgba(60,60,67,0.4)" /> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function Cta({
+  label,
+  onPress,
+  variant = "primary",
+  pending,
+  disabled,
+}: {
+  label: string;
+  onPress: () => void;
+  variant?: "primary" | "secondary";
+  pending?: boolean;
+  disabled?: boolean;
+}) {
+  const isPrimary = variant === "primary";
+  return (
+    <Pressable
+      className="items-center justify-center"
+      style={{
+        height: 50,
+        borderRadius: 78,
+        backgroundColor: isPrimary ? "#000" : "#f5f5f5",
+        opacity: disabled && !pending ? 0.4 : 1,
+      }}
+      onPress={onPress}
+      disabled={disabled || pending}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+    >
+      {pending ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text
+          className="text-[16px] font-medium"
+          style={{ color: isPrimary ? "#fff" : "#000", lineHeight: 20 }}
+        >
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+function ConfirmStep({
+  row,
+  canPick,
+  isPending,
+  onPick,
+  onClose,
+  onConfirm,
+}: {
+  row: ShieldedRow | null;
+  canPick: boolean;
+  isPending: boolean;
+  onPick: () => void;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  return (
+    <View className="w-full" style={{ flex: 1 }}>
+      <Toolbar title="Unshield" onClose={onClose} />
+
+      {row ? (
+        <>
+          <View className="w-full items-center" style={{ padding: 16 }}>
+            <Image source={{ uri: row.icon }} style={{ width: 64, height: 64, borderRadius: 32 }} />
+            <View className="flex-row items-baseline" style={{ gap: 8, marginTop: 16 }}>
+              <Text style={{ fontFamily: "Geist_600SemiBold", fontSize: 40, lineHeight: 48, color: "#000" }}>
+                {row.amountText}
+              </Text>
+              <Text
+                style={{
+                  fontFamily: "Geist_600SemiBold",
+                  fontSize: 28,
+                  lineHeight: 32,
+                  letterSpacing: 0.4,
+                  color: "rgba(60,60,67,0.4)",
+                }}
+              >
+                {row.symbol}
+              </Text>
+            </View>
+            {row.usd !== null ? (
+              <Text className="text-[17px] font-normal" style={{ color: MUTED, lineHeight: 22, marginTop: 4 }}>
+                ≈{formatShieldedUsd(row.usd)}
+              </Text>
+            ) : null}
+          </View>
+
+          <View style={{ paddingHorizontal: 16 }}>
+            <View className="w-full" style={{ backgroundColor: "#f2f2f7", borderRadius: 20, paddingVertical: 4 }}>
+              <TokenCell row={row} onPress={canPick ? onPick : undefined} showChevron={canPick} />
+            </View>
+          </View>
+        </>
+      ) : (
+        <View className="flex-1 items-center justify-center" style={{ padding: 32 }}>
+          <Text className="text-[17px] font-normal" style={{ color: MUTED, lineHeight: 22, textAlign: "center" }}>
+            No shielded balances left
+          </Text>
+        </View>
+      )}
+
+      <View style={{ marginTop: "auto", paddingTop: 16, paddingBottom: insets.bottom + 12, paddingHorizontal: 20 }}>
+        <Cta label="Unshield" onPress={onConfirm} pending={isPending} disabled={!row} />
+      </View>
+    </View>
+  );
+}
+
+function ResultStep({
+  row,
+  result,
+  onClose,
+  onRetry,
+}: {
+  row: ShieldedRow;
+  result: UnshieldResult;
+  onClose: () => void;
+  onRetry: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const env = getSolanaEnv();
+  const explorerUrl = result.signature
+    ? `https://solscan.io/tx/${result.signature}${env === "mainnet" ? "" : `?cluster=${env}`}`
+    : null;
+  return (
+    <View className="w-full" style={{ flex: 1 }}>
+      <Toolbar title="Unshield" onClose={onClose} />
+
+      <View className="flex-1 items-center justify-center" style={{ paddingHorizontal: 32, paddingVertical: 24 }}>
+        <View className="w-full items-center" style={{ gap: 20 }}>
+          {result.success ? (
+            <SendSuccessDog width={100} height={80} />
+          ) : (
+            <SendErrorDog width={100} height={80} />
+          )}
+          <View className="w-full items-center" style={{ gap: 4 }}>
+            <Text className="text-[22px] font-semibold text-black" style={{ lineHeight: 28, textAlign: "center" }}>
+              {result.success ? "Unshielded" : "Unshield failed"}
+            </Text>
+            <Text
+              className="text-[17px] font-normal"
+              style={{ color: MUTED, lineHeight: 22, textAlign: "center", maxWidth: 300 }}
+            >
+              {result.success ? (
+                <>
+                  <Text className="text-black">
+                    {row.amountText} {row.symbol}
+                  </Text>
+                  <Text style={{ color: MUTED }}>{" moved back to your wallet"}</Text>
+                </>
+              ) : (
+                (result.error ?? "Something went wrong. Please try again.")
+              )}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={{ paddingTop: 16, paddingBottom: insets.bottom + 12, paddingHorizontal: 20, gap: 10 }}>
+        {result.success ? (
+          <>
+            <Cta label="Done" onPress={onClose} />
+            {explorerUrl ? (
+              <Cta label="View on Solscan" variant="secondary" onPress={() => void Linking.openURL(explorerUrl)} />
+            ) : null}
+          </>
+        ) : (
+          <>
+            <Cta label="Try again" onPress={onRetry} />
+            <Cta label="Close" variant="secondary" onPress={onClose} />
+          </>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/wallet/UnshieldSheet.tsx
+++ b/apps/mobile/src/components/wallet/UnshieldSheet.tsx
@@ -1,0 +1,235 @@
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetView,
+} from "@gorhom/bottom-sheet";
+import type { ShieldedBalance, UnshieldResult } from "@loyal-labs/wallet-core/hooks";
+import { X } from "lucide-react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ActivityIndicator, Image, Linking, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { useFixedSheetLayout } from "@/hooks/useFixedSheetLayout";
+import type { TokenDetailsByMint } from "@/hooks/wallet/useTokenDetails";
+import { NATIVE_SOL_DECIMALS, NATIVE_SOL_MINT } from "@/lib/solana/constants";
+import { getSolanaEnv } from "@/lib/solana/rpc/connection";
+import {
+  resolveTokenIcon,
+  resolveTokenSymbol,
+} from "@/lib/solana/token-holdings/resolve-token-info";
+import type { TokenHolding } from "@/lib/solana/token-holdings/types";
+import { Pressable, Text, View } from "@/tw";
+
+// Exit-only unshield for the sunset private-transfer program (ASK-2269): one
+// row per shielded token, full-balance unshield, no shield / private send.
+
+const COLOR_CARD_BG = "#F2F2F7";
+const COLOR_ICON = "#3C3C43";
+const MUTED = "rgba(60, 60, 67, 0.6)";
+
+type UnshieldSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  balances: ShieldedBalance[];
+  executeUnshield: (tokenMint: string) => Promise<UnshieldResult>;
+  tokenHoldings: TokenHolding[];
+  tokenDetailsByMint: TokenDetailsByMint;
+  onUnshieldComplete?: () => void;
+};
+
+export function UnshieldSheet({
+  open,
+  onClose,
+  balances,
+  executeUnshield,
+  tokenHoldings,
+  tokenDetailsByMint,
+  onUnshieldComplete,
+}: UnshieldSheetProps) {
+  const { sheetHeight, snapPoints } = useFixedSheetLayout(0.6);
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const insets = useSafeAreaInsets();
+  const [pendingMint, setPendingMint] = useState<string | null>(null);
+  const [result, setResult] = useState<UnshieldResult | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setResult(null);
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [open]);
+
+  const handleUnshield = useCallback(
+    async (tokenMint: string) => {
+      setPendingMint(tokenMint);
+      setResult(null);
+      const res = await executeUnshield(tokenMint);
+      setPendingMint(null);
+      setResult(res);
+      if (res.success) onUnshieldComplete?.();
+    },
+    [executeUnshield, onUnshieldComplete],
+  );
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        opacity={0.3}
+      />
+    ),
+    [],
+  );
+
+  const env = getSolanaEnv();
+  const explorerUrl = result?.signature
+    ? `https://solscan.io/tx/${result.signature}${env === "mainnet" ? "" : `?cluster=${env}`}`
+    : null;
+
+  return (
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
+      handleComponent={null}
+      backgroundStyle={styles.sheetBackground}
+    >
+      <BottomSheetView style={[styles.container, { height: sheetHeight }]}>
+        <View className="flex-row items-center justify-between px-4 py-4">
+          <Pressable
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close"
+            hitSlop={12}
+            style={styles.iconButton}
+          >
+            <X size={28} color={COLOR_ICON} strokeWidth={2} opacity={0.6} />
+          </Pressable>
+          <Text className="text-[17px] font-semibold text-black" style={{ lineHeight: 22 }}>
+            Unshield
+          </Text>
+          <View style={styles.iconButtonSpacer} />
+        </View>
+
+        <Text className="px-6 pb-4 text-center text-[14px]" style={{ lineHeight: 20, color: MUTED }}>
+          Private balances are being retired. Move each balance back to your wallet.
+        </Text>
+
+        <View className="px-4 gap-2">
+          {balances.map((balance) => {
+            const holding = tokenHoldings.find((h) => h.mint === balance.tokenMint);
+            const detail = tokenDetailsByMint[balance.tokenMint];
+            const decimals =
+              holding?.decimals ??
+              detail?.token.decimals ??
+              (balance.tokenMint === NATIVE_SOL_MINT ? NATIVE_SOL_DECIMALS : 6);
+            const symbol = resolveTokenSymbol({
+              mint: balance.tokenMint,
+              detailSymbol: detail?.token.symbol,
+              holdingSymbol: holding?.symbol,
+            });
+            const icon = resolveTokenIcon({
+              mint: balance.tokenMint,
+              imageUrl: holding?.imageUrl,
+              detailLogoUrl: detail?.token.logoUrl,
+            });
+            const amount = Number(balance.amountRaw) / 10 ** decimals;
+            const isPending = pendingMint === balance.tokenMint;
+            return (
+              <View key={balance.tokenMint} style={styles.row}>
+                <Image source={{ uri: icon }} style={styles.icon} />
+                <View className="flex-1">
+                  <Text className="text-[17px] font-medium text-black">{symbol}</Text>
+                  <Text className="text-[14px]" style={{ color: MUTED }}>
+                    {amount.toLocaleString("en-US", { maximumFractionDigits: decimals })}
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={() => void handleUnshield(balance.tokenMint)}
+                  disabled={pendingMint !== null}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Unshield ${symbol}`}
+                  style={[styles.button, { opacity: pendingMint !== null && !isPending ? 0.4 : 1 }]}
+                >
+                  {isPending ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text className="text-[15px] font-medium text-white">Unshield</Text>
+                  )}
+                </Pressable>
+              </View>
+            );
+          })}
+          {balances.length === 0 ? (
+            <Text className="py-6 text-center text-[14px]" style={{ color: MUTED }}>
+              No shielded balances left.
+            </Text>
+          ) : null}
+        </View>
+
+        <View className="px-4" style={{ paddingBottom: insets.bottom + 12, marginTop: "auto" }}>
+          {result?.error ? (
+            <Text className="text-center text-[14px] text-[#f97362]" style={{ lineHeight: 20 }}>
+              {result.error}
+            </Text>
+          ) : null}
+          {explorerUrl ? (
+            <Pressable onPress={() => void Linking.openURL(explorerUrl)} accessibilityRole="link">
+              <Text className="text-center text-[14px] text-[#24a148]" style={{ lineHeight: 20 }}>
+                Unshielded. View on Solscan
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: "#FFF",
+    borderTopLeftRadius: 38,
+    borderTopRightRadius: 38,
+  },
+  container: {
+    backgroundColor: "#FFF",
+    borderTopLeftRadius: 38,
+    borderTopRightRadius: 38,
+    overflow: "hidden",
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: COLOR_CARD_BG,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconButtonSpacer: { width: 44, height: 44 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 12,
+    borderRadius: 16,
+    backgroundColor: COLOR_CARD_BG,
+  },
+  icon: { width: 40, height: 40, borderRadius: 20, backgroundColor: "#fff" },
+  button: {
+    height: 40,
+    minWidth: 96,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/apps/mobile/src/components/wallet/shielded-balance.ts
+++ b/apps/mobile/src/components/wallet/shielded-balance.ts
@@ -1,0 +1,63 @@
+import type { ShieldedBalance } from "@loyal-labs/wallet-core/hooks";
+
+import type { TokenDetailsByMint } from "@/hooks/wallet/useTokenDetails";
+import { NATIVE_SOL_DECIMALS, NATIVE_SOL_MINT } from "@/lib/solana/constants";
+import {
+  resolveTokenIcon,
+  resolveTokenName,
+  resolveTokenSymbol,
+} from "@/lib/solana/token-holdings/resolve-token-info";
+import type { TokenHolding } from "@/lib/solana/token-holdings/types";
+
+// Display model for a legacy shielded balance (ASK-2269): shared by the
+// category list row and the Unshield sheet so both render the same numbers.
+export type ShieldedRow = {
+  mint: string;
+  symbol: string;
+  name: string;
+  icon: string;
+  amount: number;
+  amountText: string;
+  usd: number | null;
+};
+
+export function resolveShieldedRow(
+  balance: ShieldedBalance,
+  holdings: TokenHolding[],
+  detailsByMint: TokenDetailsByMint,
+): ShieldedRow {
+  const mint = balance.tokenMint;
+  const holding = holdings.find((h) => h.mint === mint);
+  const detail = detailsByMint[mint];
+  const decimals =
+    holding?.decimals ??
+    detail?.token.decimals ??
+    (mint === NATIVE_SOL_MINT ? NATIVE_SOL_DECIMALS : 6);
+  const amount = Number(balance.amountRaw) / 10 ** decimals;
+  const price = detail?.market.priceUsd ?? holding?.priceUsd ?? null;
+  return {
+    mint,
+    symbol: resolveTokenSymbol({
+      mint,
+      detailSymbol: detail?.token.symbol,
+      holdingSymbol: holding?.symbol,
+    }),
+    name: resolveTokenName({
+      mint,
+      detailName: detail?.token.name,
+      holdingName: holding?.name,
+    }),
+    icon: resolveTokenIcon({
+      mint,
+      imageUrl: holding?.imageUrl,
+      detailLogoUrl: detail?.token.logoUrl,
+    }),
+    amount,
+    amountText: amount.toLocaleString("en-US", { maximumFractionDigits: 6 }),
+    usd: price !== null && price > 0 ? amount * price : null,
+  };
+}
+
+export function formatShieldedUsd(value: number): string {
+  return value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+}

--- a/apps/mobile/src/features/wallet-categories/model/categorize.ts
+++ b/apps/mobile/src/features/wallet-categories/model/categorize.ts
@@ -33,7 +33,9 @@ const STABLECOIN_SYMBOLS = new Set<string>([
   "USDH",
 ]);
 
-export function isStablecoinHolding(holding: TokenHolding): boolean {
+export function isStablecoinHolding(
+  holding: Pick<TokenHolding, "mint" | "symbol">,
+): boolean {
   if (STABLECOIN_MINTS.has(holding.mint)) {
     return true;
   }

--- a/apps/mobile/src/features/wallet-categories/ui/CategoryScreen.tsx
+++ b/apps/mobile/src/features/wallet-categories/ui/CategoryScreen.tsx
@@ -20,6 +20,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ReceiveSheet } from "@/components/wallet/ReceiveSheet";
 import { SendSheet } from "@/components/wallet/SendSheet";
 import { SwapSheet } from "@/components/wallet/SwapSheet";
+import { resolveShieldedRow } from "@/components/wallet/shielded-balance";
 import { UnshieldSheet } from "@/components/wallet/UnshieldSheet";
 import { buildTokenDetailHref } from "@/features/token-details/routes";
 import { useSolPrice } from "@/hooks/wallet/useSolPrice";
@@ -43,6 +44,7 @@ import { Pressable, Text, View } from "@/tw";
 
 import {
   filterHoldingsByCategory,
+  isStablecoinHolding,
   sumHoldingsUsd,
   type WalletCategory,
 } from "../model/categorize";
@@ -53,6 +55,7 @@ import { CardExpandTransition } from "./CardExpandTransition";
 import { CategoryAssetRow } from "./CategoryAssetRow";
 import { CryptoGlyph, StablecoinsGlyph } from "./CategoryGlyphs";
 import { type MoreActionsAnchor, MoreActionsSheet } from "./MoreActionsSheet";
+import { ShieldedAssetRow } from "./ShieldedAssetRow";
 
 import EllipsisIcon from "../../../../assets/images/icons/ellipsis.svg";
 
@@ -120,9 +123,20 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
         : SOLANA_USDC_MINT_DEVNET,
     ]);
     for (const holding of tokenHoldings) mints.add(holding.mint);
+    for (const balance of shieldedBalances) mints.add(balance.tokenMint);
     return Array.from(mints);
-  }, [tokenHoldings]);
+  }, [tokenHoldings, shieldedBalances]);
   const tokenDetailsByMint = useTokenDetails(tokenDetailMints);
+
+  // Shielded balances in this category, listed under the regular holdings so
+  // they stay visible without opening the Unshield sheet.
+  const shieldedRows = useMemo(
+    () =>
+      shieldedBalances
+        .map((b) => resolveShieldedRow(b, tokenHoldings, tokenDetailsByMint))
+        .filter((row) => isStablecoinHolding(row) === (category === "stablecoins")),
+    [shieldedBalances, tokenHoldings, tokenDetailsByMint, category],
+  );
 
   // Reuse the wallet list's sort + pair grouping, then keep only this
   // category's holdings (pairs stay adjacent, so connectors still line up).
@@ -144,7 +158,16 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
   const [scanOnOpen, setScanOnOpen] = useState(false);
   const [isReceiveOpen, setIsReceiveOpen] = useState(false);
   const [isSwapOpen, setIsSwapOpen] = useState(false);
+  const [unshieldMint, setUnshieldMint] = useState<string | null>(null);
   const [isUnshieldOpen, setIsUnshieldOpen] = useState(false);
+  const openUnshield = useCallback(
+    (mint: string | null) => {
+      void refreshShieldedBalances();
+      setUnshieldMint(mint);
+      setIsUnshieldOpen(true);
+    },
+    [refreshShieldedBalances],
+  );
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [moreAnchor, setMoreAnchor] = useState<MoreActionsAnchor | null>(null);
   const moreButtonRef = useRef<ComponentRef<typeof MeasureView>>(null);
@@ -305,6 +328,29 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
                     />
                   ))
                 )}
+
+                {shieldedRows.length > 0 ? (
+                  <>
+                    <View className="px-4 pb-2 pt-3">
+                      <Text
+                        className="text-[17px] font-semibold text-black"
+                        style={{ letterSpacing: -0.187, lineHeight: 22 }}
+                      >
+                        Shielded
+                      </Text>
+                    </View>
+                    {shieldedRows.map((row) => (
+                      <ShieldedAssetRow
+                        key={row.mint}
+                        row={row}
+                        onPress={() => {
+                          void Haptics.selectionAsync();
+                          openUnshield(row.mint);
+                        }}
+                      />
+                    ))}
+                  </>
+                ) : null}
               </Animated.ScrollView>
             </GestureDetector>
 
@@ -392,6 +438,7 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
         executeUnshield={executeUnshield}
         tokenHoldings={tokenHoldings}
         tokenDetailsByMint={tokenDetailsByMint}
+        initialMint={unshieldMint}
         onUnshieldComplete={refresh}
       />
 
@@ -406,12 +453,7 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
         onReceive={() => setIsReceiveOpen(true)}
         onSwap={() => setIsSwapOpen(true)}
         onUnshield={
-          shieldedBalances.length > 0
-            ? () => {
-                void refreshShieldedBalances();
-                setIsUnshieldOpen(true);
-              }
-            : undefined
+          shieldedBalances.length > 0 ? () => openUnshield(null) : undefined
         }
       />
     </>

--- a/apps/mobile/src/features/wallet-categories/ui/CategoryScreen.tsx
+++ b/apps/mobile/src/features/wallet-categories/ui/CategoryScreen.tsx
@@ -1,3 +1,4 @@
+import { useUnshield } from "@loyal-labs/wallet-core/hooks";
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { ArrowDown, ArrowLeft, ArrowUp, ScanLine } from "lucide-react-native";
@@ -19,6 +20,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ReceiveSheet } from "@/components/wallet/ReceiveSheet";
 import { SendSheet } from "@/components/wallet/SendSheet";
 import { SwapSheet } from "@/components/wallet/SwapSheet";
+import { UnshieldSheet } from "@/components/wallet/UnshieldSheet";
 import { buildTokenDetailHref } from "@/features/token-details/routes";
 import { useSolPrice } from "@/hooks/wallet/useSolPrice";
 import { useTokenDetails } from "@/hooks/wallet/useTokenDetails";
@@ -36,6 +38,7 @@ import {
   getDisplayTokenHoldings,
   getPairPositions,
 } from "@/lib/solana/token-holdings/display-holdings";
+import { useWallet } from "@/lib/wallet/wallet-provider";
 import { Pressable, Text, View } from "@/tw";
 
 import {
@@ -68,6 +71,13 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
   const { solPriceUsd } = useSolPrice();
   const { tokenHoldings, isHoldingsLoading, refreshTokenHoldings } =
     useTokenHoldings(walletAddress);
+  const { signer } = useWallet();
+  // Legacy shielded balances (ASK-2269): Unshield shows only while one exists.
+  const {
+    balances: shieldedBalances,
+    executeUnshield,
+    refreshBalances: refreshShieldedBalances,
+  } = useUnshield(signer, getSolanaEnv());
 
   // Source card geometry passed by the wallet grid, so this page can expand out
   // of (and collapse back into) the tapped card. Absent on direct navigation.
@@ -134,6 +144,7 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
   const [scanOnOpen, setScanOnOpen] = useState(false);
   const [isReceiveOpen, setIsReceiveOpen] = useState(false);
   const [isSwapOpen, setIsSwapOpen] = useState(false);
+  const [isUnshieldOpen, setIsUnshieldOpen] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [moreAnchor, setMoreAnchor] = useState<MoreActionsAnchor | null>(null);
   const moreButtonRef = useRef<ComponentRef<typeof MeasureView>>(null);
@@ -374,6 +385,16 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
         initialFromMint={initialMint}
       />
 
+      <UnshieldSheet
+        open={isUnshieldOpen}
+        onClose={() => setIsUnshieldOpen(false)}
+        balances={shieldedBalances}
+        executeUnshield={executeUnshield}
+        tokenHoldings={tokenHoldings}
+        tokenDetailsByMint={tokenDetailsByMint}
+        onUnshieldComplete={refresh}
+      />
+
       <MoreActionsSheet
         open={isMoreOpen}
         onClose={() => setIsMoreOpen(false)}
@@ -384,6 +405,14 @@ export function CategoryScreen({ category }: { category: WalletCategory }) {
         }}
         onReceive={() => setIsReceiveOpen(true)}
         onSwap={() => setIsSwapOpen(true)}
+        onUnshield={
+          shieldedBalances.length > 0
+            ? () => {
+                void refreshShieldedBalances();
+                setIsUnshieldOpen(true);
+              }
+            : undefined
+        }
       />
     </>
   );

--- a/apps/mobile/src/features/wallet-categories/ui/MoreActionsSheet.tsx
+++ b/apps/mobile/src/features/wallet-categories/ui/MoreActionsSheet.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDown,
   ArrowLeftRight,
   ArrowUp,
+  ShieldOff,
   X,
 } from "lucide-react-native";
 import {
@@ -112,6 +113,7 @@ export function MoreActionsSheet({
   onSend,
   onReceive,
   onSwap,
+  onUnshield,
 }: {
   open: boolean;
   onClose: () => void;
@@ -119,6 +121,9 @@ export function MoreActionsSheet({
   onSend?: () => void;
   onReceive?: () => void;
   onSwap?: () => void;
+  // Exit-only path for legacy shielded balances; callers pass it only when
+  // the wallet still holds one (ASK-2269).
+  onUnshield?: () => void;
 }) {
   const insets = useSafeAreaInsets();
   const { width: screenW, height: screenH } = useWindowDimensions();
@@ -177,6 +182,14 @@ export function MoreActionsSheet({
 
   // Design order, top -> bottom. Only render the actions the screen supplies.
   const actions: QuestAction[] = [];
+  if (onUnshield) {
+    actions.push({
+      key: "unshield",
+      label: "Unshield",
+      icon: <ShieldOff size={28} color="#000" strokeWidth={2} opacity={ICON_OPACITY} />,
+      run: onUnshield,
+    });
+  }
   if (onSwap) {
     actions.push({
       key: "swap",

--- a/apps/mobile/src/features/wallet-categories/ui/ShieldedAssetRow.tsx
+++ b/apps/mobile/src/features/wallet-categories/ui/ShieldedAssetRow.tsx
@@ -1,0 +1,86 @@
+import { ShieldCheck } from "lucide-react-native";
+import { Image as RNImage } from "react-native";
+
+import {
+  formatShieldedUsd,
+  type ShieldedRow,
+} from "@/components/wallet/shielded-balance";
+import { Pressable, Text, View } from "@/tw";
+
+const MUTED = "rgba(60, 60, 67, 0.6)";
+
+// Legacy shielded balance in the category asset list (ASK-2269). Same anatomy
+// as CategoryAssetRow plus a shield badge on the token icon.
+export function ShieldedAssetRow({
+  row,
+  onPress,
+}: {
+  row: ShieldedRow;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center px-4"
+      accessibilityRole="button"
+      accessibilityLabel={`Unshield ${row.symbol}`}
+    >
+      <View className="py-1.5 pr-3" style={{ position: "relative" }}>
+        <RNImage
+          source={{ uri: row.icon }}
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+            backgroundColor: "#f2f2f7",
+            borderWidth: 0.5,
+            borderColor: "rgba(0, 0, 0, 0.08)",
+          }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            left: 30,
+            top: 34,
+            width: 22,
+            height: 22,
+            borderRadius: 11,
+            backgroundColor: "#fff",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <ShieldCheck size={16} color="#000" strokeWidth={2} />
+        </View>
+      </View>
+
+      <View className="flex-1 py-2">
+        <Text
+          className="text-[17px] font-medium text-black"
+          style={{ letterSpacing: -0.187, lineHeight: 22 }}
+          numberOfLines={1}
+        >
+          {row.name}
+        </Text>
+        <Text
+          className="mt-0.5 text-[15px]"
+          style={{ color: MUTED, lineHeight: 20 }}
+          numberOfLines={1}
+        >
+          {row.amountText} {row.symbol} shielded
+        </Text>
+      </View>
+
+      {row.usd !== null ? (
+        <View className="items-end pl-3">
+          <Text
+            className="text-[17px] font-medium text-black"
+            style={{ letterSpacing: -0.187, lineHeight: 22 }}
+          >
+            {formatShieldedUsd(row.usd)}
+          </Text>
+        </View>
+      ) : null}
+    </Pressable>
+  );
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -13,6 +13,9 @@
       "@loyal-labs/shared": [
         "../../packages/shared/src/index.ts"
       ],
+      "@loyal-labs/wallet-core/hooks": [
+        "../../packages/wallet-core/src/hooks/index.ts"
+      ],
       "@loyal-labs/wallet-core/lib": [
         "../../packages/wallet-core/src/lib/index.ts"
       ],

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -41,7 +41,11 @@ import {
   SwapTokenSelectPane,
 } from "@/components/wallet-workspace/facelift/swap-pane";
 import { TokenDetailPane } from "@/components/wallet-workspace/facelift/token-detail-pane";
-import { UnshieldPane } from "@/components/wallet-workspace/facelift/unshield-pane";
+import {
+  type ShieldedRow,
+  toShieldedRow,
+  UnshieldPane,
+} from "@/components/wallet-workspace/facelift/unshield-pane";
 import { useAuthCapability } from "@/lib/auth/capability";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { usePopularTokens } from "@/hooks/use-popular-tokens";
@@ -132,10 +136,23 @@ export function CryptoPage({
     publicEnv.solanaEnv
   );
   const [isUnshieldOpen, setIsUnshieldOpen] = useState(false);
+  const [unshieldMint, setUnshieldMint] = useState<string | undefined>();
 
   const stablecoinMints = useMemo(
     () => getStablecoinMintSetForSolanaEnv(publicEnv.solanaEnv),
     [publicEnv.solanaEnv]
+  );
+  // Shielded balances as display rows, split by the same stablecoin rule as
+  // the public assets so each lands on its own page.
+  const shieldedRows = useMemo<ShieldedRow[]>(
+    () =>
+      shieldedBalances
+        .map((balance) => toShieldedRow(balance, data.positions))
+        .filter(
+          (row) =>
+            isStablecoinMint(row.mint, stablecoinMints) === (page === "stables")
+        ),
+    [data.positions, page, shieldedBalances, stablecoinMints]
   );
   // Same numbers the sidebar rows show: stablecoins summed by mint, crypto =
   // wallet total minus stablecoins.
@@ -373,11 +390,15 @@ export function CryptoPage({
     setSwapSelectSide(null);
   }, []);
 
-  const openUnshield = useCallback(() => {
-    setViewStack([]);
-    closeSwap();
-    setIsUnshieldOpen(true);
-  }, [closeSwap]);
+  const openUnshield = useCallback(
+    (mint?: string) => {
+      setViewStack([]);
+      closeSwap();
+      setUnshieldMint(mint);
+      setIsUnshieldOpen(true);
+    },
+    [closeSwap]
+  );
   const closeUnshield = useCallback(() => setIsUnshieldOpen(false), []);
 
   // Sidebar navigation abandons any in-progress action screen — the same rule
@@ -612,12 +633,14 @@ export function CryptoPage({
               />
             ) : isUnshieldOpen ? (
               <UnshieldPane
-                balances={shieldedBalances}
                 executeUnshield={executeUnshield}
+                initialMint={unshieldMint}
                 onBack={closeUnshield}
                 onDone={closeUnshield}
                 onSuccess={refreshWallet}
-                positions={data.positions}
+                rows={shieldedBalances.map((balance) =>
+                  toShieldedRow(balance, data.positions)
+                )}
               />
             ) : null
           }
@@ -635,6 +658,7 @@ export function CryptoPage({
                 shieldedBalances.length > 0 ? openUnshield : undefined
               }
               rowActions={rowActions}
+              shieldedRows={shieldedRows}
               tokenRows={
                 page === "stables"
                   ? data.cashTokenRows

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-page.tsx
@@ -3,6 +3,9 @@
 import { resolveLoyalClusterForSolanaEnv } from "@loyal-labs/actions";
 import { resolveSolanaEnv } from "@loyal-labs/solana-rpc";
 import type { PortfolioPosition } from "@loyal-labs/solana-wallet";
+import { useUnshield } from "@loyal-labs/wallet-core/hooks";
+import type { WalletSigner } from "@loyal-labs/wallet-core/types";
+import { useWallet } from "@solana/wallet-adapter-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -38,6 +41,7 @@ import {
   SwapTokenSelectPane,
 } from "@/components/wallet-workspace/facelift/swap-pane";
 import { TokenDetailPane } from "@/components/wallet-workspace/facelift/token-detail-pane";
+import { UnshieldPane } from "@/components/wallet-workspace/facelift/unshield-pane";
 import { useAuthCapability } from "@/lib/auth/capability";
 import { usePublicEnv } from "@/contexts/public-env-context";
 import { usePopularTokens } from "@/hooks/use-popular-tokens";
@@ -101,6 +105,33 @@ export function CryptoPage({
   const { isHydrated, isSignedIn } = useAuthCapability();
 
   const data = useWalletDesktopData({});
+
+  // --- legacy shielded-balance exit (ASK-2269) ---
+  // Only wallets still holding deposits in the sunset private-transfer
+  // program see the Unshield entry; reading balances needs no signature.
+  const wallet = useWallet();
+  const unshieldSigner = useMemo<WalletSigner | null>(
+    () =>
+      wallet.publicKey && wallet.signTransaction && wallet.signAllTransactions
+        ? {
+            publicKey: wallet.publicKey,
+            signTransaction: wallet.signTransaction,
+            signAllTransactions: wallet.signAllTransactions,
+            signMessage: wallet.signMessage,
+          }
+        : null,
+    [
+      wallet.publicKey,
+      wallet.signAllTransactions,
+      wallet.signMessage,
+      wallet.signTransaction,
+    ]
+  );
+  const { balances: shieldedBalances, executeUnshield } = useUnshield(
+    unshieldSigner,
+    publicEnv.solanaEnv
+  );
+  const [isUnshieldOpen, setIsUnshieldOpen] = useState(false);
 
   const stablecoinMints = useMemo(
     () => getStablecoinMintSetForSolanaEnv(publicEnv.solanaEnv),
@@ -308,6 +339,7 @@ export function CryptoPage({
       setSendRecipient(null);
       setSendSelect(null);
       setIsSendFormActive(true);
+      setIsUnshieldOpen(false);
       openAction({ type: "sendPanel" });
     },
     [openAction]
@@ -332,6 +364,7 @@ export function CryptoPage({
     }
     setViewStack([]);
     setSwapSelectSide(null);
+    setIsUnshieldOpen(false);
     setIsSwapOpen(true);
   }, []);
 
@@ -340,13 +373,21 @@ export function CryptoPage({
     setSwapSelectSide(null);
   }, []);
 
+  const openUnshield = useCallback(() => {
+    setViewStack([]);
+    closeSwap();
+    setIsUnshieldOpen(true);
+  }, [closeSwap]);
+  const closeUnshield = useCallback(() => setIsUnshieldOpen(false), []);
+
   // Sidebar navigation abandons any in-progress action screen — the same rule
   // the shell applies to Earn's deposit/withdraw/autodeposit views.
   useEffect(() => {
     setViewStack([]);
     setSendSelect(null);
     closeSwap();
-  }, [closeSwap, navigationNonce]);
+    closeUnshield();
+  }, [closeSwap, closeUnshield, navigationNonce]);
 
   // Esc backs out of the open Send/Swap flow (the shell owns Esc for
   // Earn's action screens). An open selector pane closes first; the next
@@ -357,7 +398,7 @@ export function CryptoPage({
         event.key !== "Escape" ||
         // Numbers-only amount fields don't swallow Esc — only free text does.
         isEscapeGuardedTarget(event.target) ||
-        (viewStack.length === 0 && !isSwapOpen)
+        (viewStack.length === 0 && !isSwapOpen && !isUnshieldOpen)
       ) {
         return;
       }
@@ -377,6 +418,7 @@ export function CryptoPage({
         }
         setViewStack([]);
         closeSwap();
+        closeUnshield();
       });
     };
     window.addEventListener("keydown", handleKeyDown);
@@ -568,6 +610,15 @@ export function CryptoPage({
                 onSuccess={refreshWallet}
                 toToken={swapToToken}
               />
+            ) : isUnshieldOpen ? (
+              <UnshieldPane
+                balances={shieldedBalances}
+                executeUnshield={executeUnshield}
+                onBack={closeUnshield}
+                onDone={closeUnshield}
+                onSuccess={refreshWallet}
+                positions={data.positions}
+              />
             ) : null
           }
         >
@@ -580,6 +631,9 @@ export function CryptoPage({
               onEarn={() => onEarn()}
               onSend={() => openSend()}
               onSwap={() => openSwap()}
+              onUnshield={
+                shieldedBalances.length > 0 ? openUnshield : undefined
+              }
               rowActions={rowActions}
               tokenRows={
                 page === "stables"
@@ -604,7 +658,9 @@ export function CryptoPage({
               </PaneReveal>
             </InlineSheetReveal>
           </div>
-        ) : actionView !== null ? null : isSwapOpen ? (
+        ) : actionView !== null ? null : isUnshieldOpen ? (
+          <aside className="hidden h-full w-[400px] shrink-0 rounded-3xl bg-card min-[1204px]:block" />
+        ) : isSwapOpen ? (
           // Swap's right pane: a reserved 400px slot (Figma 4813:403499
           // keeps it empty) the selector panel-reveals into and out of;
           // switching sides replays the content reveal on the open panel.

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-pane.tsx
@@ -8,6 +8,10 @@ import {
 } from "@/components/wallet-workspace/facelift/balance-visibility";
 import { SkeletonReveal } from "@/components/wallet-workspace/facelift/skeleton-reveal";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+import {
+  type ShieldedRow,
+  ShieldedTokenIcon,
+} from "@/components/wallet-workspace/facelift/unshield-pane";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
@@ -254,6 +258,54 @@ function TokenCell({
   );
 }
 
+// A balance still held in the sunset private-transfer program, listed under
+// the public assets so it is visible without opening the exit flow. Click
+// opens Unshield with this token preselected.
+function ShieldedCell({
+  isBalanceHidden,
+  onUnshield,
+  row,
+}: {
+  isBalanceHidden: boolean;
+  onUnshield: (mint: string) => void;
+  row: ShieldedRow;
+}) {
+  return (
+    <button
+      className="group relative flex w-full cursor-pointer items-center rounded-2xl px-4 text-left transition-colors duration-150 hover:bg-accent"
+      onClick={() => onUnshield(row.mint)}
+      type="button"
+    >
+      <span className="flex shrink-0 items-center py-2 pr-3">
+        <ShieldedTokenIcon icon={row.icon} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
+        <span className="truncate font-medium text-[16px] text-foreground leading-5 tracking-[-0.176px]">
+          {row.symbol}
+        </span>
+        <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+          <ScrambleText
+            isHidden={isBalanceHidden}
+            text={`${row.amountLabel} ${row.symbol} shielded`}
+          />
+        </span>
+      </span>
+      <span className="relative flex shrink-0 items-center justify-end pl-3">
+        <span className="flex flex-col items-end justify-center gap-0.5 py-[11px] transition-opacity duration-150 group-hover:opacity-0">
+          {row.valueLabel ? (
+            <SplitUsd isHidden={isBalanceHidden} value={row.valueLabel} />
+          ) : null}
+        </span>
+        <span className="pointer-events-none absolute right-0 flex items-center rounded-[40px] bg-secondary opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-hover:delay-100">
+          <span className="flex min-w-16 items-center justify-center rounded-[40px] bg-foreground px-4 py-2.5 font-medium text-[13px] text-background leading-4">
+            Unshield
+          </span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
 // Figma 4813:338844 (wide) / 4813:339148 (downsized) — the Crypto middle
 // pane, and via variant="stables" the Stablecoins one (4813:339437 /
 // 4813:339683): header actions, the stash balance cell, then the asset list.
@@ -267,6 +319,7 @@ export function CryptoPane({
   onSwap,
   onUnshield,
   rowActions,
+  shieldedRows = [],
   tokenRows,
   variant,
 }: {
@@ -278,8 +331,10 @@ export function CryptoPane({
   onSend: () => void;
   onSwap: () => void;
   /** Exit path for legacy shielded balances; only passed when the wallet holds some. */
-  onUnshield?: () => void;
+  onUnshield?: (mint?: string) => void;
   rowActions: CryptoRowActions;
+  /** Balances still held in the private-transfer program, listed under the assets. */
+  shieldedRows?: ShieldedRow[];
   tokenRows: TokenRow[];
   variant: CryptoPaneVariant;
 }) {
@@ -317,7 +372,7 @@ export function CryptoPane({
                 icon="icon-withdraw-arrow.svg"
                 iconColorClass="text-tertiary"
                 label="Unshield"
-                onClick={onUnshield}
+                onClick={() => onUnshield()}
               />
             ) : null}
             <HeaderPill
@@ -406,6 +461,21 @@ export function CryptoPane({
               variant={variant}
             />
           ))}
+          {onUnshield && shieldedRows.length > 0 ? (
+            <>
+              <p className="px-4 pt-4 pb-2 font-semibold text-[16px] text-foreground leading-5">
+                Shielded
+              </p>
+              {shieldedRows.map((row) => (
+                <ShieldedCell
+                  isBalanceHidden={isBalanceHidden}
+                  key={row.mint}
+                  onUnshield={onUnshield}
+                  row={row}
+                />
+              ))}
+            </>
+          ) : null}
         </div>
       </section>
 
@@ -441,7 +511,7 @@ export function CryptoPane({
         {onUnshield ? (
           <button
             className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-secondary p-2.5"
-            onClick={onUnshield}
+            onClick={() => onUnshield()}
             type="button"
           >
             <ThemedIcon

--- a/apps/web/src/components/wallet-workspace/facelift/crypto-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/crypto-pane.tsx
@@ -265,6 +265,7 @@ export function CryptoPane({
   onEarn,
   onSend,
   onSwap,
+  onUnshield,
   rowActions,
   tokenRows,
   variant,
@@ -276,6 +277,8 @@ export function CryptoPane({
   onEarn?: () => void;
   onSend: () => void;
   onSwap: () => void;
+  /** Exit path for legacy shielded balances; only passed when the wallet holds some. */
+  onUnshield?: () => void;
   rowActions: CryptoRowActions;
   tokenRows: TokenRow[];
   variant: CryptoPaneVariant;
@@ -308,6 +311,15 @@ export function CryptoPane({
             </h1>
           </div>
           <div className="flex shrink-0 items-start gap-2 pl-3 max-[795px]:hidden">
+            {onUnshield ? (
+              <HeaderPill
+                hideLabel
+                icon="icon-withdraw-arrow.svg"
+                iconColorClass="text-tertiary"
+                label="Unshield"
+                onClick={onUnshield}
+              />
+            ) : null}
             <HeaderPill
               hideLabel
               icon="icon-arrow-up-circle.svg"
@@ -426,6 +438,21 @@ export function CryptoPane({
             Send
           </span>
         </button>
+        {onUnshield ? (
+          <button
+            className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full bg-secondary p-2.5"
+            onClick={onUnshield}
+            type="button"
+          >
+            <ThemedIcon
+              className="size-6 text-tertiary"
+              src={`${ASSET_BASE}/icon-withdraw-arrow.svg`}
+            />
+            <span className="whitespace-nowrap pr-2.5 font-medium text-[16px] text-foreground leading-5">
+              Unshield
+            </span>
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/wallet-workspace/facelift/unshield-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/unshield-pane.tsx
@@ -6,6 +6,7 @@ import type {
   ShieldedBalance,
   UnshieldResult,
 } from "@loyal-labs/wallet-core/hooks";
+import { ShieldCheck } from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -13,28 +14,40 @@ import {
   ActionProcessingBody,
   ActionSuccessBody,
   formatTokenAmount,
+  formatUsdAmount,
 } from "@/components/wallet-workspace/facelift/action-screens";
+import {
+  ScrambleText,
+  useBalanceVisibility,
+} from "@/components/wallet-workspace/facelift/balance-visibility";
 import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transitions";
+import { SplitAmount } from "@/components/wallet-workspace/facelift/sidebar";
+import { TextSwap } from "@/components/wallet-workspace/facelift/text-swap";
 import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+import { splitUsdBalance } from "@/hooks/use-wallet-desktop-data";
 import { resolveKnownTokenMetadata } from "@/lib/solana/frontend-asset-provider";
 import { getTokenIconUrl } from "@/lib/token-icon";
 
 const ASSET_BASE = "/wallet-workspace/facelift";
 
-type UnshieldRow = {
+// A shielded position resolved for display. Symbol/decimals/price come from
+// the held position when the wallet also holds the token publicly, else the
+// static token tables; unknown mints show the raw base units so a wrong
+// scale never misreads the balance.
+export type ShieldedRow = {
+  amount: number | null;
   amountLabel: string;
   icon: string;
   mint: string;
   symbol: string;
+  usdValue: number | null;
+  valueLabel: string;
 };
 
-// Symbol/decimals come from the held position when the wallet also holds the
-// token publicly; otherwise from the static token tables. Unknown mints fall
-// back to the raw base-unit amount so nothing is misread by a wrong scale.
-function toUnshieldRow(
+export function toShieldedRow(
   balance: ShieldedBalance,
   positions: PortfolioPosition[]
-): UnshieldRow {
+): ShieldedRow {
   const position = positions.find(
     (candidate) => candidate.asset.mint === balance.tokenMint
   );
@@ -51,48 +64,89 @@ function toUnshieldRow(
     position?.asset.decimals ??
     known?.decimals ??
     (staticSymbol ? TOKEN_DECIMALS[staticSymbol] : undefined);
-  const amountLabel =
-    decimals === undefined
-      ? `${balance.amountRaw.toString()} base units`
-      : formatTokenAmount(Number(balance.amountRaw) / 10 ** decimals);
+  const amount =
+    decimals === undefined ? null : Number(balance.amountRaw) / 10 ** decimals;
+  const priceUsd = position?.priceUsd ?? null;
+  const usdValue =
+    amount !== null && priceUsd !== null ? amount * priceUsd : null;
   return {
-    amountLabel,
+    amount,
+    amountLabel:
+      amount === null
+        ? `${balance.amountRaw.toString()} base units`
+        : formatTokenAmount(amount),
     icon:
       position?.asset.imageUrl ?? known?.imageUrl ?? getTokenIconUrl(symbol),
     mint: balance.tokenMint,
     symbol,
+    usdValue,
+    valueLabel: usdValue === null ? "" : `$${formatUsdAmount(usdValue)}`,
   };
 }
 
-// Exit-only screen for the sunset private-transfer program (ASK-2269): one
-// row per shielded token, each unshielding its full balance. Results walk
-// the shared action screens like Send/Swap.
+// Token avatar with the shield badge that marks a balance as still held in
+// the private-transfer program.
+export function ShieldedTokenIcon({
+  icon,
+  size = 11,
+}: {
+  icon: string;
+  size?: 11 | 16;
+}) {
+  const box = size === 16 ? "size-16" : "size-11";
+  const badge = size === 16 ? "size-7" : "size-5";
+  const glyph = size === 16 ? 16 : 12;
+  return (
+    <span className={`relative block shrink-0 ${box}`}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        alt=""
+        className={`${box} rounded-full object-cover`}
+        src={icon}
+      />
+      <span
+        className={`-right-0.5 -bottom-0.5 absolute flex ${badge} items-center justify-center rounded-full bg-card text-foreground ring-2 ring-card`}
+      >
+        <ShieldCheck size={glyph} strokeWidth={2.2} />
+      </span>
+    </span>
+  );
+}
+
+// Exit-only screen for the sunset private-transfer program (ASK-2269): a
+// Send-style confirm for one shielded token at a time — full balance, one
+// signature. Results walk the shared action screens like Send/Swap.
 export function UnshieldPane({
-  balances,
   executeUnshield,
+  initialMint,
   onBack,
   onDone,
   onSuccess,
-  positions,
+  rows,
 }: {
-  balances: ShieldedBalance[];
   executeUnshield: (tokenMint: string) => Promise<UnshieldResult>;
+  initialMint?: string;
   onBack: () => void;
   onDone: () => void;
   onSuccess: () => void;
-  positions: PortfolioPosition[];
+  rows: ShieldedRow[];
 }) {
-  const [step, setStep] = useState<"list" | "processing" | "success" | "error">(
-    "list"
+  const { isBalanceHidden } = useBalanceVisibility();
+  const [step, setStep] = useState<
+    "confirm" | "select" | "processing" | "success" | "error"
+  >("confirm");
+  const [selectedMint, setSelectedMint] = useState<string | null>(
+    initialMint ?? rows[0]?.mint ?? null
   );
-  const [activeRow, setActiveRow] = useState<UnshieldRow | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [txSignature, setTxSignature] = useState<string | null>(null);
 
-  const rows = balances.map((balance) => toUnshieldRow(balance, positions));
+  const row = rows.find((candidate) => candidate.mint === selectedMint) ?? rows[0];
+  const canPickToken = rows.length > 1;
+  const usdSplit = splitUsdBalance(row?.usdValue ?? 0);
 
-  const handleUnshield = async (row: UnshieldRow) => {
-    setActiveRow(row);
+  const handleConfirm = async () => {
+    if (!row) return;
     setTxSignature(null);
     setStep("processing");
     const result = await executeUnshield(row.mint);
@@ -119,7 +173,7 @@ export function UnshieldPane({
           <button
             aria-label="Back"
             className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
-            onClick={onBack}
+            onClick={step === "select" ? () => setStep("confirm") : onBack}
             type="button"
           >
             <ThemedIcon
@@ -130,60 +184,145 @@ export function UnshieldPane({
         </div>
         <div className="flex min-w-0 flex-1 items-center py-2">
           <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
-            Unshield
+            {step === "select" ? "Select asset" : "Unshield"}
           </h1>
         </div>
       </header>
 
       <PaneReveal key={step}>
-        {step === "list" ? (
-          <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
-            <p className="px-4 py-2 text-[13px] leading-4 text-muted-foreground">
-              Shielded balances are being retired. Move each token back to your
-              wallet.
-            </p>
-            {rows.map((row) => (
-              <div
-                className="flex w-full items-center rounded-2xl px-4"
-                key={row.mint}
-              >
-                <div className="flex shrink-0 items-center py-2 pr-3">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    alt=""
-                    className="size-11 rounded-full object-cover"
-                    src={row.icon}
-                  />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
-                  <p className="truncate font-medium text-[16px] text-foreground leading-5">
-                    {row.symbol}
+        {step === "confirm" && row ? (
+          <>
+            <div className="flex min-h-0 w-full flex-1 flex-col">
+              {/* Hero amount (Send's amount block, read-only): the full
+                  shielded balance is what leaves — there is no partial. */}
+              <div className="flex w-full flex-1 flex-col items-center justify-center gap-4 p-8">
+                <ShieldedTokenIcon icon={row.icon} size={16} />
+                <div className="flex flex-col items-center gap-1">
+                  <p className="text-center font-semibold text-[40px] text-foreground leading-[48px] tracking-[-0.4px]">
+                    <ScrambleText
+                      isHidden={isBalanceHidden}
+                      text={`${row.amountLabel} ${row.symbol}`}
+                    />
                   </p>
-                  <p className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
-                    {row.amountLabel} shielded
-                  </p>
+                  {row.usdValue !== null ? (
+                    <p className="text-[16px] leading-5 text-muted-foreground">
+                      <ScrambleText
+                        isHidden={isBalanceHidden}
+                        text={`$${formatUsdAmount(row.usdValue)}`}
+                      />
+                    </p>
+                  ) : null}
                 </div>
+              </div>
+
+              <div className="w-full shrink-0 px-2">
+                <div className="flex w-full items-center justify-between rounded-xl bg-accent px-4 py-2.5">
+                  <span className="text-[13px] leading-4 text-muted-foreground">
+                    Destination
+                  </span>
+                  <span className="text-[13px] text-foreground leading-4">
+                    Your wallet
+                  </span>
+                </div>
+              </div>
+
+              {/* Source cell pinned above the CTA, like Send's asset cell. */}
+              <div className="mt-auto flex w-full shrink-0 flex-col gap-1 p-2">
                 <button
-                  className="t-hover flex shrink-0 items-center justify-center rounded-full bg-foreground px-4 py-2.5 font-medium text-[13px] text-background leading-4 hover:bg-foreground/90"
-                  onClick={() => void handleUnshield(row)}
+                  className={`flex w-full items-center rounded-2xl px-4 text-left ${
+                    canPickToken ? "t-hover hover:bg-accent" : "cursor-default"
+                  }`}
+                  disabled={!canPickToken}
+                  onClick={() => setStep("select")}
                   type="button"
                 >
-                  Unshield
+                  <span className="flex shrink-0 items-center py-2 pr-3">
+                    <ShieldedTokenIcon icon={row.icon} />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-1 py-2">
+                    {row.usdValue !== null ? (
+                      <SplitAmount
+                        fraction={usdSplit.balanceFraction}
+                        isHidden={isBalanceHidden}
+                        isRevealed
+                        whole={usdSplit.balanceWhole}
+                      />
+                    ) : (
+                      <span className="font-medium text-[20px] text-foreground leading-6">
+                        {row.symbol}
+                      </span>
+                    )}
+                    <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+                      <ScrambleText
+                        isHidden={isBalanceHidden}
+                        text={`${row.amountLabel} ${row.symbol} shielded`}
+                      />
+                    </span>
+                  </span>
+                  {canPickToken ? (
+                    <span className="flex shrink-0 items-center py-2 pl-3">
+                      <ThemedIcon
+                        className="size-6 text-muted-foreground"
+                        src={`${ASSET_BASE}/icon-chevron-grabber.svg`}
+                      />
+                    </span>
+                  ) : null}
                 </button>
               </div>
+            </div>
+
+            <div className="w-full shrink-0 bg-card px-4 pt-2 pb-4">
+              <button
+                className="t-hover flex h-12 w-full items-center justify-center rounded-full bg-foreground font-medium text-[16px] text-background leading-5 transition-colors hover:-translate-y-0.5 hover:bg-foreground/90 active:translate-y-0"
+                onClick={() => void handleConfirm()}
+                type="button"
+              >
+                <TextSwap text={`Unshield ${row.symbol}`} />
+              </button>
+            </div>
+          </>
+        ) : step === "select" ? (
+          <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
+            {rows.map((candidate) => (
+              <button
+                className={`t-hover flex w-full items-center rounded-2xl px-4 text-left hover:bg-accent ${
+                  candidate.mint === row?.mint ? "bg-accent" : ""
+                }`}
+                key={candidate.mint}
+                onClick={() => {
+                  setSelectedMint(candidate.mint);
+                  setStep("confirm");
+                }}
+                type="button"
+              >
+                <span className="flex shrink-0 items-center py-2 pr-3">
+                  <ShieldedTokenIcon icon={candidate.icon} />
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
+                  <span className="truncate font-medium text-[16px] text-foreground leading-5">
+                    {candidate.symbol}
+                  </span>
+                  <span className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+                    <ScrambleText
+                      isHidden={isBalanceHidden}
+                      text={`${candidate.amountLabel} ${candidate.symbol}`}
+                    />
+                  </span>
+                </span>
+                {candidate.valueLabel ? (
+                  <span className="shrink-0 pl-3 font-medium text-[16px] text-foreground leading-5">
+                    <ScrambleText
+                      isHidden={isBalanceHidden}
+                      text={candidate.valueLabel}
+                    />
+                  </span>
+                ) : null}
+              </button>
             ))}
           </div>
         ) : step === "processing" ? (
           <ActionProcessingBody
-            icons={
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                alt=""
-                aria-hidden="true"
-                className="size-16 rounded-full object-cover"
-                src={activeRow?.icon}
-              />
-            }
+            icons={<ShieldedTokenIcon icon={row?.icon ?? ""} size={16} />}
             label="Unshielding"
           />
         ) : step === "success" ? (
@@ -198,7 +337,7 @@ export function UnshieldPane({
             message={errorMessage}
             onBack={() => {
               setErrorMessage(null);
-              setStep("list");
+              setStep("confirm");
             }}
           />
         )}

--- a/apps/web/src/components/wallet-workspace/facelift/unshield-pane.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/unshield-pane.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import type { PortfolioPosition } from "@loyal-labs/solana-wallet";
+import { TOKEN_DECIMALS, TOKEN_MINTS } from "@loyal-labs/wallet-core/constants";
+import type {
+  ShieldedBalance,
+  UnshieldResult,
+} from "@loyal-labs/wallet-core/hooks";
+import { useState } from "react";
+
+import {
+  ActionErrorBody,
+  ActionProcessingBody,
+  ActionSuccessBody,
+  formatTokenAmount,
+} from "@/components/wallet-workspace/facelift/action-screens";
+import { PaneReveal } from "@/components/wallet-workspace/facelift/pane-transitions";
+import { ThemedIcon } from "@/components/wallet-workspace/facelift/themed-icon";
+import { resolveKnownTokenMetadata } from "@/lib/solana/frontend-asset-provider";
+import { getTokenIconUrl } from "@/lib/token-icon";
+
+const ASSET_BASE = "/wallet-workspace/facelift";
+
+type UnshieldRow = {
+  amountLabel: string;
+  icon: string;
+  mint: string;
+  symbol: string;
+};
+
+// Symbol/decimals come from the held position when the wallet also holds the
+// token publicly; otherwise from the static token tables. Unknown mints fall
+// back to the raw base-unit amount so nothing is misread by a wrong scale.
+function toUnshieldRow(
+  balance: ShieldedBalance,
+  positions: PortfolioPosition[]
+): UnshieldRow {
+  const position = positions.find(
+    (candidate) => candidate.asset.mint === balance.tokenMint
+  );
+  const known = resolveKnownTokenMetadata(balance.tokenMint)?.descriptor;
+  const staticSymbol = Object.keys(TOKEN_MINTS).find(
+    (symbol) => TOKEN_MINTS[symbol] === balance.tokenMint
+  );
+  const symbol =
+    position?.asset.symbol ??
+    known?.symbol ??
+    staticSymbol ??
+    `${balance.tokenMint.slice(0, 4)}…${balance.tokenMint.slice(-4)}`;
+  const decimals =
+    position?.asset.decimals ??
+    known?.decimals ??
+    (staticSymbol ? TOKEN_DECIMALS[staticSymbol] : undefined);
+  const amountLabel =
+    decimals === undefined
+      ? `${balance.amountRaw.toString()} base units`
+      : formatTokenAmount(Number(balance.amountRaw) / 10 ** decimals);
+  return {
+    amountLabel,
+    icon:
+      position?.asset.imageUrl ?? known?.imageUrl ?? getTokenIconUrl(symbol),
+    mint: balance.tokenMint,
+    symbol,
+  };
+}
+
+// Exit-only screen for the sunset private-transfer program (ASK-2269): one
+// row per shielded token, each unshielding its full balance. Results walk
+// the shared action screens like Send/Swap.
+export function UnshieldPane({
+  balances,
+  executeUnshield,
+  onBack,
+  onDone,
+  onSuccess,
+  positions,
+}: {
+  balances: ShieldedBalance[];
+  executeUnshield: (tokenMint: string) => Promise<UnshieldResult>;
+  onBack: () => void;
+  onDone: () => void;
+  onSuccess: () => void;
+  positions: PortfolioPosition[];
+}) {
+  const [step, setStep] = useState<"list" | "processing" | "success" | "error">(
+    "list"
+  );
+  const [activeRow, setActiveRow] = useState<UnshieldRow | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [txSignature, setTxSignature] = useState<string | null>(null);
+
+  const rows = balances.map((balance) => toUnshieldRow(balance, positions));
+
+  const handleUnshield = async (row: UnshieldRow) => {
+    setActiveRow(row);
+    setTxSignature(null);
+    setStep("processing");
+    const result = await executeUnshield(row.mint);
+    if (result.success) {
+      setTxSignature(result.signature ?? null);
+      onSuccess();
+      setStep("success");
+      return;
+    }
+    setErrorMessage(result.error ?? "Unshield failed. Please try again.");
+    setStep("error");
+  };
+
+  return (
+    <section
+      className={`flex h-full w-full min-w-0 flex-1 flex-col rounded-3xl bg-card max-[795px]:rounded-none ${
+        step === "success" || step === "error"
+          ? "max-[795px]:overflow-clip"
+          : "overflow-clip"
+      }`}
+    >
+      <header className="flex w-full shrink-0 items-center p-2">
+        <div className="flex shrink-0 items-center pr-3">
+          <button
+            aria-label="Back"
+            className="t-hover flex size-11 items-center justify-center rounded-3xl hover:bg-accent"
+            onClick={onBack}
+            type="button"
+          >
+            <ThemedIcon
+              className="size-6 text-muted-foreground"
+              src={`${ASSET_BASE}/icon-arrow-left.svg`}
+            />
+          </button>
+        </div>
+        <div className="flex min-w-0 flex-1 items-center py-2">
+          <h1 className="truncate whitespace-nowrap font-semibold text-[20px] text-foreground leading-6">
+            Unshield
+          </h1>
+        </div>
+      </header>
+
+      <PaneReveal key={step}>
+        {step === "list" ? (
+          <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto p-2">
+            <p className="px-4 py-2 text-[13px] leading-4 text-muted-foreground">
+              Shielded balances are being retired. Move each token back to your
+              wallet.
+            </p>
+            {rows.map((row) => (
+              <div
+                className="flex w-full items-center rounded-2xl px-4"
+                key={row.mint}
+              >
+                <div className="flex shrink-0 items-center py-2 pr-3">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    alt=""
+                    className="size-11 rounded-full object-cover"
+                    src={row.icon}
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-[11px]">
+                  <p className="truncate font-medium text-[16px] text-foreground leading-5">
+                    {row.symbol}
+                  </p>
+                  <p className="whitespace-nowrap text-[13px] leading-4 text-muted-foreground">
+                    {row.amountLabel} shielded
+                  </p>
+                </div>
+                <button
+                  className="t-hover flex shrink-0 items-center justify-center rounded-full bg-foreground px-4 py-2.5 font-medium text-[13px] text-background leading-4 hover:bg-foreground/90"
+                  onClick={() => void handleUnshield(row)}
+                  type="button"
+                >
+                  Unshield
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : step === "processing" ? (
+          <ActionProcessingBody
+            icons={
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                alt=""
+                aria-hidden="true"
+                className="size-16 rounded-full object-cover"
+                src={activeRow?.icon}
+              />
+            }
+            label="Unshielding"
+          />
+        ) : step === "success" ? (
+          <ActionSuccessBody
+            label="Unshielded"
+            onDone={onDone}
+            signature={txSignature}
+            source="unshield_success"
+          />
+        ) : (
+          <ActionErrorBody
+            message={errorMessage}
+            onBack={() => {
+              setErrorMessage(null);
+              setStep("list");
+            }}
+          />
+        )}
+      </PaneReveal>
+    </section>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -537,6 +537,7 @@
       "name": "@loyal-labs/wallet-core",
       "version": "0.1.1",
       "dependencies": {
+        "@loyal-labs/private-transactions": "0.2.11",
         "@loyal-labs/solana-rpc": "workspace:*",
         "@loyal-labs/solana-wallet": "workspace:*",
       },
@@ -1264,6 +1265,8 @@
     "@loyal-labs/loyal-smart-accounts": ["@loyal-labs/loyal-smart-accounts@workspace:packages/loyal-smart-accounts"],
 
     "@loyal-labs/loyal-smart-accounts-core": ["@loyal-labs/loyal-smart-accounts-core@workspace:packages/loyal-smart-accounts-core"],
+
+    "@loyal-labs/private-transactions": ["@loyal-labs/private-transactions@0.2.11", "", { "peerDependencies": { "@coral-xyz/anchor": "^0.32.0", "@magicblock-labs/ephemeral-rollups-sdk": "^0.11.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.95.0" } }, "sha512-bQkNIBix7TZ94ti8mCkTaK8j9DIJVQt/GBe5QVw19nQEDDxyBM31truYJXAweZqZJdG3jlBu9Xq7PySWLbLO6Q=="],
 
     "@loyal-labs/privy-showcase": ["@loyal-labs/privy-showcase@workspace:apps/privy-showcase"],
 

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -41,6 +41,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@loyal-labs/private-transactions": "0.2.11",
     "@loyal-labs/solana-rpc": "workspace:*",
     "@loyal-labs/solana-wallet": "workspace:*"
   },

--- a/packages/wallet-core/src/hooks/index.ts
+++ b/packages/wallet-core/src/hooks/index.ts
@@ -5,6 +5,13 @@ export {
   type SwapQuote,
   type SwapResult,
 } from "./use-swap";
+export {
+  createPrivateTransactionsClient,
+  fetchShieldedBalances,
+  type ShieldedBalance,
+  type UnshieldResult,
+  useUnshield,
+} from "./use-unshield";
 export { useWalletBalances, type TokenBalance } from "./use-wallet-balances";
 export { useSolanaWalletDataClient } from "./use-solana-wallet-data-client";
 export {

--- a/packages/wallet-core/src/hooks/use-unshield.ts
+++ b/packages/wallet-core/src/hooks/use-unshield.ts
@@ -1,0 +1,169 @@
+import {
+  LoyalPrivateTransactionsClient,
+  MAGIC_CONTEXT_ID,
+  MAGIC_PROGRAM_ID,
+  type WalletLike,
+} from "@loyal-labs/private-transactions";
+import {
+  type SolanaEnv,
+  getPerEndpoints,
+  getSolanaEndpoints,
+} from "@loyal-labs/solana-rpc";
+import { PublicKey } from "@solana/web3.js";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { WalletSigner } from "../types/signer";
+
+// Exit-only path for the sunset private-transfer program (ASK-2269). Users
+// still hold shielded balances on-chain; this lets them move funds back to
+// their wallet. Shield / private send are intentionally not exposed.
+//
+// Runs against the deprecated npm tarball `@loyal-labs/private-transactions`
+// 0.2.11 — the source lives in the private legacy repo. Do not add features.
+
+export type ShieldedBalance = {
+  tokenMint: string;
+  /** Raw base-unit amount held in the deposit PDA. */
+  amountRaw: bigint;
+};
+
+export type UnshieldResult = {
+  signature?: string;
+  success: boolean;
+  error?: string;
+};
+
+function cleanSolanaErrorMessage(message: string): string {
+  const logsIndex = message.indexOf("Logs:");
+  return logsIndex === -1 ? message : message.slice(0, logsIndex).trim();
+}
+
+export function createPrivateTransactionsClient(
+  signer: WalletSigner,
+  solanaEnv: SolanaEnv
+): Promise<LoyalPrivateTransactionsClient> {
+  if (!signer.signMessage) {
+    throw new Error("Wallet must support signMessage");
+  }
+  const { rpcEndpoint, websocketEndpoint } = getSolanaEndpoints(solanaEnv);
+  const { perRpcEndpoint, perWsEndpoint } = getPerEndpoints(solanaEnv);
+  const walletLike = {
+    publicKey: signer.publicKey,
+    signTransaction: signer.signTransaction.bind(signer),
+    signAllTransactions: signer.signAllTransactions.bind(signer),
+    signMessage: signer.signMessage.bind(signer),
+  } as unknown as WalletLike;
+  return LoyalPrivateTransactionsClient.fromConfig({
+    signer: walletLike,
+    baseRpcEndpoint: rpcEndpoint,
+    baseWsEndpoint: websocketEndpoint,
+    ephemeralRpcEndpoint: perRpcEndpoint,
+    ephemeralWsEndpoint: perWsEndpoint,
+  });
+}
+
+// Read-only: enumerates non-zero deposits so surfaces can gate the Unshield
+// UI on `balances.length > 0`. Uses the base-layer program (no PER auth).
+export async function fetchShieldedBalances(
+  signer: WalletSigner,
+  solanaEnv: SolanaEnv
+): Promise<ShieldedBalance[]> {
+  const client = await createPrivateTransactionsClient(signer, solanaEnv);
+  const deposits = await client.getAllDepositsByUser(signer.publicKey);
+  return deposits
+    .filter((deposit) => deposit.amount > 0n)
+    .map((deposit) => ({
+      tokenMint: deposit.tokenMint.toBase58(),
+      amountRaw: deposit.amount,
+    }));
+}
+
+export function useUnshield(signer: WalletSigner | null, solanaEnv: SolanaEnv) {
+  const [balances, setBalances] = useState<ShieldedBalance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const clientRef = useRef<LoyalPrivateTransactionsClient | null>(null);
+  const pubkey = signer?.publicKey.toBase58() ?? null;
+
+  const getClient = useCallback(async () => {
+    if (!signer) throw new Error("Wallet not connected");
+    clientRef.current ??= await createPrivateTransactionsClient(
+      signer,
+      solanaEnv
+    );
+    return clientRef.current;
+  }, [signer, solanaEnv]);
+
+  const refreshBalances = useCallback(async () => {
+    if (!signer) {
+      setBalances([]);
+      return;
+    }
+    try {
+      setBalances(await fetchShieldedBalances(signer, solanaEnv));
+    } catch {
+      // Best-effort: a read failure must not hide the wallet.
+      setBalances([]);
+    }
+  }, [signer, solanaEnv]);
+
+  useEffect(() => {
+    clientRef.current = null;
+    void refreshBalances();
+  }, [pubkey, refreshBalances]);
+
+  // Always unshields the full deposit for `tokenMint`: exit-only, so partial
+  // amounts and the Kamino share math they needed are gone.
+  const executeUnshield = useCallback(
+    async (tokenMint: string): Promise<UnshieldResult> => {
+      if (!signer) {
+        return { success: false, error: "Wallet not connected" };
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const client = await getClient();
+        const mint = new PublicKey(tokenMint);
+        const user = signer.publicKey;
+        const [ephemeral, base] = await Promise.all([
+          client.getEphemeralDeposit(user, mint).catch(() => null),
+          client.getBaseDeposit(user, mint).catch(() => null),
+        ]);
+        const amount = ephemeral?.amount ?? base?.amount ?? 0n;
+        if (amount <= 0n) {
+          throw new Error("No shielded balance for this token.");
+        }
+        const plan = await client.buildUnshieldTokensTransactionPlan({
+          tokenMint: mint,
+          amount,
+          user,
+          payer: user,
+          magicProgram: MAGIC_PROGRAM_ID,
+          magicContext: MAGIC_CONTEXT_ID,
+        });
+        const result = await client.executeUnshieldTokensTransactionPlan({
+          plan,
+        });
+        await refreshBalances();
+        return {
+          success: true,
+          signature: result.signatures[result.signatures.length - 1]?.signature,
+        };
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message.includes("User rejected")
+              ? "Transaction was rejected in your wallet."
+              : cleanSolanaErrorMessage(err.message)
+            : "Unshield failed";
+        setError(message);
+        return { success: false, error: message };
+      } finally {
+        setLoading(false);
+      }
+    },
+    [signer, getClient, refreshBalances]
+  );
+
+  return { balances, refreshBalances, executeUnshield, loading, error };
+}

--- a/packages/wallet-core/src/hooks/use-unshield.ts
+++ b/packages/wallet-core/src/hooks/use-unshield.ts
@@ -1,4 +1,5 @@
 import {
+  enumerateDepositsByUser,
   LoyalPrivateTransactionsClient,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
@@ -9,7 +10,7 @@ import {
   getPerEndpoints,
   getSolanaEndpoints,
 } from "@loyal-labs/solana-rpc";
-import { PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { WalletSigner } from "../types/signer";
@@ -63,13 +64,19 @@ export function createPrivateTransactionsClient(
 }
 
 // Read-only: enumerates non-zero deposits so surfaces can gate the Unshield
-// UI on `balances.length > 0`. Uses the base-layer program (no PER auth).
+// UI on `balances.length > 0`. Deliberately does NOT build the SDK client:
+// `fromConfig` performs PER auth (a wallet `signMessage` prompt) against the
+// TEE endpoint, which must only happen when the user actually unshields.
+// Base-layer enumeration already includes delegated deposits.
 export async function fetchShieldedBalances(
-  signer: WalletSigner,
+  user: PublicKey,
   solanaEnv: SolanaEnv
 ): Promise<ShieldedBalance[]> {
-  const client = await createPrivateTransactionsClient(signer, solanaEnv);
-  const deposits = await client.getAllDepositsByUser(signer.publicKey);
+  const { rpcEndpoint } = getSolanaEndpoints(solanaEnv);
+  const deposits = await enumerateDepositsByUser({
+    user,
+    baseConnection: new Connection(rpcEndpoint, "confirmed"),
+  });
   return deposits
     .filter((deposit) => deposit.amount > 0n)
     .map((deposit) => ({
@@ -100,7 +107,7 @@ export function useUnshield(signer: WalletSigner | null, solanaEnv: SolanaEnv) {
       return;
     }
     try {
-      setBalances(await fetchShieldedBalances(signer, solanaEnv));
+      setBalances(await fetchShieldedBalances(signer.publicKey, solanaEnv));
     } catch {
       // Best-effort: a read failure must not hide the wallet.
       setBalances([]);


### PR DESCRIPTION
Restores an unshield-only exit path on mobile, web, and extension for the ~78 wallets that still hold shielded balances in the sunset private-transfer program, using the deprecated npm tarball @loyal-labs/private-transactions@0.2.11 rather than restoring source. The Unshield entry is gated on a signer-less on-chain balance read, so wallets without deposits see nothing new (ASK-2269).