### PR TITLE
fix(mobile): show live Earn holdings when read-model position is missing

### DIFF
--- a/apps/mobile/src/hooks/wallet/useEarnPosition.ts
+++ b/apps/mobile/src/hooks/wallet/useEarnPosition.ts
@@ -28,8 +28,22 @@ function reconcileBalance(
   liveTotalRaw: string | null,
   preferReadModel: boolean,
 ): EarnPosition | null {
-  if (position === null || liveTotalRaw === null || preferReadModel) {
+  if (liveTotalRaw === null || preferReadModel) {
     return position;
+  }
+  if (position === null) {
+    // Read-model gap: the vault holds funds on-chain but the deposit was never
+    // projected (e.g. first deposit after a full exit, wallet 8p6b… 2026-09-11).
+    // Surface the live balance so Withdraw stays reachable instead of showing
+    // $0.00 and hiding the user's funds. APY/principal are unknown here.
+    return Number(liveTotalRaw) > 0
+      ? {
+          currentAmountRaw: liveTotalRaw,
+          currentSupplyApyBps: null,
+          principalAmountRaw: liveTotalRaw,
+          status: "active",
+        }
+      : null;
   }
   return { ...position, currentAmountRaw: liveTotalRaw };
 }


### PR DESCRIPTION
Wallet 8p6b… deposited 50 USDC on 2026-09-11 (tx 5iPaB4LU…) after a full exit; the deposit was never projected into loyal_yield.user_yield_positions, so /mobile/earn/state returns position=null and the Earn tab shows /bin/bash.00 with no Withdraw/Autodeposit controls while /holdings shows the funds. Fall back to the live holdings total when the read-model has no position, so user funds are never hidden by a projection gap.