### PR TITLE
docs(web): add main-only preview comparison baseline

### DIFF
--- a/apps/web/PREVIEW_BASELINE.md
+++ b/apps/web/PREVIEW_BASELINE.md
@@ -1,0 +1,14 @@
+# Main preview comparison
+
+This documentation-only branch deploys application code identical to `main` at
+`0d7e44a1b2721eeed4a2c964a53a0609561497b5` for comparison with PR #708 under
+Vercel's existing preview configuration. No application code, dependencies, or
+environment settings are changed.
+
+The file lives under `apps/web` so Vercel's unchanged ignored-build rule sees a
+web workspace change. This is a temporary diagnostic PR, not a feature to merge.
+
+Compare the same flow on production, this main-based preview, and the #708
+preview. Preview currently shares production databases and Solana mainnet;
+transactions are real, not sandboxed. Browser wallet permissions and sessions
+remain origin-specific and must also be considered when comparing behavior.


### PR DESCRIPTION
Create a temporary control preview using application code identical to main at 0d7e44a1b2721eeed4a2c964a53a0609561497b5, to distinguish #708 regressions from existing preview-environment issues; the only change is an apps/web documentation marker so the normal Vercel build runs, with no env changes. Verified the single-file diff, formatting and commitlint; after preview deployment compare the same flows against production and #708, remembering preview still uses production databases/mainnet, then close this diagnostic PR without merging.