### PR TITLE
fix(earn): distinguish inactive policies from pending withdrawals

### DIFF
--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
@@ -109,6 +109,8 @@ let currentSnapshot = holdingsSnapshot([
 let prepareCalls: Record<string, unknown>[] = [];
 let policyLookupCount = 0;
 let policyMissesRemaining = 0;
+let inactivePolicy = false;
+let snapshotCalls = 0;
 
 mock.module("@/features/identity/server/auth-session", () => ({
   resolveAuthenticatedPrincipalFromRequest: async () => currentPrincipal,
@@ -148,7 +150,10 @@ mock.module("@/lib/yield-optimization/deployment-policy-signer.server", () => ({
 }));
 
 mock.module("@/lib/yield-optimization/earn-rpc-holdings.client", () => ({
-  fetchEarnRpcHoldingsSnapshot: async () => currentSnapshot,
+  fetchEarnRpcHoldingsSnapshot: async () => {
+    snapshotCalls += 1;
+    return currentSnapshot;
+  },
 }));
 
 mock.module(
@@ -179,6 +184,7 @@ mock.module(
 );
 
 mock.module("@/lib/yield-optimization/yield-deposit-repository.server", () => ({
+  hasInactiveYieldRoutePolicyForVault: async () => inactivePolicy,
   findActiveYieldRoutePolicyPair: async () => {
     policyLookupCount += 1;
     if (policyMissesRemaining > 0) {
@@ -233,6 +239,8 @@ describe("Earn withdrawal prepare route", () => {
     prepareCalls = [];
     policyLookupCount = 0;
     policyMissesRemaining = 0;
+    inactivePolicy = false;
+    snapshotCalls = 0;
   });
 
   test("max drains only the exact selected source", async () => {
@@ -331,11 +339,34 @@ describe("Earn withdrawal prepare route", () => {
     expect(response.headers.get("retry-after")).toBe("1");
     expect(payload.error.code).toBe("earn_policy_projection_pending");
     expect(policyLookupCount).toBe(5);
+    expect(prepareCalls).toHaveLength(0);
+  });
+
+  test("rejects an inactive policy without preparing a transaction or suggesting retry", async () => {
+    const { POST } = await import("./route");
+    currentPolicy = null;
+    inactivePolicy = true;
+
+    const response = await POST(
+      createRequest({
+        amountRaw: "max",
+        sourceId: `reserve:${activePosition.currentReserve}`,
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("retry-after")).toBeNull();
+    expect(payload.error.code).toBe("earn_policy_inactive");
+    expect(snapshotCalls).toBe(0);
+    expect(prepareCalls).toHaveLength(0);
   });
 
   test("recovers when LaserStream projects the policy during the retry window", async () => {
     const { POST } = await import("./route");
     policyMissesRemaining = 1;
+    // A previous closed generation must not override newly projected setup.
+    inactivePolicy = true;
 
     const response = await POST(
       createRequest({

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -1703,6 +1703,13 @@ export function useEarnActions(deps: {
           });
         } else if (error instanceof EarnPrepareRequestError) {
           tracker.fail("prepare", getEarnPrepareLifecycleDiagnostics(error));
+          if (error.code === "earn_policy_inactive") {
+            // Another tab/device may have completed full-exit cleanup. Re-read
+            // authoritative state; don't optimistically erase a newer deposit.
+            void refreshAllEarnResources().catch(() => {
+              console.warn("[earn-sync] inactive policy refresh failed");
+            });
+          }
         } else {
           tracker.fail("wallet_submit_confirm", {
             errorCode: "unexpected_error",
@@ -1743,6 +1750,7 @@ export function useEarnActions(deps: {
       ensureCanSignAccountAction,
       expectEarnTransaction,
       prepareEarnWithdrawInBrowser,
+      refreshAllEarnResources,
       registerExpectedEarnMutation,
       requestApproval,
       setAutodepositOverride,

--- a/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-withdraw-input-resolution.server.ts
@@ -22,6 +22,7 @@ import type {
 } from "@/lib/yield-optimization/earn-withdraw-prepare-contracts.shared";
 import {
   findActiveYieldRoutePolicyPair,
+  hasInactiveYieldRoutePolicyForVault,
   type RoutePolicyRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
@@ -434,6 +435,23 @@ export async function resolveEarnUsdcWithdrawInput(args: {
     }
   }
   if (!policyResult?.routePolicy) {
+    // A completed cleanup is not projection lag. Keep the retry window above
+    // for new setups, but never tell a stale client to retry an inactive vault.
+    if (
+      await hasInactiveYieldRoutePolicyForVault({
+        authority: walletAddress,
+        cluster,
+        settings: settingsPda,
+        vaultIndex: EARN_DEPOSIT_VAULT_INDEX,
+        vaultPubkey: earnVaultPda.toBase58(),
+      })
+    ) {
+      throw new EarnWithdrawResolveError(
+        409,
+        "earn_policy_inactive",
+        "This Earn policy is no longer active. Refresh Earn before withdrawing."
+      );
+    }
     console.warn(`[${logTag}] Earn policy projection still pending`, {
       cluster,
       settings: settingsPda,

--- a/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -9,7 +9,7 @@ import {
   type YieldRouteSetupPolicyPlan,
 } from "@loyal-labs/actions";
 import { PublicKey } from "@solana/web3.js";
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 
 import {
   earnDepositOnboardingAttempts,
@@ -3324,6 +3324,42 @@ export async function findActiveYieldRoutePolicyPair(
     routePolicy,
     setupPolicy: setupPolicy ?? null,
   };
+}
+
+// Only inspect the vault's current policy pointer, not historical policy
+// generations: an old closed policy must not classify a new setup as inactive.
+export async function hasInactiveYieldRoutePolicyForVault(
+  input: {
+    authority: string;
+    cluster: string;
+    settings: string;
+    vaultIndex: number;
+    vaultPubkey: string;
+  },
+  dependencies: Pick<YieldDepositRepositoryDependencies, "client"> = {
+    client: getYieldOptimizationClient(),
+  }
+): Promise<boolean> {
+  const rows = await dependencies.client.db
+    .select({ id: managedVaults.id })
+    .from(managedVaults)
+    .innerJoin(routePolicies, eq(routePolicies.id, managedVaults.activePolicyId))
+    .where(
+      and(
+        eq(managedVaults.settings, input.settings),
+        eq(managedVaults.vaultIndex, input.vaultIndex),
+        eq(managedVaults.vaultPubkey, input.vaultPubkey),
+        eq(routePolicies.authority, input.authority),
+        // The yield-owned cluster column is not in the app's partial model.
+        sql`${routePolicies}.cluster = ${normalizeLoyalCluster(input.cluster)}`,
+        eq(routePolicies.settings, input.settings),
+        eq(routePolicies.vaultIndex, input.vaultIndex),
+        eq(routePolicies.vaultPubkey, input.vaultPubkey),
+        or(eq(managedVaults.active, false), eq(routePolicies.active, false))
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 export async function findEarnCleanupVaultState(

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -1,0 +1,30 @@
+# Withdrawal preparation and inactive policies
+
+Withdrawal preparation retries the active route-policy projection five times
+(over 1.85 seconds of backoff). If no active pair appears, it checks the requested
+vault's current policy pointer, scoped to authenticated authority, cluster,
+settings, vault index, and vault address—not historical policy generations.
+
+- An inactive vault or current route policy returns HTTP 409 with
+  `earn_policy_inactive`, without a `Retry-After` header or transaction preparation.
+  The web withdrawal handler invalidates Earn state, position, transactions, and
+  earnings so another tab/device's completed cleanup does not leave stale state.
+  It does not optimistically clear holdings or assume there is no newer deposit.
+- Missing projection without evidence of inactivity retains HTTP 503 with
+  `earn_policy_projection_pending` and `Retry-After: 1`.
+- A policy that becomes active during backoff proceeds using live RPC holdings.
+
+This classification is shared by web and mobile preparation routes. Inactivity
+is a read-model observation, not proof that the vault has no on-chain funds.
+No database repair, policy reactivation, or fund movement is performed.
+
+Regression check:
+
+```sh
+cd apps/web
+bun test src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
+```
+
+After deployment, try withdrawing from a stale tab after a full-exit cleanup:
+expect the inactive-policy message and refreshed Earn state, not a retry loop.
+Verify a fresh deposit can still prepare a withdrawal after projection catches up.


### PR DESCRIPTION
Fixes “The confirmed Earn policy is still updating. Retry this withdrawal.” after completed cleanup (ASK-2186): shared withdrawal preparation now distinguishes the authenticated vault’s inactive current policy from missing projection, returns 409 without transaction preparation, and refreshes web Earn state while preserving genuine projection retries; no migrations or production writes.

Verified 27 focused tests, scoped web lint, web tsc --noEmit, commitlint, and a read-only production inactivity probe; the pre-push build hook was bypassed with SKIP_VERIFY=1 to respect the no-local-frontend-build rule, so wait for Vercel before merging and then smoke-test stale-tab withdrawal after cleanup and fresh-deposit withdrawal.