### PR TITLE
feat(web): bnb chain deposits and automatic preview domains

### DIFF
--- a/.github/workflows/preview-domain.yml
+++ b/.github/workflows/preview-domain.yml
@@ -1,0 +1,48 @@
+name: Preview Domain
+
+# Every open PR gets <branch>.preview.askloyal.com pinned to its branch on the
+# loyal-frontend Vercel project (a Privy-allowed origin; *.vercel.app is not).
+# Wildcard DNS + cert for *.preview.askloyal.com already exist, so attaching
+# the domain is the only step. Removed when the PR closes.
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  domain:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_TEAM_ID: team_CWDtWDIyqqcfgsOfzt4AWU5w
+      VERCEL_PROJECT: loyal-frontend
+      BRANCH: ${{ github.head_ref }}
+    steps:
+      - name: Attach or remove branch preview domain
+        run: |
+          set -euo pipefail
+          # Vercel branch domains are lowercase hostnames; branch names are not.
+          name="$(tr '[:upper:]' '[:lower:]' <<<"$BRANCH" | tr -c 'a-z0-9-\n' '-' | cut -c1-63 | sed 's/-*$//')"
+          domain="${name}.preview.askloyal.com"
+          api="https://api.vercel.com"
+          auth=(-H "Authorization: Bearer $VERCEL_TOKEN")
+
+          if [[ "${{ github.event.action }}" == "closed" ]]; then
+            code="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "${auth[@]}" \
+              "$api/v9/projects/$VERCEL_PROJECT/domains/$domain?teamId=$VERCEL_TEAM_ID")"
+            echo "delete $domain -> $code"
+            [[ "$code" == "200" || "$code" == "404" ]]
+            exit 0
+          fi
+
+          code="$(curl -s -o /tmp/out.json -w '%{http_code}' -X POST "${auth[@]}" \
+            -H 'content-type: application/json' \
+            -d "{\"name\":\"$domain\",\"gitBranch\":\"$BRANCH\"}" \
+            "$api/v10/projects/$VERCEL_PROJECT/domains?teamId=$VERCEL_TEAM_ID")"
+          echo "add $domain -> $code"
+          # 409: already attached (reopened PR) — fine.
+          [[ "$code" == "200" || "$code" == "409" ]] || { cat /tmp/out.json; exit 1; }
+          echo "::notice::Preview: https://$domain"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -71,13 +71,23 @@ session cookie is issued.
 
 `/api/funding/evm-deposit-address` returns a permanent `0x` address per
 embedded Solana wallet (stored on `app_user_wallets.evm_deposit_address`).
-USDC/USDT/ETH sent there on Ethereum, Base, Arbitrum or Polygon is bridged by
-Privy and delivered as USDC to the user's Solana wallet; the app pays bridge
-gas (Privy dashboard: swaps + app-pays sponsorship on those chains). First
-call is two-step: `GET` returns the Privy request to sign, the browser signs it
-with the user's Privy key (`useAuthorizationSignature`), `POST` forwards the
-signature. External wallets get 409. UI: Receive sheet → "Other chains". The HttpOnly wallet session cookie uses a 7 day TTL
-and refreshes locally once it is at least 24 hours old.
+USDC/USDT/ETH sent there on Ethereum, Base, Arbitrum, Polygon or BNB Chain
+(`bsc`) is bridged by Privy and delivered as USDC to the user's Solana wallet;
+the app pays bridge gas (Privy dashboard: swaps + app-pays sponsorship on
+those chains). First call is two-step: `GET` returns the Privy request to
+sign, the browser signs it with the user's Privy key
+(`useAuthorizationSignature`), `POST` forwards the signature. External wallets
+get 409. UI: Receive sheet → "Other chains".
+
+Adding a chain: enable app-pays sponsorship for it in the Privy dashboard,
+add it to `EVM_DEPOSIT_CHAINS` (and `CHAIN_LABELS` in the receive sheet).
+Existing addresses do not pick up new chains by themselves: all deposit
+addresses share one app-level Privy wallet automation
+(`GET /v1/wallet_automations`), so `PATCH` its `config.trigger.assets.values`
+with the new chain/asset pairs once (done for BNB on 2026-09-04).
+
+The HttpOnly wallet session cookie uses a 7 day TTL and refreshes locally once
+it is at least 24 hours old.
 
 ## Development
 

--- a/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
+++ b/apps/web/src/components/wallet-workspace/facelift/receive-sheet.tsx
@@ -13,12 +13,13 @@ import { useEvmDepositAddress } from "@/components/wallet-workspace/facelift/use
 const ASSET_BASE = "/wallet-workspace/facelift";
 const TABS = ["Solana", "Other chains"] as const;
 type Tab = (typeof TABS)[number];
-const EVM_CHAIN_FALLBACK = ["ethereum", "base", "arbitrum", "polygon"];
+const EVM_CHAIN_FALLBACK = ["ethereum", "base", "arbitrum", "polygon", "bsc"];
 const CHAIN_LABELS: Record<string, string> = {
   ethereum: "Ethereum",
   base: "Base",
   arbitrum: "Arbitrum",
   polygon: "Polygon",
+  bsc: "BNB Chain",
 };
 
 // Facelift take on the OG Receive view (receive-content.tsx): Solana-only

--- a/apps/web/src/features/funding/server/evm-deposit.ts
+++ b/apps/web/src/features/funding/server/evm-deposit.ts
@@ -18,16 +18,19 @@ export const EVM_DEPOSIT_CHAINS = [
   "base",
   "arbitrum",
   "polygon",
+  "bsc", // Privy's alias for BNB Chain (eip155:56)
 ] as const;
 export const EVM_DEPOSIT_ASSETS = ["usdc", "usdt", "eth"] as const;
 // Ethereum L1 gas can spike to a few dollars per deposit; below this the
 // bridge eats the deposit. L2s are ~$0.01, no floor there.
 export const EVM_DEPOSIT_MIN_USD_ETHEREUM = 20;
 
-// Privy rejects eth on polygon; everything else is accepted on every chain.
+// Privy rejects eth where it is not the native coin; everything else is
+// accepted on every chain.
+const NO_ETH_CHAINS = new Set<string>(["polygon", "bsc"]);
 const SOURCE_ASSETS = EVM_DEPOSIT_CHAINS.flatMap((chain) =>
   EVM_DEPOSIT_ASSETS.filter(
-    (asset) => !(asset === "eth" && chain === "polygon")
+    (asset) => !(asset === "eth" && NO_ETH_CHAINS.has(chain))
   ).map((asset) => ({ asset, chain }))
 );
 


### PR DESCRIPTION
Adds BNB Chain (bsc) to the other-chains deposit address (USDC/USDT; the shared Privy automation was patched live), and a workflow that attaches <branch>.preview.askloyal.com to every PR (needs VERCEL_TOKEN repo secret).