### PR TITLE
fix(earn): clear stale positions after proven full exit

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -188,6 +188,7 @@ export default function EarnScreen() {
     position,
     holdings,
     policyMissing: earnPolicyMissing,
+    reconciliationKey,
     hasLoaded: earnPositionLoaded,
     refreshEarnPosition,
     markEarnMutation,
@@ -206,7 +207,7 @@ export default function EarnScreen() {
   // Withdrawal sources (reserves + idle vault USDC) — fetched lazily when the
   // user opens withdraw; drives the source picker.
   const { sources: withdrawSources, refreshSources: refreshWithdrawSources } =
-    useEarnWithdrawSources(walletAddress);
+    useEarnWithdrawSources(walletAddress, reconciliationKey, position !== null && Number(position.currentAmountRaw) > 0);
   // Per-position breakdown for the positions sheet, derived from the live
   // on-chain holdings (the same read that drives the headline) so it matches the
   // web instead of the stale DB withdraw-sources read. Display-only — the
@@ -449,6 +450,8 @@ export default function EarnScreen() {
   useEffect(() => {
     // Wait for the first real fetch so we don't clear during initial load.
     if (!earnPositionLoaded) {
+      setDepositedUsd(null);
+      setHasDeposit(false);
       return;
     }
     const raw = position ? Number(position.currentAmountRaw) : 0;
@@ -618,7 +621,8 @@ export default function EarnScreen() {
         if (!signer || !isWalletUnlocked(state)) {
           throw new Error("Unlock your wallet to deposit.");
         }
-        await executeEarnDeposit({
+        markEarnMutation({ pendingDeposit: true });
+        const deposit = await executeEarnDeposit({
           signer,
           amountUsd,
           mint,
@@ -627,16 +631,15 @@ export default function EarnScreen() {
         // Trust the read-model for the next reads — confirmEarnDeposit (inside
         // executeEarnDeposit, just awaited) wrote it with the deposited total, so
         // the next `/state` read is correct immediately while live `/holdings` lags.
-        markEarnMutation();
+        markEarnMutation({ confirmedDeposit: {
+          amountRaw: String(Math.round(((depositedUsd ?? 0) + amountUsd) * 1e6)),
+          observedSlot: deposit.confirmedSlot,
+        } });
         // The confirm also records quest progress — check now so a completion
         // celebrates immediately instead of on the watcher's next poll tick.
         nudgeQuestProgressCheck();
-        // Reveal the funded layout immediately. The optimistic total (prior balance
-        // + deposit; correct for top-ups too) bridges the network round-trip until
-        // the refresh lands the reconciled read-model value (= the same total).
-        const expectedUsd = (depositedUsd ?? 0) + amountUsd;
-        setDepositedUsd(expectedUsd);
-        setHasDeposit(true);
+        // The owning hook installs the confirmed optimistic amount and slot;
+        // the screen mirrors only that accepted state, never a second overlay.
         try {
           // Mutation metrics require the reads that drive the visible Earn state.
           // Ambient refresh remains best-effort, but this path must distinguish a
@@ -653,6 +656,7 @@ export default function EarnScreen() {
           void requestRefresh("mutation");
         }
       } catch (error) {
+        markEarnMutation();
         metric.failAfterPaint();
         throw error;
       }
@@ -737,12 +741,8 @@ export default function EarnScreen() {
         // read, which lags HIGH right after a withdraw (funds still in the obligation
         // mid-redeem). This keeps the balance from briefly bouncing back up.
         markEarnMutation();
-        // Optimistic clear only when this empties the whole position (single
-        // source); for multi-source the read-model refresh reconciles the rest.
-        if (mode === "full" && withdrawSources.length <= 1) {
-          setHasDeposit(false);
-          setDepositedUsd(null);
-        }
+        // Only the accepted read/proof may clear the position. A source count
+        // cannot prove that no other product or newer deposit remains.
         try {
           await Promise.all([
             refreshEarnPosition({ throwOnError: true }),
@@ -763,7 +763,6 @@ export default function EarnScreen() {
     [
       signer,
       state,
-      withdrawSources,
       markEarnMutation,
       requestRefresh,
       refreshAutodeposit,
@@ -1228,7 +1227,7 @@ export default function EarnScreen() {
         open={withdrawOpen}
         onClose={handleCloseWithdraw}
         onWithdraw={handleWithdrawConfirmed}
-        availableUsdc={depositedUsd}
+        availableUsdc={position ? depositedUsd ?? 0 : 0}
         sources={withdrawSources}
       />
 

--- a/apps/mobile/app/(tabs)/wallet.tsx
+++ b/apps/mobile/app/(tabs)/wallet.tsx
@@ -94,6 +94,7 @@ export default function WalletScreen() {
     isLoading: isEarnLoading,
     hasLoaded: earnLoaded,
     refreshEarnPosition,
+    markEarnMutation,
   } = useEarnPosition(walletAddress);
   // The Earn balance reads from a lagging read-model, so skeleton the card's
   // figure until a read settles (and again while one is in flight) instead of
@@ -344,13 +345,23 @@ export default function WalletScreen() {
       if (!signer || !isWalletUnlocked(state)) {
         throw new Error("Unlock your wallet to deposit.");
       }
-      await executeEarnDeposit({ signer, amountUsd, mint });
+      markEarnMutation({ pendingDeposit: true });
+      try {
+        const deposit = await executeEarnDeposit({ signer, amountUsd, mint });
+        markEarnMutation({ confirmedDeposit: {
+          amountRaw: (BigInt(earnPosition?.currentAmountRaw ?? "0") + BigInt(Math.round(amountUsd * 1e6))).toString(),
+          observedSlot: deposit.confirmedSlot,
+        } });
+      } catch (error) {
+        markEarnMutation();
+        throw error;
+      }
       void refreshEarnPosition();
       // The confirm also records quest progress — check now so a completion
       // celebrates immediately instead of on the watcher's next poll tick.
       nudgeQuestProgressCheck();
     },
-    [signer, state, refreshEarnPosition],
+    [signer, state, earnPosition, markEarnMutation, refreshEarnPosition],
   );
 
   const showTopUpAction = useMemo(

--- a/apps/mobile/src/hooks/wallet/__tests__/useEarnPosition-lifecycle.test.ts
+++ b/apps/mobile/src/hooks/wallet/__tests__/useEarnPosition-lifecycle.test.ts
@@ -1,0 +1,216 @@
+import { useEarnPosition } from "../useEarnPosition";
+import { useEarnWithdrawSources } from "../useEarnWithdrawSources";
+import type {
+  EarnHoldingsResponse,
+  EarnPosition,
+  EarnStateResponse,
+  EarnWithdrawSourceInfo,
+} from "@/lib/solana/earn/earn-api";
+
+// Run both owning hooks, substituting only React scheduling and HTTP. This
+// protects the money-movement invariant: a closed generation cannot supply a
+// replacement deposit's headline, cost basis, details or withdrawal source.
+let cells: unknown[] = [];
+let cursor = 0;
+let effects: (() => void)[] = [];
+const changed = (a: unknown[] | undefined, b: unknown[]) =>
+  !a || a.length !== b.length || a.some((value, i) => !Object.is(value, b[i]));
+jest.mock("react", () => ({
+  useRef<T>(value: T) {
+    const i = cursor++;
+    return (cells[i] ??= { current: value }) as { current: T };
+  },
+  useState<T>(value: T) {
+    const i = cursor++;
+    if (!(i in cells)) cells[i] = value;
+    return [
+      cells[i],
+      (next: T | ((previous: T) => T)) => {
+        cells[i] =
+          typeof next === "function"
+            ? (next as (previous: T) => T)(cells[i] as T)
+            : next;
+      },
+    ];
+  },
+  useCallback<T>(fn: T, deps: unknown[]) {
+    const i = cursor++;
+    const old = cells[i] as { fn: T; deps: unknown[] } | undefined;
+    if (!old || changed(old.deps, deps)) cells[i] = { fn, deps };
+    return (cells[i] as { fn: T }).fn;
+  },
+  useEffect(fn: () => void | (() => void), deps: unknown[]) {
+    const i = cursor++;
+    type Effect = { deps: unknown[]; cleanup?: void | (() => void) };
+    const old = cells[i] as Effect | undefined;
+    if (!old || changed(old.deps, deps)) {
+      const cell: Effect = { deps };
+      cells[i] = cell;
+      effects.push(() => {
+        old?.cleanup?.();
+        cell.cleanup = fn();
+      });
+    }
+  },
+}));
+jest.mock("@/config/env", () => ({ env: { solanaEnv: "mainnet" } }));
+let stateRead: () => Promise<EarnStateResponse>;
+let holdingsRead: () => Promise<EarnHoldingsResponse>;
+let sourceRows: EarnWithdrawSourceInfo[] = [];
+jest.mock("@/lib/solana/earn/earn-api", () => ({
+  fetchEarnState: () => stateRead(),
+  fetchEarnHoldings: () => holdingsRead(),
+  fetchEarnWithdrawSources: async () => ({ sources: sourceRows }),
+}));
+
+let walletId = 0;
+let output: ReturnType<typeof useEarnPosition> &
+  ReturnType<typeof useEarnWithdrawSources>;
+const render = Harness;
+function Harness() {
+  cursor = 0;
+  const owner = useEarnPosition(`lifecycle-wallet-${walletId}`);
+  const sources = useEarnWithdrawSources(
+    `lifecycle-wallet-${walletId}`,
+    owner.reconciliationKey,
+    owner.position !== null
+  );
+  output = { ...owner, ...sources };
+  const pending = effects;
+  effects = [];
+  pending.forEach((fn) => fn());
+}
+async function flush() {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+  render();
+}
+const position = (): EarnPosition => ({
+  currentAmountRaw: "100000000",
+  principalAmountRaw: "100000000",
+  currentObservedSlot: "500",
+  currentSupplyApyBps: null,
+  status: "active",
+});
+const state = (
+  value: EarnPosition | null = position(),
+  closed: string | null = null
+): EarnStateResponse => ({
+  position: value,
+  closedPositionObservedSlot: closed,
+  cluster: "mainnet-beta",
+  settingsPda: "settings-A",
+  smartAccountAddress: "vault-A",
+});
+const holdings = (
+  amount = "100000000",
+  slot: string | null = "500",
+  settings = "settings-A"
+): EarnHoldingsResponse => ({
+  currentTotalAmountRaw: amount,
+  observedSlot: slot,
+  observedAt: slot === null ? null : "2026-09-11T00:00:00Z",
+  settingsPda: settings,
+  smartAccountAddress: "vault-A",
+  holdings:
+    amount === "0"
+      ? []
+      : [
+          {
+            kind: "idle",
+            amountRaw: amount,
+            label: "USDC",
+            liquidityMint: "USDC",
+            market: null,
+            marketName: null,
+            reserve: null,
+          },
+        ],
+});
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-09-11T12:00:00Z"));
+  walletId++;
+  cells = [];
+  cursor = 0;
+  effects = [];
+  stateRead = async () => state();
+  holdingsRead = async () => holdings();
+  sourceRows = [
+    {
+      type: "idle",
+      id: "old-source",
+      amountRaw: "100000000",
+      label: "USDC",
+      liquidityMint: "USDC",
+      market: null,
+      reserve: null,
+      tokenAccount: "old-token-account",
+    },
+  ];
+});
+afterEach(() => jest.useRealTimers());
+
+async function refresh() {
+  await output.refreshEarnPosition();
+  await flush();
+}
+
+test("delayed closure cannot keep old headline/details/sources over newer funds", async () => {
+  render();
+  await flush();
+  await output.refreshSources();
+  await flush();
+  expect(output.sources[0].id).toBe("old-source");
+  stateRead = async () => state(null, "600");
+  holdingsRead = async () => holdings("25000000", "700");
+  await refresh();
+  await refresh();
+  expect(output.position?.currentAmountRaw).toBe("25000000");
+  expect(output.position?.principalAmountRaw).toBeNull();
+  expect(output.holdings.map((row) => row.amountRaw)).toEqual(["25000000"]);
+  expect(output.sources).toEqual([]);
+});
+
+test("accepted closure allows a later funded snapshot despite older accounting", async () => {
+  stateRead = async () => state(null, "600");
+  holdingsRead = async () => holdings("0", null);
+  render();
+  await flush();
+  expect(output.position).toBeNull();
+  stateRead = async () => state();
+  holdingsRead = async () => holdings("25000000", "700");
+  await refresh();
+  expect(output.position?.currentAmountRaw).toBe("25000000");
+  expect(output.position?.principalAmountRaw).toBeNull();
+  // A subsequent stale response still cannot resurrect the closed 100.
+  holdingsRead = async () => holdings("100000000", "500");
+  await refresh();
+  expect(output.position?.currentAmountRaw).toBe("25000000");
+});
+
+for (const [label, snapshot] of [
+  ["foreign scope", () => holdings("25000000", "700", "settings-other")],
+  ["same-slot funds", () => holdings("25000000", "600")],
+  ["unobserved funds", () => holdings("25000000", null)],
+] as const) {
+  test(`${label} cannot defeat a proven closure`, async () => {
+    render();
+    await flush();
+    stateRead = async () => state(null, "600");
+    holdingsRead = async () => snapshot();
+    await refresh();
+    expect(output.position).toBeNull();
+    expect(output.holdings).toEqual([]);
+  });
+}
+
+test("RPC failure is not closure evidence and retains funded state", async () => {
+  render();
+  await flush();
+  stateRead = async () => state(null);
+  holdingsRead = async () => {
+    throw new Error("offline");
+  };
+  await refresh();
+  expect(output.position?.currentAmountRaw).toBe("100000000");
+});

--- a/apps/mobile/src/hooks/wallet/useEarnPosition.ts
+++ b/apps/mobile/src/hooks/wallet/useEarnPosition.ts
@@ -186,13 +186,69 @@ export function useEarnPosition(walletAddress: string | null) {
         // A wallet prompt/pending deposit is not an empty lifecycle. No response
         // started before the mutation may commit, even if it finishes afterwards.
         if (pendingDepositRef.current || scopedMutation?.pending) return;
-        if (proofSlot !== null) {
-          closedSlots.set(
-            scope,
-            closedSlot !== null && closedSlot > proofSlot
-              ? closedSlot
-              : proofSlot
+        const closureFloor =
+          proofSlot !== null && (closedSlot === null || proofSlot > closedSlot)
+            ? proofSlot
+            : closedSlot;
+        if (closureFloor !== null) closedSlots.set(scope, closureFloor);
+        const accountingFresh =
+          state.position !== null &&
+          (closureFloor === null ||
+            (nextSlot !== null && nextSlot > closureFloor)) &&
+          (currentSlot === null ||
+            (nextSlot !== null && nextSlot >= currentSlot));
+        // The two endpoints can observe different lifecycles. Evaluate funded
+        // RPC evidence BEFORE rejecting older/null accounting, otherwise a
+        // replacement deposit stays hidden (or keeps the old withdrawal source).
+        if (
+          !accountingFresh &&
+          live &&
+          liveSlot !== null &&
+          /^\d+$/.test(live.currentTotalAmountRaw) &&
+          BigInt(live.currentTotalAmountRaw) > BigInt(0) &&
+          (currentSlot === null || liveSlot >= currentSlot) &&
+          (nextSlot === null || liveSlot >= nextSlot) &&
+          (closureFloor === null || liveSlot > closureFloor) &&
+          (Date.now() - mutatedAtRef.current >= MUTATION_TRUST_MS ||
+            (localSlot !== null && liveSlot >= localSlot))
+        ) {
+          const accounting =
+            nextSlot !== null &&
+            (closureFloor === null || nextSlot > closureFloor)
+              ? state.position
+              : null;
+          const retained =
+            positionSlot !== null &&
+            (closureFloor === null || positionSlot > closureFloor)
+              ? currentRef.current
+              : null;
+          const next: EarnPosition = {
+            currentAmountRaw: live.currentTotalAmountRaw,
+            currentObservedSlot: live.observedSlot ?? undefined,
+            currentSupplyApyBps:
+              accounting?.currentSupplyApyBps ??
+              retained?.currentSupplyApyBps ??
+              null,
+            // Holdings prove the current value, not the new lifecycle's cost
+            // basis. Do not copy principal from a closed generation or invent it.
+            principalAmountRaw:
+              accounting?.principalAmountRaw ??
+              retained?.principalAmountRaw ??
+              null,
+            status: "active",
+          };
+          currentRef.current = next;
+          setPosition(next);
+          setHoldings(live.holdings);
+          setPolicyMissing(false);
+          setAcceptedPolicies(
+            accounting
+              ? state.policyAccounts?.slice().sort().join(",") ?? null
+              : null
           );
+          return;
+        }
+        if (proofSlot !== null) {
           if (
             (currentSlot !== null && currentSlot > proofSlot) ||
             (liveSlot !== null &&

--- a/apps/mobile/src/hooks/wallet/useEarnPosition.ts
+++ b/apps/mobile/src/hooks/wallet/useEarnPosition.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { env } from "@/config/env";
 import {
   fetchEarnHoldings,
   fetchEarnState,
@@ -7,145 +8,293 @@ import {
   type EarnPosition,
 } from "@/lib/solana/earn/earn-api";
 
-// After a local deposit/withdraw, the backend read-model (`/state`
-// `currentAmountRaw`) is written synchronously by the confirm call, so it's the
-// correct intended balance immediately. The live `/holdings` read, by contrast,
-// LAGS the chain mid-sweep — it dips below the deposit right after a deposit
-// (funds still moving idle→Kamino) and reads high right after a withdraw. So for
-// a short window after a mutation we trust the read-model; outside it we trust
-// the live holdings total, which tracks market drift the read-model misses (the
-// reason the live override exists at all). This mirrors the web showing the
-// correct value the moment a deposit lands instead of a transient dip.
 const MUTATION_TRUST_MS = 20_000;
+// Keep only evidence, not balances, across Earn/wallet owners and screen reopens.
+// Settings and the actual Earn vault are part of the key; a wallet-only cache
+// would incorrectly apply an old account's cleanup to its replacement.
+const closedSlots = new Map<string, bigint>();
+const mutations = new Map<
+  string,
+  { epoch: number; pending: boolean; slot: bigint | null; scope: string | null }
+>();
 
-// Picks the balance the headline shows. `preferReadModel` (set briefly after a
-// local mutation) keeps the confirm-written read-model; otherwise the live total
-// overrides it. APY/principal/status always come from the read-model. When the
-// live read is unavailable (null) we keep the read-model rather than zeroing a
-// real balance.
-function reconcileBalance(
-  position: EarnPosition | null,
-  liveTotalRaw: string | null,
-  preferReadModel: boolean,
-): EarnPosition | null {
-  if (position === null || liveTotalRaw === null || preferReadModel) {
-    return position;
-  }
-  return { ...position, currentAmountRaw: liveTotalRaw };
+function slot(value: string | null | undefined): bigint | null {
+  return typeof value === "string" && /^\d+$/.test(value)
+    ? BigInt(value)
+    : null;
 }
 
-// Reads the wallet's current Earn position (balance + APY) from the backend
-// read-model. Like useTokenHoldings, it takes a read-only wallet address and
-// never signs — the lookup is unauthenticated by design so opening the Earn tab
-// doesn't prompt for a Seed Vault approval.
 export function useEarnPosition(walletAddress: string | null) {
   const [position, setPosition] = useState<EarnPosition | null>(null);
-  // Live per-venue holdings (Kamino obligation(s) + idle USDC) — the same data
-  // the web shows for its per-position breakdown. Exposed alongside `position`
-  // so the positions sheet can render the live split instead of the stale DB
-  // withdraw-sources read.
   const [holdings, setHoldings] = useState<EarnHoldingItem[]>([]);
-  // True when the last holdings read hit the server's no-active-policy branch
-  // (observedAt === null): the route-policy pair is missing — never created,
-  // or torn down by a full exit — so the next deposit re-runs first-time setup
-  // and needs the setup SOL even if a position balance exists. Stays false on
-  // fetch failures (fail-open, like the SOL gate itself).
   const [policyMissing, setPolicyMissing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  // Flips true once a fetch settles for the current wallet. Lets the UI tell
-  // "not loaded yet" (skeleton) apart from "loaded, genuinely empty" ($0) — the
-  // position read can legitimately resolve to null for a wallet with no Earn.
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [acceptedScope, setAcceptedScope] = useState<string | null>(null);
+  const [acceptedPolicies, setAcceptedPolicies] = useState<string | null>(null);
+  const [mutationVersion, setMutationVersion] = useState(0);
   const fetchIdRef = useRef(0);
-  // Timestamp of the last local deposit/withdraw. Within MUTATION_TRUST_MS of it
-  // we trust the read-model over the lagging live read (see reconcileBalance).
+  const currentRef = useRef<EarnPosition | null>(null);
+  const scopeRef = useRef<string | null>(null);
   const mutatedAtRef = useRef(0);
+  const pendingDepositRef = useRef(false);
+  const configuredCluster =
+    env.solanaEnv === "mainnet" ? "mainnet-beta" : env.solanaEnv;
+  const identity = `${configuredCluster}:${walletAddress ?? "disconnected"}`;
+  const identityRef = useRef(identity);
+  const identityChanged = identityRef.current !== identity;
+  if (identityChanged) {
+    identityRef.current = identity;
+    fetchIdRef.current += 1;
+    currentRef.current = null;
+    scopeRef.current = null;
+    mutatedAtRef.current = 0;
+    pendingDepositRef.current = false;
+  }
 
-  // Called by the Earn screen right before/after a deposit or withdraw so the
-  // next reads prefer the freshly-written read-model instead of the mid-sweep
-  // live total.
-  const markEarnMutation = useCallback(() => {
-    mutatedAtRef.current = Date.now();
-  }, []);
+  const markEarnMutation = useCallback(
+    (options?: {
+      pendingDeposit?: boolean;
+      confirmedDeposit?: { amountRaw: string; observedSlot: string };
+    }) => {
+      const deposit = options?.confirmedDeposit;
+      const previous = mutations.get(identity);
+      if (
+        identityRef.current !== identity ||
+        (previous?.pending &&
+          previous.scope !== null &&
+          previous.scope !== scopeRef.current)
+      ) {
+        // Settle evidence for the submitting owner without touching the newly
+        // selected wallet/account. Otherwise returning to that owner could stay
+        // pending forever after its transaction completed off-screen.
+        if (!options?.pendingDeposit && previous) {
+          mutations.set(identity, {
+            ...previous,
+            epoch: previous.epoch + 1,
+            pending: false,
+            slot: deposit ? slot(deposit.observedSlot) : previous.slot,
+          });
+        }
+        return;
+      }
+      ++fetchIdRef.current;
+      setMutationVersion((version) => version + 1);
+      mutatedAtRef.current = Date.now();
+      pendingDepositRef.current = options?.pendingDeposit ?? false;
+      mutations.set(identity, {
+        epoch: (previous?.epoch ?? 0) + 1,
+        pending: pendingDepositRef.current,
+        slot: deposit
+          ? slot(deposit.observedSlot)
+          : previous?.scope === scopeRef.current
+          ? previous.slot
+          : null,
+        scope: scopeRef.current,
+      });
+      if (deposit) {
+        const next: EarnPosition = {
+          currentAmountRaw: deposit.amountRaw,
+          currentObservedSlot: deposit.observedSlot,
+          currentSupplyApyBps: currentRef.current?.currentSupplyApyBps ?? null,
+          principalAmountRaw: deposit.amountRaw,
+          status: "active",
+        };
+        currentRef.current = next;
+        setPosition(next);
+        setHoldings([]);
+        setHasLoaded(true);
+      }
+      setIsLoading(false);
+    },
+    [identity]
+  );
 
   const refreshEarnPosition = useCallback(
     async (options?: { throwOnError?: boolean }) => {
-      if (!walletAddress) {
-        return;
-      }
+      if (!walletAddress || identityRef.current !== identity) return;
       const fetchId = ++fetchIdRef.current;
+      const mutationEpoch = mutations.get(identity)?.epoch ?? 0;
       setIsLoading(true);
       try {
-        // Fetch both concurrently: `state` for APY/principal/status (+ the
-        // post-mutation balance), `holdings` for the live balance once settled. A
-        // holdings failure must not drop the position, so each settles independently.
         const [stateResult, holdingsResult] = await Promise.allSettled([
           fetchEarnState(walletAddress),
           fetchEarnHoldings(walletAddress),
         ]);
-        if (fetchId !== fetchIdRef.current) {
-          if (options?.throwOnError) {
-            throw new Error("Earn position refresh was superseded.");
-          }
+        if (
+          fetchId !== fetchIdRef.current ||
+          identityRef.current !== identity ||
+          mutationEpoch !== (mutations.get(identity)?.epoch ?? 0)
+        )
+          return;
+        if (stateResult.status === "rejected") throw stateResult.reason;
+        const state = stateResult.value;
+        if (
+          (state.walletAddress && state.walletAddress !== walletAddress) ||
+          (state.cluster && state.cluster !== configuredCluster) ||
+          (state.vaultIndex !== undefined && state.vaultIndex !== 1)
+        ) {
+          throw new Error(
+            "Earn state does not match the selected wallet scope."
+          );
+        }
+        // Missing account mapping is not evidence of a replacement or zero funds.
+        if (!state.settingsPda || !state.smartAccountAddress) return;
+        const scope = `${identity}:${state.settingsPda}:1`;
+        if (scopeRef.current !== null && scopeRef.current !== scope) {
+          currentRef.current = null;
+          setPosition(null);
+          setHoldings([]);
+          setPolicyMissing(false);
+          pendingDepositRef.current = false;
+          mutatedAtRef.current = 0;
+        }
+        scopeRef.current = scope;
+        setAcceptedScope(scope);
+        const live =
+          holdingsResult.status === "fulfilled" ? holdingsResult.value : null;
+        const liveMatches =
+          live !== null &&
+          live.settingsPda === state.settingsPda &&
+          live.smartAccountAddress === state.smartAccountAddress &&
+          (!live.cluster || live.cluster === configuredCluster) &&
+          (!live.walletAddress || live.walletAddress === walletAddress) &&
+          (live.vaultIndex === undefined || live.vaultIndex === 1) &&
+          (!live.vaultPubkey ||
+            !state.vaultPubkey ||
+            live.vaultPubkey === state.vaultPubkey);
+        const mutation = mutations.get(identity);
+        const scopedMutation =
+          mutation?.scope === null || mutation?.scope === scope
+            ? mutation
+            : null;
+        const localSlot = scopedMutation?.slot ?? null;
+        const positionSlot = slot(currentRef.current?.currentObservedSlot);
+        const currentSlot =
+          localSlot !== null &&
+          (positionSlot === null || localSlot > positionSlot)
+            ? localSlot
+            : positionSlot;
+        const nextSlot = slot(state.position?.currentObservedSlot);
+        const proofSlot =
+          state.position === null
+            ? slot(state.closedPositionObservedSlot)
+            : null;
+        const liveSlot =
+          liveMatches && live?.observedAt ? slot(live.observedSlot) : null;
+        const closedSlot = closedSlots.get(scope) ?? null;
+        // A wallet prompt/pending deposit is not an empty lifecycle. No response
+        // started before the mutation may commit, even if it finishes afterwards.
+        if (pendingDepositRef.current || scopedMutation?.pending) return;
+        if (proofSlot !== null) {
+          closedSlots.set(
+            scope,
+            closedSlot !== null && closedSlot > proofSlot
+              ? closedSlot
+              : proofSlot
+          );
+          if (
+            (currentSlot !== null && currentSlot > proofSlot) ||
+            (liveSlot !== null &&
+              liveSlot > proofSlot &&
+              live &&
+              BigInt(live.currentTotalAmountRaw) > BigInt(0))
+          )
+            return;
+          currentRef.current = null;
+          setPosition(null);
+          setHoldings([]);
+          setPolicyMissing(true);
           return;
         }
-        if (stateResult.status === "rejected") {
-          console.error("Failed to fetch Earn position", stateResult.reason);
-          if (options?.throwOnError) {
-            throw stateResult.reason;
-          }
+        if (state.position === null) {
+          // Old servers and missing policy metadata provide no closure evidence.
+          // An initially empty wallet remains empty; a valid balance is retained.
           return;
         }
-        let liveTotalRaw: string | null = null;
-        if (holdingsResult.status === "fulfilled") {
-          // observedAt is null only when the server skipped the chain read (no
-          // active Earn policy row yet) and returned a placeholder "0" — treat
-          // that as "live read unavailable" so it can't zero a real read-model
-          // balance. A genuine snapshot always carries observedAt, even at $0.
-          if (holdingsResult.value.observedAt !== null) {
-            liveTotalRaw = holdingsResult.value.currentTotalAmountRaw;
+        if (
+          (closedSlot !== null &&
+            (nextSlot === null || nextSlot <= closedSlot)) ||
+          (currentSlot !== null &&
+            (nextSlot === null || nextSlot < currentSlot))
+        )
+          return;
+        let next = state.position;
+        const floor = nextSlot ?? currentSlot;
+        const liveFresh =
+          liveMatches &&
+          liveSlot !== null &&
+          (floor === null || liveSlot >= floor) &&
+          (closedSlot === null || liveSlot > closedSlot);
+        if (liveFresh && live) {
+          setHoldings(live.holdings);
+          if (
+            Date.now() - mutatedAtRef.current >= MUTATION_TRUST_MS ||
+            (localSlot !== null && liveSlot !== null && liveSlot >= localSlot)
+          ) {
+            next = {
+              ...next,
+              currentAmountRaw: live.currentTotalAmountRaw,
+              currentObservedSlot: live.observedSlot ?? undefined,
+            };
           }
-          setPolicyMissing(holdingsResult.value.observedAt === null);
-          setHoldings(holdingsResult.value.holdings);
-        } else {
-          console.error("Failed to fetch Earn holdings", holdingsResult.reason);
+        } else if (
+          next.currentAmountRaw !== currentRef.current?.currentAmountRaw
+        ) {
+          // A reconciled total cannot keep details from a different balance
+          // when the independent holdings request failed or is lagging.
+          setHoldings([]);
         }
-        const preferReadModel =
-          Date.now() - mutatedAtRef.current < MUTATION_TRUST_MS;
-        setPosition(
-          reconcileBalance(
-            stateResult.value.position,
-            liveTotalRaw,
-            preferReadModel,
-          ),
+        if (liveMatches && live) setPolicyMissing(live.observedAt === null);
+        currentRef.current = next;
+        setAcceptedPolicies(
+          state.policyAccounts?.slice().sort().join(",") ?? null
         );
+        setPosition(next);
+      } catch (error) {
+        if (fetchId !== fetchIdRef.current || identityRef.current !== identity)
+          return;
+        console.error("Failed to fetch Earn position", error);
+        if (options?.throwOnError) throw error;
       } finally {
-        if (fetchId === fetchIdRef.current) {
+        if (
+          fetchId === fetchIdRef.current &&
+          identityRef.current === identity
+        ) {
           setIsLoading(false);
           setHasLoaded(true);
         }
       }
     },
-    [walletAddress],
+    [walletAddress, identity, configuredCluster]
   );
 
   useEffect(() => {
-    if (walletAddress) {
-      refreshEarnPosition();
-    } else {
-      setPosition(null);
-      setHoldings([]);
-      setPolicyMissing(false);
-      setHasLoaded(false);
-    }
-  }, [walletAddress, refreshEarnPosition]);
+    setPosition(null);
+    setHoldings([]);
+    setPolicyMissing(false);
+    setHasLoaded(false);
+    setAcceptedScope(null);
+    setAcceptedPolicies(null);
+    setIsLoading(false);
+    if (walletAddress) void refreshEarnPosition();
+    return () => {
+      ++fetchIdRef.current;
+    };
+  }, [identity, walletAddress, refreshEarnPosition]);
 
   return {
-    position,
-    holdings,
-    policyMissing,
-    isLoading,
-    hasLoaded,
+    position: identityChanged ? null : position,
+    holdings: identityChanged ? [] : holdings,
+    policyMissing: identityChanged ? false : policyMissing,
+    isLoading: identityChanged ? false : isLoading,
+    hasLoaded: identityChanged ? false : hasLoaded,
+    // Source selection must be invalidated when the accepted lifecycle closes.
+    reconciliationKey: `${acceptedScope ?? identity}:${
+      acceptedPolicies ?? "unknown"
+    }:${mutationVersion}:${mutations.get(identity)?.epoch ?? 0}:${
+      position === null ? "empty" : position.currentAmountRaw
+    }`,
     refreshEarnPosition,
     markEarnMutation,
   };

--- a/apps/mobile/src/hooks/wallet/useEarnWithdrawSources.ts
+++ b/apps/mobile/src/hooks/wallet/useEarnWithdrawSources.ts
@@ -1,4 +1,6 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { env } from "@/config/env";
 
 import {
   fetchEarnWithdrawSources,
@@ -9,14 +11,33 @@ import {
 // USDC) for the withdraw source picker. Unlike the always-on position/autodeposit
 // hooks, this is fetched on demand (when the user opens withdraw) since most
 // sessions never withdraw.
-export function useEarnWithdrawSources(walletAddress: string | null) {
+export function useEarnWithdrawSources(
+  walletAddress: string | null,
+  lifecycleKey = "",
+  enabled = true
+) {
   const [sources, setSources] = useState<EarnWithdrawSourceInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const fetchIdRef = useRef(0);
+  const scope = `${env.solanaEnv}:${walletAddress}:${lifecycleKey}:${enabled}`;
+  const scopeRef = useRef(scope);
+  const changed = scopeRef.current !== scope;
+  if (changed) {
+    scopeRef.current = scope;
+    ++fetchIdRef.current;
+  }
+  useEffect(() => {
+    setSources([]);
+    setIsLoading(false);
+    const requests = fetchIdRef;
+    return () => {
+      ++requests.current;
+    };
+  }, [scope]);
 
   const refreshSources = useCallback(
     async (options?: { throwOnError?: boolean }) => {
-      if (!walletAddress) {
+      if (!walletAddress || !enabled || scopeRef.current !== scope) {
         setSources([]);
         return;
       }
@@ -24,7 +45,7 @@ export function useEarnWithdrawSources(walletAddress: string | null) {
       setIsLoading(true);
       try {
         const res = await fetchEarnWithdrawSources(walletAddress);
-        if (fetchId === fetchIdRef.current) {
+        if (fetchId === fetchIdRef.current && scopeRef.current === scope) {
           setSources(res.sources);
         } else if (options?.throwOnError) {
           throw new Error("Earn withdrawal sources refresh was superseded.");
@@ -40,8 +61,12 @@ export function useEarnWithdrawSources(walletAddress: string | null) {
         }
       }
     },
-    [walletAddress],
+    [walletAddress, scope, enabled]
   );
 
-  return { sources, isLoading, refreshSources };
+  return {
+    sources: changed || !enabled ? [] : sources,
+    isLoading: changed ? false : isLoading,
+    refreshSources,
+  };
 }

--- a/apps/mobile/src/lib/solana/earn/deposit.ts
+++ b/apps/mobile/src/lib/solana/earn/deposit.ts
@@ -52,6 +52,7 @@ function usdToStableRaw(amountUsd: number): string {
 }
 
 export type EarnDepositResult = {
+  confirmedSlot: string;
   depositSignature: string;
 };
 
@@ -157,7 +158,7 @@ async function signSendAndConfirmDeposit(args: {
   track(EARN_EVENTS.earnDeposit, { amount_usd: args.amountUsd });
 
   args.flow.complete("ui_commit");
-  return { depositSignature: deposit.signature };
+  return { depositSignature: deposit.signature, confirmedSlot: deposit.confirmedSlot };
 }
 
 // Policies are immutable permission records, so a legacy (classic-token-only)
@@ -350,7 +351,7 @@ async function runEarnDeposit(
       });
       track(EARN_EVENTS.earnDeposit, { amount_usd: args.amountUsd });
       flow.complete("ui_commit");
-      return { depositSignature: confirmations.deposit.signature };
+      return { depositSignature: confirmations.deposit.signature, confirmedSlot: confirmations.deposit.confirmedSlot };
     }
     return signSendAndConfirmDeposit({
       signer: args.signer,

--- a/apps/mobile/src/lib/solana/earn/earn-api.ts
+++ b/apps/mobile/src/lib/solana/earn/earn-api.ts
@@ -861,7 +861,8 @@ export type EarnPosition = {
   currentObservedSlot?: string;
   currentAmountRaw: string;
   currentSupplyApyBps: string | null;
-  principalAmountRaw: string;
+  // A newer live holding can precede accounting for its lifecycle.
+  principalAmountRaw: string | null;
   status: string;
 };
 

--- a/apps/mobile/src/lib/solana/earn/earn-api.ts
+++ b/apps/mobile/src/lib/solana/earn/earn-api.ts
@@ -858,13 +858,23 @@ export async function fetchEarnAutodepositSweepProgress(
 // Current on-chain Earn position read-model (balance + live APY). All amounts
 // are USDC base units (6 decimals) as strings; APY is in basis points.
 export type EarnPosition = {
+  currentObservedSlot?: string;
   currentAmountRaw: string;
   currentSupplyApyBps: string | null;
   principalAmountRaw: string;
   status: string;
 };
 
-export type EarnStateResponse = {
+export type EarnReadScope = {
+  cluster?: string;
+  walletAddress?: string;
+  vaultIndex?: number;
+  vaultPubkey?: string;
+};
+
+export type EarnStateResponse = EarnReadScope & {
+  closedPositionObservedSlot?: string | null;
+  policyAccounts?: string[];
   position: EarnPosition | null;
   settingsPda: string | null;
   smartAccountAddress: string | null;
@@ -904,7 +914,7 @@ export type EarnHoldingItem = {
   reserve: string | null;
 };
 
-export type EarnHoldingsResponse = {
+export type EarnHoldingsResponse = EarnReadScope & {
   currentTotalAmountRaw: string;
   holdings: EarnHoldingItem[];
   observedAt: string | null;

--- a/apps/web/scripts/verify-earn-confirm-single-writer.ts
+++ b/apps/web/scripts/verify-earn-confirm-single-writer.ts
@@ -23,6 +23,7 @@ const behavioralTests = [
   "apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts",
 ] as const;
 const mockIsolatedBehavioralTests = new Set([
+  "apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts",
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts",
   "apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/prepare/route.test.ts",
   "apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts",

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/holdings/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/holdings/route.ts
@@ -12,8 +12,7 @@ import { getServerEnv } from "@/lib/core/config/server";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
-import { fetchEarnRpcHoldingsSnapshot } from "@/lib/yield-optimization/earn-rpc-holdings.client";
-import { serializeRoutePolicyState } from "@/lib/yield-optimization/earn-state-serializers.server";
+import { fetchEarnFullVaultHoldingsSnapshot } from "@/lib/yield-optimization/earn-full-exit-zero-proof.server";
 import {
   findActiveYieldPositionsForVault,
   findActiveYieldRoutePolicyPair,
@@ -94,6 +93,9 @@ export async function GET(request: Request) {
   const cluster = resolveLoyalClusterForSolanaEnv(solanaEnv);
 
   const emptySnapshot = {
+    cluster,
+    walletAddress,
+    vaultIndex: EARN_VAULT_INDEX,
     currentTotalAmountRaw: "0",
     currentTotalNominalUsdMicros: "0",
     holdings: [],
@@ -143,6 +145,7 @@ export async function GET(request: Request) {
     if (!policyPair?.routePolicy) {
       return NextResponse.json({
         ...emptySnapshot,
+        vaultPubkey: earnVaultPda.toBase58(),
         settingsPda: account.settingsPda,
         smartAccountAddress: account.smartAccountAddress,
       });
@@ -169,17 +172,16 @@ export async function GET(request: Request) {
       BigInt(0)
     );
     const minContextSlot =
-      confirmedSlotFloor > BigInt(0) ? Number(confirmedSlotFloor) : undefined;
+      confirmedSlotFloor > BigInt(0)
+        ? Number(confirmedSlotFloor)
+        : await getConnection(solanaEnv).getSlot("confirmed");
 
     const readSnapshot = () =>
-      fetchEarnRpcHoldingsSnapshot({
+      fetchEarnFullVaultHoldingsSnapshot({
+        accountingPositions: positions,
         cluster,
         connection: getConnection(solanaEnv),
         minContextSlot,
-        policy: serializeRoutePolicyState(
-          policyPair.routePolicy,
-          policyPair.setupPolicy ?? null
-        ),
         programId,
         settingsPda,
       });
@@ -215,6 +217,10 @@ export async function GET(request: Request) {
     }
 
     return NextResponse.json({
+      cluster,
+      walletAddress,
+      vaultIndex: EARN_VAULT_INDEX,
+      vaultPubkey: earnVaultPda.toBase58(),
       currentTotalAmountRaw: snapshot.currentTotalAmountRaw,
       currentTotalNominalUsdMicros: snapshot.currentTotalNominalUsdMicros,
       holdings: snapshot.holdings,
@@ -231,6 +237,10 @@ export async function GET(request: Request) {
       stack: error instanceof Error ? error.stack : undefined,
       walletAddress,
     });
-    return jsonError(502, "earn_holdings_failed", "Failed to load Earn holdings.");
+    return jsonError(
+      502,
+      "earn_holdings_failed",
+      "Failed to load Earn holdings."
+    );
   }
 }

--- a/apps/web/src/app/api/smart-accounts/mobile/earn/state/route.ts
+++ b/apps/web/src/app/api/smart-accounts/mobile/earn/state/route.ts
@@ -11,11 +11,8 @@ import { decodeWalletAddress } from "@/features/identity/server/wallet-auth-sign
 import { findReadyCurrentUserSmartAccount } from "@/features/smart-accounts/server/service";
 import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
 import { getCurrentReserveUpdatesByReserve } from "@/lib/kamino/timescale-reserve-client.server";
-import {
-  findActiveYieldPositionsForVault,
-  findReconciledActiveYieldPositionForVault,
-  type UserYieldPositionRecord,
-} from "@/lib/yield-optimization/yield-deposit-repository.server";
+import { findUserFacingEarnPositions } from "@/lib/yield-optimization/earn-position-read.server";
+import type { UserYieldPositionRecord } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 // Read-only mobile twin of the session `yield-optimization/{earn-state,position}`
 // routes. The native Earn tab shows balance passively, with no signer held (a
@@ -68,43 +65,6 @@ function resolveTimescaleReserveForPosition(position: UserYieldPositionRecord) {
   return position.currentReserve;
 }
 
-// The wallet can hold one active position row per product mint (ASK-1355), so
-// the headline balance is the sum of every ACTIVE position row — exactly what
-// the deposit/withdraw confirms write synchronously, which is the value the
-// mobile client trusts in its short post-mutation window before live holdings
-// catch up. The vault snapshot tables are deliberately NOT used here: the
-// routing worker records reserve rows in collateral-unit semantics
-// (`kamino_obligation_collateral_deposited_amount`), which the user-facing
-// filter drops wholesale, collapsing that "total" to idle dust — the $0.00
-// balance regression right after a USDG deposit (2026-08-14). Falls back to
-// the reconciled single row's amount when the plural read is empty or fails.
-async function loadCurrentTotalAmountRaw(args: {
-  cluster: ReturnType<typeof resolveConfiguredCluster>;
-  position: UserYieldPositionRecord;
-  settings: string;
-  walletAddress: string;
-}): Promise<bigint> {
-  try {
-    const rows = await findActiveYieldPositionsForVault({
-      cluster: args.cluster,
-      settings: args.settings,
-      vaultIndex: EARN_VAULT_INDEX,
-      walletAddress: args.walletAddress,
-    });
-    const total = rows.reduce(
-      (sum, row) => sum + row.currentAmountRaw,
-      BigInt(0)
-    );
-    return total > BigInt(0) ? total : args.position.currentAmountRaw;
-  } catch (error) {
-    console.warn(
-      "[mobile-earn-state] failed to sum active position rows",
-      error
-    );
-    return args.position.currentAmountRaw;
-  }
-}
-
 // Best-effort: the funded balance is the headline number; APY is supplementary,
 // so a missing/empty Timescale read just yields null rather than failing.
 async function loadCurrentSupplyApyBps(
@@ -115,10 +75,14 @@ async function loadCurrentSupplyApyBps(
     const rows = await getCurrentReserveUpdatesByReserve({
       reserves: [reserve],
     });
-    const match = rows.find((row) => row.reserve === reserve) ?? rows[0] ?? null;
+    const match =
+      rows.find((row) => row.reserve === reserve) ?? rows[0] ?? null;
     return match ? toApyBps(match.supplyApy) : null;
   } catch (error) {
-    console.warn("[mobile-earn-state] APY lookup failed; returning null", error);
+    console.warn(
+      "[mobile-earn-state] APY lookup failed; returning null",
+      error
+    );
     return null;
   }
 }
@@ -165,33 +129,57 @@ export async function GET(request: Request) {
     }
 
     const cluster = resolveConfiguredCluster();
-    const position = await findReconciledActiveYieldPositionForVault({
+    const {
+      positions,
+      closedPositionObservedSlot,
+      vaultPubkey,
+      fundedSnapshot,
+    } = await findUserFacingEarnPositions({
       cluster,
       settings: account.settingsPda,
       vaultIndex: EARN_VAULT_INDEX,
       walletAddress,
     });
+    const scope = {
+      cluster,
+      walletAddress,
+      vaultIndex: EARN_VAULT_INDEX,
+      vaultPubkey,
+    };
+    const position = positions[0] ?? null;
     if (!position) {
       return NextResponse.json({
+        ...scope,
+        closedPositionObservedSlot,
         position: null,
         settingsPda: account.settingsPda,
         smartAccountAddress: account.smartAccountAddress,
       });
     }
 
-    const [currentSupplyApyBps, currentTotalAmountRaw] = await Promise.all([
-      loadCurrentSupplyApyBps(position),
-      loadCurrentTotalAmountRaw({
-        cluster,
-        position,
-        settings: account.settingsPda,
-        walletAddress,
-      }),
-    ]);
+    const currentSupplyApyBps = await loadCurrentSupplyApyBps(position);
+    const currentTotalAmountRaw = positions.reduce(
+      (total, row) => total + row.currentAmountRaw,
+      BigInt(0)
+    );
+    const currentObservedSlot = positions.reduce(
+      (slot, row) =>
+        row.currentObservedSlot > slot ? row.currentObservedSlot : slot,
+      BigInt(0)
+    );
 
     return NextResponse.json({
+      ...scope,
+      closedPositionObservedSlot,
+      policyAccounts: [
+        ...new Set(positions.map((row) => row.policyAccount)),
+      ].sort(),
       position: {
-        currentAmountRaw: currentTotalAmountRaw.toString(),
+        currentObservedSlot:
+          fundedSnapshot?.observedSlot ?? currentObservedSlot.toString(),
+        currentAmountRaw:
+          fundedSnapshot?.currentTotalAmountRaw ??
+          currentTotalAmountRaw.toString(),
         currentSupplyApyBps,
         principalAmountRaw: position.principalAmountRaw.toString(),
         status: position.status,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/earn-state/route.ts
@@ -29,6 +29,7 @@ import {
   sumEarnAutodepositCurrentPeriodDeposits,
   type CurrentEarnAutodepositState,
 } from "@/lib/yield-optimization/earn-autodeposit-repository.server";
+import { findUserFacingEarnPosition } from "@/lib/yield-optimization/earn-position-read.server";
 import { findEarnCrossMintSnapshot } from "@/lib/yield-optimization/earn-cross-mint-repository.server";
 import {
   serializeEarnDepositOnboardingState,
@@ -42,7 +43,6 @@ import {
   findCurrentEarnDepositOnboardingAttempt,
   findCurrentNonzeroYieldVaultReservePositions,
   findCurrentYieldVaultIdleTokenBalances,
-  findReconciledActiveYieldPositionForVault,
   type UserYieldPositionRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
@@ -341,7 +341,7 @@ export async function GET(request: Request) {
     autoswapResult,
   ] = await Promise.all([
     loadEarnStatePart("position", () =>
-      findReconciledActiveYieldPositionForVault({
+      findUserFacingEarnPosition({
         cluster,
         settings: principal.settingsPda,
         vaultIndex: EARN_VAULT_INDEX,
@@ -500,7 +500,7 @@ export async function GET(request: Request) {
       })
     ),
   ]);
-  const position = positionResult.data;
+  const position = positionResult.data?.position ?? null;
   const policyPair = policyResult.data;
   const policy = policyPair?.routePolicy ?? null;
   const onboarding = onboardingResult.data;
@@ -553,6 +553,8 @@ export async function GET(request: Request) {
     policy: policy
       ? serializeRoutePolicyState(policy, policyPair?.setupPolicy ?? null)
       : null,
+    closedPositionObservedSlot:
+      positionResult.data?.closedPositionObservedSlot ?? null,
     position: position
       ? serializePosition(position, currentTotalAmountRaw)
       : null,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/policies/confirm/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import {
-  getKaminoUsdcEarnTargetForCluster,
   normalizeLoyalCluster,
   resolveLoyalClusterForSolanaEnv,
 } from "@loyal-labs/actions";
@@ -13,6 +12,8 @@ import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-ov
 import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
 import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
 import { parseEarnPolicyConfirmRequestBody } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
+import { resolveEarnProductAsset } from "@/lib/yield-optimization/earn-product-mints.shared";
+import { assertSafeEarnReserveMetadata } from "@/lib/yield-optimization/earn-reserve-target.server";
 import { type ConfirmedYieldRoutePolicyInput } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
 const EARN_POLICY_VAULT_INDEX = 1;
@@ -74,19 +75,33 @@ function createCanonicalPolicyInput(
     settingsPda: settings,
     accountIndex: EARN_POLICY_VAULT_INDEX,
   })[0];
-  const earnTarget = getKaminoUsdcEarnTargetForCluster(cluster);
+  // Prepare selects an eligible Safe reserve for the chosen product. Policy
+  // setup does not deposit into the old hard-coded USDC reserve: requiring that
+  // reserve here strands an already-confirmed setup before the deposit is sent.
+  // Match the same supported-mint/Safe-market contract as deposit confirmation.
+  const product = resolveEarnProductAsset({
+    cluster,
+    mint: requestInput.liquidityMint,
+  });
+  const earnTarget = assertSafeEarnReserveMetadata({
+    cluster,
+    expectedLiquidityMint: product.mint.toBase58(),
+    liquidityMint: requestInput.liquidityMint,
+    market: requestInput.market,
+    targetReserve: requestInput.targetReserve,
+  });
   const canonicalInput = {
     ...normalizedRequestInput,
     cluster,
-    liquidityMint: earnTarget.liquidityMint.toBase58(),
-    market: earnTarget.market.toBase58(),
+    liquidityMint: earnTarget.liquidityMint,
+    market: earnTarget.market,
     policyAccount: expectedPolicyAccount.toBase58(),
     policyId: requestInput.policySeed,
     policySeed: requestInput.policySeed,
     setupPolicyAccount: expectedSetupPolicyAccount.toBase58(),
     setupPolicyId: expectedSetupPolicySeed,
     setupPolicySeed: expectedSetupPolicySeed,
-    targetReserve: earnTarget.reserve.toBase58(),
+    targetReserve: earnTarget.targetReserve,
     vaultIndex: EARN_POLICY_VAULT_INDEX,
     vaultPubkey: expectedVault.toBase58(),
   };

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/position/route.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/position/route.ts
@@ -12,13 +12,13 @@ import {
   type TimescaleReserveUpdateRow,
 } from "@/lib/kamino/timescale-reserve-client.server";
 import { resolveEarnPositionDisplay } from "@/lib/yield-optimization/earn-position-display";
+import { findUserFacingEarnPosition } from "@/lib/yield-optimization/earn-position-read.server";
 import { resolveEarnProductAsset } from "@/lib/yield-optimization/earn-product-mints.shared";
 import {
   type CurrentYieldVaultIdleTokenBalanceRecord,
   type CurrentYieldVaultReservePositionRecord,
   findCurrentNonzeroYieldVaultReservePositions,
   findCurrentYieldVaultIdleTokenBalances,
-  findReconciledActiveYieldPositionForVault,
   type UserYieldPositionRecord,
 } from "@/lib/yield-optimization/yield-deposit-repository.server";
 
@@ -273,12 +273,13 @@ export async function GET(request: Request) {
   }
 
   const cluster = resolveConfiguredCluster();
-  const position = await findReconciledActiveYieldPositionForVault({
-    cluster,
-    settings: principal.settingsPda,
-    vaultIndex: EARN_VAULT_INDEX,
-    walletAddress: principal.walletAddress,
-  });
+  const { position, closedPositionObservedSlot } =
+    await findUserFacingEarnPosition({
+      cluster,
+      settings: principal.settingsPda,
+      vaultIndex: EARN_VAULT_INDEX,
+      walletAddress: principal.walletAddress,
+    });
   const timescaleReserve = position
     ? resolveTimescaleReserveForPosition(position)
     : null;
@@ -320,6 +321,7 @@ export async function GET(request: Request) {
     : [[], []];
 
   return NextResponse.json({
+    closedPositionObservedSlot,
     position: position
       ? serializePosition(
           position,

--- a/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
+++ b/apps/web/src/app/api/smart-accounts/yield-optimization/withdrawals/cleanup/confirm/route.test.ts
@@ -25,6 +25,7 @@ const persistence = {
 
 let proofStatus: "full_exit_incomplete" | "policy_close_required";
 let proofError: Error | null;
+let proofObservedSlot: string;
 let policyAccountStillOpen: boolean;
 let callOrder: string[];
 let cleanupRecordCount: number;
@@ -78,6 +79,7 @@ mock.module(
         throw proofError;
       }
       return {
+        observedSlot: proofObservedSlot,
         status: proofStatus,
       };
     },
@@ -126,6 +128,7 @@ describe("Earn cleanup confirm route", () => {
   beforeEach(() => {
     proofStatus = "policy_close_required";
     proofError = null;
+    proofObservedSlot = "600";
     policyAccountStillOpen = false;
     callOrder = [];
     cleanupRecordCount = 0;
@@ -195,6 +198,14 @@ describe("Earn cleanup confirm route", () => {
     expect(response.status).toBe(503);
     expect(cleanupRecordCount).toBe(0);
     expect(callOrder).toEqual(["verify-zero", "verify-policy-accounts"]);
+  });
+
+  test("rejects policy closure observed before the zero-holdings proof", async () => {
+    const { POST } = await import("./route");
+    proofObservedSlot = "601";
+    const response = await POST(createRequest());
+    expect(response.status).toBe(503);
+    expect(cleanupRecordCount).toBe(0);
   });
 
   test("acknowledges verified cleanup without writing projected state", async () => {

--- a/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
+++ b/apps/web/src/components/wallet-workspace/facelift/use-earn-actions.ts
@@ -1853,7 +1853,9 @@ export function useEarnActions(deps: {
         throw new Error(result.error ?? "Earn cleanup failed.");
       }
 
-      setPosition(null);
+      // Cleanup confirms the submitted policy generation, not any deposit that
+      // arrived while the wallet prompt was open. The scoped position reader
+      // applies the full-exit proof through the registered mutation refresh.
       setAutodepositOverride({ config: null });
       registerExpectedEarnMutation({
         operation: "cleanup",
@@ -1916,7 +1918,6 @@ export function useEarnActions(deps: {
     ensureCanSignAccountAction,
     registerExpectedEarnMutation,
     setAutodepositOverride,
-    setPosition,
     smartAccountData,
   ]);
 

--- a/apps/web/src/hooks/use-active-earn-position-races.test.ts
+++ b/apps/web/src/hooks/use-active-earn-position-races.test.ts
@@ -1,0 +1,344 @@
+// Deterministic hook/cache contract runner: scheduling, HTTP and RPC are mocked.
+// This exercises commit ordering, not real React/browser or live RPC integration.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+import type { EarnRpcHoldingsSnapshot } from "@/lib/yield-optimization/earn-rpc-holdings.client";
+
+import type { ActiveEarnPosition } from "./use-active-earn-position";
+
+type EffectCell = { deps: unknown[]; cleanup?: void | (() => void) };
+let cells: unknown[] = [];
+let cursor = 0;
+let pendingEffects: (() => void)[] = [];
+const changed = (a: unknown[] | undefined, b: unknown[]) =>
+  !a || a.length !== b.length || a.some((value, i) => !Object.is(value, b[i]));
+
+mock.module("react", () => ({
+  useRef<T>(value: T) {
+    const i = cursor++;
+    return (cells[i] ??= { current: value }) as { current: T };
+  },
+  useState<T>(value: T) {
+    const i = cursor++;
+    if (!(i in cells)) cells[i] = value;
+    return [
+      cells[i],
+      (next: T | ((current: T) => T)) => {
+        cells[i] =
+          typeof next === "function"
+            ? (next as (current: T) => T)(cells[i] as T)
+            : next;
+      },
+    ];
+  },
+  useCallback<T>(fn: T, deps: unknown[]) {
+    const i = cursor++;
+    const previous = cells[i] as { fn: T; deps: unknown[] } | undefined;
+    if (!previous || changed(previous.deps, deps)) cells[i] = { fn, deps };
+    return (cells[i] as { fn: T }).fn;
+  },
+  useEffect(fn: () => void | (() => void), deps: unknown[]) {
+    const i = cursor++;
+    const previous = cells[i] as EffectCell | undefined;
+    if (!previous || changed(previous.deps, deps)) {
+      const cell: EffectCell = { deps };
+      cells[i] = cell;
+      pendingEffects.push(() => {
+        previous?.cleanup?.();
+        cell.cleanup = fn();
+      });
+    }
+  },
+}));
+
+let rpcRead: (input: {
+  minContextSlot?: number;
+}) => Promise<EarnRpcHoldingsSnapshot>;
+mock.module("@/lib/yield-optimization/earn-rpc-holdings.client", () => ({
+  fetchEarnRpcHoldingsSnapshot: (input: { minContextSlot?: number }) =>
+    rpcRead(input),
+  sumEarnRpcHoldingsAmountRaw: (
+    holdings: EarnRpcHoldingsSnapshot["holdings"]
+  ) =>
+    holdings.reduce(
+      (total, holding) => total + BigInt(holding.amountRaw),
+      BigInt(0)
+    ),
+}));
+
+const { useActiveEarnPosition, writeEarnPositionCache, readEarnPositionCache } =
+  await import("./use-active-earn-position");
+const scope = {
+  solanaEnv: "mainnet",
+  walletAddress: "11111111111111111111111111111112",
+  settingsPda: "11111111111111111111111111111113",
+};
+const policy = {
+  account: scope.walletAddress,
+  seed: "1",
+  vaultIndex: 1,
+  vaultPubkey: scope.walletAddress,
+};
+let props: Parameters<typeof useActiveEarnPosition>[0];
+let output: ReturnType<typeof useActiveEarnPosition>;
+let storage: Map<string, string>;
+const originalFetch = globalThis.fetch;
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+function render() {
+  cursor = 0;
+  // The mocked dispatcher above supplies the hook lifecycle for this runner.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  output = useActiveEarnPosition(props);
+  const effects = pendingEffects;
+  pendingEffects = [];
+  for (const effect of effects) effect();
+}
+async function flush() {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+  render();
+}
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function snapshot(slot: string): EarnRpcHoldingsSnapshot {
+  return {
+    completeness: "complete",
+    currentTotalAmountRaw: "100000000",
+    currentTotalNominalUsdMicros: "100000000",
+    observedAt: new Date(0).toISOString(),
+    observedSlot: slot,
+    holdings: [
+      {
+        amountRaw: "100000000",
+        kind: "idle",
+        liquidityMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        tokenProgramId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        market: null,
+        reserve: null,
+        label: "Idle Balance",
+        marketName: "USDC",
+        sourceId: "idle:usdc",
+        supplyApyBps: null,
+        observedAt: new Date(0).toISOString(),
+        observedSlot: slot,
+        provenance: { source: "rpc_getMultipleAccounts" },
+      },
+    ],
+    provenance: {
+      watchedAccounts: [],
+      accountCount: 1,
+      chunkCount: 1,
+      commitment: "confirmed",
+      source: "rpc_getMultipleAccounts",
+    },
+  };
+}
+function position(slot: string): ActiveEarnPosition {
+  return {
+    status: "active",
+    currentTotalAmountRaw: "100000000",
+    principalAmountRaw: "100000000",
+    currentSupplyApyBps: null,
+    display: { label: "Idle Balance", marketName: "USDC", mintSymbol: "USDC" },
+    initialHolding: {
+      liquidityMint: snapshot(slot).holdings[0].liquidityMint,
+      market: null,
+      reserve: "",
+      supplyApyBps: null,
+    },
+    currentHolding: {
+      amountRaw: "100000000",
+      liquidityMint: snapshot(slot).holdings[0].liquidityMint,
+      market: null,
+      reserve: "",
+      observedAt: new Date(0).toISOString(),
+      observedSlot: slot,
+      provenance: { lastHoldingEventId: null, lastRebalanceDecisionId: null },
+    },
+    holdings: snapshot(slot).holdings,
+  };
+}
+function respondWith(body: unknown) {
+  globalThis.fetch = mock(async () =>
+    Response.json(body)
+  ) as unknown as typeof fetch;
+}
+function expectClosed() {
+  expect(output.position).toBeNull();
+  expect(readEarnPositionCache(scope)).toBeNull();
+  // Both the scoped and last-position fallback cache must be removed.
+  expect(storage.size).toBe(0);
+}
+
+beforeEach(() => {
+  cells = [];
+  cursor = 0;
+  pendingEffects = [];
+  props = {
+    ...scope,
+    enabled: true,
+    programId: scope.walletAddress,
+    earnPolicy: policy,
+    connection: {} as never,
+  };
+  storage = new Map();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
+    },
+  });
+  rpcRead = async () => snapshot("500");
+  respondWith({ position: null, closedPositionObservedSlot: "600" });
+  writeEarnPositionCache({ ...scope, position: position("500") });
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWindow)
+    Object.defineProperty(globalThis, "window", originalWindow);
+  else Reflect.deleteProperty(globalThis, "window");
+});
+
+test("accepted closure survives subsequent lagging RPC refreshes and allows a later deposit", async () => {
+  render();
+  await flush();
+  expectClosed();
+  for (const slot of ["500", "600"]) {
+    rpcRead = async ({ minContextSlot }) => {
+      expect(minContextSlot).toBe(601);
+      return snapshot(slot); // Simulate a response violating the RPC fence too.
+    };
+    expect(await output.refresh()).toBeNull();
+    await flush();
+    expectClosed();
+  }
+  rpcRead = async ({ minContextSlot }) => {
+    expect(minContextSlot).toBe(601);
+    return snapshot("700");
+  };
+  await output.refresh();
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("700");
+  expect(readEarnPositionCache(scope)?.currentHolding.observedSlot).toBe("700");
+  for (const slot of ["500", "650"]) {
+    rpcRead = async ({ minContextSlot }) => {
+      expect(minContextSlot).toBe(700);
+      return { ...snapshot(slot), holdings: [] };
+    };
+    await output.refresh();
+    await flush();
+    expect(output.position?.currentHolding.observedSlot).toBe("700");
+    expect(readEarnPositionCache(scope)?.currentHolding.observedSlot).toBe(
+      "700"
+    );
+  }
+});
+
+test("no-policy stale tab clears on refresh and cannot resurrect from stale HTTP", async () => {
+  props.earnPolicy = null;
+  respondWith({ position: position("500") });
+  render();
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("500");
+  respondWith({ position: null, closedPositionObservedSlot: "600" });
+  await output.refresh();
+  await flush();
+  expectClosed();
+  for (const slot of ["500", "600"]) {
+    respondWith({ position: position(slot) });
+    await output.refresh();
+    await flush();
+    expectClosed();
+  }
+  respondWith({ position: position("700") });
+  await output.refresh();
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("700");
+});
+
+test("closure response preserves a later RPC deposit and fences subsequent reads", async () => {
+  rpcRead = async () => snapshot("700");
+  render();
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("700");
+  rpcRead = async () => snapshot("500");
+  await output.refresh();
+  await flush();
+  expect(readEarnPositionCache(scope)?.currentHolding.observedSlot).toBe("700");
+});
+
+test("outstanding closure cannot erase a locally confirmed later deposit", async () => {
+  const http = deferred<Response>();
+  globalThis.fetch = mock(() => http.promise) as unknown as typeof fetch;
+  render();
+  await flush();
+  output.setPosition(position("700"));
+  render();
+  http.resolve(
+    Response.json({ position: null, closedPositionObservedSlot: "600" })
+  );
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("700");
+  expect(readEarnPositionCache(scope)?.currentHolding.observedSlot).toBe("700");
+});
+
+test("accepted closure invalidates a previously outstanding refresh", async () => {
+  const http = deferred<Response>();
+  globalThis.fetch = mock(() => http.promise) as unknown as typeof fetch;
+  render();
+  await flush();
+  const rpc = deferred<EarnRpcHoldingsSnapshot>();
+  rpcRead = () => rpc.promise;
+  const refresh = output.refresh();
+  http.resolve(
+    Response.json({ position: null, closedPositionObservedSlot: "600" })
+  );
+  await flush();
+  rpc.resolve(snapshot("500"));
+  await refresh;
+  await flush();
+  expectClosed();
+});
+
+for (const change of [
+  { walletAddress: "11111111111111111111111111111114" },
+  { solanaEnv: "devnet" },
+  { settingsPda: "11111111111111111111111111111115" },
+]) {
+  test(`closure fence is isolated on ${JSON.stringify(
+    change
+  )} switch`, async () => {
+    render();
+    await flush();
+    expectClosed();
+    const pending = deferred<EarnRpcHoldingsSnapshot>();
+    rpcRead = () => pending.promise;
+    const oldRefresh = output.refresh();
+    props = { ...props, ...change };
+    rpcRead = async ({ minContextSlot }) => {
+      expect(minContextSlot).toBeUndefined();
+      return snapshot("550");
+    };
+    respondWith({ position: null });
+    render();
+    await flush();
+    pending.resolve(snapshot("800"));
+    await oldRefresh;
+    await flush();
+    expect(output.position?.currentHolding.observedSlot).toBe("550");
+    expect(
+      readEarnPositionCache({ ...scope, ...change })?.currentHolding
+        .observedSlot
+    ).toBe("550");
+    expect(readEarnPositionCache(scope)).toBeNull();
+  });
+}

--- a/apps/web/src/hooks/use-active-earn-position-races.test.ts
+++ b/apps/web/src/hooks/use-active-earn-position-races.test.ts
@@ -171,8 +171,8 @@ function respondWith(body: unknown) {
 function expectClosed() {
   expect(output.position).toBeNull();
   expect(readEarnPositionCache(scope)).toBeNull();
-  // Both the scoped and last-position fallback cache must be removed.
-  expect(storage.size).toBe(0);
+  // Neither positive cache may survive; scoped closure evidence must survive.
+  expect([...storage.keys()].filter((key) => !key.endsWith(":closed"))).toEqual([]);
 }
 
 beforeEach(() => {
@@ -342,3 +342,33 @@ for (const change of [
     expect(readEarnPositionCache(scope)).toBeNull();
   });
 }
+
+test("closure survives owner remount while its HTTP response is delayed", async () => {
+  render();
+  await flush();
+  expectClosed();
+  cells = [];
+  cursor = 0;
+  pendingEffects = [];
+  const http = deferred<Response>();
+  globalThis.fetch = mock(() => http.promise) as unknown as typeof fetch;
+  rpcRead = async () => snapshot("500");
+  render();
+  await flush();
+  expectClosed();
+});
+
+test("confirmed deposit survives lagging empty refresh without a prior closure", async () => {
+  respondWith({ position: null });
+  render();
+  await flush();
+  output.setPosition(position("700"));
+  render();
+  rpcRead = async ({ minContextSlot }) => {
+    expect(minContextSlot).toBe(700);
+    return { ...snapshot("500"), holdings: [] };
+  };
+  await output.refresh();
+  await flush();
+  expect(output.position?.currentHolding.observedSlot).toBe("700");
+});

--- a/apps/web/src/hooks/use-active-earn-position.test.ts
+++ b/apps/web/src/hooks/use-active-earn-position.test.ts
@@ -6,6 +6,7 @@ import {
   applyEarnRpcSnapshotToPosition,
   calculateWeightedEarnApyBps,
   isActiveEarnPosition,
+  shouldKeepCurrentPositionOverConfirmed,
 } from "./use-active-earn-position";
 
 function holding(
@@ -32,6 +33,49 @@ function holding(
 }
 
 describe("multi-source Earn portfolio state", () => {
+  test("closure proof clears stale RPC holdings but preserves a later deposit", () => {
+    const current = {
+      currentHolding: { observedSlot: "500" },
+      holdings: [
+        {
+          ...holding("100", "kamino", "1000", "reserve:a"),
+          provenance: { source: "rpc_getMultipleAccounts" },
+        },
+      ],
+    } as unknown as ActiveEarnPosition;
+    expect(
+      shouldKeepCurrentPositionOverConfirmed({ current, confirmed: null })
+    ).toBe(true);
+    expect(
+      shouldKeepCurrentPositionOverConfirmed({
+        current,
+        confirmed: null,
+        closedPositionObservedSlot: "not-a-slot",
+      })
+    ).toBe(true);
+    expect(
+      shouldKeepCurrentPositionOverConfirmed({
+        current,
+        confirmed: null,
+        closedPositionObservedSlot: "500",
+      })
+    ).toBe(false);
+    expect(
+      shouldKeepCurrentPositionOverConfirmed({
+        current,
+        confirmed: null,
+        closedPositionObservedSlot: "600",
+      })
+    ).toBe(false);
+    expect(
+      shouldKeepCurrentPositionOverConfirmed({
+        current,
+        confirmed: null,
+        closedPositionObservedSlot: "499",
+      })
+    ).toBe(true);
+  });
+
   test("weights reserve APY by nominal exposure and gives idle a zero rate", () => {
     expect(
       calculateWeightedEarnApyBps([

--- a/apps/web/src/hooks/use-active-earn-position.ts
+++ b/apps/web/src/hooks/use-active-earn-position.ts
@@ -90,6 +90,7 @@ type EarnPositionConnection = Pick<
   Partial<Pick<Connection, "onAccountChange" | "removeAccountChangeListener">>;
 
 type RpcPositionRead = {
+  observedSlot: string;
   position: ActiveEarnPosition | null;
   watchedAccounts: EarnRpcWatchedAccount[];
 };
@@ -469,6 +470,7 @@ export function useActiveEarnPosition({
   const reconcileRequestKeyRef = useRef<string | null>(null);
   const refreshDirtyRef = useRef(false);
   const refreshGenerationRef = useRef(0);
+  const closedPositionSlotRef = useRef<bigint | null>(null);
   const positionScope = [
     enabled ? "enabled" : "disabled",
     solanaEnv,
@@ -487,6 +489,7 @@ export function useActiveEarnPosition({
   // newly selected wallet/settings scope (including a rapid A -> B -> A).
   if (activePositionScopeRef.current !== positionScope) {
     activePositionScopeRef.current = positionScope;
+    closedPositionSlotRef.current = null;
     refreshGenerationRef.current += 1;
     refreshDirtyRef.current = false;
     refreshInFlightRef.current = null;
@@ -537,15 +540,27 @@ export function useActiveEarnPosition({
         return null;
       }
 
+      const closedSlot = closedPositionSlotRef.current;
+      const currentSlot = parseEarnObservedSlot(positionRef.current);
+      const minContextSlot =
+        closedSlot === null
+          ? undefined
+          : Number(
+              currentSlot !== null && currentSlot > closedSlot
+                ? currentSlot
+                : closedSlot + BigInt(1)
+            );
       const snapshot = await fetchEarnRpcHoldingsSnapshot({
         cluster: resolveLoyalClusterForSolanaEnv(resolveSolanaEnv(solanaEnv)),
         connection,
+        minContextSlot,
         policy: earnPolicy,
         programId: new PublicKey(programId),
         settingsPda: new PublicKey(settingsPda),
       });
 
       return {
+        observedSlot: snapshot.observedSlot,
         position: applyEarnRpcSnapshotToPosition(basePosition, snapshot),
         watchedAccounts: snapshot.provenance.watchedAccounts,
       };
@@ -556,6 +571,19 @@ export function useActiveEarnPosition({
   const commitRpcPosition = useCallback(
     (next: RpcPositionRead) => {
       if (activePositionScopeRef.current !== positionScope) {
+        return;
+      }
+      const closedSlot = closedPositionSlotRef.current;
+      const observedSlot = parseEarnRawAmount(next.observedSlot);
+      const currentSlot = parseEarnObservedSlot(positionRef.current);
+      if (
+        closedSlot !== null &&
+        (observedSlot === null ||
+          observedSlot <= closedSlot ||
+          (currentSlot !== null && observedSlot < currentSlot))
+      ) {
+        setHasResolved(true);
+        setIsLoading(false);
         return;
       }
       if (walletAddress && settingsPda) {
@@ -583,7 +611,24 @@ export function useActiveEarnPosition({
       if (activePositionScopeRef.current !== positionScope) {
         return;
       }
+      const proofSlot =
+        nextPosition === null
+          ? parseEarnRawAmount(closedPositionObservedSlot)
+          : null;
       if (
+        proofSlot !== null &&
+        proofSlot < BigInt(Number.MAX_SAFE_INTEGER) &&
+        (closedPositionSlotRef.current === null ||
+          proofSlot > closedPositionSlotRef.current)
+      ) {
+        closedPositionSlotRef.current = proofSlot;
+      }
+      const closedSlot = closedPositionSlotRef.current;
+      const nextSlot = parseEarnObservedSlot(nextPosition);
+      if (
+        (nextPosition !== null &&
+          closedSlot !== null &&
+          (nextSlot === null || nextSlot <= closedSlot)) ||
         shouldKeepCurrentPositionOverConfirmed({
           current: positionRef.current,
           confirmed: nextPosition,
@@ -646,7 +691,7 @@ export function useActiveEarnPosition({
             }
             if (next) {
               commitRpcPosition(next);
-              result = next.position;
+              result = positionRef.current;
             } else {
               const confirmed = await fetchConfirmedEarnPosition();
               if (

--- a/apps/web/src/hooks/use-active-earn-position.ts
+++ b/apps/web/src/hooks/use-active-earn-position.ts
@@ -96,6 +96,7 @@ type RpcPositionRead = {
 
 type ConfirmedEarnPositionResponse = {
   position: ActiveEarnPosition | null;
+  closedPositionObservedSlot?: string | null;
 };
 
 export function isActiveEarnPosition(
@@ -161,10 +162,19 @@ function hasRpcObservedHoldings(
   );
 }
 
-function shouldKeepCurrentPositionOverConfirmed(args: {
+export function shouldKeepCurrentPositionOverConfirmed(args: {
   current: ActiveEarnPosition | null;
   confirmed: ActiveEarnPosition | null;
+  closedPositionObservedSlot?: string | null;
 }): boolean {
+  if (args.confirmed === null && args.closedPositionObservedSlot) {
+    const closedSlot = parseEarnRawAmount(args.closedPositionObservedSlot);
+    const currentSlot = parseEarnObservedSlot(args.current);
+    if (closedSlot !== null && closedSlot >= BigInt(0)) {
+      // A closure tombstone supersedes old RPC/cache holdings, not a later deposit.
+      return currentSlot !== null && currentSlot > closedSlot;
+    }
+  }
   if (!(args.current && args.confirmed)) {
     return hasRpcObservedHoldings(args.current);
   }
@@ -410,7 +420,7 @@ function isConfirmedEarnPositionResponse(
   );
 }
 
-async function fetchConfirmedEarnPosition(): Promise<ActiveEarnPosition | null> {
+async function fetchConfirmedEarnPosition(): Promise<ConfirmedEarnPositionResponse> {
   const response = await fetch(
     "/api/smart-accounts/yield-optimization/position",
     {
@@ -427,7 +437,7 @@ async function fetchConfirmedEarnPosition(): Promise<ActiveEarnPosition | null> 
     throw new Error("Invalid confirmed Earn position response.");
   }
 
-  return data.position;
+  return data;
 }
 
 export function useActiveEarnPosition({
@@ -495,6 +505,8 @@ export function useActiveEarnPosition({
       if (activePositionScopeRef.current !== positionScope) {
         return;
       }
+      // A local confirmed/optimistic mutation supersedes outstanding reads.
+      refreshGenerationRef.current += 1;
       setHasResolved(true);
       setIsLoading(false);
       setPositionState((current) => {
@@ -564,7 +576,10 @@ export function useActiveEarnPosition({
   );
 
   const commitConfirmedPosition = useCallback(
-    (nextPosition: ActiveEarnPosition | null) => {
+    ({
+      position: nextPosition,
+      closedPositionObservedSlot,
+    }: ConfirmedEarnPositionResponse) => {
       if (activePositionScopeRef.current !== positionScope) {
         return;
       }
@@ -572,6 +587,7 @@ export function useActiveEarnPosition({
         shouldKeepCurrentPositionOverConfirmed({
           current: positionRef.current,
           confirmed: nextPosition,
+          closedPositionObservedSlot,
         })
       ) {
         setHasResolved(true);
@@ -586,6 +602,9 @@ export function useActiveEarnPosition({
           settingsPda,
           position: nextPosition,
         });
+      }
+      if (nextPosition === null && closedPositionObservedSlot) {
+        refreshGenerationRef.current += 1;
       }
       positionRef.current = nextPosition;
       setWatchedAccounts([]);
@@ -629,7 +648,14 @@ export function useActiveEarnPosition({
               commitRpcPosition(next);
               result = next.position;
             } else {
-              setHasResolved(true);
+              const confirmed = await fetchConfirmedEarnPosition();
+              if (
+                generation !== refreshGenerationRef.current ||
+                activePositionScopeRef.current !== positionScope
+              ) {
+                return positionRef.current;
+              }
+              commitConfirmedPosition(confirmed);
               result = positionRef.current;
             }
           } catch (error) {
@@ -670,7 +696,12 @@ export function useActiveEarnPosition({
     refreshInFlightRef.current = promise;
     refreshInFlightScopeRef.current = positionScope;
     return promise;
-  }, [commitRpcPosition, positionScope, readRpcPosition]);
+  }, [
+    commitConfirmedPosition,
+    commitRpcPosition,
+    positionScope,
+    readRpcPosition,
+  ]);
 
   const suppressSubscriptionRefreshThroughSlot = useCallback(
     (slot: bigint | number | string | null | undefined) => {
@@ -739,6 +770,11 @@ export function useActiveEarnPosition({
 
     let cancelled = false;
     const loadLivePosition = async () => {
+      const generation = refreshGenerationRef.current;
+      const isStale = () =>
+        cancelled ||
+        activePositionScopeRef.current !== positionScope ||
+        generation !== refreshGenerationRef.current;
       const confirmedPositionPromise = fetchConfirmedEarnPosition().catch(
         (error) => {
           console.warn(
@@ -750,17 +786,23 @@ export function useActiveEarnPosition({
       );
       const rpcBasePosition = cached ?? positionRef.current;
       const next = await readRpcPosition(rpcBasePosition);
-      if (cancelled || activePositionScopeRef.current !== positionScope) {
+      if (isStale()) {
         return;
       }
       if (next) {
         commitRpcPosition(next);
         const confirmedPosition = await confirmedPositionPromise;
-        if (cancelled || activePositionScopeRef.current !== positionScope) {
+        if (isStale()) {
+          return;
+        }
+        if (confirmedPosition?.closedPositionObservedSlot) {
+          commitConfirmedPosition(confirmedPosition);
           return;
         }
         const basePosition =
-          confirmedPosition === undefined ? rpcBasePosition : confirmedPosition;
+          confirmedPosition === undefined
+            ? rpcBasePosition
+            : confirmedPosition.position;
         if (
           shouldRequestPositionReconciliation({
             base: basePosition,
@@ -787,7 +829,7 @@ export function useActiveEarnPosition({
       }
 
       const confirmedPosition = await confirmedPositionPromise;
-      if (cancelled || activePositionScopeRef.current !== positionScope) {
+      if (isStale()) {
         return;
       }
       if (confirmedPosition !== undefined) {

--- a/apps/web/src/hooks/use-active-earn-position.ts
+++ b/apps/web/src/hooks/use-active-earn-position.ts
@@ -177,7 +177,7 @@ export function shouldKeepCurrentPositionOverConfirmed(args: {
     }
   }
   if (!(args.current && args.confirmed)) {
-    return hasRpcObservedHoldings(args.current);
+    return args.current !== null;
   }
 
   if (hasRpcObservedHoldings(args.current)) {
@@ -400,6 +400,22 @@ export function writeEarnPositionCache(args: {
   writeLastEarnPositionCache(args);
 }
 
+function readClosedEarnPositionSlot(args: {
+  solanaEnv: string;
+  walletAddress: string;
+  settingsPda: string;
+}): bigint | null {
+  const closure = readClientCache<{ slot: string }>({
+    ...args,
+    key: `${getEarnPositionCacheKey(args)}:closed`,
+    version: EARN_POSITION_CACHE_VERSION,
+    validate: (data): data is { slot: string } =>
+      typeof data === "object" && data !== null && "slot" in data &&
+      typeof data.slot === "string" && /^\d+$/.test(data.slot),
+  });
+  return parseEarnRawAmount(closure?.slot);
+}
+
 function isConfirmedEarnPositionResponse(
   data: unknown
 ): data is ConfirmedEarnPositionResponse {
@@ -497,6 +513,24 @@ export function useActiveEarnPosition({
   }
 
   const canUseCache = Boolean(enabled && walletAddress && settingsPda);
+  const readClosureFence = useCallback(() => {
+    if (activePositionScopeRef.current !== positionScope) return closedPositionSlotRef.current;
+    const stored = walletAddress && settingsPda
+      ? readClosedEarnPositionSlot({ solanaEnv, walletAddress, settingsPda }) : null;
+    if (stored !== null && (closedPositionSlotRef.current === null || stored > closedPositionSlotRef.current)) {
+      closedPositionSlotRef.current = stored;
+    }
+    const currentSlot = parseEarnObservedSlot(positionRef.current);
+    if (stored !== null && positionRef.current !== null && currentSlot !== null && currentSlot <= stored) {
+      positionRef.current = null;
+      setPositionState(null);
+      setWatchedAccounts([]);
+      if (walletAddress && settingsPda) {
+        writeEarnPositionCache({ solanaEnv, walletAddress, settingsPda, position: null });
+      }
+    }
+    return closedPositionSlotRef.current;
+  }, [positionScope, settingsPda, solanaEnv, walletAddress]);
 
   const setPosition = useCallback(
     (
@@ -540,11 +574,11 @@ export function useActiveEarnPosition({
         return null;
       }
 
-      const closedSlot = closedPositionSlotRef.current;
+      const closedSlot = readClosureFence();
       const currentSlot = parseEarnObservedSlot(positionRef.current);
       const minContextSlot =
         closedSlot === null
-          ? undefined
+          ? currentSlot === null ? undefined : Number(currentSlot)
           : Number(
               currentSlot !== null && currentSlot > closedSlot
                 ? currentSlot
@@ -565,7 +599,7 @@ export function useActiveEarnPosition({
         watchedAccounts: snapshot.provenance.watchedAccounts,
       };
     },
-    [connection, earnPolicy, programId, settingsPda, solanaEnv]
+    [connection, earnPolicy, programId, readClosureFence, settingsPda, solanaEnv]
   );
 
   const commitRpcPosition = useCallback(
@@ -573,14 +607,13 @@ export function useActiveEarnPosition({
       if (activePositionScopeRef.current !== positionScope) {
         return;
       }
-      const closedSlot = closedPositionSlotRef.current;
+      const closedSlot = readClosureFence();
       const observedSlot = parseEarnRawAmount(next.observedSlot);
       const currentSlot = parseEarnObservedSlot(positionRef.current);
       if (
-        closedSlot !== null &&
-        (observedSlot === null ||
-          observedSlot <= closedSlot ||
-          (currentSlot !== null && observedSlot < currentSlot))
+        observedSlot === null ||
+        (closedSlot !== null && observedSlot <= closedSlot) ||
+        (currentSlot !== null && observedSlot < currentSlot)
       ) {
         setHasResolved(true);
         setIsLoading(false);
@@ -600,7 +633,7 @@ export function useActiveEarnPosition({
       setHasResolved(true);
       setIsLoading(false);
     },
-    [positionScope, settingsPda, solanaEnv, walletAddress]
+    [positionScope, readClosureFence, settingsPda, solanaEnv, walletAddress]
   );
 
   const commitConfirmedPosition = useCallback(
@@ -611,6 +644,7 @@ export function useActiveEarnPosition({
       if (activePositionScopeRef.current !== positionScope) {
         return;
       }
+      readClosureFence();
       const proofSlot =
         nextPosition === null
           ? parseEarnRawAmount(closedPositionObservedSlot)
@@ -622,6 +656,18 @@ export function useActiveEarnPosition({
           proofSlot > closedPositionSlotRef.current)
       ) {
         closedPositionSlotRef.current = proofSlot;
+        if (walletAddress && settingsPda) {
+          writeClientCache<{ slot: string }>({
+            key: `${getEarnPositionCacheKey({ solanaEnv, walletAddress, settingsPda })}:closed`,
+            version: EARN_POSITION_CACHE_VERSION,
+            solanaEnv,
+            walletAddress,
+            settingsPda,
+            // Closure evidence must not expire like a positive balance cache.
+            ttlMs: Number.MAX_SAFE_INTEGER - Date.now(),
+            data: { slot: proofSlot.toString() },
+          });
+        }
       }
       const closedSlot = closedPositionSlotRef.current;
       const nextSlot = parseEarnObservedSlot(nextPosition);
@@ -657,7 +703,7 @@ export function useActiveEarnPosition({
       setHasResolved(true);
       setIsLoading(false);
     },
-    [positionScope, settingsPda, solanaEnv, walletAddress]
+    [positionScope, readClosureFence, settingsPda, solanaEnv, walletAddress]
   );
 
   const refresh = useCallback(() => {
@@ -797,11 +843,16 @@ export function useActiveEarnPosition({
       return;
     }
 
-    const cached = readEarnPositionCache({
+    closedPositionSlotRef.current = readClosedEarnPositionSlot({ solanaEnv, walletAddress, settingsPda });
+    const cachedPosition = readEarnPositionCache({
       solanaEnv,
       walletAddress,
       settingsPda,
     });
+    const cachedSlot = parseEarnObservedSlot(cachedPosition);
+    const cached = closedPositionSlotRef.current !== null &&
+      (cachedSlot === null || cachedSlot <= closedPositionSlotRef.current)
+      ? null : cachedPosition;
     if (cached) {
       positionRef.current = cached;
       setPositionState(cached);

--- a/apps/web/src/hooks/use-smart-account-sidebar-data.ts
+++ b/apps/web/src/hooks/use-smart-account-sidebar-data.ts
@@ -117,7 +117,6 @@ import {
   buildEarnWithdrawalConfirmRequestBody,
 } from "@/lib/yield-optimization/earn-confirm-contracts.shared";
 import {
-  isReusedEarnDepositPolicy,
   resolveEarnDepositConfirmPolicySignature,
 } from "@/lib/yield-optimization/earn-deposit-flow.shared";
 import {
@@ -6758,22 +6757,19 @@ export function useSmartAccountSidebarData(
                 return;
               }
 
-              // A top-up signs no policy transaction, so the confirm route
-              // resolves the reused policy's citation itself (DB row, else
-              // chain). Citing it here would dead-end every wallet whose row is
-              // gone — e.g. after a full Earn exit.
-              const policySignatureResolution = isReusedEarnDepositPolicy(
-                request.preparedDeposit
-              )
-                ? null
-                : resolveEarnDepositConfirmPolicySignature({
-                    activePolicy: currentEarnState?.policy ?? null,
-                    policyConfirmedSlot,
-                    policySignature,
-                    preparedDeposit: request.preparedDeposit,
-                    setupPolicyConfirmedSlot,
-                    setupPolicySignature,
-                  });
+              // A resumed finalize can reuse the route policy even though this
+              // attempt signs a new setup policy. Preserve that new proof while
+              // the confirm route resolves the old route citation.
+              const policySignatureResolution =
+                resolveEarnDepositConfirmPolicySignature({
+                  activePolicy: currentEarnState?.policy ?? null,
+                  policyConfirmedSlot,
+                  policySignature,
+                  preparedDeposit: request.preparedDeposit,
+                  resolveReusedPolicyOnServer: true,
+                  setupPolicyConfirmedSlot,
+                  setupPolicySignature,
+                });
               if (
                 policySignatureResolution &&
                 "error" in policySignatureResolution
@@ -6997,28 +6993,26 @@ export function useSmartAccountSidebarData(
         const onboarding = currentEarnState?.onboarding;
         // See the staged flow above: the confirm route owns the reused policy's
         // citation, so a top-up must not be blocked on the browser's copy of it.
-        const policySignatureResolution = isReusedEarnDepositPolicy(
-          preparedDeposit
-        )
-          ? null
-          : resolveEarnDepositConfirmPolicySignature({
-              activePolicy: currentEarnState?.policy ?? null,
-              policyConfirmedSlot:
-                request.policyConfirmedSlot ??
-                onboarding?.policy?.lastSeenSlot ??
-                currentEarnState?.policy?.lastSeenSlot,
-              policySignature:
-                request.policySignature ??
-                onboarding?.policy?.lastSeenSignature ??
-                currentEarnState?.policy?.lastSeenSignature,
-              preparedDeposit,
-              setupPolicyConfirmedSlot:
-                request.setupPolicyConfirmedSlot ??
-                onboarding?.setupPolicy?.lastSeenSlot,
-              setupPolicySignature:
-                request.setupPolicySignature ??
-                onboarding?.setupPolicy?.lastSeenSignature,
-            });
+        const policySignatureResolution =
+          resolveEarnDepositConfirmPolicySignature({
+            activePolicy: currentEarnState?.policy ?? null,
+            policyConfirmedSlot:
+              request.policyConfirmedSlot ??
+              onboarding?.policy?.lastSeenSlot ??
+              currentEarnState?.policy?.lastSeenSlot,
+            policySignature:
+              request.policySignature ??
+              onboarding?.policy?.lastSeenSignature ??
+              currentEarnState?.policy?.lastSeenSignature,
+            preparedDeposit,
+            resolveReusedPolicyOnServer: true,
+            setupPolicyConfirmedSlot:
+              request.setupPolicyConfirmedSlot ??
+              onboarding?.setupPolicy?.lastSeenSlot,
+            setupPolicySignature:
+              request.setupPolicySignature ??
+              onboarding?.setupPolicy?.lastSeenSignature,
+          });
         if (policySignatureResolution && "error" in policySignatureResolution) {
           return {
             success: false,

--- a/apps/web/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
@@ -123,7 +123,7 @@ export async function assertEarnFullExitProven(args: {
   policyAccounts: string[];
   programId: PublicKey;
   settingsPda: PublicKey;
-}): Promise<void> {
+}): Promise<bigint> {
   try {
     const proof = await verifyEarnFullExitZeroBalances({
       cluster: args.cluster,
@@ -147,8 +147,9 @@ export async function assertEarnFullExitProven(args: {
     await verifyPolicyAccountsClosed({
       accounts: args.policyAccounts,
       connection: args.connection,
-      minContextSlot: args.minContextSlot,
+      minContextSlot: Number(proof.observedSlot),
     });
+    return BigInt(proof.observedSlot);
   } catch (error) {
     if (error instanceof EarnCleanupConfirmError) {
       throw error;

--- a/apps/web/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-cleanup-confirm.server.ts
@@ -93,7 +93,15 @@ export async function verifyPolicyAccountsClosed(args: {
         args.accounts.map((account) => new PublicKey(account)),
         { commitment: "confirmed", minContextSlot: args.minContextSlot }
       );
-    if (context.slot < args.minContextSlot) {
+    if (
+      !Number.isSafeInteger(args.minContextSlot) ||
+      args.minContextSlot < 0 ||
+      !Number.isSafeInteger(context.slot) ||
+      context.slot < args.minContextSlot ||
+      args.accounts.length === 0 ||
+      value.length !== args.accounts.length ||
+      Array.from(value).some((account) => account === undefined)
+    ) {
       throw new EarnCleanupConfirmError(
         503,
         "full_exit_verification_retryable",

--- a/apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, spyOn, test } from "bun:test";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import {
+  getKaminoUsdcEarnTargetForCluster,
+  getRiskBasketMarketsForCluster,
+  getStablecoinMintForCluster,
+  LoyalCluster,
+  RiskBasket,
+  Stablecoin,
+} from "@loyal-labs/actions";
 
 mock.module("server-only", () => ({}));
 
@@ -11,7 +21,167 @@ const { serializeVerifiedWithdrawPosition } = await import(
 const { recordAutodepositCloseIntent, recordAutodepositSetupIntent } =
   await import("./earn-autodeposit-repository.server");
 
+// Exercise the real policy-confirm handler and parser. Only auth and the RPC
+// boundary are substituted; no signed transaction or projection write occurs.
+const policyPrincipal = {
+  walletAddress: new PublicKey(10).toBase58(),
+  settingsPda: new PublicKey(11).toBase58(),
+};
+let authenticated = true;
+mock.module("@/features/identity/server/auth-session", () => ({
+  resolveAuthenticatedPrincipalFromRequest: async () =>
+    authenticated ? policyPrincipal : null,
+}));
+mock.module("@/lib/core/config/solana-env-override", () => ({
+  resolveLoyalWebSolanaEnvFromEnv: () => "mainnet",
+}));
+mock.module("@/lib/solana/rpc-endpoints.server", () => ({
+  getServerSolanaEndpoints: () => ({
+    rpcEndpoint: "http://127.0.0.1:8899",
+    websocketEndpoint: "ws://127.0.0.1:8900",
+  }),
+}));
+const policyStatus = spyOn(Connection.prototype, "getSignatureStatuses");
+policyStatus.mockResolvedValue({
+  context: { slot: 701 },
+  value: [
+    {
+      slot: 700,
+      confirmations: null,
+      err: null,
+      confirmationStatus: "finalized",
+    },
+  ],
+});
+afterAll(() => policyStatus.mockRestore());
+const { POST: confirmPolicy } = await import(
+  "@/app/api/smart-accounts/yield-optimization/policies/confirm/route"
+);
+
 const now = new Date("2026-08-25T12:00:00.000Z");
+
+function policyBody(overrides: Record<string, unknown> = {}) {
+  const settings = new PublicKey(policyPrincipal.settingsPda);
+  const target = getKaminoUsdcEarnTargetForCluster(LoyalCluster.MainnetBeta);
+  return {
+    cluster: "mainnet-beta",
+    stage: "route_policy",
+    confirmedSlot: "700",
+    delegatedSigner: new PublicKey(12).toBase58(),
+    liquidityMint: target.liquidityMint.toBase58(),
+    market: target.market.toBase58(),
+    targetReserve: target.reserve.toBase58(),
+    policyAccount: pda
+      .getPolicyPda({ settingsPda: settings, policySeed: 46 })[0]
+      .toBase58(),
+    policyId: "46",
+    policySeed: "46",
+    policySignature: "confirmed-route-policy",
+    setupPolicyAccount: pda
+      .getPolicyPda({ settingsPda: settings, policySeed: 47 })[0]
+      .toBase58(),
+    setupPolicyId: "47",
+    setupPolicySeed: "47",
+    setupPolicySignature: "confirmed-setup-policy",
+    setupPolicyConfirmedSlot: "700",
+    settings: policyPrincipal.settingsPda,
+    walletAddress: policyPrincipal.walletAddress,
+    vaultIndex: 1,
+    vaultPubkey: pda
+      .getSmartAccountPda({ settingsPda: settings, accountIndex: 1 })[0]
+      .toBase58(),
+    ...overrides,
+  };
+}
+
+function postPolicy(overrides: Record<string, unknown> = {}) {
+  return confirmPolicy(
+    new Request("http://localhost/policies/confirm", {
+      method: "POST",
+      body: JSON.stringify(policyBody(overrides)),
+    })
+  );
+}
+
+describe("policy setup confirmation matches prepared Safe products", () => {
+  for (const stage of ["route_policy", "setup_policy"] as const) {
+    test(`${stage}: accepts the legacy target and a different Safe target`, async () => {
+      expect((await postPolicy({ stage })).status).toBe(200);
+      const response = await postPolicy({
+        stage,
+        market: getRiskBasketMarketsForCluster(
+          LoyalCluster.MainnetBeta,
+          RiskBasket.Safe
+        )[1].toBase58(),
+        targetReserve: new PublicKey(20).toBase58(),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        policy: { seed: stage === "route_policy" ? "46" : "47", vaultIndex: 1 },
+      });
+    });
+    test(`${stage}: accepts a prepared supported non-USDC product`, async () => {
+      expect(
+        (
+          await postPolicy({
+            stage,
+            liquidityMint: getStablecoinMintForCluster(
+              LoyalCluster.MainnetBeta,
+              Stablecoin.USDT
+            ).toBase58(),
+            targetReserve: new PublicKey(21).toBase58(),
+          })
+        ).status
+      ).toBe(200);
+    });
+  }
+
+  test("retains mint, market, PDA, seed, vault, owner, cluster and slot fences", async () => {
+    for (const overrides of [
+      { liquidityMint: new PublicKey(22).toBase58() },
+      { market: new PublicKey(23).toBase58() },
+      { targetReserve: "not-a-public-key" },
+      { policyAccount: new PublicKey(24).toBase58() },
+      { policyId: "48" },
+      { policySeed: "0" },
+      { vaultIndex: 0 },
+      { vaultPubkey: new PublicKey(25).toBase58() },
+      { stage: "setup_policy", setupPolicySeed: "48" },
+      { stage: "setup_policy", setupPolicySignature: null },
+      { cluster: "devnet" },
+      { confirmedSlot: "699" },
+    ])
+      expect((await postPolicy(overrides)).status).toBe(400);
+    expect(
+      (await postPolicy({ walletAddress: new PublicKey(26).toBase58() })).status
+    ).toBe(403);
+    authenticated = false;
+    try {
+      expect((await postPolicy()).status).toBe(401);
+    } finally {
+      authenticated = true;
+    }
+  });
+
+  test("never acknowledges a failed transaction", async () => {
+    policyStatus.mockResolvedValueOnce({
+      context: { slot: 701 },
+      value: [
+        {
+          slot: 700,
+          confirmations: null,
+          err: { InstructionError: [0, "InvalidArgument"] },
+          confirmationStatus: "finalized",
+        },
+      ],
+    });
+    const response = await postPolicy();
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "unconfirmed_signature" },
+    });
+  });
+});
 
 function depositInput() {
   return {

--- a/apps/web/src/lib/yield-optimization/earn-deposit-flow.shared.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-deposit-flow.shared.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { SmartAccountPreparedEarnUsdcDeposit } from "@loyal-labs/smart-account-vaults";
 import { PublicKey } from "@solana/web3.js";
 
+import { buildEarnDepositConfirmRequestBody } from "./earn-confirm-contracts.shared";
 import {
   getEarnDepositReviewStages,
   resolveEarnDepositConfirmPolicySignature,
@@ -28,6 +29,90 @@ function createPreparedDeposit(args: {
 }
 
 describe("Earn deposit flow helpers", () => {
+  test("resumed finalize retains its new proof without demanding the old route citation", () => {
+    const preparedDeposit = createPreparedDeposit({
+      policyInitialization: "reuse",
+      finalize: true,
+    });
+    const resolution = resolveEarnDepositConfirmPolicySignature({
+      preparedDeposit,
+      resolveReusedPolicyOnServer: true,
+      setupPolicySignature: "new-setup-signature",
+      setupPolicyConfirmedSlot: "122",
+    });
+    expect("error" in resolution).toBe(false);
+    if ("error" in resolution) throw new Error(resolution.error);
+    const body = buildEarnDepositConfirmRequestBody({
+      ...resolution,
+      preparedDeposit,
+      signature: "deposit-signature",
+      confirmedSlot: "123",
+      smartAccountAddress: POLICY_ACCOUNT.toBase58(),
+    });
+    // Reuse selects server citation recovery; the just-confirmed setup proof
+    // must survive the same wire builder used by batch and sequential sends.
+    expect(body.policyInitialization).toBe("reuse");
+    expect(body.setupPolicySignature).toBe("new-setup-signature");
+    expect(body.setupPolicyConfirmedSlot).toBe("122");
+    expect(resolution.policySignature).toBeUndefined();
+  });
+
+  test("resumed finalize still rejects a missing or incomplete new setup proof", () => {
+    for (const proof of [
+      {},
+      { setupPolicySignature: "new-setup-signature" },
+      { setupPolicyConfirmedSlot: "122" },
+      { setupPolicySignature: " ", setupPolicyConfirmedSlot: "122" },
+    ]) {
+      const resolution = resolveEarnDepositConfirmPolicySignature({
+        preparedDeposit: createPreparedDeposit({
+          policyInitialization: "reuse",
+          finalize: true,
+        }),
+        resolveReusedPolicyOnServer: true,
+        ...proof,
+      });
+      expect("error" in resolution).toBe(true);
+    }
+  });
+
+  test("server citation recovery never waives a new route-policy signature", () => {
+    for (const policyInitialization of ["create", "reuse"] as const) {
+      const resolution = resolveEarnDepositConfirmPolicySignature({
+        preparedDeposit: createPreparedDeposit({
+          policyInitialization,
+          setup: true,
+          finalize: true,
+        }),
+        resolveReusedPolicyOnServer: true,
+        setupPolicySignature: "new-setup-signature",
+        setupPolicyConfirmedSlot: "122",
+      });
+      expect("error" in resolution).toBe(true);
+    }
+  });
+
+  test("ordinary reuse delegates citation recovery only to a capable endpoint", () => {
+    const preparedDeposit = createPreparedDeposit({
+      policyInitialization: "reuse",
+    });
+    expect(
+      "error" in resolveEarnDepositConfirmPolicySignature({ preparedDeposit })
+    ).toBe(true);
+    const resolution = resolveEarnDepositConfirmPolicySignature({
+      preparedDeposit,
+      resolveReusedPolicyOnServer: true,
+      policySignature: "stale-onboarding-citation",
+      policyConfirmedSlot: "100",
+      setupPolicySignature: "incomplete-stale-setup-citation",
+    });
+    expect("error" in resolution).toBe(false);
+    if ("error" in resolution) throw new Error(resolution.error);
+    expect(resolution.policySignature).toBeUndefined();
+    expect(resolution.policyConfirmedSlot).toBeUndefined();
+    expect(resolution.setupPolicySignature).toBeUndefined();
+  });
+
   test("first deposit without finalize requires setup then deposit", () => {
     const preparedDeposit = createPreparedDeposit({
       policyInitialization: "create",

--- a/apps/web/src/lib/yield-optimization/earn-deposit-flow.shared.ts
+++ b/apps/web/src/lib/yield-optimization/earn-deposit-flow.shared.ts
@@ -12,7 +12,7 @@ export type EarnDepositPolicySignatureSource = {
 export type EarnDepositPolicySignatureResolution =
   | {
       policyConfirmedSlot?: string;
-      policySignature: string;
+      policySignature?: string;
       setupPolicyConfirmedSlot?: string;
       setupPolicySignature?: string;
     }
@@ -71,20 +71,15 @@ export function getEarnDepositReviewStagePosition(args: {
   };
 }
 
-// A top-up signs no policy transaction: the policy already exists on-chain and
-// the deposit just routes through it. Its "policy signature" is therefore only
-// a citation of where we last saw that policy — a server fact, resolvable from
-// the DB row or, when there is none, from the chain. The DB row legitimately
-// goes missing (a full Earn exit releases the pair; a failed confirm never
-// wrote one), and a browser cannot read the chain, so the client must never
-// gate a top-up on being able to cite it. Callers that can reach the chain
-// (the confirm routes) resolve it themselves.
+// The route policy can already exist even when the setup-policy/finalize stage
+// still needs signing after an interrupted first deposit. Its old signature is
+// a server-resolved citation, not a transaction this attempt must sign again.
+// Reusing the route policy does NOT waive proof for a newly signed finalize.
 export function isReusedEarnDepositPolicy(
   preparedDeposit: SmartAccountPreparedEarnUsdcDeposit
 ): boolean {
   return (
     !preparedDeposit.policySetupPrepared &&
-    !preparedDeposit.policyFinalizePrepared &&
     preparedDeposit.persistence.policyInitialization === "reuse"
   );
 }
@@ -94,6 +89,8 @@ export function resolveEarnDepositConfirmPolicySignature(args: {
   policyConfirmedSlot?: string | null;
   policySignature?: string | null;
   preparedDeposit: SmartAccountPreparedEarnUsdcDeposit;
+  // Only clients whose confirm endpoint resolves reused citations may omit one.
+  resolveReusedPolicyOnServer?: boolean;
   setupPolicyConfirmedSlot?: string | null;
   setupPolicySignature?: string | null;
 }): EarnDepositPolicySignatureResolution {
@@ -101,6 +98,28 @@ export function resolveEarnDepositConfirmPolicySignature(args: {
   const providedPolicyConfirmedSlot = args.policyConfirmedSlot?.trim();
   const providedSetup = args.setupPolicySignature?.trim();
   const providedSetupConfirmedSlot = args.setupPolicyConfirmedSlot?.trim();
+  if (
+    args.resolveReusedPolicyOnServer &&
+    isReusedEarnDepositPolicy(args.preparedDeposit)
+  ) {
+    if (
+      args.preparedDeposit.policyFinalizePrepared &&
+      (!providedSetup || !providedSetupConfirmedSlot)
+    ) {
+      return {
+        error:
+          "Confirming this first Earn deposit requires the setup policy signature. Review the deposit again before signing.",
+      };
+    }
+    // Do not borrow the old route citation from potentially stale onboarding
+    // state. The web confirm route resolves it for the requested policy PDA.
+    return args.preparedDeposit.policyFinalizePrepared
+      ? {
+          setupPolicySignature: providedSetup,
+          setupPolicyConfirmedSlot: providedSetupConfirmedSlot,
+        }
+      : {};
+  }
   if (provided) {
     const requiresPolicySetup = Boolean(
       args.preparedDeposit.policySetupPrepared

--- a/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
@@ -52,6 +52,7 @@ function createHolding(args: {
     provenance: {},
     reserve: args.reserve ?? null,
     supplyApyBps: null,
+    tokenProgramId: TOKEN_PROGRAM_ID.toBase58(),
   };
 }
 
@@ -171,6 +172,57 @@ describe("Earn full-exit zero proof", () => {
     expect(proof.remainingHoldings).toEqual([
       expect.objectContaining({ amountRaw: "25", reserve: secondReserve }),
     ]);
+  });
+
+  test("blocks a later idle deposit even when the older inventory is empty", async () => {
+    for (const amountRaw of ["10000", "100000000"]) {
+      const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+        fetchHoldingsSnapshot: async () =>
+          createHoldingsSnapshot(
+            [
+              {
+                ...createHolding({ amountRaw, kind: "idle" }),
+                observedSlot: "600",
+              },
+            ],
+            "600"
+          ) as never,
+        fetchVaultSnapshot: async () =>
+          createVaultSnapshot({ observedSlot: 500 }),
+      });
+      expect(proof.status).toBe("full_exit_incomplete");
+    }
+  });
+
+  test("never promotes the newest holdings chunk to a closure watermark", async () => {
+    // Both inventory programs and every holdings chunk are fenced at 500.
+    // The holdings snapshot reports its MAX context; 600 is not a zero proof
+    // for an intervening deposit at 550, even if inventory is newer still.
+    for (const inventorySlot of [500, 700]) {
+      const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+        fetchHoldingsSnapshot: async () =>
+          createHoldingsSnapshot([], "600") as never,
+        fetchVaultSnapshot: async () =>
+          createVaultSnapshot({ observedSlot: inventorySlot }),
+      });
+      expect(proof.status).toBe("policy_close_required");
+      expect(BigInt(proof.observedSlot)).toBe(BigInt(500));
+      expect(BigInt(proof.observedSlot)).toBeLessThan(BigInt(550));
+    }
+  });
+
+  test("does not treat unknown idle assets as permitted dust", async () => {
+    const proof = await verifyEarnFullExitZeroBalances(createInput(), {
+      fetchHoldingsSnapshot: async () =>
+        createHoldingsSnapshot([
+          {
+            ...createHolding({ amountRaw: "1", kind: "idle" }),
+            liquidityMint: collateralMint.toBase58(),
+          },
+        ]) as never,
+      fetchVaultSnapshot: async () => createVaultSnapshot({}),
+    });
+    expect(proof.status).toBe("full_exit_incomplete");
   });
 
   test("rejects a stale RPC context instead of authorizing closure", async () => {

--- a/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
@@ -13,13 +13,17 @@ import type { Connection, PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 
 import {
+  deriveEarnVaultPda,
   fetchEarnRpcHoldingsSnapshot,
   type EarnRpcHolding,
   type EarnRpcHoldingsSnapshot,
   type EarnRpcPolicyMetadata,
 } from "./earn-rpc-holdings.client";
 import { getEarnProductAssetsForCluster } from "./earn-product-mints.shared";
-import { EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW } from "./yield-deposit-repository.server";
+import {
+  EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW,
+  type UserYieldPositionRecord,
+} from "./yield-deposit-repository.server";
 
 const SLOT_LAG_ATTEMPTS = 3;
 const SLOT_LAG_RETRY_DELAY_MS = 500;
@@ -223,7 +227,7 @@ function classifyZeroProof(args: {
   };
 }
 
-export async function verifyEarnFullExitZeroBalances(
+async function readFullExitSnapshots(
   args: {
     cluster: LoyalCluster;
     connection: Connection;
@@ -233,7 +237,7 @@ export async function verifyEarnFullExitZeroBalances(
     settingsPda: PublicKey;
   },
   dependencies: EarnFullExitZeroProofDependencies = {}
-): Promise<EarnFullExitZeroProof> {
+) {
   if (!Number.isSafeInteger(args.minContextSlot) || args.minContextSlot < 0) {
     throw new Error("Earn full-exit minContextSlot is outside the safe range.");
   }
@@ -294,10 +298,81 @@ export async function verifyEarnFullExitZeroBalances(
     sleep,
   });
 
-  return classifyZeroProof({
+  // Validate both independent context fences even for funded display reads.
+  const proof = classifyZeroProof({
     cluster: args.cluster,
     holdingsSnapshot,
     minContextSlot: args.minContextSlot,
     vaultSnapshot,
   });
+  return { holdingsSnapshot, proof, vaultSnapshot };
+}
+
+export async function verifyEarnFullExitZeroBalances(
+  args: Parameters<typeof readFullExitSnapshots>[0],
+  dependencies: EarnFullExitZeroProofDependencies = {}
+): Promise<EarnFullExitZeroProof> {
+  return (await readFullExitSnapshots(args, dependencies)).proof;
+}
+
+// Funded totals belong to the vault's assets, not the sum of accounting
+// lifecycles. Scan the entire supported product universe, independent of a
+// lagging/replacement policy. Unknown inventory or unreadable reserves must
+// reject this replacement total rather than silently hide another product.
+export async function fetchEarnFullVaultHoldingsSnapshot(
+  args: Omit<Parameters<typeof readFullExitSnapshots>[0], "policy"> & {
+    accountingPositions: readonly Pick<
+      UserYieldPositionRecord,
+      "currentLiquidityMint" | "currentMarket"
+    >[];
+  }
+): Promise<EarnRpcHoldingsSnapshot> {
+  const assets = getEarnProductAssetsForCluster(args.cluster);
+  const markets = getRiskBasketMarketsForCluster(
+    args.cluster,
+    RiskBasket.Safe
+  ).map((market) => market.toBase58());
+  if (
+    args.accountingPositions.some(
+      (row) =>
+        !assets.some(
+          (asset) => asset.mint.toBase58() === row.currentLiquidityMint
+        ) ||
+        (row.currentMarket !== null && !markets.includes(row.currentMarket))
+    )
+  ) {
+    throw new Error(
+      "Earn accounting includes an unsupported product or venue."
+    );
+  }
+  const { holdingsSnapshot, vaultSnapshot } = await readFullExitSnapshots({
+    ...args,
+    policy: {
+      account: args.settingsPda.toBase58(),
+      seed: "0",
+      vaultIndex: 1,
+      vaultPubkey: deriveEarnVaultPda(args).toBase58(),
+      stableMints: assets.map((asset) => asset.mint.toBase58()),
+      kaminoLiquidityMints: assets.map((asset) => asset.mint.toBase58()),
+      kaminoMarkets: markets,
+    },
+  });
+  for (const account of vaultSnapshot.tokenAccounts) {
+    if (account.amountRaw === BigInt(0)) continue;
+    const holding = holdingsSnapshot.holdings.find(
+      (item) =>
+        item.kind === "idle" &&
+        item.provenance.tokenAccount === account.address.toBase58() &&
+        item.liquidityMint === account.mint.toBase58() &&
+        item.tokenProgramId === account.tokenProgramId.toBase58()
+    );
+    if (!holding || BigInt(holding.amountRaw) !== account.amountRaw) {
+      throw new Error("Earn inventory is unknown or disagrees with holdings.");
+    }
+  }
+  return {
+    ...holdingsSnapshot,
+    // Every balance-defining read established this floor, not the max chunk.
+    observedSlot: String(args.minContextSlot),
+  };
 }

--- a/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-full-exit-zero-proof.server.ts
@@ -136,19 +136,34 @@ function classifyZeroProof(args: {
       "Earn full-exit proof was observed before the withdrawal confirmation slot."
     );
   }
-  if (args.vaultSnapshot.observedSlot < args.minContextSlot) {
+  if (
+    !Number.isSafeInteger(args.vaultSnapshot.observedSlot) ||
+    args.vaultSnapshot.observedSlot < args.minContextSlot
+  ) {
     throw new Error(
       "Earn vault token inventory was observed before the withdrawal confirmation slot."
     );
   }
 
-  const remainingReserveHoldings = args.holdingsSnapshot.holdings.filter(
-    (holding) =>
-      holding.kind === "kamino" &&
-      positiveAmountRaw(holding.amountRaw) > BigInt(0)
-  );
+  const assets = getEarnProductAssetsForCluster(args.cluster);
+  const blockingHoldings = args.holdingsSnapshot.holdings.filter((holding) => {
+    const amount = positiveAmountRaw(holding.amountRaw);
+    if (amount === BigInt(0)) return false;
+    // Inventory and holdings can come from different banks. Positive holdings
+    // must block closure even when the token inventory has not caught up.
+    const isCanonicalIdle =
+      holding.kind === "idle" &&
+      assets.some(
+        (asset) =>
+          asset.mint.toBase58() === holding.liquidityMint &&
+          asset.tokenProgramId.toBase58() === holding.tokenProgramId
+      );
+    return (
+      !isCanonicalIdle || amount >= EARN_FINAL_EXIT_IDLE_DUST_TOLERANCE_RAW
+    );
+  });
   const idleAssetByTokenAccount = new Map(
-    getEarnProductAssetsForCluster(args.cluster).map((asset) => [
+    assets.map((asset) => [
       getAssociatedTokenAddressSync(
         asset.mint,
         args.vaultSnapshot.vaultPda,
@@ -190,14 +205,17 @@ function classifyZeroProof(args: {
       tokenProgramId: account.tokenProgramId.toBase58(),
     }));
   const status =
-    remainingReserveHoldings.length === 0 && blockingTokenAccounts.length === 0
+    blockingHoldings.length === 0 && blockingTokenAccounts.length === 0
       ? "policy_close_required"
       : "full_exit_incomplete";
 
   return {
     blockingTokenAccounts,
     cleanupTokenAccounts,
-    observedSlot: String(observedSlot),
+    // The holdings reader reports its newest chunk, not the oldest evidence.
+    // Only the requested floor is guaranteed across every holdings/inventory
+    // read; advertising a newer slot could tombstone an intervening deposit.
+    observedSlot: String(args.minContextSlot),
     remainingHoldings: args.holdingsSnapshot.holdings.filter(
       (holding) => positiveAmountRaw(holding.amountRaw) > BigInt(0)
     ),

--- a/apps/web/src/lib/yield-optimization/earn-position-read.server.test.ts
+++ b/apps/web/src/lib/yield-optimization/earn-position-read.server.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { findUserFacingEarnPosition } = await import(
+  "./earn-position-read.server"
+);
+type Dependencies = NonNullable<
+  Parameters<typeof findUserFacingEarnPosition>[1]
+>;
+const input = {
+  cluster: "mainnet-beta",
+  settings: "settings",
+  vaultIndex: 1,
+  walletAddress: "wallet",
+};
+const position = {
+  currentObservedSlot: BigInt(500),
+  vaultPubkey: "vault",
+} as NonNullable<Awaited<ReturnType<Dependencies["findPosition"]>>>;
+const closedState = {
+  vault: { active: false },
+  routePolicy: { active: false },
+} as NonNullable<Awaited<ReturnType<Dependencies["findCleanupState"]>>>;
+
+function fixture() {
+  const verifyClosedPosition = mock<Dependencies["verifyClosedPosition"]>(
+    async () => BigInt(600)
+  );
+  const dependencies: Dependencies = {
+    findPosition: async () => position,
+    resolveVaultPubkey: () => "vault",
+    hasInactivePolicy: async () => true,
+    findCleanupState: async () => closedState,
+    verifyClosedPosition,
+  };
+  return { dependencies, verifyClosedPosition };
+}
+
+describe("user-facing Earn position after cleanup", () => {
+  test("returns a slot-fenced closure only after proof", async () => {
+    const { dependencies, verifyClosedPosition } = fixture();
+    const result = await findUserFacingEarnPosition(input, dependencies);
+    expect(result.position).toBeNull();
+    expect(result.closedPositionObservedSlot).toBe("600");
+    // Proof cannot read an older slot than the displayed position.
+    expect(verifyClosedPosition.mock.calls[0]?.[2]).toBe(
+      position.currentObservedSlot
+    );
+  });
+
+  test("still proves closure after the worker closes the database position", async () => {
+    const { dependencies } = fixture();
+    dependencies.findPosition = async () => null;
+    const result = await findUserFacingEarnPosition(input, dependencies);
+    expect(result.position).toBeNull();
+    expect(result.closedPositionObservedSlot).toBe("600");
+  });
+
+  test("preserves funds and emits no closure on incomplete proof or RPC failure", async () => {
+    const { dependencies } = fixture();
+    for (const message of [
+      "balances remain",
+      "policy remains open",
+      "RPC unavailable",
+    ]) {
+      dependencies.verifyClosedPosition = async () => {
+        throw new Error(message);
+      };
+      const result = await findUserFacingEarnPosition(input, dependencies);
+      expect(result.position).toBe(position);
+      expect(result.closedPositionObservedSlot).toBeNull();
+    }
+  });
+
+  test("active, reactivated, or missing policies cannot close a position", async () => {
+    const { dependencies, verifyClosedPosition } = fixture();
+    dependencies.hasInactivePolicy = async () => false;
+    expect(
+      (await findUserFacingEarnPosition(input, dependencies)).position
+    ).toBe(position);
+    dependencies.hasInactivePolicy = async () => true;
+    dependencies.findCleanupState = async () => ({
+      ...closedState,
+      vault: { ...closedState.vault, active: true },
+      routePolicy: { ...closedState.routePolicy, active: true },
+    });
+    expect(
+      (await findUserFacingEarnPosition(input, dependencies)).position
+    ).toBe(position);
+    dependencies.findCleanupState = async () => null;
+    expect(
+      (await findUserFacingEarnPosition(input, dependencies)).position
+    ).toBe(position);
+    expect(verifyClosedPosition).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/yield-optimization/earn-position-read.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-position-read.server.ts
@@ -13,11 +13,14 @@ import {
   assertEarnFullExitProven,
   EarnCleanupConfirmError,
 } from "./earn-cleanup-confirm.server";
+import { fetchEarnFullVaultHoldingsSnapshot } from "./earn-full-exit-zero-proof.server";
 import {
+  findActiveYieldPositionsForVault,
   findEarnCleanupVaultState,
   findReconciledActiveYieldPositionForVault,
   hasInactiveYieldRoutePolicyForVault,
   type EarnCleanupVaultState,
+  type UserYieldPositionRecord,
 } from "./yield-deposit-repository.server";
 
 type PositionInput = Parameters<
@@ -39,35 +42,104 @@ async function verifyClosedPosition(
   state: EarnCleanupVaultState,
   positionSlot: bigint
 ): Promise<bigint> {
+  const policies = [
+    state.routePolicy,
+    ...(state.setupPolicy ? [state.setupPolicy] : []),
+  ];
+  return assertEarnFullExitProven({
+    cleanupState: state,
+    cluster: normalizeLoyalCluster(input.cluster),
+    connection: createReadConnection(),
+    minContextSlot: Number(
+      policies.reduce(
+        (slot, policy) =>
+          policy.lastSeenSlot > slot ? policy.lastSeenSlot : slot,
+        positionSlot
+      )
+    ),
+    policyAccounts: policies.map((policy) => policy.policyAccount),
+    programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+    settingsPda: new PublicKey(input.settings),
+  });
+}
+
+function createReadConnection() {
   const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(
     resolveLoyalWebSolanaEnvFromEnv(process.env)
   );
-  const connection = new Connection(rpcEndpoint, {
+  return new Connection(rpcEndpoint, {
     commitment: "confirmed",
     disableRetryOnRateLimit: true,
     fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
     wsEndpoint: websocketEndpoint,
   });
-  const policies = [
-    state.routePolicy,
-    ...(state.setupPolicy ? [state.setupPolicy] : []),
-  ];
-  const minContextSlot = Number(
-    policies.reduce(
-      (slot, policy) =>
-        policy.lastSeenSlot > slot ? policy.lastSeenSlot : slot,
-      positionSlot
+}
+
+// Mobile displays all products. Prove the entire vault empty at a floor that
+// includes EVERY accounting row before suppressing any of that aggregate. Never
+// re-query unguarded rows after accepting the proof (a new deposit may arrive).
+export async function findUserFacingEarnPositions(input: PositionInput) {
+  const positions = await findActiveYieldPositionsForVault(input);
+  const fallback =
+    positions.length === 0
+      ? await findReconciledActiveYieldPositionForVault(input)
+      : null;
+  const rows = fallback ? [fallback] : positions;
+  const vaultPubkey = resolveVaultPubkey(input);
+  if (
+    rows.some(
+      (row) =>
+        row.vaultPubkey !== vaultPubkey ||
+        row.settings !== input.settings ||
+        row.walletAddress !== input.walletAddress ||
+        row.vaultIndex !== input.vaultIndex
     )
+  ) {
+    throw new Error(
+      "Earn position rows do not match the requested vault scope."
+    );
+  }
+  const floor = rows.reduce(
+    (slot, row) =>
+      row.currentObservedSlot > slot ? row.currentObservedSlot : slot,
+    BigInt(0)
   );
-  return assertEarnFullExitProven({
-    cleanupState: state,
-    cluster: normalizeLoyalCluster(input.cluster),
-    connection,
-    minContextSlot,
-    policyAccounts: policies.map((policy) => policy.policyAccount),
-    programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
-    settingsPda: new PublicKey(input.settings),
+  const representative: UserYieldPositionRecord | null = rows[0]
+    ? { ...rows[0], currentObservedSlot: floor }
+    : null;
+  const result = await findUserFacingEarnPosition(input, {
+    findPosition: async () => representative,
+    resolveVaultPubkey,
+    hasInactivePolicy: hasInactiveYieldRoutePolicyForVault,
+    findCleanupState: findEarnCleanupVaultState,
+    verifyClosedPosition,
   });
+  let fundedSnapshot = null;
+  const cluster = normalizeLoyalCluster(input.cluster);
+  if (result.closedPositionObservedSlot === null && rows.length > 1) {
+    try {
+      const snapshot = await fetchEarnFullVaultHoldingsSnapshot({
+        accountingPositions: rows,
+        cluster,
+        connection: createReadConnection(),
+        minContextSlot: Number(floor),
+        programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+        settingsPda: new PublicKey(input.settings),
+      });
+      // Zero still requires the closed-policy proof above. A funded snapshot
+      // replaces only the display total, never deletes or reassigns product rows.
+      if (BigInt(snapshot.currentTotalAmountRaw) > BigInt(0))
+        fundedSnapshot = snapshot;
+    } catch {
+      // Incomplete/unknown inventory is not permission to reduce a balance.
+    }
+  }
+  return {
+    fundedSnapshot,
+    positions: result.closedPositionObservedSlot === null ? rows : [],
+    closedPositionObservedSlot: result.closedPositionObservedSlot,
+    vaultPubkey,
+  };
 }
 
 // A successful cleanup can reach the policy catalog before position accounting.

--- a/apps/web/src/lib/yield-optimization/earn-position-read.server.ts
+++ b/apps/web/src/lib/yield-optimization/earn-position-read.server.ts
@@ -1,0 +1,130 @@
+import "server-only";
+
+import { normalizeLoyalCluster } from "@loyal-labs/actions";
+import { pda } from "@loyal-labs/loyal-smart-accounts";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+import { getServerEnv } from "@/lib/core/config/server";
+import { resolveLoyalWebSolanaEnvFromEnv } from "@/lib/core/config/solana-env-override";
+import { getServerSolanaEndpoints } from "@/lib/solana/rpc-endpoints.server";
+import { getFrontendSolanaRpcFetch } from "@/lib/solana/rpc-rate-limit";
+
+import {
+  assertEarnFullExitProven,
+  EarnCleanupConfirmError,
+} from "./earn-cleanup-confirm.server";
+import {
+  findEarnCleanupVaultState,
+  findReconciledActiveYieldPositionForVault,
+  hasInactiveYieldRoutePolicyForVault,
+  type EarnCleanupVaultState,
+} from "./yield-deposit-repository.server";
+
+type PositionInput = Parameters<
+  typeof findReconciledActiveYieldPositionForVault
+>[0];
+
+function resolveVaultPubkey(input: PositionInput): string {
+  return pda
+    .getSmartAccountPda({
+      accountIndex: input.vaultIndex,
+      programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+      settingsPda: new PublicKey(input.settings),
+    })[0]
+    .toBase58();
+}
+
+async function verifyClosedPosition(
+  input: PositionInput,
+  state: EarnCleanupVaultState,
+  positionSlot: bigint
+): Promise<bigint> {
+  const { rpcEndpoint, websocketEndpoint } = getServerSolanaEndpoints(
+    resolveLoyalWebSolanaEnvFromEnv(process.env)
+  );
+  const connection = new Connection(rpcEndpoint, {
+    commitment: "confirmed",
+    disableRetryOnRateLimit: true,
+    fetch: getFrontendSolanaRpcFetch(globalThis.fetch),
+    wsEndpoint: websocketEndpoint,
+  });
+  const policies = [
+    state.routePolicy,
+    ...(state.setupPolicy ? [state.setupPolicy] : []),
+  ];
+  const minContextSlot = Number(
+    policies.reduce(
+      (slot, policy) =>
+        policy.lastSeenSlot > slot ? policy.lastSeenSlot : slot,
+      positionSlot
+    )
+  );
+  return assertEarnFullExitProven({
+    cleanupState: state,
+    cluster: normalizeLoyalCluster(input.cluster),
+    connection,
+    minContextSlot,
+    policyAccounts: policies.map((policy) => policy.policyAccount),
+    programId: new PublicKey(getServerEnv().loyalSmartAccounts.programId),
+    settingsPda: new PublicKey(input.settings),
+  });
+}
+
+// A successful cleanup can reach the policy catalog before position accounting.
+// Never turn inactivity alone (or an RPC failure) into evidence of zero funds.
+export async function findUserFacingEarnPosition(
+  input: PositionInput,
+  dependencies = {
+    findPosition: findReconciledActiveYieldPositionForVault,
+    resolveVaultPubkey,
+    hasInactivePolicy: hasInactiveYieldRoutePolicyForVault,
+    findCleanupState: findEarnCleanupVaultState,
+    verifyClosedPosition,
+  }
+) {
+  const position = await dependencies.findPosition(input);
+  const unchanged = {
+    position,
+    closedPositionObservedSlot: null as string | null,
+  };
+  try {
+    const scope = {
+      authority: input.walletAddress,
+      cluster: input.cluster,
+      settings: input.settings,
+      vaultIndex: input.vaultIndex,
+      vaultPubkey:
+        position?.vaultPubkey ?? dependencies.resolveVaultPubkey(input),
+    };
+    if (!(await dependencies.hasInactivePolicy(scope))) return unchanged;
+    const state = await dependencies.findCleanupState({
+      ...scope,
+      includeInactive: true,
+    });
+    if (!state || (state.vault.active && state.routePolicy.active))
+      return unchanged;
+    const observedSlot = await dependencies.verifyClosedPosition(
+      input,
+      state,
+      position?.currentObservedSlot ?? BigInt(0)
+    );
+    return {
+      position: null,
+      closedPositionObservedSlot: observedSlot.toString(),
+    };
+  } catch (error) {
+    // Preserve visibility when proof is incomplete, funds remain, or RPC is down.
+    console.warn(
+      "[earn-position] inactive position closure could not be proven",
+      {
+        code:
+          error instanceof EarnCleanupConfirmError
+            ? error.code
+            : "closure_read_failed",
+        errorName: error instanceof Error ? error.name : "UnknownError",
+        settings: input.settings,
+      }
+    );
+    return unchanged;
+  }
+}

--- a/apps/web/src/lib/yield-optimization/earn-rpc-holdings.client.ts
+++ b/apps/web/src/lib/yield-optimization/earn-rpc-holdings.client.ts
@@ -259,6 +259,14 @@ async function readAccountsInChunks(args: {
           : { minContextSlot: args.minContextSlot }),
       } satisfies GetMultipleAccountsConfig
     );
+    if (
+      !Number.isSafeInteger(result.context.slot) ||
+      result.context.slot < (args.minContextSlot ?? 0) ||
+      result.value.length !== chunk.length ||
+      Array.from(result.value).some((account) => account === undefined)
+    ) {
+      throw new Error("Earn account read is incomplete or below its context floor.");
+    }
     chunkCount += 1;
     maxObservedSlot = Math.max(maxObservedSlot, result.context.slot);
     values.push(...result.value);

--- a/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
+++ b/apps/web/src/lib/yield-optimization/yield-deposit-repository.server.ts
@@ -2906,6 +2906,22 @@ export async function findYieldPosition(
   return position ?? null;
 }
 
+// The yield-owned cluster column is intentionally outside the app's partial
+// policy model. Tie fallback accounting rows to their own policy generation,
+// including inactive policies: the current vault pointer alone is insufficient.
+function positionPolicyScope(input: ActiveYieldPositionForVaultLookupInput) {
+  return sql`exists (
+    select 1 from loyal_yield.route_policies as position_policy
+    where position_policy.id = ${userYieldPositions.policyId}
+      and position_policy.policy_account = ${userYieldPositions.policyAccount}
+      and position_policy.cluster = ${normalizeLoyalCluster(input.cluster)}
+      and position_policy.authority = ${input.walletAddress}
+      and position_policy.settings = ${input.settings}
+      and position_policy.vault_index = ${input.vaultIndex}
+      and position_policy.vault_pubkey = ${userYieldPositions.vaultPubkey}
+  )`;
+}
+
 export async function findActiveYieldPositionForVault(
   input: ActiveYieldPositionForVaultLookupInput,
   dependencies: Pick<YieldDepositRepositoryDependencies, "client"> = {
@@ -2915,6 +2931,7 @@ export async function findActiveYieldPositionForVault(
   const position =
     await dependencies.client.db.query.userYieldPositions.findFirst({
       where: and(
+        positionPolicyScope(input),
         eq(userYieldPositions.settings, input.settings),
         ...(input.liquidityMint
           ? [eq(userYieldPositions.initialLiquidityMint, input.liquidityMint)]
@@ -2940,6 +2957,7 @@ export async function findActiveYieldPositionsForVault(
 ): Promise<UserYieldPositionRecord[]> {
   return dependencies.client.db.query.userYieldPositions.findMany({
     where: and(
+      positionPolicyScope(input),
       eq(userYieldPositions.settings, input.settings),
       ...(input.liquidityMint
         ? [eq(userYieldPositions.initialLiquidityMint, input.liquidityMint)]

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -31,7 +31,8 @@ The original fix only changed the error to “This Earn policy is no longer acti
 Refresh Earn before withdrawing.” Refresh alone cannot repair a stale active
 position left behind by the worker.
 
-Web `/earn-state` and `/position` now read the inactive **current** policy generation
+Web `/earn-state` and `/position`, and the public wallet-keyed mobile `/state`,
+read the inactive **current** policy generation
 and verify full-exit zero holdings (including complete reserve reads and both token
 programs) plus closed policy accounts on-chain. Proof is fenced at the position's
 observed slot and the policies' last-seen slots. Positive reserve holdings, positive
@@ -51,9 +52,69 @@ no policy is available for a direct RPC read; local mutations and accepted closu
 proofs invalidate outstanding reads. The hook retains a wallet/cluster/settings-scoped
 closure watermark for subsequent refreshes: RPC reads are fenced strictly after
 closure (and at least at any newer displayed deposit), and stale RPC/HTTP responses
-cannot repopulate either position cache. Scope changes reset that watermark and
-invalidate responses from the previous scope. Later deposits remain visible; no
-persistent projection or database writes are added.
+cannot repopulate either position cache. Scope changes isolate that watermark and
+invalidate responses from the previous scope. Web closure evidence is stored separately
+from positive caches and does not expire with their balance TTL; remount and refresh
+read that scoped fence, including a closure written by another tab. Ordinary RPC
+refresh is fenced by the displayed position slot even before any closure. Cleanup
+callbacks request reconciliation instead of unconditionally clearing a possibly newer
+deposit. Later deposits remain visible; no persistent projection or database writes
+are added.
+
+### Mobile read and client boundaries
+
+The mobile state adapter loads all active product rows once. A whole-vault closure
+proof uses the newest observation across **all** those rows and returns an empty
+aggregate only after complete zero inventory and closed-policy proof. Positive
+funds or an open policy prevent closure; unknown, incomplete or failed evidence
+cannot authorize reducing the aggregate. There is no second unguarded query that
+can sum closed rows back into that response. Fallback
+position lookups constrain each row through its own policy's wallet/settings/vault
+and yield-owned cluster metadata, including inactive policy generations.
+
+Mobile state adds optional `closedPositionObservedSlot`, position
+`currentObservedSlot`, policy-account identities, and wallet/cluster/vault scope fields. Holdings adds the same
+scope fields. No-policy holdings still has null observations: its zero is a
+placeholder, not a verified balance. Positional account RPC responses must have one
+explicit account/null per requested key and a valid slot meeting each request's floor.
+
+The mobile position hook owns the accepted balance and details for both Earn and
+wallet tabs. It retains closure fences across owner remounts, invalidates old requests
+on identity or mutation changes, preserves funds on missing account mapping or
+HTTP/RPC failure, and rejects stale positive/empty responses. Deposit execution now
+returns the already confirmed slot; the Earn screen passes that slot and its optimistic
+amount to the owning hook from both Earn-tab and wallet-card deposit entrypoints,
+instead of independently clearing/overriding balance after a delayed transaction. Pending-deposit metadata is shared between hook instances;
+source selections are invalidated on scope changes, local mutations, accepted policy
+generation changes, or accepted emptiness. Existing
+focus, AppState, polling and mutation refreshes continue through that owner.
+
+For mixed accounting rows, supported products/venues use a complete funded vault
+snapshot as the display total instead of adding old and replacement lifecycle rows.
+The shared full-exit reader scans all supported product ATAs and Safe-market
+obligations, requires complete reserve reads, and checks both token inventories.
+Unknown positive inventory, inventory/holdings disagreement, unsupported accounting
+products/venues, or failed reads prevent this replacement. A zero snapshot still
+cannot close the position without the separate closed-policy proof. Neither rows nor
+principal accounting are rewritten, and policy closure alone never removes a product.
+The mobile holdings endpoint uses this same complete all-product reader when policy
+metadata exists; its no-policy placeholder is unchanged. Funded snapshots advertise
+only the common requested context floor, not the newest chunk.
+
+After local deposit confirmation, fresh scoped holdings at or after that confirmed
+slot may replace a lagging aggregate even during the mutation grace period; pending
+or unfenced mutations retain the grace safeguard. Balance changes invalidate cached
+withdrawal sources, and a changed total cannot retain old detail amounts when its
+independent holdings read failed. Ordinary read failures retain the last valid balance.
+
+Server changes are additive for released mobile clients, but those clients do not
+consume the new ordering metadata. Updated hook/source/pending-deposit behavior needs
+an approved compatible mobile JS rollout (OTA only for the appropriate runtime/channel,
+otherwise a binary). Deploy compatible server code first. Browser/device canaries and
+the resulting Vercel deployment are separate gates; no deployed incident resolution is
+implied by local hook simulations. Routing PR #232 remains a separate, unmerged and
+undeployed prerequisite at this review; verify its actual rollout and processing health
+before claiming durable backend convergence.
 
 Focused checks (also run scoped lint and web typecheck):
 

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -25,6 +25,52 @@ cd apps/web
 bun test src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
 ```
 
-After deployment, try withdrawing from a stale tab after a full-exit cleanup:
-expect the inactive-policy message and refreshed Earn state, not a retry loop.
-Verify a fresh deposit can still prepare a withdrawal after projection catches up.
+## Stale position after confirmed cleanup
+
+The original fix only changed the error to “This Earn policy is no longer active.
+Refresh Earn before withdrawing.” Refresh alone cannot repair a stale active
+position left behind by the worker.
+
+Web `/earn-state` and `/position` now read the inactive **current** policy generation
+and verify full-exit zero holdings (including complete reserve reads and both token
+programs) plus closed policy accounts on-chain. Proof is fenced at the position's
+observed slot and the policies' last-seen slots. Only successful proof returns
+`position: null` with `closedPositionObservedSlot`; inactive metadata, remaining
+funds, missing projection, and RPC failures do not clear a position. These reads
+do not repair the database.
+
+The position hook accepts this closure proof over older cached/RPC holdings, but
+retains a deposit observed after the proof slot. A plain null without proof keeps
+its existing conservative behavior. Explicit refresh now queries `/position` when
+no policy is available for a direct RPC read; local mutations and accepted closure
+proofs invalidate outstanding reads.
+
+Focused checks (also run scoped lint and web typecheck):
+
+```sh
+cd apps/web
+bun test src/lib/yield-optimization/earn-position-read.server.test.ts src/hooks/use-active-earn-position.test.ts
+bun test src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
+```
+
+After deployment, test both a fresh load and an already-open stale tab after full
+exit: the inactive-policy alert must refresh into the empty Earn view. Verify a
+fresh deposit remains visible and can withdraw after projection catches up; an
+RPC outage or nonzero holding must not produce a closure proof.
+
+### Worker deployment and separately approved repair
+
+The worker must also deploy the already-merged closed-obligation withdrawal and
+refund-cleanup replay fixes (routing PR #141 and its ancestors), plus the follow-up
+policy-deletion job fix. Monitor successful reconciliation and rebalance/autodeposit
+heartbeats; a running container alone does not prove services are processing.
+
+For the September 9 incident, audit settings
+`27Un5R5iXs5sLtMMCJDSUzjts7RAEvdax2iWMoqP1FWr`, vault index 1, slots
+`445608294`–`445608350`. Recover missing withdrawals first, then audit refund-only
+cleanup using `loyal-yield-routing/docs/earn-laserstream-gap-reconciliation.md`.
+Do not resend on-chain transactions or delete refund history. Execution requires
+separate production-write approval; review later deposits and settlement history,
+then verify completed jobs, immutable withdrawal/cleanup records, and position
+closure. The app read guard is not a substitute for repairing accounting or
+Autodeposit's database-backed position gate.

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -34,7 +34,12 @@ position left behind by the worker.
 Web `/earn-state` and `/position` now read the inactive **current** policy generation
 and verify full-exit zero holdings (including complete reserve reads and both token
 programs) plus closed policy accounts on-chain. Proof is fenced at the position's
-observed slot and the policies' last-seen slots. Only successful proof returns
+observed slot and the policies' last-seen slots. Positive reserve holdings, positive
+unknown assets, and canonical idle balances at or above the existing 10,000-raw
+unit dust threshold block closure, even when a separate token inventory is empty.
+The closure watermark is the requested minimum context slot shared by **all**
+proof reads, not the newest holdings chunk or inventory response; this conservative
+floor cannot supersede an intervening deposit observed above it. Only successful proof returns
 `position: null` with `closedPositionObservedSlot`; inactive metadata, remaining
 funds, missing projection, and RPC failures do not clear a position. These reads
 do not repair the database.
@@ -43,13 +48,21 @@ The position hook accepts this closure proof over older cached/RPC holdings, but
 retains a deposit observed after the proof slot. A plain null without proof keeps
 its existing conservative behavior. Explicit refresh now queries `/position` when
 no policy is available for a direct RPC read; local mutations and accepted closure
-proofs invalidate outstanding reads.
+proofs invalidate outstanding reads. The hook retains a wallet/cluster/settings-scoped
+closure watermark for subsequent refreshes: RPC reads are fenced strictly after
+closure (and at least at any newer displayed deposit), and stale RPC/HTTP responses
+cannot repopulate either position cache. Scope changes reset that watermark and
+invalidate responses from the previous scope. Later deposits remain visible; no
+persistent projection or database writes are added.
 
 Focused checks (also run scoped lint and web typecheck):
 
 ```sh
 cd apps/web
-bun test src/lib/yield-optimization/earn-position-read.server.test.ts src/hooks/use-active-earn-position.test.ts
+# Separate processes isolate Bun module mocks.
+bun test src/lib/yield-optimization/earn-position-read.server.test.ts
+bun test src/hooks/use-active-earn-position.test.ts
+bun test src/hooks/use-active-earn-position-races.test.ts
 bun test src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
 ```
 

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -35,12 +35,21 @@ seeds, configured cluster, successful signature and exact-slot checks. These end
 only acknowledge verified setup; they do not write the financial projection or send
 a deposit. A setup-confirmation failure therefore does not mean USDC was deposited.
 After refreshing, preparation can resume the already-created policy setup.
+A retry may reuse the route policy but still prepare a new setup-policy/finalize
+transaction. Both sequential and batch web deposit confirmation delegate the old
+route-policy citation to the existing server recovery path while retaining the new
+finalize signature and slot; they must not ask the retry to supply a route signature
+it never signed. Newly created route policies still require their own signature and
+slot, and a prepared finalize still requires its new confirmation before proceeding.
+Only the web caller opts into server citation recovery; the mobile confirm handler's
+existing explicit recovery/default validation is unchanged.
 
 Regression coverage (including unsupported products/markets and failed signatures):
 
 ```sh
 cd apps/web
 bun test src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
+bun test src/lib/yield-optimization/earn-deposit-flow.shared.test.ts
 ```
 
 ## Stale position after confirmed cleanup

--- a/docs/earn-withdrawal-policy-state.md
+++ b/docs/earn-withdrawal-policy-state.md
@@ -25,6 +25,24 @@ cd apps/web
 bun test src/app/api/smart-accounts/yield-optimization/withdrawals/prepare/route.test.ts
 ```
 
+## Deposit setup confirmation after a full exit
+
+Deposit preparation selects an eligible Safe reserve for the selected supported
+product; policy confirmation must validate that same product/Safe-market contract,
+not require the historical fixed USDC reserve. Both route-policy and setup-policy
+confirmation retain authenticated wallet/settings, canonical policy and vault PDAs,
+seeds, configured cluster, successful signature and exact-slot checks. These endpoints
+only acknowledge verified setup; they do not write the financial projection or send
+a deposit. A setup-confirmation failure therefore does not mean USDC was deposited.
+After refreshing, preparation can resume the already-created policy setup.
+
+Regression coverage (including unsupported products/markets and failed signatures):
+
+```sh
+cd apps/web
+bun test src/lib/yield-optimization/earn-confirm-single-writer.server.test.ts
+```
+
 ## Stale position after confirmed cleanup
 
 The original fix only changed the error to “This Earn policy is no longer active.
@@ -106,15 +124,23 @@ slot may replace a lagging aggregate even during the mutation grace period; pend
 or unfenced mutations retain the grace safeguard. Balance changes invalidate cached
 withdrawal sources, and a changed total cannot retain old detail amounts when its
 independent holdings read failed. Ordinary read failures retain the last valid balance.
+Newer scoped positive holdings are evaluated before rejecting stale/null accounting:
+a closure at slot 600 cannot hide funded holdings at 700 behind accounting at 500,
+either before or after accepting the closure. The live observation must meet both
+current/local and accounting slot fences and exceed the closure floor. Pending
+mutations and scope checks still apply. Live holdings establish current value, not
+cost basis; principal is nullable until accounting for the new lifecycle is available,
+rather than copying principal from the closed generation.
 
 Server changes are additive for released mobile clients, but those clients do not
 consume the new ordering metadata. Updated hook/source/pending-deposit behavior needs
 an approved compatible mobile JS rollout (OTA only for the appropriate runtime/channel,
 otherwise a binary). Deploy compatible server code first. Browser/device canaries and
 the resulting Vercel deployment are separate gates; no deployed incident resolution is
-implied by local hook simulations. Routing PR #232 remains a separate, unmerged and
-undeployed prerequisite at this review; verify its actual rollout and processing health
-before claiming durable backend convergence.
+implied by local hook simulations. Routing PR #232 was merged and its immutable
+image deployed only to the Earn monitor on September 11, 2026 (merge
+`2363318e524a36626a14344ef6f1a46821ce569a`). New-instance completions were verified;
+this does not establish client adoption or repair the older unprovable jobs.
 
 Focused checks (also run scoped lint and web typecheck):
 
@@ -125,6 +151,8 @@ bun test src/lib/yield-optimization/earn-position-read.server.test.ts
 bun test src/hooks/use-active-earn-position.test.ts
 bun test src/hooks/use-active-earn-position-races.test.ts
 bun test src/lib/yield-optimization/earn-full-exit-zero-proof.server.test.ts
+cd ../mobile
+bunx jest --runInBand src/hooks/wallet/__tests__/useEarnPosition-lifecycle.test.ts
 ```
 
 After deployment, test both a fresh load and an already-open stale tab after full


### PR DESCRIPTION
Fix stale full exits on web/mobile and resumed-deposit policy confirmation by fencing position reads with proven closure slots, preserving newer funded holdings, accepting prepared Safe targets, and recovering an existing route policy citation while retaining newly confirmed setup signatures and slots. The existing focused checks and preview build passed for `d379a54a`; the live browser canary now confirms deposit succeeds on-chain but withdrawal returns `This Earn policy is no longer active. Refresh Earn before withdrawing.` because closing Earn removed this account from the worker watch list, leaving the reopened policy and deposit unprojected.

Do not merge until the canary passes: [routing #235](https://github.com/loyal-labs/loyal-yield-routing/pull/235) fixes that discovery gap, with monitor/store compilation and a disposable PostgreSQL lifecycle check passing. Its deployment and the four-event, test-wallet-scoped finalized reconciliation are awaiting approval; then repeat deposit, withdrawal, full close, and reopening in this preview and verify durable records. Compatible mobile JS adoption remains a separate step after server deployment; no worker deployment, reconciliation execution, or new browser transaction has been performed in this takeover yet.
